### PR TITLE
Remove android-actions/setup-android; use pre-installed NDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,6 @@ jobs:
         with:
           go-version: stable
 
-      - uses: android-actions/setup-android@v3
-
       - name: Build
         working-directory: go-gui
         run: |


### PR DESCRIPTION
## Summary
- Removes `android-actions/setup-android@v3` step that was failing to download the Android Emulator package
- `ubuntu-latest` runners already have Android NDK pre-installed with `$ANDROID_NDK_ROOT` set — no extra setup needed for cross-compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)