### PR TITLE
fix: defer finishLaunching until after first window is created

### DIFF
--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -917,20 +917,29 @@ void metalActivateApp(void) {
     [NSApp setMainMenu:bar];
 
     [NSApp setDelegate:delegate];
-    [NSApp finishLaunching];
+    // finishLaunching is deferred to metalActivateNow — called after
+    // the first window is created and ordered front, which is required
+    // for .app bundles to show windows on the active Space.  Calling it
+    // here (before any window exists) causes windows to remain
+    // off-screen when launched via Finder/Launch Services.
 }
 
 // ─── Test helpers (called from Go tests via cgo) ─────────────────
 
-// Activate the app now that windows exist. Called from Go right
-// before the event loop starts, after all windows are created.
-// Deprecated since macOS 14 (where focus-stealing is dead
-// regardless of API), but required on older macOS for
-// CLI-launched binaries to appear above Terminal.
+// Activate the app now that windows exist.  Called from Go right
+// before the event loop starts and from metalWindowCreate for
+// dynamically-opened windows.  When windows have been created, the
+// first call also posts finishLaunching (deferred from
+// metalActivateApp so the notification fires with windows on screen,
+// which is required for .app bundles to display on the active Space).
 void metalActivateNow(void) {
-    // Intentionally not idempotent — called from both
-    // metalWindowCreate (dynamic windows) and Go (post-startup).
-    // Each call must reach activateIgnoringOtherApps:YES.
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        [NSApp finishLaunching];
+    });
+    // Intentionally not idempotent for the activation itself —
+    // called from both metalWindowCreate (dynamic windows) and Go
+    // (post-startup).  Each call must activate the app.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [NSApp activateIgnoringOtherApps:YES];

--- a/gui/view_form_test.go
+++ b/gui/view_form_test.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -305,12 +306,12 @@ func TestFormAbortOnRevalidation(t *testing.T) {
 	w := newTestWindow()
 	formID := "abort-form"
 
-	callCount := 0
+	var callCount atomic.Int32
 	slow := func(
 		_ FormFieldSnapshot, _ FormSnapshot,
 		_ *GridAbortSignal,
 	) []FormIssue {
-		callCount++
+		callCount.Add(1)
 		return nil
 	}
 


### PR DESCRIPTION
When launched as a `.app` bundle via Finder/Launch Services, `[NSApp finishLaunching]` was called in `metalActivateApp` before any window existed. This caused windows to remain off-screen (`onScreen=false` in the window server) despite the process appearing in Activity Monitor and being frontmost.

## Root cause

AppKit's window management for `.app` bundles requires `finishLaunching` to fire **after** the first `NSWindow` is created and ordered front. When it fires before any window exists, the window server registers the window but never marks it on-screen — the app is active, has a menu bar, but no visible windows.

## Fix

Move `[NSApp finishLaunching]` from `metalActivateApp` (called before window creation) into `metalActivateNow` (called after the first window is created and ordered front), gated by `dispatch_once` to preserve single-fire semantics.

The `activateIgnoringOtherApps:` call remains non-idempotent — only `finishLaunching` is deferred.

## Verification

- Built go-kite as a `.app` bundle with `make all` → window now appears on screen
- CLI launch continues to work (unchanged behavior)
- Existing metal backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)