### PR TITLE
fix: fire EventFocused on applicationDidBecomeActive:

### DIFF
--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -846,6 +846,18 @@ void metalPostEmptyEvent(void) {
     return NSTerminateCancel;
 }
 
+// After a system dialog (e.g. TCC permissions) dismisses, the
+// app becomes active but windowDidBecomeKey: may not fire if the
+// dialog only changed app activation state, not window key state.
+// Fire EventFocused for the key window so Go resets w.focused.
+- (void)applicationDidBecomeActive:(NSNotification *)notification {
+    NSWindow *keyWindow = [NSApp keyWindow];
+    if (keyWindow && [keyWindow isKindOfClass:[GUIWindow class]]) {
+        GUIWindow *gw = (GUIWindow *)keyWindow;
+        goMetalWindowFocusChanged(gw.windowID, 1);
+    }
+}
+
 @end
 
 // ─── App-level ─────────────────────────────────────────────────


### PR DESCRIPTION
When a macOS system dialog (e.g. TCC permissions) dismisses for a `.app` bundle, `applicationDidBecomeActive:` fires but `windowDidBecomeKey:` may not — leaving `w.focused=false` in Go and blocking all keyboard and left-click input via `eventAllowed()`.

## Reproduce

1. Build a macOS `.app` bundle with a terminal widget
2. Trigger a TCC permissions dialog (e.g. `ls ~/Desktop` without prior Desktop access)
3. Dismiss the dialog
4. Terminal no longer accepts keyboard or mouse input

Does not reproduce when running as a CLI binary from Terminal.app — only as a `.app` bundle with its own bundle ID.

## Fix

Add `applicationDidBecomeActive:` to `GoGuiAppDelegate`. When the app regains activation, fire `goMetalWindowFocusChanged(1)` for the key window, dispatching `EventFocused` → `w.focused = true`.

The handler is deliberately app-activation-only (not paired with `applicationDidResignActive:`), because `windowDidResignKey:` already handles focus-loss via the window delegate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)