### PR TITLE
refactor(metal): rename app lifecycle fns and dedupe activation focus

### DIFF
--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -64,7 +64,7 @@ func New(w *gui.Window) (*Backend, error) {
 
 	// Activate the app before creating any windows so the
 	// window is visible on macOS for CLI-launched binaries.
-	C.metalActivateApp()
+	C.metalAppInit()
 
 	ws, err := createWindowState(w)
 	if err != nil {
@@ -89,7 +89,7 @@ func (b *Backend) Run(w *gui.Window) {
 	iconSet := false
 
 	// Activate now that windows exist on screen.
-	C.metalActivateNow()
+	C.metalAppFinishLaunch()
 
 	wakeUp := func() {
 		C.metalPostEmptyEvent()
@@ -198,7 +198,7 @@ func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
 
 	// Activate the app before creating any windows so
 	// windows are visible on macOS for CLI-launched binaries.
-	C.metalActivateApp()
+	C.metalAppInit()
 
 	states := make(map[uint32]*windowState)
 
@@ -235,7 +235,7 @@ func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
 	}
 
 	// Activate now that windows exist on screen.
-	C.metalActivateNow()
+	C.metalAppFinishLaunch()
 
 	running := true
 	rendered := true

--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -87,10 +87,10 @@ func testWindowID(handle C.GoGuiNSWindow) uint32 {
 	return uint32(C.metalWindowGetID(handle))
 }
 
-// testActivateNow calls C.metalActivateNow directly to verify
+// testActivateNow calls C.metalAppFinishLaunch directly to verify
 // the activation function exists, links, and runs without crashing.
 func testActivateNow() {
-	C.metalActivateNow()
+	C.metalAppFinishLaunch()
 }
 
 // testInjectKeyDown sets up the C event globals to simulate a

--- a/gui/backend/metal/icon.go
+++ b/gui/backend/metal/icon.go
@@ -16,7 +16,7 @@ import (
 // and brings the app to the foreground. Must be called before
 // creating any windows for CLI-launched (non-bundled) binaries.
 func activateApp() {
-	C.metalActivateApp()
+	C.metalAppInit()
 }
 
 // setAppIcon sets the macOS Dock icon from PNG data.

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -43,26 +43,26 @@ func runMainThreadTests() {
 	//    the Dock and can become active. Regression test for
 	//    window not appearing on macOS (activation skipped).
 	if !testActivationPolicyRegular() {
-		panic("metalActivateApp: activation policy not Regular")
+		panic("metalAppInit: activation policy not Regular")
 	}
 
 	// 3. Menu bar must be fully wired — delegate, main menu, and
 	//    Quit wired to delegate. Regression test for Cmd+Q silently
 	//    failing.
 	if !testDelegateSet() {
-		panic("metalActivateApp: delegate not set")
+		panic("metalAppInit: delegate not set")
 	}
 	if !testMenuExists() {
-		panic("metalActivateApp: main menu not created")
+		panic("metalAppInit: main menu not created")
 	}
 	if !testMenuQuitWired() {
-		panic("metalActivateApp: Quit menu not wired to delegate")
+		panic("metalAppInit: Quit menu not wired to delegate")
 	}
 	if !testMenuAboutExists() {
-		panic("metalActivateApp: About menu item not found")
+		panic("metalAppInit: About menu item not found")
 	}
 	if !testWindowsMenuExists() {
-		panic("metalActivateApp: Windows menu not registered")
+		panic("metalAppInit: Windows menu not registered")
 	}
 
 	// 4. Delegate methods must set quit event AND _quitRequested —
@@ -86,7 +86,7 @@ func runMainThreadTests() {
 
 	// 5. New() must succeed with activation — creates a real window
 	//    and Metal context, then tears down. Validates that
-	//    metalActivateApp + metalWindowCreate work end-to-end.
+	//    metalAppInit + metalWindowCreate work end-to-end.
 	//    Regression test for window opening behind terminal.
 	w := gui.NewWindow(gui.WindowCfg{
 		State:  new(int),
@@ -113,7 +113,7 @@ func runMainThreadTests() {
 		panic("metal.New: window not registered in windowRegistry")
 	}
 
-	// 8. metalActivateNow must not crash — validates the C function
+	// 8. metalAppFinishLaunch must not crash — validates the C function
 	//    exists, links, and can be called from Go. Regression test
 	//    for the activation call added before the event loop.
 	testActivateNow()

--- a/gui/backend/metal/metal_window.h
+++ b/gui/backend/metal/metal_window.h
@@ -153,14 +153,24 @@ void metalWindowIMESetActive(GoGuiNSWindow w, int active);
 void metalPostEmptyEvent(void);
 
 // ─── App-level ─────────────────────────────────────────────────
+//
+// Launch sequence (see metal_window_darwin.m for the full narrative):
+//   1. metalAppInit         — before any window: NSApplication singleton,
+//                             activation policy, menu bar, app delegate.
+//   2. metalWindowCreate    — order each window front.
+//   3. metalAppFinishLaunch — after windows exist: complete the Launch
+//                             Services handshake, bring app to foreground.
 
-// Activate the NSApplication (must be called before creating windows
-// for CLI-launched binaries).
-void metalActivateApp(void);
+// Initialize the NSApplication singleton, menu bar, and delegate.
+// Must be called once before creating any windows. Idempotent.
+void metalAppInit(void);
 
-// Activate the app after all windows are created. Called just before
-// the event loop starts to ensure the app is frontmost.
-void metalActivateNow(void);
+// Complete launch and bring the app to the foreground. Must be called
+// after the first window exists (required for .app bundles to display
+// on the active Space). Runs the Launch Services handshake once;
+// re-activates the app on every call so dynamically-opened windows
+// come forward.
+void metalAppFinishLaunch(void);
 
 // Set the dock icon from PNG data.
 void metalSetDockIcon(const void *data, int len);

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -403,9 +403,9 @@ GoGuiNSWindow metalWindowCreate(const char *title, int width, int height,
     [NSApp setWindowsNeedUpdate:YES];
 
     // Bring the app forward for dynamically-opened windows.
-    // For initial windows, metalActivateNow is also called from Go
+    // For initial windows, metalAppFinishLaunch is also called from Go
     // after all windows are on screen.
-    metalActivateNow();
+    metalAppFinishLaunch();
 
     // Allocate GoGuiWindow on heap.
     GoGuiWindow *gw = (GoGuiWindow *)calloc(1, sizeof(GoGuiWindow));
@@ -869,23 +869,27 @@ static GUIWindow *metalFocusedGUIWindow(void) {
 // TCC permissions), applicationDidBecomeActive: fires but
 // windowDidBecomeKey: may not — leaving w.focused=false in Go and
 // blocking keyboard/left-click input via eventAllowed(). Restore
-// focus for the frontmost GUIWindow and make it key if needed.
+// focus for the frontmost GUIWindow.
 - (void)applicationDidBecomeActive:(NSNotification *)notification {
     GUIWindow *gw = metalFocusedGUIWindow();
     if (!gw) return;
     if ([NSApp keyWindow] != gw) {
+        // Window is not key: makeKeyAndOrderFront triggers
+        // windowDidBecomeKey:, which delivers EventFocused. Do not
+        // also fire it here, or Go's OnEvent sees a duplicate.
         [gw makeKeyAndOrderFront:nil];
+        return;
     }
+    // Window is already key but Go's focus state may have drifted to
+    // false (windowDidBecomeKey: not re-fired on reactivation). This
+    // is the only path that re-asserts focus directly.
     goMetalWindowFocusChanged(gw.windowID, 1);
 }
 
-// Completes the Launch Services launch handshake.  For a .app launched
-// via LS, AppKit posts applicationWillFinishLaunching: but withholds
-// applicationDidFinishLaunching: until the loop processes the
-// kAEOpenApplication event; metalActivateNow runs [NSApp run] to reach
-// this point.  Stop that bootstrap run so the custom event loop can take
-// over.  -stop: only takes effect after the next event is dequeued, so
-// post a dummy event to wake the run loop and force it to return.
+// Stops the bootstrap [NSApp run] started by metalAppFinishLaunch so
+// the custom event loop can take over.  -stop: only takes effect after
+// the next event is dequeued, so post a dummy event to force a return.
+// See the App-level section header for the full handshake narrative.
 - (void)applicationDidFinishLaunching:(NSNotification *)note {
     [NSApp stop:nil];
     NSEvent *wake = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
@@ -903,6 +907,35 @@ static GUIWindow *metalFocusedGUIWindow(void) {
 @end
 
 // ─── App-level ─────────────────────────────────────────────────
+//
+// Launch / activation sequence. Three steps, called in order; the
+// header (metal_window.h) lists the Go call sites.
+//
+//   1. metalAppInit  (before any window exists)
+//        NSApplication singleton + activation policy + menu bar +
+//        delegate.  Force-activates early so Launch Services registers
+//        the Dock tile and Cmd+Tab entry before it times out.
+//
+//   2. metalWindowCreate  (per window)
+//        Orders the window front and force-activates again.
+//
+//   3. metalAppFinishLaunch  (after the first window exists)
+//        finishLaunching is deferred to here: a .app bundle only shows
+//        windows on the active Space if the notification fires with a
+//        window already on screen.  The first call also drives the
+//        Launch Services handshake (below); every call force-activates
+//        so dynamically-opened windows come forward.
+//
+// Launch Services handshake: a .app launched via LS receives
+// applicationWillFinishLaunching: but NEVER applicationDidFinish-
+// Launching: until the run loop processes the kAEOpenApplication
+// event.  Until then the app is in launch-limbo (no Cmd+Tab, gray
+// titlebar, two-click close) even though -isActive is YES.
+// metalAppFinishLaunch runs [NSApp run] once to process that event;
+// applicationDidFinishLaunching: then calls [NSApp stop:] (plus a wake
+// event, since -stop takes effect only after the next dequeue) so the
+// custom event loop can take over.  A bare CLI exec has no handshake;
+// -run still calls finishLaunching and returns via the same stop.
 
 // Force the app to the foreground.  [NSApp activate] (macOS 14+) is
 // cooperative: it refuses to steal focus from the currently-active
@@ -918,7 +951,7 @@ static void metalForceActivate(void) {
 #pragma clang diagnostic pop
 }
 
-void metalActivateApp(void) {
+void metalAppInit(void) {
     // Idempotent — safe to call multiple times.
     static BOOL activated = NO;
     if (activated) return;
@@ -985,53 +1018,36 @@ void metalActivateApp(void) {
     [NSApp setMainMenu:bar];
 
     [NSApp setDelegate:delegate];
-    // finishLaunching is deferred to metalActivateNow — called after
-    // the first window is created and ordered front, which is required
-    // for .app bundles to show windows on the active Space.  Calling it
-    // here (before any window exists) causes windows to remain
-    // off-screen when launched via Finder/Launch Services.
-    //
-    // Activate early so the Dock and Cmd+Tab switcher register the app
-    // promptly.  Without this, Launch Services may time out waiting for
-    // the app to confirm it is a foreground process and drop the Dock
-    // tile.  The activate call here is idempotent; metalActivateNow
-    // calls it again once windows exist to ensure foreground ordering.
+    // finishLaunching is deferred to metalAppFinishLaunch; activate
+    // early so Launch Services registers the app before timing out.
+    // See the App-level section header for why.
     metalForceActivate();
 }
 
-// ─── Test helpers (called from Go tests via cgo) ─────────────────
-
-// Activate the app now that windows exist.  Called from Go right
-// before the event loop starts and from metalWindowCreate for
-// dynamically-opened windows.  When windows have been created, the
-// first call also posts finishLaunching (deferred from
-// metalActivateApp so the notification fires with windows on screen,
-// which is required for .app bundles to display on the active Space).
-void metalActivateNow(void) {
+void metalAppFinishLaunch(void) {
+    // Run the Launch Services handshake exactly once (see the App-level
+    // section header).  Skipped for a bare CLI exec, which is already
+    // finished launching.
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        // Complete the Launch Services launch handshake.  For a .app
-        // launched via LS, [NSApp finishLaunching] alone posts
-        // applicationWillFinishLaunching: but NEVER applicationDidFinish-
-        // Launching: — AppKit only posts the latter after the loop
-        // processes the kAEOpenApplication event.  Without it the app
-        // stays in launch-limbo (absent from Cmd+Tab, gray titlebar,
-        // two-click close) even though -isActive reports YES.  Running
-        // the loop until applicationDidFinishLaunching: fires (which
-        // calls [NSApp stop:]) processes that event and fully registers
-        // the app, then returns so the custom event loop takes over.
-        // A bare CLI exec has no such handshake; -run still calls
-        // finishLaunching and returns immediately via the same stop.
         if (![[NSRunningApplication currentApplication] isFinishedLaunching]) {
             [NSApp run];
         }
     });
-    // Intentionally not idempotent for the activation itself —
-    // called from both metalWindowCreate (dynamic windows) and Go
-    // (post-startup).  Each call must activate the app so newly-
-    // created windows come to the foreground.
+    // Not guarded by the dispatch_once: every call must re-activate so
+    // newly-created windows come to the foreground.
     metalForceActivate();
 }
+
+// ─── Test helpers (called from Go tests via cgo) ─────────────────
+//
+// These live in the production file, not a separate _test.m, on
+// purpose: they reach file-static state — the event globals (_evType,
+// _quitRequested, _evIMEGeneration…), metalCursorInContentBounds, and
+// metalFocusedGUIWindow. C `static` is translation-unit-local, so a
+// split would force exposing those symbols via the header, widening
+// the production surface just to relocate test code. Keeping the
+// helpers here preserves that encapsulation.
 
 int metalTestActivationPolicyIsRegular(void) {
     return [NSApp activationPolicy] == NSApplicationActivationPolicyRegular ? 1 : 0;


### PR DESCRIPTION
## Summary

Follow-up cleanup to the macOS launch/activation work (#13, #14, #15). No behavior change beyond one focus-event fix.

- **Rename app-launch entry points** to describe the lifecycle stage instead of the activation side effect:
  - `metalActivateApp` → `metalAppInit` (before any window exists)
  - `metalActivateNow` → `metalAppFinishLaunch` (after first window exists)
- **Consolidate the launch commentary** scattered across the file into a single App-level section header that narrates the three-step sequence (init → window create → finish launch) and the Launch Services handshake. Also documents why the cgo test helpers must live in the production translation unit (they reach file-static state).
- **Fix duplicate `EventFocused`** in `applicationDidBecomeActive:`. When the frontmost window is not key, `makeKeyAndOrderFront:` already drives `windowDidBecomeKey:` (which delivers `EventFocused`), so the method now returns early instead of also calling `goMetalWindowFocusChanged`. The direct re-assert is kept only on the already-key path, where Go's focus state may have drifted.

## Test plan

- `go build ./gui/backend/metal/` passes
- Lint hook clean (0 issues)
- Test helper references and `icon_test.go` panic messages updated to the new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)