### PR TITLE
refactor(metal): cache cursor C strings and dedupe wake event

### DIFF
--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -146,14 +146,7 @@ func (b *Backend) Run(w *gui.Window) {
 		}
 
 		// Update cursor.
-		mc := w.MouseCursorState()
-		if cs := cursorSelector(mc); cs != "" {
-			cstr := C.CString(cs)
-			C.metalWindowSetCursor(b.window, cstr,
-				C.metalEventMouseX(),
-				C.metalEventMouseY())
-			C.free(unsafe.Pointer(cstr))
-		}
+		b.updateCursor(w.MouseCursorState())
 	}
 }
 
@@ -349,23 +342,18 @@ func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
 			if w == nil {
 				continue
 			}
-			mc := w.MouseCursorState()
-			if cs := cursorSelector(mc); cs != "" {
-				cstr := C.CString(cs)
-				C.metalWindowSetCursor(ws.window, cstr,
-					C.metalEventMouseX(),
-					C.metalEventMouseY())
-				C.free(unsafe.Pointer(cstr))
-			}
+			ws.updateCursor(w.MouseCursorState())
 		}
 	}
 
-	// Cleanup remaining windows.
+	// Cleanup remaining windows. Delete each entry so the deferred
+	// cleanup above does not destroy it a second time.
 	for wid, ws := range states {
 		if w := app.Window(wid); w != nil {
 			w.WindowCleanup()
 		}
 		ws.destroy()
+		delete(states, wid)
 	}
 	return nil
 }
@@ -397,6 +385,39 @@ func cursorSelector(mc gui.MouseCursor) string {
 	default:
 		return ""
 	}
+}
+
+// cursorCStrings caches each NSCursor selector name as a C string,
+// allocated once at startup, so the per-frame cursor update avoids a
+// C.CString alloc+free on the hot path. The strings live for the
+// process lifetime and are intentionally never freed.
+var cursorCStrings = func() map[gui.MouseCursor]*C.char {
+	cursors := []gui.MouseCursor{
+		gui.CursorDefault, gui.CursorArrow, gui.CursorIBeam,
+		gui.CursorCrosshair, gui.CursorPointingHand,
+		gui.CursorResizeEW, gui.CursorResizeNS,
+		gui.CursorResizeNWSE, gui.CursorResizeNESW,
+		gui.CursorResizeAll, gui.CursorNotAllowed,
+	}
+	m := make(map[gui.MouseCursor]*C.char, len(cursors))
+	for _, c := range cursors {
+		if sel := cursorSelector(c); sel != "" {
+			m[c] = C.CString(sel)
+		}
+	}
+	return m
+}()
+
+// updateCursor sets the native cursor for the window from a cached
+// C string. No-op when the cursor has no NSCursor mapping.
+func (ws *windowState) updateCursor(mc gui.MouseCursor) {
+	cstr := cursorCStrings[mc]
+	if cstr == nil {
+		return
+	}
+	C.metalWindowSetCursor(ws.window, cstr,
+		C.metalEventMouseX(),
+		C.metalEventMouseY())
 }
 
 // windowState holds per-window backend resources for

--- a/gui/backend/metal/events_test.go
+++ b/gui/backend/metal/events_test.go
@@ -201,6 +201,42 @@ func TestCursorSelector_Unknown(t *testing.T) {
 	}
 }
 
+// The cursorCStrings cache hand-lists the cursors it allocates. Guard
+// against drift from cursorSelector: every cursor with a selector must
+// have a cached C string whose value matches, or updateCursor silently
+// no-ops for that cursor.
+func TestCursorCStrings_MatchSelector(t *testing.T) {
+	cursors := []gui.MouseCursor{
+		gui.CursorDefault, gui.CursorArrow, gui.CursorIBeam,
+		gui.CursorCrosshair, gui.CursorPointingHand,
+		gui.CursorResizeEW, gui.CursorResizeNS,
+		gui.CursorResizeNWSE, gui.CursorResizeNESW,
+		gui.CursorResizeAll, gui.CursorNotAllowed,
+	}
+	for _, mc := range cursors {
+		sel := cursorSelector(mc)
+		if sel == "" {
+			continue
+		}
+		cstr, ok := cursorCStrings[mc]
+		if !ok || cstr == nil {
+			t.Errorf("cursor %v: selector %q but no cached C string",
+				mc, sel)
+			continue
+		}
+		if got := cGoString(cstr); got != sel {
+			t.Errorf("cursor %v: cached %q, want %q", mc, got, sel)
+		}
+	}
+}
+
+// An unmapped cursor must return before dereferencing ws.window, so
+// updateCursor is safe on a zero-value windowState.
+func TestUpdateCursor_UnknownCursorNoOp(t *testing.T) {
+	ws := &windowState{}
+	ws.updateCursor(gui.MouseCursor(255)) // must not panic or touch C
+}
+
 // ─── mapMetalEvent integration (C state injection) ────────────
 
 func TestMapMetalEvent_Quit_ReturnsContFalse(t *testing.T) {

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -802,18 +802,23 @@ void metalWindowIMESetActive(GoGuiNSWindow w, int active) {
 
 // ─── Wake ─────────────────────────────────────────────────────
 
+// Build the dummy application-defined event used to wake or unblock
+// the run loop (poll wake and the launch-handshake stop:).
+static NSEvent *metalWakeEvent(void) {
+    return [NSEvent otherEventWithType:NSEventTypeApplicationDefined
+                             location:NSZeroPoint
+                        modifierFlags:0
+                            timestamp:0
+                         windowNumber:0
+                              context:nil
+                              subtype:0
+                                data1:0
+                                data2:0];
+}
+
 void metalPostEmptyEvent(void) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSEvent *dummy = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
-                                            location:NSZeroPoint
-                                       modifierFlags:0
-                                           timestamp:0
-                                        windowNumber:0
-                                             context:nil
-                                             subtype:0
-                                               data1:0
-                                               data2:0];
-        [NSApp postEvent:dummy atStart:NO];
+        [NSApp postEvent:metalWakeEvent() atStart:NO];
     });
 }
 
@@ -892,16 +897,7 @@ static GUIWindow *metalFocusedGUIWindow(void) {
 // See the App-level section header for the full handshake narrative.
 - (void)applicationDidFinishLaunching:(NSNotification *)note {
     [NSApp stop:nil];
-    NSEvent *wake = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
-                                       location:NSZeroPoint
-                                  modifierFlags:0
-                                      timestamp:0
-                                   windowNumber:0
-                                        context:nil
-                                        subtype:0
-                                          data1:0
-                                          data2:0];
-    [NSApp postEvent:wake atStart:YES];
+    [NSApp postEvent:metalWakeEvent() atStart:YES];
 }
 
 @end


### PR DESCRIPTION
## Summary
- Cache each NSCursor selector name as a C string once at startup; the per-frame cursor update no longer does a `C.CString` alloc+free on the hot path. Both `Run` and `RunAppE` now route cursor updates through `windowState.updateCursor`.
- Extract the application-defined wake-event construction into a `metalWakeEvent()` helper, shared by `metalPostEmptyEvent` and the `applicationDidFinishLaunching` `stop:` handshake.
- Delete each window-state entry after `destroy()` in `RunAppE` cleanup so the deferred cleanup cannot double-destroy it.

## Test plan
- Added `TestCursorCStrings_MatchSelector` guarding the hand-listed cache against drift from `cursorSelector`.
- Added `TestUpdateCursor_UnknownCursorNoOp` confirming `updateCursor` no-ops safely for unmapped cursors on a zero-value `windowState`.
- `go test ./gui/backend/metal/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)