### PR TITLE
Thread TextStyle.EmojiBoxWidth through to go-glyph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.29.0] - 2026-06-28
+
+### Added
+
+- **`TextStyle.EmojiBoxWidth`**: optional target cell-box width (logical px),
+  threaded through `ToGlyphStyle` and the GPU backend draw path
+  (`GuiStyleToGlyphConfig`). When > 0, go-glyph scales color/emoji glyphs to
+  fill the caller's cell box instead of the font's natural emoji advance. Used
+  by grid callers such as go-term. Requires go-glyph v1.12.0.
+
 ## [v0.28.2] - 2026-06-26
 
 ### Fixed

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Go toolchain pin: `go 1.26.0`.
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
 | `github.com/go-gl/gl` | v0.0.0-20260331235117-4566fea9a276 | OpenGL bindings for `gui/backend/gl`. |
-| `github.com/go-gui-org/go-glyph` | v1.11.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.12.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-gui-org/go-glyph/backend/sdl2` | v1.11.0 | ⚠ UNKNOWN — update directPurpose map in tools/depsdoc/main.go |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276
-	github.com/go-gui-org/go-glyph v1.11.0
+	github.com/go-gui-org/go-glyph v1.12.0
 	github.com/go-gui-org/go-glyph/backend/sdl2 v1.11.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/dlclark/regexp2/v2 v2.2.2 h1:MYWvNYw8okuqNhwTYO587EZMiDruVa2vhV6fsGpf
 github.com/dlclark/regexp2/v2 v2.2.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276 h1:IO5P06Pcj9K04d+l4nrf3c2U56+dAotIFG6u4P1wAHI=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
-github.com/go-gui-org/go-glyph v1.11.0 h1:v6/ZhHrQY5ZqJzoNAlCfVhQGA2g3RrtLVP6LVB5I8Fk=
-github.com/go-gui-org/go-glyph v1.11.0/go.mod h1:TGH4KhHIaROHLy5m8gEId+ZInQjbMFVxlieyvrfZHXI=
+github.com/go-gui-org/go-glyph v1.12.0 h1:l0dXe8DtNPd8TYfG/peIRRmHMj6u2ienM8dhOOXSSaE=
+github.com/go-gui-org/go-glyph v1.12.0/go.mod h1:TGH4KhHIaROHLy5m8gEId+ZInQjbMFVxlieyvrfZHXI=
 github.com/go-gui-org/go-glyph/backend/sdl2 v1.11.0 h1:dY3P+G2f35RQWJKUK+l9B5boqwaESpUb/GyXXvzPJjc=
 github.com/go-gui-org/go-glyph/backend/sdl2 v1.11.0/go.mod h1:yvpNc9gZY96Asllunh0faTK02eb0t3xSR7QAw3GVrwg=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=

--- a/gui/backend/internal/glyphconv/conv.go
+++ b/gui/backend/internal/glyphconv/conv.go
@@ -26,6 +26,7 @@ func GuiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {
 			Underline:     s.Underline,
 			Strikethrough: s.Strikethrough,
 			LetterSpacing: s.LetterSpacing,
+			EmojiBoxWidth: s.EmojiBoxWidth,
 			StrokeWidth:   s.StrokeWidth,
 			StrokeColor:   glyph.Color{R: s.StrokeColor.R, G: s.StrokeColor.G, B: s.StrokeColor.B, A: s.StrokeColor.A},
 			Features:      s.Features,

--- a/gui/styles.go
+++ b/gui/styles.go
@@ -53,12 +53,16 @@ type TextStyle struct {
 	LetterSpacing   float32
 	RotationRadians float32
 	StrokeWidth     float32
-	Color           Color
-	BgColor         Color
-	StrokeColor     Color
-	Align           TextAlignment
-	Underline       bool
-	Strikethrough   bool
+	// EmojiBoxWidth, when > 0, makes color/emoji glyphs scale to fill this
+	// box width (logical px), preserving aspect and centered. Grid callers
+	// (terminals) set it to cells×cellWidth. 0 = default emoji sizing.
+	EmojiBoxWidth float32
+	Color         Color
+	BgColor       Color
+	StrokeColor   Color
+	Align         TextAlignment
+	Underline     bool
+	Strikethrough bool
 }
 
 // mergeTextStyle fills zero fields in s from fallback.
@@ -80,6 +84,7 @@ func (ts TextStyle) ToGlyphStyle() glyph.TextStyle {
 		BgColor:       glyph.Color{R: ts.BgColor.R, G: ts.BgColor.G, B: ts.BgColor.B, A: ts.BgColor.A},
 		Size:          ts.Size,
 		LetterSpacing: ts.LetterSpacing,
+		EmojiBoxWidth: ts.EmojiBoxWidth,
 		Features:      ts.Features,
 		Underline:     ts.Underline,
 		Strikethrough: ts.Strikethrough,


### PR DESCRIPTION
## What
Adds `EmojiBoxWidth` to `gui.TextStyle` and copies it in both style→glyph conversions:
- `ToGlyphStyle` (rich-text path)
- `GuiStyleToGlyphConfig` in `backend/internal/glyphconv` (the GPU-backend `DrawCanvas` path — the one terminals use)

When > 0, go-glyph scales color/emoji glyphs to fill the caller's cell box rather than the font's natural emoji advance.

## ⚠️ Depends on go-glyph
References `glyph.TextStyle.EmojiBoxWidth`, added in go-gui-org/go-glyph#7. **CI will fail to compile until that PR is merged + released and this PR's `go.mod` is bumped** to the new go-glyph version. Merge order: go-glyph → release → bump here → merge → release → go-term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)