### PR TITLE
fix(svg): conditioning-aware tolerance in FuzzDecomposeTRS recompose

### DIFF
--- a/gui/svg/fuzz_transform_decompose_test.go
+++ b/gui/svg/fuzz_transform_decompose_test.go
@@ -28,6 +28,11 @@ func FuzzDecomposeTRS(f *testing.F) {
 		float32(0), float32(0))
 	f.Add(float32(math.Inf(1)), float32(0), float32(0), float32(1),
 		float32(0), float32(0))
+	// Large anisotropic scale + tiny rotation: float32 angle quantization
+	// perturbs the off-diagonal by ~1.5e-3, exact relative to the column
+	// norm. Regression for the conditioning-aware compare below.
+	f.Add(float32(-16002), float32(1), float32(0), float32(0.0125),
+		float32(0), float32(0))
 
 	f.Fuzz(func(t *testing.T, a, b, c, d, e, fv float32) {
 		m := [6]float32{a, b, c, d, e, fv}
@@ -51,23 +56,29 @@ func FuzzDecomposeTRS(f *testing.F) {
 		re := tx
 		rf := ty
 		const slack = 1e-3
-		relClose := func(want, got float32) bool {
-			if math.IsNaN(float64(want)) || math.IsInf(float64(want), 0) {
-				return false
+		// Compare each column pair against the column's Euclidean
+		// magnitude, not a per-component floor of 1. The rotation is
+		// recomposed from a float32-quantized degree angle; for a large
+		// anisotropic scale that quantization perturbs the off-diagonal
+		// term by an amount that scales with the column norm (e.g.
+		// scale(16002) with a ~0.004° rotation moves b by 1.5e-3 yet is
+		// exact to 9e-8 relative to the column). Judging the off-diagonal
+		// in isolation would flag a numerically faithful reconstruction.
+		colClose := func(wx, wy, gx, gy float32) bool {
+			for _, w := range []float32{wx, wy} {
+				if math.IsNaN(float64(w)) || math.IsInf(float64(w), 0) {
+					return false
+				}
 			}
-			diff := float64(got - want)
-			if diff < 0 {
-				diff = -diff
-			}
-			mag := math.Abs(float64(want))
+			mag := math.Hypot(float64(wx), float64(wy))
 			if mag < 1 {
 				mag = 1
 			}
-			return diff <= slack*mag
+			return math.Abs(float64(gx-wx)) <= slack*mag &&
+				math.Abs(float64(gy-wy)) <= slack*mag
 		}
-		if !relClose(a, ra) || !relClose(b, rb) ||
-			!relClose(c, rc) || !relClose(d, rd) ||
-			!relClose(e, re) || !relClose(fv, rf) {
+		if !colClose(a, b, ra, rb) || !colClose(c, d, rc, rd) ||
+			!colClose(e, fv, re, rf) {
 			t.Fatalf("recompose mismatch input=%v got=[%v %v %v %v %v %v]",
 				m, ra, rb, rc, rd, re, rf)
 		}


### PR DESCRIPTION
## What

The scheduled Fuzz job ([run 28370996762](https://github.com/go-gui-org/go-gui/actions/runs/28370996762)) failed: `gui/svg FuzzDecomposeTRS` found input `[-16002 1 0 0.0125 0 0]`.

```
recompose mismatch input=[-16002 1 0 0.0125 0 0]
                      got=[-16002 1.0014738 7.8230363e-07 0.0125 0 0]
```

## Diagnosis — test tolerance, not algorithm

`decomposeTRS` stores rotation as float32 **degrees**; production (`tessellate.go`) recomposes via `cos/sin × scale`, exactly what the fuzz target models. For this input the angle is `179.99641°`. Quantizing that to float32 and amplifying by `sx=16002` perturbs the reconstructed off-diagonal `b` by `~1.5e-3`.

That tripped the test's `relClose`, which floored the comparison magnitude at 1 and judged each component in isolation — so a `0.15%` per-component error failed the `1e-3` slack. But relative to the column magnitude (`|(a,b)| ≈ 16002`), the error is `9.2e-8`: the decompose is exact to float32 in any geometric sense. An off-diagonal's reconstruction error naturally scales with its column norm, so a large anisotropic scale amplifies the float32 angle quantization.

## Fix

- Replace per-component `relClose` with column-aware `colClose`, comparing each column pair `(a,b)`, `(c,d)`, `(e,f)` against the column's Euclidean magnitude.
- Seed the failing input as an `f.Add` regression (repo gitignores fuzz corpus files, so a seed is the committable guard).
- `decomposeTRS` itself is unchanged.

## Verification

- `FuzzDecomposeTRS` replay passes including the new seed.
- 20s / ~1.9M-exec fuzz run surfaced no new failures.
- Full `gui/svg` package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)