### PR TITLE
fix(metal): halve precise trackpad scroll deltas on macOS

### DIFF
--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -10,6 +10,14 @@
 #include <stdlib.h>
 #include <math.h>
 
+// Scale applied to AppKit precise (trackpad / high-res) scrolling
+// deltas before they reach the shared gui ScrollMultiplier. AppKit
+// reports precise deltas in points; the gui multiplier was tuned
+// against the SDL2 backend, which delivers deltas pre-scaled to a
+// smaller unit. Without this factor trackpad scrolling runs ~2x too
+// fast on the native macOS backend. See go-gui-org/go-gui#22.
+static const float kPreciseScrollScale = 0.5f;
+
 // Event mask covering all event types the app needs to receive.
 // MouseEntered/Exited are required by AppKit's internal tracking-
 // area system — filtering them out prevents traffic-light button
@@ -575,8 +583,8 @@ static void storeEvent(NSEvent *event, uint32_t wid) {
                 else                                     _evScrollPhase = 0;
             }
             if ([event hasPreciseScrollingDeltas]) {
-                _evScrollX = (float)[event scrollingDeltaX];
-                _evScrollY = (float)[event scrollingDeltaY];
+                _evScrollX = (float)[event scrollingDeltaX] * kPreciseScrollScale;
+                _evScrollY = (float)[event scrollingDeltaY] * kPreciseScrollScale;
             } else {
                 // Mouse wheel: multiply by 10 for line-to-pixel conversion.
                 _evScrollX = (float)([event scrollingDeltaX] * 10.0);


### PR DESCRIPTION
## Summary

Trackpad scrolling on the native macOS Metal backend ran ~2x too fast. Root cause: the Metal backend forwarded AppKit's precise (trackpad / high-res) scrolling deltas verbatim, while the shared `guiTheme.ScrollMultiplier` (default `20`) was tuned against the SDL2 backend, which delivers precise deltas pre-scaled to a smaller unit.

This scales precise deltas by a named constant `kPreciseScrollScale = 0.5` in the Metal backend before they reach the gui multiplier. The non-precise mouse-wheel branch (`* 10.0` line-to-pixel) is unchanged.

```objc
if ([event hasPreciseScrollingDeltas]) {
    _evScrollX = (float)[event scrollingDeltaX] * kPreciseScrollScale;
    _evScrollY = (float)[event scrollingDeltaY] * kPreciseScrollScale;
}
```

## Testing

- `go build ./gui/backend/metal/` — clean
- `go vet ./gui/backend/metal/` — clean
- CGo scroll behavior can't be exercised headlessly; the `0.5` factor matches the observed 2x overshoot but should be confirmed by feel against a native app. It's a single named constant if further tuning is needed.

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)