### PR TITLE
fix(dialog): track native dialog visibility and retain modal focus (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native dialogs**: track native (OS) modal visibility so `DialogIsVisible`
+  and the quit/close dedup see `NSAlert`-style dialogs too. Previously a
+  native confirm-before-quit could stack a duplicate dialog because the
+  second quit/close re-invoked `OnCloseRequest`. `DispatchCloseRequest` now
+  guards its hook path while a dialog is showing (the no-hook path still
+  closes). (#18)
+- **Modal dialogs**: retain keyboard focus inside an in-app modal dialog when
+  a focus-claiming widget (one that re-asserts `SetIDFocus` every view
+  rebuild) tries to steal it, so Tab/Esc/Enter keep working. Apps no longer
+  need to guard their own `SetIDFocus` with `DialogIsVisible`. (#18)
+
 ## [v0.29.0] - 2026-06-28
 
 ### Added

--- a/gui/layout_arrange.go
+++ b/gui/layout_arrange.go
@@ -37,6 +37,9 @@ func layoutArrange(layout *Layout, w *Window) []Layout {
 	// Inject dialog as last floating layer (always on top).
 	if w.dialogCfg.visible {
 		injectFloatingLayer(dialogViewGenerator(w.dialogCfg), w, &floatingLayouts)
+		if n := len(floatingLayouts); n > 0 {
+			w.retainDialogFocus(floatingLayouts[n-1])
+		}
 	}
 
 	// Run pipeline on main layout.

--- a/gui/native_dialog.go
+++ b/gui/native_dialog.go
@@ -155,6 +155,17 @@ func (w *Window) NativeSaveDiscardDialog(cfg NativeSaveDiscardDialogCfg) {
 
 // --- impl functions ---
 
+// markNativeDialogVisible flags the window as showing a native modal
+// for the duration of the blocking platform call. The returned cleanup
+// must be deferred. Lets DialogIsVisible — and quit/close dedup — see
+// native dialogs, which otherwise never touch dialogCfg. The platform
+// call and this flag both run on the command goroutine, so the modal's
+// nested event loop sees the flag set.
+func markNativeDialogVisible(w *Window) func() {
+	w.nativeDialogVisible = true
+	return func() { w.nativeDialogVisible = false }
+}
+
 func nativeOpenDialogImpl(w *Window, cfg NativeOpenDialogCfg) {
 	extensions, err := nativeExtensionsFromFilters(cfg.Filters)
 	if err != nil {
@@ -165,6 +176,7 @@ func nativeOpenDialogImpl(w *Window, cfg NativeOpenDialogCfg) {
 		dispatchDialogDone(w, cfg.OnDone, nativeDialogErrorResult("unsupported", "no native platform"))
 		return
 	}
+	defer markNativeDialogVisible(w)()
 	pr := w.nativePlatform.ShowOpenDialog(cfg.Title, cfg.StartDir, extensions, cfg.AllowMultiple)
 	dispatchDialogDone(w, cfg.OnDone, nativeResultFromPlatform(pr, w))
 }
@@ -184,6 +196,7 @@ func nativeSaveDialogImpl(w *Window, cfg NativeSaveDialogCfg) {
 		dispatchDialogDone(w, cfg.OnDone, nativeDialogErrorResult("unsupported", "no native platform"))
 		return
 	}
+	defer markNativeDialogVisible(w)()
 	pr := w.nativePlatform.ShowSaveDialog(cfg.Title, cfg.StartDir, cfg.DefaultName, defaultExt, extensions, cfg.ConfirmOverwrite)
 	dispatchDialogDone(w, cfg.OnDone, nativeResultFromPlatform(pr, w))
 }
@@ -193,6 +206,7 @@ func nativeFolderDialogImpl(w *Window, cfg NativeFolderDialogCfg) {
 		dispatchDialogDone(w, cfg.OnDone, nativeDialogErrorResult("unsupported", "no native platform"))
 		return
 	}
+	defer markNativeDialogVisible(w)()
 	pr := w.nativePlatform.ShowFolderDialog(cfg.Title, cfg.StartDir)
 	dispatchDialogDone(w, cfg.OnDone, nativeResultFromPlatform(pr, w))
 }
@@ -202,6 +216,7 @@ func nativeMessageDialogImpl(w *Window, cfg NativeMessageDialogCfg) {
 		dispatchAlertDone(w, cfg.OnDone, nativeAlertErrorResult("unsupported", "no native platform"))
 		return
 	}
+	defer markNativeDialogVisible(w)()
 	result := w.nativePlatform.ShowMessageDialog(cfg.Title, cfg.Body, cfg.Level)
 	dispatchAlertDone(w, cfg.OnDone, result)
 }
@@ -211,6 +226,7 @@ func nativeConfirmDialogImpl(w *Window, cfg NativeConfirmDialogCfg) {
 		dispatchAlertDone(w, cfg.OnDone, nativeAlertErrorResult("unsupported", "no native platform"))
 		return
 	}
+	defer markNativeDialogVisible(w)()
 	result := w.nativePlatform.ShowConfirmDialog(cfg.Title, cfg.Body, cfg.Level)
 	dispatchAlertDone(w, cfg.OnDone, result)
 }
@@ -220,6 +236,7 @@ func nativeSaveDiscardDialogImpl(w *Window, cfg NativeSaveDiscardDialogCfg) {
 		dispatchAlertDone(w, cfg.OnDone, nativeAlertErrorResult("unsupported", "no native platform"))
 		return
 	}
+	defer markNativeDialogVisible(w)()
 	result := w.nativePlatform.ShowSaveDiscardDialog(cfg.Title, cfg.Body, cfg.Level)
 	dispatchAlertDone(w, cfg.OnDone, result)
 }

--- a/gui/native_dialog_test.go
+++ b/gui/native_dialog_test.go
@@ -394,6 +394,73 @@ func TestNativeConfirmDialogSuccess(t *testing.T) {
 	}
 }
 
+// TestNativeConfirmDialogMarksVisible verifies the window reports a
+// native dialog as visible for the duration of the blocking platform
+// call (so quit/close dedup can see it) and clears the flag afterward.
+func TestNativeConfirmDialogMarksVisible(t *testing.T) {
+	w := &Window{}
+	var visibleDuring bool
+	w.nativePlatform = mockDialogPlatform{
+		alertResult: NativeAlertResult{Status: DialogOK},
+	}
+	cfg := NativeConfirmDialogCfg{
+		Title: "Confirm?",
+		// OnDone runs inside the impl, before the visibility flag's
+		// deferred clear, so it observes the modal as visible.
+		OnDone: func(NativeAlertResult, *Window) {
+			visibleDuring = w.DialogIsVisible()
+		},
+	}
+	nativeConfirmDialogImpl(w, cfg)
+	if !visibleDuring {
+		t.Fatal("DialogIsVisible must be true while native dialog shows")
+	}
+	if w.DialogIsVisible() {
+		t.Fatal("DialogIsVisible must be false after native dialog closes")
+	}
+}
+
+// TestNativeOpenDialogMarksVisible covers the dialog-result dispatch path
+// (dispatchDialogDone), distinct from the alert path above.
+func TestNativeOpenDialogMarksVisible(t *testing.T) {
+	w := &Window{}
+	var visibleDuring bool
+	w.nativePlatform = mockDialogPlatform{
+		openResult: PlatformDialogResult{Status: DialogCancel},
+	}
+	cfg := NativeOpenDialogCfg{
+		OnDone: func(NativeDialogResult, *Window) {
+			visibleDuring = w.DialogIsVisible()
+		},
+	}
+	nativeOpenDialogImpl(w, cfg)
+	if !visibleDuring {
+		t.Fatal("DialogIsVisible must be true while native dialog shows")
+	}
+	if w.DialogIsVisible() {
+		t.Fatal("DialogIsVisible must be false after native dialog closes")
+	}
+}
+
+// TestNativeSaveDiscardDialogMarksVisible covers the 3-button alert path.
+func TestNativeSaveDiscardDialogMarksVisible(t *testing.T) {
+	w := &Window{}
+	var visibleDuring bool
+	w.nativePlatform = saveDiscardPlatform{}
+	cfg := NativeSaveDiscardDialogCfg{
+		OnDone: func(NativeAlertResult, *Window) {
+			visibleDuring = w.DialogIsVisible()
+		},
+	}
+	nativeSaveDiscardDialogImpl(w, cfg)
+	if !visibleDuring {
+		t.Fatal("DialogIsVisible must be true while native dialog shows")
+	}
+	if w.DialogIsVisible() {
+		t.Fatal("DialogIsVisible must be false after native dialog closes")
+	}
+}
+
 func TestNativeOpenDialogCancelled(t *testing.T) {
 	w := &Window{}
 	w.nativePlatform = mockDialogPlatform{

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -293,7 +293,38 @@ func (w *Window) DialogDismiss() {
 	w.SetIDFocus(oldFocus)
 }
 
-// DialogIsVisible returns true if a dialog is showing.
+// DialogIsVisible returns true if a dialog is showing — either the
+// in-app modal overlay or a native (OS) modal dialog.
 func (w *Window) DialogIsVisible() bool {
-	return w.dialogCfg.visible
+	return w.dialogCfg.visible || w.nativeDialogVisible
+}
+
+// retainDialogFocus keeps keyboard focus inside the modal dialog. A
+// focus-claiming widget (one that re-asserts SetIDFocus on every view
+// rebuild, e.g. a terminal that wants keystrokes without a prior click)
+// can steal idFocus back from the dialog overlay. Events still route to
+// the dialog layer, but with no focused element there Tab/Esc/Enter stop
+// working while mouse clicks still land by coordinate. When the current
+// focus is not a focusable element within the freshly generated dialog
+// subtree, reassert the dialog's focus id so apps need not guard their
+// own SetIDFocus with DialogIsVisible.
+//
+// dialog is the dialog's layout for this frame. Called from layoutArrange
+// under w.mu; acquires w.animMu only when a reassert is needed.
+func (w *Window) retainDialogFocus(dialog *Layout) {
+	// A malformed/empty dialog layer has no focusable target; leave focus
+	// untouched rather than blindly reasserting (which could steal it).
+	if dialog == nil || dialog.Shape == nil {
+		return
+	}
+	// idFocus 0 means nothing is focused: FindLayoutByIDFocus would match
+	// the dialog root (its IDFocus is 0), so treat it as escaped.
+	if id := w.viewState.idFocus; id != 0 {
+		if _, ok := FindLayoutByIDFocus(dialog, id); ok {
+			return
+		}
+	}
+	w.animMu.Lock()
+	w.setIDFocusLocked(w.dialogCfg.IDFocus)
+	w.animMu.Unlock()
 }

--- a/gui/view_dialog_test.go
+++ b/gui/view_dialog_test.go
@@ -2,6 +2,82 @@ package gui
 
 import "testing"
 
+// TestRetainDialogFocus_RestoresStolenFocus verifies that when a
+// focus-claiming widget steals idFocus away from a visible modal dialog,
+// retainDialogFocus reasserts the dialog's focus id so keyboard routing
+// (Tab/Esc/Enter) keeps working.
+func TestRetainDialogFocus_RestoresStolenFocus(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.Dialog(DialogCfg{DialogType: DialogConfirm, Title: "Quit?"})
+	dialog := GenerateViewLayout(dialogViewGenerator(w.dialogCfg), w)
+
+	// Simulate a widget re-asserting focus onto itself (id 42, not in
+	// the dialog subtree).
+	w.SetIDFocus(42)
+	w.retainDialogFocus(&dialog)
+
+	if got := w.IDFocus(); got != w.dialogCfg.IDFocus {
+		t.Fatalf("idFocus = %d, want dialog focus %d", got, w.dialogCfg.IDFocus)
+	}
+}
+
+// TestRetainDialogFocus_KeepsDialogFocus verifies focus already inside
+// the dialog subtree (e.g. after Tab) is left untouched.
+func TestRetainDialogFocus_KeepsDialogFocus(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.Dialog(DialogCfg{DialogType: DialogConfirm, Title: "Quit?"})
+	dialog := GenerateViewLayout(dialogViewGenerator(w.dialogCfg), w)
+
+	// Confirm dialog's "Yes" button uses IDFocus+1; a legitimate Tab
+	// target inside the dialog must be preserved.
+	yes := w.dialogCfg.IDFocus + 1
+	w.SetIDFocus(yes)
+	w.retainDialogFocus(&dialog)
+
+	if got := w.IDFocus(); got != yes {
+		t.Fatalf("idFocus = %d, want %d (in-dialog focus preserved)", got, yes)
+	}
+}
+
+// TestRetainDialogFocus_NoFocusReasserts verifies that no focus (id 0),
+// which would spuriously match the dialog root, is treated as escaped.
+func TestRetainDialogFocus_NoFocusReasserts(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.Dialog(DialogCfg{DialogType: DialogConfirm, Title: "Quit?"})
+	dialog := GenerateViewLayout(dialogViewGenerator(w.dialogCfg), w)
+
+	w.SetIDFocus(0)
+	w.retainDialogFocus(&dialog)
+
+	if got := w.IDFocus(); got != w.dialogCfg.IDFocus {
+		t.Fatalf("idFocus = %d, want dialog focus %d", got, w.dialogCfg.IDFocus)
+	}
+}
+
+// TestRetainDialogFocus_NilLayoutNoPanic verifies a nil dialog layer is
+// a no-op (no panic, focus untouched) rather than dereferencing it.
+func TestRetainDialogFocus_NilLayoutNoPanic(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.Dialog(DialogCfg{DialogType: DialogConfirm, Title: "Quit?"})
+	w.SetIDFocus(42)
+	w.retainDialogFocus(nil)
+	if got := w.IDFocus(); got != 42 {
+		t.Fatalf("idFocus = %d, want 42 (nil layer must not touch focus)", got)
+	}
+}
+
+// TestRetainDialogFocus_NilShapeNoPanic verifies a layout with a nil
+// Shape (which FindLayoutByIDFocus would dereference) is a no-op.
+func TestRetainDialogFocus_NilShapeNoPanic(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.Dialog(DialogCfg{DialogType: DialogConfirm, Title: "Quit?"})
+	w.SetIDFocus(42)
+	w.retainDialogFocus(&Layout{})
+	if got := w.IDFocus(); got != 42 {
+		t.Fatalf("idFocus = %d, want 42 (nil Shape must not touch focus)", got)
+	}
+}
+
 func TestDialogCfgDefaults(t *testing.T) {
 	cfg := DialogCfg{}
 	applyDialogDefaults(&cfg)

--- a/gui/window.go
+++ b/gui/window.go
@@ -194,6 +194,13 @@ type Window struct {
 	// Dialog state.
 	dialogCfg DialogCfg
 
+	// nativeDialogVisible is true while a native (OS) modal dialog is
+	// showing. Native dialogs block in runModal and never touch
+	// dialogCfg, so this flag lets DialogIsVisible — and the quit/close
+	// dedup that relies on it — see them too. Set/cleared on the command
+	// goroutine around the blocking platform call (see native_dialog.go).
+	nativeDialogVisible bool
+
 	windowAnimation
 
 	// Window dimensions (logical pixels).

--- a/gui/window_close.go
+++ b/gui/window_close.go
@@ -5,12 +5,21 @@ package gui
 // hook owns calling Window.Close() to proceed. Otherwise the window
 // is marked for destruction via the closeReq loop.
 //
+// While a dialog (in-app or native) is already showing, the
+// OnCloseRequest hook is not re-invoked: a second close — e.g. a
+// repeated window-close click while a confirm dialog is up — would
+// otherwise stack a duplicate dialog. The no-hook path still closes,
+// so a dialog does not trap an explicit per-window close.
+//
 // Intended for backend use. Safe for a nil window (no-op).
 func DispatchCloseRequest(w *Window) {
 	if w == nil {
 		return
 	}
 	if cb := w.Config.OnCloseRequest; cb != nil {
+		if w.DialogIsVisible() {
+			return
+		}
 		cb(w)
 		return
 	}

--- a/gui/window_close_test.go
+++ b/gui/window_close_test.go
@@ -33,6 +33,34 @@ func TestDispatchCloseRequest_HookVetoes(t *testing.T) {
 	}
 }
 
+func TestDispatchCloseRequest_DialogDedupsHook(t *testing.T) {
+	// A close request while a dialog is already showing must not
+	// re-invoke OnCloseRequest, which would stack a duplicate dialog.
+	var calls int
+	w := NewWindow(WindowCfg{
+		OnCloseRequest: func(*Window) { calls++ },
+	})
+	w.Dialog(DialogCfg{})
+	DispatchCloseRequest(w)
+	if calls != 0 {
+		t.Fatalf("calls = %d, want 0 (dialog visible: hook deduped)", calls)
+	}
+}
+
+func TestDispatchCloseRequest_NativeDialogDedupsHook(t *testing.T) {
+	// Native modal visibility (nativeDialogVisible) must dedup the close
+	// hook just like the in-app dialog, preventing a stacked dialog.
+	var calls int
+	w := NewWindow(WindowCfg{
+		OnCloseRequest: func(*Window) { calls++ },
+	})
+	w.nativeDialogVisible = true
+	DispatchCloseRequest(w)
+	if calls != 0 {
+		t.Fatalf("calls = %d, want 0 (native dialog visible: hook deduped)", calls)
+	}
+}
+
 func TestDispatchCloseRequest_HookProceeds(t *testing.T) {
 	w := NewWindow(WindowCfg{
 		OnCloseRequest: func(w *Window) { w.Close() },
@@ -132,6 +160,29 @@ func TestDispatchQuitRequest_DialogBlocksQuit(t *testing.T) {
 	}
 	if w.CloseRequested() {
 		t.Fatal("dialog visible: must not mark close-requested")
+	}
+}
+
+func TestDispatchQuitRequest_NativeDialogBlocksQuit(t *testing.T) {
+	// A native (OS) modal — tracked via nativeDialogVisible, not the
+	// in-app dialogCfg — must also veto quit and not re-invoke the hook.
+	// This is issue #18's native confirm-before-quit scenario.
+	var hookCalls int
+	a := NewApp()
+	w := NewWindow(WindowCfg{
+		OnCloseRequest: func(*Window) { hookCalls++ },
+	})
+	a.Register(1, w)
+	w.nativeDialogVisible = true
+
+	if !DispatchQuitRequest(a) {
+		t.Fatal("native dialog visible: must report vetoed=true")
+	}
+	if hookCalls != 0 {
+		t.Fatalf("hookCalls = %d, want 0 (native dialog dedups)", hookCalls)
+	}
+	if w.CloseRequested() {
+		t.Fatal("native dialog visible: must not mark close-requested")
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses three of the four issues in #18 (native dialogs lose focus / stack duplicates under the metal backend). The native NSAlert keyboard-focus race (suggested fix #2) is deliberately left out — see below.

- **Native dialog visibility tracking.** Native dialogs (`NSAlert runModal`) block in the platform layer and never touched `dialogCfg`, so `DialogIsVisible()` couldn't see them and the quit/close dedup re-fired. Added `Window.nativeDialogVisible`, toggled around each blocking native call via a small `markNativeDialogVisible` helper, and folded into `DialogIsVisible()`. (issue root cause #2)
- **`DispatchCloseRequest` dedup guard.** The window-close path had no guard, so a repeat close while a confirm dialog was up re-invoked `OnCloseRequest` and stacked a duplicate. Guard added on the hook path only — the no-hook path still closes, preserving the existing intentional asymmetry vs `DispatchQuitRequest`. (issue root cause #2 / suggested fix #3)
- **In-app modal focus retention.** A widget that re-asserts `SetIDFocus` every view rebuild (e.g. a terminal claiming focus) could steal focus from the modal overlay, leaving Tab/Esc/Enter dead. `retainDialogFocus` runs each frame in `layoutArrange` and reasserts the dialog's focus id when focus escapes the dialog subtree, so apps no longer need to guard their own `SetIDFocus` with `DialogIsVisible()`. (issue root cause #3 / suggested fix #4)

## Not included

The native NSAlert keyboard-focus race (suggested fix #2 — present as a sheet or activate synchronously before `runModal`) is out of scope here: doing it properly means converting the native dialog C API from synchronous-return to async-completion across the CGo boundary. With these changes the in-app dialog (the adopted go-term workaround) works without the app-side focus guard, which is the recommended path.

## Testing

- `go build ./...`, `go vet ./gui/...`, `golangci-lint run ./gui/...` — clean.
- `go test ./gui/...` — green, including new coverage:
  - `retainDialogFocus`: restores stolen focus, preserves in-dialog focus, treats id 0 as escaped, and no-ops (no panic) on nil layout / nil Shape.
  - native-dialog visibility lifecycle across the alert and dialog-result dispatch paths.
  - close-hook and quit-veto dedup via the native visibility flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)