### PR TITLE
fix(filedialog): synchronous activation before runModal (#25)

### DIFF
--- a/gui/backend/filedialog/dialog_darwin.m
+++ b/gui/backend/filedialog/dialog_darwin.m
@@ -61,6 +61,9 @@ static DialogResult resultFromURLs(NSArray<NSURL *> *urls) {
     return r;
 }
 
+// Defined below, near the alert helpers; used by the panels too.
+static void activateForModal(void);
+
 static void setDirectoryURL(NSSavePanel *panel, const char *dir) {
     if (dir != NULL && dir[0] != '\0') {
         NSString *s = [NSString stringWithUTF8String:dir];
@@ -84,6 +87,7 @@ DialogResult filedialogOpen(const char *title, const char *startDir,
         if (types != nil)
             panel.allowedContentTypes = types;
 
+        activateForModal();
         NSModalResponse resp = [panel runModal];
         if (resp != NSModalResponseOK) {
             DialogResult r = {0};
@@ -115,6 +119,7 @@ DialogResult filedialogSave(const char *title, const char *startDir,
         if (types != nil)
             panel.allowedContentTypes = types;
 
+        activateForModal();
         NSModalResponse resp = [panel runModal];
         if (resp != NSModalResponseOK) {
             DialogResult r = {0};
@@ -135,6 +140,7 @@ DialogResult filedialogFolder(const char *title, const char *startDir) {
         panel.canChooseDirectories = YES;
         panel.allowsMultipleSelection = NO;
 
+        activateForModal();
         NSModalResponse resp = [panel runModal];
         if (resp != NSModalResponseOK) {
             DialogResult r = {0};
@@ -153,6 +159,34 @@ static NSAlertStyle alertStyleFromLevel(int level) {
     }
 }
 
+// Force the app frontmost and pump the run loop until activation lands,
+// so a modal NSAlert / NSSavePanel reliably becomes key on its FIRST
+// presentation. Manual-pump backends (metal) start the modal loop
+// before the asynchronous activateIgnoringOtherApps: takes effect,
+// leaving the dialog non-key (Return/Esc/Tab dead) until a later one
+// happens to come up after activation — the "first no, second yes"
+// race. Spinning here makes activation synchronous w.r.t. runModal.
+// No-op when already active; bounded so it degrades to prior behavior
+// if activation never lands.
+static void activateForModal(void) {
+    // Nil guard: with NSApp nil, [nil isActive] is NO and
+    // [nil nextEventMatchingMask:...] returns immediately rather than
+    // blocking to the deadline, turning the wait into a 0.5s hot spin.
+    if (NSApp == nil || [NSApp isActive]) return;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [NSApp activateIgnoringOtherApps:YES];
+#pragma clang diagnostic pop
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:0.5];
+    while (![NSApp isActive] && [deadline timeIntervalSinceNow] > 0) {
+        NSEvent *e = [NSApp nextEventMatchingMask:NSEventMaskAny
+            untilDate:deadline
+            inMode:NSDefaultRunLoopMode
+            dequeue:YES];
+        if (e != nil) [NSApp sendEvent:e];
+    }
+}
+
 AlertResult filedialogMessage(const char *title, const char *body,
     int level) {
     @autoreleasepool {
@@ -165,6 +199,7 @@ AlertResult filedialogMessage(const char *title, const char *body,
             alert.informativeText =
                 [NSString stringWithUTF8String:body];
         [alert addButtonWithTitle:@"OK"];
+        activateForModal();
         [alert runModal];
         AlertResult r = {0};
         r.status = DIALOG_OK;
@@ -185,6 +220,7 @@ AlertResult filedialogConfirm(const char *title, const char *body,
                 [NSString stringWithUTF8String:body];
         [alert addButtonWithTitle:@"OK"];
         [alert addButtonWithTitle:@"Cancel"];
+        activateForModal();
         NSModalResponse resp = [alert runModal];
         AlertResult r = {0};
         r.status = (resp == NSAlertFirstButtonReturn)
@@ -212,6 +248,7 @@ AlertResult filedialogSaveDiscard(const char *title, const char *body,
         [alert addButtonWithTitle:@"Save"];
         [alert addButtonWithTitle:@"Cancel"];
         [alert addButtonWithTitle:@"Don't Save"];
+        activateForModal();
         NSModalResponse resp = [alert runModal];
         AlertResult r = {0};
         if (resp == NSAlertFirstButtonReturn)


### PR DESCRIPTION
Fixes #25.

## Problem

Native `NSAlert` / `NSSavePanel` dialogs intermittently appear **without keyboard focus** under the metal backend on macOS — Return/Esc/Tab do nothing, only a mouse click dismisses them. A later dialog (after activation lands) works, matching the "first no, second yes" symptom.

Root cause: the metal backend pumps `NSEvent`s manually via `nextEventMatchingMask:` rather than `[NSApp run]`. macOS only routes keyboard to a modal dialog when the app is **active**, but `activateIgnoringOtherApps:` is asynchronous — the first modal loop starts before activation lands.

## Fix

Took the issue's accepted `runModal` alternative (not the larger async-sheet rewrite) but made activation **synchronous**. New `activateForModal()`:

- No-op when `[NSApp isActive]` (the common case: dialogs opened from user interaction).
- Otherwise force-activates, then **pumps the run loop until activation actually lands**, bounded at 0.5s. On timeout it degrades to prior behavior.
- Nil-`NSApp` guard: `[nil nextEventMatchingMask:]` returns immediately instead of blocking to the deadline, which would turn the wait into a 0.5s hot spin — guarded out.

Wired into all six `runModal` sites: the three alerts named in #25 (`filedialogMessage`/`filedialogConfirm`/`filedialogSaveDiscard`) plus the three file panels (`filedialogOpen`/`filedialogSave`/`filedialogFolder`), which share the identical latent race — harmless there since the helper short-circuits when already active.

## Why not the sheet approach

The issue's "preferred" sheet fix requires converting the whole native-dialog C API from synchronous return-value to async completion-handler, threading the parent `NSWindow` through Go→C, and re-dispatching via `QueueCommand` — a large change across the `NativePlatform` interface. The synchronous-activation fallback is contained to one file and addresses the same root cause.

## Testing

`go build ./...`, `go vet`, `go test`, and `golangci-lint` all clean for the package.

The focus behavior is a GUI run-loop side effect below the CGo boundary — it can't be exercised by the headless test backend. **Manual verification needed:** on a real macOS metal launch, confirm the first `NativeConfirmDialog` after cold start accepts Return/Esc/Tab without a prior mouse click.

## Caveat

The activation pump calls `sendEvent:` on any events it dequeues while waiting. In the sub-millisecond-to-activation window this is virtually always empty, but a stray click could in theory be delivered to the parent window just before the modal opens. Can restrict the pumped mask to non-mouse events if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)