### PR TITLE
perf(view): frame-scoped arena for generateViewLayout child slices

### DIFF
--- a/gui/list_core_alloc_bench_test.go
+++ b/gui/list_core_alloc_bench_test.go
@@ -58,6 +58,7 @@ func BenchmarkComboboxGenerateLayout(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
+			w.scratch.resetViewPools()
 			_ = generateViewLayout(v, w)
 		}
 	})
@@ -71,6 +72,7 @@ func BenchmarkComboboxGenerateLayout(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
+			w.scratch.resetViewPools()
 			_ = generateViewLayout(v, w)
 		}
 	})
@@ -104,6 +106,7 @@ func BenchmarkCommandPaletteGenerateLayout(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
+		w.scratch.resetViewPools()
 		_ = generateViewLayout(v, w)
 	}
 }
@@ -131,6 +134,7 @@ func BenchmarkListBoxGenerateLayout(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
+			w.scratch.resetViewPools()
 			_ = generateViewLayout(v, w)
 		}
 	})
@@ -151,6 +155,7 @@ func BenchmarkListBoxGenerateLayout(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
+			w.scratch.resetViewPools()
 			_ = generateViewLayout(v, w)
 		}
 	})

--- a/gui/scratch_pools.go
+++ b/gui/scratch_pools.go
@@ -102,6 +102,15 @@ type scratchPools struct {
 	// still reference it.
 	svgVColArena []Color
 
+	// layoutChildrenArena is a grow-only, frame-scoped arena for the
+	// []Layout child slices built by generateViewLayout. Each node
+	// reserves a pinned subslice via takeLayoutChildren; the arena is
+	// reset to len=0 in resetViewPools. Realloc mid-build is safe by
+	// the same argument as svgVColArena: a parent that reserved before
+	// a realloc keeps the old backing array alive through its slice
+	// header, and per-node Children headers stay internally consistent.
+	layoutChildrenArena []Layout
+
 	floatingLayouts      []*Layout
 	floatingLayoutPool   []*Layout
 	placeholderShapePool []*Shape
@@ -189,11 +198,54 @@ func (p *scratchPools) beginFillPass() {
 }
 
 // resetViewPools resets the view-phase object pools. Called
-// before generateViewLayout.
+// before generateViewLayout. The layoutChildrenArena is shrunk when
+// it has grown past its retain cap so a one-off deep frame does not
+// hold the capacity indefinitely.
 func (p *scratchPools) resetViewPools() {
 	p.viewShapes.reset()
 	p.buttonColors.reset()
 	p.viewEvents.reset()
+	if cap(p.layoutChildrenArena) > layoutChildrenRetainMax {
+		p.layoutChildrenArena = make([]Layout, 0, layoutChildrenShrinkTo)
+	} else {
+		p.layoutChildrenArena = p.layoutChildrenArena[:0]
+	}
+}
+
+const (
+	layoutChildrenRetainMax = 1 << 14 // 16 384 Layout values
+	layoutChildrenShrinkTo  = 1 << 10 // 1 024 Layout values
+
+	// maxLayoutChildrenReservation bounds a single reservation. Beyond
+	// this a standalone slice is returned so arena memory is not held
+	// across frames and no arithmetic overflow can occur.
+	maxLayoutChildrenReservation = 1 << 20
+)
+
+// takeLayoutChildren reserves a pinned, zero-length subslice with
+// capacity n from the frame-scoped layout-children arena. The cap is
+// pinned to n so the caller's appends cannot bleed into a later
+// reservation. Realloc of the underlying arena is safe: prior
+// reservations stay valid because their slice headers keep the old
+// backing array alive. Non-positive n returns nil; pathological sizes
+// bypass the arena entirely.
+func (p *scratchPools) takeLayoutChildren(n int) []Layout {
+	if n <= 0 {
+		return nil
+	}
+	if n > maxLayoutChildrenReservation {
+		return make([]Layout, 0, n)
+	}
+	start := len(p.layoutChildrenArena)
+	need := start + n
+	if cap(p.layoutChildrenArena) < need {
+		grown := make([]Layout, need, growCap(cap(p.layoutChildrenArena), need))
+		copy(grown, p.layoutChildrenArena)
+		p.layoutChildrenArena = grown
+	} else {
+		p.layoutChildrenArena = p.layoutChildrenArena[:need]
+	}
+	return p.layoutChildrenArena[start:start:need]
 }
 
 // resetRenderPools resets the render-phase object pools. Called at the

--- a/gui/scratch_pools_test.go
+++ b/gui/scratch_pools_test.go
@@ -310,6 +310,111 @@ func TestResetRenderPools_ShrinksOversizedVColArena(t *testing.T) {
 	}
 }
 
+// --- takeLayoutChildren ---
+
+func TestTakeLayoutChildren_NonPositiveReturnsNil(t *testing.T) {
+	var p scratchPools
+	if p.takeLayoutChildren(0) != nil {
+		t.Fatal("n=0 must return nil")
+	}
+	if p.takeLayoutChildren(-5) != nil {
+		t.Fatal("negative n must return nil")
+	}
+}
+
+func TestTakeLayoutChildren_BasicReservation(t *testing.T) {
+	var p scratchPools
+	// Reservations are zero-length with the cap pinned to n so the
+	// caller's appends stay in-region (mirrors view.go usage).
+	a := p.takeLayoutChildren(4)
+	if len(a) != 0 || cap(a) != 4 {
+		t.Fatalf("want len=0 cap=4, got len=%d cap=%d", len(a), cap(a))
+	}
+	marker := &Shape{}
+	for range cap(a) {
+		a = append(a, Layout{Shape: marker})
+	}
+	// The next reservation must not overlap a.
+	b := p.takeLayoutChildren(3)
+	if len(b) != 0 || cap(b) != 3 {
+		t.Fatalf("want len=0 cap=3, got len=%d cap=%d", len(b), cap(b))
+	}
+	other := &Shape{}
+	for range cap(b) {
+		b = append(b, Layout{Shape: other})
+	}
+	// Writes to b must not overwrite a.
+	for i := range a {
+		if a[i].Shape != marker {
+			t.Fatalf("a[%d] clobbered by b", i)
+		}
+	}
+}
+
+// Arena growth must preserve slices returned before the realloc.
+// Prior reservations reference the old backing array; Go's GC
+// keeps it alive.
+func TestTakeLayoutChildren_ArenaGrowthPreservesPriorSlices(t *testing.T) {
+	var p scratchPools
+	first := p.takeLayoutChildren(4)
+	markers := [4]*Shape{{}, {}, {}, {}}
+	for i := range markers {
+		first = append(first, Layout{Shape: markers[i]})
+	}
+	// Force at least one realloc by requesting a large chunk.
+	_ = p.takeLayoutChildren(4096)
+	for i := range first {
+		if first[i].Shape != markers[i] {
+			t.Fatalf("first[%d] clobbered by arena growth", i)
+		}
+	}
+}
+
+func TestTakeLayoutChildren_OversizeBypassesArena(t *testing.T) {
+	var p scratchPools
+	// Large n must bypass the arena; the returned slice has cap=n but
+	// the arena stays empty (no capacity held across frames).
+	a := p.takeLayoutChildren(maxLayoutChildrenReservation + 10)
+	if cap(a) != maxLayoutChildrenReservation+10 {
+		t.Fatalf("expected cap=%d, got %d",
+			maxLayoutChildrenReservation+10, cap(a))
+	}
+	if len(p.layoutChildrenArena) != 0 {
+		t.Fatalf("arena should stay empty for oversize requests, "+
+			"got len=%d", len(p.layoutChildrenArena))
+	}
+}
+
+func TestResetViewPools_TruncatesLayoutChildrenArena(t *testing.T) {
+	var p scratchPools
+	_ = p.takeLayoutChildren(32)
+	if len(p.layoutChildrenArena) == 0 {
+		t.Fatal("precondition: arena should have content")
+	}
+	prevCap := cap(p.layoutChildrenArena)
+	p.resetViewPools()
+	if len(p.layoutChildrenArena) != 0 {
+		t.Fatalf("arena len should reset to 0, got %d",
+			len(p.layoutChildrenArena))
+	}
+	if cap(p.layoutChildrenArena) != prevCap {
+		t.Fatal("small arena cap should be retained across reset")
+	}
+}
+
+// A spike frame must not hold the child capacity forever; the arena
+// shrinks back to layoutChildrenShrinkTo when it has grown past
+// layoutChildrenRetainMax.
+func TestResetViewPools_ShrinksOversizedLayoutChildrenArena(t *testing.T) {
+	var p scratchPools
+	_ = p.takeLayoutChildren(layoutChildrenRetainMax + 1)
+	p.resetViewPools()
+	if cap(p.layoutChildrenArena) > layoutChildrenShrinkTo {
+		t.Fatalf("expected shrink to <=%d, got cap=%d",
+			layoutChildrenShrinkTo, cap(p.layoutChildrenArena))
+	}
+}
+
 // --- growCap ---
 
 func TestGrowCap_NormalDoubling(t *testing.T) {

--- a/gui/view.go
+++ b/gui/view.go
@@ -41,10 +41,19 @@ func generateViewLayout(view View, w *Window) Layout {
 	if len(children) > maxEventChildren {
 		children = children[:maxEventChildren]
 	}
-	// Pre-size to final length so append never reallocates.
+	// Pre-size to final length so append never reallocates. Child
+	// slices come from a frame-scoped arena (reset each frame in
+	// resetViewPools) to avoid a per-node heap allocation; the
+	// reservation is pinned to wantCap so appends stay in-region.
 	wantCap := len(layout.Children) + len(children)
 	if cap(layout.Children) < wantCap {
-		grown := make([]Layout, len(layout.Children), wantCap)
+		var grown []Layout
+		if w != nil {
+			grown = w.scratch.takeLayoutChildren(wantCap)
+		} else {
+			grown = make([]Layout, 0, wantCap)
+		}
+		grown = grown[:len(layout.Children)]
 		copy(grown, layout.Children)
 		layout.Children = grown
 	}

--- a/gui/view_bench_test.go
+++ b/gui/view_bench_test.go
@@ -69,11 +69,16 @@ func benchViewDeep(depth int) *benchView {
 }
 
 func BenchmarkGenerateViewLayout(b *testing.B) {
+	// resetViewPools runs once per frame in the real pipeline
+	// (window_update.go), recycling the frame-scoped layout-children
+	// arena. Mirror that here so steady-state per-frame cost is
+	// measured rather than unbounded cross-iteration arena growth.
 	b.Run("flat_100", func(b *testing.B) {
 		w := &Window{scratch: newScratchPools()}
 		view := benchViewFlat(100)
 		b.ReportAllocs()
 		for b.Loop() {
+			w.scratch.resetViewPools()
 			_ = generateViewLayout(view, w)
 		}
 	})
@@ -83,6 +88,7 @@ func BenchmarkGenerateViewLayout(b *testing.B) {
 		view := benchViewNested(3, 10)
 		b.ReportAllocs()
 		for b.Loop() {
+			w.scratch.resetViewPools()
 			_ = generateViewLayout(view, w)
 		}
 	})
@@ -92,6 +98,7 @@ func BenchmarkGenerateViewLayout(b *testing.B) {
 		view := benchViewDeep(12)
 		b.ReportAllocs()
 		for b.Loop() {
+			w.scratch.resetViewPools()
 			_ = generateViewLayout(view, w)
 		}
 	})


### PR DESCRIPTION
## Summary

Replace the per-node `make([]Layout, ...)` in `generateViewLayout` with a grow-only, frame-scoped `layoutChildrenArena` reserved via `takeLayoutChildren` and reset once per frame in `resetViewPools`.

Mirrors the existing `svgVColArena` pattern:
- Per-node reservation cap is pinned (`[start:start:need]`) so appends stay in-region.
- Mid-build realloc stays safe — prior reservations keep the old backing array alive through their slice headers.
- The arena shrinks past `layoutChildrenRetainMax` so a one-off deep frame does not hold capacity indefinitely.

Safe under the established serialized-events / single-goroutine view-phase invariant — the same model already relied on by the `viewShapes`/`viewEvents`/`svgVColArena` pools that reuse backing across frames.

## Impact

`BenchmarkGenerateViewLayout` (steady state):

| case | allocs/op | B/op |
|------|-----------|------|
| nested_3x10 | 222 → **111** | 63936 → **17761** |
| deep_12x1 | 24 → **12** | 768 → **192** |
| flat_100 | 2 → **1** | 5888 → **1792** |

## Tests

- Added `takeLayoutChildren`/`resetViewPools` arena tests mirroring the `takeVColors` suite (non-positive → nil, basic reservation isolation, realloc preservation, oversize bypass, reset truncate/shrink).
- Benchmarks reset the arena each iteration to measure steady-state per-frame cost rather than unbounded cross-iteration growth.

## Verification

- `go build ./...` ✅
- `go test ./...` ✅
- `golangci-lint run ./...` ✅ 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)