### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.os }})

--- a/.github/workflows/deploy-showcase.yml
+++ b/.github/workflows/deploy-showcase.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/deploy-showcase.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,6 +11,9 @@ on:
         default: '60s'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     name: Fuzz


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` at the root of the `ci`, `fuzz`, and `deploy-showcase` workflows. Without an explicit block, jobs inherit the repo/org default `GITHUB_TOKEN` scope (read-write on older orgs), violating least privilege.

Resolves all 14 CodeQL `actions/missing-workflow-permissions` alerts (#1, #8–#20).

## Scope justification

All jobs are read-only — checkout, build, test, vet, `$GITHUB_STEP_SUMMARY`, artifact upload, and the actions cache. The showcase deploy pushes to an **external** repo via a separate PAT (`secrets.WEBSITE_DEPLOY_TOKEN`), not the default `GITHUB_TOKEN`, so root-level `contents: read` is sufficient everywhere.

If a future job needs write (PR comments, releases, Pages via `GITHUB_TOKEN`), give that specific job its own `permissions:` block rather than loosening the root default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)