### PR TITLE
style: gofmt tools/depsdoc/main.go map alignment

### DIFF
--- a/tools/depsdoc/main.go
+++ b/tools/depsdoc/main.go
@@ -34,16 +34,16 @@ func main() {
 var directPurpose = map[string]string{
 	"github.com/go-gui-org/go-glyph":              "Text shaping + glyph rasterization. Required by every backend.",
 	"github.com/go-gui-org/go-glyph/backend/sdl2": "SDL2-specific glyph rasterisation backend used by `gui/backend/sdl2`.",
-	"github.com/veandco/go-sdl2":      "SDL2 backend (`gui/backend/sdl2`). Window, input, GL/Metal context glue.",
-	"github.com/go-gl/gl":             "OpenGL bindings for `gui/backend/gl`.",
-	"github.com/tdewolff/parse/v2":    "CSS tokenizer for the SVG `<style>` / `style=\"\"` cascade pipeline.",
-	"github.com/alecthomas/chroma/v2": "Syntax highlighting in the markdown widget.",
-	"github.com/yuin/goldmark":        "Markdown parser (markdown widget + showcase docs).",
-	"github.com/yuin/goldmark-emoji":  "Goldmark extension: `:emoji:` shortcodes.",
-	"github.com/go-pdf/fpdf":          "PDF generation for the print-dialog backend.",
-	"github.com/godbus/dbus/v5":       "Linux native platform: notifications, portals.",
-	"golang.org/x/mod":                "Module version parsing; imported by `requiredid` analyzer.",
-	"golang.org/x/tools":              "`go/analysis` framework for the `requiredid` analyzer (`tools/`).",
+	"github.com/veandco/go-sdl2":                  "SDL2 backend (`gui/backend/sdl2`). Window, input, GL/Metal context glue.",
+	"github.com/go-gl/gl":                         "OpenGL bindings for `gui/backend/gl`.",
+	"github.com/tdewolff/parse/v2":                "CSS tokenizer for the SVG `<style>` / `style=\"\"` cascade pipeline.",
+	"github.com/alecthomas/chroma/v2":             "Syntax highlighting in the markdown widget.",
+	"github.com/yuin/goldmark":                    "Markdown parser (markdown widget + showcase docs).",
+	"github.com/yuin/goldmark-emoji":              "Goldmark extension: `:emoji:` shortcodes.",
+	"github.com/go-pdf/fpdf":                      "PDF generation for the print-dialog backend.",
+	"github.com/godbus/dbus/v5":                   "Linux native platform: notifications, portals.",
+	"golang.org/x/mod":                            "Module version parsing; imported by `requiredid` analyzer.",
+	"golang.org/x/tools":                          "`go/analysis` framework for the `requiredid` analyzer (`tools/`).",
 }
 
 // indirectPulledBy maps indirect-dependency modules to what pulls them in.


### PR DESCRIPTION
Pre-existing gofmt violation, independent of any feature work.

`b2a1b62` added a longer key (`go-gui-org/go-glyph/backend/sdl2`) to the `directPurpose` map without re-running gofmt, leaving the map values misaligned. `golangci-lint run ./...` (whole module) flags it, which reds CI on any branch cut from current `main`.

Realignment only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)