### PR TITLE
feat(gui): TermGrid character-grid primitive (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`TermGrid` primitive**: a terminal character-grid widget
+  (`TermGrid`/`TermGridCfg`) that draws a fixed-pitch cell buffer in a single
+  `RenderTermGrid` command — no per-cell `Layout` node and no per-cell
+  `RenderText`. Callers hand over a row-major `[]TermCell` with pre-resolved
+  RGBA foreground/background, plus cursor and selection state; the backend
+  batches same-background runs into fills and pins glyphs to exact cell
+  columns via `DrawLayoutPlaced`. Honors the reverse and underline
+  attributes; bold/italic are reserved in `TermAttr` for a follow-up.
+  Rendered by the Metal and SDL2 backends (OpenGL out of scope). Built for
+  go-term and reusable across siblings. See `examples/termgrid`. (#30)
+
 ### Fixed
 
 - **Native dialogs**: track native (OS) modal visibility so `DialogIsVisible`

--- a/examples/termgrid/main.go
+++ b/examples/termgrid/main.go
@@ -1,0 +1,120 @@
+// Termgrid demonstrates the TermGrid primitive: a fixed-pitch
+// character grid drawn straight from a cell buffer in one render
+// command (no per-cell Layout nodes). It shows per-cell foreground /
+// background colors, the reverse and underline attributes, a block
+// cursor, and a selection range.
+package main
+
+import (
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend"
+)
+
+const (
+	cols  = 48
+	rows  = 14
+	cellW = 9
+	cellH = 20
+)
+
+type App struct {
+	cells []gui.TermCell
+}
+
+func main() {
+	gui.SetTheme(gui.ThemeDark)
+
+	app := &App{cells: buildCells()}
+
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  app,
+		Title:  "termgrid",
+		Width:  cols*cellW + 40,
+		Height: rows*cellH + 40,
+		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+	})
+	backend.Run(w)
+}
+
+func view(w *gui.Window) gui.View {
+	ww, wh := w.WindowSize()
+	app := gui.State[App](w)
+
+	return gui.Column(gui.ContainerCfg{
+		Width:  float32(ww),
+		Height: float32(wh),
+		Sizing: gui.FixedFixed,
+		HAlign: gui.HAlignCenter,
+		VAlign: gui.VAlignMiddle,
+		Color:  gui.RGB(16, 16, 20),
+		Content: []gui.View{
+			gui.TermGrid(gui.TermGridCfg{
+				Cols:      cols,
+				Rows:      rows,
+				CellW:     cellW,
+				CellH:     cellH,
+				Cells:     app.cells,
+				TextStyle: monoStyle(),
+				Cursor: gui.TermCursor{
+					Col: 10, Row: 6, Visible: true,
+					Style: gui.TermCursorBlock,
+					Color: gui.RGB(120, 220, 120),
+				},
+				Selection: gui.TermSelRange{
+					Start: 8*cols + 2,
+					End:   8*cols + 22,
+				},
+			}),
+		},
+	})
+}
+
+func monoStyle() gui.TextStyle {
+	s := gui.CurrentTheme().M3
+	s.Size = cellH * 0.75
+	return s
+}
+
+// buildCells lays out demo content over a blank grid.
+func buildCells() []gui.TermCell {
+	cells := make([]gui.TermCell, cols*rows)
+	bg := gui.RGB(16, 16, 20)
+	fg := gui.RGB(220, 220, 220)
+	for i := range cells {
+		cells[i] = gui.TermCell{Ch: ' ', FG: fg, BG: bg, Width: 1}
+	}
+
+	put := func(row, col int, s string, cf, cb gui.Color, attr gui.TermAttr) {
+		for i, ch := range s {
+			c := col + i
+			if row < 0 || row >= rows || c < 0 || c >= cols {
+				continue
+			}
+			cells[row*cols+c] = gui.TermCell{
+				Ch: ch, FG: cf, BG: cb, Attrs: attr, Width: 1,
+			}
+		}
+	}
+
+	cyan := gui.RGB(80, 220, 220)
+	green := gui.RGB(120, 220, 120)
+	yellow := gui.RGB(230, 210, 90)
+	red := gui.RGB(230, 110, 110)
+	blue := gui.RGB(110, 160, 240)
+
+	put(0, 1, "go-gui TermGrid — single render command", cyan, bg, 0)
+	put(2, 1, "$ ls -la", green, bg, 0)
+	put(3, 1, "drwxr-xr-x  6 mike  staff   192 main.go", fg, bg, 0)
+	put(4, 1, "-rw-r--r--  1 mike  staff  1024 README.md", fg, bg, 0)
+	put(6, 1, "cursor -> ", yellow, bg, 0)
+	put(8, 1, "selection spans these cells on this row", fg, bg, 0)
+	put(10, 1, "reverse video", gui.RGB(16, 16, 20), yellow, gui.TermReverse)
+	put(10, 18, "underlined text", blue, bg, gui.TermUnderline)
+	put(12, 1, "colors:", fg, bg, 0)
+	put(12, 9, "red", red, bg, 0)
+	put(12, 13, "green", green, bg, 0)
+	put(12, 19, "blue", blue, bg, 0)
+	put(12, 24, "on-bg", gui.RGB(20, 20, 24), red, 0)
+
+	return cells
+}

--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -435,6 +435,9 @@ type windowState struct {
 
 	svgVerts           []gpu.Vertex
 	textPathPlacements []glyph.GlyphPlacement
+	termRunText        []rune                 // TermGrid: scratch run text
+	termRunCols        []int                  // TermGrid: scratch run columns
+	termPlace          []glyph.GlyphPlacement // TermGrid: scratch placements
 	normBuf            []gui.GradientStop
 	sampledBuf         []gui.GradientStop
 

--- a/gui/backend/metal/draw.go
+++ b/gui/backend/metal/draw.go
@@ -60,6 +60,8 @@ func (b *windowState) renderersDraw(w *gui.Window) {
 			b.drawRtf(r)
 		case gui.RenderCustomShader:
 			b.drawCustomShader(r)
+		case gui.RenderTermGrid:
+			b.drawTermGrid(r)
 		case gui.RenderFilterBegin:
 			b.beginFilter(r)
 		case gui.RenderFilterEnd:

--- a/gui/backend/metal/termgrid.go
+++ b/gui/backend/metal/termgrid.go
@@ -1,0 +1,262 @@
+//go:build darwin && !ios
+
+package metal
+
+import (
+	"math"
+
+	"github.com/go-gui-org/go-glyph"
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// defaultTermSelTint is the fallback selection highlight when the
+// caller leaves TermSelRange.Color unset.
+var defaultTermSelTint = gui.RGBA(51, 153, 255, 100)
+
+// drawTermGrid renders a terminal character grid from a shared cell
+// buffer in a single pass: background fills, glyph runs (pinned to
+// exact cell columns via DrawLayoutPlaced so the grid never drifts),
+// then cursor and selection overlays. No per-cell Layout nodes exist.
+//
+// Attribute support (v1): reverse (swaps fg/bg) and underline are
+// honored; bold/italic are reserved in TermAttr but not yet rendered.
+func (b *windowState) drawTermGrid(r *gui.RenderCmd) {
+	tg := r.TermGrid
+	if b.textSys == nil || tg == nil || tg.Cols <= 0 || tg.Rows <= 0 ||
+		tg.CellW <= 0 || math.IsNaN(float64(tg.CellW)) || math.IsInf(float64(tg.CellW), 0) ||
+		tg.CellH <= 0 || math.IsNaN(float64(tg.CellH)) || math.IsInf(float64(tg.CellH), 0) ||
+		len(tg.Cells) < tg.Cols*tg.Rows {
+		return
+	}
+	gx, gy := r.X, r.Y
+	cw, ch := tg.CellW, tg.CellH
+
+	cfg := guiStyleToGlyphConfig(tg.Style)
+	ascent := ch * 0.8
+	if m, err := b.textSys.FontMetrics(cfg); err == nil && m.Ascender > 0 {
+		ascent = m.Ascender
+	}
+
+	b.termGridBackgrounds(tg, gx, gy, cw, ch)
+	b.termGridSelection(tg, gx, gy, cw, ch)
+	b.termGridCursorUnder(tg, gx, gy, cw, ch)
+	b.termGridGlyphs(tg, cfg, gx, gy, cw, ch, ascent)
+	b.termGridDecorations(tg, gx, gy, cw, ch)
+}
+
+// termCellFB returns the effective foreground/background for a cell,
+// applying the reverse attribute.
+func termCellFB(c *gui.TermCell) (fg, bg gui.Color) {
+	fg, bg = c.FG, c.BG
+	if c.Attrs&gui.TermReverse != 0 {
+		fg, bg = bg, fg
+	}
+	return fg, bg
+}
+
+// termGridBackgrounds fills batched runs of same-background cells.
+func (b *windowState) termGridBackgrounds(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	for row := 0; row < tg.Rows; row++ {
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			_, bg := termCellFB(c)
+			if bg.A == 0 {
+				col++
+				continue
+			}
+			start := col
+			for col < tg.Cols {
+				_, nbg := termCellFB(&tg.Cells[row*tg.Cols+col])
+				if nbg != bg {
+					break
+				}
+				col++
+			}
+			b.fillTermRect(
+				gx+float32(start)*cw, gy+float32(row)*ch,
+				float32(col-start)*cw, ch, bg)
+		}
+	}
+}
+
+// termGridSelection tints the selected cell range per row.
+func (b *windowState) termGridSelection(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	sel := tg.Selection
+	if sel.End <= sel.Start {
+		return
+	}
+	tint := sel.Color
+	if tint.A == 0 {
+		tint = defaultTermSelTint
+	}
+	total := tg.Cols * tg.Rows
+	beg := max(sel.Start, 0)
+	end := min(sel.End, total)
+	for row := 0; row < tg.Rows && beg < end; row++ {
+		rowStart := row * tg.Cols
+		rowEnd := rowStart + tg.Cols
+		s := max(beg, rowStart)
+		e := min(end, rowEnd)
+		if s >= e {
+			continue
+		}
+		c0 := s - rowStart
+		c1 := e - rowStart
+		b.fillTermRect(
+			gx+float32(c0)*cw, gy+float32(row)*ch,
+			float32(c1-c0)*cw, ch, tint)
+	}
+}
+
+// termGridCursorUnder draws the block cursor beneath the glyphs so the
+// character remains visible on top.
+func (b *windowState) termGridCursorUnder(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	cur := tg.Cursor
+	if !cur.Visible || cur.Style != gui.TermCursorBlock ||
+		cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	b.fillTermRect(
+		gx+float32(cur.Col)*cw, gy+float32(cur.Row)*ch,
+		cw, ch, cur.Color)
+}
+
+// termGridGlyphs shapes each row into foreground-color runs and draws
+// them with glyphs pinned to their cell columns.
+func (b *windowState) termGridGlyphs(
+	tg *gui.TermGridData, cfg glyph.TextConfig,
+	gx, gy, cw, ch, ascent float32,
+) {
+	b.useGlyphPipeline()
+	for row := 0; row < tg.Rows; row++ {
+		baseline := gy + float32(row)*ch + ascent
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Width == 0 { // continuation of a wide cell
+				col++
+				continue
+			}
+			fg, _ := termCellFB(c)
+			// Extend a run of glyphs sharing this foreground color.
+			b.termGridRunReset()
+			runFG := fg
+			for col < tg.Cols {
+				cell := &tg.Cells[row*tg.Cols+col]
+				if cell.Width == 0 {
+					col++
+					continue
+				}
+				fg2, _ := termCellFB(cell)
+				blank := cell.Ch == 0 || cell.Ch == ' '
+				if !blank && fg2 != runFG {
+					break
+				}
+				if blank {
+					b.termGridRunAppend(' ', col)
+				} else {
+					b.termGridRunAppend(cell.Ch, col)
+				}
+				col++
+			}
+			b.termGridDrawRun(cfg, runFG, gx, baseline, cw)
+		}
+	}
+}
+
+// termGridDecorations draws underline attributes and the bar /
+// underline cursor styles on top of the glyphs.
+func (b *windowState) termGridDecorations(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	thick := max(ch*0.08, 1)
+	for row := 0; row < tg.Rows; row++ {
+		for col := 0; col < tg.Cols; col++ {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Attrs&gui.TermUnderline == 0 {
+				continue
+			}
+			fg, _ := termCellFB(c)
+			b.fillTermRect(
+				gx+float32(col)*cw, gy+float32(row+1)*ch-thick,
+				cw, thick, fg)
+		}
+	}
+
+	cur := tg.Cursor
+	if !cur.Visible || cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	x := gx + float32(cur.Col)*cw
+	y := gy + float32(cur.Row)*ch
+	switch cur.Style {
+	case gui.TermCursorBar:
+		b.fillTermRect(x, y, max(cw*0.15, 1), ch, cur.Color)
+	case gui.TermCursorUnderline:
+		b.fillTermRect(x, y+ch-thick, cw, thick, cur.Color)
+	case gui.TermCursorBlock:
+		// Drawn under the glyph in termGridCursorUnder.
+	}
+}
+
+// --- run assembly helpers (reuse scratch buffers) ---
+
+func (b *windowState) termGridRunReset() {
+	b.termRunText = b.termRunText[:0]
+	b.termRunCols = b.termRunCols[:0]
+}
+
+func (b *windowState) termGridRunAppend(ch rune, col int) {
+	b.termRunText = append(b.termRunText, ch)
+	b.termRunCols = append(b.termRunCols, col)
+}
+
+// termGridDrawRun shapes the accumulated run and draws its glyphs at
+// fixed cell columns. Falls back to natural flow if the shaper does
+// not produce one glyph per cell (e.g. clustered non-ASCII runs).
+func (b *windowState) termGridDrawRun(
+	cfg glyph.TextConfig, fg gui.Color, gx, baseline, cw float32,
+) {
+	if len(b.termRunCols) == 0 {
+		return
+	}
+	cfg.Style.Color = glyph.Color{R: fg.R, G: fg.G, B: fg.B, A: fg.A}
+	layout, err := b.textSys.LayoutText(string(b.termRunText), cfg)
+	if err != nil {
+		return
+	}
+	if len(layout.Glyphs) != len(b.termRunCols) {
+		// Cluster/ligature mismatch — draw at the run's first column.
+		b.textSys.DrawLayout(layout, gx+float32(b.termRunCols[0])*cw, baseline)
+		return
+	}
+	b.termPlace = b.termPlace[:0]
+	for _, col := range b.termRunCols {
+		b.termPlace = append(b.termPlace, glyph.GlyphPlacement{
+			X: gx + float32(col)*cw,
+			Y: baseline,
+		})
+	}
+	b.textSys.DrawLayoutPlaced(layout, b.termPlace)
+}
+
+// fillTermRect draws a solid filled rectangle in logical coordinates.
+func (b *windowState) fillTermRect(x, y, w, h float32, c gui.Color) {
+	if w <= 0 || h <= 0 || c.A == 0 {
+		return
+	}
+	cmd := gui.RenderCmd{
+		Kind: gui.RenderRect, X: x, Y: y, W: w, H: h,
+		Color: c, Fill: true,
+	}
+	b.drawRect(&cmd)
+}

--- a/gui/backend/sdl2/backend.go
+++ b/gui/backend/sdl2/backend.go
@@ -37,6 +37,9 @@ type Backend struct {
 	filterPixels       []uint32     // reusable pixel buffer for color matrix
 	svgVerts           []sdl.Vertex // reusable vertex buffer for SVG geometry
 	textPathPlacements []glyph.GlyphPlacement
+	termRunText        []rune                 // TermGrid: scratch run text
+	termRunCols        []int                  // TermGrid: scratch run columns
+	termPlace          []glyph.GlyphPlacement // TermGrid: scratch placements
 	allowedImageRoots  []string
 	roundedClipStack   []roundedClipState
 	normBuf            []gui.GradientStop // reusable buffer for gradient normalization

--- a/gui/backend/sdl2/draw.go
+++ b/gui/backend/sdl2/draw.go
@@ -63,6 +63,8 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 		case gui.RenderStencilEnd:
 			b.endStencilClip()
 
+		case gui.RenderTermGrid:
+			b.drawTermGrid(r)
 		case gui.RenderRotateBegin,
 			gui.RenderRotateEnd:
 			// Rotation requires MVP transform — unsupported in SDL2.

--- a/gui/backend/sdl2/termgrid.go
+++ b/gui/backend/sdl2/termgrid.go
@@ -1,0 +1,260 @@
+//go:build !js && !darwin
+
+package sdl2
+
+import (
+	"math"
+
+	"github.com/go-gui-org/go-glyph"
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// defaultTermSelTint is the fallback selection highlight when the
+// caller leaves TermSelRange.Color unset.
+var defaultTermSelTint = gui.RGBA(51, 153, 255, 100)
+
+// drawTermGrid renders a terminal character grid from a shared cell
+// buffer in a single pass: background fills, glyph runs (pinned to
+// exact cell columns via DrawLayoutPlaced so the grid never drifts),
+// then cursor and selection overlays. No per-cell Layout nodes exist.
+//
+// Attribute support (v1): reverse (swaps fg/bg) and underline are
+// honored; bold/italic are reserved in TermAttr but not yet rendered.
+func (b *Backend) drawTermGrid(r *gui.RenderCmd) {
+	tg := r.TermGrid
+	if b.textSys == nil || tg == nil || tg.Cols <= 0 || tg.Rows <= 0 ||
+		tg.CellW <= 0 || math.IsNaN(float64(tg.CellW)) || math.IsInf(float64(tg.CellW), 0) ||
+		tg.CellH <= 0 || math.IsNaN(float64(tg.CellH)) || math.IsInf(float64(tg.CellH), 0) ||
+		len(tg.Cells) < tg.Cols*tg.Rows {
+		return
+	}
+	gx, gy := r.X, r.Y
+	cw, ch := tg.CellW, tg.CellH
+
+	cfg := guiStyleToGlyphConfig(tg.Style)
+	ascent := ch * 0.8
+	if m, err := b.textSys.FontMetrics(cfg); err == nil && m.Ascender > 0 {
+		ascent = m.Ascender
+	}
+
+	b.termGridBackgrounds(tg, gx, gy, cw, ch)
+	b.termGridSelection(tg, gx, gy, cw, ch)
+	b.termGridCursorUnder(tg, gx, gy, cw, ch)
+	b.termGridGlyphs(tg, cfg, gx, gy, cw, ch, ascent)
+	b.termGridDecorations(tg, gx, gy, cw, ch)
+}
+
+// termCellFB returns the effective foreground/background for a cell,
+// applying the reverse attribute.
+func termCellFB(c *gui.TermCell) (fg, bg gui.Color) {
+	fg, bg = c.FG, c.BG
+	if c.Attrs&gui.TermReverse != 0 {
+		fg, bg = bg, fg
+	}
+	return fg, bg
+}
+
+// termGridBackgrounds fills batched runs of same-background cells.
+func (b *Backend) termGridBackgrounds(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	for row := 0; row < tg.Rows; row++ {
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			_, bg := termCellFB(c)
+			if bg.A == 0 {
+				col++
+				continue
+			}
+			start := col
+			for col < tg.Cols {
+				_, nbg := termCellFB(&tg.Cells[row*tg.Cols+col])
+				if nbg != bg {
+					break
+				}
+				col++
+			}
+			b.fillTermRect(
+				gx+float32(start)*cw, gy+float32(row)*ch,
+				float32(col-start)*cw, ch, bg)
+		}
+	}
+}
+
+// termGridSelection tints the selected cell range per row.
+func (b *Backend) termGridSelection(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	sel := tg.Selection
+	if sel.End <= sel.Start {
+		return
+	}
+	tint := sel.Color
+	if tint.A == 0 {
+		tint = defaultTermSelTint
+	}
+	total := tg.Cols * tg.Rows
+	beg := max(sel.Start, 0)
+	end := min(sel.End, total)
+	for row := 0; row < tg.Rows && beg < end; row++ {
+		rowStart := row * tg.Cols
+		rowEnd := rowStart + tg.Cols
+		s := max(beg, rowStart)
+		e := min(end, rowEnd)
+		if s >= e {
+			continue
+		}
+		c0 := s - rowStart
+		c1 := e - rowStart
+		b.fillTermRect(
+			gx+float32(c0)*cw, gy+float32(row)*ch,
+			float32(c1-c0)*cw, ch, tint)
+	}
+}
+
+// termGridCursorUnder draws the block cursor beneath the glyphs so the
+// character remains visible on top.
+func (b *Backend) termGridCursorUnder(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	cur := tg.Cursor
+	if !cur.Visible || cur.Style != gui.TermCursorBlock ||
+		cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	b.fillTermRect(
+		gx+float32(cur.Col)*cw, gy+float32(cur.Row)*ch,
+		cw, ch, cur.Color)
+}
+
+// termGridGlyphs shapes each row into foreground-color runs and draws
+// them with glyphs pinned to their cell columns.
+func (b *Backend) termGridGlyphs(
+	tg *gui.TermGridData, cfg glyph.TextConfig,
+	gx, gy, cw, ch, ascent float32,
+) {
+	for row := 0; row < tg.Rows; row++ {
+		baseline := gy + float32(row)*ch + ascent
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Width == 0 { // continuation of a wide cell
+				col++
+				continue
+			}
+			fg, _ := termCellFB(c)
+			b.termGridRunReset()
+			runFG := fg
+			for col < tg.Cols {
+				cell := &tg.Cells[row*tg.Cols+col]
+				if cell.Width == 0 {
+					col++
+					continue
+				}
+				fg2, _ := termCellFB(cell)
+				blank := cell.Ch == 0 || cell.Ch == ' '
+				if !blank && fg2 != runFG {
+					break
+				}
+				if blank {
+					b.termGridRunAppend(' ', col)
+				} else {
+					b.termGridRunAppend(cell.Ch, col)
+				}
+				col++
+			}
+			b.termGridDrawRun(cfg, runFG, gx, baseline, cw)
+		}
+	}
+}
+
+// termGridDecorations draws underline attributes and the bar /
+// underline cursor styles on top of the glyphs.
+func (b *Backend) termGridDecorations(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	thick := max(ch*0.08, 1)
+	for row := 0; row < tg.Rows; row++ {
+		for col := 0; col < tg.Cols; col++ {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Attrs&gui.TermUnderline == 0 {
+				continue
+			}
+			fg, _ := termCellFB(c)
+			b.fillTermRect(
+				gx+float32(col)*cw, gy+float32(row+1)*ch-thick,
+				cw, thick, fg)
+		}
+	}
+
+	cur := tg.Cursor
+	if !cur.Visible || cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	x := gx + float32(cur.Col)*cw
+	y := gy + float32(cur.Row)*ch
+	switch cur.Style {
+	case gui.TermCursorBar:
+		b.fillTermRect(x, y, max(cw*0.15, 1), ch, cur.Color)
+	case gui.TermCursorUnderline:
+		b.fillTermRect(x, y+ch-thick, cw, thick, cur.Color)
+	case gui.TermCursorBlock:
+		// Drawn under the glyph in termGridCursorUnder.
+	}
+}
+
+// --- run assembly helpers (reuse scratch buffers) ---
+
+func (b *Backend) termGridRunReset() {
+	b.termRunText = b.termRunText[:0]
+	b.termRunCols = b.termRunCols[:0]
+}
+
+func (b *Backend) termGridRunAppend(ch rune, col int) {
+	b.termRunText = append(b.termRunText, ch)
+	b.termRunCols = append(b.termRunCols, col)
+}
+
+// termGridDrawRun shapes the accumulated run and draws its glyphs at
+// fixed cell columns. Falls back to natural flow if the shaper does
+// not produce one glyph per cell (e.g. clustered non-ASCII runs).
+func (b *Backend) termGridDrawRun(
+	cfg glyph.TextConfig, fg gui.Color, gx, baseline, cw float32,
+) {
+	if len(b.termRunCols) == 0 {
+		return
+	}
+	cfg.Style.Color = glyph.Color{R: fg.R, G: fg.G, B: fg.B, A: fg.A}
+	layout, err := b.textSys.LayoutText(string(b.termRunText), cfg)
+	if err != nil {
+		return
+	}
+	if len(layout.Glyphs) != len(b.termRunCols) {
+		// Cluster/ligature mismatch — draw at the run's first column.
+		b.textSys.DrawLayout(layout, gx+float32(b.termRunCols[0])*cw, baseline)
+		return
+	}
+	b.termPlace = b.termPlace[:0]
+	for _, col := range b.termRunCols {
+		b.termPlace = append(b.termPlace, glyph.GlyphPlacement{
+			X: gx + float32(col)*cw,
+			Y: baseline,
+		})
+	}
+	b.textSys.DrawLayoutPlaced(layout, b.termPlace)
+}
+
+// fillTermRect draws a solid filled rectangle in logical coordinates.
+func (b *Backend) fillTermRect(x, y, w, h float32, c gui.Color) {
+	if w <= 0 || h <= 0 || c.A == 0 {
+		return
+	}
+	cmd := gui.RenderCmd{
+		Kind: gui.RenderRect, X: x, Y: y, W: w, H: h,
+		Color: c, Fill: true,
+	}
+	b.drawRect(&cmd)
+}

--- a/gui/inspector.go
+++ b/gui/inspector.go
@@ -537,6 +537,8 @@ func inspectorTypeName(shape *Shape) string {
 		return "svg"
 	case shapeDrawCanvas:
 		return "draw_canvas"
+	case shapeTermGrid:
+		return "termgrid"
 	case shapeNone, shapeRectangle:
 		switch shape.Axis {
 		case AxisTopToBottom:

--- a/gui/layout_sizing_fuzz_test.go
+++ b/gui/layout_sizing_fuzz_test.go
@@ -307,7 +307,7 @@ func FuzzLayoutSizingWithMix(f *testing.F) {
 func shapeTypeFromUint(v uint32) shapeType {
 	types := []shapeType{
 		shapeRectangle, shapeCircle, shapeText, shapeImage,
-		shapeSVG, shapeRTF, shapeNone,
+		shapeSVG, shapeRTF, shapeTermGrid, shapeNone,
 	}
 	return types[v%uint32(len(types))]
 }

--- a/gui/render_layout.go
+++ b/gui/render_layout.go
@@ -161,13 +161,15 @@ func renderShapeInner(shape *Shape, parentColor Color, clip drawClip, w *Window)
 	isImage := shape.shapeType == shapeImage
 	isSvg := shape.shapeType == shapeSVG
 	isCanvas := shape.shapeType == shapeDrawCanvas
+	isTermGrid := shape.shapeType == shapeTermGrid
 	hasFX := shape.fx != nil && (shape.fx.Gradient != nil ||
 		shape.fx.BorderGradient != nil)
 
 	isRTF := shape.shapeType == shapeRTF
 
 	if shape.Color == ColorTransparent && !hasFX && !hasBorder &&
-		!hasText && !isImage && !isSvg && !isCanvas && !isRTF {
+		!hasText && !isImage && !isSvg && !isCanvas && !isRTF &&
+		!isTermGrid {
 		return
 	}
 
@@ -186,6 +188,8 @@ func renderShapeInner(shape *Shape, parentColor Color, clip drawClip, w *Window)
 		renderSvg(shape, clip, w)
 	case shapeDrawCanvas:
 		renderDrawCanvas(shape, clip, w)
+	case shapeTermGrid:
+		renderTermGrid(shape, clip, w)
 	case shapeNone:
 		// no-op
 	}

--- a/gui/render_termgrid.go
+++ b/gui/render_termgrid.go
@@ -1,0 +1,27 @@
+package gui
+
+import "math"
+
+// renderTermGrid emits a single RenderTermGrid command for a terminal
+// character grid. The whole grid is drawn by the backend from the
+// shared TermGridData buffer in one pass — no per-cell Layout nodes
+// and no per-cell RenderText commands.
+func renderTermGrid(shape *Shape, clip drawClip, w *Window) {
+	tg := shape.tg
+	if tg == nil || tg.Cols <= 0 || tg.Rows <= 0 ||
+		tg.CellW <= 0 || math.IsNaN(float64(tg.CellW)) || math.IsInf(float64(tg.CellW), 0) ||
+		tg.CellH <= 0 || math.IsNaN(float64(tg.CellH)) || math.IsInf(float64(tg.CellH), 0) {
+		return
+	}
+	if !rectsOverlap(shapeBounds(shape), clip) {
+		return
+	}
+	emitRenderer(RenderCmd{
+		Kind:     RenderTermGrid,
+		X:        shape.X,
+		Y:        shape.Y,
+		W:        shape.Width,
+		H:        shape.Height,
+		TermGrid: tg,
+	}, w)
+}

--- a/gui/render_termgrid_test.go
+++ b/gui/render_termgrid_test.go
@@ -1,0 +1,194 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+func termCells(cols, rows int) []TermCell {
+	cells := make([]TermCell, cols*rows)
+	for i := range cells {
+		cells[i] = TermCell{Ch: 'x', FG: White, BG: Black, Width: 1}
+	}
+	return cells
+}
+
+func TestTermGridFactoryLayout(t *testing.T) {
+	w := makeWindowWithScratch()
+	v := TermGrid(TermGridCfg{
+		Cols: 80, Rows: 24,
+		CellW: 8, CellH: 16,
+		Cells: termCells(80, 24),
+	})
+	l := v.GenerateLayout(w)
+	s := l.Shape
+	if s.shapeType != shapeTermGrid {
+		t.Fatalf("shapeType = %d, want shapeTermGrid", s.shapeType)
+	}
+	if s.Width != 640 || s.Height != 384 {
+		t.Errorf("size = (%v,%v), want (640,384)", s.Width, s.Height)
+	}
+	if s.Sizing != FixedFixed {
+		t.Errorf("Sizing = %v, want FixedFixed", s.Sizing)
+	}
+	if s.tg == nil {
+		t.Fatal("shape.tg is nil")
+	}
+	if s.tg.Cols != 80 || s.tg.Rows != 24 {
+		t.Errorf("tg dims = (%d,%d), want (80,24)", s.tg.Cols, s.tg.Rows)
+	}
+}
+
+func TestRenderTermGridEmitsOneCommand(t *testing.T) {
+	w := makeWindowWithScratch()
+	tg := &TermGridData{
+		Cells: termCells(4, 2),
+		Cols:  4, Rows: 2,
+		CellW: 8, CellH: 16,
+	}
+	shape := &Shape{
+		shapeType: shapeTermGrid,
+		X:         10, Y: 20,
+		Width: 32, Height: 32,
+		tg: tg,
+	}
+	renderTermGrid(shape, makeClip(0, 0, 200, 200), w)
+
+	var n int
+	var cmd *RenderCmd
+	for i := range w.renderers {
+		if w.renderers[i].Kind == RenderTermGrid {
+			n++
+			cmd = &w.renderers[i]
+		}
+	}
+	if n != 1 {
+		t.Fatalf("RenderTermGrid count = %d, want 1 (single-pass, no per-cell)", n)
+	}
+	if cmd.TermGrid != tg {
+		t.Error("RenderCmd.TermGrid does not point at the grid buffer")
+	}
+	if cmd.X != 10 || cmd.Y != 20 || cmd.W != 32 || cmd.H != 32 {
+		t.Errorf("cmd geom = (%v,%v,%v,%v), want (10,20,32,32)",
+			cmd.X, cmd.Y, cmd.W, cmd.H)
+	}
+}
+
+func TestRenderTermGridNoPerCellNodes(t *testing.T) {
+	w := makeWindowWithScratch()
+	tg := &TermGridData{
+		Cells: termCells(40, 10), // 400 cells
+		Cols:  40, Rows: 10,
+		CellW: 8, CellH: 16,
+	}
+	shape := &Shape{
+		shapeType: shapeTermGrid,
+		Width:     320, Height: 160,
+		tg: tg,
+	}
+	renderTermGrid(shape, makeClip(0, 0, 400, 400), w)
+
+	if len(w.renderers) != 1 {
+		t.Errorf("emitted %d renderers for 400 cells, want 1", len(w.renderers))
+	}
+}
+
+func TestRenderTermGridOutsideClipSkips(t *testing.T) {
+	w := makeWindowWithScratch()
+	tg := &TermGridData{
+		Cells: termCells(4, 2),
+		Cols:  4, Rows: 2,
+		CellW: 8, CellH: 16,
+	}
+	shape := &Shape{
+		shapeType: shapeTermGrid,
+		X:         500, Y: 500,
+		Width: 32, Height: 32,
+		tg: tg,
+	}
+	renderTermGrid(shape, makeClip(0, 0, 100, 100), w)
+
+	if len(w.renderers) != 0 {
+		t.Errorf("got %d renderers, want 0 for out-of-clip grid", len(w.renderers))
+	}
+}
+
+func TestRenderTermGridDegenerateSkips(t *testing.T) {
+	w := makeWindowWithScratch()
+	cases := []struct {
+		name string
+		tg   *TermGridData
+	}{
+		{"nil", nil},
+		{"zero cols", &TermGridData{Rows: 2, CellW: 8, CellH: 16}},
+		{"zero cellW", &TermGridData{Cols: 4, Rows: 2, CellH: 16}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w.renderers = w.renderers[:0]
+			shape := &Shape{
+				shapeType: shapeTermGrid,
+				Width:     32, Height: 32,
+				tg: tc.tg,
+			}
+			renderTermGrid(shape, makeClip(0, 0, 200, 200), w)
+			if len(w.renderers) != 0 {
+				t.Errorf("got %d renderers, want 0", len(w.renderers))
+			}
+		})
+	}
+}
+
+func TestRenderTermGridSkipsOnNaNCellW(t *testing.T) {
+	w := makeWindowWithScratch()
+	tg := &TermGridData{
+		Cells: termCells(4, 2),
+		Cols:  4, Rows: 2,
+		CellW: float32(math.NaN()), CellH: 16,
+	}
+	shape := &Shape{
+		shapeType: shapeTermGrid,
+		Width:     32, Height: 32,
+		tg: tg,
+	}
+	renderTermGrid(shape, makeClip(0, 0, 200, 200), w)
+	if len(w.renderers) != 0 {
+		t.Errorf("got %d renderers, want 0 for NaN CellW", len(w.renderers))
+	}
+}
+
+func TestRenderTermGridSkipsOnInfCellW(t *testing.T) {
+	w := makeWindowWithScratch()
+	tg := &TermGridData{
+		Cells: termCells(4, 2),
+		Cols:  4, Rows: 2,
+		CellW: float32(math.Inf(1)), CellH: 16,
+	}
+	shape := &Shape{
+		shapeType: shapeTermGrid,
+		Width:     32, Height: 32,
+		tg: tg,
+	}
+	renderTermGrid(shape, makeClip(0, 0, 200, 200), w)
+	if len(w.renderers) != 0 {
+		t.Errorf("got %d renderers, want 0 for Inf CellW", len(w.renderers))
+	}
+}
+
+func TestRenderTermGridSkipsOnZeroRows(t *testing.T) {
+	w := makeWindowWithScratch()
+	tg := &TermGridData{
+		Cells: termCells(4, 2),
+		Cols:  4, Rows: 0,
+		CellW: 8, CellH: 16,
+	}
+	shape := &Shape{
+		shapeType: shapeTermGrid,
+		Width:     32, Height: 32,
+		tg: tg,
+	}
+	renderTermGrid(shape, makeClip(0, 0, 200, 200), w)
+	if len(w.renderers) != 0 {
+		t.Errorf("got %d renderers, want 0 for zero rows", len(w.renderers))
+	}
+}

--- a/gui/render_types.go
+++ b/gui/render_types.go
@@ -35,6 +35,7 @@ const (
 	RenderRotateEnd
 	RenderStencilBegin
 	RenderStencilEnd
+	RenderTermGrid
 )
 
 // RenderCmd is a flat discriminated struct holding all draw
@@ -50,6 +51,7 @@ type RenderCmd struct {
 	TextStylePtr    *TextStyle            // full text style (typeface, etc.)
 	TextGradient    *glyph.GradientConfig // text gradient for glyph-layout draws
 	TextPath        *TextPathData         // SVG textPath placement data
+	TermGrid        *TermGridData         // terminal grid buffer (RenderTermGrid)
 	LayoutPtr       *glyph.Layout         // pre-shaped glyph layout
 	LayoutTransform *glyph.AffineTransform
 

--- a/gui/render_types_test.go
+++ b/gui/render_types_test.go
@@ -57,6 +57,8 @@ func renderCmdKindName(k RenderKind) string {
 		return "RenderStencilBegin"
 	case RenderStencilEnd:
 		return "RenderStencilEnd"
+	case RenderTermGrid:
+		return "RenderTermGrid"
 	default:
 		return "Unknown"
 	}
@@ -93,6 +95,7 @@ func TestRenderCmdKindNameExhaustive(t *testing.T) {
 		{RenderRotateEnd, "RenderRotateEnd"},
 		{RenderStencilBegin, "RenderStencilBegin"},
 		{RenderStencilEnd, "RenderStencilEnd"},
+		{RenderTermGrid, "RenderTermGrid"},
 		{RenderKind(255), "Unknown"},
 	}
 	for _, tt := range tests {

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -22,6 +22,7 @@ type Shape struct {
 	A11Y    *AccessInfo        // accessibility metadata
 	bc      *shapeButtonColors // button hover/focus colors
 	SvgOpts *SvgParseOpts      // per-render SVG parse overrides
+	tg      *TermGridData      // terminal grid buffer (shapeTermGrid)
 
 	// ID is a user-assigned string identifier. Used for event routing,
 	// form field lookup, and debugging. Optional but recommended for
@@ -200,6 +201,7 @@ const (
 	shapeRTF
 	shapeSVG
 	shapeDrawCanvas
+	shapeTermGrid
 )
 
 // TextDirection controls text/layout direction.

--- a/gui/termgrid.go
+++ b/gui/termgrid.go
@@ -1,0 +1,183 @@
+package gui
+
+import "math"
+
+// TermGrid is a terminal character-grid primitive. It draws a
+// fixed-pitch grid of cells straight from a caller-owned backing
+// buffer in a single render command — no per-cell Layout node and no
+// per-cell RenderText. Intended for terminal emulators (go-term), a
+// go-edit terminal pane, and similar consumers that regenerate
+// thousands of cells every frame.
+//
+// go-gui stays palette/escape-sequence agnostic: the caller resolves
+// every cell's foreground and background to an RGBA Color before
+// handing the buffer over. The grid is laid out like any other widget
+// (Fixed default sizing of Cols*CellW x Rows*CellH); the backend draws
+// glyphs pinned to exact cell positions so the grid never drifts.
+
+// TermAttr is a per-cell attribute bitset. Combine with bitwise OR.
+type TermAttr uint8
+
+// TermAttr flags.
+const (
+	TermBold TermAttr = 1 << iota
+	TermItalic
+	TermUnderline
+	TermReverse
+)
+
+// TermCell is a single grid cell. Colors are pre-resolved RGBA;
+// go-gui does not consult any palette. Width distinguishes normal
+// cells from wide (CJK/emoji) cells and their continuation slots.
+type TermCell struct {
+	Ch    rune  // cell rune; 0 or ' ' renders as blank
+	FG    Color // resolved foreground (glyph) color
+	BG    Color // resolved background color
+	Attrs TermAttr
+	Width uint8 // 1 normal, 2 wide (occupies this + next cell), 0 continuation of a wide cell
+}
+
+// TermCursorStyle selects how the cursor is drawn.
+type TermCursorStyle uint8
+
+// TermCursorStyle values.
+const (
+	TermCursorBlock TermCursorStyle = iota
+	TermCursorBar
+	TermCursorUnderline
+)
+
+// TermCursor positions and styles the text cursor within the grid.
+type TermCursor struct {
+	Col     int
+	Row     int
+	Color   Color
+	Style   TermCursorStyle
+	Visible bool
+}
+
+// TermSelRange is a linear (row-major) selection over cell indices,
+// half-open [Start, End). Start == End means no selection. Color is
+// the selection highlight; unset falls back to a default tint.
+type TermSelRange struct {
+	Start int
+	End   int
+	Color Color
+}
+
+// TermGridData is the resolved grid buffer carried by a RenderCmd.
+// The caller may reuse the Cells slice across frames. Held by pointer
+// so no per-cell data is copied into the render command stream.
+type TermGridData struct {
+	Cells        []TermCell // len == Cols*Rows, row-major
+	Style        TextStyle  // font/size for the whole grid
+	Cursor       TermCursor
+	Selection    TermSelRange
+	Cols         int
+	Rows         int
+	CellW, CellH float32
+}
+
+// TermGridCfg configures a TermGrid widget.
+type TermGridCfg struct {
+	OnKeyDown     func(*Layout, *Event, *Window)
+	OnClick       func(*Layout, *Event, *Window)
+	OnMouseScroll func(*Layout, *Event, *Window)
+
+	ID              string
+	A11YLabel       string
+	A11YDescription string
+
+	Cells     []TermCell // len must be >= Cols*Rows; row-major
+	Cursor    TermCursor
+	Selection TermSelRange
+	TextStyle TextStyle
+
+	Cols    int
+	Rows    int
+	CellW   float32
+	CellH   float32
+	IDFocus uint32
+	Sizing  Sizing
+}
+
+// termGridView implements View for a terminal character grid.
+type termGridView struct {
+	cfg TermGridCfg
+}
+
+// TermGrid creates a terminal character-grid widget. Cols, Rows,
+// CellW, and CellH define the geometry; Cells is the row-major cell
+// buffer (len >= Cols*Rows). Default sizing is Fixed at
+// Cols*CellW x Rows*CellH.
+func TermGrid(cfg TermGridCfg) View {
+	if cfg.Sizing == (Sizing{}) {
+		cfg.Sizing = FixedFixed
+	}
+	if cfg.TextStyle == (TextStyle{}) {
+		cfg.TextStyle = DefaultTextStyle
+	}
+	if cfg.Cols <= 0 || cfg.Rows <= 0 ||
+		cfg.CellW <= 0 || math.IsNaN(float64(cfg.CellW)) || math.IsInf(float64(cfg.CellW), 0) ||
+		cfg.CellH <= 0 || math.IsNaN(float64(cfg.CellH)) || math.IsInf(float64(cfg.CellH), 0) {
+		panic("TermGrid: Cols, Rows must be positive; CellW, CellH must be positive and finite")
+	}
+	if len(cfg.Cells) < cfg.Cols*cfg.Rows {
+		panic("TermGrid: len(Cells) must be >= Cols*Rows")
+	}
+	return &termGridView{cfg: cfg}
+}
+
+func (tv *termGridView) Content() []View { return nil }
+
+func (tv *termGridView) GenerateLayout(w *Window) Layout {
+	c := &tv.cfg
+
+	var events *eventHandlers
+	if c.OnKeyDown != nil || c.OnClick != nil || c.OnMouseScroll != nil {
+		events = w.allocEventHandlers(eventHandlers{
+			OnKeyDown:     c.OnKeyDown,
+			OnClick:       c.OnClick,
+			ClickButton:   MouseLeft,
+			OnMouseScroll: c.OnMouseScroll,
+		})
+	}
+
+	// Default fixed geometry from cell metrics.
+	width := float32(c.Cols) * c.CellW
+	height := float32(c.Rows) * c.CellH
+
+	// Focusable grid advertises as a text box to assistive tech.
+	a11yRole := AccessRoleImage
+	if c.IDFocus > 0 {
+		a11yRole = AccessRoleTextArea
+	}
+
+	tg := &TermGridData{
+		Cells:     c.Cells,
+		Style:     c.TextStyle,
+		Cursor:    c.Cursor,
+		Selection: c.Selection,
+		Cols:      c.Cols,
+		Rows:      c.Rows,
+		CellW:     c.CellW,
+		CellH:     c.CellH,
+	}
+
+	layout := Layout{
+		Shape: w.allocShape(Shape{
+			shapeType: shapeTermGrid,
+			ID:        c.ID,
+			A11YRole:  a11yRole,
+			A11Y:      makeA11YInfo(c.A11YLabel, c.A11YDescription),
+			Width:     width,
+			Height:    height,
+			Sizing:    c.Sizing,
+			IDFocus:   c.IDFocus,
+			events:    events,
+			tg:        tg,
+		}),
+	}
+	applyFixedSizingConstraints(layout.Shape)
+	return layout
+}

--- a/gui/termgrid_test.go
+++ b/gui/termgrid_test.go
@@ -1,0 +1,213 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTermGridPanicsOnZeroCols(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on zero Cols")
+		}
+	}()
+	TermGrid(TermGridCfg{Cols: 0, Rows: 1, CellW: 8, CellH: 16})
+}
+
+func TestTermGridPanicsOnZeroRows(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on zero Rows")
+		}
+	}()
+	TermGrid(TermGridCfg{Cols: 1, Rows: 0, CellW: 8, CellH: 16})
+}
+
+func TestTermGridPanicsOnZeroCellW(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on zero CellW")
+		}
+	}()
+	TermGrid(TermGridCfg{Cols: 1, Rows: 1, CellW: 0, CellH: 16})
+}
+
+func TestTermGridPanicsOnZeroCellH(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on zero CellH")
+		}
+	}()
+	TermGrid(TermGridCfg{Cols: 1, Rows: 1, CellW: 8, CellH: 0})
+}
+
+func TestTermGridPanicsOnNaNCellW(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on NaN CellW")
+		}
+	}()
+	TermGrid(TermGridCfg{
+		Cols: 1, Rows: 1, CellW: float32(math.NaN()), CellH: 16,
+	})
+}
+
+func TestTermGridPanicsOnNaNCellH(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on NaN CellH")
+		}
+	}()
+	TermGrid(TermGridCfg{
+		Cols: 1, Rows: 1, CellW: 8, CellH: float32(math.NaN()),
+	})
+}
+
+func TestTermGridPanicsOnInfCellW(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on Inf CellW")
+		}
+	}()
+	TermGrid(TermGridCfg{
+		Cols: 1, Rows: 1, CellW: float32(math.Inf(1)), CellH: 16,
+	})
+}
+
+func TestTermGridPanicsOnInfCellH(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on Inf CellH")
+		}
+	}()
+	TermGrid(TermGridCfg{
+		Cols: 1, Rows: 1, CellW: 8, CellH: float32(math.Inf(1)),
+	})
+}
+
+func TestTermGridPanicsOnInsufficientCells(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on insufficient Cells")
+		}
+	}()
+	TermGrid(TermGridCfg{
+		Cols: 4, Rows: 2, CellW: 8, CellH: 16,
+		Cells: make([]TermCell, 7), // need 8
+	})
+}
+
+func TestTermGridLayoutWiresEventHandlers(t *testing.T) {
+	w := makeWindowWithScratch()
+	keyDownFired := false
+	clickFired := false
+	scrollFired := false
+	v := TermGrid(TermGridCfg{
+		Cols: 4, Rows: 2, CellW: 8, CellH: 16,
+		Cells: termCells(4, 2),
+		OnKeyDown: func(_ *Layout, _ *Event, _ *Window) {
+			keyDownFired = true
+		},
+		OnClick: func(_ *Layout, _ *Event, _ *Window) {
+			clickFired = true
+		},
+		OnMouseScroll: func(_ *Layout, _ *Event, _ *Window) {
+			scrollFired = true
+		},
+	})
+	l := v.GenerateLayout(w)
+	s := l.Shape
+	if s.events == nil {
+		t.Fatal("events is nil, expected event handlers")
+	}
+	if s.events.OnKeyDown == nil {
+		t.Error("OnKeyDown not wired")
+	}
+	if s.events.OnClick == nil {
+		t.Error("OnClick not wired")
+	}
+	if s.events.OnMouseScroll == nil {
+		t.Error("OnMouseScroll not wired")
+	}
+	s.events.OnKeyDown(nil, nil, nil)
+	s.events.OnClick(nil, nil, nil)
+	s.events.OnMouseScroll(nil, nil, nil)
+	if !keyDownFired {
+		t.Error("OnKeyDown callback did not fire")
+	}
+	if !clickFired {
+		t.Error("OnClick callback did not fire")
+	}
+	if !scrollFired {
+		t.Error("OnMouseScroll callback did not fire")
+	}
+}
+
+func TestTermGridLayoutNoEventsWhenNoCallbacks(t *testing.T) {
+	w := makeWindowWithScratch()
+	v := TermGrid(TermGridCfg{
+		Cols: 4, Rows: 2, CellW: 8, CellH: 16,
+		Cells: termCells(4, 2),
+	})
+	l := v.GenerateLayout(w)
+	if l.Shape.events != nil {
+		t.Error("expected nil events when no callbacks set")
+	}
+}
+
+func TestTermGridLayoutIDFocusSetsA11YRole(t *testing.T) {
+	w := makeWindowWithScratch()
+	v := TermGrid(TermGridCfg{
+		Cols: 4, Rows: 2, CellW: 8, CellH: 16,
+		Cells:   termCells(4, 2),
+		IDFocus: 1,
+	})
+	l := v.GenerateLayout(w)
+	if l.Shape.A11YRole != AccessRoleTextArea {
+		t.Errorf("A11YRole = %v, want AccessRoleTextArea", l.Shape.A11YRole)
+	}
+}
+
+func TestTermGridLayoutDefaultA11YRoleIsImage(t *testing.T) {
+	w := makeWindowWithScratch()
+	v := TermGrid(TermGridCfg{
+		Cols: 4, Rows: 2, CellW: 8, CellH: 16,
+		Cells: termCells(4, 2),
+	})
+	l := v.GenerateLayout(w)
+	if l.Shape.A11YRole != AccessRoleImage {
+		t.Errorf("A11YRole = %v, want AccessRoleImage", l.Shape.A11YRole)
+	}
+}
+
+func TestTermGridLayoutCustomSizing(t *testing.T) {
+	w := makeWindowWithScratch()
+	v := TermGrid(TermGridCfg{
+		Cols: 4, Rows: 2, CellW: 8, CellH: 16,
+		Cells:  termCells(4, 2),
+		Sizing: FillFill,
+	})
+	l := v.GenerateLayout(w)
+	if l.Shape.Sizing != FillFill {
+		t.Errorf("Sizing = %v, want FillFill", l.Shape.Sizing)
+	}
+}
+
+func TestTermGridLayoutPassesTextStyle(t *testing.T) {
+	w := makeWindowWithScratch()
+	ts := TextStyle{Size: 14}
+	v := TermGrid(TermGridCfg{
+		Cols: 4, Rows: 2,
+		CellW: 8, CellH: 16,
+		Cells:     termCells(4, 2),
+		TextStyle: ts,
+	})
+	l := v.GenerateLayout(w)
+	if l.Shape.tg == nil {
+		t.Fatal("shape.tg is nil")
+	}
+	if l.Shape.tg.Style.Size != 14 {
+		t.Errorf("TermGridData.Style.Size = %v, want 14",
+			l.Shape.tg.Style.Size)
+	}
+}


### PR DESCRIPTION
Closes #30.

## What

`TermGrid` — a fixed-pitch terminal character-grid widget that draws a caller-owned cell buffer in a **single** `RenderTermGrid` command: no per-cell `Layout` node, no per-cell `RenderText`. Built for go-term and reusable by any consumer regenerating thousands of cells per frame.

## Public surface (`gui/termgrid.go`)

`TermGrid`/`TermGridCfg` plus `TermCell`, `TermAttr` (bold/italic/underline/reverse bitset), `TermCursor`, `TermSelRange`. go-gui stays palette/escape-sequence agnostic — the caller pre-resolves each cell's FG/BG to RGBA. Default sizing is Fixed at `Cols*CellW × Rows*CellH`; grows like any other widget.

## Render path

One `RenderTermGrid` command carrying a `*TermGridData` pointer (mirrors `LayoutPtr`/`TextPath`) — no per-cell data copied into the command stream. Wired through `shapeType`, `RenderKind`, `RenderCmd`, and the `render_layout` dispatch.

## Backends — Metal + SDL2

`drawTermGrid` batches same-background runs into fills, shapes each row into foreground-color runs via `LayoutText` (**hits go-glyph's ASCII monospace fast-path automatically**), and pins glyphs to exact cell columns via `DrawLayoutPlaced`, falling back to natural flow on a cluster/ligature mismatch. Honors reverse + underline; bold/italic reserved in `TermAttr` for a follow-up. OpenGL out of scope.

## Tests

Factory validation/panics, single-command emit, no-per-cell-node assertion, clip/degenerate/NaN/Inf skips, event wiring, a11y roles. Adds `shapeTermGrid` to the sizing fuzz corpus. Example in `examples/termgrid` (verified rendering on macOS/Metal).

Local `go build/test/vet ./...` and `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)