### PR TITLE
feat(gui): window vibrancy (macOS NSVisualEffectView backdrop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Window vibrancy** (macOS): `Window.SetWindowVibrancy(VibrancyMaterial)`
+  places a translucent, blurred native `NSVisualEffectView` backdrop behind
+  the window content. Pair with a translucent `WindowCfg.BgColor` (alpha <
+  255) to reveal the backdrop; `VibrancyNone` restores an opaque window.
+  Implemented on the Metal backend (makes the window and its `CAMetalLayer`
+  non-opaque so content composites over the blur); no-op on SDL2, OpenGL,
+  web, iOS, and Android (Linux/Windows are out of scope, matching the
+  `TermGrid` issue). Built for go-term. See `examples/vibrancy`. (#31)
 - **`TermGrid` primitive**: a terminal character-grid widget
   (`TermGrid`/`TermGridCfg`) that draws a fixed-pitch cell buffer in a single
   `RenderTermGrid` command — no per-cell `Layout` node and no per-cell

--- a/examples/vibrancy/main.go
+++ b/examples/vibrancy/main.go
@@ -1,0 +1,68 @@
+// Vibrancy demonstrates a translucent, blurred native window backdrop on
+// macOS via w.SetWindowVibrancy. The window BgColor is translucent (alpha <
+// 255) so the NSVisualEffectView behind the content shows through. On other
+// platforms SetWindowVibrancy is a no-op and the window renders normally.
+package main
+
+import (
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend"
+)
+
+type App struct {
+	Material gui.VibrancyMaterial
+}
+
+func main() {
+	gui.SetTheme(gui.ThemeDark.WithBorders(true))
+
+	w := gui.NewWindow(gui.WindowCfg{
+		State: &App{Material: gui.VibrancyUnderWindow},
+		Title: "vibrancy",
+		Width: 360,
+		// Near-transparent background so the vibrancy backdrop dominates;
+		// a faint tint keeps text legible over the blur.
+		BgColor: gui.RGBA(20, 20, 30, 24),
+		Height:  260,
+		OnInit: func(w *gui.Window) {
+			w.SetWindowVibrancy(gui.State[App](w).Material)
+			w.UpdateView(mainView)
+		},
+	})
+
+	backend.Run(w)
+}
+
+func mainView(w *gui.Window) gui.View {
+	ww, wh := w.WindowSize()
+
+	return gui.Column(gui.ContainerCfg{
+		Width:  float32(ww),
+		Height: float32(wh),
+		Sizing: gui.FixedFixed,
+		HAlign: gui.HAlignCenter,
+		VAlign: gui.VAlignMiddle,
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{
+				Text:      "Vibrant window (macOS)",
+				TextStyle: gui.CurrentTheme().B1,
+			}),
+			gui.Button(gui.ButtonCfg{
+				IDFocus: 1,
+				Content: []gui.View{
+					gui.Text(gui.TextCfg{Text: "Cycle material"}),
+				},
+				OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+					app := gui.State[App](w)
+					// Cycle through the materials, wrapping back to Sidebar.
+					app.Material++
+					if app.Material > gui.VibrancyUnderWindow {
+						app.Material = gui.VibrancySidebar
+					}
+					w.SetWindowVibrancy(app.Material)
+					e.IsHandled = true
+				},
+			}),
+		},
+	})
+}

--- a/examples/vibrancy/main_test.go
+++ b/examples/vibrancy/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestMainViewNoPanic(t *testing.T) {
+	t.Parallel()
+	gui.SetTheme(gui.ThemeDark.WithBorders(true))
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  &App{Material: gui.VibrancyUnderWindow},
+		Width:  360,
+		Height: 260,
+	})
+	// SetWindowVibrancy is a no-op with a nil native platform (tests).
+	w.SetWindowVibrancy(gui.VibrancyUnderWindow)
+	_ = mainView(w).GenerateLayout(w)
+}

--- a/gui/backend/android/native_platform.go
+++ b/gui/backend/android/native_platform.go
@@ -81,6 +81,9 @@ func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
 }
 func (n *nativePlatform) TitlebarDark(_ bool)                     {}
 func (n *nativePlatform) SpellCheck(text string) []gui.SpellRange { return spellcheck.Check(text) }
+
+func (n *nativePlatform) SetWindowVibrancy(_ gui.VibrancyMaterial) {}
+
 func (n *nativePlatform) SpellSuggest(text string, s, l int) []string {
 	return spellcheck.Suggest(text, s, l)
 }

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -73,6 +73,8 @@ func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
 
 func (n *nativePlatform) TitlebarDark(_ bool) {}
 
+func (n *nativePlatform) SetWindowVibrancy(_ gui.VibrancyMaterial) {}
+
 // --- Spell check ---
 
 func (n *nativePlatform) SpellCheck(text string) []gui.SpellRange {

--- a/gui/backend/ios/native_platform.go
+++ b/gui/backend/ios/native_platform.go
@@ -80,6 +80,9 @@ func (n *nativePlatform) IMEStop()                                {}
 func (n *nativePlatform) IMESetRect(_, _, _, _ int32)             {}
 func (n *nativePlatform) TitlebarDark(_ bool)                     {}
 func (n *nativePlatform) SpellCheck(text string) []gui.SpellRange { return spellcheck.Check(text) }
+
+func (n *nativePlatform) SetWindowVibrancy(_ gui.VibrancyMaterial) {}
+
 func (n *nativePlatform) SpellSuggest(text string, s, l int) []string {
 	return spellcheck.Suggest(text, s, l)
 }

--- a/gui/backend/metal/metal_window.h
+++ b/gui/backend/metal/metal_window.h
@@ -122,6 +122,15 @@ int         metalEventIMELength(void); // composition length
 void metalWindowSetCursor(GoGuiNSWindow w, const char *cursorName,
                           float mouseX, float mouseY);
 
+// ─── Vibrancy ──────────────────────────────────────────────────
+
+// Set the window's translucent backdrop material (macOS NSVisualEffectView).
+// material: 0 = None (opaque window, effect removed); 1..N map to
+// NSVisualEffectMaterial (see metalWindowSetVibrancy in the .m file). Makes the
+// window and its CAMetalLayer non-opaque so the backdrop shows through content
+// drawn with a translucent clear color.
+void metalWindowSetVibrancy(GoGuiNSWindow w, int material);
+
 // ─── Clipboard ─────────────────────────────────────────────────
 
 // Get the clipboard text. Returns NULL if empty or not a string.

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -348,6 +348,7 @@ static uint32_t _nextWindowID = 1;
 typedef struct {
     GUIWindow          *nsWindow;
     MetalContentView   *contentView;
+    NSVisualEffectView *effectView;  // vibrancy backdrop; nil when opaque
     uint32_t            windowID;
 } GoGuiWindow;
 
@@ -489,6 +490,59 @@ unsigned int metalWindowGetID(GoGuiNSWindow w) {
     if (!w) return 0;
     GoGuiWindow *gw = (GoGuiWindow *)w;
     return gw->windowID;
+}
+
+// ─── Vibrancy ──────────────────────────────────────────────────
+
+// Map the cross-platform material enum (see gui.VibrancyMaterial) to an
+// NSVisualEffectMaterial. Keep in sync with the Go enum order.
+static NSVisualEffectMaterial vibrancyMaterial(int material) {
+    switch (material) {
+        case 1:  return NSVisualEffectMaterialSidebar;
+        case 2:  return NSVisualEffectMaterialMenu;
+        case 3:  return NSVisualEffectMaterialHUDWindow;
+        case 4:  return NSVisualEffectMaterialUnderWindowBackground;
+        default: return NSVisualEffectMaterialUnderWindowBackground;
+    }
+}
+
+void metalWindowSetVibrancy(GoGuiNSWindow w, int material) {
+    if (!w) return;
+    GoGuiWindow *gw = (GoGuiWindow *)w;
+    CAMetalLayer *layer = (CAMetalLayer *)gw->contentView.layer;
+
+    if (material == 0) {
+        // Disable: remove the backdrop and restore an opaque window.
+        [gw->effectView removeFromSuperview];
+        gw->effectView = nil;
+        gw->nsWindow.opaque = YES;
+        gw->nsWindow.backgroundColor = [NSColor windowBackgroundColor];
+        layer.opaque = YES;
+        return;
+    }
+
+    // Lazily create the effect view and insert it behind the Metal content
+    // view (as a sibling in the window frame). The content view stays the
+    // first responder, so key events, resize, and cursor tracking are
+    // unaffected.
+    if (!gw->effectView) {
+        NSVisualEffectView *fx =
+            [[NSVisualEffectView alloc] initWithFrame:gw->contentView.frame];
+        fx.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+        fx.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+        fx.state = NSVisualEffectStateActive;
+        [gw->contentView.superview addSubview:fx
+                                   positioned:NSWindowBelow
+                                   relativeTo:gw->contentView];
+        gw->effectView = fx;
+    }
+    gw->effectView.material = vibrancyMaterial(material);
+
+    // Make the window and drawable non-opaque so the backdrop shows through
+    // content cleared with a translucent color (see renderFrame in Go).
+    gw->nsWindow.opaque = NO;
+    gw->nsWindow.backgroundColor = [NSColor clearColor];
+    layer.opaque = NO;
 }
 
 // ─── Event callbacks (weak, defined in Go) ─────────────────────

--- a/gui/backend/metal/native_platform.go
+++ b/gui/backend/metal/native_platform.go
@@ -113,6 +113,10 @@ func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
 
 func (n *nativePlatform) TitlebarDark(_ bool) {}
 
+func (n *nativePlatform) SetWindowVibrancy(m gui.VibrancyMaterial) {
+	C.metalWindowSetVibrancy(n.window, C.int(m))
+}
+
 // --- Spell check ---
 
 func (n *nativePlatform) SpellCheck(text string) []gui.SpellRange {

--- a/gui/backend/sdl2/native_platform.go
+++ b/gui/backend/sdl2/native_platform.go
@@ -73,6 +73,8 @@ func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
 
 func (n *nativePlatform) TitlebarDark(_ bool) {}
 
+func (n *nativePlatform) SetWindowVibrancy(_ gui.VibrancyMaterial) {}
+
 // --- Spell check ---
 
 func (n *nativePlatform) SpellCheck(text string) []gui.SpellRange {

--- a/gui/backend/web/native_platform.go
+++ b/gui/backend/web/native_platform.go
@@ -396,6 +396,8 @@ func (n *nativePlatform) IMESetRect(x, y, _, _ int32) {
 
 func (n *nativePlatform) TitlebarDark(_ bool) {}
 
+func (n *nativePlatform) SetWindowVibrancy(_ gui.VibrancyMaterial) {}
+
 // --- Spell check (no browser JS API exposes spell results) ---
 
 func (n *nativePlatform) SpellCheck(_ string) []gui.SpellRange     { return nil }

--- a/gui/native_platform.go
+++ b/gui/native_platform.go
@@ -78,6 +78,7 @@ type NativePlatform interface {
 	NativeSystemTray
 	OpenURI(uri string) error
 	TitlebarDark(dark bool)
+	SetWindowVibrancy(material VibrancyMaterial)
 }
 
 // SpellRange represents a misspelled byte range in text.

--- a/gui/native_platform_noop.go
+++ b/gui/native_platform_noop.go
@@ -44,6 +44,7 @@ func (NoopNativePlatform) IMEStop()                                            {
 func (NoopNativePlatform) IMESetRect(_, _, _, _ int32)                         {}
 func (NoopNativePlatform) OpenURI(_ string) error                              { return nil }
 func (NoopNativePlatform) TitlebarDark(_ bool)                                 {}
+func (NoopNativePlatform) SetWindowVibrancy(_ VibrancyMaterial)                {}
 func (NoopNativePlatform) SpellCheck(_ string) []SpellRange                    { return nil }
 func (NoopNativePlatform) SpellSuggest(_ string, _, _ int) []string            { return nil }
 func (NoopNativePlatform) SpellLearn(_ string)                                 {}

--- a/gui/vibrancy.go
+++ b/gui/vibrancy.go
@@ -1,0 +1,25 @@
+package gui
+
+// VibrancyMaterial selects the macOS NSVisualEffectView material shown behind
+// a vibrant window. macOS-only; other platforms treat every value as a no-op.
+type VibrancyMaterial uint8
+
+// VibrancyMaterial constants. VibrancyNone disables the effect and restores an
+// opaque window.
+const (
+	VibrancyNone VibrancyMaterial = iota // no effect (opaque window)
+	VibrancySidebar
+	VibrancyMenu
+	VibrancyHUD
+	VibrancyUnderWindow
+)
+
+// SetWindowVibrancy places a translucent native backdrop (blur) behind the
+// window content. macOS only; no-op on other platforms or when no native
+// platform is set. Pair with a translucent WindowCfg.BgColor (alpha < 255) so
+// the backdrop shows through the rendered content.
+func (w *Window) SetWindowVibrancy(m VibrancyMaterial) {
+	if w.nativePlatform != nil {
+		w.nativePlatform.SetWindowVibrancy(m)
+	}
+}

--- a/gui/vibrancy_test.go
+++ b/gui/vibrancy_test.go
@@ -1,0 +1,11 @@
+package gui
+
+import "testing"
+
+func TestSetWindowVibrancyNilPlatform(_ *testing.T) {
+	w := NewWindow(WindowCfg{})
+	defer w.Close()
+	// Should not panic with nil nativePlatform.
+	w.SetWindowVibrancy(VibrancyUnderWindow)
+	w.SetWindowVibrancy(VibrancyNone)
+}


### PR DESCRIPTION
## Summary

Adds `Window.SetWindowVibrancy(VibrancyMaterial)`, which places a translucent, blurred native `NSVisualEffectView` backdrop behind the window content. Pair with a translucent `WindowCfg.BgColor` (alpha < 255) to reveal the backdrop; `VibrancyNone` restores an opaque window.

Built for go-term.

## Details

- **New API** (`gui/vibrancy.go`): `VibrancyMaterial` enum (`VibrancyNone`, `VibrancySidebar`, `VibrancyMenu`, `VibrancyHUD`, `VibrancyUnderWindow`) + `(*Window).SetWindowVibrancy`. No-op when no native platform is set.
- **Metal backend** (`gui/backend/metal/`): real implementation. Lazily inserts an `NSVisualEffectView` (blend mode *behind window*, active state) as a sibling below the Metal content view, and makes the window + `CAMetalLayer` non-opaque so content clears over the blur. Content view stays first responder — key events, resize, and cursor tracking are unaffected. `VibrancyNone` removes the backdrop and restores opacity.
- **Other backends** (SDL2, OpenGL, web, iOS, Android): no-op stubs satisfying the `NativePlatform` interface. Linux/Windows out of scope (matches the `TermGrid` issue).
- **Example**: `examples/vibrancy`.
- **Test**: nil-platform safety check (no panic).

## Testing

- `go build ./...` ✓
- `go test ./...` — 5276 passed across 84 packages ✓
- `golangci-lint run ./...` — 0 issues ✓

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)