### PR TITLE
feat(backend): SDL2-free native Win32+WGL backend on Windows (#37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
             mingw-w64-x86_64-harfbuzz
             mingw-w64-x86_64-pango
             mingw-w64-x86_64-fontconfig
+            mingw-w64-x86_64-mesa
 
       - uses: actions/checkout@v6
 
@@ -274,6 +275,12 @@ jobs:
 
       - name: Smoke test showcase
         run: |
+          # The runner has no GPU: system opengl32.dll is GDI-generic
+          # OpenGL 1.1, but the native backend needs 3.3. Drop Mesa's
+          # software opengl32.dll (llvmpipe) next to the exe so the
+          # app-dir DLL search resolves it first.
+          cp /mingw64/bin/opengl32.dll build/
+          export GALLIUM_DRIVER=llvmpipe
           echo "Launching showcase (10s timeout to catch DLL load failures)..."
           ./build/showcase-windows.exe &
           PID=$!

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -21,6 +21,7 @@ Go toolchain pin: `go 1.26.0`.
 | `github.com/yuin/goldmark` | v1.8.2 | Markdown parser (markdown widget + showcase docs). |
 | `github.com/yuin/goldmark-emoji` | v1.0.6 | Goldmark extension: `:emoji:` shortcodes. |
 | `golang.org/x/mod` | v0.37.0 | Module version parsing; imported by `requiredid` analyzer. |
+| `golang.org/x/sys` | v0.46.0 | Win32 + WGL syscalls for the native Windows backend (`gui/backend/gl`, `winkey`). |
 | `golang.org/x/tools` | v0.46.0 | `go/analysis` framework for the `requiredid` analyzer (`tools/`). |
 
 ## Indirect Dependencies
@@ -33,7 +34,6 @@ Pulled in transitively; listed for completeness.
 | `github.com/rivo/uniseg` | v0.4.7 | grapheme segmentation (chroma/glyph) |
 | `golang.org/x/mobile` | v0.0.0-20260602190626-68735029466e | gobind tool (Android AAR builds) |
 | `golang.org/x/sync` | v0.21.0 | x/tools |
-| `golang.org/x/sys` | v0.46.0 | sdl2 / godbus |
 | `golang.org/x/text` | v0.38.0 | misc. text processing (transitive) |
 
 ## Updating

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/yuin/goldmark v1.8.2
 	github.com/yuin/goldmark-emoji v1.0.6
 	golang.org/x/mod v0.37.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/tools v0.46.0
 )
 
@@ -22,7 +23,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/mobile v0.0.0-20260602190626-68735029466e // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 )
 

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -1,19 +1,23 @@
 //go:build !js
 
 // Package gl provides an OpenGL 3.3 backend for go-gui.
+//
+// Windowing, GL-context creation, and the event loop are
+// platform-specific and selected by build tag: SDL2 on non-Windows
+// (platform_sdl2.go), native Win32 + WGL on Windows (platform_win32.go).
+// The rendering pipeline in this and the other shared files
+// (draw.go, pipeline.go, buffers.go, textures.go, rotation.go,
+// text.go) is pure OpenGL and platform-agnostic.
 package gl
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 
 	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gui-org/go-glyph"
-	"github.com/veandco/go-sdl2/sdl"
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
@@ -23,15 +27,15 @@ import (
 	"github.com/go-gui-org/go-gui/gui/svg"
 )
 
-// Backend is the OpenGL 3.3 backend for go-gui.
+// Backend is the OpenGL 3.3 backend for go-gui. Platform-specific
+// windowing state lives in plat (platformState), defined per platform.
 type Backend struct {
+	plat platformState
+
 	pipelines pipelineSet
-	cursors   [11]*sdl.Cursor
 
 	textures          texcache.Cache[string, glTexture]
 	imagePathCache    texcache.Cache[string, string]
-	window            *sdl.Window
-	glCtx             sdl.GLContext
 	textSys           *glyph.TextSystem
 	filterColorMatrix *[16]float32
 
@@ -52,13 +56,12 @@ type Backend struct {
 	maxImagePixels    int64
 	mvp               [16]float32
 
-	customOnce sync.Once
-	dpiScale   float32
-	physW      int32
-	physH      int32
-	quadVAO    uint32
-	quadVBO    uint32
-	quadIBO    uint32
+	dpiScale float32
+	physW    int32
+	physH    int32
+	quadVAO  uint32
+	quadVBO  uint32
+	quadIBO  uint32
 
 	// Reusable buffers.
 	svgVAO        uint32
@@ -70,544 +73,73 @@ type Backend struct {
 	filterW       int32
 	filterH       int32
 	filterBlur    float32
+
+	customOnce sync.Once
 }
 
-// New creates an OpenGL 3.3 backend and initializes the window.
-func New(w *gui.Window) (*Backend, error) {
-	runtime.LockOSThread()
-
-	if err := sdl.Init(sdl.INIT_VIDEO | sdl.INIT_EVENTS); err != nil {
-		return nil, fmt.Errorf("gl: Init: %w", err)
-	}
-
-	// Request OpenGL 3.3 core profile.
-	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_MAJOR_VERSION, 3)
-	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_MINOR_VERSION, 3)
-	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_PROFILE_MASK,
-		sdl.GL_CONTEXT_PROFILE_CORE)
-	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_FLAGS,
-		sdl.GL_CONTEXT_FORWARD_COMPATIBLE_FLAG)
-	_ = sdl.GLSetAttribute(sdl.GL_DOUBLEBUFFER, 1)
-	_ = sdl.GLSetAttribute(sdl.GL_STENCIL_SIZE, 8)
-
-	cfg := w.Config
-	title := cfg.Title
-	if title == "" {
-		title = "go-gui"
-	}
-	width := int32(cfg.Width)
-	if width <= 0 {
-		width = 640
-	}
-	height := int32(cfg.Height)
-	if height <= 0 {
-		height = 480
-	}
-	flags := uint32(sdl.WINDOW_SHOWN | sdl.WINDOW_ALLOW_HIGHDPI | sdl.WINDOW_OPENGL)
-	if !cfg.FixedSize {
-		flags |= sdl.WINDOW_RESIZABLE
-	}
-
-	win, err := sdl.CreateWindow(
-		title,
-		sdl.WINDOWPOS_CENTERED, sdl.WINDOWPOS_CENTERED,
-		width, height,
-		flags,
-	)
-	if err != nil {
-		sdl.Quit()
-		return nil, fmt.Errorf("gl: CreateWindow: %w", err)
-	}
-
-	glCtx, err := win.GLCreateContext()
-	if err != nil {
-		_ = win.Destroy()
-		sdl.Quit()
-		return nil, fmt.Errorf(
-			"gl: GLCreateContext: %w — OpenGL 3.3 required. "+
-				"Install GPU drivers with OpenGL 3.3+ support, or "+
-				"drop the -tags gl build tag to use the default SDL2 renderer", err)
-	}
-
-	if err := gl.Init(); err != nil {
-		sdl.GLDeleteContext(glCtx)
-		_ = win.Destroy()
-		sdl.Quit()
-		return nil, fmt.Errorf("gl: gl.Init: %w", err)
-	}
-
-	// Enable vsync.
-	_ = sdl.GLSetSwapInterval(1)
-
-	// Compute DPI scale.
-	glW, glH := win.GLGetDrawableSize()
-	winW, _ := win.GetSize()
-	dpiScale := float32(1.0)
-	if winW > 0 {
-		dpiScale = float32(glW) / float32(winW)
-	}
-
-	b := &Backend{
-		window:         win,
-		glCtx:          glCtx,
-		dpiScale:       dpiScale,
-		physW:          glW,
-		physH:          glH,
-		textures:       newGLTexCacheLRU(128),
-		imagePathCache: texcache.New[string, string](1024, nil),
-		maxImageBytes:  cfg.MaxImageBytes,
-		maxImagePixels: cfg.MaxImagePixels,
-	}
+// initCaches initializes the platform-neutral caches and image
+// limits from the window config.
+func (b *Backend) initCaches(cfg gui.WindowCfg) {
+	b.textures = newGLTexCacheLRU(128)
+	b.imagePathCache = texcache.New[string, string](1024, nil)
+	b.maxImageBytes = cfg.MaxImageBytes
+	b.maxImagePixels = cfg.MaxImagePixels
 	b.allowedImageRoots = imgpath.NormalizeRoots(cfg.AllowedImageRoots)
+}
 
-	// Initialize GL state.
+// initGLResources sets up GL state, shader pipelines, buffers, and
+// the glyph text system, then wires the platform-neutral injected
+// interfaces onto the window. b.physW, b.physH, and b.dpiScale must
+// be set before calling. The GL context must already be current.
+func (b *Backend) initGLResources(w *gui.Window) error {
 	gl.Enable(gl.BLEND)
 	gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Disable(gl.CULL_FACE)
-	gl.Viewport(0, 0, glW, glH)
+	gl.Viewport(0, 0, b.physW, b.physH)
 
-	// Compile shader pipelines.
 	if err := b.initPipelines(); err != nil {
-		sdl.GLDeleteContext(glCtx)
-		_ = win.Destroy()
-		sdl.Quit()
-		return nil, fmt.Errorf("gl: initPipelines: %w", err)
+		return err
 	}
-
-	// Initialize quad buffers.
 	b.initQuadBuffers()
 	b.initSvgBuffers()
-
-	// Build ortho projection.
 	b.updateProjection()
 
-	// Initialize glyph text system with GL backend.
-	b.glyphBack = newGlyphBackend(dpiScale)
+	b.glyphBack = newGlyphBackend(b.dpiScale)
 	textSys, err := glyph.NewTextSystem(b.glyphBack)
 	if err != nil {
-		b.Destroy()
-		return nil, fmt.Errorf("gl: NewTextSystem: %w", err)
+		return err
 	}
 	b.textSys = textSys
 
-	// Load embedded icon font. File must persist because
-	// FontConfig registers the path; FreeType reads it lazily.
+	// Load embedded icon font. File must persist because FontConfig
+	// registers the path; FreeType reads it lazily.
 	if data := gui.IconFontData; len(data) > 0 {
-		tmp, err := tempfont.Write("go_gui_feathericon", data)
-		if err != nil {
-			log.Printf("gl: write icon font: %v", err)
-		} else if err := textSys.AddFontFile(tmp); err != nil {
-			log.Printf("gl: load icon font: %v", err)
+		tmp, ferr := tempfont.Write("go_gui_feathericon", data)
+		if ferr != nil {
+			log.Printf("gl: write icon font: %v", ferr)
+		} else if aerr := textSys.AddFontFile(tmp); aerr != nil {
+			log.Printf("gl: load icon font: %v", aerr)
 			_ = os.Remove(tmp)
 		} else {
 			b.iconFontPath = tmp
 		}
 	}
-
 	for _, p := range gui.AppFontPaths {
-		if err := textSys.AddFontFile(p); err != nil {
-			log.Printf("gl: load app font %q: %v", filepath.Base(p), err)
+		if aerr := textSys.AddFontFile(p); aerr != nil {
+			log.Printf("gl: load app font %q: %v", filepath.Base(p), aerr)
 		}
 	}
 
-	// Create system cursors.
-	b.cursors[gui.CursorDefault] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_ARROW)
-	b.cursors[gui.CursorArrow] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_ARROW)
-	b.cursors[gui.CursorIBeam] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_IBEAM)
-	b.cursors[gui.CursorCrosshair] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_CROSSHAIR)
-	b.cursors[gui.CursorPointingHand] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_HAND)
-	b.cursors[gui.CursorResizeEW] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZEWE)
-	b.cursors[gui.CursorResizeNS] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZENS)
-	b.cursors[gui.CursorResizeNWSE] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZENWSE)
-	b.cursors[gui.CursorResizeNESW] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZENESW)
-	b.cursors[gui.CursorResizeAll] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZEALL)
-	b.cursors[gui.CursorNotAllowed] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_NO)
-
-	// Set injected interfaces on gui Window.
 	w.SetTextMeasurer(&textMeasurer{textSys: textSys})
 	w.SetSvgParser(svg.New())
-	w.SetClipboardFn(func(text string) {
-		if err := sdl.SetClipboardText(text); err != nil {
-			log.Printf("gl: set clipboard: %v", err)
-		}
-	})
-	w.SetClipboardGetFn(func() string {
-		text, _ := sdl.GetClipboardText()
-		return text
-	})
-	w.SetTitleFn(func(t string) {
-		b.window.SetTitle(t)
-	})
 	w.SetNativePlatform(&nativePlatform{})
-
-	return b, nil
-}
-
-// Run starts the event loop. Blocks until quit.
-func (b *Backend) Run(w *gui.Window) {
-	defer w.WindowCleanup()
-	if w.Config.OnInit != nil {
-		w.Config.OnInit(w)
-	}
-
-	// Register event watcher for live resize on macOS and Windows.
-	// During window drag-resize, the OS enters a modal loop that
-	// blocks PollEvent. This callback fires from within that
-	// loop, allowing re-layout and re-render at the new size.
-	resizeEvent := &gui.Event{Type: gui.EventResized}
-	var watchHandle sdl.EventWatchHandle
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		watchHandle = sdl.AddEventWatchFunc(
-			func(ev sdl.Event, _ any) bool {
-				we, ok := ev.(*sdl.WindowEvent)
-				if !ok || we.Event != sdl.WINDOWEVENT_SIZE_CHANGED {
-					return true
-				}
-				b.handleResize()
-				resizeEvent.WindowWidth = int(we.Data1)
-				resizeEvent.WindowHeight = int(we.Data2)
-				w.EventFn(resizeEvent)
-				w.FrameFn()
-				b.renderFrame(w)
-				return true
-			}, nil)
-		defer sdl.DelEventWatch(watchHandle)
-	}
-
-	wakeType := sdl.RegisterEvents(1)
-	w.SetWakeMainFn(func() {
-		_, _ = sdl.PushEvent(&sdl.UserEvent{Type: wakeType})
-	})
-
-	running := true
-	rendered := true
-	evt := new(gui.Event)
-	for running {
-		waitMs := 0
-		if !rendered {
-			waitMs = 100
-		}
-		for ev := sdl.WaitEventTimeout(waitMs); ev != nil; ev = sdl.PollEvent() {
-			mapped, cont := mapEvent(ev, b)
-			*evt = mapped
-			if !cont {
-				running = false
-				break
-			}
-			if evt.Type != gui.EventInvalid {
-				w.EventFn(evt)
-			}
-		}
-		if !running {
-			break
-		}
-
-		rendered = w.FrameFn()
-		if rendered {
-			b.renderFrame(w)
-		}
-
-		mc := w.MouseCursorState()
-		if int(mc) < len(b.cursors) && b.cursors[mc] != nil {
-			sdl.SetCursor(b.cursors[mc])
-		}
-	}
-}
-
-// renderFrame clears the screen, draws the current layout, and
-// swaps buffers. Makes this window's GL context current first.
-func (b *Backend) renderFrame(w *gui.Window) {
-	_ = b.window.GLMakeCurrent(b.glCtx)
-	bg := w.Config.BgColor
-	if bg == (gui.Color{}) {
-		t := gui.CurrentTheme()
-		bg = t.ColorBackground
-	}
-	gl.ClearColor(
-		float32(bg.R)/255.0,
-		float32(bg.G)/255.0,
-		float32(bg.B)/255.0,
-		float32(bg.A)/255.0,
-	)
-	gl.Disable(gl.SCISSOR_TEST)
-	gl.Clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT)
-
-	w.Lock()
-	w.BackingScale = b.dpiScale
-	b.renderersDraw(w)
-	w.Unlock()
-
-	b.textSys.Commit()
-	b.window.GLSwap()
-}
-
-func (b *Backend) handleResize() {
-	glW, glH := b.window.GLGetDrawableSize()
-	b.physW = glW
-	b.physH = glH
-	winW, _ := b.window.GetSize()
-	if winW > 0 {
-		b.dpiScale = float32(glW) / float32(winW)
-	}
-	gl.Viewport(0, 0, glW, glH)
-	b.updateProjection()
-}
-
-func (b *Backend) updateProjection() {
-	gpu.Ortho(&b.mvp,
-		0, float32(b.physW),
-		float32(b.physH), 0,
-		-1, 1)
-}
-
-// Run initializes the GL backend, runs the event loop, and cleans
-// up on exit. Panics on error; call RunE for error-returning variant.
-func Run(w *gui.Window) {
-	if err := RunE(w); err != nil {
-		panic(fmt.Sprintf("gl: %v", err))
-	}
-}
-
-// RunE initializes the GL backend, runs the event loop, and cleans
-// up on exit. Returns an error instead of panicking so embedders
-// and tests can handle backend init failures gracefully.
-func RunE(w *gui.Window) error {
-	b, err := New(w)
-	if err != nil {
-		return fmt.Errorf("gl: %w", err)
-	}
-	defer b.Destroy()
-	b.Run(w)
 	return nil
 }
 
-// RunApp starts a multi-window event loop. Panics on error; call
-// RunAppE for error-returning variant.
-func RunApp(app *gui.App, initialWindows ...*gui.Window) {
-	if err := RunAppE(app, initialWindows...); err != nil {
-		panic(fmt.Sprintf("gl: %v", err))
-	}
-}
-
-// RunAppE starts a multi-window event loop. Each window in
-// initialWindows is created and registered with app. Blocks
-// until the app signals exit. Returns an error instead of
-// panicking so embedders and tests can handle init failures.
-//
-//nolint:gocyclo // backend event loop
-func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
-	runtime.LockOSThread()
-
-	if err := sdl.Init(sdl.INIT_VIDEO | sdl.INIT_EVENTS); err != nil {
-		return fmt.Errorf("gl: Init: %w", err)
-	}
-	defer sdl.Quit()
-
-	backends := make(map[uint32]*Backend)
-
-	// Create initial windows.
-	for _, w := range initialWindows {
-		b, err := New(w)
-		if err != nil {
-			return fmt.Errorf("gl: create window: %w", err)
-		}
-		sdlID, _ := b.window.GetID()
-		backends[sdlID] = b
-		app.Register(sdlID, w)
-		if w.Config.OnInit != nil {
-			w.Config.OnInit(w)
-		}
-	}
-
-	// Event watcher for live resize on macOS and Windows.
-	resizeEvent := &gui.Event{Type: gui.EventResized}
-	var watchHandle sdl.EventWatchHandle
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		watchHandle = sdl.AddEventWatchFunc(
-			func(ev sdl.Event, _ any) bool {
-				we, ok := ev.(*sdl.WindowEvent)
-				if !ok ||
-					we.Event != sdl.WINDOWEVENT_SIZE_CHANGED {
-					return true
-				}
-				wid := we.WindowID
-				b := backends[wid]
-				w := app.Window(wid)
-				if b == nil || w == nil {
-					return true
-				}
-				b.handleResize()
-				resizeEvent.WindowID = wid
-				resizeEvent.WindowWidth = int(we.Data1)
-				resizeEvent.WindowHeight = int(we.Data2)
-				w.EventFn(resizeEvent)
-				w.FrameFn()
-				b.renderFrame(w)
-				return true
-			}, nil)
-		defer sdl.DelEventWatch(watchHandle)
-	}
-
-	wakeType := sdl.RegisterEvents(1)
-	setWakeFn := func(w *gui.Window) {
-		w.SetWakeMainFn(func() {
-			_, _ = sdl.PushEvent(&sdl.UserEvent{Type: wakeType})
-		})
-	}
-	for _, w := range initialWindows {
-		setWakeFn(w)
-	}
-
-	running := true
-	rendered := true
-	evt := new(gui.Event)
-
-	for running {
-		// Drain pending window opens.
-	drain:
-		for {
-			select {
-			case cfg := <-app.PendingOpen():
-				w := gui.NewWindow(cfg)
-				b, err := New(w)
-				if err != nil {
-					log.Printf("gl: open window: %v", err)
-					continue
-				}
-				sdlID, _ := b.window.GetID()
-				backends[sdlID] = b
-				app.Register(sdlID, w)
-				setWakeFn(w)
-				if cfg.OnInit != nil {
-					cfg.OnInit(w)
-				}
-			default:
-				break drain
-			}
-		}
-
-		// Poll events. When idle, wait up to 100ms.
-		waitMs := 0
-		if !rendered {
-			waitMs = 100
-		}
-		for ev := sdl.WaitEventTimeout(waitMs); ev != nil; ev = sdl.PollEvent() {
-			wid := sdlEventWindowID(ev)
-			mapped, cont := mapEventMulti(ev, backends[wid])
-			*evt = mapped
-			evt.WindowID = wid
-			if !cont {
-				// QuitEvent — dispatch to per-window hooks.
-				if !gui.DispatchQuitRequest(app) {
-					running = false
-				}
-				break
-			}
-			if evt.Type == gui.EventInvalid {
-				continue
-			}
-
-			// Window close event — dispatch to hook or closeReq.
-			if isWindowClose(ev) {
-				gui.DispatchCloseRequest(app.Window(wid))
-				continue
-			}
-
-			if w := app.Window(wid); w != nil {
-				w.EventFn(evt)
-			}
-		}
-		if !running {
-			break
-		}
-
-		// Handle close requests.
-		for wid, b := range backends {
-			w := app.Window(wid)
-			if w == nil || !w.CloseRequested() {
-				continue
-			}
-			w.WindowCleanup()
-			b.Destroy()
-			delete(backends, wid)
-			if app.Unregister(wid) {
-				running = false
-				break
-			}
-		}
-		if !running {
-			break
-		}
-
-		// Frame + render each window.
-		rendered = false
-		for wid, b := range backends {
-			w := app.Window(wid)
-			if w == nil {
-				continue
-			}
-			if w.FrameFn() {
-				b.renderFrame(w)
-				rendered = true
-			}
-		}
-
-		// Cursor for focused window.
-		if focused := sdl.GetKeyboardFocus(); focused != nil {
-			fid, _ := focused.GetID()
-			if w := app.Window(fid); w != nil {
-				if b := backends[fid]; b != nil {
-					mc := w.MouseCursorState()
-					if int(mc) < len(b.cursors) &&
-						b.cursors[mc] != nil {
-						sdl.SetCursor(b.cursors[mc])
-					}
-				}
-			}
-		}
-	}
-
-	// Cleanup remaining windows.
-	for wid, b := range backends {
-		if w := app.Window(wid); w != nil {
-			w.WindowCleanup()
-		}
-		b.Destroy()
-		delete(backends, wid)
-	}
-	return nil
-}
-
-// sdlEventWindowID extracts the SDL window ID from any event.
-func sdlEventWindowID(ev sdl.Event) uint32 {
-	switch e := ev.(type) {
-	case *sdl.WindowEvent:
-		return e.WindowID
-	case *sdl.MouseButtonEvent:
-		return e.WindowID
-	case *sdl.MouseMotionEvent:
-		return e.WindowID
-	case *sdl.MouseWheelEvent:
-		return e.WindowID
-	case *sdl.KeyboardEvent:
-		return e.WindowID
-	case *sdl.TextInputEvent:
-		return e.WindowID
-	case *sdl.TextEditingEvent:
-		return e.WindowID
-	}
-	return 0
-}
-
-// isWindowClose returns true if the event is a window close.
-func isWindowClose(ev sdl.Event) bool {
-	we, ok := ev.(*sdl.WindowEvent)
-	return ok && we.Event == sdl.WINDOWEVENT_CLOSE
-}
-
-// Destroy releases all backend resources.
-func (b *Backend) Destroy() {
+// destroyGLResources releases all GL and glyph resources. Safe to
+// call with partially-initialized state.
+func (b *Backend) destroyGLResources() {
 	b.textures.DestroyAll()
 	b.destroyPipelines()
 	if b.quadVAO != 0 {
@@ -636,17 +168,47 @@ func (b *Backend) Destroy() {
 		_ = os.Remove(b.iconFontPath)
 		b.iconFontPath = ""
 	}
-	for i, c := range b.cursors {
-		if c != nil {
-			sdl.FreeCursor(c)
-			b.cursors[i] = nil
-		}
+}
+
+// renderFrame clears the screen, draws the current layout, and swaps
+// buffers. Makes this window's GL context current first.
+func (b *Backend) renderFrame(w *gui.Window) {
+	b.plat.makeCurrent()
+	bg := w.Config.BgColor
+	if bg == (gui.Color{}) {
+		t := gui.CurrentTheme()
+		bg = t.ColorBackground
 	}
-	if b.glCtx != nil {
-		sdl.GLDeleteContext(b.glCtx)
-	}
-	if b.window != nil {
-		_ = b.window.Destroy()
-	}
-	sdl.Quit()
+	gl.ClearColor(
+		float32(bg.R)/255.0,
+		float32(bg.G)/255.0,
+		float32(bg.B)/255.0,
+		float32(bg.A)/255.0,
+	)
+	gl.Disable(gl.SCISSOR_TEST)
+	gl.Clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT)
+
+	w.Lock()
+	w.BackingScale = b.dpiScale
+	b.renderersDraw(w)
+	w.Unlock()
+
+	b.textSys.Commit()
+	b.plat.swap()
+}
+
+// handleResize refreshes the drawable size and DPI scale from the
+// platform window and updates the viewport and projection.
+func (b *Backend) handleResize() {
+	b.physW, b.physH = b.plat.drawableSize()
+	b.dpiScale = b.plat.dpiScale()
+	gl.Viewport(0, 0, b.physW, b.physH)
+	b.updateProjection()
+}
+
+func (b *Backend) updateProjection() {
+	gpu.Ortho(&b.mvp,
+		0, float32(b.physW),
+		float32(b.physH), 0,
+		-1, 1)
 }

--- a/gui/backend/gl/events_sdl2.go
+++ b/gui/backend/gl/events_sdl2.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !windows && !js
 
 package gl
 

--- a/gui/backend/gl/events_win32.go
+++ b/gui/backend/gl/events_win32.go
@@ -1,0 +1,240 @@
+//go:build windows && !js
+
+package gl
+
+import (
+	"unicode/utf16"
+	"unsafe"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/winkey"
+)
+
+// Win32 window messages (subset).
+const (
+	wmSize        = 0x0005
+	wmSetFocus    = 0x0007
+	wmKillFocus   = 0x0008
+	wmPaint       = 0x000F
+	wmClose       = 0x0010
+	wmEraseBkgnd  = 0x0014
+	wmSetCursor   = 0x0020
+	wmKeyDown     = 0x0100
+	wmKeyUp       = 0x0101
+	wmChar        = 0x0102
+	wmSysKeyDown  = 0x0104
+	wmSysKeyUp    = 0x0105
+	wmMouseMove   = 0x0200
+	wmLButtonDown = 0x0201
+	wmLButtonUp   = 0x0202
+	wmRButtonDown = 0x0204
+	wmRButtonUp   = 0x0205
+	wmMButtonDown = 0x0207
+	wmMButtonUp   = 0x0208
+	wmMouseWheel  = 0x020A
+	wmMouseHWheel = 0x020E
+	wmApp         = 0x8000
+
+	htClient      = 1
+	sizeMinimized = 1
+	wheelDelta    = 120
+	keyRepeatBit  = 0x40000000 // lParam bit 30: previous key state
+)
+
+func loWordS(v uintptr) int32 { return int32(int16(v & 0xFFFF)) }
+func hiWordS(v uintptr) int32 { return int32(int16((v >> 16) & 0xFFFF)) }
+
+// emit dispatches an event, reusing a single gui.Event stored on the
+// platform state to avoid a heap allocation per message. EventFn does
+// not retain the pointer beyond the call (same contract the SDL2 path
+// relies on).
+func (b *Backend) emit(e gui.Event) {
+	b.plat.evt = e
+	b.plat.w.EventFn(&b.plat.evt)
+}
+
+// logicalXY converts physical client-pixel coordinates to logical
+// points using the current DPI scale.
+func (b *Backend) logicalXY(px, py int32) (float32, float32) {
+	s := b.dpiScale
+	if s <= 0 {
+		s = 1
+	}
+	return float32(px) / s, float32(py) / s
+}
+
+// handleMessage translates a window message to a gui.Event and
+// dispatches it. Returns (result, true) when the message is fully
+// handled, or (0, false) to defer to DefWindowProc.
+//
+//nolint:gocyclo // message dispatch switch
+func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
+	w := b.plat.w
+	switch msg {
+	case wmMouseMove:
+		x, y := b.logicalXY(loWordS(lparam), hiWordS(lparam))
+		b.emit(gui.Event{
+			Type:      gui.EventMouseMove,
+			MouseX:    x,
+			MouseY:    y,
+			Modifiers: winkey.ModState() | winkey.MouseButtons(wparam),
+		})
+		return 0, true
+
+	case wmLButtonDown:
+		return b.mouseButton(gui.EventMouseDown, gui.MouseLeft, lparam, true)
+	case wmLButtonUp:
+		return b.mouseButton(gui.EventMouseUp, gui.MouseLeft, lparam, false)
+	case wmRButtonDown:
+		return b.mouseButton(gui.EventMouseDown, gui.MouseRight, lparam, true)
+	case wmRButtonUp:
+		return b.mouseButton(gui.EventMouseUp, gui.MouseRight, lparam, false)
+	case wmMButtonDown:
+		return b.mouseButton(gui.EventMouseDown, gui.MouseMiddle, lparam, true)
+	case wmMButtonUp:
+		return b.mouseButton(gui.EventMouseUp, gui.MouseMiddle, lparam, false)
+
+	case wmMouseWheel:
+		return b.mouseWheel(0, float32(hiWordS(wparam))/wheelDelta, lparam)
+	case wmMouseHWheel:
+		return b.mouseWheel(float32(hiWordS(wparam))/wheelDelta, 0, lparam)
+
+	case wmKeyDown, wmSysKeyDown:
+		b.emit(gui.Event{
+			Type:      gui.EventKeyDown,
+			KeyCode:   winkey.MapVKey(wparam),
+			Modifiers: winkey.ModState(),
+			KeyRepeat: lparam&keyRepeatBit != 0,
+		})
+		return 0, true
+	case wmKeyUp, wmSysKeyUp:
+		b.emit(gui.Event{
+			Type:      gui.EventKeyUp,
+			KeyCode:   winkey.MapVKey(wparam),
+			Modifiers: winkey.ModState(),
+		})
+		return 0, true
+
+	case wmChar:
+		return b.charInput(wparam)
+
+	case wmSize:
+		if wparam == sizeMinimized {
+			return 0, true
+		}
+		// Refresh physical size + DPI, then derive the logical size
+		// from the authoritative client rect rather than lParam's
+		// 16-bit words (which sign-extend past 32767).
+		b.handleResize()
+		lw, lh := b.logicalXY(b.physW, b.physH)
+		b.emit(gui.Event{
+			Type:         gui.EventResized,
+			WindowWidth:  int(lw),
+			WindowHeight: int(lh),
+		})
+		// Repaint live during modal drag-resize.
+		w.FrameFn()
+		b.renderFrame(w)
+		return 0, true
+
+	case wmPaint:
+		pValidateRect.Call(b.plat.hwnd, 0)
+		return 0, true
+	case wmEraseBkgnd:
+		return 1, true // avoid background flicker; GL clears each frame
+
+	case wmSetFocus:
+		b.emit(gui.Event{Type: gui.EventFocused})
+		return 0, true
+	case wmKillFocus:
+		b.emit(gui.Event{Type: gui.EventUnfocused})
+		return 0, true
+
+	case wmSetCursor:
+		if loWordS(lparam) == htClient {
+			if b.plat.curCursor != 0 {
+				pSetCursor.Call(b.plat.curCursor)
+			}
+			return 1, true
+		}
+		return 0, false
+
+	case wmClose:
+		gui.DispatchCloseRequest(w)
+		return 0, true
+	}
+	return 0, false
+}
+
+func (b *Backend) mouseButton(t gui.EventType, btn gui.MouseButton,
+	lparam uintptr, down bool) (uintptr, bool) {
+
+	if down {
+		pSetCapture.Call(b.plat.hwnd)
+	} else {
+		pReleaseCapture.Call()
+	}
+	x, y := b.logicalXY(loWordS(lparam), hiWordS(lparam))
+	b.emit(gui.Event{
+		Type:        t,
+		MouseX:      x,
+		MouseY:      y,
+		MouseButton: btn,
+		Modifiers:   winkey.ModState(),
+	})
+	return 0, true
+}
+
+func (b *Backend) mouseWheel(sx, sy float32, lparam uintptr) (uintptr, bool) {
+	// Wheel coordinates are screen-relative; convert to client.
+	pt := pointW{x: loWordS(lparam), y: hiWordS(lparam)}
+	pScreenToClient.Call(b.plat.hwnd, uintptr(unsafe.Pointer(&pt)))
+	x, y := b.logicalXY(pt.x, pt.y)
+	b.emit(gui.Event{
+		Type:      gui.EventMouseScroll,
+		ScrollX:   sx,
+		ScrollY:   sy,
+		MouseX:    x,
+		MouseY:    y,
+		Modifiers: winkey.ModState(),
+	})
+	return 0, true
+}
+
+// charInput handles WM_CHAR, reassembling UTF-16 surrogate pairs and
+// filtering control characters (which arrive as key events instead).
+func (b *Backend) charInput(wparam uintptr) (uintptr, bool) {
+	c := uint16(wparam)
+	if utf16.IsSurrogate(rune(c)) {
+		if c >= 0xD800 && c <= 0xDBFF {
+			b.plat.highSurr = c
+			return 0, true
+		}
+		// Low surrogate: combine with the pending high surrogate.
+		if b.plat.highSurr != 0 {
+			r := utf16.DecodeRune(rune(b.plat.highSurr), rune(c))
+			b.plat.highSurr = 0
+			b.emitChar(r)
+		}
+		return 0, true
+	}
+	b.plat.highSurr = 0
+	r := rune(c)
+	if r < 0x20 || r == 0x7F {
+		return 0, true // control chars come through as key events
+	}
+	b.emitChar(r)
+	return 0, true
+}
+
+func (b *Backend) emitChar(r rune) {
+	if r == 0xFFFD {
+		return
+	}
+	b.emit(gui.Event{
+		Type:      gui.EventChar,
+		CharCode:  uint32(r),
+		IMEText:   string(r),
+		Modifiers: winkey.ModState(),
+	})
+}

--- a/gui/backend/gl/events_win32_test.go
+++ b/gui/backend/gl/events_win32_test.go
@@ -1,0 +1,106 @@
+//go:build windows && !js
+
+package gl
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// newCharTestBackend returns a Backend wired to a minimal headless
+// window so charInput's b.emit path can run without a real GL context.
+// charInput stores each emitted event in b.plat.evt (the reused event),
+// so tests observe that field to distinguish emit from suppress.
+func newCharTestBackend(t *testing.T) *Backend {
+	t.Helper()
+	w := gui.NewWindow(gui.WindowCfg{State: new(int), Width: 100, Height: 100})
+	w.UpdateView(func(_ *gui.Window) gui.View {
+		return gui.Column(gui.ContainerCfg{})
+	})
+	w.FrameFn()
+	b := &Backend{}
+	b.plat.w = w
+	return b
+}
+
+func TestCharInputSurrogatePairEmitsRune(t *testing.T) {
+	b := newCharTestBackend(t)
+
+	// U+1F600 GRINNING FACE = high 0xD83D, low 0xDE00.
+	b.plat.evt = gui.Event{Type: gui.EventInvalid}
+	b.charInput(0xD83D)
+	if b.plat.evt.Type != gui.EventInvalid {
+		t.Fatalf("high surrogate emitted an event: %v", b.plat.evt.Type)
+	}
+	if b.plat.highSurr != 0xD83D {
+		t.Fatalf("high surrogate not stored: got %#x", b.plat.highSurr)
+	}
+
+	b.charInput(0xDE00)
+	if b.plat.evt.Type != gui.EventChar {
+		t.Fatalf("low surrogate did not emit EventChar: %v", b.plat.evt.Type)
+	}
+	if b.plat.evt.CharCode != 0x1F600 {
+		t.Errorf("CharCode = %#x, want 0x1F600", b.plat.evt.CharCode)
+	}
+	if b.plat.highSurr != 0 {
+		t.Errorf("highSurr not cleared after pair: %#x", b.plat.highSurr)
+	}
+}
+
+func TestCharInputEmitsBMPRune(t *testing.T) {
+	b := newCharTestBackend(t)
+	b.plat.evt = gui.Event{Type: gui.EventInvalid}
+	b.charInput('A')
+	if b.plat.evt.Type != gui.EventChar || b.plat.evt.CharCode != 'A' {
+		t.Fatalf("charInput('A') = {%v, %#x}, want {EventChar, 0x41}",
+			b.plat.evt.Type, b.plat.evt.CharCode)
+	}
+}
+
+func TestCharInputSuppressed(t *testing.T) {
+	cases := []struct {
+		name   string
+		wparam uintptr
+	}{
+		{"lone low surrogate", 0xDE00},
+		{"null", 0x00},
+		{"backspace", 0x08},
+		{"unit separator", 0x1F},
+		{"delete", 0x7F},
+		{"replacement char", 0xFFFD},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newCharTestBackend(t)
+			b.plat.evt = gui.Event{Type: gui.EventInvalid}
+			b.charInput(tc.wparam)
+			if b.plat.evt.Type != gui.EventInvalid {
+				t.Errorf("charInput(%#x) emitted %v, want no event",
+					tc.wparam, b.plat.evt.Type)
+			}
+		})
+	}
+}
+
+func TestLoHiWordSSignedExtraction(t *testing.T) {
+	// Low/high words are signed 16-bit: mouse coords can be negative
+	// when the pointer is captured outside the window. 0xFFFD = -3,
+	// 0xFFF9 = -7 as int16.
+	lparam := uintptr(0xFFF9FFFD)
+	if got := loWordS(lparam); got != -3 {
+		t.Errorf("loWordS = %d, want -3", got)
+	}
+	if got := hiWordS(lparam); got != -7 {
+		t.Errorf("hiWordS = %d, want -7", got)
+	}
+
+	lparam = uintptr(uint32(1200) | uint32(800)<<16)
+	if got := loWordS(lparam); got != 1200 {
+		t.Errorf("loWordS = %d, want 1200", got)
+	}
+	if got := hiWordS(lparam); got != 800 {
+		t.Errorf("hiWordS = %d, want 800", got)
+	}
+}

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -5,7 +5,6 @@ package gl
 import (
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/nativehost"
-	"github.com/veandco/go-sdl2/sdl"
 )
 
 // nativePlatform implements gui.NativePlatform for the GL backend.
@@ -61,13 +60,8 @@ func (n *nativePlatform) BookmarkLoadAll(_ string) []gui.BookmarkEntry { return 
 func (n *nativePlatform) BookmarkPersist(_, _ string, _ []byte)        {}
 func (n *nativePlatform) BookmarkStopAccess(_ []byte)                  {}
 
-// --- IME ---
-
-func (n *nativePlatform) IMEStart() { sdl.StartTextInput() }
-func (n *nativePlatform) IMEStop()  { sdl.StopTextInput() }
-func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
-	sdl.SetTextInputRect(&sdl.Rect{X: x, Y: y, W: w, H: h})
-}
+// IME methods (IMEStart/IMEStop/IMESetRect) are platform-specific
+// and defined in platform_sdl2.go / platform_win32.go.
 
 // --- Appearance ---
 

--- a/gui/backend/gl/platform_sdl2.go
+++ b/gui/backend/gl/platform_sdl2.go
@@ -1,0 +1,500 @@
+//go:build !windows && !js
+
+package gl
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+
+	"github.com/go-gl/gl/v3.3-core/gl"
+	"github.com/veandco/go-sdl2/sdl"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// platformState holds the SDL2 windowing state for the GL backend.
+type platformState struct {
+	window  *sdl.Window
+	glCtx   sdl.GLContext
+	cursors [11]*sdl.Cursor
+}
+
+func (p *platformState) makeCurrent() { _ = p.window.GLMakeCurrent(p.glCtx) }
+func (p *platformState) swap()        { p.window.GLSwap() }
+
+func (p *platformState) drawableSize() (int32, int32) {
+	return p.window.GLGetDrawableSize()
+}
+
+func (p *platformState) dpiScale() float32 {
+	glW, _ := p.window.GLGetDrawableSize()
+	winW, _ := p.window.GetSize()
+	if winW <= 0 {
+		return 1.0
+	}
+	return float32(glW) / float32(winW)
+}
+
+func (p *platformState) setCursor(mc gui.MouseCursor) {
+	if int(mc) < len(p.cursors) && p.cursors[mc] != nil {
+		sdl.SetCursor(p.cursors[mc])
+	}
+}
+
+func (p *platformState) destroy() {
+	for i, c := range p.cursors {
+		if c != nil {
+			sdl.FreeCursor(c)
+			p.cursors[i] = nil
+		}
+	}
+	if p.glCtx != nil {
+		sdl.GLDeleteContext(p.glCtx)
+	}
+	if p.window != nil {
+		_ = p.window.Destroy()
+	}
+	sdl.Quit()
+}
+
+// New creates an OpenGL 3.3 backend and initializes the SDL2 window.
+func New(w *gui.Window) (*Backend, error) {
+	runtime.LockOSThread()
+
+	if err := sdl.Init(sdl.INIT_VIDEO | sdl.INIT_EVENTS); err != nil {
+		return nil, fmt.Errorf("gl: Init: %w", err)
+	}
+
+	// Request OpenGL 3.3 core profile.
+	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_MAJOR_VERSION, 3)
+	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_MINOR_VERSION, 3)
+	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_PROFILE_MASK,
+		sdl.GL_CONTEXT_PROFILE_CORE)
+	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_FLAGS,
+		sdl.GL_CONTEXT_FORWARD_COMPATIBLE_FLAG)
+	_ = sdl.GLSetAttribute(sdl.GL_DOUBLEBUFFER, 1)
+	_ = sdl.GLSetAttribute(sdl.GL_STENCIL_SIZE, 8)
+
+	cfg := w.Config
+	title := cfg.Title
+	if title == "" {
+		title = "go-gui"
+	}
+	width := int32(cfg.Width)
+	if width <= 0 {
+		width = 640
+	}
+	height := int32(cfg.Height)
+	if height <= 0 {
+		height = 480
+	}
+	flags := uint32(sdl.WINDOW_SHOWN | sdl.WINDOW_ALLOW_HIGHDPI | sdl.WINDOW_OPENGL)
+	if !cfg.FixedSize {
+		flags |= sdl.WINDOW_RESIZABLE
+	}
+
+	win, err := sdl.CreateWindow(
+		title,
+		sdl.WINDOWPOS_CENTERED, sdl.WINDOWPOS_CENTERED,
+		width, height,
+		flags,
+	)
+	if err != nil {
+		sdl.Quit()
+		return nil, fmt.Errorf("gl: CreateWindow: %w", err)
+	}
+
+	glCtx, err := win.GLCreateContext()
+	if err != nil {
+		_ = win.Destroy()
+		sdl.Quit()
+		return nil, fmt.Errorf(
+			"gl: GLCreateContext: %w — OpenGL 3.3 required. "+
+				"Install GPU drivers with OpenGL 3.3+ support, or "+
+				"drop the -tags gl build tag to use the default SDL2 renderer", err)
+	}
+
+	if err := gl.Init(); err != nil {
+		sdl.GLDeleteContext(glCtx)
+		_ = win.Destroy()
+		sdl.Quit()
+		return nil, fmt.Errorf("gl: gl.Init: %w", err)
+	}
+
+	// Enable vsync.
+	_ = sdl.GLSetSwapInterval(1)
+
+	// Compute DPI scale.
+	glW, glH := win.GLGetDrawableSize()
+	winW, _ := win.GetSize()
+	dpiScale := float32(1.0)
+	if winW > 0 {
+		dpiScale = float32(glW) / float32(winW)
+	}
+
+	b := &Backend{}
+	b.plat.window = win
+	b.plat.glCtx = glCtx
+	b.dpiScale = dpiScale
+	b.physW = glW
+	b.physH = glH
+	b.initCaches(cfg)
+
+	if err := b.initGLResources(w); err != nil {
+		b.Destroy()
+		return nil, fmt.Errorf("gl: initGLResources: %w", err)
+	}
+
+	// Create system cursors.
+	b.plat.cursors[gui.CursorDefault] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_ARROW)
+	b.plat.cursors[gui.CursorArrow] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_ARROW)
+	b.plat.cursors[gui.CursorIBeam] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_IBEAM)
+	b.plat.cursors[gui.CursorCrosshair] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_CROSSHAIR)
+	b.plat.cursors[gui.CursorPointingHand] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_HAND)
+	b.plat.cursors[gui.CursorResizeEW] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZEWE)
+	b.plat.cursors[gui.CursorResizeNS] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZENS)
+	b.plat.cursors[gui.CursorResizeNWSE] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZENWSE)
+	b.plat.cursors[gui.CursorResizeNESW] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZENESW)
+	b.plat.cursors[gui.CursorResizeAll] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_SIZEALL)
+	b.plat.cursors[gui.CursorNotAllowed] = sdl.CreateSystemCursor(sdl.SYSTEM_CURSOR_NO)
+
+	// Set platform-specific injected interfaces on gui Window.
+	w.SetClipboardFn(func(text string) {
+		if err := sdl.SetClipboardText(text); err != nil {
+			log.Printf("gl: set clipboard: %v", err)
+		}
+	})
+	w.SetClipboardGetFn(func() string {
+		text, _ := sdl.GetClipboardText()
+		return text
+	})
+	w.SetTitleFn(func(t string) {
+		b.plat.window.SetTitle(t)
+	})
+
+	return b, nil
+}
+
+// Destroy releases all backend resources.
+func (b *Backend) Destroy() {
+	b.destroyGLResources()
+	b.plat.destroy()
+}
+
+// Run starts the event loop. Blocks until quit.
+func (b *Backend) Run(w *gui.Window) {
+	defer w.WindowCleanup()
+	if w.Config.OnInit != nil {
+		w.Config.OnInit(w)
+	}
+
+	// Register event watcher for live resize on macOS and Windows.
+	// During window drag-resize, the OS enters a modal loop that
+	// blocks PollEvent. This callback fires from within that
+	// loop, allowing re-layout and re-render at the new size.
+	resizeEvent := &gui.Event{Type: gui.EventResized}
+	var watchHandle sdl.EventWatchHandle
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		watchHandle = sdl.AddEventWatchFunc(
+			func(ev sdl.Event, _ any) bool {
+				we, ok := ev.(*sdl.WindowEvent)
+				if !ok || we.Event != sdl.WINDOWEVENT_SIZE_CHANGED {
+					return true
+				}
+				b.handleResize()
+				resizeEvent.WindowWidth = int(we.Data1)
+				resizeEvent.WindowHeight = int(we.Data2)
+				w.EventFn(resizeEvent)
+				w.FrameFn()
+				b.renderFrame(w)
+				return true
+			}, nil)
+		defer sdl.DelEventWatch(watchHandle)
+	}
+
+	wakeType := sdl.RegisterEvents(1)
+	w.SetWakeMainFn(func() {
+		_, _ = sdl.PushEvent(&sdl.UserEvent{Type: wakeType})
+	})
+
+	running := true
+	rendered := true
+	evt := new(gui.Event)
+	for running {
+		waitMs := 0
+		if !rendered {
+			waitMs = 100
+		}
+		for ev := sdl.WaitEventTimeout(waitMs); ev != nil; ev = sdl.PollEvent() {
+			mapped, cont := mapEvent(ev, b)
+			*evt = mapped
+			if !cont {
+				running = false
+				break
+			}
+			if evt.Type != gui.EventInvalid {
+				w.EventFn(evt)
+			}
+		}
+		if !running {
+			break
+		}
+
+		rendered = w.FrameFn()
+		if rendered {
+			b.renderFrame(w)
+		}
+
+		b.plat.setCursor(w.MouseCursorState())
+	}
+}
+
+// Run initializes the GL backend, runs the event loop, and cleans
+// up on exit. Panics on error; call RunE for error-returning variant.
+func Run(w *gui.Window) {
+	if err := RunE(w); err != nil {
+		panic(fmt.Sprintf("gl: %v", err))
+	}
+}
+
+// RunE initializes the GL backend, runs the event loop, and cleans
+// up on exit. Returns an error instead of panicking so embedders
+// and tests can handle backend init failures gracefully.
+func RunE(w *gui.Window) error {
+	b, err := New(w)
+	if err != nil {
+		return fmt.Errorf("gl: %w", err)
+	}
+	defer b.Destroy()
+	b.Run(w)
+	return nil
+}
+
+// RunApp starts a multi-window event loop. Panics on error; call
+// RunAppE for error-returning variant.
+func RunApp(app *gui.App, initialWindows ...*gui.Window) {
+	if err := RunAppE(app, initialWindows...); err != nil {
+		panic(fmt.Sprintf("gl: %v", err))
+	}
+}
+
+// RunAppE starts a multi-window event loop. Each window in
+// initialWindows is created and registered with app. Blocks
+// until the app signals exit. Returns an error instead of
+// panicking so embedders and tests can handle init failures.
+//
+//nolint:gocyclo // backend event loop
+func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
+	runtime.LockOSThread()
+
+	if err := sdl.Init(sdl.INIT_VIDEO | sdl.INIT_EVENTS); err != nil {
+		return fmt.Errorf("gl: Init: %w", err)
+	}
+	defer sdl.Quit()
+
+	backends := make(map[uint32]*Backend)
+
+	// Create initial windows.
+	for _, w := range initialWindows {
+		b, err := New(w)
+		if err != nil {
+			return fmt.Errorf("gl: create window: %w", err)
+		}
+		sdlID, _ := b.plat.window.GetID()
+		backends[sdlID] = b
+		app.Register(sdlID, w)
+		if w.Config.OnInit != nil {
+			w.Config.OnInit(w)
+		}
+	}
+
+	// Event watcher for live resize on macOS and Windows.
+	resizeEvent := &gui.Event{Type: gui.EventResized}
+	var watchHandle sdl.EventWatchHandle
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		watchHandle = sdl.AddEventWatchFunc(
+			func(ev sdl.Event, _ any) bool {
+				we, ok := ev.(*sdl.WindowEvent)
+				if !ok ||
+					we.Event != sdl.WINDOWEVENT_SIZE_CHANGED {
+					return true
+				}
+				wid := we.WindowID
+				b := backends[wid]
+				w := app.Window(wid)
+				if b == nil || w == nil {
+					return true
+				}
+				b.handleResize()
+				resizeEvent.WindowID = wid
+				resizeEvent.WindowWidth = int(we.Data1)
+				resizeEvent.WindowHeight = int(we.Data2)
+				w.EventFn(resizeEvent)
+				w.FrameFn()
+				b.renderFrame(w)
+				return true
+			}, nil)
+		defer sdl.DelEventWatch(watchHandle)
+	}
+
+	wakeType := sdl.RegisterEvents(1)
+	setWakeFn := func(w *gui.Window) {
+		w.SetWakeMainFn(func() {
+			_, _ = sdl.PushEvent(&sdl.UserEvent{Type: wakeType})
+		})
+	}
+	for _, w := range initialWindows {
+		setWakeFn(w)
+	}
+
+	running := true
+	rendered := true
+	evt := new(gui.Event)
+
+	for running {
+		// Drain pending window opens.
+	drain:
+		for {
+			select {
+			case cfg := <-app.PendingOpen():
+				w := gui.NewWindow(cfg)
+				b, err := New(w)
+				if err != nil {
+					log.Printf("gl: open window: %v", err)
+					continue
+				}
+				sdlID, _ := b.plat.window.GetID()
+				backends[sdlID] = b
+				app.Register(sdlID, w)
+				setWakeFn(w)
+				if cfg.OnInit != nil {
+					cfg.OnInit(w)
+				}
+			default:
+				break drain
+			}
+		}
+
+		// Poll events. When idle, wait up to 100ms.
+		waitMs := 0
+		if !rendered {
+			waitMs = 100
+		}
+		for ev := sdl.WaitEventTimeout(waitMs); ev != nil; ev = sdl.PollEvent() {
+			wid := sdlEventWindowID(ev)
+			mapped, cont := mapEventMulti(ev, backends[wid])
+			*evt = mapped
+			evt.WindowID = wid
+			if !cont {
+				// QuitEvent — dispatch to per-window hooks.
+				if !gui.DispatchQuitRequest(app) {
+					running = false
+				}
+				break
+			}
+			if evt.Type == gui.EventInvalid {
+				continue
+			}
+
+			// Window close event — dispatch to hook or closeReq.
+			if isWindowClose(ev) {
+				gui.DispatchCloseRequest(app.Window(wid))
+				continue
+			}
+
+			if w := app.Window(wid); w != nil {
+				w.EventFn(evt)
+			}
+		}
+		if !running {
+			break
+		}
+
+		// Handle close requests.
+		for wid, b := range backends {
+			w := app.Window(wid)
+			if w == nil || !w.CloseRequested() {
+				continue
+			}
+			w.WindowCleanup()
+			b.Destroy()
+			delete(backends, wid)
+			if app.Unregister(wid) {
+				running = false
+				break
+			}
+		}
+		if !running {
+			break
+		}
+
+		// Frame + render each window.
+		rendered = false
+		for wid, b := range backends {
+			w := app.Window(wid)
+			if w == nil {
+				continue
+			}
+			if w.FrameFn() {
+				b.renderFrame(w)
+				rendered = true
+			}
+		}
+
+		// Cursor for focused window.
+		if focused := sdl.GetKeyboardFocus(); focused != nil {
+			fid, _ := focused.GetID()
+			if w := app.Window(fid); w != nil {
+				if b := backends[fid]; b != nil {
+					b.plat.setCursor(w.MouseCursorState())
+				}
+			}
+		}
+	}
+
+	// Cleanup remaining windows.
+	for wid, b := range backends {
+		if w := app.Window(wid); w != nil {
+			w.WindowCleanup()
+		}
+		b.Destroy()
+		delete(backends, wid)
+	}
+	return nil
+}
+
+// sdlEventWindowID extracts the SDL window ID from any event.
+func sdlEventWindowID(ev sdl.Event) uint32 {
+	switch e := ev.(type) {
+	case *sdl.WindowEvent:
+		return e.WindowID
+	case *sdl.MouseButtonEvent:
+		return e.WindowID
+	case *sdl.MouseMotionEvent:
+		return e.WindowID
+	case *sdl.MouseWheelEvent:
+		return e.WindowID
+	case *sdl.KeyboardEvent:
+		return e.WindowID
+	case *sdl.TextInputEvent:
+		return e.WindowID
+	case *sdl.TextEditingEvent:
+		return e.WindowID
+	}
+	return 0
+}
+
+// isWindowClose returns true if the event is a window close.
+func isWindowClose(ev sdl.Event) bool {
+	we, ok := ev.(*sdl.WindowEvent)
+	return ok && we.Event == sdl.WINDOWEVENT_CLOSE
+}
+
+// --- IME (SDL2) ---
+
+func (n *nativePlatform) IMEStart() { sdl.StartTextInput() }
+func (n *nativePlatform) IMEStop()  { sdl.StopTextInput() }
+func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
+	sdl.SetTextInputRect(&sdl.Rect{X: x, Y: y, W: w, H: h})
+}

--- a/gui/backend/gl/platform_sdl2.go
+++ b/gui/backend/gl/platform_sdl2.go
@@ -189,13 +189,13 @@ func (b *Backend) Run(w *gui.Window) {
 		w.Config.OnInit(w)
 	}
 
-	// Register event watcher for live resize on macOS and Windows.
+	// Register event watcher for live resize on macOS.
 	// During window drag-resize, the OS enters a modal loop that
 	// blocks PollEvent. This callback fires from within that
 	// loop, allowing re-layout and re-render at the new size.
 	resizeEvent := &gui.Event{Type: gui.EventResized}
 	var watchHandle sdl.EventWatchHandle
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+	if runtime.GOOS == "darwin" {
 		watchHandle = sdl.AddEventWatchFunc(
 			func(ev sdl.Event, _ any) bool {
 				we, ok := ev.(*sdl.WindowEvent)
@@ -309,10 +309,10 @@ func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		}
 	}
 
-	// Event watcher for live resize on macOS and Windows.
+	// Event watcher for live resize on macOS.
 	resizeEvent := &gui.Event{Type: gui.EventResized}
 	var watchHandle sdl.EventWatchHandle
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+	if runtime.GOOS == "darwin" {
 		watchHandle = sdl.AddEventWatchFunc(
 			func(ev sdl.Event, _ any) bool {
 				we, ok := ev.(*sdl.WindowEvent)

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -1,0 +1,617 @@
+//go:build windows && !js
+
+package gl
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/go-gl/gl/v3.3-core/gl"
+	"golang.org/x/sys/windows"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// --- Win32 API bindings ---
+
+var (
+	kernel32 = windows.NewLazySystemDLL("kernel32.dll")
+	user32   = windows.NewLazySystemDLL("user32.dll")
+
+	pGetModuleHandleW = kernel32.NewProc("GetModuleHandleW")
+	pGlobalAlloc      = kernel32.NewProc("GlobalAlloc")
+	pGlobalLock       = kernel32.NewProc("GlobalLock")
+	pGlobalUnlock     = kernel32.NewProc("GlobalUnlock")
+	pRtlMoveMemory    = kernel32.NewProc("RtlMoveMemory")
+	pLstrlenW         = kernel32.NewProc("lstrlenW")
+
+	pRegisterClassExW = user32.NewProc("RegisterClassExW")
+	pCreateWindowExW  = user32.NewProc("CreateWindowExW")
+	pDestroyWindow    = user32.NewProc("DestroyWindow")
+	pDefWindowProcW   = user32.NewProc("DefWindowProcW")
+	pShowWindow       = user32.NewProc("ShowWindow")
+	pUpdateWindow     = user32.NewProc("UpdateWindow")
+	pPeekMessageW     = user32.NewProc("PeekMessageW")
+	pTranslateMessage = user32.NewProc("TranslateMessage")
+	pDispatchMessageW = user32.NewProc("DispatchMessageW")
+	pPostMessageW     = user32.NewProc("PostMessageW")
+	pGetDC            = user32.NewProc("GetDC")
+	pReleaseDC        = user32.NewProc("ReleaseDC")
+	pMsgWaitForMulti  = user32.NewProc("MsgWaitForMultipleObjectsEx")
+	pLoadCursorW      = user32.NewProc("LoadCursorW")
+	pSetCursor        = user32.NewProc("SetCursor")
+	pGetClientRect    = user32.NewProc("GetClientRect")
+	pSetWindowTextW   = user32.NewProc("SetWindowTextW")
+	pScreenToClient   = user32.NewProc("ScreenToClient")
+	pSetCapture       = user32.NewProc("SetCapture")
+	pReleaseCapture   = user32.NewProc("ReleaseCapture")
+	pValidateRect     = user32.NewProc("ValidateRect")
+	pGetDpiForWindow  = user32.NewProc("GetDpiForWindow")
+	pGetDpiForSystem  = user32.NewProc("GetDpiForSystem")
+	pSetDpiAware      = user32.NewProc("SetProcessDpiAwarenessContext")
+	pAdjustRectDpi    = user32.NewProc("AdjustWindowRectExForDpi")
+	pOpenClipboard    = user32.NewProc("OpenClipboard")
+	pCloseClipboard   = user32.NewProc("CloseClipboard")
+	pEmptyClipboard   = user32.NewProc("EmptyClipboard")
+	pGetClipboardData = user32.NewProc("GetClipboardData")
+	pSetClipboardData = user32.NewProc("SetClipboardData")
+)
+
+const (
+	csVRedraw = 0x0001
+	csHRedraw = 0x0002
+	csOwnDC   = 0x0020
+
+	wsOverlappedWindow = 0x00CF0000
+	wsFixed            = 0x00CA0000 // caption|sysmenu|minimizebox
+	wsClipSiblings     = 0x04000000
+	wsClipChildren     = 0x02000000
+
+	swShow       = 5
+	pmRemove     = 0x0001
+	cwUseDefault = 0x80000000
+
+	qsAllInput         = 0x04FF
+	mwmoInputAvailable = 0x0004
+
+	gmemMoveable  = 0x0002
+	cfUnicodeText = 13
+
+	idcArrow    = 32512
+	idcIBeam    = 32513
+	idcCross    = 32515
+	idcSizeNWSE = 32642
+	idcSizeNESW = 32643
+	idcSizeWE   = 32644
+	idcSizeNS   = 32645
+	idcSizeAll  = 32646
+	idcNo       = 32648
+	idcHand     = 32649
+
+	// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 == (HANDLE)-4.
+	dpiPerMonitorV2 = ^uintptr(3)
+
+	// maxClipboardChars bounds a clipboard read. Any process can place
+	// arbitrarily large text on the clipboard; cap the allocation to
+	// avoid an out-of-memory DoS (32 MiB of UTF-16).
+	maxClipboardChars = 16 << 20
+)
+
+type wndClassExW struct {
+	cbSize        uint32
+	style         uint32
+	lpfnWndProc   uintptr
+	cbClsExtra    int32
+	cbWndExtra    int32
+	hInstance     uintptr
+	hIcon         uintptr
+	hCursor       uintptr
+	hbrBackground uintptr
+	lpszMenuName  *uint16
+	lpszClassName *uint16
+	hIconSm       uintptr
+}
+
+type pointW struct{ x, y int32 }
+
+type rectW struct{ left, top, right, bottom int32 }
+
+type msgW struct {
+	hwnd     uintptr
+	message  uint32
+	wParam   uintptr
+	lParam   uintptr
+	time     uint32
+	pt       pointW
+	lPrivate uint32
+}
+
+// --- window registry (hwnd → Backend) ---
+
+var (
+	winMu  sync.Mutex
+	winReg = map[uintptr]*Backend{}
+
+	wndProcCallback = syscall.NewCallback(wndProc)
+	classOnce       sync.Once
+	className       = windows.StringToUTF16Ptr("GoGuiGLWindow")
+)
+
+func registerWindow(hwnd uintptr, b *Backend) {
+	winMu.Lock()
+	winReg[hwnd] = b
+	winMu.Unlock()
+}
+
+func unregisterWindow(hwnd uintptr) {
+	winMu.Lock()
+	delete(winReg, hwnd)
+	winMu.Unlock()
+}
+
+func lookupWindow(hwnd uintptr) *Backend {
+	winMu.Lock()
+	b := winReg[hwnd]
+	winMu.Unlock()
+	return b
+}
+
+// wndProc is the window procedure. It routes messages to the owning
+// Backend, falling back to DefWindowProc for unhandled messages and
+// for messages that arrive before the window is fully wired.
+func wndProc(hwnd, msg, wparam, lparam uintptr) uintptr {
+	if b := lookupWindow(hwnd); b != nil && b.plat.w != nil {
+		if res, handled := b.handleMessage(msg, wparam, lparam); handled {
+			return res
+		}
+	}
+	r, _, _ := pDefWindowProcW.Call(hwnd, msg, wparam, lparam)
+	return r
+}
+
+// --- platformState (Win32 + WGL) ---
+
+type platformState struct {
+	hwnd      uintptr
+	hdc       uintptr
+	hglrc     uintptr
+	cursors   [11]uintptr
+	curCursor uintptr
+	w         *gui.Window
+	evt       gui.Event // reused per message to avoid per-event allocation
+	highSurr  uint16    // pending UTF-16 high surrogate for WM_CHAR
+}
+
+func (p *platformState) wake() {
+	pPostMessageW.Call(p.hwnd, wmApp, 0, 0)
+}
+
+// pumpMessages drains all pending window messages, dispatching each
+// through wndProc (which delivers gui events synchronously).
+func pumpMessages(msg *msgW) {
+	for {
+		r, _, _ := pPeekMessageW.Call(
+			uintptr(unsafe.Pointer(msg)), 0, 0, 0, pmRemove)
+		if r == 0 {
+			return
+		}
+		pTranslateMessage.Call(uintptr(unsafe.Pointer(msg)))
+		pDispatchMessageW.Call(uintptr(unsafe.Pointer(msg)))
+	}
+}
+
+// waitMessage blocks until a message arrives or the timeout elapses.
+func waitMessage(ms uintptr) {
+	pMsgWaitForMulti.Call(0, 0, ms, qsAllInput, mwmoInputAvailable)
+}
+
+func (p *platformState) makeCurrent() { wglMakeCurrent(p.hdc, p.hglrc) }
+func (p *platformState) swap()        { swapBuffers(p.hdc) }
+
+func (p *platformState) drawableSize() (int32, int32) {
+	return clientSize(p.hwnd)
+}
+
+func (p *platformState) dpiScale() float32 {
+	return float32(dpiForWindow(p.hwnd)) / 96.0
+}
+
+func (p *platformState) setCursor(mc gui.MouseCursor) {
+	if int(mc) >= len(p.cursors) {
+		return
+	}
+	c := p.cursors[mc]
+	if c == 0 {
+		return
+	}
+	p.curCursor = c
+	pSetCursor.Call(c)
+}
+
+func (p *platformState) destroy() {
+	if p.hglrc != 0 {
+		wglMakeCurrent(0, 0)
+		wglDeleteContext(p.hglrc)
+		p.hglrc = 0
+	}
+	if p.hdc != 0 && p.hwnd != 0 {
+		pReleaseDC.Call(p.hwnd, p.hdc)
+		p.hdc = 0
+	}
+	if p.hwnd != 0 {
+		unregisterWindow(p.hwnd)
+		pDestroyWindow.Call(p.hwnd)
+		p.hwnd = 0
+	}
+}
+
+// --- helpers ---
+
+func clientSize(hwnd uintptr) (int32, int32) {
+	var r rectW
+	pGetClientRect.Call(hwnd, uintptr(unsafe.Pointer(&r)))
+	return r.right - r.left, r.bottom - r.top
+}
+
+func dpiForWindow(hwnd uintptr) uint32 {
+	r, _, _ := pGetDpiForWindow.Call(hwnd)
+	if r == 0 {
+		return 96
+	}
+	return uint32(r)
+}
+
+func dpiForSystem() uint32 {
+	r, _, _ := pGetDpiForSystem.Call()
+	if r == 0 {
+		return 96
+	}
+	return uint32(r)
+}
+
+func registerClass(hInstance uintptr) {
+	classOnce.Do(func() {
+		wc := wndClassExW{
+			style:         csHRedraw | csVRedraw | csOwnDC,
+			lpfnWndProc:   wndProcCallback,
+			hInstance:     hInstance,
+			lpszClassName: className,
+		}
+		hArrow, _, _ := pLoadCursorW.Call(0, idcArrow)
+		wc.hCursor = hArrow
+		wc.cbSize = uint32(unsafe.Sizeof(wc))
+		pRegisterClassExW.Call(uintptr(unsafe.Pointer(&wc)))
+	})
+}
+
+func loadCursors(p *platformState) {
+	ld := func(id uintptr) uintptr {
+		h, _, _ := pLoadCursorW.Call(0, id)
+		return h
+	}
+	p.cursors[gui.CursorDefault] = ld(idcArrow)
+	p.cursors[gui.CursorArrow] = ld(idcArrow)
+	p.cursors[gui.CursorIBeam] = ld(idcIBeam)
+	p.cursors[gui.CursorCrosshair] = ld(idcCross)
+	p.cursors[gui.CursorPointingHand] = ld(idcHand)
+	p.cursors[gui.CursorResizeEW] = ld(idcSizeWE)
+	p.cursors[gui.CursorResizeNS] = ld(idcSizeNS)
+	p.cursors[gui.CursorResizeNWSE] = ld(idcSizeNWSE)
+	p.cursors[gui.CursorResizeNESW] = ld(idcSizeNESW)
+	p.cursors[gui.CursorResizeAll] = ld(idcSizeAll)
+	p.cursors[gui.CursorNotAllowed] = ld(idcNo)
+}
+
+func setClipboard(hwnd uintptr, s string) {
+	u := windows.StringToUTF16(s) // NUL-terminated
+	if r, _, _ := pOpenClipboard.Call(hwnd); r == 0 {
+		return
+	}
+	defer pCloseClipboard.Call()
+	pEmptyClipboard.Call()
+	n := uintptr(len(u) * 2)
+	h, _, _ := pGlobalAlloc.Call(gmemMoveable, n)
+	if h == 0 {
+		return
+	}
+	dst, _, _ := pGlobalLock.Call(h)
+	if dst == 0 {
+		return
+	}
+	// Copy via RtlMoveMemory to avoid a uintptr→unsafe.Pointer
+	// conversion on the locked handle (go vet unsafeptr).
+	pRtlMoveMemory.Call(dst, uintptr(unsafe.Pointer(&u[0])), n)
+	pGlobalUnlock.Call(h)
+	pSetClipboardData.Call(cfUnicodeText, h)
+}
+
+func getClipboard(hwnd uintptr) string {
+	if r, _, _ := pOpenClipboard.Call(hwnd); r == 0 {
+		return ""
+	}
+	defer pCloseClipboard.Call()
+	h, _, _ := pGetClipboardData.Call(cfUnicodeText)
+	if h == 0 {
+		return ""
+	}
+	src, _, _ := pGlobalLock.Call(h)
+	if src == 0 {
+		return ""
+	}
+	defer pGlobalUnlock.Call(h)
+	n, _, _ := pLstrlenW.Call(src) // uint16 count, excluding NUL
+	if n == 0 {
+		return ""
+	}
+	if n > maxClipboardChars {
+		n = maxClipboardChars // cap oversized clipboard content
+	}
+	buf := make([]uint16, n)
+	pRtlMoveMemory.Call(uintptr(unsafe.Pointer(&buf[0])), src, n*2)
+	return windows.UTF16ToString(buf)
+}
+
+// --- lifecycle ---
+
+// New creates an OpenGL 3.3 backend backed by a native Win32 window
+// and a WGL context. No SDL2.
+func New(w *gui.Window) (*Backend, error) {
+	runtime.LockOSThread()
+
+	pSetDpiAware.Call(dpiPerMonitorV2) // best-effort; ignore result
+	hInst, _, _ := pGetModuleHandleW.Call(0)
+	registerClass(hInst)
+
+	cfg := w.Config
+	title := cfg.Title
+	if title == "" {
+		title = "go-gui"
+	}
+	width := cfg.Width
+	if width <= 0 {
+		width = 640
+	}
+	height := cfg.Height
+	if height <= 0 {
+		height = 480
+	}
+
+	style := uintptr(wsClipSiblings | wsClipChildren)
+	if cfg.FixedSize {
+		style |= wsFixed
+	} else {
+		style |= wsOverlappedWindow
+	}
+
+	// Size the window so its client area matches the requested
+	// logical size at the current system DPI.
+	dpi := dpiForSystem()
+	scale := float64(dpi) / 96.0
+	rc := rectW{0, 0, int32(float64(width) * scale), int32(float64(height) * scale)}
+	pAdjustRectDpi.Call(uintptr(unsafe.Pointer(&rc)), style, 0, 0, uintptr(dpi))
+	winW := rc.right - rc.left
+	winH := rc.bottom - rc.top
+
+	hwnd, _, err := pCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(className)),
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(title))),
+		style,
+		cwUseDefault, cwUseDefault,
+		uintptr(winW), uintptr(winH),
+		0, 0, hInst, 0,
+	)
+	if hwnd == 0 {
+		return nil, fmt.Errorf("gl: CreateWindowExW: %w", err)
+	}
+
+	b := &Backend{}
+	b.plat.hwnd = hwnd
+	registerWindow(hwnd, b)
+
+	hdc, _, _ := pGetDC.Call(hwnd)
+	if hdc == 0 {
+		b.plat.destroy()
+		return nil, fmt.Errorf("gl: GetDC failed")
+	}
+	b.plat.hdc = hdc
+
+	hglrc, err := createContext(hdc)
+	if err != nil {
+		b.plat.destroy()
+		return nil, fmt.Errorf("gl: createContext: %w", err)
+	}
+	b.plat.hglrc = hglrc
+
+	if err := gl.Init(); err != nil {
+		b.plat.destroy()
+		return nil, fmt.Errorf("gl: gl.Init: %w", err)
+	}
+
+	b.dpiScale = float32(dpiForWindow(hwnd)) / 96.0
+	b.physW, b.physH = clientSize(hwnd)
+	b.initCaches(cfg)
+
+	if err := b.initGLResources(w); err != nil {
+		b.Destroy()
+		return nil, fmt.Errorf("gl: initGLResources: %w", err)
+	}
+
+	loadCursors(&b.plat)
+	b.plat.curCursor = b.plat.cursors[gui.CursorDefault]
+
+	w.SetClipboardFn(func(text string) { setClipboard(hwnd, text) })
+	w.SetClipboardGetFn(func() string { return getClipboard(hwnd) })
+	w.SetTitleFn(func(t string) {
+		pSetWindowTextW.Call(hwnd, uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(t))))
+	})
+
+	pShowWindow.Call(hwnd, swShow)
+	pUpdateWindow.Call(hwnd)
+	return b, nil
+}
+
+// Destroy releases all backend resources.
+func (b *Backend) Destroy() {
+	b.destroyGLResources()
+	b.plat.destroy()
+}
+
+// Run starts the event loop. Blocks until the window is closed.
+func (b *Backend) Run(w *gui.Window) {
+	defer w.WindowCleanup()
+	b.plat.w = w
+	if w.Config.OnInit != nil {
+		w.Config.OnInit(w)
+	}
+	w.SetWakeMainFn(b.plat.wake)
+
+	rendered := true
+	var msg msgW
+	for {
+		pumpMessages(&msg)
+		if w.CloseRequested() {
+			break
+		}
+		rendered = w.FrameFn()
+		if rendered {
+			b.renderFrame(w)
+		}
+		b.plat.setCursor(w.MouseCursorState())
+		if !rendered {
+			waitMessage(100)
+		}
+	}
+}
+
+// Run initializes the backend, runs the event loop, and cleans up on
+// exit. Panics on error; call RunE for the error-returning variant.
+func Run(w *gui.Window) {
+	if err := RunE(w); err != nil {
+		panic(fmt.Sprintf("gl: %v", err))
+	}
+}
+
+// RunE initializes the backend, runs the event loop, and cleans up on
+// exit. Returns an error instead of panicking.
+func RunE(w *gui.Window) error {
+	b, err := New(w)
+	if err != nil {
+		return fmt.Errorf("gl: %w", err)
+	}
+	defer b.Destroy()
+	b.Run(w)
+	return nil
+}
+
+// RunApp starts a multi-window event loop. Panics on error; call
+// RunAppE for the error-returning variant.
+func RunApp(app *gui.App, initialWindows ...*gui.Window) {
+	if err := RunAppE(app, initialWindows...); err != nil {
+		panic(fmt.Sprintf("gl: %v", err))
+	}
+}
+
+// RunAppE starts a multi-window event loop. Each window is created and
+// registered with app. Blocks until the last window closes.
+//
+//nolint:gocyclo // backend event loop
+func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
+	runtime.LockOSThread()
+
+	backends := make(map[uintptr]*Backend) // hwnd → backend
+	ids := make(map[uintptr]uint32)        // hwnd → app id
+	var nextID uint32
+
+	register := func(b *Backend, w *gui.Window) {
+		nextID++
+		ids[b.plat.hwnd] = nextID
+		backends[b.plat.hwnd] = b
+		app.Register(nextID, w)
+	}
+
+	open := func(w *gui.Window) error {
+		b, err := New(w)
+		if err != nil {
+			return err
+		}
+		b.plat.w = w
+		register(b, w)
+		w.SetWakeMainFn(b.plat.wake)
+		if w.Config.OnInit != nil {
+			w.Config.OnInit(w)
+		}
+		return nil
+	}
+
+	for _, w := range initialWindows {
+		if err := open(w); err != nil {
+			for _, b := range backends {
+				b.Destroy()
+			}
+			return fmt.Errorf("gl: create window: %w", err)
+		}
+	}
+
+	rendered := true
+	var msg msgW
+	for {
+		// Drain pending window opens.
+	drain:
+		for {
+			select {
+			case cfg := <-app.PendingOpen():
+				if err := open(gui.NewWindow(cfg)); err != nil {
+					log.Printf("gl: open window: %v", err)
+				}
+			default:
+				break drain
+			}
+		}
+
+		pumpMessages(&msg)
+
+		// Close windows whose close was requested.
+		for hwnd, b := range backends {
+			w := b.plat.w
+			if w == nil || !w.CloseRequested() {
+				continue
+			}
+			w.WindowCleanup()
+			b.Destroy()
+			delete(backends, hwnd)
+			if app.Unregister(ids[hwnd]) {
+				return nil // last window closed
+			}
+			delete(ids, hwnd)
+		}
+		if len(backends) == 0 {
+			return nil
+		}
+
+		// Frame + render each window.
+		rendered = false
+		for _, b := range backends {
+			w := b.plat.w
+			if w.FrameFn() {
+				b.renderFrame(w)
+				rendered = true
+			}
+			b.plat.setCursor(w.MouseCursorState())
+		}
+
+		if !rendered {
+			waitMessage(100)
+		}
+	}
+}
+
+// --- IME (stub; WM_CHAR still yields EventChar) ---
+
+func (n *nativePlatform) IMEStart()                   {}
+func (n *nativePlatform) IMEStop()                    {}
+func (n *nativePlatform) IMESetRect(_, _, _, _ int32) {}

--- a/gui/backend/gl/wgl_windows.go
+++ b/gui/backend/gl/wgl_windows.go
@@ -1,0 +1,169 @@
+//go:build windows && !js
+
+package gl
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	gdi32    = windows.NewLazySystemDLL("gdi32.dll")
+	opengl32 = windows.NewLazySystemDLL("opengl32.dll")
+
+	pChoosePixelFormat = gdi32.NewProc("ChoosePixelFormat")
+	pSetPixelFormat    = gdi32.NewProc("SetPixelFormat")
+	pSwapBuffers       = gdi32.NewProc("SwapBuffers")
+
+	pWglCreateContext  = opengl32.NewProc("wglCreateContext")
+	pWglMakeCurrent    = opengl32.NewProc("wglMakeCurrent")
+	pWglDeleteContext  = opengl32.NewProc("wglDeleteContext")
+	pWglGetProcAddress = opengl32.NewProc("wglGetProcAddress")
+)
+
+type pixelFormatDescriptor struct {
+	nSize           uint16
+	nVersion        uint16
+	dwFlags         uint32
+	iPixelType      byte
+	cColorBits      byte
+	cRedBits        byte
+	cRedShift       byte
+	cGreenBits      byte
+	cGreenShift     byte
+	cBlueBits       byte
+	cBlueShift      byte
+	cAlphaBits      byte
+	cAlphaShift     byte
+	cAccumBits      byte
+	cAccumRedBits   byte
+	cAccumGreenBits byte
+	cAccumBlueBits  byte
+	cAccumAlphaBits byte
+	cDepthBits      byte
+	cStencilBits    byte
+	cAuxBuffers     byte
+	iLayerType      byte
+	bReserved       byte
+	dwLayerMask     uint32
+	dwVisibleMask   uint32
+	dwDamageMask    uint32
+}
+
+const (
+	pfdDrawToWindow = 0x00000004
+	pfdSupportOGL   = 0x00000020
+	pfdDoubleBuffer = 0x00000001
+	pfdTypeRGBA     = 0
+
+	// wglCreateContextAttribsARB attribute keys/values.
+	wglContextMajorVersionARB = 0x2091
+	wglContextMinorVersionARB = 0x2092
+	wglContextFlagsARB        = 0x2094
+	wglContextProfileMaskARB  = 0x9126
+	wglContextCoreProfileARB  = 0x00000001
+	wglContextFwdCompatARB    = 0x00000002
+)
+
+func wglMakeCurrent(hdc, hglrc uintptr) {
+	pWglMakeCurrent.Call(hdc, hglrc)
+}
+
+func wglDeleteContext(hglrc uintptr) {
+	pWglDeleteContext.Call(hglrc)
+}
+
+func swapBuffers(hdc uintptr) {
+	pSwapBuffers.Call(hdc)
+}
+
+func basePixelFormat() pixelFormatDescriptor {
+	var pfd pixelFormatDescriptor
+	pfd.nSize = uint16(unsafe.Sizeof(pfd))
+	pfd.nVersion = 1
+	pfd.dwFlags = pfdDrawToWindow | pfdSupportOGL | pfdDoubleBuffer
+	pfd.iPixelType = pfdTypeRGBA
+	pfd.cColorBits = 32
+	pfd.cAlphaBits = 8
+	pfd.cDepthBits = 24
+	pfd.cStencilBits = 8
+	return pfd
+}
+
+// createContext sets a pixel format on hdc and creates an OpenGL 3.3
+// core-profile context via wglCreateContextAttribsARB, falling back to
+// a legacy context if the ARB extension is unavailable. On success the
+// returned context is current on hdc.
+func createContext(hdc uintptr) (uintptr, error) {
+	pfd := basePixelFormat()
+	pf, _, err := pChoosePixelFormat.Call(hdc, uintptr(unsafe.Pointer(&pfd)))
+	if pf == 0 {
+		return 0, fmt.Errorf("ChoosePixelFormat: %w", err)
+	}
+	if r, _, e := pSetPixelFormat.Call(hdc, pf, uintptr(unsafe.Pointer(&pfd))); r == 0 {
+		return 0, fmt.Errorf("SetPixelFormat: %w", e)
+	}
+
+	// Legacy context first: required both as a fallback and to load
+	// the wglCreateContextAttribsARB entry point.
+	legacy, _, err := pWglCreateContext.Call(hdc)
+	if legacy == 0 {
+		return 0, fmt.Errorf("wglCreateContext: %w", err)
+	}
+	if r, _, e := pWglMakeCurrent.Call(hdc, legacy); r == 0 {
+		pWglDeleteContext.Call(legacy)
+		return 0, fmt.Errorf("wglMakeCurrent(legacy): %w", e)
+	}
+
+	createAttribs := wglProc("wglCreateContextAttribsARB")
+	if createAttribs == 0 {
+		// No ARB path; keep the legacy context.
+		return legacy, nil
+	}
+
+	attribs := []int32{
+		wglContextMajorVersionARB, 3,
+		wglContextMinorVersionARB, 3,
+		wglContextProfileMaskARB, wglContextCoreProfileARB,
+		wglContextFlagsARB, wglContextFwdCompatARB,
+		0,
+	}
+	core, _, _ := syscall.SyscallN(createAttribs,
+		hdc, 0, uintptr(unsafe.Pointer(&attribs[0])))
+	if core == 0 {
+		// Core creation failed; fall back to the legacy context.
+		return legacy, nil
+	}
+
+	// Switch to the core context and drop the legacy one.
+	pWglMakeCurrent.Call(0, 0)
+	pWglDeleteContext.Call(legacy)
+	if r, _, e := pWglMakeCurrent.Call(hdc, core); r == 0 {
+		pWglDeleteContext.Call(core)
+		return 0, fmt.Errorf("wglMakeCurrent(core): %w", e)
+	}
+
+	if swapInterval := wglProc("wglSwapIntervalEXT"); swapInterval != 0 {
+		syscall.SyscallN(swapInterval, 1) // enable vsync
+	}
+	return core, nil
+}
+
+// wglProc resolves a WGL extension entry point. A context must be
+// current. Returns 0 if unavailable.
+func wglProc(name string) uintptr {
+	cname, err := syscall.BytePtrFromString(name)
+	if err != nil {
+		return 0
+	}
+	r, _, _ := pWglGetProcAddress.Call(uintptr(unsafe.Pointer(cname)))
+	// wglGetProcAddress may return 1,2,3,-1 for error sentinels.
+	switch r {
+	case 0, 1, 2, 3, ^uintptr(0):
+		return 0
+	}
+	return r
+}

--- a/gui/backend/internal/winkey/winkey.go
+++ b/gui/backend/internal/winkey/winkey.go
@@ -1,0 +1,196 @@
+//go:build windows
+
+// Package winkey maps Win32 virtual-key codes and modifier state to
+// go-gui key and modifier values. It mirrors the sdlkey package for
+// the native Windows backend.
+package winkey
+
+import (
+	"golang.org/x/sys/windows"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+var (
+	user32       = windows.NewLazySystemDLL("user32.dll")
+	pGetKeyState = user32.NewProc("GetKeyState")
+)
+
+// Win32 virtual-key codes (subset).
+const (
+	vkBack    = 0x08
+	vkTab     = 0x09
+	vkReturn  = 0x0D
+	vkShift   = 0x10
+	vkControl = 0x11
+	vkMenu    = 0x12 // Alt
+	vkCapital = 0x14
+	vkEscape  = 0x1B
+	vkSpace   = 0x20
+	vkPrior   = 0x21 // PageUp
+	vkNext    = 0x22 // PageDown
+	vkEnd     = 0x23
+	vkHome    = 0x24
+	vkLeft    = 0x25
+	vkUp      = 0x26
+	vkRight   = 0x27
+	vkDown    = 0x28
+	vkInsert  = 0x2D
+	vkDelete  = 0x2E
+
+	vkLWin     = 0x5B
+	vkRWin     = 0x5C
+	vkLShift   = 0xA0
+	vkRShift   = 0xA1
+	vkLControl = 0xA2
+	vkRControl = 0xA3
+	vkLMenu    = 0xA4
+	vkRMenu    = 0xA5
+
+	vkOEM1      = 0xBA // ;:
+	vkOEMPlus   = 0xBB // =+
+	vkOEMComma  = 0xBC // ,<
+	vkOEMMinus  = 0xBD // -_
+	vkOEMPeriod = 0xBE // .>
+	vkOEM2      = 0xBF // /?
+	vkOEM3      = 0xC0 // `~
+	vkOEM4      = 0xDB // [{
+	vkOEM5      = 0xDC // \|
+	vkOEM6      = 0xDD // ]}
+
+	vkF1  = 0x70
+	vkF12 = 0x7B
+
+	// Mouse button flags in WM_MOUSEMOVE / button-event wparam.
+	mkLButton = 0x0001
+	mkRButton = 0x0002
+	mkMButton = 0x0010
+)
+
+// MapVKey maps a Win32 virtual-key code to a gui.KeyCode.
+//
+//nolint:gocyclo // key-mapping switch
+func MapVKey(vk uintptr) gui.KeyCode {
+	// A-Z and 0-9 share ASCII values with gui.KeyCode.
+	if vk >= 'A' && vk <= 'Z' {
+		return gui.KeyCode(vk)
+	}
+	if vk >= '0' && vk <= '9' {
+		return gui.KeyCode(vk)
+	}
+	if vk >= vkF1 && vk <= vkF12 {
+		return gui.KeyF1 + gui.KeyCode(vk-vkF1)
+	}
+
+	switch vk {
+	case vkSpace:
+		return gui.KeySpace
+	case vkReturn:
+		return gui.KeyEnter
+	case vkEscape:
+		return gui.KeyEscape
+	case vkTab:
+		return gui.KeyTab
+	case vkBack:
+		return gui.KeyBackspace
+	case vkDelete:
+		return gui.KeyDelete
+	case vkInsert:
+		return gui.KeyInsert
+	case vkRight:
+		return gui.KeyRight
+	case vkLeft:
+		return gui.KeyLeft
+	case vkDown:
+		return gui.KeyDown
+	case vkUp:
+		return gui.KeyUp
+	case vkPrior:
+		return gui.KeyPageUp
+	case vkNext:
+		return gui.KeyPageDown
+	case vkHome:
+		return gui.KeyHome
+	case vkEnd:
+		return gui.KeyEnd
+	case vkShift, vkLShift:
+		return gui.KeyLeftShift
+	case vkRShift:
+		return gui.KeyRightShift
+	case vkControl, vkLControl:
+		return gui.KeyLeftControl
+	case vkRControl:
+		return gui.KeyRightControl
+	case vkMenu, vkLMenu:
+		return gui.KeyLeftAlt
+	case vkRMenu:
+		return gui.KeyRightAlt
+	case vkLWin:
+		return gui.KeyLeftSuper
+	case vkRWin:
+		return gui.KeyRightSuper
+	case vkOEMComma:
+		return gui.KeyComma
+	case vkOEMMinus:
+		return gui.KeyMinus
+	case vkOEMPeriod:
+		return gui.KeyPeriod
+	case vkOEM2:
+		return gui.KeySlash
+	case vkOEM1:
+		return gui.KeySemicolon
+	case vkOEMPlus:
+		return gui.KeyEqual
+	case vkOEM4:
+		return gui.KeyLeftBracket
+	case vkOEM5:
+		return gui.KeyBackslash
+	case vkOEM6:
+		return gui.KeyRightBracket
+	case vkOEM3:
+		return gui.KeyGraveAccent
+	case vkCapital:
+		return gui.KeyCapsLock
+	default:
+		return gui.KeyInvalid
+	}
+}
+
+func keyDown(vk uintptr) bool {
+	r, _, _ := pGetKeyState.Call(vk)
+	return uint16(r)&0x8000 != 0
+}
+
+// ModState returns the current keyboard modifier bitmask.
+func ModState() gui.Modifier {
+	var m gui.Modifier
+	if keyDown(vkShift) {
+		m |= gui.ModShift
+	}
+	if keyDown(vkControl) {
+		m |= gui.ModCtrl
+	}
+	if keyDown(vkMenu) {
+		m |= gui.ModAlt
+	}
+	if keyDown(vkLWin) || keyDown(vkRWin) {
+		m |= gui.ModSuper
+	}
+	return m
+}
+
+// MouseButtons maps the MK_* button flags from a mouse-message
+// wparam into gui mouse-button modifiers.
+func MouseButtons(wparam uintptr) gui.Modifier {
+	var m gui.Modifier
+	if wparam&mkLButton != 0 {
+		m |= gui.ModLMB
+	}
+	if wparam&mkRButton != 0 {
+		m |= gui.ModRMB
+	}
+	if wparam&mkMButton != 0 {
+		m |= gui.ModMMB
+	}
+	return m
+}

--- a/gui/backend/internal/winkey/winkey_test.go
+++ b/gui/backend/internal/winkey/winkey_test.go
@@ -1,0 +1,143 @@
+//go:build windows
+
+package winkey
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestMapVKeyLettersAndDigits(t *testing.T) {
+	if got := MapVKey('A'); got != gui.KeyCode('A') {
+		t.Errorf("MapVKey('A') = %v, want %v", got, gui.KeyCode('A'))
+	}
+	if got := MapVKey('Z'); got != gui.KeyCode('Z') {
+		t.Errorf("MapVKey('Z') = %v, want %v", got, gui.KeyCode('Z'))
+	}
+	if got := MapVKey('0'); got != gui.KeyCode('0') {
+		t.Errorf("MapVKey('0') = %v, want %v", got, gui.KeyCode('0'))
+	}
+	if got := MapVKey('9'); got != gui.KeyCode('9') {
+		t.Errorf("MapVKey('9') = %v, want %v", got, gui.KeyCode('9'))
+	}
+}
+
+func TestMapVKeyFunctionKeys(t *testing.T) {
+	want := []gui.KeyCode{
+		gui.KeyF1, gui.KeyF2, gui.KeyF3, gui.KeyF4,
+		gui.KeyF5, gui.KeyF6, gui.KeyF7, gui.KeyF8,
+		gui.KeyF9, gui.KeyF10, gui.KeyF11, gui.KeyF12,
+	}
+	for i, exp := range want {
+		vk := uintptr(vkF1 + i)
+		if got := MapVKey(vk); got != exp {
+			t.Errorf("MapVKey(F%d) = %v, want %v", i+1, got, exp)
+		}
+	}
+}
+
+func TestMapVKeyModifiers(t *testing.T) {
+	tests := []struct {
+		vk   uintptr
+		want gui.KeyCode
+	}{
+		{vkShift, gui.KeyLeftShift},
+		{vkLShift, gui.KeyLeftShift},
+		{vkRShift, gui.KeyRightShift},
+		{vkControl, gui.KeyLeftControl},
+		{vkLControl, gui.KeyLeftControl},
+		{vkRControl, gui.KeyRightControl},
+		{vkMenu, gui.KeyLeftAlt},
+		{vkLMenu, gui.KeyLeftAlt},
+		{vkRMenu, gui.KeyRightAlt},
+		{vkLWin, gui.KeyLeftSuper},
+		{vkRWin, gui.KeyRightSuper},
+		{vkCapital, gui.KeyCapsLock},
+	}
+	for _, tt := range tests {
+		if got := MapVKey(tt.vk); got != tt.want {
+			t.Errorf("MapVKey(%#x) = %v, want %v", tt.vk, got, tt.want)
+		}
+	}
+}
+
+func TestMapVKeyNavigationAndEditing(t *testing.T) {
+	tests := []struct {
+		vk   uintptr
+		want gui.KeyCode
+	}{
+		{vkSpace, gui.KeySpace},
+		{vkReturn, gui.KeyEnter},
+		{vkEscape, gui.KeyEscape},
+		{vkTab, gui.KeyTab},
+		{vkBack, gui.KeyBackspace},
+		{vkDelete, gui.KeyDelete},
+		{vkInsert, gui.KeyInsert},
+		{vkLeft, gui.KeyLeft},
+		{vkRight, gui.KeyRight},
+		{vkUp, gui.KeyUp},
+		{vkDown, gui.KeyDown},
+		{vkPrior, gui.KeyPageUp},
+		{vkNext, gui.KeyPageDown},
+		{vkHome, gui.KeyHome},
+		{vkEnd, gui.KeyEnd},
+	}
+	for _, tt := range tests {
+		if got := MapVKey(tt.vk); got != tt.want {
+			t.Errorf("MapVKey(%#x) = %v, want %v", tt.vk, got, tt.want)
+		}
+	}
+}
+
+func TestMapVKeyOEMPunctuation(t *testing.T) {
+	tests := []struct {
+		vk   uintptr
+		want gui.KeyCode
+	}{
+		{vkOEMComma, gui.KeyComma},
+		{vkOEMMinus, gui.KeyMinus},
+		{vkOEMPeriod, gui.KeyPeriod},
+		{vkOEM2, gui.KeySlash},
+		{vkOEM1, gui.KeySemicolon},
+		{vkOEMPlus, gui.KeyEqual},
+		{vkOEM4, gui.KeyLeftBracket},
+		{vkOEM5, gui.KeyBackslash},
+		{vkOEM6, gui.KeyRightBracket},
+		{vkOEM3, gui.KeyGraveAccent},
+	}
+	for _, tt := range tests {
+		if got := MapVKey(tt.vk); got != tt.want {
+			t.Errorf("MapVKey(%#x) = %v, want %v", tt.vk, got, tt.want)
+		}
+	}
+}
+
+func TestMapVKeyUnknown(t *testing.T) {
+	// 0x07 is an undefined VK code.
+	if got := MapVKey(0x07); got != gui.KeyInvalid {
+		t.Errorf("MapVKey(0x07) = %v, want KeyInvalid", got)
+	}
+	if got := MapVKey(0xFF); got != gui.KeyInvalid {
+		t.Errorf("MapVKey(0xFF) = %v, want KeyInvalid", got)
+	}
+}
+
+func TestMouseButtons(t *testing.T) {
+	tests := []struct {
+		wparam uintptr
+		want   gui.Modifier
+	}{
+		{0, 0},
+		{mkLButton, gui.ModLMB},
+		{mkRButton, gui.ModRMB},
+		{mkMButton, gui.ModMMB},
+		{mkLButton | mkRButton, gui.ModLMB | gui.ModRMB},
+		{mkLButton | mkRButton | mkMButton, gui.ModLMB | gui.ModRMB | gui.ModMMB},
+	}
+	for _, tt := range tests {
+		if got := MouseButtons(tt.wparam); got != tt.want {
+			t.Errorf("MouseButtons(%#x) = %v, want %v", tt.wparam, got, tt.want)
+		}
+	}
+}

--- a/gui/backend/run_default.go
+++ b/gui/backend/run_default.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !js && !android && !gl
+//go:build !darwin && !js && !android && !gl && !windows
 
 // Package backend provides platform-specific backend initialization.
 package backend

--- a/gui/backend/run_windows.go
+++ b/gui/backend/run_windows.go
@@ -1,0 +1,18 @@
+//go:build windows && !js && !android && !gl
+
+package backend
+
+import (
+	"github.com/go-gui-org/go-gui/gui"
+	glbackend "github.com/go-gui-org/go-gui/gui/backend/gl"
+)
+
+// Run starts the application event loop using the native Win32 + WGL
+// backend (SDL2-free).
+func Run(w *gui.Window) { glbackend.Run(w) }
+
+// RunApp starts a multi-window event loop. Multi-window is not yet
+// supported on the native Windows backend.
+func RunApp(app *gui.App, windows ...*gui.Window) {
+	glbackend.RunApp(app, windows...)
+}

--- a/tools/depsdoc/main.go
+++ b/tools/depsdoc/main.go
@@ -43,6 +43,7 @@ var directPurpose = map[string]string{
 	"github.com/go-pdf/fpdf":                      "PDF generation for the print-dialog backend.",
 	"github.com/godbus/dbus/v5":                   "Linux native platform: notifications, portals.",
 	"golang.org/x/mod":                            "Module version parsing; imported by `requiredid` analyzer.",
+	"golang.org/x/sys":                            "Win32 + WGL syscalls for the native Windows backend (`gui/backend/gl`, `winkey`).",
 	"golang.org/x/tools":                          "`go/analysis` framework for the `requiredid` analyzer (`tools/`).",
 }
 
@@ -53,7 +54,6 @@ var indirectPulledBy = map[string]string{
 	"github.com/rivo/uniseg":        "grapheme segmentation (chroma/glyph)",
 	"golang.org/x/mobile":           "gobind tool (Android AAR builds)",
 	"golang.org/x/sync":             "x/tools",
-	"golang.org/x/sys":              "sdl2 / godbus",
 	"golang.org/x/text":             "misc. text processing (transitive)",
 }
 


### PR DESCRIPTION
## Summary

Removes the SDL2 dependency from go-gui's **Windows** build (issue #37). The default Windows build now creates its own Win32 window + WGL 3.3-core context and runs a native message loop — no SDL2 linked, no CGo. Linux/macOS unchanged (macOS already SDL2-free via Metal; Linux native deferred).

## Approach

- Split `gui/backend/gl` into a **shared OpenGL render core** and **build-tagged platform windowing**: SDL2 on non-Windows (`platform_sdl2.go`/`events_sdl2.go`), native Win32+WGL on Windows (`platform_win32.go`/`wgl_windows.go`/`events_win32.go`), via an embedded `platformState`.
- Reuses the `gl` OpenGL renderer. go-glyph `gpu.New()` only draws filled rects/textured quads (no SVG/filters/gradients/stencils), so it is not used as the renderer.
- Pure Go via `golang.org/x/sys/windows` + `syscall.NewCallback`. Validated that `go-gl/gl.Init()` resolves against a pure-Go WGL context.
- `internal/winkey`: VK -> gui key/modifier mapping (mirrors `sdlkey`).
- Routing: `run_default.go` excludes `windows`; new `run_windows.go` -> native `gl` backend. SDL2 unreachable on Windows.
- Multi-window `RunApp` supported. IME composition deferred; WM_CHAR text input works.
- Hardening: clipboard read capped (OOM DoS); WM_SIZE dims from authoritative client rect.

## Verification

- Windows: `go build`, `go vet`, `go test` pass; `get_started` + `showcase` run; `go list -deps` shows no SDL2 in the default build.
- New tests: `winkey` mapping, `charInput` surrogate/control handling, signed word extraction.

## Notes

- `go.mod` SDL2 deps retained (Linux still uses them; drop gated on Linux work).
- golangci-lint runs on Linux CI, so `//go:build windows` files aren't linted there; bare `LazyProc.Call()` matches the repo's Windows convention (`tray_windows.go`).

Closes #37 (Windows portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)