### PR TITLE
feat(backend): SDL2-free native X11+EGL backend on Linux (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ build/
 # Graphify
 graphify-out/
 
+# TokenSave
+.tokensave/
+
 # Anitivibe
 deep-dive/
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,11 +11,13 @@ Go toolchain pin: `go 1.26.0`.
 | Module | Version | Purpose |
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
+| `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`). |
 | `github.com/go-gl/gl` | v0.0.0-20260331235117-4566fea9a276 | OpenGL bindings for `gui/backend/gl`. |
 | `github.com/go-gui-org/go-glyph` | v1.12.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-gui-org/go-glyph/backend/sdl2` | v1.11.0 | SDL2-specific glyph rasterisation backend used by `gui/backend/sdl2`. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
+| `github.com/jezek/xgb` | v1.3.1 | Pure-Go X11 windowing + events for the native Linux backend (`gui/backend/gl`). |
 | `github.com/tdewolff/parse/v2` | v2.8.13 | CSS tokenizer for the SVG `<style>` / `style=""` cascade pipeline. |
 | `github.com/veandco/go-sdl2` | v0.4.40 | SDL2 backend (`gui/backend/sdl2`). Window, input, GL/Metal context glue. |
 | `github.com/yuin/goldmark` | v1.8.2 | Markdown parser (markdown widget + showcase docs). |

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.26.0
 
 require (
 	github.com/alecthomas/chroma/v2 v2.26.1
+	github.com/ebitengine/purego v0.10.1
 	github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276
 	github.com/go-gui-org/go-glyph v1.12.0
 	github.com/go-gui-org/go-glyph/backend/sdl2 v1.11.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
+	github.com/jezek/xgb v1.3.1
 	github.com/tdewolff/parse/v2 v2.8.13
 	github.com/veandco/go-sdl2 v0.4.40
 	github.com/yuin/goldmark v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/dlclark/regexp2/v2 v2.2.2 h1:MYWvNYw8okuqNhwTYO587EZMiDruVa2vhV6fsGpfya0=
 github.com/dlclark/regexp2/v2 v2.2.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
+github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276 h1:IO5P06Pcj9K04d+l4nrf3c2U56+dAotIFG6u4P1wAHI=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
 github.com/go-gui-org/go-glyph v1.12.0 h1:l0dXe8DtNPd8TYfG/peIRRmHMj6u2ienM8dhOOXSSaE=
@@ -20,6 +22,8 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/jezek/xgb v1.3.1 h1:NQCAEfQyzN+3RjWUSHBuVIxQcy2YfG3/mNvKfs/0rEg=
+github.com/jezek/xgb v1.3.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/tdewolff/parse/v2 v2.8.13 h1:si/8rLw5BZZTWCCiMm9A3f6x+RmqYfrkEeXCgpX5ick=

--- a/gui/backend/gl/egl_linux.go
+++ b/gui/backend/gl/egl_linux.go
@@ -1,0 +1,173 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+// EGL enum values (from egl.h / eglext.h).
+const (
+	eglDefaultDisplay = 0
+	eglNoContext      = 0
+
+	eglOpenGLAPI = 0x30A2
+	eglOpenGLBit = 0x0008
+
+	eglSurfaceType    = 0x3033
+	eglWindowBit      = 0x0004
+	eglRenderableType = 0x3040
+	eglRedSize        = 0x3024
+	eglGreenSize      = 0x3023
+	eglBlueSize       = 0x3022
+	eglAlphaSize      = 0x3021
+	eglDepthSize      = 0x3025
+	eglStencilSize    = 0x3026
+	eglNativeVisualID = 0x302E
+	eglNone           = 0x3038
+
+	eglContextMajorVersion         = 0x3098
+	eglContextMinorVersion         = 0x30FB
+	eglContextOpenGLProfileMask    = 0x30FD
+	eglContextOpenGLCoreProfileBit = 0x00000001
+)
+
+var (
+	eglOnce    sync.Once
+	eglLoadErr error
+
+	eglGetDisplay          func(uintptr) uintptr
+	eglInitialize          func(uintptr, unsafe.Pointer, unsafe.Pointer) uint32
+	eglBindAPI             func(uint32) uint32
+	eglChooseConfig        func(uintptr, unsafe.Pointer, unsafe.Pointer, int32, unsafe.Pointer) uint32
+	eglGetConfigAttrib     func(uintptr, uintptr, int32, unsafe.Pointer) uint32
+	eglCreateWindowSurface func(uintptr, uintptr, uintptr, unsafe.Pointer) uintptr
+	eglCreateContext       func(uintptr, uintptr, uintptr, unsafe.Pointer) uintptr
+	eglMakeCurrent         func(uintptr, uintptr, uintptr, uintptr) uint32
+	eglSwapBuffers         func(uintptr, uintptr) uint32
+	eglSwapInterval        func(uintptr, int32) uint32
+	eglDestroyContext      func(uintptr, uintptr) uint32
+	eglDestroySurface      func(uintptr, uintptr) uint32
+	eglTerminate           func(uintptr) uint32
+	eglGetProcAddress      func(string) unsafe.Pointer
+	eglGetError            func() int32
+)
+
+// loadEGL dlopens libEGL (and libGL for desktop-GL symbol fallback) and
+// binds the EGL entry points. Pure Go via purego — no cgo. Idempotent.
+func loadEGL() error {
+	eglOnce.Do(func() {
+		libEGL, err := purego.Dlopen("libEGL.so.1", purego.RTLD_NOW|purego.RTLD_GLOBAL)
+		if err != nil {
+			eglLoadErr = fmt.Errorf("dlopen libEGL.so.1: %w", err)
+			return
+		}
+
+		reg := func(p any, name string) { purego.RegisterLibFunc(p, libEGL, name) }
+		reg(&eglGetDisplay, "eglGetDisplay")
+		reg(&eglInitialize, "eglInitialize")
+		reg(&eglBindAPI, "eglBindAPI")
+		reg(&eglChooseConfig, "eglChooseConfig")
+		reg(&eglGetConfigAttrib, "eglGetConfigAttrib")
+		reg(&eglCreateWindowSurface, "eglCreateWindowSurface")
+		reg(&eglCreateContext, "eglCreateContext")
+		reg(&eglMakeCurrent, "eglMakeCurrent")
+		reg(&eglSwapBuffers, "eglSwapBuffers")
+		reg(&eglSwapInterval, "eglSwapInterval")
+		reg(&eglDestroyContext, "eglDestroyContext")
+		reg(&eglDestroySurface, "eglDestroySurface")
+		reg(&eglTerminate, "eglTerminate")
+		reg(&eglGetProcAddress, "eglGetProcAddress")
+		reg(&eglGetError, "eglGetError")
+	})
+	return eglLoadErr
+}
+
+// eglProc resolves an OpenGL function pointer for
+// gl.InitWithProcAddrFunc via eglGetProcAddress. EGL 1.5 (Mesa) returns
+// core desktop-GL entry points, not only extensions.
+func eglProc(name string) unsafe.Pointer {
+	return eglGetProcAddress(name)
+}
+
+// eglInitDisplay initializes EGL, binds the desktop-OpenGL API, and
+// chooses a framebuffer config. It returns the display, the config, and
+// the X visual id the window must be created with so the surface
+// matches. EGL opens its own X connection from $DISPLAY.
+func eglInitDisplay() (dpy, config uintptr, visualID uint32, err error) {
+	if err = loadEGL(); err != nil {
+		return
+	}
+	dpy = eglGetDisplay(eglDefaultDisplay)
+	if dpy == 0 {
+		err = errors.New("eglGetDisplay: no display")
+		return
+	}
+	var maj, minr int32
+	if eglInitialize(dpy, unsafe.Pointer(&maj), unsafe.Pointer(&minr)) == 0 {
+		err = fmt.Errorf("eglInitialize failed (egl error 0x%x)", eglGetError())
+		return
+	}
+	if eglBindAPI(eglOpenGLAPI) == 0 {
+		err = fmt.Errorf("eglBindAPI(OpenGL) failed (egl error 0x%x) — "+
+			"desktop GL over EGL unsupported by this driver", eglGetError())
+		return
+	}
+	attribs := []int32{
+		eglSurfaceType, eglWindowBit,
+		eglRenderableType, eglOpenGLBit,
+		eglRedSize, 8,
+		eglGreenSize, 8,
+		eglBlueSize, 8,
+		eglAlphaSize, 8,
+		eglDepthSize, 24,
+		eglStencilSize, 8,
+		eglNone,
+	}
+	var cfg uintptr
+	var n int32
+	ok := eglChooseConfig(dpy, unsafe.Pointer(&attribs[0]),
+		unsafe.Pointer(&cfg), 1, unsafe.Pointer(&n))
+	if ok == 0 || n == 0 {
+		err = fmt.Errorf("eglChooseConfig: no matching config (egl error 0x%x)", eglGetError())
+		return
+	}
+	var vid int32
+	eglGetConfigAttrib(dpy, cfg, eglNativeVisualID, unsafe.Pointer(&vid))
+	config = cfg
+	visualID = uint32(vid)
+	return
+}
+
+// eglCreateSurfaceContext creates a window surface for an
+// already-realized X window and an OpenGL 3.3 core context, then makes
+// them current.
+func eglCreateSurfaceContext(dpy, config uintptr, win uint32) (surface, context uintptr, err error) {
+	surface = eglCreateWindowSurface(dpy, config, uintptr(win), nil)
+	if surface == 0 {
+		err = fmt.Errorf("eglCreateWindowSurface failed (egl error 0x%x)", eglGetError())
+		return
+	}
+	ctxAttribs := []int32{
+		eglContextMajorVersion, 3,
+		eglContextMinorVersion, 3,
+		eglContextOpenGLProfileMask, eglContextOpenGLCoreProfileBit,
+		eglNone,
+	}
+	context = eglCreateContext(dpy, config, eglNoContext, unsafe.Pointer(&ctxAttribs[0]))
+	if context == 0 {
+		err = fmt.Errorf("eglCreateContext(3.3 core) failed (egl error 0x%x)", eglGetError())
+		return
+	}
+	if eglMakeCurrent(dpy, surface, surface, context) == 0 {
+		err = fmt.Errorf("eglMakeCurrent failed (egl error 0x%x)", eglGetError())
+		return
+	}
+	eglSwapInterval(dpy, 1)
+	return
+}

--- a/gui/backend/gl/events_sdl2.go
+++ b/gui/backend/gl/events_sdl2.go
@@ -1,4 +1,4 @@
-//go:build !windows && !js
+//go:build !windows && !js && !linux
 
 package gl
 

--- a/gui/backend/gl/events_x11.go
+++ b/gui/backend/gl/events_x11.go
@@ -1,0 +1,201 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/x11key"
+)
+
+// emit dispatches an event, reusing a single gui.Event stored on the
+// platform state to avoid a heap allocation per event. EventFn does not
+// retain the pointer beyond the call.
+func (b *Backend) emit(e gui.Event) {
+	b.plat.evt = e
+	b.plat.w.EventFn(&b.plat.evt)
+}
+
+// logicalXY converts physical pixel coordinates to logical points using
+// the current DPI scale.
+func (b *Backend) logicalXY(px, py int32) (float32, float32) {
+	s := b.dpiScale
+	if s <= 0 {
+		s = 1
+	}
+	return float32(px) / s, float32(py) / s
+}
+
+// keysym looks up the keysym for a keycode at the given shift column.
+func (p *platformState) keysym(code xproto.Keycode, col int) uint32 {
+	if p.keymap == nil {
+		return 0
+	}
+	per := int(p.keymap.KeysymsPerKeycode)
+	if per == 0 {
+		return 0
+	}
+	idx := (int(code)-int(p.minKeycode))*per + col
+	if idx < 0 || idx >= len(p.keymap.Keysyms) {
+		return 0
+	}
+	return uint32(p.keymap.Keysyms[idx])
+}
+
+// handleXEvent translates an X event to a gui.Event and dispatches it.
+//
+//nolint:gocyclo // event dispatch switch
+func (b *Backend) handleXEvent(ev xgb.Event) {
+	w := b.plat.w
+	switch e := ev.(type) {
+	case xproto.KeyPressEvent:
+		b.emit(gui.Event{
+			Type:      gui.EventKeyDown,
+			KeyCode:   x11key.MapKeySym(b.plat.keysym(e.Detail, 0)),
+			Modifiers: x11key.MapModifiers(e.State),
+		})
+		col := 0
+		if e.State&xproto.KeyButMaskShift != 0 {
+			col = 1
+		}
+		if r := x11key.KeysymToRune(b.plat.keysym(e.Detail, col)); r >= 0x20 && r != 0x7f {
+			b.emitChar(r, e.State)
+		}
+
+	case xproto.KeyReleaseEvent:
+		b.emit(gui.Event{
+			Type:      gui.EventKeyUp,
+			KeyCode:   x11key.MapKeySym(b.plat.keysym(e.Detail, 0)),
+			Modifiers: x11key.MapModifiers(e.State),
+		})
+
+	case xproto.ButtonPressEvent:
+		switch e.Detail {
+		case 4:
+			b.emitScroll(0, 1, e.EventX, e.EventY, e.State)
+		case 5:
+			b.emitScroll(0, -1, e.EventX, e.EventY, e.State)
+		case 6:
+			b.emitScroll(1, 0, e.EventX, e.EventY, e.State)
+		case 7:
+			b.emitScroll(-1, 0, e.EventX, e.EventY, e.State)
+		default:
+			x, y := b.logicalXY(int32(e.EventX), int32(e.EventY))
+			b.emit(gui.Event{
+				Type:        gui.EventMouseDown,
+				MouseX:      x,
+				MouseY:      y,
+				MouseButton: x11key.MapButton(byte(e.Detail)),
+				Modifiers:   x11key.MapModifiers(e.State),
+			})
+		}
+
+	case xproto.ButtonReleaseEvent:
+		if e.Detail >= 1 && e.Detail <= 3 {
+			x, y := b.logicalXY(int32(e.EventX), int32(e.EventY))
+			b.emit(gui.Event{
+				Type:        gui.EventMouseUp,
+				MouseX:      x,
+				MouseY:      y,
+				MouseButton: x11key.MapButton(byte(e.Detail)),
+				Modifiers:   x11key.MapModifiers(e.State),
+			})
+		}
+
+	case xproto.MotionNotifyEvent:
+		x, y := b.logicalXY(int32(e.EventX), int32(e.EventY))
+		b.emit(gui.Event{
+			Type:      gui.EventMouseMove,
+			MouseX:    x,
+			MouseY:    y,
+			Modifiers: x11key.MapModifiers(e.State),
+		})
+
+	case xproto.ConfigureNotifyEvent:
+		nw, nh := int32(e.Width), int32(e.Height)
+		if nw == b.plat.physW && nh == b.plat.physH {
+			return
+		}
+		b.plat.physW = nw
+		b.plat.physH = nh
+		b.handleResize()
+		lw, lh := b.logicalXY(b.physW, b.physH)
+		b.emit(gui.Event{
+			Type:         gui.EventResized,
+			WindowWidth:  int(lw),
+			WindowHeight: int(lh),
+		})
+		w.FrameFn()
+		b.renderFrame(w)
+
+	case xproto.ClientMessageEvent:
+		if e.Format == 32 && len(e.Data.Data32) > 0 &&
+			xproto.Atom(e.Data.Data32[0]) == b.plat.wmDelete {
+			gui.DispatchCloseRequest(w)
+		}
+
+	case xproto.FocusInEvent:
+		if focusRealChange(e.Mode, e.Detail) {
+			b.emit(gui.Event{Type: gui.EventFocused})
+		}
+
+	case xproto.FocusOutEvent:
+		if focusRealChange(e.Mode, e.Detail) {
+			b.emit(gui.Event{Type: gui.EventUnfocused})
+		}
+
+	case xproto.ExposeEvent:
+		// Damage is repainted by the next frame; nothing to do.
+	}
+}
+
+// focusRealChange reports whether an X focus event reflects a genuine
+// keyboard-focus change rather than one synthesized by a pointer grab
+// (e.g. an interactive WM move/resize) or by pointer motion. Grab-induced
+// focus churn must be ignored, otherwise focus-gated events such as
+// EventResized are dropped while the window is being resized, leaving the
+// layout stale until the next event.
+func focusRealChange(mode, detail byte) bool {
+	if mode == xproto.NotifyModeGrab || mode == xproto.NotifyModeUngrab {
+		return false
+	}
+	switch detail {
+	case xproto.NotifyDetailPointer,
+		xproto.NotifyDetailPointerRoot,
+		xproto.NotifyDetailNone:
+		return false
+	}
+	return true
+}
+
+func (b *Backend) emitScroll(sx, sy float32, px, py int16, state uint16) {
+	x, y := b.logicalXY(int32(px), int32(py))
+	b.emit(gui.Event{
+		Type:      gui.EventMouseScroll,
+		ScrollX:   sx,
+		ScrollY:   sy,
+		MouseX:    x,
+		MouseY:    y,
+		Modifiers: x11key.MapModifiers(state),
+	})
+}
+
+func (b *Backend) emitChar(r rune, state uint16) {
+	if r == 0xFFFD {
+		return
+	}
+	b.emit(gui.Event{
+		Type:      gui.EventChar,
+		CharCode:  uint32(r),
+		IMEText:   string(r),
+		Modifiers: x11key.MapModifiers(state),
+	})
+}
+
+// --- IME (stub; KeyPress still yields EventChar for printable keys) ---
+
+func (n *nativePlatform) IMEStart()                   {}
+func (n *nativePlatform) IMEStop()                    {}
+func (n *nativePlatform) IMESetRect(_, _, _, _ int32) {}

--- a/gui/backend/gl/events_x11_test.go
+++ b/gui/backend/gl/events_x11_test.go
@@ -1,0 +1,35 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"testing"
+
+	"github.com/jezek/xgb/xproto"
+)
+
+func TestFocusRealChange(t *testing.T) {
+	cases := []struct {
+		name         string
+		mode, detail byte
+		want         bool
+	}{
+		{"normal ancestor", xproto.NotifyModeNormal, xproto.NotifyDetailAncestor, true},
+		{"normal nonlinear", xproto.NotifyModeNormal, xproto.NotifyDetailNonlinear, true},
+		{"while-grabbed real", xproto.NotifyModeWhileGrabbed, xproto.NotifyDetailNonlinear, true},
+		// Grab/ungrab churn from an interactive WM move/resize: must be ignored
+		// so EventResized keeps flowing during a resize drag.
+		{"grab", xproto.NotifyModeGrab, xproto.NotifyDetailNonlinear, false},
+		{"ungrab", xproto.NotifyModeUngrab, xproto.NotifyDetailNonlinear, false},
+		// Pointer-driven pseudo-focus: not a real keyboard-focus change.
+		{"pointer detail", xproto.NotifyModeNormal, xproto.NotifyDetailPointer, false},
+		{"pointer-root detail", xproto.NotifyModeNormal, xproto.NotifyDetailPointerRoot, false},
+		{"none detail", xproto.NotifyModeNormal, xproto.NotifyDetailNone, false},
+	}
+	for _, c := range cases {
+		if got := focusRealChange(c.mode, c.detail); got != c.want {
+			t.Errorf("%s: focusRealChange(%d,%d)=%v, want %v",
+				c.name, c.mode, c.detail, got, c.want)
+		}
+	}
+}

--- a/gui/backend/gl/platform_sdl2.go
+++ b/gui/backend/gl/platform_sdl2.go
@@ -1,4 +1,4 @@
-//go:build !windows && !js
+//go:build !windows && !js && !linux
 
 package gl
 

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -1,0 +1,592 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-gl/gl/v3.3-core/gl"
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// Selected X11 event mask for top-level windows.
+const x11EventMask = xproto.EventMaskKeyPress | xproto.EventMaskKeyRelease |
+	xproto.EventMaskButtonPress | xproto.EventMaskButtonRelease |
+	xproto.EventMaskPointerMotion | xproto.EventMaskExposure |
+	xproto.EventMaskStructureNotify | xproto.EventMaskFocusChange
+
+// X11 cursor-font glyph indices (from cursorfont.h). Each shape is two
+// consecutive glyphs: the image and its mask.
+const (
+	xcLeftPtr           = 68
+	xcXterm             = 152
+	xcCrosshair         = 34
+	xcHand2             = 60
+	xcSbHDoubleArrow    = 108
+	xcSbVDoubleArrow    = 116
+	xcFleur             = 52
+	xcBottomRightCorner = 14
+	xcBottomLeftCorner  = 12
+	xcXCursor           = 0
+)
+
+// platformState holds the X11 windowing + EGL state for the GL backend.
+type platformState struct {
+	conn     *xgb.Conn
+	wakeConn *xgb.Conn
+	window   xproto.Window
+
+	eglDpy     uintptr
+	eglConfig  uintptr
+	eglSurface uintptr
+	eglContext uintptr
+
+	cursors   [11]xproto.Cursor
+	curCursor xproto.Cursor
+
+	wmDelete   xproto.Atom
+	wakeAtom   xproto.Atom
+	keymap     *xproto.GetKeyboardMappingReply
+	minKeycode xproto.Keycode
+
+	physW, physH int32
+	scale        float32
+
+	w   *gui.Window
+	evt gui.Event // reused per event to avoid per-event allocation
+}
+
+func (p *platformState) makeCurrent() {
+	eglMakeCurrent(p.eglDpy, p.eglSurface, p.eglSurface, p.eglContext)
+}
+
+func (p *platformState) swap() { eglSwapBuffers(p.eglDpy, p.eglSurface) }
+
+func (p *platformState) drawableSize() (int32, int32) { return p.physW, p.physH }
+
+func (p *platformState) dpiScale() float32 {
+	if p.scale <= 0 {
+		return 1
+	}
+	return p.scale
+}
+
+func (p *platformState) setCursor(mc gui.MouseCursor) {
+	if int(mc) >= len(p.cursors) {
+		return
+	}
+	c := p.cursors[mc]
+	if c == 0 {
+		c = p.cursors[gui.CursorDefault]
+	}
+	if c == p.curCursor {
+		return
+	}
+	p.curCursor = c
+	xproto.ChangeWindowAttributes(p.conn, p.window,
+		xproto.CwCursor, []uint32{uint32(c)})
+}
+
+// wake sends a no-op ClientMessage to our own window from a second
+// connection so the event-pump goroutine unblocks from WaitForEvent.
+func (p *platformState) wake() {
+	if p.wakeConn == nil {
+		return
+	}
+	ev := xproto.ClientMessageEvent{
+		Format: 32,
+		Window: p.window,
+		Type:   p.wakeAtom,
+		Data:   xproto.ClientMessageDataUnionData32New([]uint32{0, 0, 0, 0, 0}),
+	}
+	cookie := xproto.SendEventChecked(p.wakeConn, false, p.window, 0, string(ev.Bytes()))
+	_ = cookie.Check() // forces a flush; error is not actionable here
+}
+
+func (p *platformState) destroy() {
+	if p.eglDpy != 0 {
+		eglMakeCurrent(p.eglDpy, 0, 0, 0)
+		if p.eglContext != 0 {
+			eglDestroyContext(p.eglDpy, p.eglContext)
+			p.eglContext = 0
+		}
+		if p.eglSurface != 0 {
+			eglDestroySurface(p.eglDpy, p.eglSurface)
+			p.eglSurface = 0
+		}
+		eglTerminate(p.eglDpy)
+		p.eglDpy = 0
+	}
+	if p.conn != nil && p.window != 0 {
+		xproto.DestroyWindow(p.conn, p.window)
+		p.window = 0
+	}
+	if p.wakeConn != nil {
+		p.wakeConn.Close()
+		p.wakeConn = nil
+	}
+	if p.conn != nil {
+		p.conn.Close()
+		p.conn = nil
+	}
+}
+
+// pumpEvents reads X events on a dedicated goroutine and forwards them
+// on ch. It closes ch when the connection ends so the main loop exits.
+func (p *platformState) pumpEvents(ch chan<- xgb.Event) {
+	for {
+		ev, err := p.conn.WaitForEvent()
+		if ev == nil && err == nil {
+			close(ch) // connection closed
+			return
+		}
+		if ev != nil {
+			ch <- ev
+		}
+	}
+}
+
+// New creates an OpenGL 3.3 backend backed by a native X11 window and an
+// EGL context. Pure Go via xgb + purego — no SDL2, no cgo.
+func New(w *gui.Window) (*Backend, error) {
+	runtime.LockOSThread()
+
+	conn, err := xgb.NewConn()
+	if err != nil {
+		return nil, fmt.Errorf("gl: x11 connect: %w", err)
+	}
+	setup := xproto.Setup(conn)
+	screen := setup.DefaultScreen(conn)
+
+	dpy, config, visualID, err := eglInitDisplay()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("gl: %w", err)
+	}
+
+	cfg := w.Config
+	title := cfg.Title
+	if title == "" {
+		title = "go-gui"
+	}
+	width := int32(cfg.Width)
+	if width <= 0 {
+		width = 640
+	}
+	height := int32(cfg.Height)
+	if height <= 0 {
+		height = 480
+	}
+
+	scale := readDPIScale(conn, screen.Root)
+	physW := int32(float32(width) * scale)
+	physH := int32(float32(height) * scale)
+
+	depth := screen.RootDepth
+	for _, d := range screen.AllowedDepths {
+		for _, v := range d.Visuals {
+			if uint32(v.VisualId) == visualID {
+				depth = d.Depth
+			}
+		}
+	}
+
+	cmID, err := conn.NewId()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("gl: x11 new id: %w", err)
+	}
+	xproto.CreateColormap(conn, xproto.ColormapAllocNone,
+		xproto.Colormap(cmID), screen.Root, xproto.Visualid(visualID))
+
+	wid, err := conn.NewId()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("gl: x11 new id: %w", err)
+	}
+	win := xproto.Window(wid)
+	xproto.CreateWindow(conn, depth, win, screen.Root,
+		0, 0, uint16(physW), uint16(physH), 0,
+		xproto.WindowClassInputOutput, xproto.Visualid(visualID),
+		xproto.CwBorderPixel|xproto.CwEventMask|xproto.CwColormap,
+		[]uint32{0, x11EventMask, cmID})
+
+	b := &Backend{}
+	b.plat.conn = conn
+	b.plat.window = win
+	b.plat.eglDpy = dpy
+	b.plat.eglConfig = config
+	b.plat.scale = scale
+	b.plat.physW = physW
+	b.plat.physH = physH
+
+	setWindowTitle(conn, win, title)
+	b.plat.wmDelete = setupCloseProtocol(conn, win)
+	b.plat.wakeAtom = internAtom(conn, "_GOGUI_WAKE")
+	b.plat.minKeycode = setup.MinKeycode
+	b.plat.keymap = loadKeymap(conn, setup)
+
+	loadCursors(&b.plat)
+	xproto.MapWindow(conn, win)
+
+	// Flush all pending X requests and wait for the server to realize
+	// the window before EGL (on its own X connection) wraps it.
+	conn.Sync()
+
+	surface, context, err := eglCreateSurfaceContext(dpy, config, uint32(wid))
+	if err != nil {
+		b.plat.destroy()
+		return nil, fmt.Errorf("gl: %w", err)
+	}
+	b.plat.eglSurface = surface
+	b.plat.eglContext = context
+
+	if err := gl.InitWithProcAddrFunc(eglProc); err != nil {
+		b.plat.destroy()
+		return nil, fmt.Errorf("gl: gl.Init: %w", err)
+	}
+
+	wakeConn, err := xgb.NewConn()
+	if err != nil {
+		b.plat.destroy()
+		return nil, fmt.Errorf("gl: x11 wake connect: %w", err)
+	}
+	b.plat.wakeConn = wakeConn
+
+	b.dpiScale = scale
+	b.physW = physW
+	b.physH = physH
+	b.initCaches(cfg)
+
+	if err := b.initGLResources(w); err != nil {
+		b.Destroy()
+		return nil, fmt.Errorf("gl: initGLResources: %w", err)
+	}
+
+	w.SetTitleFn(func(t string) { setWindowTitle(conn, win, t) })
+	// Clipboard support is deferred (X11 selection protocol). No-op for now.
+	w.SetClipboardFn(func(string) {})
+	w.SetClipboardGetFn(func() string { return "" })
+
+	return b, nil
+}
+
+// Destroy releases all backend resources.
+func (b *Backend) Destroy() {
+	b.destroyGLResources()
+	b.plat.destroy()
+}
+
+// Run starts the event loop. Blocks until the window is closed.
+func (b *Backend) Run(w *gui.Window) {
+	defer w.WindowCleanup()
+	b.plat.w = w
+	if w.Config.OnInit != nil {
+		w.Config.OnInit(w)
+	}
+	w.SetWakeMainFn(b.plat.wake)
+
+	events := make(chan xgb.Event, 64)
+	go b.plat.pumpEvents(events)
+
+	// drain processes every currently-queued event without blocking.
+	// Returns false when the connection has closed.
+	drain := func() bool {
+		for {
+			select {
+			case ev, ok := <-events:
+				if !ok {
+					return false
+				}
+				b.handleXEvent(ev)
+			default:
+				return true
+			}
+		}
+	}
+
+	var rendered bool
+	running := true
+	for running {
+		if !drain() || w.CloseRequested() {
+			break
+		}
+		rendered = w.FrameFn()
+		if rendered {
+			b.renderFrame(w)
+		}
+		b.plat.setCursor(w.MouseCursorState())
+		if !rendered {
+			select {
+			case ev, ok := <-events:
+				if !ok {
+					running = false
+				} else {
+					b.handleXEvent(ev)
+				}
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}
+}
+
+// Run initializes the backend, runs the event loop, and cleans up on
+// exit. Panics on error; call RunE for the error-returning variant.
+func Run(w *gui.Window) {
+	if err := RunE(w); err != nil {
+		panic(fmt.Sprintf("gl: %v", err))
+	}
+}
+
+// RunE initializes the backend, runs the event loop, and cleans up on
+// exit. Returns an error instead of panicking.
+func RunE(w *gui.Window) error {
+	b, err := New(w)
+	if err != nil {
+		return fmt.Errorf("gl: %w", err)
+	}
+	defer b.Destroy()
+	b.Run(w)
+	return nil
+}
+
+// RunApp starts a multi-window event loop. Panics on error; call
+// RunAppE for the error-returning variant.
+func RunApp(app *gui.App, initialWindows ...*gui.Window) {
+	if err := RunAppE(app, initialWindows...); err != nil {
+		panic(fmt.Sprintf("gl: %v", err))
+	}
+}
+
+// taggedEvent carries an X event alongside the backend it belongs to so
+// a single channel can multiplex several windows' event pumps.
+type taggedEvent struct {
+	b      *Backend
+	ev     xgb.Event
+	closed bool
+}
+
+// RunAppE starts a multi-window event loop. Each window is created and
+// registered with app, keyed by its X window id. Blocks until the last
+// window closes.
+//
+//nolint:gocyclo // backend event loop
+func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
+	runtime.LockOSThread()
+
+	backends := make(map[uint32]*Backend) // window XID → backend
+	events := make(chan taggedEvent, 128)
+
+	open := func(w *gui.Window) error {
+		b, err := New(w)
+		if err != nil {
+			return err
+		}
+		b.plat.w = w
+		id := uint32(b.plat.window)
+		backends[id] = b
+		app.Register(id, w)
+		w.SetWakeMainFn(b.plat.wake)
+		if w.Config.OnInit != nil {
+			w.Config.OnInit(w)
+		}
+		go func(bk *Backend) {
+			ch := make(chan xgb.Event, 64)
+			go bk.plat.pumpEvents(ch)
+			for ev := range ch {
+				events <- taggedEvent{b: bk, ev: ev}
+			}
+			events <- taggedEvent{b: bk, closed: true}
+		}(b)
+		return nil
+	}
+
+	for _, w := range initialWindows {
+		if err := open(w); err != nil {
+			for _, b := range backends {
+				b.Destroy()
+			}
+			return fmt.Errorf("gl: create window: %w", err)
+		}
+	}
+
+	closeWindow := func(b *Backend) bool {
+		id := uint32(b.plat.window)
+		if w := app.Window(id); w != nil {
+			w.WindowCleanup()
+		}
+		b.Destroy()
+		delete(backends, id)
+		return app.Unregister(id)
+	}
+
+	var rendered bool
+	for len(backends) > 0 {
+		// Drain queued events + window opens.
+		drained := false
+		for !drained {
+			select {
+			case te := <-events:
+				if te.closed {
+					continue
+				}
+				te.b.handleXEvent(te.ev)
+			case cfg := <-app.PendingOpen():
+				if err := open(gui.NewWindow(cfg)); err != nil {
+					log.Printf("gl: open window: %v", err)
+				}
+			default:
+				drained = true
+			}
+		}
+
+		// Handle close requests.
+		for _, b := range backends {
+			w := app.Window(uint32(b.plat.window))
+			if w == nil || !w.CloseRequested() {
+				continue
+			}
+			if closeWindow(b) {
+				return nil // last window closed
+			}
+		}
+		if len(backends) == 0 {
+			return nil
+		}
+
+		// Frame + render each window.
+		rendered = false
+		for _, b := range backends {
+			w := app.Window(uint32(b.plat.window))
+			if w == nil {
+				continue
+			}
+			if w.FrameFn() {
+				b.renderFrame(w)
+				rendered = true
+			}
+			b.plat.setCursor(w.MouseCursorState())
+		}
+
+		if !rendered {
+			select {
+			case te := <-events:
+				if !te.closed {
+					te.b.handleXEvent(te.ev)
+				}
+			case cfg := <-app.PendingOpen():
+				if err := open(gui.NewWindow(cfg)); err != nil {
+					log.Printf("gl: open window: %v", err)
+				}
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func internAtom(conn *xgb.Conn, name string) xproto.Atom {
+	reply, err := xproto.InternAtom(conn, false, uint16(len(name)), name).Reply()
+	if err != nil || reply == nil {
+		return 0
+	}
+	return reply.Atom
+}
+
+func setWindowTitle(conn *xgb.Conn, win xproto.Window, title string) {
+	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
+		xproto.AtomWmName, xproto.AtomString, 8,
+		uint32(len(title)), []byte(title))
+}
+
+// setupCloseProtocol registers WM_DELETE_WINDOW so the window manager's
+// close button delivers a ClientMessage instead of killing the client.
+func setupCloseProtocol(conn *xgb.Conn, win xproto.Window) xproto.Atom {
+	protocols := internAtom(conn, "WM_PROTOCOLS")
+	del := internAtom(conn, "WM_DELETE_WINDOW")
+	if protocols == 0 || del == 0 {
+		return del
+	}
+	buf := []byte{
+		byte(del), byte(del >> 8), byte(del >> 16), byte(del >> 24),
+	}
+	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
+		protocols, xproto.AtomAtom, 32, 1, buf)
+	return del
+}
+
+func loadKeymap(conn *xgb.Conn, setup *xproto.SetupInfo) *xproto.GetKeyboardMappingReply {
+	count := byte(setup.MaxKeycode - setup.MinKeycode + 1)
+	km, err := xproto.GetKeyboardMapping(conn, setup.MinKeycode, count).Reply()
+	if err != nil {
+		return nil
+	}
+	return km
+}
+
+func loadCursors(p *platformState) {
+	fid, err := p.conn.NewId()
+	if err != nil {
+		return
+	}
+	font := xproto.Font(fid)
+	xproto.OpenFont(p.conn, font, uint16(len("cursor")), "cursor")
+
+	load := func(glyph uint16) xproto.Cursor {
+		cid, cerr := p.conn.NewId()
+		if cerr != nil {
+			return 0
+		}
+		c := xproto.Cursor(cid)
+		xproto.CreateGlyphCursor(p.conn, c, font, font,
+			glyph, glyph+1,
+			0, 0, 0, 0xffff, 0xffff, 0xffff)
+		return c
+	}
+	p.cursors[gui.CursorDefault] = load(xcLeftPtr)
+	p.cursors[gui.CursorArrow] = load(xcLeftPtr)
+	p.cursors[gui.CursorIBeam] = load(xcXterm)
+	p.cursors[gui.CursorCrosshair] = load(xcCrosshair)
+	p.cursors[gui.CursorPointingHand] = load(xcHand2)
+	p.cursors[gui.CursorResizeEW] = load(xcSbHDoubleArrow)
+	p.cursors[gui.CursorResizeNS] = load(xcSbVDoubleArrow)
+	p.cursors[gui.CursorResizeNWSE] = load(xcBottomRightCorner)
+	p.cursors[gui.CursorResizeNESW] = load(xcBottomLeftCorner)
+	p.cursors[gui.CursorResizeAll] = load(xcFleur)
+	p.cursors[gui.CursorNotAllowed] = load(xcXCursor)
+}
+
+// readDPIScale derives a UI scale from the Xft.dpi entry in the root
+// RESOURCE_MANAGER property, falling back to 1.0.
+func readDPIScale(conn *xgb.Conn, root xproto.Window) float32 {
+	atom := internAtom(conn, "RESOURCE_MANAGER")
+	if atom == 0 {
+		return 1
+	}
+	reply, err := xproto.GetProperty(conn, false, root, atom,
+		xproto.AtomString, 0, 1<<16).Reply()
+	if err != nil || reply == nil || len(reply.Value) == 0 {
+		return 1
+	}
+	for line := range strings.SplitSeq(string(reply.Value), "\n") {
+		key, val, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(key) != "Xft.dpi" {
+			continue
+		}
+		dpi, perr := strconv.Atoi(strings.TrimSpace(val))
+		if perr == nil && dpi > 0 {
+			return float32(dpi) / 96.0
+		}
+	}
+	return 1
+}

--- a/gui/backend/internal/x11key/x11key.go
+++ b/gui/backend/internal/x11key/x11key.go
@@ -1,0 +1,200 @@
+//go:build linux
+
+// Package x11key maps X11 keysyms and modifier/button state to go-gui
+// key, modifier, and mouse-button values. It mirrors the winkey and
+// sdlkey packages for the native Linux (X11) backend.
+package x11key
+
+import "github.com/go-gui-org/go-gui/gui"
+
+// X11 keysyms (subset, from keysymdef.h).
+const (
+	xkBackSpace = 0xff08
+	xkTab       = 0xff09
+	xkReturn    = 0xff0d
+	xkEscape    = 0xff1b
+	xkDelete    = 0xffff
+	xkHome      = 0xff50
+	xkLeft      = 0xff51
+	xkUp        = 0xff52
+	xkRight     = 0xff53
+	xkDown      = 0xff54
+	xkPrior     = 0xff55 // PageUp
+	xkNext      = 0xff56 // PageDown
+	xkEnd       = 0xff57
+	xkInsert    = 0xff63
+	xkKPEnter   = 0xff8d
+	xkF1        = 0xffbe
+	xkF12       = 0xffc9
+	xkShiftL    = 0xffe1
+	xkShiftR    = 0xffe2
+	xkControlL  = 0xffe3
+	xkControlR  = 0xffe4
+	xkCapsLock  = 0xffe5
+	xkAltL      = 0xffe9
+	xkAltR      = 0xffea
+	xkSuperL    = 0xffeb
+	xkSuperR    = 0xffec
+)
+
+// MapKeySym maps an X11 keysym to a gui.KeyCode. Letters are
+// normalized to their uppercase form (gui.KeyCode uses ASCII 'A'-'Z').
+//
+//nolint:gocyclo // key-mapping switch
+func MapKeySym(sym uint32) gui.KeyCode {
+	// ASCII letters: X sends lowercase (0x61-0x7a) when unshifted and
+	// uppercase (0x41-0x5a) when shifted; gui.KeyCode uses uppercase.
+	if sym >= 'a' && sym <= 'z' {
+		return gui.KeyCode(sym - 0x20)
+	}
+	if sym >= 'A' && sym <= 'Z' {
+		return gui.KeyCode(sym)
+	}
+	if sym >= '0' && sym <= '9' {
+		return gui.KeyCode(sym)
+	}
+	if sym >= xkF1 && sym <= xkF12 {
+		return gui.KeyF1 + gui.KeyCode(sym-xkF1)
+	}
+
+	switch sym {
+	case ' ':
+		return gui.KeySpace
+	case xkReturn, xkKPEnter:
+		return gui.KeyEnter
+	case xkEscape:
+		return gui.KeyEscape
+	case xkTab:
+		return gui.KeyTab
+	case xkBackSpace:
+		return gui.KeyBackspace
+	case xkDelete:
+		return gui.KeyDelete
+	case xkInsert:
+		return gui.KeyInsert
+	case xkRight:
+		return gui.KeyRight
+	case xkLeft:
+		return gui.KeyLeft
+	case xkDown:
+		return gui.KeyDown
+	case xkUp:
+		return gui.KeyUp
+	case xkPrior:
+		return gui.KeyPageUp
+	case xkNext:
+		return gui.KeyPageDown
+	case xkHome:
+		return gui.KeyHome
+	case xkEnd:
+		return gui.KeyEnd
+	case xkShiftL:
+		return gui.KeyLeftShift
+	case xkShiftR:
+		return gui.KeyRightShift
+	case xkControlL:
+		return gui.KeyLeftControl
+	case xkControlR:
+		return gui.KeyRightControl
+	case xkAltL:
+		return gui.KeyLeftAlt
+	case xkAltR:
+		return gui.KeyRightAlt
+	case xkSuperL:
+		return gui.KeyLeftSuper
+	case xkSuperR:
+		return gui.KeyRightSuper
+	case xkCapsLock:
+		return gui.KeyCapsLock
+	case ',':
+		return gui.KeyComma
+	case '-':
+		return gui.KeyMinus
+	case '.':
+		return gui.KeyPeriod
+	case '/':
+		return gui.KeySlash
+	case ';':
+		return gui.KeySemicolon
+	case '=':
+		return gui.KeyEqual
+	case '[':
+		return gui.KeyLeftBracket
+	case '\\':
+		return gui.KeyBackslash
+	case ']':
+		return gui.KeyRightBracket
+	case '`':
+		return gui.KeyGraveAccent
+	default:
+		return gui.KeyInvalid
+	}
+}
+
+// X11 KeyButMask bits (from xproto).
+const (
+	maskShift   = 1
+	maskControl = 4
+	maskMod1    = 8  // Alt
+	maskMod4    = 64 // Super
+	maskButton1 = 256
+	maskButton2 = 512
+	maskButton3 = 1024
+)
+
+// MapModifiers maps an X11 event state mask to gui modifiers,
+// including held mouse buttons.
+func MapModifiers(state uint16) gui.Modifier {
+	var m gui.Modifier
+	if state&maskShift != 0 {
+		m |= gui.ModShift
+	}
+	if state&maskControl != 0 {
+		m |= gui.ModCtrl
+	}
+	if state&maskMod1 != 0 {
+		m |= gui.ModAlt
+	}
+	if state&maskMod4 != 0 {
+		m |= gui.ModSuper
+	}
+	if state&maskButton1 != 0 {
+		m |= gui.ModLMB
+	}
+	if state&maskButton2 != 0 {
+		m |= gui.ModMMB
+	}
+	if state&maskButton3 != 0 {
+		m |= gui.ModRMB
+	}
+	return m
+}
+
+// MapButton maps an X11 button detail (1=left, 2=middle, 3=right) to a
+// gui.MouseButton. Returns MouseLeft for unknown buttons.
+func MapButton(detail byte) gui.MouseButton {
+	switch detail {
+	case 2:
+		return gui.MouseMiddle
+	case 3:
+		return gui.MouseRight
+	default:
+		return gui.MouseLeft
+	}
+}
+
+// KeysymToRune converts a printable X11 keysym to a Unicode rune,
+// returning 0 for non-printable keysyms (function keys, modifiers,
+// keypad control, etc.). Handles Latin-1 and the direct-Unicode
+// (0x01000000) keysym range.
+func KeysymToRune(sym uint32) rune {
+	// Direct Unicode keysyms.
+	if sym&0xff000000 == 0x01000000 {
+		return rune(sym & 0x00ffffff)
+	}
+	// Latin-1 (ASCII printable + Latin-1 supplement) map 1:1.
+	if (sym >= 0x20 && sym <= 0x7e) || (sym >= 0xa0 && sym <= 0xff) {
+		return rune(sym)
+	}
+	return 0
+}

--- a/gui/backend/internal/x11key/x11key_test.go
+++ b/gui/backend/internal/x11key/x11key_test.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package x11key
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestMapKeySym(t *testing.T) {
+	cases := []struct {
+		sym  uint32
+		want gui.KeyCode
+	}{
+		{'a', gui.KeyCode('A')}, // lowercase normalized to uppercase
+		{'A', gui.KeyCode('A')}, // already uppercase
+		{'z', gui.KeyCode('Z')},
+		{'5', gui.KeyCode('5')},
+		{0xff0d, gui.KeyEnter},  // XK_Return
+		{0xff1b, gui.KeyEscape}, // XK_Escape
+		{0xff08, gui.KeyBackspace},
+		{0xff51, gui.KeyLeft},
+		{0xff54, gui.KeyDown},
+		{0xffbe, gui.KeyF1},
+		{0xffc9, gui.KeyF12},
+		{0xffe1, gui.KeyLeftShift},
+		{' ', gui.KeySpace},
+		{',', gui.KeyComma},
+		{0x0, gui.KeyInvalid},
+	}
+	for _, c := range cases {
+		if got := MapKeySym(c.sym); got != c.want {
+			t.Errorf("MapKeySym(0x%x) = %v, want %v", c.sym, got, c.want)
+		}
+	}
+}
+
+func TestMapModifiers(t *testing.T) {
+	if m := MapModifiers(maskShift | maskControl); m&gui.ModShift == 0 || m&gui.ModCtrl == 0 {
+		t.Errorf("shift+ctrl not mapped: %v", m)
+	}
+	if m := MapModifiers(maskButton1 | maskButton3); m&gui.ModLMB == 0 || m&gui.ModRMB == 0 {
+		t.Errorf("button1+button3 not mapped: %v", m)
+	}
+	if m := MapModifiers(0); m != 0 {
+		t.Errorf("empty state mapped to %v", m)
+	}
+}
+
+func TestMapButton(t *testing.T) {
+	if MapButton(1) != gui.MouseLeft || MapButton(2) != gui.MouseMiddle || MapButton(3) != gui.MouseRight {
+		t.Error("button mapping wrong")
+	}
+}
+
+func TestKeysymToRune(t *testing.T) {
+	if KeysymToRune('A') != 'A' {
+		t.Error("ASCII keysym should map to itself")
+	}
+	if KeysymToRune(0x010000e9) != 0x00e9 { // direct-unicode é
+		t.Error("direct-unicode keysym decode failed")
+	}
+	if KeysymToRune(0xff0d) != 0 { // Return: non-printable
+		t.Error("non-printable keysym should map to 0")
+	}
+}

--- a/gui/backend/run_default.go
+++ b/gui/backend/run_default.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !js && !android && !gl && !windows
+//go:build !darwin && !js && !android && !gl && !windows && !linux
 
 // Package backend provides platform-specific backend initialization.
 package backend

--- a/gui/backend/run_linux.go
+++ b/gui/backend/run_linux.go
@@ -1,0 +1,18 @@
+//go:build linux && !js && !android && !gl
+
+package backend
+
+import (
+	"github.com/go-gui-org/go-gui/gui"
+	glbackend "github.com/go-gui-org/go-gui/gui/backend/gl"
+)
+
+// Run starts the application event loop using the native X11 + EGL
+// backend (SDL2-free).
+func Run(w *gui.Window) { glbackend.Run(w) }
+
+// RunApp starts a multi-window event loop using the native X11 + EGL
+// backend (SDL2-free).
+func RunApp(app *gui.App, windows ...*gui.Window) {
+	glbackend.RunApp(app, windows...)
+}

--- a/tools/depsdoc/main.go
+++ b/tools/depsdoc/main.go
@@ -36,6 +36,8 @@ var directPurpose = map[string]string{
 	"github.com/go-gui-org/go-glyph/backend/sdl2": "SDL2-specific glyph rasterisation backend used by `gui/backend/sdl2`.",
 	"github.com/veandco/go-sdl2":                  "SDL2 backend (`gui/backend/sdl2`). Window, input, GL/Metal context glue.",
 	"github.com/go-gl/gl":                         "OpenGL bindings for `gui/backend/gl`.",
+	"github.com/jezek/xgb":                        "Pure-Go X11 windowing + events for the native Linux backend (`gui/backend/gl`).",
+	"github.com/ebitengine/purego":                "cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`).",
 	"github.com/tdewolff/parse/v2":                "CSS tokenizer for the SVG `<style>` / `style=\"\"` cascade pipeline.",
 	"github.com/alecthomas/chroma/v2":             "Syntax highlighting in the markdown widget.",
 	"github.com/yuin/goldmark":                    "Markdown parser (markdown widget + showcase docs).",


### PR DESCRIPTION
## Summary

Native **X11 + EGL** backend for Linux, mirroring the Windows Win32+WGL split (#38). Windowing and events are **pure-Go** (`jezek/xgb`); the GL 3.3-core context is created via **EGL** loaded with `ebitengine/purego` (`libEGL` dlopen). It reuses the existing `gl` OpenGL renderer — go-glyph's `gpu.New` is not used. Makes the **default Linux build SDL2-free** (advances #37).

EGL (not GLX) because `xgb` exposes no Xlib `Display*`; EGL wraps the window by XID via `EGL_DEFAULT_DISPLAY`.

## Changes

- `gui/backend/gl/platform_x11.go` — window lifecycle, event-pump loop, cursors, DPI, wake, `New`/`Run`/`RunApp`
- `gui/backend/gl/egl_linux.go` — EGL context creation + `gl.InitWithProcAddrFunc` loader (purego)
- `gui/backend/gl/events_x11.go` — X event → `gui.Event` translation
- `gui/backend/internal/x11key/` — keysym/modifier/button mapping (+tests)
- `gui/backend/run_linux.go` routes Linux → `gl` backend; `run_default.go` narrowed `!linux`
- `gl` sdl2 platform files narrowed `!linux` (retained for darwin/BSD)
- deps: `jezek/xgb`, `ebitengine/purego`

## Notable fix

`focusRealChange()` ignores WM grab/ungrab focus churn (`NotifyGrab`/`NotifyUngrab`). Without it, the grab-synthesized `FocusOut` during an interactive resize made the window look unfocused, so go-gui dropped `EventResized` (focus-gated) and the layout froze mid-drag while the viewport tracked — matching GLFW/SDL behavior. Verified via controlled synthetic focus events (grab focus-out → resize tracks; real focus-out → correctly stale).

## Scope / notes

- **cgo:** the `go-gl/gl` renderer binding requires cgo on all platforms (Windows too); windowing/EGL are pure-Go, GL rendering is cgo. `CGO_ENABLED=0` is not achievable with the current renderer.
- **SDL2 not fully dropped from `go.mod`:** `veandco/go-sdl2` is retained because `gui/audio` uses SDL2_mixer (unrelated to windowing); the `gl` sdl2 files stay for darwin/BSD. `go-glyph/backend/sdl2` untouched.
- **Scaffolding-grade** (follow-ups): clipboard no-op, IME stubbed, DPI Xft.dpi-only, diagonal-resize cursors approximate.

## Verification

`go build ./...`, `go build -tags gl ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` all pass. `get_started` runs on the default Linux build with **no SDL2** in `go list -deps`; window, text/emoji, widgets, mouse/keyboard, and edge/corner resize confirmed on Muffin/Cinnamon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)