### PR TITLE
gui/backend/gl: per-monitor DPI via RandR (issue #43)

### DIFF
--- a/gui/backend/gl/dpi_x11_test.go
+++ b/gui/backend/gl/dpi_x11_test.go
@@ -1,0 +1,80 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"math"
+	"os"
+	"testing"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/randr"
+	"github.com/jezek/xgb/xproto"
+)
+
+// TestCrtcDPI covers the per-monitor DPI math headlessly (no X server).
+func TestCrtcDPI(t *testing.T) {
+	cases := []struct {
+		name     string
+		w, h     uint16
+		rotation uint16
+		mmW, mmH uint32
+		wantDPI  float64 // 0 ⇒ expect ok=false
+	}{
+		// 1366x768 over 344x193mm ≈ 101 DPI (matches a real 15" laptop).
+		{"laptop", 1366, 768, randr.RotationRotate0, 344, 193, 101},
+		// 90° rotation swaps pixel axes; DPI must be unchanged.
+		{"rotated90", 768, 1366, randr.RotationRotate90, 344, 193, 101},
+		// 3840x2160 over 344x194mm ≈ 283 DPI (4K laptop panel).
+		{"hidpi", 3840, 2160, randr.RotationRotate0, 344, 194, 283},
+		{"no-physical-size", 1920, 1080, randr.RotationRotate0, 0, 0, 0},
+		{"implausible-tiny-mm", 1920, 1080, randr.RotationRotate0, 5, 5, 0},
+	}
+	for _, c := range cases {
+		info := &randr.GetCrtcInfoReply{Width: c.w, Height: c.h, Rotation: c.rotation}
+		out := &randr.GetOutputInfoReply{MmWidth: c.mmW, MmHeight: c.mmH}
+		dpi, ok := crtcDPI(info, out)
+		if c.wantDPI == 0 {
+			if ok {
+				t.Errorf("%s: expected ok=false, got dpi=%.1f", c.name, dpi)
+			}
+			continue
+		}
+		if !ok {
+			t.Errorf("%s: expected ok=true", c.name)
+			continue
+		}
+		if math.Abs(dpi-c.wantDPI) > 1.5 {
+			t.Errorf("%s: dpi=%.2f, want ~%.1f", c.name, dpi, c.wantDPI)
+		}
+	}
+}
+
+// TestDPIScaleForWindowLive checks per-monitor detection against the live
+// X server. Opt-in via GOGUI_X11_IT=1: it opens an X connection which, when
+// sharing a process with the EGL/GL context test, can trip a native
+// Mesa/Xlib threading crash unrelated to the DPI code.
+func TestDPIScaleForWindowLive(t *testing.T) {
+	if os.Getenv("GOGUI_X11_IT") == "" {
+		t.Skip("set GOGUI_X11_IT=1 to run the live X11 DPI test")
+	}
+	if os.Getenv("DISPLAY") == "" {
+		t.Skip("no DISPLAY; live DPI test needs an X server")
+	}
+	conn, err := xgb.NewConn()
+	if err != nil {
+		t.Skipf("x11 connect: %v", err)
+	}
+	defer conn.Close()
+
+	root := xproto.Setup(conn).DefaultScreen(conn).Root
+	haveRandr := randr.Init(conn) == nil
+	scale, crtc := dpiScaleForWindow(conn, root, haveRandr, 0, 0)
+	t.Logf("dpiScaleForWindow(0,0) = %.4f crtc=%d haveRandr=%v", scale, crtc, haveRandr)
+	if scale <= 0 {
+		t.Fatalf("scale = %v, want > 0", scale)
+	}
+	if scale < 0.5 || scale > 4.5 {
+		t.Errorf("scale = %.4f outside plausible range [0.5,4.5]", scale)
+	}
+}

--- a/gui/backend/gl/events_x11.go
+++ b/gui/backend/gl/events_x11.go
@@ -114,8 +114,9 @@ func (b *Backend) handleXEvent(ev xgb.Event) {
 		})
 
 	case xproto.ConfigureNotifyEvent:
+		scaleChanged := b.maybeRescaleDPI()
 		nw, nh := int32(e.Width), int32(e.Height)
-		if nw == b.plat.physW && nh == b.plat.physH {
+		if !scaleChanged && nw == b.plat.physW && nh == b.plat.physH {
 			return
 		}
 		b.plat.physW = nw

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/randr"
 	"github.com/jezek/xgb/xproto"
 
 	"github.com/go-gui-org/go-gui/gui"
@@ -66,6 +67,16 @@ type platformState struct {
 	ownsClipboard bool
 	clipReadConn  *xgb.Conn     // dedicated connection for reads
 	clipReadWin   xproto.Window // requestor window on clipReadConn
+
+	// Per-monitor DPI (RandR). root anchors monitor queries; curCrtc is
+	// the CRTC the window currently sits on; lastRootXY caches the last
+	// root-relative position so ConfigureNotify only rescans on a move.
+	root        xproto.Window
+	haveRandr   bool
+	curCrtc     randr.Crtc
+	lastRootX   int16
+	lastRootY   int16
+	haveLastPos bool
 
 	physW, physH int32
 	scale        float32
@@ -200,7 +211,10 @@ func New(w *gui.Window) (*Backend, error) {
 		height = 480
 	}
 
-	scale := readDPIScale(conn, screen.Root)
+	haveRandr := randr.Init(conn) == nil
+	// The window is created at 0,0, so its initial monitor is whichever
+	// CRTC covers the origin.
+	scale, crtc := dpiScaleForWindow(conn, screen.Root, haveRandr, 0, 0)
 	physW := int32(float32(width) * scale)
 	physH := int32(float32(height) * scale)
 
@@ -241,6 +255,9 @@ func New(w *gui.Window) (*Backend, error) {
 	b.plat.scale = scale
 	b.plat.physW = physW
 	b.plat.physH = physH
+	b.plat.root = screen.Root
+	b.plat.haveRandr = haveRandr
+	b.plat.curCrtc = crtc
 
 	setWindowTitle(conn, win, title)
 	b.plat.wmDelete = setupCloseProtocol(conn, win)
@@ -606,4 +623,123 @@ func readDPIScale(conn *xgb.Conn, root xproto.Window) float32 {
 		}
 	}
 	return 1
+}
+
+// Plausible bounds for a physical display DPI. Values outside this range
+// usually mean a bogus EDID physical size, so the RandR path is rejected
+// in favor of the Xft.dpi fallback.
+const (
+	minPlausibleDPI = 50
+	maxPlausibleDPI = 400
+)
+
+// dpiScaleForWindow computes the UI scale for the monitor containing the
+// root-relative point (x,y), using that monitor's RandR-reported physical
+// size. It falls back to the global Xft.dpi scale when RandR is
+// unavailable or reports no usable physical size. Returns the scale and
+// the CRTC the point lands on (0 when none was resolved).
+func dpiScaleForWindow(conn *xgb.Conn, root xproto.Window, haveRandr bool, x, y int32) (float32, randr.Crtc) {
+	if haveRandr {
+		if s, crtc, ok := randrDPIScale(conn, root, x, y); ok {
+			return s, crtc
+		}
+	}
+	return readDPIScale(conn, root), 0
+}
+
+// randrDPIScale finds the CRTC covering (x,y) and derives a UI scale from
+// its output's physical size. ok is false when RandR data is missing or
+// implausible.
+func randrDPIScale(conn *xgb.Conn, root xproto.Window, x, y int32) (float32, randr.Crtc, bool) {
+	res, err := randr.GetScreenResourcesCurrent(conn, root).Reply()
+	if err != nil || res == nil {
+		return 0, 0, false
+	}
+	for _, crtc := range res.Crtcs {
+		info, ierr := randr.GetCrtcInfo(conn, crtc, res.ConfigTimestamp).Reply()
+		if ierr != nil || info == nil || info.Width == 0 || info.Height == 0 {
+			continue // disabled/disconnected CRTC
+		}
+		if x < int32(info.X) || x >= int32(info.X)+int32(info.Width) ||
+			y < int32(info.Y) || y >= int32(info.Y)+int32(info.Height) {
+			continue
+		}
+		if len(info.Outputs) == 0 {
+			return 0, 0, false
+		}
+		out, oerr := randr.GetOutputInfo(conn, info.Outputs[0], res.ConfigTimestamp).Reply()
+		if oerr != nil || out == nil {
+			return 0, 0, false
+		}
+		if dpi, ok := crtcDPI(info, out); ok {
+			return float32(dpi / 96.0), crtc, true
+		}
+		return 0, 0, false
+	}
+	return 0, 0, false
+}
+
+// crtcDPI averages the horizontal and vertical DPI from the CRTC pixel
+// size and the output's physical millimetre size. ok is false when no
+// physical dimension is reported or the result is implausible.
+func crtcDPI(info *randr.GetCrtcInfoReply, out *randr.GetOutputInfoReply) (float64, bool) {
+	const mmPerInch = 25.4
+	// A 90/270° rotation swaps the pixel axes relative to physical size.
+	pw, ph := float64(info.Width), float64(info.Height)
+	if info.Rotation&(randr.RotationRotate90|randr.RotationRotate270) != 0 {
+		pw, ph = ph, pw
+	}
+	var sum float64
+	var n int
+	if out.MmWidth > 0 {
+		sum += pw / (float64(out.MmWidth) / mmPerInch)
+		n++
+	}
+	if out.MmHeight > 0 {
+		sum += ph / (float64(out.MmHeight) / mmPerInch)
+		n++
+	}
+	if n == 0 {
+		return 0, false
+	}
+	dpi := sum / float64(n)
+	if dpi < minPlausibleDPI || dpi > maxPlausibleDPI {
+		return 0, false
+	}
+	return dpi, true
+}
+
+// maybeRescaleDPI re-evaluates the per-monitor scale when the window has
+// moved to a CRTC with a different DPI, updating plat.scale and the glyph
+// backend. It reports whether the scale changed so the caller can trigger
+// a relayout. ConfigureNotify coordinates are frame-relative under a
+// reparenting WM, so the true root position is queried explicitly and a
+// RandR rescan runs only when that position changed.
+func (b *Backend) maybeRescaleDPI() bool {
+	if !b.plat.haveRandr {
+		return false
+	}
+	t, err := xproto.TranslateCoordinates(b.plat.conn, b.plat.window,
+		b.plat.root, 0, 0).Reply()
+	if err != nil || t == nil {
+		return false
+	}
+	if b.plat.haveLastPos && t.DstX == b.plat.lastRootX &&
+		t.DstY == b.plat.lastRootY {
+		return false // no move → still on the same monitor
+	}
+	b.plat.lastRootX, b.plat.lastRootY = t.DstX, t.DstY
+	b.plat.haveLastPos = true
+
+	scale, crtc := dpiScaleForWindow(b.plat.conn, b.plat.root, true,
+		int32(t.DstX), int32(t.DstY))
+	b.plat.curCrtc = crtc
+	if scale == b.plat.scale {
+		return false
+	}
+	b.plat.scale = scale
+	if b.glyphBack != nil {
+		b.glyphBack.dpiScale = scale
+	}
+	return true
 }


### PR DESCRIPTION
Part of #43 (Linux native backend polish). Second of two PRs; the clipboard PR is #44.

## What

Replaces the global-only `Xft.dpi` scale — which is system-wide and inaccurate on mixed-DPI multi-monitor setups — with true per-monitor DPI via RandR.

- `dpiScaleForWindow` — finds the CRTC covering the window origin and derives DPI from that output's physical millimetre size (both axes averaged, rotation-aware, clamped to a plausible 50–400 DPI). Falls back to `Xft.dpi`, then `1.0`, when RandR is unavailable or reports no usable physical size.
- `maybeRescaleDPI` — when the window moves to a monitor with a different DPI, updates `plat.scale` + the glyph backend scale and relayouts. `ConfigureNotify` now checks DPI *before* the size early-return, so a pure move (unchanged size) still rescales. True root position comes from `TranslateCoordinates` (ConfigureNotify coords are frame-relative under a reparenting WM); the RandR rescan runs only when the position actually changed.

RandR is a subpackage of the already-required `github.com/jezek/xgb`, so there is no `go.mod` change.

## Verification

- Headless `TestCrtcDPI` covers the DPI math: 15" laptop (~101 DPI), 90° rotation (axis swap), 4K panel (~283 DPI), and the zero/implausible-mm rejection paths.
- Opt-in live test (`GOGUI_X11_IT=1`) on a 1366×768 / 344×193mm panel returns scale **1.0517** (~101 DPI) vs the global `Xft.dpi:96` → 1.0, demonstrating correct per-monitor detection.
- `go build ./...`, `go vet ./...`, `golangci-lint run`, and full `go test ./...` all green; default suite stable across repeated runs.

## Notes

- The live test is opt-in for the same reason as PR #44: opening an X connection alongside the EGL/GL context test (`TestBackendRenderSmoke`) can intermittently trip a native Mesa/Xlib threading crash unrelated to this code. Headless CI skips it anyway.
- Physical-size DPI is used as approved in the plan (clamped to a plausible range) rather than snapping to integer scales; the drag-between-monitors rescale path mirrors the existing verified resize path but was not observed across two differing-DPI displays (single-monitor dev machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)