### PR TITLE
deps: bump go-glyph to v1.13.0

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -13,7 +13,7 @@ Go toolchain pin: `go 1.26.0`.
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`). |
 | `github.com/go-gl/gl` | v0.0.0-20260331235117-4566fea9a276 | OpenGL bindings for `gui/backend/gl`. |
-| `github.com/go-gui-org/go-glyph` | v1.12.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.13.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio playback (sound effects, music, mixer, fade) for `gui/audio`. |
@@ -55,7 +55,7 @@ go mod tidy
 Example:
 
 ```bash
-go get github.com/go-gui-org/go-glyph@v1.9.0
+go get github.com/go-gui-org/go-glyph@v1.13.0
 go mod tidy
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/ebitengine/purego v0.10.1
 	github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276
-	github.com/go-gui-org/go-glyph v1.12.0
+	github.com/go-gui-org/go-glyph v1.13.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276 h1:IO5P06Pcj9K04d+l4nrf3c2U56+dAotIFG6u4P1wAHI=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
-github.com/go-gui-org/go-glyph v1.12.0 h1:l0dXe8DtNPd8TYfG/peIRRmHMj6u2ienM8dhOOXSSaE=
-github.com/go-gui-org/go-glyph v1.12.0/go.mod h1:TGH4KhHIaROHLy5m8gEId+ZInQjbMFVxlieyvrfZHXI=
+github.com/go-gui-org/go-glyph v1.13.0 h1:k95UVFNVnxMAy8YtxMOWQivykwDvCnmJlpdD4PFu5JQ=
+github.com/go-gui-org/go-glyph v1.13.0/go.mod h1:TGH4KhHIaROHLy5m8gEId+ZInQjbMFVxlieyvrfZHXI=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=

--- a/tools/depsdoc/main.go
+++ b/tools/depsdoc/main.go
@@ -149,7 +149,7 @@ func run() error {
 	b.WriteString("```\n\n")
 	b.WriteString("Example:\n\n")
 	b.WriteString("```bash\n")
-	b.WriteString("go get github.com/go-gui-org/go-glyph@v1.9.0\n")
+	b.WriteString("go get github.com/go-gui-org/go-glyph@v1.13.0\n")
 	b.WriteString("go mod tidy\n")
 	b.WriteString("```\n\n")
 	b.WriteString("After updating dependencies, regenerate this file:\n\n")


### PR DESCRIPTION
Bump go-glyph from v1.12.0 to v1.13.0.

v1.13.0 is the existing v2.0.0 release retagged — v2.0.0 had no /v2 suffix on the module path, making it invalid for Go module resolution.