### PR TITLE
gui/backend/gl: fix 50 unused-code lint warnings on macOS

### DIFF
--- a/gui/backend/gl/a11y_other.go
+++ b/gui/backend/gl/a11y_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !js
+//go:build !linux && !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 // Package gl provides an OpenGL 3.3 backend for go-gui.
 //

--- a/gui/backend/gl/buffers.go
+++ b/gui/backend/gl/buffers.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/pipeline.go
+++ b/gui/backend/gl/pipeline.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/render_test.go
+++ b/gui/backend/gl/render_test.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/render_test.go
+++ b/gui/backend/gl/render_test.go
@@ -3,7 +3,6 @@
 package gl
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/go-gui-org/go-gui/gui"
@@ -71,14 +70,6 @@ func TestBackendRenderSmoke(t *testing.T) {
 			},
 		})
 	})
-
-	// SDL2 init on macOS requires the main thread for Cocoa.
-	// go test runs tests in goroutines, so TestBackendRenderSmoke
-	// is only safe on Linux where SDL has no main-thread constraint.
-	if runtime.GOOS == "darwin" {
-		t.Skip("SDL init requires main thread on macOS; " +
-			"backend smoke test runs on Linux CI instead")
-	}
 
 	b, err := New(w)
 	if err != nil {

--- a/gui/backend/gl/rotation.go
+++ b/gui/backend/gl/rotation.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/rotation_test.go
+++ b/gui/backend/gl/rotation_test.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/text.go
+++ b/gui/backend/gl/text.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/textures.go
+++ b/gui/backend/gl/textures.go
@@ -1,4 +1,4 @@
-//go:build !js
+//go:build !js && !darwin
 
 package gl
 

--- a/gui/backend/gl/types_darwin.go
+++ b/gui/backend/gl/types_darwin.go
@@ -1,0 +1,36 @@
+//go:build darwin
+
+package gl
+
+// On macOS the GL backend is not used — platform_other.go provides
+// a stub New that returns nil.  These minimal type definitions exist
+// only so platform_other.go's method receivers and return types compile.
+// The var block references all stub methods to suppress "unused" lint
+// warnings — they are intentionally present for interface consistency
+// across platforms.
+
+// Backend is a stub for the GL rendering backend on macOS.
+type Backend struct{}
+
+type nativePlatform struct{}
+
+var (
+	_ = (*Backend)(nil)
+	_ = (*nativePlatform)(nil)
+
+	_ = (*platformState).makeCurrent
+	_ = (*platformState).swap
+	_ = (*platformState).drawableSize
+	_ = (*platformState).dpiScale
+	_ = (*platformState).setCursor
+	_ = (*platformState).wake
+	_ = (*platformState).destroy
+	_ = (*platformState).pumpEvents
+
+	_ = (*nativePlatform).IMEStart
+	_ = (*nativePlatform).IMEStop
+	_ = (*nativePlatform).IMESetRect
+	_ = (*nativePlatform).CreateSystemTray
+	_ = (*nativePlatform).UpdateSystemTray
+	_ = (*nativePlatform).RemoveSystemTray
+)


### PR DESCRIPTION
Build-tag the GL backend's real implementation files with `!darwin` so they don't compile on macOS where the platform stub returns nil.

Add `types_darwin.go` with minimal `Backend`/`nativePlatform` stubs plus a var block referencing all stub methods to suppress unused lint on macOS.

The GL backend is linux/windows only — Metal is the macOS backend.