### PR TITLE
release: v0.30.1 — deps-doc fix for go-glyph v1.13.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ deep-dive/
 .direnv/
 docs/specs/
 .tokensave/
+.codegraph/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.30.1] - 2026-07-10
+
+### Changed
+
+- **Dependencies**: go-glyph bumped to v1.13.1 (Windows proportional-font
+  substitution now falls back to Consolas; internal draw/renderer dedup
+  between the FreeType and Darwin backends). Regenerates
+  `docs/dependencies.md` to match.
+
 ## [v0.30.0] - 2026-07-08
 
 ### Changed

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -13,7 +13,7 @@ Go toolchain pin: `go 1.26.0`.
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`). |
 | `github.com/go-gl/gl` | v0.0.0-20260331235117-4566fea9a276 | OpenGL bindings for `gui/backend/gl`. |
-| `github.com/go-gui-org/go-glyph` | v1.13.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.13.1 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio playback (sound effects, music, mixer, fade) for `gui/audio`. |


### PR DESCRIPTION
## Why

`main` CI is currently **red**: commit `419cbbb` (`deps: bump go-glyph to
v1.13.1`) was pushed directly to `main` and bumped `go.mod` but did **not**
regenerate `docs/dependencies.md`, so the `deps-doc-check` gate fails
(run 29090732818).

## What

- Regenerate `docs/dependencies.md` via `make deps-doc` → go-glyph `v1.13.1`.
- Add `CHANGELOG.md` entry `[v0.30.1]`.
- Ignore `.codegraph/` (local index dir).

go-glyph `v1.13.1` = Windows proportional-font fallback to Consolas +
FreeType/Darwin draw-renderer dedup.

Verified locally with `GOWORK=off`: `make vet deps-doc-check large-files
generate-check`, `go build ./...`, `go test ./...` all pass. Tag `v0.30.1`
will be cut on the merged commit so downstream consumers get a go-gui built
against the latest go-glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)