### PR TITLE
ci: trim vestigial MSYS2 packages from Windows CI (#58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,13 +246,6 @@ jobs:
           path-type: inherit
           install: >-
             mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-pkg-config
-            mingw-w64-x86_64-SDL2
-            mingw-w64-x86_64-SDL2_mixer
-            mingw-w64-x86_64-freetype
-            mingw-w64-x86_64-harfbuzz
-            mingw-w64-x86_64-pango
-            mingw-w64-x86_64-fontconfig
             mingw-w64-x86_64-mesa
 
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -153,16 +153,19 @@ version and [`examples/web_demo/`](examples/web_demo/) for the browser build.
 
 ## Installation
 
-Requires **Go 1.26+** and SDL2 development libraries. See the
+Requires **Go 1.26+** and a C toolchain (CGo). The desktop backends are
+SDL2-free: macOS uses Metal + CoreText, Linux uses native X11/GLX +
+FreeType/HarfBuzz (bundled), and Windows uses native Win32/WGL +
+DirectWrite. See the
 [Installation Guide](https://github.com/go-gui-org/go-gui/wiki/Installation)
 for platform-specific instructions.
 
 ```bash
-# macOS:   brew install go pkg-config sdl2 sdl2_mixer freetype harfbuzz pango fontconfig
-# Ubuntu:  sudo apt-get install golang libsdl2-dev libsdl2-mixer-dev libfreetype6-dev libharfbuzz-dev libpango1.0-dev libfontconfig1-dev
-# Fedora:  sudo dnf install golang SDL2-devel SDL2_mixer-devel freetype-devel harfbuzz-devel pango-devel fontconfig-devel
-# Arch:    sudo pacman -S go sdl2 sdl2_mixer freetype2 harfbuzz pango fontconfig
-# Windows: Use MSYS2 MinGW x64 — pacman -S mingw-w64-x86_64-go mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-freetype mingw-w64-x86_64-harfbuzz mingw-w64-x86_64-pango mingw-w64-x86_64-fontconfig
+# macOS:   brew install go                  # Metal + CoreText are system frameworks
+# Ubuntu:  sudo apt-get install golang gcc pkg-config libgl1-mesa-dev libx11-dev
+# Fedora:  sudo dnf install golang gcc pkgconf-pkg-config mesa-libGL-devel libX11-devel
+# Arch:    sudo pacman -S go gcc pkgconf mesa libx11
+# Windows: Use MSYS2 MinGW x64 — pacman -S mingw-w64-x86_64-go mingw-w64-x86_64-gcc
 
 go get github.com/go-gui-org/go-gui
 ```
@@ -175,12 +178,14 @@ go get github.com/go-gui-org/go-gui
 
 ### Backend Selection
 
-`backend.Run(w)` auto-selects Metal on macOS, SDL2 on Linux/Windows (OpenGL with the `gl` build tag):
+`backend.Run(w)` auto-selects the native backend per platform — Metal on
+macOS, X11/GLX on Linux, Win32/WGL on Windows (force portable OpenGL with
+the `gl` build tag):
 
 ```go
 import "github.com/go-gui-org/go-gui/gui/backend"
 
-backend.Run(w) // Metal on macOS, SDL2 (or GL with -tags gl) on Linux/Windows
+backend.Run(w) // Metal on macOS; native X11/Win32 GL on Linux/Windows (portable GL with -tags gl)
 ```
 
 To force a specific backend, import it directly:
@@ -426,10 +431,11 @@ The root `Makefile` builds standalone showcase binaries for each platform.
 | `make build-wasm`    | `build/showcase.wasm`        | `GOOS=js GOARCH=wasm go build`          |
 | `make release`       | `.tar.gz`, `.dmg`, `.zip`    | All of the above + packaging            |
 
-**Linux and Windows** use `-tags static` which activates go-sdl2's bundled
-pre-compiled static libraries. No SDL2 installation required — a single
-`go build -tags static ./examples/showcase/` produces a self-contained
-binary.
+**Linux and Windows** produce self-contained binaries with no SDL2
+dependency: go-glyph statically bundles FreeType/HarfBuzz on Linux, and
+Windows text uses the system DirectWrite DLL. A plain
+`go build ./examples/showcase/` is self-contained; add `-tags audio` for
+sound.
 
 **Windows cross-compilation** requires `mingw-w64`. On Windows (MSYS2),
 use `make build-windows CC_WINDOWS=gcc`.
@@ -440,7 +446,7 @@ Version and commit are injected from git tags via `-ldflags`.
 
 ## Contributing
 
-1. Install **Go 1.26+** and SDL2 development libraries (see
+1. Install **Go 1.26+** and a C toolchain (see
    [Installation](#installation)).
 2. Clone the repo.
 3. Run tests and lint:


### PR DESCRIPTION
## Summary

Fixes #58. The Windows CI job installed 9 MSYS2 packages, but the current Windows build path uses none of the graphics/audio libraries:

- Text: go-glyph's Windows path uses **DirectWrite + GDI**, not FreeType/HarfBuzz/Pango/Fontconfig
- Audio: **pure-Go oto** (gopxl/beep + ebitengine/oto), not SDL2_mixer
- Windowing: **native Win32 + WGL**, not SDL2

The install list is reduced to the two packages actually used:
- `mingw-w64-x86_64-gcc` — CGo compiler (go-glyph DirectWrite + WGL)
- `mingw-w64-x86_64-mesa` — software OpenGL 3.3 `opengl32.dll` for the headless smoke test

`pkg-config` verified unused on the Windows path (only Linux `spellcheck_linux.go` uses it; go-glyph's Windows cgo links directly with `-lopengl32 -lgdi32`).

## README refresh

Also corrects stale SDL2 references. Desktop backends are now SDL2-free (per `backend/run_*.go`): Metal+CoreText on macOS, native X11/GLX on Linux, native Win32/WGL on Windows. Fixes:
- Per-platform install commands (macOS needs no brew libs; Linux needs only GL/X11 + pkg-config since go-glyph bundles FreeType/HarfBuzz statically by default)
- `backend.Run` auto-select description
- Removed the obsolete "`-tags static` activates go-sdl2 static libs" claim (no go-sdl2 dependency exists; `static` maps to no build constraint)

Retained legitimate SDL2 mentions (the `gui/backend/sdl2/` fallback package still exists).

## Scope

Deliberately **not** touching `release.yml` / `bundle-windows-dlls.sh` — that path still bundles SDL2 runtime DLLs into the shipped release zip and is a larger change best handled separately.

## Verification

- `go build ./...` and `go test ./...` pass locally
- Authoritative check: the Windows CI job on this PR building green with only gcc+mesa

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786312861&installation_id=145733661&pr_number=59&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F59&signature=e07265fac7706478c5328dc51dee20a04390f10c06db1d0d66b90efb0b1b78bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->