### PR TITLE
changelog: add v0.31.0 (go-glyph v1.15.0, markdown line-spacing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.31.0] - 2026-07-11
+
+### Changed
+
+- **Dependencies**: go-glyph bumped to v1.15.0 — pure-Go text backends on
+  Linux, Android, macOS, and Windows (`go-text/typesetting` +
+  `x/image/vector`, `CGO_ENABLED=0`), replacing the cgo FreeType+HarfBuzz
+  stack. Pulls in `go-text/typesetting` and `golang.org/x/image` as indirect
+  deps; regenerates `docs/dependencies.md`. Drops the obsolete Android
+  native-deps build step from CI/release workflows.
+- **Markdown defaults**: paragraph `LineSpacing` reduced to 3 and
+  `BlockSpacing` raised to 12 so inter-block gaps stay larger than
+  intra-line gaps (fixes cramped spacing between wrapped list items).
 
 ### Fixed
 
@@ -13,12 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rich-text (RTF) rendering. Line spacing lives on glyph's `BlockStyle`, so
   `ToGlyphStyle` dropped it and markdown paragraph/list line spacing was a
   no-op; the value is now carried through both RTF layout paths.
-
-### Changed
-
-- **Markdown defaults**: paragraph `LineSpacing` reduced to 3 and
-  `BlockSpacing` raised to 12 so inter-block gaps stay larger than
-  intra-line gaps (fixes cramped spacing between wrapped list items).
 
 ## [v0.30.2] - 2026-07-10
 


### PR DESCRIPTION
Release notes for **v0.31.0**:
- go-glyph bumped to v1.15.0 (pure-Go text backends on Linux/Android/macOS/Windows).
- Markdown line-spacing now applies to wrapped RTF; retuned paragraph/block spacing defaults.

Cut to expose these to downstream siblings (go-charts, go-edit, go-kite, go-map, go-term).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786384770&installation_id=145733661&pr_number=65&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F65&signature=a101048f0243685a90f5edc5369cf8a0d384e1d98be22d9ec71ff96a42caec3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->