### PR TITLE
fix(svg): reject non-finite tx/ty in decomposeTRS

### DIFF
--- a/gui/svg/transform_decompose.go
+++ b/gui/svg/transform_decompose.go
@@ -9,8 +9,12 @@ const decomposeTRSEpsilon = 1e-4
 // Convention: (x',y') = (a*x + c*y + e, b*x + d*y + f).
 // ok=false when the matrix has shear; caller must bake instead.
 func decomposeTRS(m [6]float32) (tx, ty, sx, sy, rotDeg float32, ok bool) {
-	a, b, c, d := m[0], m[1], m[2], m[3]
 	tx, ty = m[4], m[5]
+	if math.IsNaN(float64(tx)) || math.IsInf(float64(tx), 0) ||
+		math.IsNaN(float64(ty)) || math.IsInf(float64(ty), 0) {
+		return 0, 0, 0, 0, 0, false
+	}
+	a, b, c, d := m[0], m[1], m[2], m[3]
 
 	sx = float32(math.Sqrt(float64(a*a + b*b)))
 	if sx == 0 {

--- a/gui/svg/transform_decompose_test.go
+++ b/gui/svg/transform_decompose_test.go
@@ -111,6 +111,38 @@ func TestDecomposeTRSShearFallback(t *testing.T) {
 	}
 }
 
+func TestDecomposeTRSRejectsNonFiniteTX(t *testing.T) {
+	m := [6]float32{1, 0, 0, 1, float32(math.NaN()), 0}
+	_, _, _, _, _, ok := decomposeTRS(m)
+	if ok {
+		t.Fatalf("matrix with NaN tx must not decompose ok")
+	}
+}
+
+func TestDecomposeTRSRejectsNonFiniteTY(t *testing.T) {
+	m := [6]float32{1, 0, 0, 1, 0, float32(math.Inf(1))}
+	_, _, _, _, _, ok := decomposeTRS(m)
+	if ok {
+		t.Fatalf("matrix with +Inf ty must not decompose ok")
+	}
+}
+
+func TestDecomposeTRSRejectsNegativeInfTX(t *testing.T) {
+	m := [6]float32{1, 0, 0, 1, float32(math.Inf(-1)), 0}
+	_, _, _, _, _, ok := decomposeTRS(m)
+	if ok {
+		t.Fatalf("matrix with -Inf tx must not decompose ok")
+	}
+}
+
+func TestDecomposeTRSRejectsNaN_TY(t *testing.T) {
+	m := [6]float32{1, 0, 0, 1, 0, float32(math.NaN())}
+	_, _, _, _, _, ok := decomposeTRS(m)
+	if ok {
+		t.Fatalf("matrix with NaN ty must not decompose ok")
+	}
+}
+
 func TestDecomposeTRSRotate45Scale2(t *testing.T) {
 	// rotate(45) * scale(2): a=2*cos45, b=2*sin45, c=-2*sin45, d=2*cos45.
 	c45 := float32(math.Cos(math.Pi / 4))


### PR DESCRIPTION
## Problem
`decomposeTRS` passes `tx` and `ty` through from the input matrix without checking finiteness. When the fuzzer generates a matrix like `(0, 0, 0, 0, NaN, 0)`, the function returns `ok=true` with NaN outputs, violating the fuzz test's postcondition that `ok=true` implies all outputs are finite.

This caused the scheduled Fuzz CI job to fail on `FuzzDecomposeTRS`.

## Fix
Add an early guard at the top of `decomposeTRS` that returns `ok=false` immediately when `tx` or `ty` is NaN or Inf. Non-finite `a,b,c,d` values are already caught by the downstream epsilon comparisons (`NaN <= eps` is always false).

## Tests
- `TestDecomposeTRSRejectsNonFiniteTX` — NaN tx
- `TestDecomposeTRSRejectsNonFiniteTY` — +Inf ty
- `TestDecomposeTRSRejectsNegativeInfTX` — -Inf tx
- `TestDecomposeTRSRejectsNaN_TY` — NaN ty

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786454724&installation_id=145733661&pr_number=67&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F67&signature=b590da818d7bc01c8378fe36baf21e29528e37675bcd6d73453d5428e9dd3487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->