### PR TITLE
Bump go-glyph to v1.16.0; drop manual markdown line spacing

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -13,7 +13,7 @@ Go toolchain pin: `go 1.26.0`.
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`). |
 | `github.com/go-gl/gl` | v0.0.0-20260331235117-4566fea9a276 | OpenGL bindings for `gui/backend/gl`. |
-| `github.com/go-gui-org/go-glyph` | v1.15.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.16.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio playback (sound effects, music, mixer, fade) for `gui/audio`. |

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/ebitengine/purego v0.10.1
 	github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276
-	github.com/go-gui-org/go-glyph v1.15.0
+	github.com/go-gui-org/go-glyph v1.16.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276 h1:IO5P06Pcj9K04d+l4nrf3c2U56+dAotIFG6u4P1wAHI=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
-github.com/go-gui-org/go-glyph v1.15.0 h1:WyCNJeTu2KAi5rhoUMgVmjAetRCl1U5Ze2k6iH3gpJA=
-github.com/go-gui-org/go-glyph v1.15.0/go.mod h1:vKnhyn26lBroDbt0noTYjAUJlWZ+N2j7ZsNQiXlyOKQ=
+github.com/go-gui-org/go-glyph v1.16.0 h1:+tRlukTeSXkNS8gB93yoNtdsXikoTDN6jpz5DoXsr/0=
+github.com/go-gui-org/go-glyph v1.16.0/go.mod h1:vKnhyn26lBroDbt0noTYjAUJlWZ+N2j7ZsNQiXlyOKQ=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -68,14 +68,12 @@ type MarkdownStyle struct {
 // DefaultMarkdownStyle returns a MarkdownStyle using the
 // current theme.
 func DefaultMarkdownStyle() MarkdownStyle {
+	// Line spacing comes from go-glyph's recommended line height (font
+	// leading, floored to a minimum em ratio); no manual LineSpacing needed.
 	text := guiTheme.N4
-	text.LineSpacing = 3
 	bold := guiTheme.B4
-	bold.LineSpacing = 3
 	italic := guiTheme.I4
-	italic.LineSpacing = 3
 	bi := guiTheme.BI4
-	bi.LineSpacing = 3
 
 	return MarkdownStyle{
 		Text:              text,


### PR DESCRIPTION
## Change

- Bump `go-glyph` v1.15.0 → **v1.16.0**, which supplies a recommended line
  height (font leading floored to 1.15×em) and stops discarding leading in
  multi-line layout — wrapped text now stacks with correct spacing.
- Remove the manual `LineSpacing = 3` workaround in `DefaultMarkdownStyle`
  (`view_markdown.go`); spacing now comes from the font.
- Regenerated `docs/dependencies.md`.

## Verification (GOWORK=off)

- `go build`, `go test`, `go vet` clean.
- Gate: `vet deps-doc-check large-files generate-check tidy-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786468030&installation_id=145733661&pr_number=68&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F68&signature=c8eb052ac57c2fd55ecdb2493ae59db815f771622f448df914e366f27f977a7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->