### PR TITLE
changelog: add v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.32.0] - 2026-07-12
+
+### Changed
+
+- **Dependencies**: go-glyph bumped to v1.16.0 — supplies a recommended line
+  height (`TextMetrics.LineHeight`: font leading floored to 1.15×em) and no
+  longer discards leading in multi-line layout, so wrapped text stacks with
+  correct spacing. Regenerates `docs/dependencies.md`.
+- **Markdown defaults**: removed the manual paragraph `LineSpacing = 3`
+  workaround in `DefaultMarkdownStyle`; line spacing now comes from the font's
+  recommended line height provided by go-glyph.
+
+### Fixed
+
+- **gl backend**: populate `MouseDX`/`MouseDY` on motion events so scrollbar
+  thumb drags track the pointer. (#66)
+- **svg**: reject non-finite `tx`/`ty` in `decomposeTRS`. (#67)
+
 ## [v0.31.0] - 2026-07-11
 
 ### Changed


### PR DESCRIPTION
Roll changes since v0.31.0 into **v0.32.0**: go-glyph v1.16.0 bump (recommended
line height), markdown line-spacing hack removal (#68), gl scrollbar-drag fix
(#66), svg non-finite TRS fix (#67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786468453&installation_id=145733661&pr_number=69&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F69&signature=c158b06fc08a1245697057494584c2affcc9008e824c146ab2dd99387ca968d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->