### PR TITLE
Left-align markdown table headers per column alignment

### DIFF
--- a/gui/markdown_test.go
+++ b/gui/markdown_test.go
@@ -155,6 +155,40 @@ func TestMarkdownBuildTableData(t *testing.T) {
 	}
 }
 
+func TestMarkdownTableHeaderHonorsColumnAlignment(t *testing.T) {
+	style := DefaultMarkdownStyle()
+	// Default (start/left), centered, right-aligned columns.
+	blocks := markdownToBlocks(
+		"| L | C | R |\n|:--|:-:|--:|\n| a | b | c |", style)
+
+	var td *ParsedTable
+	for i := range blocks {
+		if blocks[i].IsTable && blocks[i].TableData != nil {
+			td = blocks[i].TableData
+			break
+		}
+	}
+	if td == nil {
+		t.Fatal("expected table block with data")
+	}
+
+	rows := buildMarkdownTableData(*td, style)
+	if len(rows) < 1 || len(rows[0].Cells) != 3 {
+		t.Fatalf("header cells: got %v", rows)
+	}
+
+	want := []HorizontalAlign{HAlignLeft, HAlignCenter, HAlignRight}
+	for i, c := range rows[0].Cells {
+		if c.HAlign == nil {
+			t.Fatalf("header cell %d: HAlign = nil, want %v", i, want[i])
+		}
+		if *c.HAlign != want[i] {
+			t.Errorf("header cell %d: HAlign = %v, want %v",
+				i, *c.HAlign, want[i])
+		}
+	}
+}
+
 func TestMarkdownDefaultsToWrap(t *testing.T) {
 	w := &Window{}
 	layout := generateViewLayout(w.Markdown(MarkdownCfg{

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -212,11 +212,13 @@ func buildMarkdownTableData(
 ) []TableRowCfg {
 	rows := make([]TableRowCfg, 0, len(parsed.Rows)+1)
 
-	// Header row.
+	// Header row. Honor per-column alignment (GFM: the delimiter
+	// row's alignment applies to header and body alike) instead of
+	// the table's default head alignment.
 	hCells := make([]TableCellCfg, 0, len(parsed.Headers))
-	for _, h := range parsed.Headers {
+	for i, h := range parsed.Headers {
 		rt := h
-		hCells = append(hCells, TableCellCfg{
+		cell := TableCellCfg{
 			Value:    richTextPlain(h),
 			HeadCell: true,
 			RichText: &rt,
@@ -224,7 +226,12 @@ func buildMarkdownTableData(
 				RichText: h,
 				Mode:     TextModeSingleLine,
 			}),
-		})
+		}
+		if i < len(parsed.Alignments) {
+			a := parsed.Alignments[i]
+			cell.HAlign = &a
+		}
+		hCells = append(hCells, cell)
 	}
 	rows = append(rows, TableRowCfg{Cells: hCells})
 


### PR DESCRIPTION
## Summary

Markdown table headers rendered centered instead of left-aligned. Header cells are marked `HeadCell`, and `tableBuildRow` aligns head cells with the table's default `AlignHead` (`HAlignCenter`), ignoring per-column alignment.

Fix: `buildMarkdownTableData` now sets each header cell's `HAlign` from `parsed.Alignments`, so headers follow their column's GFM delimiter-row alignment (left by default), matching the body.

## Testing
- Added `TestMarkdownTableHeaderHonorsColumnAlignment` verifying `:--`/`:-:`/`--:` map header cells to `HAlignLeft`/`HAlignCenter`/`HAlignRight`.
- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786576040&installation_id=145733661&pr_number=71&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F71&signature=bdf8c3d65fe3c0b13cd9c441af3e07a13ea8360837eec96a9a629500ef32f899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->