### PR TITLE
gui: exponential scroll easing for discrete mouse wheels

### DIFF
--- a/gui/backend/metal/events.go
+++ b/gui/backend/metal/events.go
@@ -53,13 +53,15 @@ func mapMetalEvent() (gui.Event, bool) {
 		}, true
 
 	case C.METAL_EVENT_SCROLL_WHEEL:
+		precise := C.metalEventScrollPrecise() != 0
 		return gui.Event{
-			Type:      gui.EventMouseScroll,
-			MouseX:    float32(C.metalEventMouseX()),
-			MouseY:    float32(C.metalEventMouseY()),
-			ScrollX:   float32(C.metalEventScrollX()),
-			ScrollY:   float32(C.metalEventScrollY()),
-			Modifiers: mapMetalModifiers(uint32(C.metalEventModifiers())),
+			Type:          gui.EventMouseScroll,
+			MouseX:        float32(C.metalEventMouseX()),
+			MouseY:        float32(C.metalEventMouseY()),
+			ScrollX:       float32(C.metalEventScrollX()),
+			ScrollY:       float32(C.metalEventScrollY()),
+			ScrollPrecise: precise,
+			Modifiers:     mapMetalModifiers(uint32(C.metalEventModifiers())),
 		}, true
 
 	case C.METAL_EVENT_KEY_DOWN:

--- a/gui/backend/metal/metal_window.h
+++ b/gui/backend/metal/metal_window.h
@@ -100,6 +100,7 @@ int   metalEventClickCount(void);
 float metalEventScrollX(void);
 float metalEventScrollY(void);
 int   metalEventScrollPhase(void);   // 0=normal, 1=maybegin, 2=began, 3=ended
+int   metalEventScrollPrecise(void); // 1 if trackpad/high-res precise deltas
 
 // Keyboard event fields.
 unsigned short metalEventKeyCode(void);   // macOS virtual key code

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -11,12 +11,21 @@
 #include <math.h>
 
 // Scale applied to AppKit precise (trackpad / high-res) scrolling
-// deltas before they reach the shared gui ScrollMultiplier. AppKit
-// reports precise deltas in points; the gui multiplier was tuned
-// against the SDL2 backend, which delivers deltas pre-scaled to a
-// smaller unit. Without this factor trackpad scrolling runs ~2x too
-// fast on the native macOS backend. See go-gui-org/go-gui#22.
-static const float kPreciseScrollScale = 0.5f;
+// deltas before they reach the shared gui ScrollMultiplier (20).
+// AppKit reports precise deltas in points; combined with the gui
+// multiplier this factor lands trackpad motion at ~1.5x raw points,
+// close to a 1:1 feel. NOTE: this value is coupled to gui's
+// ScrollMultiplier — it exists to divide most of that gain back out
+// for the precise path, which (unlike the mouse wheel) is not
+// smoothed on the gui side. See go-gui-org/go-gui#22.
+static const float kPreciseScrollScale = 0.075f;
+
+// Scale applied to AppKit line-based (discrete mouse wheel) scrolling
+// deltas. A notch reports ~1 line; combined with gui's ScrollMultiplier
+// (20) this lands one notch at ~50px, which the gui side then eases
+// into place (exponential smoothing). Was 10.0 (net ~200px/notch),
+// which felt far too fast and abrupt.
+static const float kWheelScrollScale = 2.5f;
 
 // Event mask covering all event types the app needs to receive.
 // MouseEntered/Exited are required by AppKit's internal tracking-
@@ -53,6 +62,7 @@ static int             _evMouseButton;
 static int             _evClickCount;
 static float           _evScrollX, _evScrollY;
 static int             _evScrollPhase;
+static int             _evScrollPrecise;  // 1 if hasPreciseScrollingDeltas
 static unsigned short  _evKeyCode;
 static unsigned int    _evModifiers;
 static int             _evKeyRepeat;
@@ -637,12 +647,14 @@ static void storeEvent(NSEvent *event, uint32_t wid) {
                 else                                     _evScrollPhase = 0;
             }
             if ([event hasPreciseScrollingDeltas]) {
+                _evScrollPrecise = 1;
                 _evScrollX = (float)[event scrollingDeltaX] * kPreciseScrollScale;
                 _evScrollY = (float)[event scrollingDeltaY] * kPreciseScrollScale;
             } else {
-                // Mouse wheel: multiply by 10 for line-to-pixel conversion.
-                _evScrollX = (float)([event scrollingDeltaX] * 10.0);
-                _evScrollY = (float)([event scrollingDeltaY] * 10.0);
+                // Discrete mouse wheel: line deltas scaled toward pixels.
+                _evScrollPrecise = 0;
+                _evScrollX = (float)[event scrollingDeltaX] * kWheelScrollScale;
+                _evScrollY = (float)[event scrollingDeltaY] * kWheelScrollScale;
             }
             break;
 
@@ -766,6 +778,7 @@ int   metalEventClickCount(void) { return _evClickCount; }
 float metalEventScrollX(void) { return _evScrollX; }
 float metalEventScrollY(void) { return _evScrollY; }
 int   metalEventScrollPhase(void) { return _evScrollPhase; }
+int   metalEventScrollPrecise(void) { return _evScrollPrecise; }
 unsigned short metalEventKeyCode(void) { return _evKeyCode; }
 unsigned int   metalEventModifiers(void) { return _evModifiers; }
 int            metalEventKeyRepeat(void) { return _evKeyRepeat; }

--- a/gui/event.go
+++ b/gui/event.go
@@ -338,6 +338,10 @@ type Event struct {
 	GesturePhase      GesturePhase
 	KeyRepeat         bool
 	IsHandled         bool
+	// ScrollPrecise is true for high-res / trackpad scroll deltas
+	// (already carrying OS momentum). False for discrete mouse-wheel
+	// notches, which the gui side eases via scrollSmoothAnimation.
+	ScrollPrecise bool
 }
 
 // eventRelativeTo returns a copy of the event with mouse

--- a/gui/event_handlers.go
+++ b/gui/event_handlers.go
@@ -335,16 +335,25 @@ func mouseScrollFallbackHandler(layout *Layout, e *Event, w *Window) {
 			}
 		}
 	}
-	// Handle scroll on scroll container under cursor.
+	// Handle scroll on scroll container under cursor. Discrete mouse
+	// wheels (ScrollPrecise == false) ease toward their target via
+	// scrollSmoothBy; trackpad/precise deltas already carry OS
+	// momentum and scroll instantly.
 	if layout.Shape.IDScroll > 0 {
 		if layout.Shape.PointInShape(e.MouseX, e.MouseY) {
 			switch e.Modifiers {
 			case ModShift:
-				e.IsHandled = scrollHorizontal(
-					layout, e.ScrollX, w)
+				if e.ScrollPrecise {
+					e.IsHandled = scrollHorizontal(layout, e.ScrollX, w)
+				} else {
+					e.IsHandled = scrollSmoothBy(w, layout, scrollAxisX, e.ScrollX)
+				}
 			case ModNone:
-				e.IsHandled = scrollVertical(
-					layout, e.ScrollY, w)
+				if e.ScrollPrecise {
+					e.IsHandled = scrollVertical(layout, e.ScrollY, w)
+				} else {
+					e.IsHandled = scrollSmoothBy(w, layout, scrollAxisY, e.ScrollY)
+				}
 			}
 		}
 	}

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -89,8 +89,10 @@ func inputScrollCursorIntoView(
 
 	if cursorTop < visibleTop {
 		sy.Set(idScroll, -cursorTop)
+		scrollSmoothCancel(w, idScroll, scrollAxisY)
 	} else if cursorBot > visibleBot {
 		sy.Set(idScroll, -(cursorBot - viewportH))
+		scrollSmoothCancel(w, idScroll, scrollAxisY)
 	}
 }
 
@@ -154,25 +156,43 @@ func textScrollCursorIntoView(layout *Layout, w *Window) {
 			(viewTop - cursorAbsTop)
 		sy.Set(scrollID,
 			f32Clamp(newScroll, maxScrollNeg, 0))
+		scrollSmoothCancel(w, scrollID, scrollAxisY)
 	} else if cursorAbsBot > viewBot {
 		newScroll := scrollOffset -
 			(cursorAbsBot - viewBot)
 		sy.Set(scrollID,
 			f32Clamp(newScroll, maxScrollNeg, 0))
+		scrollSmoothCancel(w, scrollID, scrollAxisY)
 	}
 }
 
+// scrollMaxOffsetX returns the most-negative horizontal offset a
+// layout can scroll to (0 when content fits).
+func scrollMaxOffsetX(layout *Layout) float32 {
+	return f32Min(0,
+		layout.Shape.Width-layout.Shape.paddingWidth()-
+			contentWidth(layout))
+}
+
+// scrollMaxOffsetY returns the most-negative vertical offset a
+// layout can scroll to (0 when content fits).
+func scrollMaxOffsetY(layout *Layout) float32 {
+	return f32Min(0,
+		layout.Shape.Height-layout.Shape.paddingHeight()-
+			contentHeight(layout))
+}
+
 // scrollHorizontal adjusts the horizontal scroll offset of a
-// scrollable layout. Returns true if offset was adjusted.
+// scrollable layout. Returns true if offset was adjusted. Instant:
+// used by the precise/trackpad and keyboard paths. The discrete
+// mouse-wheel path eases via scrollSmoothBy instead.
 func scrollHorizontal(layout *Layout, delta float32, w *Window) bool {
 	idScroll := layout.Shape.IDScroll
 	if idScroll == 0 ||
 		layout.Shape.ScrollMode == ScrollVerticalOnly {
 		return false
 	}
-	maxOffset := f32Min(0,
-		layout.Shape.Width-layout.Shape.paddingWidth()-
-			contentWidth(layout))
+	maxOffset := scrollMaxOffsetX(layout)
 	sx := w.scrollX()
 	old, _ := sx.Get(idScroll)
 	clamped := f32Clamp(
@@ -181,21 +201,22 @@ func scrollHorizontal(layout *Layout, delta float32, w *Window) bool {
 		return false
 	}
 	sx.Set(idScroll, clamped)
+	scrollSmoothCancel(w, idScroll, scrollAxisX)
 	fireOnScroll(layout, w)
 	return true
 }
 
 // scrollVertical adjusts the vertical scroll offset of a
-// scrollable layout. Returns true if offset was adjusted.
+// scrollable layout. Returns true if offset was adjusted. Instant:
+// used by the precise/trackpad and keyboard paths. The discrete
+// mouse-wheel path eases via scrollSmoothBy instead.
 func scrollVertical(layout *Layout, delta float32, w *Window) bool {
 	idScroll := layout.Shape.IDScroll
 	if idScroll == 0 ||
 		layout.Shape.ScrollMode == ScrollHorizontalOnly {
 		return false
 	}
-	maxOffset := f32Min(0,
-		layout.Shape.Height-layout.Shape.paddingHeight()-
-			contentHeight(layout))
+	maxOffset := scrollMaxOffsetY(layout)
 	sy := w.scrollY()
 	old, _ := sy.Get(idScroll)
 	clamped := f32Clamp(
@@ -204,6 +225,7 @@ func scrollVertical(layout *Layout, delta float32, w *Window) bool {
 		return false
 	}
 	sy.Set(idScroll, clamped)
+	scrollSmoothCancel(w, idScroll, scrollAxisY)
 	fireOnScroll(layout, w)
 	return true
 }
@@ -224,11 +246,10 @@ func (w *Window) ScrollToView(id string) {
 			current, _ := sy.Get(scrollID)
 			baseY := p.Shape.Y + p.Shape.Padding.Top
 			newScroll := baseY - target.Shape.Y + current
-			maxScrollNeg := f32Min(0,
-				p.Shape.Height-p.Shape.paddingHeight()-
-					contentHeight(p))
+			maxScrollNeg := scrollMaxOffsetY(p)
 			sy.Set(scrollID,
 				f32Clamp(newScroll, maxScrollNeg, 0))
+			scrollSmoothCancel(w, scrollID, scrollAxisY)
 			w.UpdateWindow()
 			return
 		}
@@ -237,13 +258,12 @@ func (w *Window) ScrollToView(id string) {
 
 // ScrollHorizontalBy scrolls the given scrollable by delta.
 func (w *Window) ScrollHorizontalBy(idScroll uint32, delta float32) {
+	scrollSmoothCancel(w, idScroll, scrollAxisX)
 	sx := w.scrollX()
 	current, _ := sx.Get(idScroll)
 	newVal := current + delta
 	if ly, ok := findScrollLayout(w, idScroll); ok {
-		maxOffset := f32Min(0,
-			ly.Shape.Width-ly.Shape.paddingWidth()-
-				contentWidth(ly))
+		maxOffset := scrollMaxOffsetX(ly)
 		newVal = f32Clamp(newVal, maxOffset, 0)
 		sx.Set(idScroll, newVal)
 		fireOnScroll(ly, w)
@@ -255,11 +275,10 @@ func (w *Window) ScrollHorizontalBy(idScroll uint32, delta float32) {
 // ScrollHorizontalTo scrolls the given scrollable to offset
 // (negative).
 func (w *Window) ScrollHorizontalTo(idScroll uint32, offset float32) {
+	scrollSmoothCancel(w, idScroll, scrollAxisX)
 	sx := w.scrollX()
 	if ly, ok := findScrollLayout(w, idScroll); ok {
-		maxOffset := f32Min(0,
-			ly.Shape.Width-ly.Shape.paddingWidth()-
-				contentWidth(ly))
+		maxOffset := scrollMaxOffsetX(ly)
 		sx.Set(idScroll, f32Clamp(offset, maxOffset, 0))
 		fireOnScroll(ly, w)
 		return
@@ -275,14 +294,13 @@ func (w *Window) ScrollHorizontalToPct(idScroll uint32, pct float32) {
 	if !ok {
 		return
 	}
-	maxOffset := f32Min(0,
-		ly.Shape.Width-ly.Shape.paddingWidth()-
-			contentWidth(ly))
+	maxOffset := scrollMaxOffsetX(ly)
 	if maxOffset == 0 {
 		return
 	}
 	sx := w.scrollX()
 	sx.Set(idScroll, maxOffset*f32Clamp(pct, 0, 1))
+	scrollSmoothCancel(w, idScroll, scrollAxisX)
 }
 
 // ScrollHorizontalPct returns the current horizontal scroll
@@ -293,9 +311,7 @@ func (w *Window) ScrollHorizontalPct(idScroll uint32) float32 {
 	if !ok {
 		return 0
 	}
-	maxOffset := f32Min(0,
-		ly.Shape.Width-ly.Shape.paddingWidth()-
-			contentWidth(ly))
+	maxOffset := scrollMaxOffsetX(ly)
 	if maxOffset == 0 {
 		return 0
 	}
@@ -306,13 +322,12 @@ func (w *Window) ScrollHorizontalPct(idScroll uint32) float32 {
 
 // ScrollVerticalBy scrolls the given scrollable by delta.
 func (w *Window) ScrollVerticalBy(idScroll uint32, delta float32) {
+	scrollSmoothCancel(w, idScroll, scrollAxisY)
 	sy := w.scrollY()
 	current, _ := sy.Get(idScroll)
 	newVal := current + delta
 	if ly, ok := findScrollLayout(w, idScroll); ok {
-		maxOffset := f32Min(0,
-			ly.Shape.Height-ly.Shape.paddingHeight()-
-				contentHeight(ly))
+		maxOffset := scrollMaxOffsetY(ly)
 		newVal = f32Clamp(newVal, maxOffset, 0)
 		sy.Set(idScroll, newVal)
 		fireOnScroll(ly, w)
@@ -324,11 +339,10 @@ func (w *Window) ScrollVerticalBy(idScroll uint32, delta float32) {
 // ScrollVerticalTo scrolls the given scrollable to offset
 // (negative).
 func (w *Window) ScrollVerticalTo(idScroll uint32, offset float32) {
+	scrollSmoothCancel(w, idScroll, scrollAxisY)
 	sy := w.scrollY()
 	if ly, ok := findScrollLayout(w, idScroll); ok {
-		maxOffset := f32Min(0,
-			ly.Shape.Height-ly.Shape.paddingHeight()-
-				contentHeight(ly))
+		maxOffset := scrollMaxOffsetY(ly)
 		sy.Set(idScroll, f32Clamp(offset, maxOffset, 0))
 		fireOnScroll(ly, w)
 		return
@@ -344,14 +358,13 @@ func (w *Window) ScrollVerticalToPct(idScroll uint32, pct float32) {
 	if !ok {
 		return
 	}
-	maxOffset := f32Min(0,
-		ly.Shape.Height-ly.Shape.paddingHeight()-
-			contentHeight(ly))
+	maxOffset := scrollMaxOffsetY(ly)
 	if maxOffset == 0 {
 		return
 	}
 	sy := w.scrollY()
 	sy.Set(idScroll, maxOffset*f32Clamp(pct, 0, 1))
+	scrollSmoothCancel(w, idScroll, scrollAxisY)
 }
 
 // ScrollVerticalPct returns the current vertical scroll
@@ -362,9 +375,7 @@ func (w *Window) ScrollVerticalPct(idScroll uint32) float32 {
 	if !ok {
 		return 0
 	}
-	maxOffset := f32Min(0,
-		ly.Shape.Height-ly.Shape.paddingHeight()-
-			contentHeight(ly))
+	maxOffset := scrollMaxOffsetY(ly)
 	if maxOffset == 0 {
 		return 0
 	}

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -1,0 +1,252 @@
+package gui
+
+import "time"
+
+// Discrete mouse-wheel scrolling eases toward a target offset instead
+// of jumping instantly. This is a cheap exponential lerp — not a
+// spring or momentum simulation. Each tick moves the displayed offset
+// a fixed fraction of the remaining distance, so it decelerates
+// naturally and settles in ~100ms. Trackpad/precise scrolling already
+// carries OS momentum and is NOT routed here (see scrollVertical).
+const (
+	scrollSmoothAnimationID = "___scroll_smooth___"
+	// scrollSmoothFactor is the fraction of remaining distance moved
+	// per 16ms tick (~87% closed in ~7 frames / ~112ms).
+	scrollSmoothFactor = float32(0.25)
+	// scrollSmoothSnap: within this many px of target, snap and stop.
+	scrollSmoothSnap = float32(0.5)
+)
+
+// scrollAxis selects which scroll map an entry drives.
+type scrollAxis uint8
+
+const (
+	scrollAxisY scrollAxis = iota
+	scrollAxisX
+)
+
+// scrollSmoothEntry tracks one scrollable's eased offset. current is
+// what layout reads (pushed to the scrollX/scrollY map each tick);
+// target is where the wheel deltas want it.
+type scrollSmoothEntry struct {
+	idScroll uint32
+	axis     scrollAxis
+	target   float32
+	current  float32
+	active   bool
+	settled  bool // reached target this tick; retire next tick
+}
+
+// scrollApply is a lock-free snapshot of an entry for the apply pass.
+type scrollApply struct {
+	idScroll uint32
+	axis     scrollAxis
+	val      float32
+}
+
+// scrollSmoothAnimation is a per-window singleton Animation that eases
+// every actively-scrolling container. Its entries are guarded by
+// w.animMu: mutated by Update on the animation goroutine (which holds
+// animMu) and by scrollSmoothBy/Cancel on the main goroutine.
+// Displayed offsets are written only on the main goroutine, via a
+// deferred commandApplyScrollSmooth, so the scrollX/scrollY maps stay
+// single-goroutine.
+type scrollSmoothAnimation struct {
+	start   time.Time
+	entries []scrollSmoothEntry
+	pending []scrollApply // apply-pass scratch, main goroutine only
+	stopped bool
+}
+
+// ID implements Animation.
+func (s *scrollSmoothAnimation) ID() string { return scrollSmoothAnimationID }
+
+// RefreshKind implements Animation. Scroll offset repositions children
+// during layout arrange, so a full layout rebuild is required.
+func (s *scrollSmoothAnimation) RefreshKind() AnimationRefreshKind {
+	return AnimationRefreshLayout
+}
+
+// IsStopped implements Animation.
+func (s *scrollSmoothAnimation) IsStopped() bool { return s.stopped }
+
+// SetStart implements Animation.
+func (s *scrollSmoothAnimation) SetStart(t time.Time) { s.start = t }
+
+// Update implements Animation. Runs on the animation goroutine while
+// w.animMu is held (see animationLoop).
+func (s *scrollSmoothAnimation) Update(_ *Window, _ float32, ac *AnimationCommands) bool {
+	anyActive := false
+	for i := range s.entries {
+		e := &s.entries[i]
+		if !e.active {
+			continue
+		}
+		if e.settled {
+			// Final value was applied last tick; retire now.
+			e.active = false
+			continue
+		}
+		diff := e.target - e.current
+		if !f32IsFinite(diff) {
+			// Poisoned entry (NaN/Inf target or current): retire
+			// instead of ticking forever without converging.
+			e.active = false
+			continue
+		}
+		if f32Abs(diff) < scrollSmoothSnap {
+			e.current = e.target
+			e.settled = true
+		} else {
+			e.current += diff * scrollSmoothFactor
+		}
+		anyActive = true
+	}
+	if !anyActive {
+		s.stopped = true
+		return false
+	}
+	ac.AppendOnDone(commandApplyScrollSmooth)
+	return true
+}
+
+// entryFor returns the entry for idScroll+axis, creating an inactive
+// one if absent. Caller must hold w.animMu.
+func (s *scrollSmoothAnimation) entryFor(idScroll uint32, axis scrollAxis) *scrollSmoothEntry {
+	if e := s.findEntry(idScroll, axis); e != nil {
+		return e
+	}
+	s.entries = append(s.entries, scrollSmoothEntry{idScroll: idScroll, axis: axis})
+	return &s.entries[len(s.entries)-1]
+}
+
+// findEntry returns the entry for idScroll+axis, or nil. Caller must
+// hold w.animMu.
+func (s *scrollSmoothAnimation) findEntry(idScroll uint32, axis scrollAxis) *scrollSmoothEntry {
+	for i := range s.entries {
+		if s.entries[i].idScroll == idScroll && s.entries[i].axis == axis {
+			return &s.entries[i]
+		}
+	}
+	return nil
+}
+
+// scrollSmoothBy accumulates a discrete-wheel delta into the eased
+// target for layout's scrollable and (re)arms the smoother. Mirrors
+// scrollVertical/Horizontal's clamp/ScrollMultiplier math but defers
+// the displayed offset to the animation. Returns true if a repaint is
+// warranted. Main goroutine only.
+func scrollSmoothBy(w *Window, layout *Layout, axis scrollAxis, delta float32) bool {
+	idScroll := layout.Shape.IDScroll
+	if idScroll == 0 {
+		return false
+	}
+	if axis == scrollAxisY && layout.Shape.ScrollMode == ScrollHorizontalOnly {
+		return false
+	}
+	if axis == scrollAxisX && layout.Shape.ScrollMode == ScrollVerticalOnly {
+		return false
+	}
+
+	var maxOffset, displayed float32
+	if axis == scrollAxisY {
+		maxOffset = scrollMaxOffsetY(layout)
+		displayed, _ = w.scrollY().Get(idScroll)
+	} else {
+		maxOffset = scrollMaxOffsetX(layout)
+		displayed, _ = w.scrollX().Get(idScroll)
+	}
+	increment := delta * guiTheme.ScrollMultiplier
+
+	w.animMu.Lock()
+	defer w.animMu.Unlock()
+	if w.scrollSmooth == nil {
+		w.scrollSmooth = &scrollSmoothAnimation{}
+	}
+	ss := w.scrollSmooth
+	e := ss.entryFor(idScroll, axis)
+
+	base := displayed
+	if e.active {
+		base = e.target
+	}
+	newTarget := f32Clamp(base+increment, maxOffset, 0)
+	if !f32IsFinite(newTarget) {
+		// NaN delta, multiplier, or displayed offset would poison the
+		// ease into a never-settling animation. Reject the event.
+		return false
+	}
+	if newTarget == base {
+		return false // already at/heading to this offset
+	}
+	if !e.active {
+		e.current = displayed
+	}
+	e.target = newTarget
+	e.active = true
+	e.settled = false
+	ss.stopped = false
+	w.animationAddLocked(ss)
+	return true
+}
+
+// scrollSmoothCancel deactivates any eased scroll for idScroll+axis so
+// a direct offset write (trackpad, keyboard, scrollbar drag,
+// programmatic) is not overwritten by an in-flight ease. No-op if none
+// active. Main goroutine only.
+func scrollSmoothCancel(w *Window, idScroll uint32, axis scrollAxis) {
+	w.animMu.Lock()
+	defer w.animMu.Unlock()
+	if w.scrollSmooth == nil {
+		return
+	}
+	if e := w.scrollSmooth.findEntry(idScroll, axis); e != nil {
+		e.active = false
+		e.settled = false
+	}
+}
+
+// scrollSmoothReset drops all eased-scroll state. Called when the view
+// tree is rebuilt (clearHotMaps), since idScroll keys may change.
+func (w *Window) scrollSmoothReset() {
+	w.animMu.Lock()
+	defer w.animMu.Unlock()
+	if w.scrollSmooth != nil {
+		w.scrollSmooth.stopped = true
+		w.scrollSmooth.entries = w.scrollSmooth.entries[:0]
+	}
+}
+
+// commandApplyScrollSmooth writes each active entry's eased offset to
+// the scroll map and fires OnScroll. Runs on the main goroutine
+// (enqueued via AppendOnDone). Snapshots under animMu, then applies
+// outside it so OnScroll callbacks may safely re-enter animMu.
+func commandApplyScrollSmooth(w *Window) {
+	ss := w.scrollSmooth
+	if ss == nil {
+		return
+	}
+	w.animMu.Lock()
+	ss.pending = ss.pending[:0]
+	for i := range ss.entries {
+		e := &ss.entries[i]
+		if !e.active {
+			continue
+		}
+		ss.pending = append(ss.pending, scrollApply{
+			idScroll: e.idScroll, axis: e.axis, val: e.current,
+		})
+	}
+	w.animMu.Unlock()
+
+	for _, p := range ss.pending {
+		if p.axis == scrollAxisY {
+			w.scrollY().Set(p.idScroll, p.val)
+		} else {
+			w.scrollX().Set(p.idScroll, p.val)
+		}
+		if ly, ok := findScrollLayout(w, p.idScroll); ok {
+			fireOnScroll(ly, w)
+		}
+	}
+}

--- a/gui/scroll_smooth_test.go
+++ b/gui/scroll_smooth_test.go
@@ -1,0 +1,338 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+// driveScrollSmooth runs the smoother's Update/apply cycle until it
+// stops or maxTicks is reached, mimicking the animation loop +
+// main-goroutine flush. Returns the number of ticks executed.
+func driveScrollSmooth(w *Window, maxTicks int) int {
+	ss := w.scrollSmooth
+	ticks := 0
+	for ticks < maxTicks {
+		deferred := make([]queuedCommand, 0, 2)
+		ac := newAnimationCommands(&deferred)
+		cont := ss.Update(w, 0.016, &ac)
+		for i := range deferred {
+			if deferred[i].windowFn != nil {
+				deferred[i].windowFn(w)
+			}
+		}
+		ticks++
+		if !cont {
+			break
+		}
+	}
+	return ticks
+}
+
+func TestScrollSmoothTargetSetDisplayUnchangedFrame0(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(1, 100, 100, 100, 300)
+
+	ok := scrollSmoothBy(w, layout, scrollAxisY, -50)
+	if !ok {
+		t.Fatal("expected scrollSmoothBy to report change")
+	}
+
+	// Displayed offset must NOT have moved yet — no apply has run.
+	sy := w.scrollY()
+	if v, present := sy.Get(1); present && v != 0 {
+		t.Errorf("displayed offset changed on frame 0: got %v", v)
+	}
+
+	e := w.scrollSmooth.findEntry(1, scrollAxisY)
+	if e == nil || !e.active {
+		t.Fatal("expected an active entry")
+	}
+	if e.target != -50 {
+		t.Errorf("target = %v, want -50", e.target)
+	}
+	if e.current != 0 {
+		t.Errorf("current = %v, want 0", e.current)
+	}
+}
+
+func TestScrollSmoothConvergesAndStops(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(2, 100, 100, 100, 300)
+	scrollSmoothBy(w, layout, scrollAxisY, -50)
+
+	prev := float32(0)
+	applied := func() float32 { v, _ := w.scrollY().Get(2); return v }
+
+	// Drive one tick at a time, asserting monotonic approach (never
+	// overshoots past the -50 target).
+	ss := w.scrollSmooth
+	ticks := 0
+	for ticks < 100 {
+		deferred := make([]queuedCommand, 0, 2)
+		ac := newAnimationCommands(&deferred)
+		cont := ss.Update(w, 0.016, &ac)
+		for i := range deferred {
+			if deferred[i].windowFn != nil {
+				deferred[i].windowFn(w)
+			}
+		}
+		cur := applied()
+		if cur < -50.0001 {
+			t.Fatalf("overshoot: applied %v past target -50", cur)
+		}
+		if cur > prev {
+			t.Fatalf("non-monotonic: %v then %v", prev, cur)
+		}
+		prev = cur
+		ticks++
+		if !cont {
+			break
+		}
+	}
+
+	if !ss.IsStopped() {
+		t.Error("expected smoother to stop after converging")
+	}
+	if v := applied(); v != -50 {
+		t.Errorf("final offset = %v, want -50", v)
+	}
+	if ticks < 3 {
+		t.Errorf("converged too fast (%d ticks) — not actually easing", ticks)
+	}
+	if ticks > 40 {
+		t.Errorf("took %d ticks to settle — too sluggish", ticks)
+	}
+}
+
+func TestScrollSmoothClampsAtBounds(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(3, 100, 100, 100, 300) // maxOffset -200
+
+	// Huge delta clamps target to the max offset.
+	scrollSmoothBy(w, layout, scrollAxisY, -9999)
+	e := w.scrollSmooth.findEntry(3, scrollAxisY)
+	if e.target != -200 {
+		t.Fatalf("target = %v, want -200 (clamped)", e.target)
+	}
+	driveScrollSmooth(w, 200)
+	if v, _ := w.scrollY().Get(3); v != -200 {
+		t.Errorf("settled offset = %v, want -200", v)
+	}
+
+	// Already at the bottom: another downward notch is a no-op.
+	if scrollSmoothBy(w, layout, scrollAxisY, -10) {
+		t.Error("expected false scrolling past max bound")
+	}
+	// At the top, an upward notch is a no-op.
+	w.scrollY().Set(3, 0)
+	scrollSmoothCancel(w, 3, scrollAxisY)
+	if scrollSmoothBy(w, layout, scrollAxisY, 10) {
+		t.Error("expected false scrolling past min bound")
+	}
+}
+
+func TestScrollSmoothAccumulatesTarget(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(4, 100, 100, 100, 300)
+
+	// Two rapid notches before any tick: targets accumulate.
+	scrollSmoothBy(w, layout, scrollAxisY, -30)
+	scrollSmoothBy(w, layout, scrollAxisY, -30)
+
+	e := w.scrollSmooth.findEntry(4, scrollAxisY)
+	if e.target != -60 {
+		t.Errorf("target = %v, want -60 (accumulated)", e.target)
+	}
+	if e.current != 0 {
+		t.Errorf("current = %v, want 0 (not yet eased)", e.current)
+	}
+}
+
+func TestScrollSmoothCanceledByInstantScroll(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(5, 100, 100, 100, 300)
+
+	scrollSmoothBy(w, layout, scrollAxisY, -50)
+	if e := w.scrollSmooth.findEntry(5, scrollAxisY); e == nil || !e.active {
+		t.Fatal("expected active entry before instant scroll")
+	}
+
+	// An instant (precise/keyboard) scroll cancels the in-flight ease.
+	scrollVertical(layout, -10, w)
+
+	e := w.scrollSmooth.findEntry(5, scrollAxisY)
+	if e.active {
+		t.Error("instant scroll should deactivate the smoother entry")
+	}
+	if v, _ := w.scrollY().Get(5); v != -10 {
+		t.Errorf("instant offset = %v, want -10", v)
+	}
+}
+
+func TestScrollSmoothHorizontalAxis(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	w := &Window{}
+	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 50}}
+	layout := Layout{
+		Shape: &Shape{
+			shapeType: shapeRectangle,
+			IDScroll:  6,
+			Width:     100,
+			Height:    50,
+			Axis:      AxisLeftToRight,
+		},
+		Children: []Layout{child},
+	}
+	w.layout = Layout{
+		Shape:    &Shape{shapeType: shapeRectangle},
+		Children: []Layout{layout},
+	}
+	ly := &w.layout.Children[0]
+
+	scrollSmoothBy(w, ly, scrollAxisX, -50)
+	driveScrollSmooth(w, 200)
+	if v, _ := w.scrollX().Get(6); v != -50 {
+		t.Errorf("horizontal settled = %v, want -50", v)
+	}
+}
+
+func TestScrollSmoothFiresOnScroll(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(7, 100, 100, 100, 300)
+	w.layout.Children[0].Parent = &w.layout
+	fired := 0
+	layout.Shape.events = &eventHandlers{
+		OnScroll: func(_ *Layout, _ *Window) { fired++ },
+	}
+	scrollSmoothBy(w, layout, scrollAxisY, -50)
+	driveScrollSmooth(w, 200)
+	if fired == 0 {
+		t.Error("OnScroll never fired during easing")
+	}
+}
+
+func TestScrollSmoothResetClearsEntries(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(8, 100, 100, 100, 300)
+	scrollSmoothBy(w, layout, scrollAxisY, -50)
+	w.scrollSmoothReset()
+	if len(w.scrollSmooth.entries) != 0 {
+		t.Errorf("entries not cleared: %d remain", len(w.scrollSmooth.entries))
+	}
+	if !w.scrollSmooth.stopped {
+		t.Error("expected stopped after reset")
+	}
+}
+
+// TestScrollSmoothNoAllocSteadyState guards the per-event allocation
+// budget: once an entry exists, accumulating deltas must not allocate.
+func TestScrollSmoothNoAllocSteadyState(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(9, 100, 100, 100, 900) // maxOffset -800
+	// Warm up: create the entry and animations map.
+	scrollSmoothBy(w, layout, scrollAxisY, -5)
+
+	i := 0
+	allocs := testing.AllocsPerRun(200, func() {
+		// Oscillate within bounds so target keeps changing (full path).
+		if i%2 == 0 {
+			scrollSmoothBy(w, layout, scrollAxisY, -5)
+		} else {
+			scrollSmoothBy(w, layout, scrollAxisY, 5)
+		}
+		i++
+	})
+	if allocs != 0 {
+		t.Errorf("scrollSmoothBy allocated %v times/op in steady state", allocs)
+	}
+}
+
+// TestScrollSmoothRejectsNonFiniteDelta guards against NaN/Inf wheel
+// deltas poisoning the ease target into a never-settling animation
+// (60fps layout-refresh DoS).
+func TestScrollSmoothRejectsNonFiniteDelta(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	nan := float32(math.NaN())
+	layout, w := makeScrollLayout(10, 100, 100, 100, 300)
+
+	if scrollSmoothBy(w, layout, scrollAxisY, nan) {
+		t.Error("NaN delta must be rejected")
+	}
+	if e := w.scrollSmooth.findEntry(10, scrollAxisY); e != nil && e.active {
+		t.Error("NaN delta must not arm an entry")
+	}
+
+	// -Inf clamps to maxOffset (finite) and is accepted like any
+	// large delta; the settled offset must stay in bounds.
+	if !scrollSmoothBy(w, layout, scrollAxisY, float32(math.Inf(-1))) {
+		t.Fatal("expected -Inf delta to clamp and arm")
+	}
+	driveScrollSmooth(w, 200)
+	if v, _ := w.scrollY().Get(10); v != -200 {
+		t.Errorf("settled offset = %v, want -200", v)
+	}
+}
+
+// TestScrollSmoothRetiresPoisonedEntry verifies Update deactivates an
+// entry whose target became non-finite instead of ticking forever.
+func TestScrollSmoothRetiresPoisonedEntry(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(11, 100, 100, 100, 300)
+	scrollSmoothBy(w, layout, scrollAxisY, -50)
+	e := w.scrollSmooth.findEntry(11, scrollAxisY)
+	e.target = float32(math.NaN())
+
+	ticks := driveScrollSmooth(w, 10)
+	if ticks >= 10 {
+		t.Fatal("poisoned entry never retired")
+	}
+	if e.active {
+		t.Error("poisoned entry still active")
+	}
+	if v, _ := w.scrollY().Get(11); v != 0 {
+		t.Errorf("offset moved to %v despite poisoned target", v)
+	}
+}
+
+func TestScrollSmoothByNoScrollID(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(0, 100, 100, 100, 300)
+	if scrollSmoothBy(w, layout, scrollAxisY, -50) {
+		t.Error("expected false for IDScroll == 0")
+	}
+}
+
+func TestScrollSmoothByRespectsScrollMode(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(12, 100, 100, 100, 300)
+
+	layout.Shape.ScrollMode = ScrollHorizontalOnly
+	if scrollSmoothBy(w, layout, scrollAxisY, -50) {
+		t.Error("vertical ease must be rejected for ScrollHorizontalOnly")
+	}
+	layout.Shape.ScrollMode = ScrollVerticalOnly
+	if scrollSmoothBy(w, layout, scrollAxisX, -50) {
+		t.Error("horizontal ease must be rejected for ScrollVerticalOnly")
+	}
+}
+
+func TestScrollSmoothCanceledByScrollToPct(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	layout, w := makeScrollLayout(13, 100, 100, 100, 300)
+	scrollSmoothBy(w, layout, scrollAxisY, -50)
+
+	w.ScrollVerticalToPct(13, 1)
+
+	e := w.scrollSmooth.findEntry(13, scrollAxisY)
+	if e.active {
+		t.Error("programmatic scroll must cancel the in-flight ease")
+	}
+	if v, _ := w.scrollY().Get(13); v != -200 {
+		t.Errorf("offset = %v, want -200", v)
+	}
+}
+
+func TestCommandApplyScrollSmoothNilSafe(t *testing.T) {
+	w := &Window{}
+	commandApplyScrollSmooth(w) // must not panic
+}

--- a/gui/state_registry.go
+++ b/gui/state_registry.go
@@ -117,6 +117,7 @@ func (w *Window) clearHotMaps() {
 	w.scrollXMap = nil
 	w.scrollYMap = nil
 	w.overflowMap = nil
+	w.scrollSmoothReset()
 }
 
 // RequireID panics if id is empty. Use in stateful widget factories

--- a/gui/view_scrollbar.go
+++ b/gui/view_scrollbar.go
@@ -268,6 +268,7 @@ func scrollbarMouseMove(orientation ScrollbarOrientation, idScroll uint32, layou
 			sx := w.scrollX()
 			offset := offsetMouseChangeX(sx, ly, e.MouseDX, idScroll)
 			sx.Set(idScroll, offset)
+			scrollSmoothCancel(w, idScroll, scrollAxisX)
 			fireOnScroll(ly, w)
 		}
 	} else {
@@ -276,6 +277,7 @@ func scrollbarMouseMove(orientation ScrollbarOrientation, idScroll uint32, layou
 			sy := w.scrollY()
 			offset := offsetMouseChangeY(sy, ly, e.MouseDY, idScroll)
 			sy.Set(idScroll, offset)
+			scrollSmoothCancel(w, idScroll, scrollAxisY)
 			fireOnScroll(ly, w)
 		}
 	}
@@ -321,6 +323,7 @@ func offsetFromMouseX(layout *Layout, mouseX float32, idScroll uint32, w *Window
 	}
 	sx := w.scrollX()
 	sx.Set(idScroll, -percent*(totalWidth-sb.Shape.Width))
+	scrollSmoothCancel(w, idScroll, scrollAxisX)
 	fireOnScroll(sb, w)
 }
 
@@ -342,5 +345,6 @@ func offsetFromMouseY(layout *Layout, mouseY float32, idScroll uint32, w *Window
 	}
 	sy := w.scrollY()
 	sy.Set(idScroll, -percent*(totalHeight-sb.Shape.Height))
+	scrollSmoothCancel(w, idScroll, scrollAxisY)
 	fireOnScroll(sb, w)
 }

--- a/gui/window.go
+++ b/gui/window.go
@@ -184,6 +184,10 @@ type Window struct {
 	scrollYMap     *BoundedMap[uint32, float32]
 	overflowMap    *BoundedMap[string, int]
 
+	// scrollSmooth eases discrete mouse-wheel scrolling toward a
+	// target offset. Guarded by animMu (see gui/scroll_smooth.go).
+	scrollSmooth *scrollSmoothAnimation
+
 	windowToast
 
 	// Embedded concern groups.


### PR DESCRIPTION
Route discrete (non-precise) mouse-wheel deltas through a per-window animation that eases toward the target offset instead of jumping instantly. Trackpad/precise deltas already carry OS momentum and continue to land without easing.

- Add ScrollPrecise field to Event
- Metal backend: detect hasPreciseScrollingDeltas and set the flag
- Metal backend: retune kPreciseScrollScale (0.075) and add kWheelScrollScale (2.5) so one notch lands at ~50 px pre-ease
- mouseScrollFallbackHandler: route precise deltas to scrollVertical / scrollHorizontal (instant); route discrete to scrollSmoothBy
- Add scroll_smooth.go: exponential lerp Animation that runs per-window, accumulating wheel deltas and writing eased offsets to the scroll map
- Cancel in-flight eases when instant scroll sources intervene (keyboard, scrollbar drag, programmatic scroll, cursor-into-view)
- Extract scrollMaxOffsetX/Y helpers

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786634519&installation_id=145733661&pr_number=73&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F73&signature=933a3c41554ac2d17da739096720c49b1df7232bbd77ada180ccf8e87ba0688f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->