### PR TITLE
changelog: add v0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.33.1] - 2026-07-14
+
+### Fixed
+
+- **Dependencies**: go-glyph bumped to v1.16.2 — text symbols across many
+  Unicode blocks (heavy asterisk U+2731 ✱, mahjong tiles, playing cards,
+  alchemical and chess symbols, Supplemental Arrows-C, ~760 codepoints) no
+  longer render as the base font's `.notdef` tofu box, and default-text
+  emoji such as U+2733 ✳, ❄, ❤, ☀ now render as monochrome text glyphs
+  instead of being forced to color, matching Core Text and Ghostty. Also
+  propagates InlineObject metadata through rich-text layout and applies
+  script fallback in `LayoutRichText`.
+
 ## [v0.32.1] - 2026-07-12
 
 ### Fixed


### PR DESCRIPTION
Release v0.33.1 — go-glyph bumped to v1.16.2 (symbol tofu / default-text emoji rendering fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786639556&installation_id=145733661&pr_number=75&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F75&signature=3221603aad87207675c03929ac86c2f15eabced52faa19d41a9e6e41e028dcbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->