### PR TITLE
changelog: add v0.35.1 (un-deprecate GenerateViewLayout; README fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.35.1] - 2026-07-15
+
+Documentation-only release. No code or behavior changes; no migration needed.
 
 ### Changed
 
@@ -18,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   avoid the warning should call `GenerateViewLayout` again; it applies
   shape normalization, the child-count clamp, and frame-arena pre-sizing
   that a hand-rolled copy misses. (#52)
+
+### Fixed
+
+- **README**: removed SDL2-era install steps, corrected the text stack
+  description to the current pure-Go path, and refreshed the code samples
+  to the current API.
 
 ## [v0.35.0] - 2026-07-15
 


### PR DESCRIPTION
Release prep for **v0.35.1**.

## Why patch, not minor

Both commits since `v0.35.0` are documentation. No new user-facing features, no breaking changes, no code:

| Commit | Change |
|---|---|
| `956a34f` | un-deprecate `GenerateViewLayout` (#79, closes #52) |
| `e025ab6` | fix stale README — SDL2-era install steps, pure-Go text stack, current API in samples |

`GenerateViewLayout` has the same signature and same body as in `v0.35.0` — only its doc comment changed. Consumers upgrading from `v0.35.0` need no migration; the sole visible effect is that `SA1019` stops firing on calls to it.

## Why cut it now

To unblock go-gui-org/go-map#13. go-map hand-rolled a `layoutRecursive` copy of `GenerateViewLayout` to dodge the deprecation warning, and uses it in production code (`legend.go:69`, `gallery.go:108`) on the per-frame view path. That fork drops `ensureLayoutShape`, the `maxEventChildren` clamp, and frame-arena pre-sizing — so it heap-allocates a child slice per node, every frame, in the map render path. go-map can't delete the fork while pinned to a tag where the symbol is still marked deprecated; it would just be trading the fork for a `//nolint`.

So: tag here → bump go-map → close #13 and recover the allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786740620&installation_id=145733661&pr_number=80&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F80&signature=030a8fa5b8a9ce8eb40bdea53da808d6f8aa1cc51e26fbf560b09feb176e8425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->