### PR TITLE
docs: remove SDL2 vestiges and dead static,audio build tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,8 +51,5 @@ linters:
       - path: native_platform_noop\.go
         linters:
           - revive
-      - path: gui/backend/internal/sdlkey/sdlkey\.go
-        linters:
-          - cyclop
       - path: gui/backend/(gl|metal|ios|android)/
         text: "unkeyed fields"

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,18 @@ LDFLAGS  = -X github.com/go-gui-org/go-gui/gui.Version=$(VERSION) \
            -X github.com/go-gui-org/go-gui/gui.Commit=$(COMMIT)
 
 CC_WINDOWS ?= x86_64-w64-mingw32-gcc
-STATIC_TAG  = static,audio
 LINT_VERSION = v2.12.2
 
 .PHONY: build-linux build-windows build-macos build-wasm build-ios build-android build-examples release clean test test-race vet lint check bench bench-gate deps-doc deps-doc-check security gosec govulncheck large-files deadcode generate-check tidy-check workflow-audit cov-report license-check
 
 build-linux:
 	CGO_ENABLED=1 \
-	go build -tags $(STATIC_TAG) -ldflags "$(LDFLAGS)" \
+	go build -ldflags "$(LDFLAGS)" \
 	  -o build/showcase-linux ./examples/showcase/
 
 build-windows:
 	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=$(CC_WINDOWS) \
-	go build -tags $(STATIC_TAG) -ldflags "$(LDFLAGS)" \
+	go build -ldflags "$(LDFLAGS)" \
 	  -o build/showcase-windows.exe ./examples/showcase/
 
 build-macos:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ in the upper-right corner that displays documentation about the widget._
 | -------------- | ----------------------------------------------------------------------------------------------- |
 | Browser (WASM) | [**Open Showcase**](https://go-gui-org.github.io/showcase/) — zero install, instant evaluation  |
 | macOS          | [Go-Gui-Showcase-\<version\>.dmg](https://github.com/go-gui-org/go-gui/releases)                |
-| Linux          | [Go-Gui-Showcase-\<version\>-linux-amd64.tar.gz](https://github.com/go-gui-org/go-gui/releases) |
-| Windows        | [Go-Gui-Showcase-\<version\>-windows-amd64.zip](https://github.com/go-gui-org/go-gui/releases)  |
+| Linux          | [go-gui-showcase-\<version\>-linux-amd64.tar.gz](https://github.com/go-gui-org/go-gui/releases) |
+| Windows        | [go-gui-showcase-\<version\>-windows-amd64.zip](https://github.com/go-gui-org/go-gui/releases)  |
 
 Sibling projects:
 
@@ -157,7 +157,7 @@ version and [`examples/web_demo/`](examples/web_demo/) for the browser build.
 ## Installation
 
 Requires **Go 1.26+** and a C toolchain (CGo). The desktop backends are
-native and SDL2-free: Metal on macOS, X11 + EGL on Linux, Win32 + WGL on
+native: Metal on macOS, X11 + EGL on Linux, Win32 + WGL on
 Windows. Text shaping and rasterization are pure Go via go-glyph — no
 FreeType, HarfBuzz, Pango, CoreText, or DirectWrite libraries required. See
 the
@@ -428,13 +428,17 @@ go build ./...
 
 The root `Makefile` builds standalone showcase binaries for each platform.
 
-| Target               | Output                       | Command                                 |
-| -------------------- | ---------------------------- | --------------------------------------- |
-| `make build-linux`   | `build/showcase-linux`       | `go build -tags static`                 |
-| `make build-macos`   | `build/showcase-macos`       | `go build`                              |
-| `make build-windows` | `build/showcase-windows.exe` | `go build -tags static` (cross-compile) |
-| `make build-wasm`    | `build/showcase.wasm`        | `GOOS=js GOARCH=wasm go build`          |
-| `make release`       | `.tar.gz`, `.dmg`, `.zip`    | All of the above + packaging            |
+| Target               | Output                                 | Command                              |
+| -------------------- | -------------------------------------- | ------------------------------------ |
+| `make build-macos`   | `build/showcase-macos`                 | `go build`                           |
+| `make build-linux`   | `build/showcase-linux`                 | `go build`                           |
+| `make build-windows` | `build/showcase-windows.exe`           | `go build` (mingw-w64 cross-compile) |
+| `make build-wasm`    | `build/showcase.wasm` + `wasm_exec.js` | `GOOS=js GOARCH=wasm go build`       |
+| `make release`       | `.tar.gz`, `.zip`, `.dmg`              | All of the above + packaging         |
+
+Related targets: `make build-ios` (c-archive for the iOS demo),
+`make build-android` (gomobile `.aar`), `make build-examples` (compile
+every example to `examples/bin/`).
 
 **Linux and Windows** produce self-contained binaries with no external
 library dependencies: text shaping and rasterization are pure Go

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -358,7 +358,7 @@ func getClipboard(hwnd uintptr) string {
 // --- lifecycle ---
 
 // New creates an OpenGL 3.3 backend backed by a native Win32 window
-// and a WGL context. No SDL2.
+// and a WGL context.
 func New(w *gui.Window) (*Backend, error) {
 	runtime.LockOSThread()
 

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -180,7 +180,7 @@ func (p *platformState) pumpEvents(ch chan<- xgb.Event) {
 }
 
 // New creates an OpenGL 3.3 backend backed by a native X11 window and an
-// EGL context. Pure Go via xgb + purego — no SDL2, no cgo.
+// EGL context. Pure Go via xgb + purego — no cgo.
 func New(w *gui.Window) (*Backend, error) {
 	runtime.LockOSThread()
 

--- a/gui/backend/internal/winkey/winkey.go
+++ b/gui/backend/internal/winkey/winkey.go
@@ -1,7 +1,7 @@
 //go:build windows
 
 // Package winkey maps Win32 virtual-key codes and modifier state to
-// go-gui key and modifier values. It mirrors the sdlkey package for
+// go-gui key and modifier values. It mirrors the x11key package for
 // the native Windows backend.
 package winkey
 

--- a/gui/backend/internal/x11key/x11key.go
+++ b/gui/backend/internal/x11key/x11key.go
@@ -1,8 +1,8 @@
 //go:build linux
 
 // Package x11key maps X11 keysyms and modifier/button state to go-gui
-// key, modifier, and mouse-button values. It mirrors the winkey and
-// sdlkey packages for the native Linux (X11) backend.
+// key, modifier, and mouse-button values. It mirrors the winkey
+// package for the native Linux (X11) backend.
 package x11key
 
 import "github.com/go-gui-org/go-gui/gui"

--- a/gui/backend/metal/metal_window.h
+++ b/gui/backend/metal/metal_window.h
@@ -2,7 +2,7 @@
 #define METAL_WINDOW_H
 
 // metal_window.h — Native NSWindow + CAMetalLayer window manager.
-// Replaces SDL2 window creation and event loop for the Metal backend.
+// Owns window creation and the event loop for the Metal backend.
 
 #ifdef __OBJC__
 #import <Cocoa/Cocoa.h>

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -1,5 +1,5 @@
 // metal_window.m — Native NSWindow + CAMetalLayer window manager.
-// Replaces SDL2 window creation, event loop, clipboard, cursors, and IME.
+// Owns window creation, the event loop, clipboard, cursors, and IME.
 
 #import "metal_window.h"
 #import <Cocoa/Cocoa.h>
@@ -249,10 +249,9 @@ static uint32_t _nextWindowID = 1;
 
 // ─── GUIApplication (NSApplication subclass) ────────────────────
 // Exists so [GUIApplication sharedApplication] returns an instance
-// of this class rather than plain NSApplication. This matches
-// SDL2's SDLApplication pattern — any code that checks
-// isKindOfClass: or swizzles on the application class will see
-// GUIApplication. The sendEvent: override is intentionally a
+// of this class rather than plain NSApplication — any code that
+// checks isKindOfClass: or swizzles on the application class will
+// see GUIApplication. The sendEvent: override is intentionally a
 // passthrough; custom event routing happens in metalPollEvent.
 
 @interface GUIApplication : NSApplication

--- a/gui/backend/run_linux.go
+++ b/gui/backend/run_linux.go
@@ -8,11 +8,11 @@ import (
 )
 
 // Run starts the application event loop using the native X11 + EGL
-// backend (SDL2-free).
+// backend.
 func Run(w *gui.Window) { glbackend.Run(w) }
 
 // RunApp starts a multi-window event loop using the native X11 + EGL
-// backend (SDL2-free).
+// backend.
 func RunApp(app *gui.App, windows ...*gui.Window) {
 	glbackend.RunApp(app, windows...)
 }

--- a/gui/backend/run_windows.go
+++ b/gui/backend/run_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Run starts the application event loop using the native Win32 + WGL
-// backend (SDL2-free).
+// backend.
 func Run(w *gui.Window) { glbackend.Run(w) }
 
 // RunApp starts a multi-window event loop. Multi-window is not yet


### PR DESCRIPTION
## Summary

- **Makefile**: drop `STATIC_TAG = static,audio` and `-tags $(STATIC_TAG)` from `build-linux`/`build-windows`. No Go source (or dependency path we use) gates on these tags since the SDL2 removal (#60) — they were vestiges of `go-sdl2 -tags static` linking and the old audio opt-in tag (#8, replaced by beep in #41).
- **README**: fix the stale *Building the Showcase* section — remove the bogus `-tags static`, add missing `build-ios`/`build-android`/`build-examples` targets and the `wasm_exec.js` output, correct release-artifact casing in *Try It* (`go-gui-showcase-…` for tar.gz/zip), drop "SDL2-free" wording from Installation.
- **.golangci.yml**: remove stale `cyclop` exclusion for the deleted `gui/backend/internal/sdlkey/` package.
- **Comments**: rewrite SDL2 references in `gl`/`metal` backend comments and `winkey`/`x11key` package docs (CHANGELOG.md intentionally untouched — it is history).

## Verification

- `go build ./...` clean
- `go test ./...` pass
- `golangci-lint run ./...` — 0 issues
- `make build-macos` builds the showcase after Makefile change
- `rg -i sdl` (excluding CHANGELOG.md, go.sum, .git) — zero remaining references

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786752436&installation_id=145733661&pr_number=81&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F81&signature=a0b7a730d2c580b4f9fd17e18caf34dcf694180b8ac663edf69c8152fbc78aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->