### PR TITLE
fix: make Focusable widgets actually keyboard-reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`CommandButton` now auto-fills `ID`** from the command ID, prefixed
+  with `cmdbtn:`. Focus traversal is keyed by `Shape.ID`, so a
+  `CommandButton` with `Focusable: true` but no explicit `ID` was
+  silently unreachable by keyboard. The prefix keeps the button's focus
+  ID distinct from the menu item driven by the same command, which
+  carries the raw command ID. Widgets that were dead tab stops now join
+  the tab order; pass an explicit `cfg.ID` for two buttons on one
+  command in the same window.
+- **36 examples** set `Focusable: true` without an `ID` and were not
+  keyboard-reachable, including `get_started`. All now carry stable IDs.
+  `snake` also dropped `controlsIDBase`/`startButtonID` numeric focus
+  IDs left over from the removed `IDFocus uint32` API.
+
+### Changed
+
+- **`requiredid` analyzer** now also flags Cfg literals that set
+  `Focusable: true` without a non-empty `ID`, catching this class of
+  silent no-op at `go vet` time.
+
 ## [v0.35.1] - 2026-07-15
 
 Documentation-only release. No code or behavior changes; no migration needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,10 @@ View fn → generateViewLayout() → Layout tree
 - `Shape` — central renderable. Position, size, color, type, events, text, effects
 - `RenderCmd` — single draw op (rect, text, circle, image, SVG, …)
 - `Window` — top-level container. Holds typed state slot, layout tree, animations
-- `View` — interface satisfied by `*Layout`. Widget factories return `*Layout`
+- `View` — interface (`Content() []View`, `GenerateLayout(*Window) Layout`).
+  Widget factories return `View`, not `*Layout`; `*Layout` does NOT
+  implement it. In tests, reach a widget's shape via
+  `v.GenerateLayout(w).Shape`
 
 ### State Management
 
@@ -67,8 +70,15 @@ app := gui.State[App](w)  // type-asserts; panics if wrong type
 ### Widgets
 
 All widgets take `*Cfg` struct (zero-initializable). Event callbacks share
-sig `func(*Layout, *Event, *Window)`. `IDFocus uint32 > 0` opts widget into
-tab-order focus.
+sig `func(*Layout, *Event, *Window)`.
+
+Focus requires **both** `Focusable: true` **and** a non-empty `ID`
+(`isFocusedTarget`, `gui/event_traversal.go`); tab order additionally
+needs `!FocusSkip && !Disabled` (`layout_query.go`). `Focusable: true`
+without an `ID` is a silent no-op — the widget renders and clicks but
+never joins the tab order. The `requiredid` analyzer flags this. IDs must
+be unique per window: menu items are keyed by raw command ID, so
+`CommandButton` namespaces its auto-filled ID with `cmdbtn:`.
 
 ### External Dependencies
 

--- a/examples/2048/main.go
+++ b/examples/2048/main.go
@@ -157,6 +157,7 @@ func landingView(w *gui.Window) gui.View {
 					}),
 
 					gui.Button(gui.ButtonCfg{
+						ID:          "g2048_start",
 						Focusable:   true,
 						MinWidth:    200,
 						Color:       gui.RGB(237, 194, 46),
@@ -398,6 +399,7 @@ func gameOverlay(msg string) gui.View {
 				TextStyle: textStyle(theme.B1, 48, gui.RGB(119, 110, 101)),
 			}),
 			gui.Button(gui.ButtonCfg{
+				ID:        "g2048_try_again",
 				Focusable: true,
 				Color:     gui.RGB(143, 122, 102),
 				Padding:   gui.SomeP(12, 24, 12, 24),

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -203,6 +203,7 @@ func benchView(w *gui.Window) gui.View {
 						},
 					}),
 					gui.Button(gui.ButtonCfg{
+						ID:        "bench_run",
 						Focusable: true,
 						Content: []gui.View{
 							gui.Text(gui.TextCfg{Text: btnLabel}),

--- a/examples/data_grid_data_source/main.go
+++ b/examples/data_grid_data_source/main.go
@@ -82,6 +82,7 @@ func mainView(w *gui.Window) gui.View {
 				Spacing: gui.Some(theme.SpacingSmall),
 				Content: []gui.View{
 					gui.Switch(gui.SwitchCfg{
+						ID:        "dgds_use_offset",
 						Focusable: true,
 						Label:     "Use offset pagination",
 						Selected:  app.UseOffset,
@@ -93,6 +94,7 @@ func mainView(w *gui.Window) gui.View {
 						},
 					}),
 					gui.Switch(gui.SwitchCfg{
+						ID:        "dgds_slow_mode",
 						Focusable: true,
 						Label:     "Simulate latency",
 						Selected:  app.SimulateLatency,

--- a/examples/dialogs/main.go
+++ b/examples/dialogs/main.go
@@ -69,6 +69,7 @@ func mainView(w *gui.Window) gui.View {
 
 func messageButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_message",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -90,6 +91,7 @@ func messageButton() gui.View {
 
 func confirmButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_confirm",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -113,6 +115,7 @@ func confirmButton() gui.View {
 
 func promptButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_prompt",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -139,6 +142,7 @@ func promptButton() gui.View {
 
 func customButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_custom",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -156,7 +160,8 @@ func customButton() gui.View {
 								Text: "Custom Content",
 							}),
 							gui.Button(gui.ButtonCfg{
-								Focusable: true, // dialogBaseIDFocus
+								ID:        "dlg_custom_close",
+								Focusable: true,
 								Content: []gui.View{gui.Text(gui.TextCfg{
 									Text: "Close Me",
 								})},
@@ -174,6 +179,7 @@ func customButton() gui.View {
 
 func nativeOpenButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_native_open",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -201,6 +207,7 @@ func nativeOpenButton() gui.View {
 
 func nativeSaveButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_native_save",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -224,6 +231,7 @@ func nativeSaveButton() gui.View {
 
 func nativeFolderButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_native_folder",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -242,6 +250,7 @@ func nativeFolderButton() gui.View {
 
 func nativeMessageButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_native_message",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{
@@ -262,6 +271,7 @@ func nativeMessageButton() gui.View {
 
 func nativeConfirmButton() gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        "dlg_native_confirm",
 		Focusable: true,
 		Sizing:    gui.FillFit,
 		Content: []gui.View{gui.Text(gui.TextCfg{

--- a/examples/get_started/main.go
+++ b/examples/get_started/main.go
@@ -49,6 +49,7 @@ func mainView(w *gui.Window) gui.View {
 				Text: "Click to increment counter",
 				Content: []gui.View{
 					gui.Button(gui.ButtonCfg{
+						ID:        "gs_counter",
 						Focusable: true,
 						Shadow: &gui.BoxShadow{
 							Color:      gui.RGBA(0, 0, 64, 64),

--- a/examples/key_up_demo/main.go
+++ b/examples/key_up_demo/main.go
@@ -52,6 +52,7 @@ func mainView(w *gui.Window) gui.View {
 				Text: fmt.Sprintf("Key Up: %d (Last: %v)", app.keyUpCount, app.lastKeyUp),
 			}),
 			gui.Input(gui.InputCfg{
+				ID:        "kud_input",
 				Focusable: true,
 				Text:      "Type here to test key up events...",
 				OnKeyDown: func(layout *gui.Layout, e *gui.Event, w *gui.Window) {

--- a/examples/menu_demo/main.go
+++ b/examples/menu_demo/main.go
@@ -149,6 +149,7 @@ func menu(w *gui.Window) gui.View {
 						Padding: gui.NoPadding,
 						CustomView: gui.Input(gui.InputCfg{
 							Text:        app.SearchText,
+							ID:          "menu_search_input",
 							Focusable:   true,
 							Width:       100,
 							MinWidth:    100,
@@ -207,6 +208,7 @@ func body(w *gui.Window) gui.View {
 				TextStyle: theme.B1,
 			}),
 			gui.Button(gui.ButtonCfg{
+				ID:        "menu_welcome_button",
 				Focusable: true,
 				Content: []gui.View{
 					gui.Text(gui.TextCfg{

--- a/examples/minesweeper/main.go
+++ b/examples/minesweeper/main.go
@@ -268,6 +268,9 @@ func landingContent(w *gui.Window, app *App, theme gui.Theme) []gui.View {
 func diffButton(w *gui.Window, title, subtitle string, diff Difficulty, color gui.Color) gui.View {
 	theme := gui.CurrentTheme()
 	return gui.Button(gui.ButtonCfg{
+		// title is a distinct literal at every call site, so it yields a
+		// unique, frame-stable focus ID without widening the signature.
+		ID:          "mine_diff_" + title,
 		Focusable:   true,
 		MinWidth:    130,
 		Color:       color.WithOpacity(0.15),
@@ -549,6 +552,7 @@ func headerView(app *App, theme gui.Theme, boardW float32) gui.View {
 				HAlign: gui.HAlignCenter, VAlign: gui.VAlignMiddle,
 				Content: []gui.View{
 					gui.Button(gui.ButtonCfg{
+						ID:          "mine_reset",
 						Focusable:   true,
 						Color:       gui.RGB(40, 44, 52),
 						ColorHover:  gui.RGB(55, 60, 68),

--- a/examples/multi_window/main.go
+++ b/examples/multi_window/main.go
@@ -63,6 +63,7 @@ func mainView(w *gui.Window) gui.View {
 				TextStyle: gui.CurrentTheme().B1,
 			}),
 			gui.Button(gui.ButtonCfg{
+				ID:        "mw_open_child",
 				Focusable: true,
 				Content: []gui.View{
 					gui.Text(gui.TextCfg{
@@ -93,6 +94,7 @@ func mainView(w *gui.Window) gui.View {
 				},
 			}),
 			gui.Button(gui.ButtonCfg{
+				ID:        "mw_close_child",
 				Focusable: true,
 				Content: []gui.View{
 					gui.Text(gui.TextCfg{

--- a/examples/particles/main.go
+++ b/examples/particles/main.go
@@ -220,6 +220,7 @@ func landingView(w *gui.Window, ww, wh float32) gui.View {
 				Color:  colorNeonCyan.WithOpacity(0.3),
 			}),
 			gui.Button(gui.ButtonCfg{
+				ID:          "particles_start",
 				Focusable:   true,
 				MinWidth:    180,
 				Color:       colorNeonGreen.WithOpacity(0.12),

--- a/examples/scroll_demo/main.go
+++ b/examples/scroll_demo/main.go
@@ -147,6 +147,7 @@ func themeButton(app *App) gui.View {
 	textSel := gui.IconMoon
 	textUnsel := gui.IconSunnyO
 	return gui.Toggle(gui.ToggleCfg{
+		ID:           "scroll_theme_toggle",
 		Focusable:    true,
 		TextSelect:   textSel,
 		TextUnselect: textUnsel,

--- a/examples/showcase/demo_data.go
+++ b/examples/showcase/demo_data.go
@@ -121,6 +121,7 @@ func demoTable(w *gui.Window) gui.View {
 						Spacing:    gui.SomeF(6),
 						Content: []gui.View{
 							gui.Toggle(gui.ToggleCfg{
+								ID:        "showcase_table_multiselect",
 								Focusable: true,
 								Label:     "Multi-select",
 								Selected:  app.TableMultiSelect,
@@ -131,6 +132,7 @@ func demoTable(w *gui.Window) gui.View {
 								},
 							}),
 							gui.Toggle(gui.ToggleCfg{
+								ID:        "showcase_table_freeze_header",
 								Focusable: true,
 								Label:     "Freeze header",
 								Selected:  app.TableFreezeHeader,

--- a/examples/showcase/demo_layout.go
+++ b/examples/showcase/demo_layout.go
@@ -590,6 +590,7 @@ func multiWindowChildView(parent *gui.Window) func(*gui.Window) gui.View {
 					TextStyle: t.B2,
 				}),
 				gui.Button(gui.ButtonCfg{
+					ID:        "showcase_child_window_button",
 					Focusable: true,
 					Padding:   gui.SomeP(8, 16, 8, 16),
 					Content: []gui.View{
@@ -619,6 +620,7 @@ func multiWindowChildView(parent *gui.Window) func(*gui.Window) gui.View {
 					Padding: gui.NoPadding,
 				}),
 				gui.Button(gui.ButtonCfg{
+					ID:        "showcase_child_window_close",
 					Focusable: true,
 					Padding:   gui.SomeP(8, 16, 8, 16),
 					Content: []gui.View{

--- a/examples/showcase/demo_navigation.go
+++ b/examples/showcase/demo_navigation.go
@@ -169,6 +169,7 @@ func demoMenus(w *gui.Window) gui.View {
 						Padding: gui.NoPadding,
 						CustomView: gui.Input(gui.InputCfg{
 							Text:        app.MenuSearchText,
+							ID:          "showcase_menu_search",
 							Focusable:   true,
 							Width:       100,
 							MinWidth:    100,

--- a/examples/showcase/demo_text.go
+++ b/examples/showcase/demo_text.go
@@ -412,6 +412,7 @@ func demoMarkdown(w *gui.Window) gui.View {
 	style := gui.DefaultMarkdownStyle()
 	style.CodeHighlighter = highlight.Default()
 	return w.Markdown(gui.MarkdownCfg{
+		ID:        "showcase_markdown",
 		Focusable: true,
 		Style:     style,
 		Source:    embeddedText("docs/markdown_demo.md"),

--- a/examples/snake/main.go
+++ b/examples/snake/main.go
@@ -11,14 +11,13 @@ import (
 )
 
 const (
-	gridWidth      = 20
-	gridHeight     = 20
-	cellSize       = 18
-	tickMs         = 120
-	tickAnimation  = "snake-tick"
-	paddingOuter   = 16
-	controlsIDBase = 100
-	startButtonID  = 1
+	gridWidth     = 20
+	gridHeight    = 20
+	cellSize      = 18
+	tickMs        = 120
+	tickAnimation = "snake-tick"
+	paddingOuter  = 16
+	startButtonID = "snake_start"
 )
 
 type App struct {
@@ -197,6 +196,7 @@ func landingView(w *gui.Window, ww, wh float32) gui.View {
 								TextStyle: textStyle(theme.M4, 14, gui.RGB(178, 191, 222)),
 							}),
 							gui.Button(gui.ButtonCfg{
+								ID:          startButtonID,
 								Focusable:   true,
 								MinWidth:    230,
 								Color:       gui.RGB(255, 110, 61),
@@ -362,30 +362,35 @@ func renderControls(g *Game) gui.View {
 		HAlign:  gui.HAlignCenter,
 		Spacing: gui.Some[float32](8),
 		Content: []gui.View{
-			controlButton("Up", controlsIDBase+1, func(g *Game) { g.SetDirection(DirUp) }),
+			controlButton("Up", "snake_up", func(g *Game) { g.SetDirection(DirUp) }),
 			gui.Row(gui.ContainerCfg{
 				HAlign:  gui.HAlignCenter,
 				Spacing: gui.Some[float32](8),
 				Content: []gui.View{
-					controlButton("Left", controlsIDBase+2, func(g *Game) { g.SetDirection(DirLeft) }),
-					controlButton("Down", controlsIDBase+3, func(g *Game) { g.SetDirection(DirDown) }),
-					controlButton("Right", controlsIDBase+4, func(g *Game) { g.SetDirection(DirRight) }),
+					controlButton("Left", "snake_left", func(g *Game) { g.SetDirection(DirLeft) }),
+					controlButton("Down", "snake_down", func(g *Game) { g.SetDirection(DirDown) }),
+					controlButton("Right", "snake_right", func(g *Game) { g.SetDirection(DirRight) }),
 				},
 			}),
 			gui.Row(gui.ContainerCfg{
 				HAlign:  gui.HAlignCenter,
 				Spacing: gui.Some[float32](8),
 				Content: []gui.View{
-					controlButton(pauseLabel, controlsIDBase+5, func(g *Game) { g.TogglePause() }),
-					controlButton("Restart", controlsIDBase+6, func(g *Game) { g.Reset() }),
+					controlButton(pauseLabel, "snake_pause", func(g *Game) { g.TogglePause() }),
+					controlButton("Restart", "snake_restart", func(g *Game) { g.Reset() }),
 				},
 			}),
 		},
 	})
 }
 
-func controlButton(label string, id uint32, action func(*Game)) gui.View {
+// controlButton builds one on-screen D-pad/action button. id must be
+// stable across frames and independent of label: the pause button's
+// label flips between Pause/Resume, and a label-derived ID would drop
+// focus on every toggle.
+func controlButton(label, id string, action func(*Game)) gui.View {
 	return gui.Button(gui.ButtonCfg{
+		ID:        id,
 		Focusable: true,
 		MinWidth:  72,
 		Content: []gui.View{

--- a/examples/solitaire/main.go
+++ b/examples/solitaire/main.go
@@ -238,6 +238,9 @@ func landingView(w *gui.Window, ww, wh float32) gui.View {
 func modeButton(w *gui.Window, title string, mode DrawMode, color gui.Color) gui.View {
 	theme := gui.CurrentTheme()
 	return gui.Button(gui.ButtonCfg{
+		// title is a distinct literal at every call site, so it yields a
+		// unique, frame-stable focus ID without widening the signature.
+		ID:          "sol_mode_" + title,
 		Focusable:   true,
 		MinWidth:    140,
 		Color:       color.WithOpacity(0.12),

--- a/examples/vibrancy/main.go
+++ b/examples/vibrancy/main.go
@@ -48,6 +48,7 @@ func mainView(w *gui.Window) gui.View {
 				TextStyle: gui.CurrentTheme().B1,
 			}),
 			gui.Button(gui.ButtonCfg{
+				ID:        "vibrancy_button",
 				Focusable: true,
 				Content: []gui.View{
 					gui.Text(gui.TextCfg{Text: "Cycle material"}),

--- a/examples/web_demo/main.go
+++ b/examples/web_demo/main.go
@@ -46,6 +46,7 @@ func mainView(w *gui.Window) gui.View {
 				TextStyle: gui.CurrentTheme().B1,
 			}),
 			gui.Button(gui.ButtonCfg{
+				ID:        "web_demo_button",
 				Focusable: true,
 				Content: []gui.View{
 					gui.Text(gui.TextCfg{

--- a/gui/command_test.go
+++ b/gui/command_test.go
@@ -275,6 +275,70 @@ func TestCommandButtonUnknownReturnsErrorView(t *testing.T) {
 	}
 }
 
+// A CommandButton must carry an ID: focus traversal is keyed by it, so
+// Focusable: true is a silent no-op without one.
+func TestCommandButtonDefaultsIDToCommandID(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "edit.increment",
+		Label:   "Increment",
+		Execute: func(_ *Event, _ *Window) {},
+	})
+
+	v := CommandButton(w, "edit.increment", ButtonCfg{Focusable: true})
+	l := v.GenerateLayout(w)
+	want := commandButtonIDPrefix + "edit.increment"
+	if got := l.Shape.ID; got != want {
+		t.Errorf("ID = %q, want %q", got, want)
+	}
+	if !l.Shape.Focusable {
+		t.Error("Focusable should survive to the shape")
+	}
+	// Focusable && ID != "" is what isFocusedTarget requires.
+	w.SetFocus(want)
+	if !isFocusedTarget(&l, w) {
+		t.Error("button is not keyboard-reachable after SetFocus")
+	}
+}
+
+// The auto-filled ID must not collide with the menu item that the same
+// command drives: menu item shapes carry the raw command ID, so an
+// unprefixed button ID would put two shapes under one focus ID.
+func TestCommandButtonIDDoesNotCollideWithMenuItem(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "file.new",
+		Label:   "New",
+		Execute: func(_ *Event, _ *Window) {},
+	})
+
+	btn := CommandButton(w, "file.new", ButtonCfg{Focusable: true})
+	btnID := btn.GenerateLayout(w).Shape.ID
+
+	// A menubar item for the same command renders a shape keyed by the
+	// raw command ID (view_menu_item.go sets ID: itemCfg.ID).
+	if btnID == "file.new" {
+		t.Errorf("button ID %q collides with the menu item ID for the "+
+			"same command", btnID)
+	}
+}
+
+// An explicit ID must win over the command-ID default.
+func TestCommandButtonExplicitIDWins(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "edit.undo",
+		Label:   "Undo",
+		Execute: func(_ *Event, _ *Window) {},
+	})
+
+	v := CommandButton(w, "edit.undo", ButtonCfg{ID: "custom"})
+	l := v.GenerateLayout(w)
+	if got := l.Shape.ID; got != "custom" {
+		t.Errorf("ID = %q, want %q", got, "custom")
+	}
+}
+
 func TestUnregisterCommandNoOp(_ *testing.T) {
 	w := NewWindow(WindowCfg{State: new(int)})
 	// Should not panic when unregistering a non-existent ID.

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -212,10 +212,21 @@ func Button(cfg ButtonCfg) View {
 	}
 }
 
+// commandButtonIDPrefix namespaces auto-filled CommandButton IDs.
+// Menu items are keyed by raw command ID (see MenuItemCfg.CommandID),
+// and menu item shapes carry that ID; without the prefix a menubar and
+// a CommandButton for the same command would produce two shapes with
+// the same ID in one window, making focus ambiguous.
+const commandButtonIDPrefix = "cmdbtn:"
+
 // CommandButton creates a button wired to a registered
 // command. Auto-fills label from Command.Label when Content
-// is nil. Auto-disables via CanExecute. Wires OnClick to
-// Command.Execute.
+// is nil. Auto-fills ID from cmdID. Auto-disables via
+// CanExecute. Wires OnClick to Command.Execute.
+//
+// The auto-filled ID is commandButtonIDPrefix + cmdID. Set cfg.ID
+// explicitly when placing two buttons for the same command in one
+// window, otherwise both get the same focus ID.
 func CommandButton(w *Window, cmdID string, cfg ButtonCfg) View {
 	cmd, ok := w.CommandByID(cmdID)
 	if !ok {
@@ -223,6 +234,12 @@ func CommandButton(w *Window, cmdID string, cfg ButtonCfg) View {
 			Text:      "unknown command: " + cmdID,
 			TextStyle: TextStyle{Color: Red},
 		})
+	}
+
+	// Focus traversal is keyed by ID (see isFocusedTarget), so
+	// Focusable: true is a silent no-op without one.
+	if cfg.ID == "" {
+		cfg.ID = commandButtonIDPrefix + cmdID
 	}
 
 	// Auto-fill content from command label.

--- a/tools/requiredid/requiredid.go
+++ b/tools/requiredid/requiredid.go
@@ -1,6 +1,10 @@
 // Package requiredid provides a go/analysis pass that flags composite
 // literals of struct types whose fields are tagged `gui:"required"`
 // when the required field is absent or set to an empty string literal.
+//
+// It also flags Cfg literals that set Focusable: true without an ID.
+// Focus traversal is keyed by ID, so such a widget is silently
+// unreachable by keyboard.
 package requiredid
 
 import (
@@ -50,24 +54,55 @@ func run(pass *analysis.Pass) (any, error) {
 			if !isFactoryArg(lit, named.Obj().Name(), parents) {
 				return true
 			}
-			required := requiredFields(st)
-			if len(required) == 0 {
-				return true
-			}
 			if ignored[pass.Fset.Position(lit.Pos()).Line] {
 				return true
 			}
-			for _, name := range required {
-				if !hasNonEmptyField(lit, name) {
-					pass.Reportf(lit.Pos(),
-						"%s.%s is required (gui:\"required\") and must be non-empty",
-						named.Obj().Name(), name)
-				}
-			}
+			checkRequired(pass, lit, named, st)
+			checkFocusableID(pass, lit, named, st)
 			return true
 		})
 	}
 	return nil, nil
+}
+
+// checkRequired reports fields tagged gui:"required" that are absent
+// or set to an empty string literal.
+func checkRequired(
+	pass *analysis.Pass, lit *ast.CompositeLit,
+	named *types.Named, st *types.Struct,
+) {
+	for _, name := range requiredFields(st) {
+		if !hasNonEmptyField(lit, name) {
+			pass.Reportf(lit.Pos(),
+				"%s.%s is required (gui:\"required\") and must be non-empty",
+				named.Obj().Name(), name)
+		}
+	}
+}
+
+// checkFocusableID reports literals that set Focusable: true but leave
+// ID unset or empty. Focus traversal skips shapes with an empty ID
+// (see isFocusedTarget in the gui package), so Focusable: true alone
+// is a silent no-op: the widget renders but never joins the tab order.
+func checkFocusableID(
+	pass *analysis.Pass, lit *ast.CompositeLit,
+	named *types.Named, st *types.Struct,
+) {
+	if !hasTrueField(lit, "Focusable") {
+		return
+	}
+	// A Cfg with no ID field at all has no way to satisfy the rule;
+	// stay quiet rather than emit an unfixable diagnostic.
+	if !hasField(st, "ID") {
+		return
+	}
+	if hasNonEmptyField(lit, "ID") {
+		return
+	}
+	pass.Reportf(lit.Pos(),
+		"%s sets Focusable: true without an ID; focus traversal is keyed "+
+			"by ID, so the widget is not keyboard-reachable",
+		named.Obj().Name())
 }
 
 // parentCalls maps each CompositeLit directly used as a call
@@ -134,6 +169,36 @@ func requiredFields(st *types.Struct) []string {
 		}
 	}
 	return out
+}
+
+// hasField reports whether st declares a field with the given name.
+func hasField(st *types.Struct, name string) bool {
+	for f := range st.Fields() {
+		if f.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hasTrueField reports whether the literal sets name to the bool
+// literal true. A non-literal value (variable, call) is treated as
+// not-true: the analyzer cannot know it statically, and guessing
+// would produce false positives.
+func hasTrueField(lit *ast.CompositeLit, name string) bool {
+	for _, e := range lit.Elts {
+		kv, ok := e.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		id, ok := kv.Key.(*ast.Ident)
+		if !ok || id.Name != name {
+			continue
+		}
+		val, ok := kv.Value.(*ast.Ident)
+		return ok && val.Name == "true"
+	}
+	return false
 }
 
 func hasNonEmptyField(lit *ast.CompositeLit, name string) bool {

--- a/tools/requiredid/testdata/src/widgets/widgets.go
+++ b/tools/requiredid/testdata/src/widgets/widgets.go
@@ -9,6 +9,18 @@ type NoReqCfg struct {
 	ID string
 }
 
+// FocusCfg has an untagged ID: the Focusable rule must fire on its own,
+// independent of gui:"required".
+type FocusCfg struct {
+	ID        string
+	Focusable bool
+}
+
+// NoIDCfg is focusable but has no ID field to set.
+type NoIDCfg struct {
+	Focusable bool
+}
+
 type S struct{}
 
 func (S) Widget(_ WidgetCfg) {}
@@ -16,6 +28,8 @@ func (S) Widget(_ WidgetCfg) {}
 func Widget(_ WidgetCfg) {}
 func helper(_ WidgetCfg) {}
 func useN(_ NoReqCfg)    {}
+func Focus(_ FocusCfg)   {}
+func NoID(_ NoIDCfg)     {}
 
 func good() {
 	Widget(WidgetCfg{ID: "ok", Name: "x"})
@@ -52,4 +66,41 @@ func returnedSkipped() WidgetCfg {
 
 func varAssignSkipped() {
 	_ = WidgetCfg{Name: "x"}
+}
+
+func focusableNoID() {
+	Focus(FocusCfg{Focusable: true}) // want `FocusCfg sets Focusable: true without an ID`
+}
+
+func focusableEmptyID() {
+	Focus(FocusCfg{ID: "", Focusable: true}) // want `FocusCfg sets Focusable: true without an ID`
+}
+
+func focusableWithID() {
+	Focus(FocusCfg{ID: "ok", Focusable: true})
+}
+
+// A non-literal ID cannot be proven empty; stay quiet.
+func focusableComputedID() {
+	id := "x"
+	Focus(FocusCfg{ID: id, Focusable: true})
+}
+
+// Focusable is not statically true; stay quiet.
+func focusableComputedFlag() {
+	on := true
+	Focus(FocusCfg{Focusable: on})
+}
+
+func notFocusableNoID() {
+	Focus(FocusCfg{})
+}
+
+// No ID field exists to set, so the diagnostic would be unfixable.
+func focusableCfgWithoutIDField() {
+	NoID(NoIDCfg{Focusable: true})
+}
+
+func focusableIgnoredByDirective() {
+	Focus(FocusCfg{Focusable: true}) //requiredid:ignore
 }


### PR DESCRIPTION
## The bug

Focus traversal requires **both** `Focusable: true` **and** a non-empty `ID` — `gui/event_traversal.go:15`:

```go
if !layout.Shape.Focusable || layout.Shape.ID == "" {
    return false
}
```

`Focusable: true` without an `ID` is a silent no-op: the widget renders, styles, and clicks, but Tab never reaches it. 36 sites had exactly that — including `examples/get_started`, where the counter button sits inside a tooltip that *does* have an ID while the button itself has none.

Breakdown: 27 Button, 3 Toggle, 3 Input, 2 Switch, 1 Markdown.

## `CommandButton` was the biggest source

It auto-filled Content and OnClick but never `ID`, so every `CommandButton` with `Focusable: true` was keyboard-dead — all 8 in `examples/command_demo`.

It now derives `ID` from the command ID, namespaced `cmdbtn:`. The prefix is load-bearing: menu items are keyed by the raw command ID and `view_menu_item.go:162` renders them as shapes carrying it, so an unprefixed button ID would put **two shapes under one focus ID** in any window with both a menubar and a `CommandButton` for the same command. `command_demo` is exactly that window. `TestCommandButtonIDDoesNotCollideWithMenuItem` pins this.

## Analyzer guard

`requiredid` now flags `Focusable: true` with a missing or empty `ID`, so this fails at `go vet` time (already wired into CI at `.github/workflows/ci.yml:137`). It only fires when it can statically prove both conditions on a direct factory argument — non-literal IDs and wrapper-filled configs produce no false positives. Nine new testdata cases pin the behavior.

## Incidental findings

- **`snake`** still had the removed `IDFocus uint32` API fossilized in it: `controlButton(label string, id uint32, ...)` took an id it never used, `controlsIDBase = 100` fed six dead offsets, and `startButtonID = 1` was declared and never referenced. Now real string IDs.
- **`CLAUDE.md`** had two stale claims that misled me while working: the `IDFocus uint32` note, and "`View` — interface satisfied by `*Layout`" (it isn't — that's why my first test draft didn't compile). Both corrected.

## Verification

- `TestCommandButtonDefaultsIDToCommandID` fails with `ID = ""` when the fix is stripped, passes with it.
- Analyzer clean across `./...`; duplicate shape-ID scan clean for all IDs introduced here.
- `gofmt`, `go vet`, `golangci-lint` (0 issues), full suite (0 failures).

## Blast radius

None external. `CommandButton` has **zero** usages across all five consumers (go-charts, go-edit, go-kite, go-map, go-term) — verified by grep. The tab-order change is confined to go-gui's own examples.

## Follow-up

`InputCfg.ReadOnly` ships separately. #82 tracks extending it to the `NumericInput` / `InputDate` wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786761170&installation_id=145733661&pr_number=83&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F83&signature=074d3391a9cbe7a972e79bdc0b41409a73cda8262b3300619502dc3c0a9cac86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->