### PR TITLE
feat: add InputCfg.ReadOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`InputCfg.ReadOnly`** — blocks text edits while the field stays
+  focusable and selectable. Navigation, selection, and copy keep
+  working; typing, IME text, paste, cut, undo/redo, delete, multiline
+  Enter, and `PostCommitNormalize` are all skipped. Single-line Enter
+  still fires `OnEnter`/`OnTextCommit`, with the text uncommitted and
+  unnormalized. The field is announced to assistive tech as
+  `AccessStateReadOnly`. Mirrors HTML's `readonly`, and is distinct from
+  `Disabled`, which removes the field from interaction entirely.
+
+  This state was previously inexpressible: `AccessStateReadOnly` could
+  only be produced by setting `Focusable: false`, which also dropped the
+  field from the tab order — so an Input was either editable or
+  unreachable, with nothing in between. Non-focusable Inputs still
+  report read-only, so existing behavior is unchanged.
+
+  Known limitation: an IME composition started on a read-only field
+  renders a preedit that can never commit. It clears on focus change.
+
 ### Fixed
 
 - **`CommandButton` now auto-fills `ID`** from the command ID, prefixed

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -76,6 +76,21 @@ type InputCfg struct {
 
 	Focusable bool
 
+	// ReadOnly blocks text edits while the field stays focusable and
+	// selectable: navigation, selection, and copy keep working, and the
+	// field is announced to assistive tech as read-only. Typing, paste,
+	// cut, undo/redo, delete, and PostCommitNormalize are all skipped.
+	// Mirrors HTML's readonly.
+	//
+	// Distinct from Disabled, which also removes the field from
+	// interaction entirely and announces AccessStateDisabled.
+	//
+	// Known limitation: an IME composition started on a read-only field
+	// still renders its preedit (render_text.go gates that on Focusable,
+	// which read-only fields keep). The composition can never commit and
+	// clears on focus change, so the effect is a transient artifact.
+	ReadOnly bool
+
 	// Scrollable opts a multiline input into the scroll system.
 	// Scroll state is keyed by Cfg.ID - pass that same id to
 	// Window.ScrollVerticalTo. Requires Mode == InputMultiline.
@@ -137,6 +152,7 @@ func Input(cfg InputCfg) View {
 		FocusID:             cfg.ID,
 		ScrollID:            inputScrollIDFor(&cfg),
 		IsPassword:          cfg.IsPassword,
+		ReadOnly:            cfg.ReadOnly,
 		Mode:                cfg.Mode,
 		Mask:                cfg.Mask,
 		MaskPreset:          cfg.MaskPreset,
@@ -176,8 +192,14 @@ func Input(cfg InputCfg) View {
 	if cfg.Mode == InputMultiline {
 		a11yRole = AccessRoleTextArea
 	}
+	// ReadOnly states it outright. A non-focusable field is also
+	// uneditable in practice, so it keeps reporting read-only; that
+	// fallback is the only way this was expressible before ReadOnly
+	// existed. If Focusable ever defaults to true, drop the second
+	// clause — a missing ID would otherwise announce read-only on a
+	// field the caller never marked as such.
 	a11yState := AccessStateNone
-	if !cfg.Focusable {
+	if cfg.ReadOnly || !cfg.Focusable {
 		a11yState = AccessStateReadOnly
 	}
 
@@ -287,8 +309,37 @@ type inputHandlerCfg struct {
 	FocusID             string
 	ScrollID            string
 	IsPassword          bool
+	ReadOnly            bool
 	Mode                InputMode
 	MaskPreset          InputMaskPreset
+}
+
+// fireTextChanged notifies the caller that the text changed. Every
+// mutation path in this file ends here, which makes it the one place
+// ReadOnly has to be enforced: a read-only field by definition never
+// changes text, so the notification is dropped rather than relying on
+// each entry point to remember to check. Gating only the entry points
+// missed the commit paths, where PostCommitNormalize reaches this
+// without going through any text mutator.
+func (h *inputHandlerCfg) fireTextChanged(
+	layout *Layout, text string, w *Window,
+) {
+	if h.ReadOnly || h.OnTextChanged == nil {
+		return
+	}
+	h.OnTextChanged(layout, text, w)
+}
+
+// normalizeOnCommit applies PostCommitNormalize, which transforms the
+// text and is therefore an edit: read-only fields skip it and commit
+// the text unchanged.
+func (h *inputHandlerCfg) normalizeOnCommit(
+	text string, reason InputCommitReason,
+) string {
+	if h.ReadOnly || h.PostCommitNormalize == nil {
+		return text
+	}
+	return h.PostCommitNormalize(text, reason)
 }
 
 // compiledMask returns a non-nil *CompiledInputMask if the
@@ -446,16 +497,11 @@ func inputAmendLayout(
 		focusMap.Set(layout.Shape.ID, focused)
 		if wasFocused && !focused {
 			text := inputTextFromLayout(layout)
-			if hcfg.PostCommitNormalize != nil {
-				normalized := hcfg.PostCommitNormalize(
-					text, CommitBlur)
-				if normalized != text {
-					text = normalized
-					if hcfg.OnTextChanged != nil {
-						hcfg.OnTextChanged(
-							layout, text, w)
-					}
-				}
+			if normalized := hcfg.normalizeOnCommit(
+				text, CommitBlur,
+			); normalized != text {
+				text = normalized
+				hcfg.fireTextChanged(layout, text, w)
 			}
 			if hcfg.OnTextCommit != nil {
 				hcfg.OnTextCommit(
@@ -535,6 +581,12 @@ func makeInputOnChar(hcfg inputHandlerCfg) func(*Layout, *Event, *Window) {
 		if hcfg.FocusID == "" || !w.IsFocus(hcfg.FocusID) {
 			return
 		}
+		// Swallow typed and IME-composed text; the field keeps focus so
+		// navigation, selection, and copy still work.
+		if hcfg.ReadOnly {
+			e.IsHandled = true
+			return
+		}
 		ch := e.CharCode
 		id := hcfg.FocusID
 
@@ -553,9 +605,7 @@ func makeInputOnChar(hcfg inputHandlerCfg) func(*Layout, *Event, *Window) {
 
 		if changed {
 			resetBlinkCursorVisible(w)
-			if hcfg.OnTextChanged != nil {
-				hcfg.OnTextChanged(layout, text, w)
-			}
+			hcfg.fireTextChanged(layout, text, w)
 			inputScrollCursorIntoView(
 				hcfg.ScrollID, text, layout, w,
 			)
@@ -564,10 +614,35 @@ func makeInputOnChar(hcfg inputHandlerCfg) func(*Layout, *Event, *Window) {
 	}
 }
 
+// inputKeyMutatesText reports whether a key event would change the
+// input's text. Read-only fields swallow these while navigation
+// (arrows/Home/End), selection (Shift, Ctrl+A), and copy (Ctrl+C) stay
+// live. Cut/undo/redo only mutate with a Ctrl/Super modifier; without
+// one their handlers decline the key, so it must not be swallowed here.
+func inputKeyMutatesText(e *Event, mode InputMode) bool {
+	switch e.KeyCode {
+	case KeyBackspace, KeyDelete:
+		return true
+	case KeyEnter:
+		// Multiline Enter inserts a newline. Single-line Enter commits
+		// and must stay allowed so OnEnter/OnTextCommit still fire; its
+		// one edit is PostCommitNormalize, which normalizeOnCommit
+		// skips when read-only.
+		return mode == InputMultiline
+	case KeyV, KeyX, KeyZ:
+		return e.Modifiers.HasAny(ModCtrl, ModSuper)
+	}
+	return false
+}
+
 func makeInputOnKeyDown(hcfg inputHandlerCfg) func(*Layout, *Event, *Window) {
 	mask := hcfg.CompiledMask
 	return func(layout *Layout, e *Event, w *Window) {
 		if hcfg.FocusID == "" || !w.IsFocus(hcfg.FocusID) {
+			return
+		}
+		if hcfg.ReadOnly && inputKeyMutatesText(e, hcfg.Mode) {
+			e.IsHandled = true
 			return
 		}
 		id := hcfg.FocusID
@@ -651,8 +726,8 @@ func makeInputOnKeyDown(hcfg inputHandlerCfg) func(*Layout, *Event, *Window) {
 
 		if handled {
 			resetBlinkCursorVisible(w)
-			if textChanged && hcfg.OnTextChanged != nil {
-				hcfg.OnTextChanged(layout, text, w)
+			if textChanged {
+				hcfg.fireTextChanged(layout, text, w)
 			}
 			inputScrollCursorIntoView(
 				hcfg.ScrollID, text, layout, w,

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -242,16 +242,11 @@ func inputCommitEnter(
 	layout *Layout, text string, e *Event, w *Window,
 ) {
 	commitText := text
-	if hcfg.PostCommitNormalize != nil {
-		normalized := hcfg.PostCommitNormalize(
-			text, CommitEnter)
-		if normalized != text {
-			commitText = normalized
-			if hcfg.OnTextChanged != nil {
-				hcfg.OnTextChanged(
-					layout, commitText, w)
-			}
-		}
+	if normalized := hcfg.normalizeOnCommit(
+		text, CommitEnter,
+	); normalized != text {
+		commitText = normalized
+		hcfg.fireTextChanged(layout, commitText, w)
 	}
 	if hcfg.OnTextCommit != nil {
 		hcfg.OnTextCommit(

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -913,3 +913,307 @@ func TestMakeInputOnKeyUp_NilHandler(t *testing.T) {
 
 	handler(layout, e, w)
 }
+
+// --- ReadOnly tests ---
+
+// newInputTestReadOnly mirrors newInputTest but marks the field
+// read-only. Focusable stays true: the point of ReadOnly is a field
+// that keeps focus and selection while refusing edits.
+func newInputTestReadOnly(
+	text string, focusID string, cursorPos int, mode InputMode,
+) *inputTestCtx {
+	ctx := &inputTestCtx{}
+	ctx.w = newTestWindow()
+	ctx.lastText = text
+	ctx.w.SetFocus(focusID)
+	setInputState(ctx.w, focusID, InputState{CursorPos: cursorPos})
+	ctx.layout = generateViewLayout(Input(InputCfg{
+		Text:      text,
+		ID:        focusID,
+		Focusable: true,
+		ReadOnly:  true,
+		Mode:      mode,
+		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
+			ctx.lastText = newText
+		},
+	}), ctx.w)
+	return ctx
+}
+
+// The state that was previously inexpressible: focusable AND announced
+// read-only. Before ReadOnly, AccessStateReadOnly required
+// Focusable: false, which also dropped the field from the tab order.
+func TestInputReadOnlyIsFocusableAndAnnouncedReadOnly(t *testing.T) {
+	w := newTestWindow()
+	v := Input(InputCfg{
+		ID: "ro_a11y", Text: "x", Focusable: true, ReadOnly: true,
+	})
+	layout := generateViewLayout(v, w)
+
+	if layout.Shape.A11YState != AccessStateReadOnly {
+		t.Errorf("A11YState = %d, want AccessStateReadOnly",
+			layout.Shape.A11YState)
+	}
+	// Focusable && ID != "" is what isFocusedTarget requires.
+	if !layout.Shape.Focusable || layout.Shape.ID == "" {
+		t.Error("read-only field must stay keyboard-reachable")
+	}
+}
+
+func TestInputReadOnlyBlocksTyping(t *testing.T) {
+	ctx := newInputTestReadOnly("hello", "ro1", 5, InputSingleLine)
+	ctx.fireChar('!')
+	if ctx.lastText != "hello" {
+		t.Fatalf("typing mutated read-only field: got %q", ctx.lastText)
+	}
+}
+
+func TestInputReadOnlyBlocksIMEText(t *testing.T) {
+	ctx := newInputTestReadOnly("hello", "ro_ime", 5, InputSingleLine)
+	e := &Event{Type: EventChar, CharCode: 'a', IMEText: "日本"}
+	ctx.layout.Shape.events.OnChar(&ctx.layout, e, ctx.w)
+	if ctx.lastText != "hello" {
+		t.Fatalf("IME text mutated read-only field: got %q", ctx.lastText)
+	}
+}
+
+func TestInputReadOnlyBlocksDeleteKeys(t *testing.T) {
+	for _, key := range []struct {
+		name string
+		code KeyCode
+	}{{"backspace", KeyBackspace}, {"delete", KeyDelete}} {
+		ctx := newInputTestReadOnly("hello", "ro_"+key.name, 3,
+			InputSingleLine)
+		ctx.fireKeyDown(key.code, 0)
+		if ctx.lastText != "hello" {
+			t.Errorf("%s mutated read-only field: got %q",
+				key.name, ctx.lastText)
+		}
+	}
+}
+
+func TestInputReadOnlyBlocksPaste(t *testing.T) {
+	ctx := newInputTestReadOnly("hello", "ro2", 5, InputSingleLine)
+	ctx.w.SetClipboardGetFn(func() string { return "XX" })
+	ctx.fireKeyDown(KeyV, ModCtrl)
+	if ctx.lastText != "hello" {
+		t.Fatalf("paste mutated read-only field: got %q", ctx.lastText)
+	}
+}
+
+func TestInputReadOnlyBlocksCut(t *testing.T) {
+	var clipboard string
+	ctx := newInputTestReadOnly("abcd", "ro3", 2, InputSingleLine)
+	ctx.w.SetClipboardFn(func(s string) { clipboard = s })
+	setInputState(ctx.w, "ro3", InputState{
+		CursorPos: 2, SelectBeg: 1, SelectEnd: 3,
+	})
+	ctx.fireKeyDown(KeyX, ModCtrl)
+	if ctx.lastText != "abcd" {
+		t.Errorf("cut mutated read-only field: got %q", ctx.lastText)
+	}
+	if clipboard != "" {
+		t.Errorf("cut wrote clipboard %q on read-only field", clipboard)
+	}
+}
+
+// Undo needs real history to be a meaningful test: seed it by editing
+// the field while it is still editable, then flip it to read-only and
+// confirm Ctrl+Z cannot roll the text back.
+func TestInputReadOnlyBlocksUndo(t *testing.T) {
+	ctx := newInputTest("hello", "ro4", 5)
+	ctx.fireChar('!')
+	if ctx.lastText != "hello!" {
+		t.Fatalf("setup: insert failed, got %q", ctx.lastText)
+	}
+
+	ctx.layout = generateViewLayout(Input(InputCfg{
+		Text: ctx.lastText, ID: "ro4", Focusable: true, ReadOnly: true,
+		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
+			ctx.lastText = newText
+		},
+	}), ctx.w)
+
+	ctx.fireKeyDown(KeyZ, ModCtrl)
+	if ctx.lastText != "hello!" {
+		t.Fatalf("undo mutated read-only field: got %q, want %q",
+			ctx.lastText, "hello!")
+	}
+}
+
+func TestInputReadOnlyBlocksMultilineEnter(t *testing.T) {
+	ctx := newInputTestReadOnly("ab", "ro5", 1, InputMultiline)
+	ctx.fireKeyDown(KeyEnter, 0)
+	if ctx.lastText != "ab" {
+		t.Fatalf("Enter inserted newline in read-only multiline: got %q",
+			ctx.lastText)
+	}
+}
+
+// Single-line Enter commits without changing text, so it must still
+// reach OnEnter on a read-only field (HTML readonly submits too).
+func TestInputReadOnlySingleLineEnterStillCommits(t *testing.T) {
+	w := newTestWindow()
+	w.SetFocus("ro6")
+	enterFired := false
+	layout := generateViewLayout(Input(InputCfg{
+		Text: "hello", ID: "ro6", Focusable: true, ReadOnly: true,
+		OnEnter: func(_ *Layout, _ *Event, _ *Window) {
+			enterFired = true
+		},
+	}), w)
+	e := &Event{Type: EventKeyDown, KeyCode: KeyEnter}
+	layout.Shape.events.OnKeyDown(&layout, e, w)
+	if !enterFired {
+		t.Error("single-line Enter should still commit when read-only")
+	}
+}
+
+// Navigation, selection, and copy are the whole reason ReadOnly is not
+// just Focusable: false — they must keep working.
+func TestInputReadOnlyAllowsNavigation(t *testing.T) {
+	ctx := newInputTestReadOnly("hello", "ro7", 0, InputSingleLine)
+	ctx.fireKeyDown(KeyRight, 0)
+	if got := ctx.state().CursorPos; got != 1 {
+		t.Fatalf("CursorPos = %d, want 1: arrows must work read-only", got)
+	}
+}
+
+func TestInputReadOnlyAllowsSelectAll(t *testing.T) {
+	ctx := newInputTestReadOnly("abc", "ro8", 1, InputSingleLine)
+	ctx.fireKeyDown(KeyA, ModCtrl)
+	is := ctx.state()
+	if is.SelectBeg != 0 || is.SelectEnd != 3 {
+		t.Fatalf("select all: got %d-%d, want 0-3",
+			is.SelectBeg, is.SelectEnd)
+	}
+}
+
+func TestInputReadOnlyAllowsCopy(t *testing.T) {
+	var clipboard string
+	ctx := newInputTestReadOnly("hello", "ro9", 5, InputSingleLine)
+	ctx.w.SetClipboardFn(func(s string) { clipboard = s })
+	setInputState(ctx.w, "ro9", InputState{
+		CursorPos: 5, SelectBeg: 0, SelectEnd: 5,
+	})
+	ctx.fireKeyDown(KeyC, ModCtrl)
+	if clipboard != "hello" {
+		t.Fatalf("copy: clipboard=%q, want hello", clipboard)
+	}
+}
+
+// Default (ReadOnly: false) must be unaffected.
+func TestInputNotReadOnlyStillEdits(t *testing.T) {
+	ctx := newInputTest("hello", "ro10", 5)
+	ctx.fireChar('!')
+	if ctx.lastText != "hello!" {
+		t.Fatalf("got %q, want %q", ctx.lastText, "hello!")
+	}
+}
+
+// --- ReadOnly commit-path tests ---
+//
+// These cover the paths that the char/key gates cannot see:
+// PostCommitNormalize transforms text and notifies via OnTextChanged
+// without going through any text mutator, so gating the two
+// dispatchers left it reachable. Both cases below failed before
+// normalizeOnCommit/fireTextChanged existed.
+
+func TestInputReadOnlyEnterDoesNotNormalize(t *testing.T) {
+	w := newTestWindow()
+	w.SetFocus("ro_norm_enter")
+	changed := ""
+	committed := ""
+	layout := generateViewLayout(Input(InputCfg{
+		Text: "  hi  ", ID: "ro_norm_enter", Focusable: true,
+		ReadOnly: true,
+		PostCommitNormalize: func(_ string, _ InputCommitReason) string {
+			return "NORMALIZED"
+		},
+		OnTextChanged: func(_ *Layout, nt string, _ *Window) {
+			changed = nt
+		},
+		OnTextCommit: func(
+			_ *Layout, ct string, _ InputCommitReason, _ *Window,
+		) {
+			committed = ct
+		},
+	}), w)
+
+	e := &Event{Type: EventKeyDown, KeyCode: KeyEnter}
+	layout.Shape.events.OnKeyDown(&layout, e, w)
+
+	if changed != "" {
+		t.Errorf("OnTextChanged fired with %q on a read-only field", changed)
+	}
+	// Commit still fires — with the original text, not the normalized one.
+	if committed != "  hi  " {
+		t.Errorf("OnTextCommit got %q, want the unnormalized %q",
+			committed, "  hi  ")
+	}
+}
+
+func TestInputReadOnlyBlurDoesNotNormalize(t *testing.T) {
+	w := newTestWindow()
+	changed := ""
+	committed := ""
+	cfg := InputCfg{
+		Text: "  hi  ", ID: "ro_norm_blur", Focusable: true,
+		ReadOnly: true,
+		PostCommitNormalize: func(_ string, _ InputCommitReason) string {
+			return "NORMALIZED"
+		},
+		OnTextChanged: func(_ *Layout, nt string, _ *Window) {
+			changed = nt
+		},
+		OnTextCommit: func(
+			_ *Layout, ct string, _ InputCommitReason, _ *Window,
+		) {
+			committed = ct
+		},
+	}
+
+	// Frame 1: focused. AmendLayout records focus in nsInputFocus.
+	w.SetFocus("ro_norm_blur")
+	l1 := generateViewLayout(Input(cfg), w)
+	l1.Shape.events.AmendLayout(&l1, w)
+
+	// Frame 2: focus moved away -> blur commit path runs.
+	w.SetFocus("elsewhere")
+	l2 := generateViewLayout(Input(cfg), w)
+	l2.Shape.events.AmendLayout(&l2, w)
+
+	if changed != "" {
+		t.Errorf("OnTextChanged fired with %q on blur of a read-only field",
+			changed)
+	}
+	if committed != "  hi  " {
+		t.Errorf("OnTextCommit got %q, want the unnormalized %q",
+			committed, "  hi  ")
+	}
+}
+
+// An editable field must still normalize on both paths — the guard
+// must not have disabled the feature outright.
+func TestInputEditableEnterStillNormalizes(t *testing.T) {
+	w := newTestWindow()
+	w.SetFocus("rw_norm_enter")
+	changed := ""
+	layout := generateViewLayout(Input(InputCfg{
+		Text: "  hi  ", ID: "rw_norm_enter", Focusable: true,
+		PostCommitNormalize: func(_ string, _ InputCommitReason) string {
+			return "NORMALIZED"
+		},
+		OnTextChanged: func(_ *Layout, nt string, _ *Window) {
+			changed = nt
+		},
+	}), w)
+
+	e := &Event{Type: EventKeyDown, KeyCode: KeyEnter}
+	layout.Shape.events.OnKeyDown(&layout, e, w)
+
+	if changed != "NORMALIZED" {
+		t.Errorf("editable field: OnTextChanged got %q, want NORMALIZED",
+			changed)
+	}
+}


### PR DESCRIPTION
> Stacked on #83 — review that first. Base retargets to `main` automatically when #83 merges.

## The gap

An `Input` could be **editable** or **unreachable**, with nothing in between. `AccessStateReadOnly` was only ever produced as a side effect of `Focusable: false` (`gui/view_input.go`), which also dropped the field from the tab order:

| Intent | Before |
|---|---|
| Editable | `Focusable: true` |
| Read-only — reachable, selectable, copyable, announced read-only, not editable | **inexpressible** |
| Disabled | `Disabled: true` |

`go-edit` hit this and built its own `EditorCfg.ReadOnly` (`edit/editor.go:35`) that gates edit actions while keeping `Focusable: true` unconditionally — the same design, already validated in a consumer. This brings it to the base widget.

## Two layers, because they cover different things

**`fireTextChanged` — the choke point.** Every mutation path ends at `OnTextChanged`, so dropping the notification there enforces "text never changes" *by construction*, including paths added later. Demonstrated: with both entry gates removed, 6 of 7 blocking tests still pass on this alone.

**The entry gates** (`makeInputOnChar`, `makeInputOnKeyDown` via `inputKeyMutatesText`) prevent side effects the choke point cannot see — clipboard writes on cut, undo-stack pushes, cursor jumps. `TestInputReadOnlyBlocksCut` is the test that fails without them.

Neither is redundant; both are demonstrated load-bearing by removing them independently.

## The subtle bug this fixes

`PostCommitNormalize` transforms text and notifies via `OnTextChanged` **without calling any text mutator**. So it was reachable from two paths that never touch the dispatchers:

- **single-line Enter** → `inputCommitEnter` (`view_input_keys.go:245`)
- **blur** → the commit block in `inputAmendLayout` (`view_input.go`), which runs from `AmendLayout`, not from an event handler

Both were confirmed firing `OnTextChanged("NORMALIZED")` on a field marked `ReadOnly: true`. `normalizeOnCommit` now skips the transform when read-only, so commits carry the original text. This mattered concretely: `NumericInput` already sets `PostCommitNormalize` (`view_input_numeric.go:196`), so #82 would have walked straight into it.

## Behavior

Blocked: typing, IME text, paste, cut, undo/redo, Backspace/Delete, multiline Enter, `PostCommitNormalize`.
Kept live: arrows/Home/End, Shift-selection, Ctrl+A, Ctrl+C, and single-line Enter (still fires `OnEnter`/`OnTextCommit` with unnormalized text — HTML readonly still submits).

Non-focusable Inputs still report read-only, so **existing behavior is unchanged** (`TestInputReadOnlyWithoutFocus` passes untouched).

## Known limitation

An IME composition started on a read-only field renders a preedit that can never commit — `render_text.go:51` gates preedit on `Focusable`, which read-only fields keep by design. Verified reachable. Fixing it needs `render_text` to distinguish read-only from unfocusable, and the shortcut (dropping `Focusable` on the inner `Text`) would kill selection and the cursor — the very things read-only should keep. Documented on the field; tracked separately.

## Verification

Every blocking test was checked by removing the guard and confirming it fails:
- Removing `normalizeOnCommit`'s guard → both commit-path tests fail.
- Removing both entry gates → `BlocksCut` fails; the rest hold via the choke point.
- `TestInputEditableEnterStillNormalizes` proves the guard didn't disable the feature for editable fields.

`gofmt`, `go vet`, `golangci-lint` (0 issues), full suite (0 failures).

## Blast radius

None external. Zero `gui.Input(` usages in go-edit and go-term; `Focusable: false` appears **zero** times across all five consumers, so nothing relies on the old read-only-by-unfocusable idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786761455&installation_id=145733661&pr_number=84&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F84&signature=53553c8ede19bffdef457da267f2094bf785d0544f1f2c1cb092f33f57af24c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->