### PR TITLE
fix: suppress IME preedit on read-only Input (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unreachable, with nothing in between. Non-focusable Inputs still
   report read-only, so existing behavior is unchanged.
 
-  Known limitation: an IME composition started on a read-only field
-  renders a preedit that can never commit. It clears on focus change.
-
 ### Fixed
+
+- **Read-only Input no longer renders IME preedit.** A composition
+  started on a read-only field displayed preedit text that could never
+  commit (`makeInputOnChar` swallows the commit), leaving a stray
+  artifact until focus change. Preedit rendering is now suppressed for
+  read-only fields; selection and cursor still render, since the field
+  stays `Focusable`. Editable fields are unaffected.
 
 - **`CommandButton` now auto-fills `ID`** from the command ID, prefixed
   with `cmdbtn:`. Focus traversal is keyed by `Shape.ID`, so a

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -48,7 +48,11 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 	}
 
 	// Insert IME preedit text at cursor position for display.
-	imeComposing := shape.Focusable && w.IsFocus(shape.ID) && w.IMEComposing()
+	// A read-only field stays Focusable (to keep selection and
+	// cursor) but can never commit a composition, so its preedit
+	// must not render — makeInputOnChar would swallow the commit.
+	imeComposing := shape.Focusable && !tc.TextReadOnly &&
+		w.IsFocus(shape.ID) && w.IMEComposing()
 	compText := ""
 	compRuneLen := 0
 	compInsertPos := 0

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -351,9 +351,13 @@ type ShapeTextConfig struct {
 	TextMode           TextMode
 	TextIsPassword     bool
 	TextIsPlaceholder  bool
-	wrapCacheValid     bool
-	textLayoutValid    bool
-	textLayoutMode     TextMode
+	// TextReadOnly suppresses IME preedit rendering for read-only
+	// fields, which stay Focusable (for selection/cursor) but can
+	// never commit a composition. See render_text.go.
+	TextReadOnly    bool
+	wrapCacheValid  bool
+	textLayoutValid bool
+	textLayoutMode  TextMode
 }
 
 // hasRtfLayout returns true if the shape has an RTF layout.

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -84,11 +84,6 @@ type InputCfg struct {
 	//
 	// Distinct from Disabled, which also removes the field from
 	// interaction entirely and announces AccessStateDisabled.
-	//
-	// Known limitation: an IME composition started on a read-only field
-	// still renders its preedit (render_text.go gates that on Focusable,
-	// which read-only fields keep). The composition can never commit and
-	// clears on focus change, so the effect is a transient artifact.
 	ReadOnly bool
 
 	// Scrollable opts a multiline input into the scroll system.
@@ -185,6 +180,7 @@ func Input(cfg InputCfg) View {
 			Mode:              mode,
 			IsPassword:        cfg.IsPassword,
 			PlaceholderActive: placeholderActive,
+			readOnly:          cfg.ReadOnly,
 		}),
 	}
 

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -1215,5 +1216,74 @@ func TestInputEditableEnterStillNormalizes(t *testing.T) {
 	if changed != "NORMALIZED" {
 		t.Errorf("editable field: OnTextChanged got %q, want NORMALIZED",
 			changed)
+	}
+}
+
+// renderInnerInputText renders the inner Text shape of an Input and
+// returns the concatenation of every emitted command's Text field.
+// The rendered string includes the IME preedit when the field is
+// composing, so it is the observable signal for #85.
+func renderInnerInputText(t *testing.T, w *Window, v View) string {
+	t.Helper()
+	layout := generateViewLayout(v, w)
+	// Input tree is Column -> Row/Column -> Text.
+	if len(layout.Children) == 0 || len(layout.Children[0].Children) == 0 {
+		t.Fatal("input layout missing inner text child")
+	}
+	txt := layout.Children[0].Children[0].Shape
+	if txt.TC == nil {
+		t.Fatal("inner text shape has no TC")
+	}
+	// Give the shape a real box so it overlaps the clip rect
+	// (rectsOverlap is strict-<, so a zero-size shape never draws).
+	txt.X, txt.Y, txt.Width, txt.Height = 0, 0, 100, 20
+	w.renderers = w.renderers[:0]
+	renderText(txt, drawClip{Width: 800, Height: 600}, w)
+	var sb strings.Builder
+	for i := range w.renderers {
+		sb.WriteString(w.renderers[i].Text)
+	}
+	return sb.String()
+}
+
+// TestInputReadOnlyDoesNotRenderIMEPreedit covers #85: a composition
+// started on a read-only field must not render its preedit, because
+// makeInputOnChar swallows the commit and the preedit would sit there
+// until focus change. The editable control case proves the probe
+// actually observes preedit rendering (guards against a vacuous pass:
+// remove the !tc.TextReadOnly gate in render_text.go and the read-only
+// assertion below fails).
+func TestInputReadOnlyDoesNotRenderIMEPreedit(t *testing.T) {
+	const id = "f-ro-ime"
+	const preedit = "ㅎ" // Hangul jamo, mid-composition
+
+	// Control: an editable field with the same IME state DOES insert
+	// the preedit into the rendered text.
+	we := newTestWindow()
+	we.SetFocus(id)
+	we.ime.composing = true
+	we.ime.compText = preedit
+	editable := renderInnerInputText(t, we, Input(InputCfg{
+		ID: id, Focusable: true, Text: "abc",
+	}))
+	if !strings.Contains(editable, preedit) {
+		t.Fatalf("editable field: preedit not rendered; got %q", editable)
+	}
+
+	// Read-only field with identical IME state must not render preedit.
+	wr := newTestWindow()
+	wr.SetFocus(id)
+	wr.ime.composing = true
+	wr.ime.compText = preedit
+	readonly := renderInnerInputText(t, wr, Input(InputCfg{
+		ID: id, Focusable: true, ReadOnly: true, Text: "abc",
+	}))
+	if strings.Contains(readonly, preedit) {
+		t.Fatalf("read-only field rendered IME preedit; got %q", readonly)
+	}
+	// Sanity: the underlying text is still rendered — only the preedit
+	// is suppressed, not the field content.
+	if !strings.Contains(readonly, "abc") {
+		t.Fatalf("read-only field dropped its text; got %q", readonly)
 	}
 }

--- a/gui/view_text.go
+++ b/gui/view_text.go
@@ -36,6 +36,11 @@ type TextCfg struct {
 	// Hero marks this text element for hero transition
 	// animations between views.
 	Hero bool
+
+	// readOnly is set by input widgets (view_input.go) to suppress
+	// IME preedit on a read-only field that stays Focusable.
+	// Unexported: not a meaningful knob for standalone Text callers.
+	readOnly bool
 }
 
 // textView implements View for text rendering.
@@ -65,6 +70,7 @@ func (tv *textView) GenerateLayout(w *Window) Layout {
 		TextIsPlaceholder: c.PlaceholderActive,
 		TextMode:          c.Mode,
 		TextTabSize:       c.TabSize,
+		TextReadOnly:      c.readOnly,
 	}
 
 	layout := Layout{


### PR DESCRIPTION
## Summary

Closes #85. A composition started on a read-only `Input` rendered preedit text that could never commit — `makeInputOnChar` swallows the commit — leaving a stray artifact until focus change. `render_text` gated preedit rendering only on `Focusable`, which read-only fields keep (that is the point of `ReadOnly`).

## Approach (issue Option 1, the contained fix)

- Add exported `TextReadOnly bool` to `ShapeTextConfig` (`Shape.TC`) — per CLAUDE.md, text fields live on `TC`, not `Shape`.
- Plumb `InputCfg.ReadOnly` to the inner `Text` via an **unexported** `TextCfg.readOnly` field, so the public `TextCfg` API is not widened.
- Gate `imeComposing` on `!tc.TextReadOnly` in `render_text.go`.

Selection and cursor still render on a read-only field: both gate on `!imeComposing`, so suppressing the preedit lets those paths run exactly as they do for any focused, non-composing field. Editable fields are unaffected.

## Testing

- New `TestInputReadOnlyDoesNotRenderIMEPreedit` with an **editable control case** (proves the probe observes preedit rendering). Verified non-vacuous: removing the `!tc.TextReadOnly` gate makes the read-only assertion fail with `"ㅎabc"`.
- Full test suite, `golangci-lint` (0 issues), and `make check` all green.

## Acceptance (#85)

- [x] No preedit renders on a read-only field
- [x] Selection highlight and cursor still render on a read-only field
- [x] Editable fields unaffected — preedit still renders normally
- [x] Removed the "Known limitation" note from `InputCfg.ReadOnly` and CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786792239&installation_id=145733661&pr_number=87&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F87&signature=1f96c6c44b2e3f268218a7a6cfc2bfe24cce77c959c087f662da36b6c4f209fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->