### PR TITLE
feat: extend ReadOnly to NumericInput and InputDate wrappers (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unreachable, with nothing in between. Non-focusable Inputs still
   report read-only, so existing behavior is unchanged.
 
+- **`NumericInputCfg.ReadOnly` and `InputDateCfg.ReadOnly`** — extend
+  `InputCfg.ReadOnly` to the two composite wrappers. Both forward the
+  flag to their inner `Input` (blocking typing) and gate the secondary
+  mutation paths that bypass the text field: `NumericInput` disables and
+  gates its step buttons at the `numericInputApplyStep` choke point, and
+  `InputDate` keeps the calendar popup closed so its picker can never
+  emit a selection. Enter-commit on the read-only inner `Input` no longer
+  surfaces a value/date change. Both wrappers announce
+  `AccessStateReadOnly`. `NumericInputCfg` and `InputDateCfg` already had
+  `Disabled`; `ReadOnly` is the focusable-but-uneditable counterpart.
+
 ### Fixed
 
 - **Read-only Input no longer renders IME preedit.** A composition

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -115,6 +115,17 @@ type InputCfg struct {
 	Invisible bool
 }
 
+// a11yReadOnlyState maps a ReadOnly flag to the announced accessibility
+// state. Used by the NumericInput/InputDate wrappers, which are always
+// focusable in practice and so need only the ReadOnly signal (unlike
+// Input, which also reports read-only for non-focusable fields).
+func a11yReadOnlyState(readOnly bool) AccessState {
+	if readOnly {
+		return AccessStateReadOnly
+	}
+	return AccessStateNone
+}
+
 // Input creates a text input field view.
 func Input(cfg InputCfg) View {
 	applyInputDefaults(&cfg)

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -46,6 +46,13 @@ type InputDateCfg struct {
 	HideTodayIndicator   bool
 	MondayFirstDayOfWeek bool
 	ShowAdjacentMonths   bool
+
+	// ReadOnly blocks date edits while the field stays focusable and
+	// selectable, mirroring InputCfg.ReadOnly. Typing is blocked on the
+	// inner Input and the calendar popup is gated shut so it cannot
+	// change the date. Distinct from Disabled, which removes interaction
+	// entirely.
+	ReadOnly bool
 }
 
 type inputDateView struct {
@@ -63,7 +70,10 @@ func InputDate(cfg InputDateCfg) View {
 func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 	cfg := &idv.cfg
 
-	isOpen := StateReadOr(w, nsInputDate, cfg.ID, false)
+	// A read-only date field never opens the calendar popup, closing
+	// the picker's OnSelect mutation path structurally regardless of any
+	// stored open state.
+	isOpen := StateReadOr(w, nsInputDate, cfg.ID, false) && !cfg.ReadOnly
 	cfgID := cfg.ID
 
 	// Format date for display.
@@ -105,7 +115,7 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 			Content: []View{
 				inputDateTextField(cfg, cfgID, isOpen, editText),
 				Button(ButtonCfg{
-					Disabled:   cfg.Disabled,
+					Disabled:   cfg.Disabled || cfg.ReadOnly,
 					Padding:    NoPadding,
 					SizeBorder: NoBorder,
 					Content: []View{Text(TextCfg{
@@ -182,6 +192,7 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 	col := Column(ContainerCfg{
 		ID:          cfg.ID,
 		A11YRole:    AccessRoleDateField,
+		A11YState:   a11yReadOnlyState(cfg.ReadOnly),
 		A11YLabel:   a11yLabel(cfg.A11YLabel, "Date Input"),
 		Color:       cfg.Color,
 		ColorBorder: cfg.ColorBorder,
@@ -221,6 +232,7 @@ func inputDateTextField(
 	return Input(InputCfg{
 		ID:               cfgID + ".input",
 		Focusable:        cfg.Focusable,
+		ReadOnly:         cfg.ReadOnly,
 		Text:             dateText,
 		Placeholder:      inputDatePlaceholder(cfg),
 		Mask:             localeDateMaskPattern(ActiveLocale.Date.ShortDate),
@@ -236,6 +248,11 @@ func inputDateTextField(
 			sm.Set(cfgID, s)
 		},
 		OnTextCommit: func(_ *Layout, text string, _ InputCommitReason, w *Window) {
+			// A read-only inner Input still fires OnTextCommit on Enter
+			// (text unchanged); do not surface it as a date selection.
+			if cfg.ReadOnly {
+				return
+			}
 			if text == "" {
 				if cfg.OnSelect != nil {
 					cfg.OnSelect(nil, &Event{}, w)

--- a/gui/view_input_date_test.go
+++ b/gui/view_input_date_test.go
@@ -189,3 +189,63 @@ func layoutContainsText(l *Layout, text string) bool {
 	}
 	return false
 }
+
+// TestInputDateReadOnlyForwardsToInput checks that a read-only
+// InputDate forwards ReadOnly to its inner Input (announced as
+// AccessStateReadOnly) and that the outer date field announces it too.
+func TestInputDateReadOnlyForwardsToInput(t *testing.T) {
+	w := &Window{}
+	v := InputDate(InputDateCfg{
+		ID:        "id-ro-fwd",
+		Focusable: true,
+		ReadOnly:  true,
+		Date:      time.Date(2025, 3, 15, 0, 0, 0, 0, time.Local),
+	})
+	layout := generateViewLayout(v, w)
+	if layout.Shape.A11YState != AccessStateReadOnly {
+		t.Errorf("outer A11YState=%d, want ReadOnly", layout.Shape.A11YState)
+	}
+	inp := findShapeByID(&layout, "id-ro-fwd.input")
+	if inp == nil {
+		t.Fatal("inner input not found")
+	}
+	if inp.Shape.A11YState != AccessStateReadOnly {
+		t.Errorf("inner input A11YState=%d, want ReadOnly", inp.Shape.A11YState)
+	}
+}
+
+// TestInputDateReadOnlyDoesNotOpenPicker covers #82: a read-only date
+// field must not open the calendar popup, which fires OnSelect
+// independently of the text field. The stored open-state is forced true
+// so only the ReadOnly gate can keep the picker closed. The editable
+// control proves the probe observes the open picker (remove the
+// !cfg.ReadOnly clause on isOpen and the read-only assertion fails).
+func TestInputDateReadOnlyDoesNotOpenPicker(t *testing.T) {
+	openChildren := func(readOnly bool) int {
+		w := &Window{}
+		inputDateOpen("id-open", w) // force stored open-state true
+		v := InputDate(InputDateCfg{
+			ID:        "id-open",
+			Focusable: true,
+			ReadOnly:  readOnly,
+		})
+		layout := generateViewLayout(v, w)
+		// Closed: 1 child (the text+icon row). Open: 3 (row, backdrop,
+		// floating picker). The picker's presence is the OnSelect path.
+		hasPicker := findShapeByID(&layout, "id-open.picker") != nil
+		if readOnly && hasPicker {
+			t.Error("read-only date field opened the calendar picker")
+		}
+		if !readOnly && !hasPicker {
+			t.Error("editable open date field did not render the picker")
+		}
+		return len(layout.Children)
+	}
+
+	if got := openChildren(false); got != 3 {
+		t.Errorf("editable open field: got %d children, want 3", got)
+	}
+	if got := openChildren(true); got != 1 {
+		t.Errorf("read-only field: got %d children, want 1 (picker gated)", got)
+	}
+}

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -48,6 +48,13 @@ type NumericInputCfg struct {
 	Sizing Sizing
 	Mode   NumericInputMode
 
+	// ReadOnly blocks value edits while the field stays focusable and
+	// selectable, mirroring InputCfg.ReadOnly. Typing is blocked on the
+	// inner Input and the step buttons are gated so they cannot mutate
+	// the value. Distinct from Disabled, which removes interaction
+	// entirely.
+	ReadOnly bool
+
 	Disabled  bool
 	Invisible bool
 }
@@ -89,6 +96,7 @@ func NumericInput(cfg NumericInputCfg) View {
 		ID:          cfg.ID,
 		Focusable:   cfg.Focusable,
 		A11YRole:    AccessRoleTextField,
+		A11YState:   a11yReadOnlyState(cfg.ReadOnly),
 		A11YLabel:   a11yLabel(cfg.A11YLabel, cfg.Placeholder),
 		Width:       cfg.Width,
 		Height:      cfg.Height,
@@ -168,6 +176,7 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 	return Input(InputCfg{
 		ID:               inputID,
 		Focusable:        cfg.Focusable,
+		ReadOnly:         cfg.ReadOnly,
 		Text:             cfg.Text,
 		Placeholder:      cfg.Placeholder,
 		Sizing:           sizing,
@@ -200,6 +209,11 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 			return committed
 		},
 		OnTextCommit: func(layout *Layout, text string, _ InputCommitReason, w *Window) {
+			// A read-only inner Input still fires OnTextCommit on Enter
+			// (with text unchanged); do not surface it as a value commit.
+			if cfg.ReadOnly {
+				return
+			}
 			value, committed := numericInputCommitResultMode(
 				text, cfg.Value, cfg.Min, cfg.Max,
 				cfg.Decimals, locale, modeCfg)
@@ -228,15 +242,21 @@ func numericInputStepButtons(cfg NumericInputCfg, locale NumericLocaleCfg, stepC
 		stepDownID = cfg.ID + "_step_down"
 	}
 
+	// Read-only fields disable the steppers so they cannot mutate the
+	// value (numericInputApplyStep is the load-bearing gate; this is the
+	// affordance).
+	stepDisabled := cfg.Disabled || cfg.ReadOnly
+
 	return Column(ContainerCfg{
 		Spacing:   SomeF(0),
 		Sizing:    FitFill,
-		Disabled:  cfg.Disabled,
+		Disabled:  stepDisabled,
 		Invisible: cfg.Invisible,
 		Padding:   SomeP(0, PadSmall, 0, 0),
 		Content: []View{
 			Button(ButtonCfg{
 				ID:          stepUpID,
+				Disabled:    stepDisabled,
 				Sizing:      FillFill,
 				Padding:     NoPadding,
 				Color:       baseColor,
@@ -260,6 +280,7 @@ func numericInputStepButtons(cfg NumericInputCfg, locale NumericLocaleCfg, stepC
 			}),
 			Button(ButtonCfg{
 				ID:          stepDownID,
+				Disabled:    stepDisabled,
 				Sizing:      FillFill,
 				Padding:     NoPadding,
 				Color:       baseColor,
@@ -294,6 +315,12 @@ func numericInputApplyStep(
 	e *Event,
 	w *Window,
 ) {
+	// Choke point for every step mutation. Read-only fields must not
+	// change value, so gate here by construction — even if a disabled
+	// step button's OnClick were somehow reached.
+	if cfg.ReadOnly {
+		return
+	}
 	modeCfg := numericModeCfgFromInput(cfg)
 	value, committed := numericInputStepResultMode(
 		cfg.Text, cfg.Value, cfg.Min, cfg.Max,

--- a/gui/view_input_numeric_test.go
+++ b/gui/view_input_numeric_test.go
@@ -54,3 +54,67 @@ func TestNumericInputPlaceholder(t *testing.T) {
 		t.Fatal("expected shape")
 	}
 }
+
+// TestNumericInputReadOnlyForwardsToInput checks that a read-only
+// NumericInput (no steppers) forwards ReadOnly to its inner Input,
+// which announces AccessStateReadOnly.
+func TestNumericInputReadOnlyForwardsToInput(t *testing.T) {
+	w := &Window{}
+	v := NumericInput(NumericInputCfg{
+		ID:        "ni-ro-plain",
+		Focusable: true,
+		ReadOnly:  true,
+		Text:      "5",
+	})
+	layout := generateViewLayout(v, w)
+	if layout.Shape.A11YState != AccessStateReadOnly {
+		t.Errorf("A11YState=%d, want ReadOnly (%d)",
+			layout.Shape.A11YState, AccessStateReadOnly)
+	}
+}
+
+// TestNumericInputReadOnlyStepButtonsGated covers #82: a read-only
+// numeric input must not increment via its step buttons. The buttons
+// are visually disabled, and numericInputApplyStep (the choke point)
+// blocks the mutation even when the handler is invoked directly. The
+// editable control below proves the probe observes stepping (remove the
+// ReadOnly gate in numericInputApplyStep and the read-only assertion
+// fails).
+func TestNumericInputReadOnlyStepButtonsGated(t *testing.T) {
+	step := func(readOnly bool) bool {
+		committed := false
+		w := &Window{}
+		v := NumericInput(NumericInputCfg{
+			ID:        "ni-step",
+			Focusable: true,
+			ReadOnly:  readOnly,
+			Text:      "5",
+			StepCfg:   NumericStepCfg{ShowButtons: true, Step: 1},
+			OnValueCommit: func(_ *Layout, _ Opt[float64], _ string, _ *Window) {
+				committed = true
+			},
+		})
+		layout := generateViewLayout(v, w)
+		up := findShapeByID(&layout, "ni-step_step_up")
+		if up == nil {
+			t.Fatal("step-up button not found")
+		}
+		if readOnly && !up.Shape.Disabled {
+			t.Error("read-only step-up button should be Disabled")
+		}
+		if up.Shape.events == nil || up.Shape.events.OnClick == nil {
+			t.Fatal("step-up button missing OnClick")
+		}
+		// Invoke directly, bypassing the dispatch-level Disabled gate,
+		// to exercise the choke point.
+		up.Shape.events.OnClick(up, &Event{}, w)
+		return committed
+	}
+
+	if !step(false) {
+		t.Error("editable numeric input did not step the value")
+	}
+	if step(true) {
+		t.Error("read-only numeric input stepped the value")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #82. Extends `InputCfg.ReadOnly` (#86) to the two composite wrappers. This is deliberately **not** a mechanical pass-through: each wrapper has a secondary mutation path that bypasses the inner text field, and forwarding `ReadOnly` without closing that path would yield a field that refuses typing while another control keeps changing the value.

## NumericInput

- Forward `ReadOnly` to the inner `Input` (blocks typing/paste/undo/normalize).
- **Steppers gated at the choke point.** `numericInputApplyStep` — where every step mutation converges — returns early when `ReadOnly`, so the value can't change by construction. The step buttons are also disabled for affordance.
- Enter-commit on the read-only inner `Input` no longer surfaces `OnValueCommit`.

## InputDate

- Forward `ReadOnly` to the inner `Input`.
- **Calendar popup closed structurally**: `isOpen := stored && !ReadOnly`, so the picker never renders and its `OnSelect` path cannot fire. The calendar toggle button is disabled too.
- Enter-commit no longer surfaces `OnSelect`.

Both wrappers announce `AccessStateReadOnly` via a shared `a11yReadOnlyState` helper.

## Notes

- The issue's claim that `NumericInputCfg` lacks a `Disabled` field is stale — both `NumericInputCfg` and `InputDateCfg` already have `Disabled` (wired). `ReadOnly` is the focusable-but-uneditable counterpart; no new `Disabled` field was needed.
- Out-of-scope internal `Input`s (color-picker hex, command-palette search, datagrid cell editor) are untouched, per the issue.

## Testing

- Read-only forwarding (inner Input announces `AccessStateReadOnly`).
- Stepper gate + editable control; popup gate + editable-open control.
- Both structural gates proven **non-vacuous** by removal: dropping the `numericInputApplyStep` gate makes "read-only numeric input stepped the value" fail; dropping the `!cfg.ReadOnly` isOpen clause makes "read-only date field opened the calendar picker" fail.
- Full suite, `golangci-lint` (0 issues), and `make check` all green. Rebased on `main` after #87 merged.

## Acceptance (#82)

- [x] `ReadOnly` on both Cfgs, forwarded to the inner `Input`
- [x] Every secondary mutation path gated (steppers, calendar popup, Enter-commit)
- [x] Tests that fail without the gate (verified by removal)
- [x] Navigation, selection, and copy still work in read-only mode (inherited from `InputCfg.ReadOnly`)
- [x] `Disabled` decision: both Cfgs already have it — no new field
- [x] CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786793353&installation_id=145733661&pr_number=88&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F88&signature=ad980dbeee4ca8483b3b6a6f9718e92e35f2ac14ddcaf2bf19b310c5bc348442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->