### PR TITLE
feat: input controls focusable by default (FocusDisabled opt-out)

### DIFF
--- a/.claude/skills/widget/SKILL.md
+++ b/.claude/skills/widget/SKILL.md
@@ -15,7 +15,7 @@ Create a new widget in the `gui/` package following established conventions.
 
 Every widget consists of:
 1. A `*Cfg` struct (zero-initializable, exported fields)
-2. A factory function returning `*Layout`
+2. A factory function returning `View`
 3. Event callbacks using `func(*Layout, *Event, *Window)` signature
 
 ## Template
@@ -25,8 +25,16 @@ package gui
 
 // <Name>Cfg configures the <Name> widget.
 type <Name>Cfg struct {
-    // IDFocus opts into tab-order focus when > 0.
-    IDFocus uint32
+    // ID keys focus, scroll, and widget state. Focus requires a
+    // non-empty ID — without one the widget is inert (never a tab
+    // stop).
+    ID string
+
+    // Focusable opts into the focus system (with a non-empty ID).
+    // NOTE: input controls (Input, Select, Slider, Toggle, Switch)
+    // are focusable by default and expose FocusDisabled instead —
+    // pick the convention that matches the widget class.
+    Focusable bool
 
     // Widget-specific fields...
 
@@ -35,10 +43,10 @@ type <Name>Cfg struct {
 }
 
 // <Name> creates a <Name> widget.
-func <Name>(cfg <Name>Cfg) *Layout {
+func <Name>(cfg <Name>Cfg) View {
     // Build layout tree
     // Wire event handlers (set e.IsHandled = true when consumed)
-    // Return root *Layout
+    // Return root View
 }
 ```
 
@@ -46,7 +54,9 @@ func <Name>(cfg <Name>Cfg) *Layout {
 - File name: `view_<lowercase_name>.go` in `gui/`
 - Cfg struct must be zero-initializable (sensible defaults)
 - Event callbacks: `func(*Layout, *Event, *Window)`, set `e.IsHandled = true`
-- `IDFocus uint32` field for tab-order focus support
+- Focus needs both `Focusable` (or default-on with no `FocusDisabled`)
+  **and** a non-empty `ID`; the `requiredid` analyzer flags
+  `Focusable: true` without an `ID`
 - No variable shadowing (use `=` not `:=` for outer-scope vars)
 - Read existing widgets (e.g., `view_button.go`, `view_slider.go`) for patterns
 - Must pass `golangci-lint run ./gui/...`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This state was previously inexpressible: `AccessStateReadOnly` could
   only be produced by setting `Focusable: false`, which also dropped the
   field from the tab order — so an Input was either editable or
-  unreachable, with nothing in between. Non-focusable Inputs still
-  report read-only, so existing behavior is unchanged.
+  unreachable, with nothing in between. (With the focusable-by-default
+  flip below, `ReadOnly` is now the only trigger for the read-only
+  announcement.)
 
 - **`NumericInputCfg.ReadOnly` and `InputDateCfg.ReadOnly`** — extend
   `InputCfg.ReadOnly` to the two composite wrappers. Both forward the
@@ -58,6 +59,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   IDs left over from the removed `IDFocus uint32` API.
 
 ### Changed
+
+- **BREAKING: input controls are focusable by default.** `InputCfg`,
+  `SelectCfg`, `SliderCfg`, `ToggleCfg`, and `SwitchCfg` drop
+  `Focusable bool` and gain `FocusDisabled bool`: the zero value is now
+  _focusable_, and `FocusDisabled: true` is the explicit opt-out. An
+  input the user can't tab to is a bug, not a design choice — and for
+  `Select`/`Slider`/`Toggle`/`Switch` this is an accessibility fix, not
+  just deboilerplating: ID-bearing call sites that never set `Focusable`
+  now join the Tab order (a slider should be keyboard-adjustable).
+
+  Focus still requires a non-empty `ID` (`Focusable && ID != ""`). An
+  ID-less control is **inert**: it renders but never becomes a tab stop,
+  and no ID is ever fabricated. `Disabled` still excludes a control from
+  the tab order; `ReadOnly` still keeps it focusable.
+
+  Migration (compile error on the removed field is the guide):
+  - `Focusable: true` → delete the line (now the default).
+  - `Focusable: <expr>` → `FocusDisabled: !<expr>`.
+  - `Focusable: false` → `FocusDisabled: true`.
+
+  Out-of-scope widgets keep opt-in `Focusable bool`: Button, Container,
+  Text, and the composites/wrappers (`Combobox`, `DatePicker`,
+  `ListBox`, `RadioButtonGroup`, `NumericInput`, `InputDate`, `Radio`,
+  ColorPicker, ThemePicker, Tree) — the wrappers translate their
+  `Focusable` into the inner Input's `FocusDisabled`.
+
+  The four focus flags, disambiguated:
+
+  | Flag                  | Meaning                                                 |
+  | --------------------- | ------------------------------------------------------- |
+  | `Shape.Focusable`     | widget participates in the focus system                 |
+  | `FocusSkip`           | focusable + click/selection, but excluded from Tab order |
+  | `FocusDisabled` (Cfg) | opt out of the default-on focus (in-scope Cfgs)         |
+  | `Disabled`            | non-interactive; also excluded from Tab order           |
+
+- **A non-focusable Input no longer announces `AccessStateReadOnly`.**
+  Before the flip, `Focusable: false` was the only way to express an
+  uneditable field, so it doubled as the read-only signal. Now that
+  non-focusable means an explicit `FocusDisabled` opt-out, only
+  `ReadOnly: true` announces read-only.
 
 - **`requiredid` analyzer** now also flags Cfg literals that set
   `Focusable: true` without a non-empty `ID`, catching this class of

--- a/README.md
+++ b/README.md
@@ -251,6 +251,21 @@ gui.Input(gui.InputCfg{
 })
 ```
 
+### Focus
+
+Input controls (`Input`, `Select`, `Slider`, `Toggle`, `Switch`) are
+**focusable by default**; opt out with `FocusDisabled: true`. Other
+widgets (e.g. `Button`) opt in with `Focusable: true`. Focus always
+requires a non-empty `ID` — a focusable control without an `ID` is
+inert: it renders but never joins the Tab order.
+
+| Flag                  | Meaning                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `Focusable`           | opt in to the focus system (opt-in widgets)              |
+| `FocusDisabled`       | opt out of the default-on focus (input controls)         |
+| `FocusSkip`           | focusable + click/selection, but excluded from Tab order |
+| `Disabled`            | non-interactive; also excluded from Tab order            |
+
 ### Stdlib Data Binding
 
 Data widgets accept Go stdlib types via convenience fields. This is the

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -171,10 +171,9 @@ func benchView(w *gui.Window) gui.View {
 						TextStyle: theme.B3,
 					}),
 					gui.Select(gui.SelectCfg{
-						ID:        "bench-count",
-						Selected:  []string{selectedCount},
-						Options:   countOptions,
-						Focusable: true,
+						ID:       "bench-count",
+						Selected: []string{selectedCount},
+						Options:  countOptions,
 						OnSelect: func(sel []string, _ *gui.Event, w *gui.Window) {
 							if len(sel) > 0 {
 								if n, err := strconv.Atoi(sel[0]); err == nil {
@@ -190,10 +189,9 @@ func benchView(w *gui.Window) gui.View {
 						TextStyle: theme.B3,
 					}),
 					gui.Select(gui.SelectCfg{
-						ID:        "bench-type",
-						Selected:  []string{app.WidgetType},
-						Options:   typeOptions,
-						Focusable: true,
+						ID:       "bench-type",
+						Selected: []string{app.WidgetType},
+						Options:  typeOptions,
 						OnSelect: func(sel []string, _ *gui.Event, w *gui.Window) {
 							if len(sel) > 0 {
 								app := gui.State[App](w)

--- a/examples/data_grid_data_source/main.go
+++ b/examples/data_grid_data_source/main.go
@@ -82,10 +82,9 @@ func mainView(w *gui.Window) gui.View {
 				Spacing: gui.Some(theme.SpacingSmall),
 				Content: []gui.View{
 					gui.Switch(gui.SwitchCfg{
-						ID:        "dgds_use_offset",
-						Focusable: true,
-						Label:     "Use offset pagination",
-						Selected:  app.UseOffset,
+						ID:       "dgds_use_offset",
+						Label:    "Use offset pagination",
+						Selected: app.UseOffset,
 						OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
 							state := gui.State[App](w)
 							state.UseOffset = !state.UseOffset
@@ -94,10 +93,9 @@ func mainView(w *gui.Window) gui.View {
 						},
 					}),
 					gui.Switch(gui.SwitchCfg{
-						ID:        "dgds_slow_mode",
-						Focusable: true,
-						Label:     "Simulate latency",
-						Selected:  app.SimulateLatency,
+						ID:       "dgds_slow_mode",
+						Label:    "Simulate latency",
+						Selected: app.SimulateLatency,
 						OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
 							state := gui.State[App](w)
 							state.SimulateLatency = !state.SimulateLatency

--- a/examples/key_up_demo/main.go
+++ b/examples/key_up_demo/main.go
@@ -52,9 +52,8 @@ func mainView(w *gui.Window) gui.View {
 				Text: fmt.Sprintf("Key Up: %d (Last: %v)", app.keyUpCount, app.lastKeyUp),
 			}),
 			gui.Input(gui.InputCfg{
-				ID:        "kud_input",
-				Focusable: true,
-				Text:      "Type here to test key up events...",
+				ID:   "kud_input",
+				Text: "Type here to test key up events...",
 				OnKeyDown: func(layout *gui.Layout, e *gui.Event, w *gui.Window) {
 					app := gui.State[App](w)
 					app.keyDownCount++

--- a/examples/menu_demo/main.go
+++ b/examples/menu_demo/main.go
@@ -150,7 +150,6 @@ func menu(w *gui.Window) gui.View {
 						CustomView: gui.Input(gui.InputCfg{
 							Text:        app.SearchText,
 							ID:          "menu_search_input",
-							Focusable:   true,
 							Width:       100,
 							MinWidth:    100,
 							MaxWidth:    100,

--- a/examples/multiline_input/main.go
+++ b/examples/multiline_input/main.go
@@ -105,7 +105,6 @@ func mainView(w *gui.Window) gui.View {
 		Content: []gui.View{
 			gui.Input(gui.InputCfg{
 				ID:         inputFocusID,
-				Focusable:  true,
 				Scrollable: true,
 				Mode:       gui.InputMultiline,
 				Sizing:     gui.FillFill,

--- a/examples/particles/main.go
+++ b/examples/particles/main.go
@@ -337,7 +337,6 @@ func sidebarView(w *gui.Window, wh float32) gui.View {
 						ID:          "emitter-type",
 						Selected:    []string{emitterName(app.EmitterType)},
 						Options:     []string{"Point", "Ring", "Line"},
-						Focusable:   true,
 						FloatZIndex: 10,
 						OnSelect: func(sel []string, _ *gui.Event, w *gui.Window) {
 							a := gui.State[App](w)

--- a/examples/scroll_demo/main.go
+++ b/examples/scroll_demo/main.go
@@ -148,7 +148,6 @@ func themeButton(app *App) gui.View {
 	textUnsel := gui.IconSunnyO
 	return gui.Toggle(gui.ToggleCfg{
 		ID:           "scroll_theme_toggle",
-		Focusable:    true,
 		TextSelect:   textSel,
 		TextUnselect: textUnsel,
 		TextStyle:    gui.CurrentTheme().Icon3,

--- a/examples/showcase/catalog.go
+++ b/examples/showcase/catalog.go
@@ -76,7 +76,6 @@ func catalogPanel(w *gui.Window) gui.View {
 func searchInput(app *ShowcaseApp) gui.View {
 	return gui.Input(gui.InputCfg{
 		ID:          "showcase-nav-search",
-		Focusable:   true,
 		Sizing:      gui.FillFit,
 		Text:        app.NavQuery,
 		Placeholder: "Search controls...",

--- a/examples/showcase/demo_data.go
+++ b/examples/showcase/demo_data.go
@@ -121,10 +121,9 @@ func demoTable(w *gui.Window) gui.View {
 						Spacing:    gui.SomeF(6),
 						Content: []gui.View{
 							gui.Toggle(gui.ToggleCfg{
-								ID:        "showcase_table_multiselect",
-								Focusable: true,
-								Label:     "Multi-select",
-								Selected:  app.TableMultiSelect,
+								ID:       "showcase_table_multiselect",
+								Label:    "Multi-select",
+								Selected: app.TableMultiSelect,
 								OnClick: func(_ *gui.Layout, _ *gui.Event, w *gui.Window) {
 									a := gui.State[ShowcaseApp](w)
 									a.TableMultiSelect = !a.TableMultiSelect
@@ -132,10 +131,9 @@ func demoTable(w *gui.Window) gui.View {
 								},
 							}),
 							gui.Toggle(gui.ToggleCfg{
-								ID:        "showcase_table_freeze_header",
-								Focusable: true,
-								Label:     "Freeze header",
-								Selected:  app.TableFreezeHeader,
+								ID:       "showcase_table_freeze_header",
+								Label:    "Freeze header",
+								Selected: app.TableFreezeHeader,
 								OnClick: func(_ *gui.Layout, _ *gui.Event, w *gui.Window) {
 									gui.State[ShowcaseApp](w).TableFreezeHeader = !app.TableFreezeHeader
 								},

--- a/examples/showcase/demo_input.go
+++ b/examples/showcase/demo_input.go
@@ -32,7 +32,6 @@ func demoInput(w *gui.Window) gui.View {
 			}),
 			labeledRow(t, "Text", gui.Input(gui.InputCfg{
 				ID:          "input-text",
-				Focusable:   true,
 				Sizing:      gui.FillFit,
 				Text:        app.InputText,
 				Placeholder: "Enter text...",
@@ -43,7 +42,6 @@ func demoInput(w *gui.Window) gui.View {
 			})),
 			labeledRow(t, "Password", gui.Input(gui.InputCfg{
 				ID:          "input-password",
-				Focusable:   true,
 				Sizing:      gui.FillFit,
 				Text:        app.InputPassword,
 				Placeholder: "Enter password...",
@@ -54,7 +52,6 @@ func demoInput(w *gui.Window) gui.View {
 			})),
 			labeledRow(t, "Phone", gui.Input(gui.InputCfg{
 				ID:          "input-phone",
-				Focusable:   true,
 				Sizing:      gui.FillFit,
 				Text:        app.InputPhone,
 				Placeholder: "(555) 000-0000",
@@ -65,7 +62,6 @@ func demoInput(w *gui.Window) gui.View {
 			})),
 			labeledRow(t, "Expiry", gui.Input(gui.InputCfg{
 				ID:          "input-expiry",
-				Focusable:   true,
 				Sizing:      gui.FillFit,
 				Text:        app.InputExpiry,
 				Placeholder: "MM/YY",
@@ -76,7 +72,6 @@ func demoInput(w *gui.Window) gui.View {
 			})),
 			labeledRow(t, "Multiline", gui.Input(gui.InputCfg{
 				ID:          "input-multi",
-				Focusable:   true,
 				Sizing:      gui.FillFit,
 				Text:        app.InputMultiline,
 				Placeholder: "Multiple lines...",
@@ -383,7 +378,6 @@ func demoForms(w *gui.Window) gui.View {
 		Content: []gui.View{
 			showcaseFormRow("Username", gui.Input(gui.InputCfg{
 				ID:          "showcase-form-username",
-				Focusable:   true,
 				Width:       260,
 				Sizing:      gui.FixedFit,
 				Text:        form.Username,
@@ -402,7 +396,6 @@ func demoForms(w *gui.Window) gui.View {
 
 			showcaseFormRow("Email", gui.Input(gui.InputCfg{
 				ID:          "showcase-form-email",
-				Focusable:   true,
 				Width:       260,
 				Sizing:      gui.FixedFit,
 				Text:        form.Email,

--- a/examples/showcase/demo_navigation.go
+++ b/examples/showcase/demo_navigation.go
@@ -170,7 +170,6 @@ func demoMenus(w *gui.Window) gui.View {
 						CustomView: gui.Input(gui.InputCfg{
 							Text:        app.MenuSearchText,
 							ID:          "showcase_menu_search",
-							Focusable:   true,
 							Width:       100,
 							MinWidth:    100,
 							MaxWidth:    100,

--- a/examples/showcase/demo_selection.go
+++ b/examples/showcase/demo_selection.go
@@ -14,20 +14,18 @@ func demoToggle(w *gui.Window) gui.View {
 		Padding: gui.NoPadding,
 		Content: []gui.View{
 			gui.Toggle(gui.ToggleCfg{
-				ID:        "toggle-a",
-				Focusable: true,
-				Label:     "Toggle",
-				Selected:  app.ToggleA,
+				ID:       "toggle-a",
+				Label:    "Toggle",
+				Selected: app.ToggleA,
 				OnClick: func(_ *gui.Layout, _ *gui.Event, w *gui.Window) {
 					a := gui.State[ShowcaseApp](w)
 					a.ToggleA = !a.ToggleA
 				},
 			}),
 			gui.Toggle(gui.ToggleCfg{
-				ID:        "checkbox-a",
-				Focusable: true,
-				Label:     "Checkbox",
-				Selected:  app.CheckboxA,
+				ID:       "checkbox-a",
+				Label:    "Checkbox",
+				Selected: app.CheckboxA,
 				OnClick: func(_ *gui.Layout, _ *gui.Event, w *gui.Window) {
 					a := gui.State[ShowcaseApp](w)
 					a.CheckboxA = !a.CheckboxA
@@ -46,10 +44,9 @@ func demoSwitch(w *gui.Window) gui.View {
 		VAlign:  gui.VAlignMiddle,
 		Content: []gui.View{
 			gui.Switch(gui.SwitchCfg{
-				ID:        "switch-a",
-				Focusable: true,
-				Label:     "Enable feature",
-				Selected:  app.SwitchA,
+				ID:       "switch-a",
+				Label:    "Enable feature",
+				Selected: app.SwitchA,
 				OnClick: func(_ *gui.Layout, _ *gui.Event, w *gui.Window) {
 					a := gui.State[ShowcaseApp](w)
 					a.SwitchA = !a.SwitchA

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -137,7 +137,6 @@ func composerView(w *gui.Window) gui.View {
 		Content: []gui.View{
 			gui.Input(gui.InputCfg{
 				ID:               "todo-input",
-				Focusable:        true,
 				Sizing:           gui.FillFit,
 				Text:             app.Draft,
 				Placeholder:      "Add your task",

--- a/gui/datagrid/data_source_grid.go
+++ b/gui/datagrid/data_source_grid.go
@@ -722,7 +722,6 @@ func dataGridSourcePagerRow(cfg *DataGridCfg, focusID string, state dataGridSour
 		}))
 		content = append(content, gg.Input(gg.InputCfg{
 			ID:          jumpInputID,
-			Focusable:   true,
 			Text:        jumpText,
 			Placeholder: "#",
 			Disabled:    !jumpEnabled,

--- a/gui/datagrid/view_data_grid_edit.go
+++ b/gui/datagrid/view_data_grid_edit.go
@@ -32,7 +32,6 @@ func dataGridCellEditorView(cfg *DataGridCfg, rowID string, rowIdx int, col Grid
 		}
 		editor = gg.Select(gg.SelectCfg{
 			ID:         editorID,
-			Focusable:  true,
 			Selected:   selectVal,
 			Options:    options,
 			Sizing:     gg.FillFill,
@@ -82,10 +81,9 @@ func dataGridCellEditorView(cfg *DataGridCfg, rowID string, rowIdx int, col Grid
 		editorTrueValue := col.EditorTrueValue
 		editorFalseValue := col.EditorFalseValue
 		editor = gg.Toggle(gg.ToggleCfg{
-			ID:        editorID,
-			Focusable: true,
-			Selected:  checked,
-			Padding:   gg.NoPadding,
+			ID:       editorID,
+			Selected: checked,
+			Padding:  gg.NoPadding,
 			OnClick: func(_ *gg.Layout, e *gg.Event, w *gg.Window) {
 				nextValue := editorFalseValue
 				if !checked {

--- a/gui/datagrid/view_data_grid_edit.go
+++ b/gui/datagrid/view_data_grid_edit.go
@@ -105,7 +105,6 @@ func dataGridCellEditorView(cfg *DataGridCfg, rowID string, rowIdx int, col Grid
 	default: // GridCellEditorText
 		editor = gg.Input(gg.InputCfg{
 			ID:         editorID,
-			Focusable:  true,
 			Text:       value,
 			Sizing:     gg.FillFill,
 			Padding:    gg.NoPadding,

--- a/gui/datagrid/view_data_grid_events.go
+++ b/gui/datagrid/view_data_grid_events.go
@@ -43,7 +43,6 @@ func dataGridQuickFilterRow(cfg *DataGridCfg) gg.View {
 		Content: []gg.View{
 			gg.Input(gg.InputCfg{
 				ID:               inputID,
-				Focusable:        true,
 				Text:             value,
 				Placeholder:      cfg.QuickFilterPlaceholder,
 				Sizing:           gg.FillFill,

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -314,7 +314,6 @@ func dataGridFilterCell(cfg *DataGridCfg, col GridColumnCfg, width float32) gg.V
 		Content: []gg.View{
 			gg.Input(gg.InputCfg{
 				ID:          inputID,
-				Focusable:   true,
 				Text:        value,
 				Placeholder: placeholder,
 				Disabled:    !col.Filterable || onQueryChange == nil,

--- a/gui/datagrid/view_data_grid_pager.go
+++ b/gui/datagrid/view_data_grid_pager.go
@@ -171,7 +171,6 @@ func dataGridJumpContextFromPager(pctx dataGridPagerContext) dataGridJumpContext
 func dataGridPagerJumpInput(cfg *DataGridCfg, inputID string, focusID string, jumpText string, jumpEnabled bool, jumpCtx dataGridJumpContext, gridFocusID string) gg.View {
 	return gg.Input(gg.InputCfg{
 		ID:          inputID,
-		Focusable:   true,
 		Text:        jumpText,
 		Placeholder: "#",
 		Disabled:    !jumpEnabled,

--- a/gui/spell_check_test.go
+++ b/gui/spell_check_test.go
@@ -27,7 +27,7 @@ func newSpellCheckWindow(spellChk bool, text string) *Window {
 	w.viewGenerator = func(w *Window) View {
 		app := State[appState](w)
 		return Input(InputCfg{
-			Focusable: true, ID: "f1",
+			ID:         "f1",
 			Sizing:     FillFit,
 			Text:       app.text,
 			SpellCheck: spellChk,
@@ -54,7 +54,7 @@ func TestSpellCheckTriggerOnEnable(t *testing.T) {
 	// Enable spell check by switching the view generator.
 	w.viewGenerator = func(_ *Window) View {
 		return Input(InputCfg{
-			Focusable: true, ID: "f1",
+			ID:         "f1",
 			Sizing:     FillFit,
 			Text:       "helo",
 			SpellCheck: true,
@@ -148,7 +148,7 @@ func TestSpellCheckClearOnDisable(t *testing.T) {
 	// Disable spell check.
 	w.viewGenerator = func(_ *Window) View {
 		return Input(InputCfg{
-			Focusable: true, ID: "f1",
+			ID:         "f1",
 			Sizing:     FillFit,
 			Text:       "helo",
 			SpellCheck: false,

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -337,7 +337,6 @@ func cpPreviewRow(cfg *ColorPickerCfg) View {
 			}),
 			Input(InputCfg{
 				ID:        cfgID + ".hex",
-				Focusable: true,
 				Text:      c.ToHexString(),
 				TextStyle: cfg.Style.TextStyle,
 				Width:     100,
@@ -439,7 +438,6 @@ func cpInputColumn(
 			}),
 			Input(InputCfg{
 				ID:        inputID,
-				Focusable: true,
 				Text:      strconv.Itoa(val),
 				TextStyle: cfg.Style.TextStyle,
 				Width:     50,

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -210,7 +210,6 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 								Text:          query,
 								Placeholder:   cfg.Placeholder,
 								TextStyle:     cfg.TextStyle,
-								Focusable:     true,
 								Sizing:        FillFit,
 								OnTextChanged: makePaletteOnTextChanged(cfg.ID),
 								OnKeyDown:     makePaletteOnKeyDown(paletteID, onAction, onDismiss, filtered, filteredIDs),

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -203,10 +203,9 @@ func promptView(cfg DialogCfg) []View {
 	var views []View
 
 	views = append(views, Input(InputCfg{
-		ID:        cfg.FocusID,
-		Focusable: true,
-		Text:      cfg.Reply,
-		Sizing:    FillFit,
+		ID:     cfg.FocusID,
+		Text:   cfg.Reply,
+		Sizing: FillFit,
 		OnTextChanged: func(_ *Layout, text string, w *Window) {
 			w.dialogCfg.Reply = text
 		},

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -74,7 +74,11 @@ type InputCfg struct {
 	MinHeight  float32
 	MaxHeight  float32
 
-	Focusable bool
+	// FocusDisabled opts the field out of the focus system. Inputs
+	// are focusable by default; set this to exclude the field from
+	// Tab order and focus. Note focus also requires a non-empty ID —
+	// an ID-less input renders but is inert (never a tab stop).
+	FocusDisabled bool
 
 	// ReadOnly blocks text edits while the field stays focusable and
 	// selectable: navigation, selection, and copy keep working, and the
@@ -116,9 +120,7 @@ type InputCfg struct {
 }
 
 // a11yReadOnlyState maps a ReadOnly flag to the announced accessibility
-// state. Used by the NumericInput/InputDate wrappers, which are always
-// focusable in practice and so need only the ReadOnly signal (unlike
-// Input, which also reports read-only for non-focusable fields).
+// state. Used by the NumericInput/InputDate wrappers.
 func a11yReadOnlyState(readOnly bool) AccessState {
 	if readOnly {
 		return AccessStateReadOnly
@@ -183,7 +185,7 @@ func Input(cfg InputCfg) View {
 	txtContent := []View{
 		Text(TextCfg{
 			ID:                cfg.ID,
-			Focusable:         cfg.Focusable,
+			Focusable:         !cfg.FocusDisabled,
 			FocusSkip:         true,
 			Sizing:            txtSizing,
 			Text:              txt,
@@ -199,14 +201,12 @@ func Input(cfg InputCfg) View {
 	if cfg.Mode == InputMultiline {
 		a11yRole = AccessRoleTextArea
 	}
-	// ReadOnly states it outright. A non-focusable field is also
-	// uneditable in practice, so it keeps reporting read-only; that
-	// fallback is the only way this was expressible before ReadOnly
-	// existed. If Focusable ever defaults to true, drop the second
-	// clause — a missing ID would otherwise announce read-only on a
-	// field the caller never marked as such.
+	// ReadOnly is the only signal for the read-only announcement.
+	// Inputs are focusable by default, so non-focusable is now an
+	// explicit FocusDisabled opt-out — no longer a proxy for
+	// read-only.
 	a11yState := AccessStateNone
-	if cfg.ReadOnly || !cfg.Focusable {
+	if cfg.ReadOnly {
 		a11yState = AccessStateReadOnly
 	}
 
@@ -232,7 +232,7 @@ func Input(cfg InputCfg) View {
 
 	return Column(ContainerCfg{
 		ID:              cfg.ID,
-		Focusable:       cfg.Focusable,
+		Focusable:       !cfg.FocusDisabled,
 		A11YRole:        a11yRole,
 		A11YState:       a11yState,
 		A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.Placeholder),

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -230,8 +230,10 @@ func inputDateTextField(
 		})
 	}
 	return Input(InputCfg{
-		ID:               cfgID + ".input",
-		Focusable:        cfg.Focusable,
+		ID: cfgID + ".input",
+		// InputDate stays opt-in (deferred from the focusable-
+		// by-default flip); translate its Focusable intent.
+		FocusDisabled:    !cfg.Focusable,
 		ReadOnly:         cfg.ReadOnly,
 		Text:             dateText,
 		Placeholder:      inputDatePlaceholder(cfg),

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -174,8 +174,10 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 	modeCfg := numericModeCfgFromInput(cfg)
 
 	return Input(InputCfg{
-		ID:               inputID,
-		Focusable:        cfg.Focusable,
+		ID: inputID,
+		// NumericInput stays opt-in (deferred from the focusable-
+		// by-default flip); translate its Focusable intent.
+		FocusDisabled:    !cfg.Focusable,
 		ReadOnly:         cfg.ReadOnly,
 		Text:             cfg.Text,
 		Placeholder:      cfg.Placeholder,

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -14,7 +14,6 @@ func TestInputGeneratesLayout(t *testing.T) {
 		ID:          "email",
 		Text:        "hello",
 		Placeholder: "Enter email",
-		Focusable:   true,
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape.ID != "email" {
@@ -28,8 +27,8 @@ func TestInputGeneratesLayout(t *testing.T) {
 func TestInputMultilineRole(t *testing.T) {
 	w := newTestWindow()
 	v := Input(InputCfg{
-		Mode:      InputMultiline,
-		Focusable: true, ID: "f11",
+		Mode: InputMultiline,
+		ID:   "f11",
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape.A11YRole != AccessRoleTextArea {
@@ -37,12 +36,63 @@ func TestInputMultilineRole(t *testing.T) {
 	}
 }
 
+// ReadOnly is the only trigger for the read-only announcement.
+// FocusDisabled alone must NOT announce read-only: with the
+// focusable-by-default flip, non-focusable is an explicit opt-out,
+// not the historical proxy for an uneditable field.
 func TestInputReadOnlyWithoutFocus(t *testing.T) {
 	w := newTestWindow()
-	v := Input(InputCfg{Text: "readonly"})
-	layout := generateViewLayout(v, w)
-	if layout.Shape.A11YState != AccessStateReadOnly {
-		t.Fatalf("got state %d, want ReadOnly", layout.Shape.A11YState)
+
+	ro := generateViewLayout(Input(InputCfg{Text: "readonly", ReadOnly: true}), w)
+	if ro.Shape.A11YState != AccessStateReadOnly {
+		t.Fatalf("ReadOnly: got state %d, want ReadOnly", ro.Shape.A11YState)
+	}
+
+	fd := generateViewLayout(Input(InputCfg{Text: "x", FocusDisabled: true}), w)
+	if fd.Shape.A11YState == AccessStateReadOnly {
+		t.Fatal("FocusDisabled alone must not announce ReadOnly")
+	}
+}
+
+// countFocusCandidates walks the layout and returns the number of
+// distinct tab stops, pinning against duplicate focus candidates.
+func countFocusCandidates(layout *Layout) int {
+	var candidates []focusCandidate
+	collectFocusCandidates(layout, &candidates, map[string]struct{}{})
+	return len(candidates)
+}
+
+// An Input with an ID and no FocusDisabled is focusable by default and
+// exposes exactly one tab stop (the inner Text is FocusSkip).
+func TestInputFocusableByDefaultOneCandidate(t *testing.T) {
+	w := newTestWindow()
+	layout := generateViewLayout(Input(InputCfg{ID: "f_def", Text: "x"}), w)
+	if got := countFocusCandidates(&layout); got != 1 {
+		t.Fatalf("got %d focus candidates, want 1", got)
+	}
+}
+
+// FocusDisabled opts out: zero candidates.
+func TestInputFocusDisabledNoCandidates(t *testing.T) {
+	w := newTestWindow()
+	layout := generateViewLayout(Input(InputCfg{
+		ID: "f_off", Text: "x", FocusDisabled: true,
+	}), w)
+	if got := countFocusCandidates(&layout); got != 0 {
+		t.Fatalf("got %d focus candidates, want 0", got)
+	}
+}
+
+// No ID → inert: focusable by default but never a tab stop (focus
+// requires a non-empty ID). The field still renders.
+func TestInputNoIDInert(t *testing.T) {
+	w := newTestWindow()
+	layout := generateViewLayout(Input(InputCfg{Text: "x"}), w)
+	if got := countFocusCandidates(&layout); got != 0 {
+		t.Fatalf("got %d focus candidates, want 0", got)
+	}
+	if layout.Shape.shapeType == shapeNone {
+		t.Fatal("ID-less input must still render")
 	}
 }
 
@@ -50,7 +100,7 @@ func TestInputPlaceholderWhenEmpty(t *testing.T) {
 	w := newTestWindow()
 	v := Input(InputCfg{
 		Placeholder: "Type here",
-		Focusable:   true, ID: "f12",
+		ID:          "f12",
 	})
 	layout := generateViewLayout(v, w)
 	// The inner Row → Text child should use placeholder text.
@@ -80,7 +130,7 @@ func TestInputClickPlaceholderResetsCursorToStart(t *testing.T) {
 	})
 	layout := generateViewLayout(Input(InputCfg{
 		Placeholder: "Type here",
-		Focusable:   true, ID: "f14",
+		ID:          "f14",
 	}), w)
 	if len(layout.Children) == 0 {
 		t.Fatal("no children")
@@ -142,7 +192,7 @@ func TestInputA11YLabelFallback(t *testing.T) {
 	w := newTestWindow()
 	v := Input(InputCfg{
 		Placeholder: "Search...",
-		Focusable:   true, ID: "f13",
+		ID:          "f13",
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape.A11Y == nil {
@@ -170,9 +220,8 @@ func newInputTest(text string, focusID string, cursorPos int) *inputTestCtx {
 	ctx.w.SetFocus(focusID)
 	setInputState(ctx.w, focusID, InputState{CursorPos: cursorPos})
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text:      text,
-		ID:        focusID,
-		Focusable: true,
+		Text: text,
+		ID:   focusID,
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
@@ -187,10 +236,9 @@ func newInputTestMultiline(text string, focusID string, cursorPos int) *inputTes
 	ctx.w.SetFocus(focusID)
 	setInputState(ctx.w, focusID, InputState{CursorPos: cursorPos})
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text:      text,
-		ID:        focusID,
-		Focusable: true,
-		Mode:      InputMultiline,
+		Text: text,
+		ID:   focusID,
+		Mode: InputMultiline,
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
@@ -264,8 +312,8 @@ func TestInputKeyDownEnterSingleLine(t *testing.T) {
 	w.SetFocus("f600")
 	setInputState(w, "f600", InputState{CursorPos: 2})
 	layout := generateViewLayout(Input(InputCfg{
-		Text:      "hi",
-		Focusable: true, ID: "f600",
+		Text: "hi",
+		ID:   "f600",
 		OnTextCommit: func(_ *Layout, _ string, reason InputCommitReason, _ *Window) {
 			committed = true
 			if reason != CommitEnter {
@@ -288,8 +336,8 @@ func TestInputOnCharUndo(t *testing.T) {
 	}
 	// Rebuild layout with new text for undo.
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text:      ctx.lastText,
-		Focusable: true, ID: "f506",
+		Text: ctx.lastText,
+		ID:   "f506",
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
@@ -305,16 +353,16 @@ func TestInputOnCharRedo(t *testing.T) {
 	ctx.fireChar('!')
 	// Rebuild with new text.
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text:      ctx.lastText,
-		Focusable: true, ID: "f507",
+		Text: ctx.lastText,
+		ID:   "f507",
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
 	}), ctx.w)
 	ctx.fireKeyDown(KeyZ, ModCtrl) // undo
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text:      ctx.lastText,
-		Focusable: true, ID: "f507",
+		Text: ctx.lastText,
+		ID:   "f507",
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
@@ -351,8 +399,8 @@ func TestInputCopyPaste(t *testing.T) {
 	// Move cursor to end, paste.
 	setInputState(ctx.w, "f509", InputState{CursorPos: 5})
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text:      "hello",
-		Focusable: true, ID: "f509",
+		Text: "hello",
+		ID:   "f509",
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
@@ -918,8 +966,9 @@ func TestMakeInputOnKeyUp_NilHandler(t *testing.T) {
 // --- ReadOnly tests ---
 
 // newInputTestReadOnly mirrors newInputTest but marks the field
-// read-only. Focusable stays true: the point of ReadOnly is a field
-// that keeps focus and selection while refusing edits.
+// read-only. The field stays focusable (the default): the point of
+// ReadOnly is a field that keeps focus and selection while refusing
+// edits.
 func newInputTestReadOnly(
 	text string, focusID string, cursorPos int, mode InputMode,
 ) *inputTestCtx {
@@ -929,11 +978,10 @@ func newInputTestReadOnly(
 	ctx.w.SetFocus(focusID)
 	setInputState(ctx.w, focusID, InputState{CursorPos: cursorPos})
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text:      text,
-		ID:        focusID,
-		Focusable: true,
-		ReadOnly:  true,
-		Mode:      mode,
+		Text:     text,
+		ID:       focusID,
+		ReadOnly: true,
+		Mode:     mode,
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
@@ -947,7 +995,7 @@ func newInputTestReadOnly(
 func TestInputReadOnlyIsFocusableAndAnnouncedReadOnly(t *testing.T) {
 	w := newTestWindow()
 	v := Input(InputCfg{
-		ID: "ro_a11y", Text: "x", Focusable: true, ReadOnly: true,
+		ID: "ro_a11y", Text: "x", ReadOnly: true,
 	})
 	layout := generateViewLayout(v, w)
 
@@ -1029,7 +1077,7 @@ func TestInputReadOnlyBlocksUndo(t *testing.T) {
 	}
 
 	ctx.layout = generateViewLayout(Input(InputCfg{
-		Text: ctx.lastText, ID: "ro4", Focusable: true, ReadOnly: true,
+		Text: ctx.lastText, ID: "ro4", ReadOnly: true,
 		OnTextChanged: func(_ *Layout, newText string, _ *Window) {
 			ctx.lastText = newText
 		},
@@ -1058,7 +1106,7 @@ func TestInputReadOnlySingleLineEnterStillCommits(t *testing.T) {
 	w.SetFocus("ro6")
 	enterFired := false
 	layout := generateViewLayout(Input(InputCfg{
-		Text: "hello", ID: "ro6", Focusable: true, ReadOnly: true,
+		Text: "hello", ID: "ro6", ReadOnly: true,
 		OnEnter: func(_ *Layout, _ *Event, _ *Window) {
 			enterFired = true
 		},
@@ -1126,8 +1174,7 @@ func TestInputReadOnlyEnterDoesNotNormalize(t *testing.T) {
 	changed := ""
 	committed := ""
 	layout := generateViewLayout(Input(InputCfg{
-		Text: "  hi  ", ID: "ro_norm_enter", Focusable: true,
-		ReadOnly: true,
+		Text: "  hi  ", ID: "ro_norm_enter", ReadOnly: true,
 		PostCommitNormalize: func(_ string, _ InputCommitReason) string {
 			return "NORMALIZED"
 		},
@@ -1159,8 +1206,7 @@ func TestInputReadOnlyBlurDoesNotNormalize(t *testing.T) {
 	changed := ""
 	committed := ""
 	cfg := InputCfg{
-		Text: "  hi  ", ID: "ro_norm_blur", Focusable: true,
-		ReadOnly: true,
+		Text: "  hi  ", ID: "ro_norm_blur", ReadOnly: true,
 		PostCommitNormalize: func(_ string, _ InputCommitReason) string {
 			return "NORMALIZED"
 		},
@@ -1201,8 +1247,7 @@ func TestInputEditableEnterStillNormalizes(t *testing.T) {
 	w.SetFocus("rw_norm_enter")
 	changed := ""
 	layout := generateViewLayout(Input(InputCfg{
-		Text: "  hi  ", ID: "rw_norm_enter", Focusable: true,
-		PostCommitNormalize: func(_ string, _ InputCommitReason) string {
+		Text: "  hi  ", ID: "rw_norm_enter", PostCommitNormalize: func(_ string, _ InputCommitReason) string {
 			return "NORMALIZED"
 		},
 		OnTextChanged: func(_ *Layout, nt string, _ *Window) {
@@ -1264,7 +1309,7 @@ func TestInputReadOnlyDoesNotRenderIMEPreedit(t *testing.T) {
 	we.ime.composing = true
 	we.ime.compText = preedit
 	editable := renderInnerInputText(t, we, Input(InputCfg{
-		ID: id, Focusable: true, Text: "abc",
+		ID: id, Text: "abc",
 	}))
 	if !strings.Contains(editable, preedit) {
 		t.Fatalf("editable field: preedit not rendered; got %q", editable)
@@ -1276,7 +1321,7 @@ func TestInputReadOnlyDoesNotRenderIMEPreedit(t *testing.T) {
 	wr.ime.composing = true
 	wr.ime.compText = preedit
 	readonly := renderInnerInputText(t, wr, Input(InputCfg{
-		ID: id, Focusable: true, ReadOnly: true, Text: "abc",
+		ID: id, ReadOnly: true, Text: "abc",
 	}))
 	if strings.Contains(readonly, preedit) {
 		t.Fatalf("read-only field rendered IME preedit; got %q", readonly)

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -23,17 +23,19 @@ type SelectCfg struct {
 	ID               string
 	Placeholder      string
 
-	A11YLabel        string
-	A11YDescription  string
-	Selected         []string // currently selected option text(s)
-	Options          []string
-	FloatZIndex      int
-	Padding          Opt[Padding]
-	SizeBorder       Opt[float32]
-	Radius           Opt[float32]
-	MinWidth         float32
-	MaxWidth         float32
-	Focusable        bool
+	A11YLabel       string
+	A11YDescription string
+	Selected        []string // currently selected option text(s)
+	Options         []string
+	FloatZIndex     int
+	Padding         Opt[Padding]
+	SizeBorder      Opt[float32]
+	Radius          Opt[float32]
+	MinWidth        float32
+	MaxWidth        float32
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled    bool
 	Color            Color
 	ColorBorder      Color
 	ColorBorderFocus Color
@@ -155,7 +157,7 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 	// Build the outer row layout directly.
 	ccfg := ContainerCfg{
 		ID:          cfg.ID,
-		Focusable:   cfg.Focusable,
+		Focusable:   !cfg.FocusDisabled,
 		Clip:        clip,
 		A11YRole:    AccessRoleComboBox,
 		A11YLabel:   a11yLabel(cfg.A11YLabel, cfg.Placeholder),

--- a/gui/view_slider.go
+++ b/gui/view_slider.go
@@ -25,19 +25,21 @@ type SliderCfg struct {
 	Height          float32
 	Size            float32
 	ThumbSize       float32
-	Focusable       bool
-	Color           Color
-	ColorBorder     Color
-	ColorThumb      Color
-	ColorFocus      Color
-	ColorHover      Color
-	ColorLeft       Color
-	ColorClick      Color
-	Sizing          Sizing
-	RoundValue      bool
-	Vertical        bool
-	Disabled        bool
-	Invisible       bool
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled bool
+	Color         Color
+	ColorBorder   Color
+	ColorThumb    Color
+	ColorFocus    Color
+	ColorHover    Color
+	ColorLeft     Color
+	ColorClick    Color
+	Sizing        Sizing
+	RoundValue    bool
+	Vertical      bool
+	Disabled      bool
+	Invisible     bool
 }
 
 // Slider creates a slider view.
@@ -137,7 +139,7 @@ func Slider(cfg SliderCfg) View {
 
 	return container(ContainerCfg{
 		ID:        cfg.ID,
-		Focusable: cfg.Focusable,
+		Focusable: !cfg.FocusDisabled,
 		A11YRole:  AccessRoleSlider,
 		A11Y: &AccessInfo{
 			Label:       a11yLabel(cfg.A11YLabel, cfg.ID),

--- a/gui/view_switch.go
+++ b/gui/view_switch.go
@@ -7,13 +7,15 @@ type SwitchCfg struct {
 	ID        string
 	Label     string
 
-	A11YLabel        string
-	A11YDescription  string
-	Padding          Opt[Padding]
-	SizeBorder       Opt[float32]
-	Width            Opt[float32]
-	Height           Opt[float32]
-	Focusable        bool
+	A11YLabel       string
+	A11YDescription string
+	Padding         Opt[Padding]
+	SizeBorder      Opt[float32]
+	Width           Opt[float32]
+	Height          Opt[float32]
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled    bool
 	Color            Color
 	ColorFocus       Color
 	ColorHover       Color
@@ -89,7 +91,7 @@ func Switch(cfg SwitchCfg) View {
 
 	return Row(ContainerCfg{
 		ID:              cfg.ID,
-		Focusable:       cfg.Focusable,
+		Focusable:       !cfg.FocusDisabled,
 		Disabled:        cfg.Disabled,
 		Invisible:       cfg.Invisible,
 		SizeBorder:      NoBorder,

--- a/gui/view_toggle.go
+++ b/gui/view_toggle.go
@@ -10,13 +10,15 @@ type ToggleCfg struct {
 	TextSelect     string
 	TextUnselect   string
 
-	A11YLabel        string
-	A11YDescription  string
-	Padding          Opt[Padding]
-	SizeBorder       Opt[float32]
-	Radius           Opt[float32]
-	MinWidth         float32
-	Focusable        bool
+	A11YLabel       string
+	A11YDescription string
+	Padding         Opt[Padding]
+	SizeBorder      Opt[float32]
+	Radius          Opt[float32]
+	MinWidth        float32
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled    bool
 	Color            Color
 	ColorFocus       Color
 	ColorHover       Color
@@ -85,7 +87,7 @@ func Toggle(cfg ToggleCfg) View {
 
 	return Row(ContainerCfg{
 		ID:              cfg.ID,
-		Focusable:       cfg.Focusable,
+		Focusable:       !cfg.FocusDisabled,
 		Disabled:        cfg.Disabled,
 		Invisible:       cfg.Invisible,
 		SizeBorder:      NoBorder,

--- a/gui/view_widget_test.go
+++ b/gui/view_widget_test.go
@@ -151,9 +151,9 @@ func TestRadioCustomTextStyleMerged(t *testing.T) {
 func TestToggleGeneratesLayout(t *testing.T) {
 	w := newTestWindow()
 	v := Toggle(ToggleCfg{
-		Label:     "Accept",
-		OnClick:   noop,
-		Focusable: true, ID: "f2",
+		Label:   "Accept",
+		OnClick: noop,
+		ID:      "f2",
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape.A11YRole != AccessRoleCheckbox {
@@ -238,7 +238,7 @@ func TestToggleClickHoverChangesColor(t *testing.T) {
 func TestToggleFocusBorder(t *testing.T) {
 	w := newTestWindow()
 	w.viewState.focusID = "f5"
-	v := Toggle(ToggleCfg{OnClick: noop, Focusable: true, ID: "f5"})
+	v := Toggle(ToggleCfg{OnClick: noop, ID: "f5"})
 	layout := generateViewLayout(v, w)
 	layout.Shape.events.AmendLayout(&layout, w)
 	if layout.Children[0].Shape.ColorBorder != DefaultToggleStyle.ColorBorderFocus {
@@ -298,9 +298,9 @@ func TestToggleUnselectedText(t *testing.T) {
 func TestSwitchGeneratesLayout(t *testing.T) {
 	w := newTestWindow()
 	v := Switch(SwitchCfg{
-		Label:     "Dark mode",
-		OnClick:   noop,
-		Focusable: true, ID: "f3",
+		Label:   "Dark mode",
+		OnClick: noop,
+		ID:      "f3",
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape.A11YRole != AccessRoleSwitchToggle {
@@ -385,7 +385,7 @@ func TestSwitchClickHoverChangesColor(t *testing.T) {
 
 func TestSwitchFocusBorder(t *testing.T) {
 	w := newTestWindow()
-	v := Switch(SwitchCfg{OnClick: noop, Focusable: true, ID: "f5"})
+	v := Switch(SwitchCfg{OnClick: noop, ID: "f5"})
 	layout := generateViewLayout(v, w)
 	w.SetFocus("f5")
 	layout.Shape.events.AmendLayout(&layout, w)
@@ -450,10 +450,9 @@ func TestSwitchOuterRowNoBorder(t *testing.T) {
 func TestSelectGeneratesLayout(t *testing.T) {
 	w := newTestWindow()
 	v := Select(SelectCfg{
-		ID:        "country",
-		Options:   []string{"US", "UK", "DE"},
-		OnSelect:  func(_ []string, _ *Event, _ *Window) {},
-		Focusable: true,
+		ID:       "country",
+		Options:  []string{"US", "UK", "DE"},
+		OnSelect: func(_ []string, _ *Event, _ *Window) {},
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape.A11YRole != AccessRoleComboBox {
@@ -768,5 +767,63 @@ func TestListBoxScrollWithSubheadings(t *testing.T) {
 	want := -(float32(10)*rowH - listH)
 	if sy != want {
 		t.Fatalf("scrollY = %f, want %f", sy, want)
+	}
+}
+
+// --- Focusable-by-default (Phase 2 flip) ---
+
+// Each in-scope control with an ID and no FocusDisabled exposes exactly
+// one focus candidate; FocusDisabled yields zero; and for optional-ID
+// controls, no ID yields zero (inert). Pins against duplicate tab stops.
+func TestPhase2WidgetsFocusableByDefault(t *testing.T) {
+	w := newTestWindow()
+	cases := []struct {
+		name     string
+		withID   View
+		disabled View
+		noID     View // nil when the widget requires an ID
+	}{
+		{
+			name:     "Toggle",
+			withID:   Toggle(ToggleCfg{ID: "fc-t", OnClick: noop}),
+			disabled: Toggle(ToggleCfg{ID: "fc-t", OnClick: noop, FocusDisabled: true}),
+			noID:     Toggle(ToggleCfg{OnClick: noop}),
+		},
+		{
+			name:     "Switch",
+			withID:   Switch(SwitchCfg{ID: "fc-s", OnClick: noop}),
+			disabled: Switch(SwitchCfg{ID: "fc-s", OnClick: noop, FocusDisabled: true}),
+			noID:     Switch(SwitchCfg{OnClick: noop}),
+		},
+		{
+			name:     "Select",
+			withID:   Select(SelectCfg{ID: "fc-sel", Options: []string{"a"}}),
+			disabled: Select(SelectCfg{ID: "fc-sel", Options: []string{"a"}, FocusDisabled: true}),
+			noID:     Select(SelectCfg{Options: []string{"a"}}),
+		},
+		{
+			// Slider's ID is required (RequireID panics without one),
+			// so the no-ID case does not apply.
+			name:     "Slider",
+			withID:   Slider(SliderCfg{ID: "fc-sl", Max: 10}),
+			disabled: Slider(SliderCfg{ID: "fc-sl", Max: 10, FocusDisabled: true}),
+		},
+	}
+	for _, tc := range cases {
+		layout := generateViewLayout(tc.withID, w)
+		if got := countFocusCandidates(&layout); got != 1 {
+			t.Errorf("%s with ID: got %d focus candidates, want 1", tc.name, got)
+		}
+		layout = generateViewLayout(tc.disabled, w)
+		if got := countFocusCandidates(&layout); got != 0 {
+			t.Errorf("%s FocusDisabled: got %d focus candidates, want 0", tc.name, got)
+		}
+		if tc.noID == nil {
+			continue
+		}
+		layout = generateViewLayout(tc.noID, w)
+		if got := countFocusCandidates(&layout); got != 0 {
+			t.Errorf("%s without ID: got %d focus candidates, want 0 (inert)", tc.name, got)
+		}
 	}
 }

--- a/gui/window_event_test.go
+++ b/gui/window_event_test.go
@@ -358,8 +358,7 @@ func TestKeyUpEventFlow_WindowToInput(t *testing.T) {
 
 	// Create an input widget with OnKeyUp handler
 	input := Input(InputCfg{
-		ID:        "test-input",
-		Focusable: true,
+		ID: "test-input",
 		OnKeyUp: func(_ *Layout, e *Event, _ *Window) {
 			called = true
 			e.IsHandled = true

--- a/tools/requiredid/testdata/src/widgets/widgets.go
+++ b/tools/requiredid/testdata/src/widgets/widgets.go
@@ -21,6 +21,14 @@ type NoIDCfg struct {
 	Focusable bool
 }
 
+// FlipCfg mirrors the focusable-by-default Cfgs (Input, Select, …):
+// no Focusable field, FocusDisabled opt-out. The analyzer keys on the
+// literal `Focusable` field, so these literals must never diagnose.
+type FlipCfg struct {
+	ID            string
+	FocusDisabled bool
+}
+
 type S struct{}
 
 func (S) Widget(_ WidgetCfg) {}
@@ -30,6 +38,7 @@ func helper(_ WidgetCfg) {}
 func useN(_ NoReqCfg)    {}
 func Focus(_ FocusCfg)   {}
 func NoID(_ NoIDCfg)     {}
+func Flip(_ FlipCfg)     {}
 
 func good() {
 	Widget(WidgetCfg{ID: "ok", Name: "x"})
@@ -103,4 +112,13 @@ func focusableCfgWithoutIDField() {
 
 func focusableIgnoredByDirective() {
 	Focus(FocusCfg{Focusable: true}) //requiredid:ignore
+}
+
+// Focusable-by-default Cfgs never set Focusable, so the rule stays
+// silent — with or without an ID (no-ID is a valid inert choice), and
+// regardless of FocusDisabled.
+func flippedCfgSilent() {
+	Flip(FlipCfg{})
+	Flip(FlipCfg{ID: "ok"})
+	Flip(FlipCfg{FocusDisabled: true})
 }


### PR DESCRIPTION
Implements docs/specs/focusable-default-input.md (v0.36.0, breaking).

## What

`InputCfg`, `SelectCfg`, `SliderCfg`, `ToggleCfg`, `SwitchCfg` drop
`Focusable bool` and gain `FocusDisabled bool` — the zero value is now
*focusable*. An input the user can't tab to is a bug, not a design
choice. For Select/Slider/Toggle/Switch this is an a11y fix: ID-bearing
call sites that never set `Focusable` now join the Tab order.

- Focus still requires a non-empty `ID`; ID-less controls stay inert
  (render, never a tab stop). No ID is ever fabricated.
- A non-focusable Input no longer announces `AccessStateReadOnly`;
  only `ReadOnly: true` does.
- Deferred (keep opt-in `Focusable`): NumericInput/InputDate wrappers
  (translate via `FocusDisabled: !cfg.Focusable`), composites
  (Combobox, DatePicker, ListBox, RadioButtonGroup), Button et al.

## Commits

1. Phase 1 — `InputCfg` flip + whole in-repo call-graph migration
2. Phase 2 — `Select`/`Slider`/`Toggle`/`Switch` flip + migration
3. Phase 3 — CHANGELOG, README Focus section + flag table, widget
   skill scaffold, `requiredid` FlipCfg testdata

## Migration

- `Focusable: true` → delete the line
- `Focusable: <expr>` → `FocusDisabled: !<expr>`
- `Focusable: false` → `FocusDisabled: true` (zero occurrences found)

Gate: `make check && go test ./... && golangci-lint run ./...` green
on every commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786800594&installation_id=145733661&pr_number=89&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F89&signature=79f3b1857387bdb483a0496a070e23300566bc84c282237dae8818ebb7a4c5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->