### PR TITLE
docs: refresh stale API references across six docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,8 +56,10 @@ entire UI from the view function.
 │  ios            → Metal (CGo) + UIKit windowing                     │
 │  android        → OpenGL ES 3.0 (CGo) + Android Activity/View       │
 │  js && wasm     → Canvas2D + WebGL2 (custom shaders)                │
-│  !darwin && !js && !android && gl → OpenGL 3.3 + native windowing   │
-│  !darwin && !js && !android && !gl → native GL backend              │
+│  linux   && !js && !android && !gl → native GL backend              │
+│  windows && !js && !android && !gl → native GL backend              │
+│  !darwin && !js && !android && gl  → force GL backend               │
+│  (any other combination            → panics: unsupported platform)  │
 │                                                                     │
 │  ┌──────────┬──────────┬──────────┬──────────┬──────────┐           │
 │  │ macOS    │ iOS      │ Linux    │ Windows  │ Web      │           │
@@ -110,7 +112,7 @@ entire UI from the view function.
 │  └─ AmendLayout func       ← post-sizing hook                    │
 ├──────────────────────────────────────────────────────────────────┤
 │ RenderCmd                                                        │
-│  ├─ Kind     RenderCmdKind ← what to draw                        │
+│  ├─ Kind     RenderKind    ← what to draw                        │
 │  ├─ Pos, Size              ← screen coordinates                  │
 │  ├─ Color, Radius          ← visual properties                   │
 │  └─ ...per-kind fields     ← text, image, SVG data, clip, etc.   │

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -126,7 +126,7 @@ stages are skipped. This means:
 Creates a button automatically wired to a registered command.
 
 ```go
-gui.CommandButton(w, "edit.undo", gui.ButtonCfg{IDFocus: 10})
+gui.CommandButton(w, "edit.undo", gui.ButtonCfg{Focusable: true})
 ```
 
 **Auto behaviors:**
@@ -202,12 +202,15 @@ func paletteAction(id string, e *gui.Event, w *gui.Window) {
 
 ### Visibility Functions
 
-| Function                                         | Description          |
-| ------------------------------------------------ | -------------------- |
-| `CommandPaletteShow(id, idFocus, idScroll, w)`   | Show and focus input |
-| `CommandPaletteDismiss(id, w)`                   | Hide and reset query |
-| `CommandPaletteToggle(id, idFocus, idScroll, w)` | Toggle visibility    |
-| `CommandPaletteIsVisible(id, w) bool`            | Check if showing     |
+| Function                              | Description          |
+| ------------------------------------- | -------------------- |
+| `CommandPaletteShow(id, w)`           | Show and focus input |
+| `CommandPaletteDismiss(id, w)`        | Hide and reset query |
+| `CommandPaletteToggle(id, w)`         | Toggle visibility    |
+| `CommandPaletteIsVisible(id, w) bool` | Check if showing     |
+
+The palette derives its internal focus and scroll identities from `id`
+(`id + ".input"` and `id + ":scroll"`).
 
 ### Palette Keyboard Navigation
 

--- a/docs/cookbook-add-widget.md
+++ b/docs/cookbook-add-widget.md
@@ -14,7 +14,11 @@ Every widget has a `*Cfg` struct. Conventions:
   distinguish "not set" from an explicit zero. Use `cfg.Radius.Get(default)`
   in the factory.
 - **Common fields** — every interactive widget includes: `ID string`,
-  `IDFocus uint32`, `Disabled bool`, `Invisible bool`. Container-like
+  `Disabled bool`, `Invisible bool`, and a focus field: either
+  `Focusable bool` (opt-in, e.g. Button) or `FocusDisabled bool`
+  (opt-out, for controls focusable by default, e.g. Input, Toggle,
+  Slider, Select). Focus always requires a non-empty `ID` — without
+  one the control never joins the tab order. Container-like
   widgets add `Sizing Sizing`, `Float bool`, `FloatAnchor FloatAttach`,
   `FloatTieOff FloatAttach`, `Padding Opt[Padding]`, `Radius Opt[float32]`,
   `SizeBorder Opt[float32]`.
@@ -44,8 +48,9 @@ type ToggleCfg struct {
     Padding          Opt[Padding]
     SizeBorder       Opt[float32]
     Radius           Opt[float32]
-    MinWidth         float32
-    IDFocus          uint32
+    MinWidth        float32
+    // FocusDisabled opts out of the default-on focus.
+    FocusDisabled    bool
     Color            Color
     ColorFocus       Color
     ColorHover       Color
@@ -120,9 +125,14 @@ func Toggle(cfg ToggleCfg) View {
         a11yState = AccessStateChecked
     }
 
+    colorFocus := cfg.ColorFocus
+    colorBorderFocus := cfg.ColorBorderFocus
+    colorHover := cfg.ColorHover
+    colorClick := cfg.ColorClick
+
     return Row(ContainerCfg{
         ID:              cfg.ID,
-        IDFocus:         cfg.IDFocus,
+        Focusable:       !cfg.FocusDisabled,
         Disabled:        cfg.Disabled,
         Invisible:       cfg.Invisible,
         SizeBorder:      NoBorder,
@@ -132,8 +142,10 @@ func Toggle(cfg ToggleCfg) View {
         A11YState:       a11yState,
         A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.Label),
         A11YDescription: cfg.A11YDescription,
-        OnChar:          spacebarToClick(cfg.OnClick),
-        OnClick:         leftClickOnly(cfg.OnClick),
+        ClickOnSpace:    true,
+        OnClick:         cfg.OnClick,
+        ClickButton:     MouseLeft,
+        MinWidth:        cfg.MinWidth,
         OnHover:         /* hover highlight */,
         AmendLayout:     /* focus highlight */,
         Content:         content,
@@ -143,19 +155,21 @@ func Toggle(cfg ToggleCfg) View {
 
 ### Key patterns
 
-**OnClick wrapping** — wrap raw callbacks with event filters:
+**OnClick + keyboard activation** — use `ContainerCfg` fields to wire
+standard click semantics without per-frame closures:
 
 ```go
-// Only fire on left-click (not right/middle).
-OnClick: leftClickOnly(cfg.OnClick),
+// Left-click only (not right/middle).
+OnClick:     cfg.OnClick,
+ClickButton: MouseLeft,
 
-// Fire on Space/Enter keyboard activation (IDFocus required).
-OnChar: spacebarToClick(cfg.OnClick),
+// Space/Enter keyboard activation (Focusable + non-empty ID required).
+ClickOnSpace: true,
 ```
 
 **Hover/focus feedback** — use `OnHover` for mouse hover, `AmendLayout`
 for keyboard focus. `AmendLayout` runs every frame after sizing — use it
-to update child colors based on `w.IsFocus(idFocus)`.
+to update child colors based on `w.IsFocus(layout.Shape.ID)`.
 
 **a11yLabel helper** — `a11yLabel(userLabel, fallback)` returns the
 user-supplied label if non-empty, otherwise the fallback. Always set
@@ -317,8 +331,8 @@ go run ./examples/showcase/ # visual check
 - [ ] Cfg zero-initializable, Opt[T] for optional fields
 - [ ] `gui:"required"` tag on mandatory fields (if any)
 - [ ] a11y role, state, label set on the root shape
-- [ ] Callbacks wrapped with `leftClickOnly` / `spacebarToClick` where
-      appropriate
+- [ ] Keyboard/click semantics via `ClickOnSpace` / `ClickButton` /
+      `ClickOnEnter` where appropriate
 - [ ] Theme defaults in `theme_defaults.go` (or skip if not needed)
 - [ ] `apply<Name>Defaults` function for theme fallback
 - [ ] `gui/view_<name>_test.go` — layout structure, config passthrough,

--- a/docs/native-platform-matrix.md
+++ b/docs/native-platform-matrix.md
@@ -156,13 +156,15 @@ No-op on all backends. Requires platform-specific window manager calls (macOS `N
 
 ## Backend Selection Summary
 
-| OS      | Default Backend | Alt Backend |        Build Tag        |
-| ------- | :-------------: | :---------: | :---------------------: |
-| macOS   |      Metal      |     GL      |    `darwin && !ios`     |
-| Linux   |       GL        |      —      | `!darwin && !js && !gl` |
-| Windows |       GL        |      —      | `!darwin && !js && !gl` |
-| Web     |   Web (WASM)    |      —      |      `js && wasm`       |
-| Android |     Android     |      —      |        `android`        |
-| iOS     |       iOS       |      —      |          `ios`          |
+| OS      | Default Backend | Alt Backend |              Build Tag              |
+| ------- | :-------------: | :---------: | :---------------------------------: |
+| macOS   |      Metal      |      —      |          `darwin && !ios`           |
+| Linux   |       GL        |      —      |  `linux && !js && !android && !gl`  |
+| Windows |       GL        |      —      | `windows && !js && !android && !gl` |
+| Web     |   Web (WASM)    |      —      |            `js && wasm`             |
+| Android |     Android     |      —      |              `android`              |
+| iOS     |       iOS       |      —      |                `ios`                |
 
-GL backend is selected with `-tags gl`. On macOS, GL can be forced with `-tags gl` (overrides the Metal default).
+The GL backend can be forced on non-Apple desktop platforms with `-tags gl`
+(build tag `!darwin && !js && !android && gl`). macOS always uses Metal —
+`run_darwin.go` matches `darwin && !ios` unconditionally.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -134,14 +134,14 @@ files live in `gui/svg/testdata/`:
 Run goldens before and after SVG changes:
 
 ```bash
-go test ./gui/svg/ -run 'TestPhase0_Golden|TestPhaseG_Golden' -count=1
+go test ./gui/svg/ -run 'TestPhase0SmilSpinnerFingerprint|TestPhaseGCssSpinnerFingerprint' -count=1
 ```
 
 If a tessellation or animation change intentionally alters output, regenerate:
 
 ```bash
-go test ./gui/svg/ -run TestPhase0_Golden -phase0-update
-go test ./gui/svg/ -run TestPhaseG_Golden  -phaseG-update
+go test ./gui/svg/ -run TestPhase0SmilSpinnerFingerprint -phase0-update
+go test ./gui/svg/ -run TestPhaseGCssSpinnerFingerprint -phaseG-update
 ```
 
 Review the diff in `testdata/` before committing regenerated goldens.
@@ -164,7 +164,8 @@ The most common allocation source in hot paths is slice growth. Pre-size with
 `make([]T, 0, cap)` when the upper bound is known. Check `renderLayout` and
 `generateViewLayout` call trees for slice append without pre-allocation.
 
-### sync.Pool review
+### Scratch pool review
 
-`scratchPools` in `gui/scratch.go` holds per-window pools for frequently
-allocated types. When adding new hot-path allocations, consider pooling.
+`scratchPools` in `gui/scratch_pools.go` holds reusable per-frame buffers
+for frequently allocated types. When adding new hot-path allocations,
+consider pooling.

--- a/docs/subpackage-analysis.md
+++ b/docs/subpackage-analysis.md
@@ -6,7 +6,8 @@ package into subpackages (`gui/layout/`, `gui/animation/`, etc.).
 ## Current state
 
 - Root `gui/` package: ~200 non-test .go files at top level (~400 including tests)
-- 33 total packages (most under `backend/`)
+- 25 library packages under `gui/` (16 under `backend/`); 82 total in the
+  module including examples and tools
 - Compile time: 0.28s — not a problem
 - File naming convention: `layout_*.go`, `render_*.go`, `view_*.go`,
   `animation_*.go` — provides grep-level discoverability
@@ -19,16 +20,19 @@ package into subpackages (`gui/layout/`, `gui/animation/`, etc.).
 
 Core types are mutually dependent. Examples:
 
-- `Layout` embeds animation state (`AnimationOffset`, `AnimationOpacity`, etc.)
-- Animation functions (`animation_layout.go`) reference `Layout`, `Sizing`
+- `Window` embeds animation lifecycle state (`windowAnimation`: the active
+  `map[string]Animation`, loop state)
+- Animation types (`animation_layout.go`, `animation_tween.go`) reference
+  `Window`, `Layout`, `Sizing`
 - Layout engine (`layout_arrange.go`) references `Shape`, `Layout`
-- Render engine (`render_layout.go`) walks `Layout` trees and reads animation state
+- Render engine (`render_layout.go`) walks `Layout` trees and reads shape
+  state (e.g. `Opacity`) that animations mutate
 
-Moving `Layout` to `gui/layout` and animation to `gui/animation` creates:
+Moving `Window` to `gui/window` and animation to `gui/animation` creates:
 
 ```
-gui/layout → gui/animation  (Layout references animation state)
-gui/animation → gui/layout  (animation functions reference Layout)
+gui/window → gui/animation  (Window embeds animation lifecycle state)
+gui/animation → gui/window  (Animation.Update takes *Window)
 ```
 
 Go forbids import cycles. The single-package design avoids this by design — it's


### PR DESCRIPTION
Audit of docs/ against current code found stale API references dating from the uint32→string focus/scroll identity migration (#76, #78), the focusable-by-default flip (#89), and various renames.

## Changes

- **commands.md** — `ButtonCfg{IDFocus}` → `Focusable: true`; `CommandPaletteShow`/`CommandPaletteToggle` table now shows current `(id string, w *Window)` signatures with a note on derived `.input`/`:scroll` identities
- **cookbook-add-widget.md** — rewritten for the string focus identity model: `FocusDisabled` opt-out field on ToggleCfg, `Focusable: !cfg.FocusDisabled` in the factory, `ClickOnSpace`/`ClickButton` fields replacing `spacebarToClick`/`leftClickOnly` closure wrappers, `w.IsFocus(layout.Shape.ID)`
- **architecture.md** — `RenderCmdKind` → `RenderKind`; backend dispatch diagram now matches actual `run_*.go` build tags (linux/windows-specific, gl force tag, panic fallback)
- **native-platform-matrix.md** — Linux/Windows build tags corrected to `linux/windows && !js && !android && !gl`; removed false claim that macOS can force GL (`run_darwin.go` matches `darwin && !ios` unconditionally)
- **profiling.md** — golden test names corrected to `TestPhase0SmilSpinnerFingerprint` / `TestPhaseGCssSpinnerFingerprint` (old `-run` patterns matched zero tests); `gui/scratch.go` → `gui/scratch_pools.go`
- **subpackage-analysis.md** — package count corrected (25 under gui/, 82 in module); import-cycle example rewritten around the real `Window`↔animation coupling (the cited `AnimationOffset`/`AnimationOpacity` Layout fields don't exist)

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all green
- Corrected golden test command executed and passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786813656&installation_id=145733661&pr_number=90&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F90&signature=9bfcd42d10c31e2086e535b6526b2369567c517e8b80b82eb4aecef2ffb2b064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->