### PR TITLE
gui: auto-fill FillFill root against window dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,6 @@ Sibling projects:
 - **go-glyph**\
   Text rendering engine on steroids. https://github.com/go-gui-org/go-glyph
 
-## How it works
-
-Each frame, a plain Go view function returns a layout tree. The framework sizes,
-positions, and renders it in a single pass — no virtual DOM, no diffing.
-
-```
-View fn → generateViewLayout() → Layout tree
-  → layoutArrange() (Fit/Fixed/Grow sizing)
-  → renderLayout() (emits draw commands)
-  → Backend (Metal / OpenGL / Web/WASM)
-```
-
-State lives in a typed slot per window (`gui.State[T](w)`). Backend interfaces
-(TextMeasurer, SvgParser, NativePlatform) are injected at startup — swap backends
-without changing widget code. Tests run headlessly with no backend at all.
-
 ---
 
 ## Features
@@ -108,7 +92,7 @@ func main() {
 
     w := gui.NewWindow(gui.WindowCfg{
         State:  &App{},
-        Title:  "get_started",
+        Title:  "Get Started",
         Width:  300,
         Height: 300,
         OnInit: func(w *gui.Window) { w.UpdateView(mainView) },
@@ -118,13 +102,11 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-    ww, wh := w.WindowSize()
     app := gui.State[App](w)
 
+    // FillFill fills the window and tracks resize automatically.
     return gui.Column(gui.ContainerCfg{
-        Width:  float32(ww),
-        Height: float32(wh),
-        Sizing: gui.FixedFixed,
+        Sizing: gui.FillFill,
         HAlign: gui.HAlignCenter,
         VAlign: gui.VAlignMiddle,
         Content: []gui.View{
@@ -133,7 +115,7 @@ func mainView(w *gui.Window) gui.View {
                 TextStyle: gui.CurrentTheme().B1,
             }),
             gui.Button(gui.ButtonCfg{
-                Focusable: true,
+                ID: "gs_counter",
                 Content: []gui.View{
                     gui.Text(gui.TextCfg{
                         Text: fmt.Sprintf("%d Clicks", app.Clicks),
@@ -179,266 +161,6 @@ go get github.com/go-gui-org/go-gui
 
 ---
 
-## Configuration
-
-### Backend Selection
-
-`backend.Run(w)` auto-selects the native backend per platform — Metal on
-macOS, X11 + EGL on Linux, Win32/WGL on Windows (force portable OpenGL with
-the `gl` build tag):
-
-```go
-import "github.com/go-gui-org/go-gui/gui/backend"
-
-backend.Run(w) // Metal on macOS; native X11/Win32 GL on Linux/Windows (portable GL with -tags gl)
-```
-
-To force a specific backend, import it directly:
-
-```go
-import metal "github.com/go-gui-org/go-gui/gui/backend/metal" // macOS only
-import gl    "github.com/go-gui-org/go-gui/gui/backend/gl"    // cross-platform
-import web   "github.com/go-gui-org/go-gui/gui/backend/web"   // WASM/browser
-import ios   "github.com/go-gui-org/go-gui/gui/backend/ios"   // iOS
-```
-
-### Themes
-
-```go
-gui.SetTheme(gui.ThemeDark)                   // set globally before NewWindow
-gui.SetTheme(gui.ThemeDark.WithBorders(true)) // dark with visible borders
-t := gui.CurrentTheme()                       // read anywhere
-```
-
-Custom themes are built with `gui.ThemeMaker` and registered via
-`gui.ThemeRegister`.
-
----
-
-## Usage Examples
-
-### State Management
-
-Per-window state via a single typed slot — no globals, no closures:
-
-```go
-type Counter struct{ N int }
-
-w := gui.NewWindow(gui.WindowCfg{State: &Counter{}})
-
-// Inside any callback or view:
-s := gui.State[Counter](w)
-s.N++
-```
-
-### Event Handling
-
-Events are wired through `Cfg` structs:
-
-```go
-gui.Button(gui.ButtonCfg{
-    Focusable: true,
-    OnClick: func(l *gui.Layout, e *gui.Event, w *gui.Window) {
-        // handle click
-        e.IsHandled = true
-    },
-})
-
-gui.Input(gui.InputCfg{
-    OnKeyDown:    func(l *gui.Layout, e *gui.Event, w *gui.Window) { … },
-    OnCharInput:  func(l *gui.Layout, e *gui.Event, w *gui.Window) { … },
-    OnTextCommit: func(l *gui.Layout, e *gui.Event, w *gui.Window) { … },
-})
-```
-
-### Focus
-
-Input controls (`Input`, `Select`, `Slider`, `Toggle`, `Switch`) are
-**focusable by default**; opt out with `FocusDisabled: true`. Other
-widgets (e.g. `Button`) opt in with `Focusable: true`. Focus always
-requires a non-empty `ID` — a focusable control without an `ID` is
-inert: it renders but never joins the Tab order.
-
-| Flag                  | Meaning                                                  |
-| --------------------- | -------------------------------------------------------- |
-| `Focusable`           | opt in to the focus system (opt-in widgets)              |
-| `FocusDisabled`       | opt out of the default-on focus (input controls)         |
-| `FocusSkip`           | focusable + click/selection, but excluded from Tab order |
-| `Disabled`            | non-interactive; also excluded from Tab order            |
-
-### Stdlib Data Binding
-
-Data widgets accept Go stdlib types via convenience fields. This is the
-zero-configuration path:
-
-| Widget           | Field       | Type                  | Replaces           |
-| ---------------- | ----------- | --------------------- | ------------------ |
-| Select, Combobox | `Options`   | `[]string`            | _(already stdlib)_ |
-| ListBox          | `Items`     | `[]string`            | `Data`             |
-| RadioButtonGroup | `Items`     | `[]string`            | `Options`          |
-| Table            | `RawData`   | `[][]string`          | `Data`             |
-| Tree             | `ItemPaths` | `[]string`            | `Nodes`            |
-| DataGrid         | `RowsData`  | `[]map[string]string` | `Rows`             |
-
-When both the stdlib field and the typed struct field are set, the stdlib
-field takes precedence. Use the typed field when you need IDs different
-from display text, per-row styling, lazy loading, or custom cell editors.
-
-**ListBox — simple string list**
-
-```go
-gui.ListBox(gui.ListBoxCfg{
-    ID:    "langs",
-    Items: []string{"Go", "Rust", "Zig"},
-    OnSelect: func(ids []string, _ *gui.Event, w *gui.Window) {
-        gui.State[App](w).Selected = ids
-    },
-})
-```
-
-**Table — CSV-style data**
-
-```go
-w.Table(gui.TableCfg{
-    ID: "simple-table",
-    RawData: [][]string{
-        {"Name", "Age"},
-        {"Alice", "30"},
-        {"Bob",   "25"},
-    },
-})
-```
-
-**Tree — flat path strings**
-
-```go
-gui.Tree(gui.TreeCfg{
-    ID:        "project",
-    ItemPaths: []string{"src/main.go", "src/lib.go", "docs/readme.md"},
-    OnSelect: func(id string, _ *gui.Event, w *gui.Window) { ... },
-})
-```
-
-**DataGrid — key-value maps**
-
-```go
-import "github.com/go-gui-org/go-gui/gui/datagrid"
-
-datagrid.New(w, datagrid.DataGridCfg{
-    ID: "simple-grid",
-    RowsData: []map[string]string{
-        {"name": "Alice", "age": "30"},
-        {"name": "Bob",   "age": "25"},
-    },
-})
-```
-
-### Example Apps
-
-55 example apps in [`examples/`](examples/) — from `get_started` to
-`showcase`, `calculator`, `snake`, `dock_layout`, `digital_rain`, and more.
-
-```bash
-go run ./examples/get_started/
-go run ./examples/showcase/
-```
-
-![Digital Rain Screenshot](assets/digital-rain.png)
-
----
-
-Full widget reference: [Widget Catalogue](https://github.com/go-gui-org/go-gui/wiki/Widget-Catalogue)
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                    Application Layer                    │
-│      examples/  ──  View fn(w *Window) *Layout          │
-│                 gui.State[T](w) typed state slot        │
-└────────────────────────┬────────────────────────────────┘
-                         │
-┌────────────────────────▼────────────────────────────────┐
-│                  gui/ (core package)                    │
-│                                                         │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────────┐  │
-│  │   Widgets    │  │  State Mgmt  │  │   Animation   │  │
-│  │  Button,Text │  │  StateMap    │  │   Subsystem   │  │
-│  │  Container…  │  │  per-window  │  │               │  │
-│  └──────┬───────┘  └──────┬───────┘  └───────┬───────┘  │
-│         │                 │                  │          │
-│  ┌──────▼─────────────────▼──────────────────▼───────┐  │
-│  │              Layout Engine                        │  │
-│  │  GenerateViewLayout() → Layout tree               │  │
-│  │  layoutArrange() — Fit/Fixed/Grow sizing          │  │
-│  │  renderLayout() → []RenderCmd                     │  │
-│  └──────────────────────┬────────────────────────────┘  │
-│                         │                               │
-│  ┌──────────────────────▼────────────────────────────┐  │
-│  │            Event Dispatch                         │  │
-│  │  Mouse · Keyboard · Focus · Scroll                │  │
-│  └───────────────────────────────────────────────────┘  │
-└────────────────────────┬────────────────────────────────┘
-                         │
-        ┌────────────────┼─────────────────┐
-        │                │                 │
-┌───────▼──────┐ ┌───────▼──────┐ ┌────────▼───────┐
-│ TextMeasurer │ │   SvgParser  │ │ NativePlatform │
-│  (interface) │ │  (interface) │ │  (interface)   │
-└───────┬──────┘ └───────┬──────┘ └────────┬───────┘
-        │                │                 │
-┌───────▼────────────────▼─────────────────▼───────────┐
-│  Injects interfaces at startup · Window management   │
-├──────────────┬───────────────┬───────────────────────┤
-│  backend/    │  backend/gl/  │  backend/filedialog/  │
-│  metal/      │  OpenGL       │  backend/printdialog/ │
-│  Metal(macOS)│               │                       │
-├──────────────┼───────────────┼───────────────────────┤
-│  backend/    │  backend/ios/ │  backend/spellcheck/  │
-│  web/        │  Metal+UIKit  │  backend/atspi/       │
-│  WASM+Canvas │  (iOS)        │  (Linux a11y)         │
-└──────────────┴───────────────┴───────────────────────┘
-        │
-┌───────▼───────┐
-│   go-glyph    │
-│  Text shaping │
-│  rendering    │
-│  wrapping     │
-└───────────────┘
-```
-
-**Key types:** `Layout` (tree node), `Shape` (renderable), `RenderCmd`
-(draw op), `Window` (top-level + state slot)
-
-![calculator example](assets/calculator.png)
-
----
-
-## Running Tests
-
-Tests run headlessly — the injected backend interfaces are nil in tests, so
-no display server is required.
-
-```bash
-# Run all tests
-go test ./...
-
-# Run a specific test
-go test ./gui/... -run TestFoo
-
-# Static analysis
-go vet ./...
-
-# Full lint suite (govet, staticcheck, errcheck, gocyclo, cyclop, modernize,
-# unused, revive, gocritic, perfsprint, gosmopolitan + gofmt/goimports)
-golangci-lint run ./...
-
-# Build all packages
-go build ./...
-```
-
----
-
 ## Building the Showcase
 
 The root `Makefile` builds standalone showcase binaries for each platform.
@@ -465,6 +187,8 @@ on Linux the showcase's audio demo needs ALSA headers at build time
 use `make build-windows CC_WINDOWS=gcc`.
 
 Version and commit are injected from git tags via `-ldflags`.
+
+![Digital Rain Screenshot](assets/digital-rain.png)
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -126,7 +126,7 @@ stages are skipped. This means:
 Creates a button automatically wired to a registered command.
 
 ```go
-gui.CommandButton(w, "edit.undo", gui.ButtonCfg{Focusable: true})
+gui.CommandButton(w, "edit.undo", gui.ButtonCfg{})
 ```
 
 **Auto behaviors:**

--- a/examples/get_started/main.go
+++ b/examples/get_started/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	w := gui.NewWindow(gui.WindowCfg{
 		State:  &App{},
-		Title:  "get_started",
+		Title:  "Get Started",
 		Width:  300,
 		Height: 300,
 		OnInit: func(w *gui.Window) {
@@ -30,13 +30,12 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
+	// FillFill fills the window and tracks resize automatically — no
+	// need to fetch WindowSize() or set an explicit Width/Height.
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Content: []gui.View{
@@ -44,27 +43,17 @@ func mainView(w *gui.Window) gui.View {
 				Text:      "Hello GUI! 😀🚀🎉👍",
 				TextStyle: gui.CurrentTheme().B1,
 			}),
-			gui.WithTooltip(w, gui.WithTooltipCfg{
-				ID:   "btn_tip",
-				Text: "Click to increment counter",
+			gui.Button(gui.ButtonCfg{
+				ID: "gs_counter",
 				Content: []gui.View{
-					gui.Button(gui.ButtonCfg{
-						ID: "gs_counter",
-						Shadow: &gui.BoxShadow{
-							Color:      gui.RGBA(0, 0, 64, 64),
-							BlurRadius: 3,
-						},
-						Content: []gui.View{
-							gui.Text(gui.TextCfg{
-								Text: fmt.Sprintf("%d Clicks", app.Clicks),
-							}),
-						},
-						OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
-							// Update the typed window state; the next frame reads it back.
-							gui.State[App](w).Clicks++
-							e.IsHandled = true
-						},
+					gui.Text(gui.TextCfg{
+						Text: fmt.Sprintf("%d Clicks", app.Clicks),
 					}),
+				},
+				OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+					// Update the typed window state; the next frame reads it back.
+					gui.State[App](w).Clicks++
+					e.IsHandled = true
 				},
 			}),
 		},

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -206,6 +206,24 @@ func (w *Window) Update() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	// The root layout has no parent to Fill against, so a FillFill
+	// root would otherwise collapse to content size. Pin each Fill
+	// axis to the window dimension via min=max so the intuitive
+	// spelling (Sizing: FillFill, no Width/Height) fills the window
+	// and tracks resize automatically. Constraining min=max (rather
+	// than seeding Width/Height) is robust to the fit pass, which
+	// accumulates on the main axis, and the subsequent fill pass still
+	// distributes the remaining space to any Fill children.
+	ensureLayoutShape(&rootLayout)
+	if rootLayout.Shape.Sizing.Width == SizingFill {
+		rootLayout.Shape.MinWidth = float32(w.windowWidth)
+		rootLayout.Shape.MaxWidth = float32(w.windowWidth)
+	}
+	if rootLayout.Shape.Sizing.Height == SizingFill {
+		rootLayout.Shape.MinHeight = float32(w.windowHeight)
+		rootLayout.Shape.MaxHeight = float32(w.windowHeight)
+	}
+
 	if t {
 		t1 = time.Now()
 	}


### PR DESCRIPTION
## What

A root layout has no parent to `Fill` against, so a `Sizing: FillFill` root **silently collapsed to content size**. The only working way to fill the window was the boilerplate `WindowSize()` + explicit `Width/Height` + `FixedFixed` — the intuitive spelling failed quietly.

This pins each `Fill` axis of the root to the window dimension via `min = max` in `updateLayout`, before `layoutArrange`.

## Why min=max (not seeding Width/Height)

Seeding raw `Width/Height` breaks on the main axis: the fit pass (`layoutHeights`/`layoutWidths`) **accumulates** into the main-axis dimension, so a seeded `600` becomes `600 + children`. Constraining `min = max` survives the fit pass and still lets the subsequent fill pass distribute remaining space to any `Fill` children.

Verified across cases: `FillFill` → exact window size; `FillFit` → fills width, fits height; `FitFit` → content-fit unchanged.

## Also

- Simplify `examples/get_started` + README/docs snippets to the new spelling (drop `WindowSize()`, casts, `FixedFixed`).
- Folds in a pending docs cleanup: trim redundant README sections, drop stale `Focusable: true` from the `CommandButton` example in `docs/commands.md`.

## Test plan

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green.
- Manual: `go run ./examples/get_started/` and resize — content stays centered, column tracks the window on both axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786821151&installation_id=145733661&pr_number=93&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F93&signature=86ea009efc07c133dedca729f3acbeab27b8ebc0dd1292b08fe17dfba6ba6bfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->