### PR TITLE
gui: degrade Fixed sizing to content when the fixed size is 0 (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Immediate-mode pipeline. No virtual DOM, no diffing:
 
 ```
 View fn → generateViewLayout() → Layout tree
-  → layoutArrange() (Fit/Fixed/Grow sizing)
+  → layoutArrange() (Fit/Fixed/Fill sizing)
   → renderLayout() (emits into w.renderers)
   → Backend (Metal on macOS; native GL on Linux/Windows)
 ```
@@ -63,9 +63,12 @@ app := gui.State[App](w)  // type-asserts; panics if wrong type
 
 ### Sizing
 
-`Sizing` = combined axis enum: `SizingFit`, `SizingFixed`, `SizingGrow`,
-`SizingFitFixed`, `SizingFixedFixed`, `SizingGrowGrow`, `SizingFixedGrow`,
-`SizingGrowFixed`. Aliases: `FitFit`, `FixedFixed`, `GrowGrow`, etc.
+`Sizing` = struct `{Width, Height SizingType}`. Per-axis `SizingType`:
+`SizingFit` (shrink to content), `SizingFill` (fill parent),
+`SizingFixed` (unchanged). Named combos are `Sizing` vars: `FitFit`,
+`FitFill`, `FitFixed`, `FixedFit`, `FixedFill`, `FixedFixed`, `FillFit`,
+`FillFill`, `FillFixed`. A `FillFill` root fills the window (min=max
+seed in `updateLayout`).
 
 ### Widgets
 

--- a/gui/layout_sizing.go
+++ b/gui/layout_sizing.go
@@ -351,7 +351,13 @@ func layoutWidths(layout *Layout) {
 	padding := layout.Shape.paddingWidth()
 	if layout.Shape.Axis == AxisLeftToRight {
 		sp := layout.spacing()
-		if layout.Shape.Sizing.Width == SizingFixed {
+		// A Fixed axis with an explicit 0 size degrades to content
+		// sizing. A zero-size Fixed box renders (children self-draw)
+		// but its own bounds stay 0, collapsing the shapeClip — and
+		// therefore the hit-test and clip region — of every descendant
+		// (see issue #94). Content sizing keeps bounds enclosing the
+		// children. Childless boxes still resolve to 0, unchanged.
+		if layout.Shape.Sizing.Width == SizingFixed && layout.Shape.Width > 0 {
 			for i := range layout.Children {
 				layoutWidths(&layout.Children[i])
 			}
@@ -384,9 +390,13 @@ func layoutWidths(layout *Layout) {
 			}
 		}
 	} else if layout.Shape.Axis == AxisTopToBottom {
+		// Fixed cross-axis with a 0 size degrades to content sizing
+		// (see the AxisLeftToRight note above / issue #94). Captured
+		// before the loop mutates Width, so it stays stable per child.
+		fitWidth := layout.Shape.Sizing.Width != SizingFixed || layout.Shape.Width == 0
 		for i := range layout.Children {
 			layoutWidths(&layout.Children[i])
-			if layout.Shape.Sizing.Width != SizingFixed {
+			if fitWidth {
 				layout.Shape.Width = f32Max(layout.Shape.Width, layout.Children[i].Shape.Width+padding)
 				if !layout.Shape.Clip {
 					layout.Shape.MinWidth = f32Max(layout.Shape.MinWidth, layout.Children[i].Shape.MinWidth+padding)
@@ -407,7 +417,10 @@ func layoutHeights(layout *Layout) {
 	padding := layout.Shape.paddingHeight()
 	if layout.Shape.Axis == AxisTopToBottom {
 		sp := layout.spacing()
-		if layout.Shape.Sizing.Height == SizingFixed {
+		// Fixed with an explicit 0 height degrades to content sizing
+		// (see layoutWidths / issue #94): a zero-height Fixed box would
+		// otherwise collapse every descendant's clip/hit-test region.
+		if layout.Shape.Sizing.Height == SizingFixed && layout.Shape.Height > 0 {
 			for i := range layout.Children {
 				layoutHeights(&layout.Children[i])
 			}
@@ -435,9 +448,12 @@ func layoutHeights(layout *Layout) {
 			}
 		}
 	} else if layout.Shape.Axis == AxisLeftToRight {
+		// Fixed cross-axis with a 0 height degrades to content sizing
+		// (see issue #94). Captured before the loop mutates Height.
+		fitHeight := layout.Shape.Sizing.Height != SizingFixed || layout.Shape.Height == 0
 		for i := range layout.Children {
 			layoutHeights(&layout.Children[i])
-			if layout.Shape.Sizing.Height != SizingFixed {
+			if fitHeight {
 				layout.Shape.Height = f32Max(layout.Shape.Height, layout.Children[i].Shape.Height+padding)
 				layout.Shape.MinHeight = f32Max(layout.Shape.MinHeight, layout.Children[i].Shape.MinHeight+padding)
 			}

--- a/gui/layout_sizing_test.go
+++ b/gui/layout_sizing_test.go
@@ -195,6 +195,79 @@ func TestLayoutWidthsFixedSizingSkipsAccumulation(t *testing.T) {
 	}
 }
 
+// A Fixed width of 0 must degrade to content sizing so the box's bounds
+// enclose its children — otherwise the zero-width box collapses the
+// shapeClip (and hence hit-test and clip region) of every descendant.
+// Regression for issue #94.
+func TestLayoutWidthsFixedZeroDegradesToContent(t *testing.T) {
+	// Main axis (row width).
+	row := &Layout{
+		Shape: &Shape{Axis: AxisLeftToRight, Sizing: FixedFixed},
+		Children: []Layout{
+			{Shape: &Shape{Width: 50}},
+			{Shape: &Shape{Width: 50}},
+		},
+	}
+	layoutWidths(row)
+	if !f32AreClose(row.Shape.Width, 100) {
+		t.Errorf("row width: got %f, want 100 (content)", row.Shape.Width)
+	}
+
+	// Cross axis (column width).
+	col := &Layout{
+		Shape: &Shape{Axis: AxisTopToBottom, Sizing: FixedFixed},
+		Children: []Layout{
+			{Shape: &Shape{Width: 70}},
+		},
+	}
+	layoutWidths(col)
+	if !f32AreClose(col.Shape.Width, 70) {
+		t.Errorf("col width: got %f, want 70 (content)", col.Shape.Width)
+	}
+
+	// Childless Fixed-zero box stays 0 (leaf images/svg unaffected).
+	leaf := &Layout{Shape: &Shape{Axis: AxisLeftToRight, Sizing: FixedFixed}}
+	layoutWidths(leaf)
+	if !f32AreClose(leaf.Shape.Width, 0) {
+		t.Errorf("leaf width: got %f, want 0", leaf.Shape.Width)
+	}
+}
+
+// Mirror of the width case for the height axis. Regression for #94.
+func TestLayoutHeightsFixedZeroDegradesToContent(t *testing.T) {
+	// Main axis (column height).
+	col := &Layout{
+		Shape: &Shape{Axis: AxisTopToBottom, Sizing: FixedFixed},
+		Children: []Layout{
+			{Shape: &Shape{Height: 30}},
+			{Shape: &Shape{Height: 30}},
+		},
+	}
+	layoutHeights(col)
+	if !f32AreClose(col.Shape.Height, 60) {
+		t.Errorf("col height: got %f, want 60 (content)", col.Shape.Height)
+	}
+
+	// Cross axis (row height).
+	row := &Layout{
+		Shape: &Shape{Axis: AxisLeftToRight, Sizing: FixedFixed},
+		Children: []Layout{
+			{Shape: &Shape{Height: 45}},
+		},
+	}
+	layoutHeights(row)
+	if !f32AreClose(row.Shape.Height, 45) {
+		t.Errorf("row height: got %f, want 45 (content)", row.Shape.Height)
+	}
+
+	// Childless Fixed-zero box stays 0.
+	leaf := &Layout{Shape: &Shape{Axis: AxisTopToBottom, Sizing: FixedFixed}}
+	layoutHeights(leaf)
+	if !f32AreClose(leaf.Shape.Height, 0) {
+		t.Errorf("leaf height: got %f, want 0", leaf.Shape.Height)
+	}
+}
+
 func TestLayoutFillWidths_NilPool(t *testing.T) {
 	root := &Layout{
 		Shape: &Shape{


### PR DESCRIPTION
## Summary

Fixes the root cause behind #94. A container with `Sizing.Width`/`Height` == `SizingFixed` and an explicit **0** size renders (its children self-draw) but keeps zero-area bounds, which collapses its own and every descendant's `shapeClip`. Both hit-testing (`Shape.PointInShape`) and the render clip derive from `shapeClip`, so the box becomes **inert** (the symptom reported in #94) *and* any descendant with `Clip: true` is **clipped away to nothing**.

Discovered independently while debugging blank preview text in `examples/fontviewer`: a zero-width grid row collapsed the clip chain, so the card's clipped preview text was dropped even though it shaped, positioned, and colored correctly.

## Fix

Degrade `Fixed` → content sizing when the fixed dimension is 0, in `layoutWidths`/`layoutHeights` on both the main and cross axis. Childless boxes still resolve to 0, so leaf images/svg/canvas are unaffected — only containers *with children* gain correct enclosing bounds. This fixes the inert-events and clipped-children symptoms together.

Chose the "uniformly degrade" option (over reject-at-construction) to stay backward-compatible: zero-size fixed spacers and similar keep working.

## Tests

- `TestLayoutWidthsFixedZeroDegradesToContent` / `TestLayoutHeightsFixedZeroDegradesToContent`: main + cross axis compute content size for `Fixed`+0, childless stays 0.
- Full `go test ./...`, `go vet ./...`, `golangci-lint run` green.

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786883725&installation_id=145733661&pr_number=95&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F95&signature=26c3182b2c1662e38328495121e134551448c12816db3b031c42e54b5b3a12f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->