### PR TITLE
examples: add font viewer over a new font-enumeration API

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -13,7 +13,7 @@ Go toolchain pin: `go 1.26.0`.
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`). |
 | `github.com/go-gl/gl` | v0.0.0-20260331235117-4566fea9a276 | OpenGL bindings for `gui/backend/gl`. |
-| `github.com/go-gui-org/go-glyph` | v1.16.2 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.17.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio playback (sound effects, music, mixer, fade) for `gui/audio`. |

--- a/examples/fontviewer/main.go
+++ b/examples/fontviewer/main.go
@@ -1,0 +1,512 @@
+// Font Viewer — browsable system-font catalog.
+//
+// Virtualized card grid with filter, sample text, size slider,
+// and click-to-copy. Follows the get_started pattern: state is
+// retrieved via gui.State[T](w) in every callback — no closure
+// captures.
+//
+// Behavioral constraints (see docs/specs/font-viewer.md):
+//   - Grid is virtualized (P0) via gui.ListVisibleRange.
+//   - Cards are fixed-size → O(visible) per frame.
+//   - Mouse-first, Latin-only preview.
+package main
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend"
+)
+
+// --- State ---
+
+type FontViewerState struct {
+	Sample   string   // current sample text (init: random pangram)
+	Filter   string   // case-insensitive family-name substring
+	FontSize float32  // preview size in px (12–72; init: 28)
+	Families []string // all discovered family names, sorted; may be nil
+	Loaded   bool     // families have been enumerated (backend was ready)
+
+	// ShapeAll drops virtualization and shapes every family in one
+	// frame (the --shape-all stress mode). Off by default.
+	ShapeAll bool
+
+	CopiedFam   string  // family whose "Copied" badge is showing ("" = none)
+	CopyOpacity float32 // 1→0, written by the fade tween
+	HoveredFam  string  // family under the pointer ("" = none); cleared on eviction
+}
+
+// --- Constants ---
+
+const (
+	gridID       = "font-grid"
+	cardMaxW     = 380
+	gap          = 16
+	sidePad      = 24
+	scrollbarW   = 14
+	nameRowH     = 28
+	previewPad   = 24
+	previewLines = 3
+	lineFactor   = 1.4
+	headerH      = 72
+	toolbarH     = 104
+	overscanRows = 4
+	minFontSize  = float32(12)
+	maxFontSize  = float32(72)
+)
+
+var pangrams = []string{
+	"The quick brown fox jumps over the lazy dog",
+	"Sphinx of black quartz, judge my vow",
+	"Pack my box with five dozen liquor jugs",
+	"How vexingly quick daft zebras jump",
+	"Waltz, bad nymph, for quick jigs vex",
+	"Jackdaws love my big sphinx of quartz",
+}
+
+// --- Helpers ---
+
+// cardHeight is uniform per FontSize, driving both the card box and
+// the virtualization rowH. Uses the engine's 1.4× line height so
+// three preview lines fit without clipping.
+func cardHeight(fontSize float32) float32 {
+	return nameRowH + previewPad + previewLines*fontSize*lineFactor
+}
+
+func filterFontFamilies(all []string, filter string) []string {
+	if filter == "" {
+		return all
+	}
+	lf := strings.ToLower(filter)
+	var out []string
+	for _, f := range all {
+		if strings.Contains(strings.ToLower(f), lf) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// inWindow reports whether fam's row in matches lies within the
+// emitted [firstRow, lastRow] window — used to clear HoveredFam when a
+// card is evicted by virtualization (layoutMouseLeave never visits an
+// off-window card, so its OnMouseLeave never fires).
+func inWindow(matches []string, fam string, firstRow, lastRow, cols int) bool {
+	for r := firstRow; r <= lastRow; r++ {
+		start := r * cols
+		end := min((r+1)*cols, len(matches))
+		for i := start; i < end; i++ {
+			if matches[i] == fam {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// spacerV is a fixed-height gap that pads the virtualized grid above
+// the first and below the last emitted row, keeping the scroll range
+// equal to the full catalog.
+func spacerV(h float32) gui.View {
+	return gui.Column(gui.ContainerCfg{Sizing: gui.FillFixed, Height: h})
+}
+
+// --- Main ---
+
+func main() {
+	state := &FontViewerState{
+		FontSize: 28,
+		Sample:   pangrams[rand.IntN(len(pangrams))],
+		ShapeAll: len(os.Args) > 1 && os.Args[1] == "--shape-all",
+	}
+
+	gui.SetTheme(gui.ThemeLight.WithBorders(true))
+
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  state,
+		Title:  "go-gui font viewer",
+		Width:  900,
+		Height: 700,
+		OnInit: func(w *gui.Window) {
+			w.UpdateView(mainView)
+			w.SetFocus("sample-input")
+		},
+	})
+
+	backend.Run(w)
+}
+
+// --- View tree ---
+
+func mainView(w *gui.Window) gui.View {
+	s := gui.State[FontViewerState](w)
+
+	// Lazy one-time enumeration. ListSystemFonts reads a pre-built set
+	// (cheap, no shaping); nil until the backend is ready → retry next
+	// frame.
+	if !s.Loaded {
+		s.Families = gui.ListSystemFonts(w)
+		s.Loaded = s.Families != nil
+	}
+
+	matches := filterFontFamilies(s.Families, s.Filter)
+
+	// Zero all inherited chrome (default is PaddingMedium + SpacingMedium
+	// + SizeBorderDef 1.5) so listH = winH - headerH - toolbarH is exact.
+	return gui.Column(gui.ContainerCfg{
+		Sizing:     gui.FillFill,
+		Padding:    gui.NoPadding,
+		Spacing:    gui.SomeF(0),
+		SizeBorder: gui.Some(float32(0)),
+		Content:    []gui.View{header(), toolbar(w, len(matches)), fontGrid(w, matches)},
+	})
+}
+
+// --- Header ---
+
+func header() gui.View {
+	t := gui.CurrentTheme()
+	return gui.Column(gui.ContainerCfg{
+		Sizing:     gui.FillFixed,
+		Height:     headerH,
+		Padding:    gui.Some(gui.Padding{Left: sidePad, Top: 14, Right: sidePad, Bottom: 0}),
+		Spacing:    gui.SomeF(4),
+		SizeBorder: gui.Some(float32(0)),
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{Text: "go-gui font viewer", TextStyle: t.N1}),
+			gui.Text(gui.TextCfg{Text: "Browse and preview installed system fonts", TextStyle: t.B2}),
+		},
+	})
+}
+
+// --- Toolbar ---
+
+func toolbar(w *gui.Window, matchCount int) gui.View {
+	s := gui.State[FontViewerState](w)
+	t := gui.CurrentTheme()
+
+	row1 := gui.Row(gui.ContainerCfg{
+		Sizing:     gui.FillFixed,
+		Height:     toolbarH / 2,
+		Padding:    gui.Some(gui.Padding{Left: sidePad, Right: sidePad, Top: 8, Bottom: 4}),
+		Spacing:    gui.SomeF(8),
+		VAlign:     gui.VAlignMiddle,
+		SizeBorder: gui.Some(float32(0)),
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{Text: "Sample Text", TextStyle: t.B2}),
+			gui.Input(gui.InputCfg{
+				ID:        "sample-input",
+				Text:      s.Sample,
+				TextStyle: t.B2,
+				Sizing:    gui.FillFit,
+				OnTextChanged: func(_ *gui.Layout, text string, w *gui.Window) {
+					gui.State[FontViewerState](w).Sample = text
+				},
+			}),
+			gui.Button(gui.ButtonCfg{
+				Content: []gui.View{gui.Text(gui.TextCfg{
+					Text:      gui.IconSync,
+					TextStyle: gui.TextStyle{Family: gui.IconFontName, Size: t.Icon1.Size, Color: t.Icon1.Color},
+				})},
+				OnClick: shuffleSample,
+			}),
+		},
+	})
+
+	row2 := gui.Row(gui.ContainerCfg{
+		Sizing:     gui.FillFixed,
+		Height:     toolbarH / 2,
+		Padding:    gui.Some(gui.Padding{Left: sidePad, Right: sidePad, Top: 4, Bottom: 8}),
+		Spacing:    gui.SomeF(8),
+		VAlign:     gui.VAlignMiddle,
+		SizeBorder: gui.Some(float32(0)),
+		Content:    toolbarRow2(s, t, matchCount),
+	})
+
+	return gui.Column(gui.ContainerCfg{
+		Sizing:     gui.FillFixed,
+		Height:     toolbarH,
+		Padding:    gui.NoPadding,
+		Spacing:    gui.SomeF(0),
+		SizeBorder: gui.Some(float32(0)),
+		Content:    []gui.View{row1, row2},
+	})
+}
+
+// toolbarRow2 builds the filter / size / count controls.
+func toolbarRow2(s *FontViewerState, t gui.Theme, matchCount int) []gui.View {
+	content := []gui.View{
+		gui.Text(gui.TextCfg{Text: "Filter Fonts", TextStyle: t.B2}),
+		gui.Input(gui.InputCfg{
+			ID:        "filter-input",
+			Text:      s.Filter,
+			TextStyle: t.B2,
+			Width:     200,
+			Sizing:    gui.FixedFit,
+			OnTextChanged: func(_ *gui.Layout, text string, w *gui.Window) {
+				gui.State[FontViewerState](w).Filter = text
+				w.ScrollVerticalTo(gridID, 0)
+			},
+		}),
+	}
+	if s.Filter != "" {
+		content = append(content, gui.Button(gui.ButtonCfg{
+			Content: []gui.View{gui.Text(gui.TextCfg{Text: "×", TextStyle: t.B2})},
+			OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+				gui.State[FontViewerState](w).Filter = ""
+				w.ScrollVerticalTo(gridID, 0)
+				e.IsHandled = true
+			},
+		}))
+	}
+
+	return append(content,
+		gui.Column(gui.ContainerCfg{Sizing: gui.FillFit}), // flexible gap
+		gui.Text(gui.TextCfg{Text: "Size", TextStyle: t.B2}),
+		gui.Slider(gui.SliderCfg{
+			ID:     "size-slider",
+			Value:  s.FontSize,
+			Min:    minFontSize,
+			Max:    maxFontSize,
+			Step:   1,
+			Width:  170,
+			Sizing: gui.FixedFit,
+			OnChange: func(v float32, e *gui.Event, w *gui.Window) {
+				gui.State[FontViewerState](w).FontSize = v
+				w.ScrollVerticalTo(gridID, 0) // rowH changed → reset offset
+				e.IsHandled = true
+			},
+		}),
+		gui.Text(gui.TextCfg{
+			Text:      fmt.Sprintf("%d px", int(s.FontSize)),
+			TextStyle: t.B2,
+			MinWidth:  45,
+		}),
+		gui.Text(gui.TextCfg{
+			Text:      fmt.Sprintf("%d / %d fonts", matchCount, len(s.Families)),
+			TextStyle: t.B2,
+			MinWidth:  120,
+		}),
+	)
+}
+
+// shuffleSample picks a new pangram distinct from the current one.
+func shuffleSample(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+	s := gui.State[FontViewerState](w)
+	for {
+		p := pangrams[rand.IntN(len(pangrams))]
+		if p != s.Sample || len(pangrams) == 1 {
+			s.Sample = p
+			break
+		}
+	}
+	e.IsHandled = true
+}
+
+// --- FontGrid (virtualized) ---
+
+func fontGrid(w *gui.Window, matches []string) gui.View {
+	s := gui.State[FontViewerState](w)
+
+	if len(matches) == 0 {
+		return emptyState(len(s.Families) == 0)
+	}
+
+	winW, winH := w.WindowSize()
+	cardH := cardHeight(s.FontSize)
+	rowH := cardH + gap
+	outerW := float32(winW)
+	listH := max(rowH, float32(winH)-headerH-toolbarH) // clamp: never <= 0
+	contentW := outerW - 2*sidePad - scrollbarW
+
+	cols := max(1, int((contentW+gap)/(cardMaxW+gap)))
+	cardW := min(cardMaxW, (contentW-float32(cols-1)*gap)/float32(cols))
+	rows := (len(matches) + cols - 1) / cols
+
+	// Which rows to emit. ShapeAll drops virtualization to stress
+	// all-N shaping in one frame; the default path windows to [first,
+	// last] read from the previous frame's scroll offset.
+	first, last := 0, rows-1
+	if !s.ShapeAll {
+		scrollY, _ := w.ScrollY().Get(gridID)
+		first, last = gui.ListVisibleRange(rows, rowH, listH, scrollY, overscanRows)
+
+		// Clear a stale hover whose card was evicted by windowing.
+		if s.HoveredFam != "" && !inWindow(matches, s.HoveredFam, first, last, cols) {
+			s.HoveredFam = ""
+		}
+	}
+
+	children := []gui.View{spacerV(float32(first) * rowH)}
+	for r := first; r <= last; r++ {
+		children = append(children, gridRow(w, matches, r, cols, cardW, cardH, rowH))
+	}
+	children = append(children, spacerV(float32(rows-1-last)*rowH))
+
+	// FixedFixed with explicit Width AND Height — the same numbers feed
+	// the cols/range math, so neither axis can disagree with arrange.
+	return gui.Column(gui.ContainerCfg{
+		ID: gridID, Scrollable: true,
+		Sizing:     gui.FixedFixed,
+		Width:      outerW,
+		Height:     listH,
+		Padding:    gui.Some(gui.Padding{Left: sidePad, Right: sidePad + scrollbarW}),
+		Spacing:    gui.SomeF(0), // vertical gap lives in rowH, not spacing
+		SizeBorder: gui.Some(float32(0)),
+		Content:    children,
+	})
+}
+
+// emptyState distinguishes an empty catalog (nil or no fonts) from a
+// filter that excludes everything.
+func emptyState(noFonts bool) gui.View {
+	msg := "No fonts match the filter"
+	if noFonts {
+		msg = "No system fonts found"
+	}
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		HAlign:  gui.HAlignCenter,
+		Padding: gui.Some(gui.Padding{Top: 60}),
+		Content: []gui.View{gui.Text(gui.TextCfg{Text: msg, TextStyle: gui.CurrentTheme().N3})},
+	})
+}
+
+// gridRow emits one row of up to cols cards. FitFixed: width fits the
+// cards (never zero — a zero-width row collapses the descendant clip
+// chain), height is exactly rowH so the spacer math stays honest.
+func gridRow(w *gui.Window, matches []string, rowIdx, cols int, cardW, cardH, rowH float32) gui.View {
+	start := rowIdx * cols
+	end := min(start+cols, len(matches))
+	cards := make([]gui.View, 0, end-start)
+	for i := start; i < end; i++ {
+		cards = append(cards, fontCard(w, matches[i], cardW, cardH))
+	}
+	return gui.Row(gui.ContainerCfg{
+		Sizing:     gui.FitFixed,
+		Height:     rowH,
+		Spacing:    gui.SomeF(gap), // horizontal gutter between cards
+		Padding:    gui.NoPadding,
+		SizeBorder: gui.Some(float32(0)),
+		Content:    cards,
+	})
+}
+
+// --- FontCard ---
+
+func fontCard(w *gui.Window, name string, cardW, cardH float32) gui.View {
+	s := gui.State[FontViewerState](w)
+	t := gui.CurrentTheme()
+
+	bg := gui.Color{R: 248, G: 248, B: 248, A: 255}
+	if s.HoveredFam == name {
+		bg = gui.Color{R: 200, G: 220, B: 255, A: 255}
+	}
+
+	return gui.Column(gui.ContainerCfg{
+		ID:      "card:" + name,
+		Width:   cardW,
+		Height:  cardH,
+		Sizing:  gui.FixedFixed,
+		Color:   bg,
+		Radius:  gui.Some(float32(8)),
+		Padding: gui.Some(gui.Padding{Left: previewPad, Right: previewPad, Top: 8, Bottom: 8}),
+		Spacing: gui.SomeF(4),
+		Content: []gui.View{
+			cardNameRow(s, t, name),
+			cardPreview(s.Sample, name, s.FontSize),
+		},
+		OnClick: copyFamily(name),
+		OnHover: hoverFamily(name),
+	})
+}
+
+// cardNameRow renders the family name plus a hover "Copy" / post-click
+// "Copied" affordance. Clip truncates over-long names.
+func cardNameRow(s *FontViewerState, t gui.Theme, name string) gui.View {
+	content := []gui.View{gui.Text(gui.TextCfg{Text: name, TextStyle: t.B3})}
+	switch {
+	case s.CopiedFam == name:
+		content = append(content, gui.Text(gui.TextCfg{
+			Text:    "Copied",
+			Opacity: gui.Some(s.CopyOpacity),
+			TextStyle: gui.TextStyle{
+				Family: t.N6.Family, Size: t.N6.Size,
+				Color: gui.RGB(40, 140, 40),
+			},
+		}))
+	case s.HoveredFam == name:
+		content = append(content, gui.Text(gui.TextCfg{Text: "Copy", TextStyle: t.N6}))
+	}
+	return gui.Row(gui.ContainerCfg{
+		Sizing:     gui.FillFixed,
+		Height:     nameRowH,
+		Clip:       true,
+		Spacing:    gui.SomeF(4),
+		VAlign:     gui.VAlignMiddle,
+		Padding:    gui.NoPadding,
+		SizeBorder: gui.Some(float32(0)),
+		Content:    content,
+	})
+}
+
+// cardPreview fills the card space below the name and clips the wrapped
+// sample to it. FillFill lets the engine size the box — no manual math.
+func cardPreview(sample, name string, fontSize float32) gui.View {
+	return gui.Column(gui.ContainerCfg{
+		Sizing:     gui.FillFill,
+		Clip:       true,
+		Padding:    gui.NoPadding,
+		SizeBorder: gui.Some(float32(0)),
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{
+				Text: sample,
+				Mode: gui.TextModeWrap,
+				TextStyle: gui.TextStyle{
+					Family: name,
+					Size:   fontSize,
+					Color:  gui.RGB(32, 32, 32),
+				},
+			}),
+		},
+	})
+}
+
+// copyFamily copies the family name and starts the "Copied" fade.
+func copyFamily(name string) func(*gui.Layout, *gui.Event, *gui.Window) {
+	return func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+		s := gui.State[FontViewerState](w)
+		s.CopiedFam = name
+		s.CopyOpacity = 1
+		w.SetClipboard(name)
+		w.AnimationAdd(&gui.TweenAnimation{
+			AnimID:   "copied-fade",
+			Duration: 1200 * time.Millisecond,
+			Easing:   gui.EaseOutCubic,
+			From:     1,
+			To:       0,
+			OnValue:  func(v float32, _ *gui.Window) { gui.State[FontViewerState](w).CopyOpacity = v },
+			OnDone:   func(_ *gui.Window) { gui.State[FontViewerState](w).CopiedFam = "" },
+		})
+		e.IsHandled = true
+	}
+}
+
+// hoverFamily tracks the hovered card for the "Copy" affordance and bg.
+func hoverFamily(name string) func(*gui.Layout, *gui.Event, *gui.Window) {
+	return func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+		s := gui.State[FontViewerState](w)
+		switch e.Type {
+		case gui.EventMouseEnter:
+			s.HoveredFam = name
+		case gui.EventMouseLeave:
+			if s.HoveredFam == name {
+				s.HoveredFam = ""
+			}
+		}
+	}
+}

--- a/examples/fontviewer/main_test.go
+++ b/examples/fontviewer/main_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestMainViewNoPanic(t *testing.T) {
+	t.Parallel()
+	gui.SetTheme(gui.ThemeLight.WithPadding(false))
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  &FontViewerState{FontSize: 28, Sample: "The quick brown fox"},
+		Width:  900,
+		Height: 700,
+	})
+	_ = mainView(w).GenerateLayout(w)
+}
+
+func TestFilterFontFamilies(t *testing.T) {
+	all := []string{"Arial", "Courier New", "Times New Roman", "Zapfino"}
+	got := filterFontFamilies(all, "")
+	if len(got) != len(all) {
+		t.Fatalf("empty filter should return all: got %d, want %d", len(got), len(all))
+	}
+
+	got = filterFontFamilies(all, "aria")
+	if len(got) != 1 || got[0] != "Arial" {
+		t.Fatalf(`"aria" filter: got %v, want ["Arial"]`, got)
+	}
+
+	got = filterFontFamilies(all, "zzz")
+	if len(got) != 0 {
+		t.Fatalf(`"zzz" filter: got %d results, want 0`, len(got))
+	}
+
+	got = filterFontFamilies(nil, "foo")
+	if got != nil {
+		t.Fatalf("nil input should return nil, got %v", got)
+	}
+}
+
+func TestFilterFontFamiliesCaseInsensitive(t *testing.T) {
+	all := []string{"Arial", "ARIAL", "arial"}
+	got := filterFontFamilies(all, "ARI")
+	if len(got) != 3 {
+		t.Fatalf("case-insensitive: got %d, want 3", len(got))
+	}
+}
+
+func TestCardHeight(t *testing.T) {
+	h28 := cardHeight(28)
+	h12 := cardHeight(12)
+	h72 := cardHeight(72)
+
+	if h12 >= h28 {
+		t.Errorf("cardHeight(12)=%v should be < cardHeight(28)=%v", h12, h28)
+	}
+	if h28 >= h72 {
+		t.Errorf("cardHeight(28)=%v should be < cardHeight(72)=%v", h28, h72)
+	}
+	if h12 < nameRowH+previewPad {
+		t.Errorf("cardHeight(12)=%v too small, should be > %v", h12, nameRowH+previewPad)
+	}
+}
+
+func TestInWindow(t *testing.T) {
+	matches := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	// 4 cols → rows: 0=[a,b,c,d], 1=[e,f,g,h]
+	// Emitted rows 0-0 → only a-d.
+	if !inWindow(matches, "a", 0, 0, 4) {
+		t.Error("a should be in window rows 0-0 cols 4")
+	}
+	if inWindow(matches, "e", 0, 0, 4) {
+		t.Error("e should not be in window rows 0-0 cols 4")
+	}
+	// Emitted rows 1-1 → only e-h.
+	if !inWindow(matches, "h", 1, 1, 4) {
+		t.Error("h should be in window rows 1-1 cols 4")
+	}
+	if inWindow(matches, "z", 0, 1, 4) {
+		t.Error("z should not be in window")
+	}
+}
+
+// TestVisibleRangeMath verifies the spacer invariant for known inputs.
+func TestVisibleRangeMath(t *testing.T) {
+	// Simulate a grid with 500 matches, ~200px rows, 600px viewport.
+	n := 500
+	cols := 4
+	rows := (n + cols - 1) / cols // 125
+	rowH := float32(200)
+	listH := float32(600)
+	scrollY := float32(-4000) // scrolled ~20 rows down
+	overscan := 4
+
+	first, last := gui.ListVisibleRange(rows, rowH, listH, scrollY, overscan)
+
+	// Emitted count.
+	emitted := last - first + 1
+	if emitted < 1 {
+		t.Fatalf("no visible rows: first=%d last=%d", first, last)
+	}
+
+	// Spacer invariant.
+	topSpacer := float32(first) * rowH
+	bottomSpacer := float32(rows-1-last) * rowH
+	total := topSpacer + float32(emitted)*rowH + bottomSpacer
+	want := float32(rows) * rowH
+	if total != want {
+		t.Errorf("spacer invariant: top(%d)*%v + %d*%v + bottom(%d)*%v = %v, want %v",
+			first, rowH, emitted, rowH, rows-1-last, rowH, total, want)
+	}
+}
+
+func TestMainViewEmptyCatalog(t *testing.T) {
+	t.Parallel()
+	gui.SetTheme(gui.ThemeLight.WithBorders(true))
+	// Families is nil, Loaded is false → empty state shows "No system fonts".
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  &FontViewerState{FontSize: 28},
+		Width:  900,
+		Height: 700,
+	})
+	_ = mainView(w).GenerateLayout(w)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/ebitengine/purego v0.10.1
 	github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276
-	github.com/go-gui-org/go-glyph v1.16.2
+	github.com/go-gui-org/go-glyph v1.17.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276 h1:IO5P06Pcj9K04d+l4nrf3c2U56+dAotIFG6u4P1wAHI=
 github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
-github.com/go-gui-org/go-glyph v1.16.2 h1:QLXLaKcQz1SlTlGNUsLoYYYV+Zw2Yab57bhBq06KJbA=
-github.com/go-gui-org/go-glyph v1.16.2/go.mod h1:uLoMxwozAaPIdKcen6eX8jmFMKSGj09GjtVPyfFZyZg=
+github.com/go-gui-org/go-glyph v1.17.0 h1:1IHKKshJ1oJkgTLjMeGtnNrP0a4MUxW5YqCl7685y5k=
+github.com/go-gui-org/go-glyph v1.17.0/go.mod h1:uLoMxwozAaPIdKcen6eX8jmFMKSGj09GjtVPyfFZyZg=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=

--- a/gui/backend/android/text.go
+++ b/gui/backend/android/text.go
@@ -251,6 +251,10 @@ func (tm *textMeasurer) LayoutRichText(
 	return tm.textSys.LayoutRichText(rt, cfg)
 }
 
+func (tm *textMeasurer) ListFontFamilies() []string {
+	return tm.textSys.ListFontFamilies()
+}
+
 func guiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {
 	return glyphconv.GuiStyleToGlyphConfig(s)
 }

--- a/gui/backend/gl/text.go
+++ b/gui/backend/gl/text.go
@@ -287,6 +287,10 @@ func (tm *textMeasurer) LayoutRichText(
 	return tm.textSys.LayoutRichText(rt, cfg)
 }
 
+func (tm *textMeasurer) ListFontFamilies() []string {
+	return tm.textSys.ListFontFamilies()
+}
+
 func guiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {
 	return glyphconv.GuiStyleToGlyphConfig(s)
 }

--- a/gui/backend/ios/text.go
+++ b/gui/backend/ios/text.go
@@ -251,6 +251,10 @@ func (tm *textMeasurer) LayoutRichText(
 	return tm.textSys.LayoutRichText(rt, cfg)
 }
 
+func (tm *textMeasurer) ListFontFamilies() []string {
+	return tm.textSys.ListFontFamilies()
+}
+
 func guiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {
 	return glyphconv.GuiStyleToGlyphConfig(s)
 }

--- a/gui/backend/metal/text.go
+++ b/gui/backend/metal/text.go
@@ -254,6 +254,10 @@ func (tm *textMeasurer) LayoutRichText(
 	return tm.textSys.LayoutRichText(rt, cfg)
 }
 
+func (tm *textMeasurer) ListFontFamilies() []string {
+	return tm.textSys.ListFontFamilies()
+}
+
 func guiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {
 	return glyphconv.GuiStyleToGlyphConfig(s)
 }

--- a/gui/backend/web/text.go
+++ b/gui/backend/web/text.go
@@ -72,3 +72,6 @@ func (tm *textMeasurer) LayoutRichText(
 ) (glyph.Layout, error) {
 	return tm.textSys.LayoutRichText(rt, cfg)
 }
+func (tm *textMeasurer) ListFontFamilies() []string {
+	return tm.textSys.ListFontFamilies()
+}

--- a/gui/list_core.go
+++ b/gui/list_core.go
@@ -127,6 +127,30 @@ func listCoreVisibleRange(itemCount int, rowHeight, listHeight, scrollY float32)
 	return firstVisible, lastVisible
 }
 
+// ListVisibleRange computes the visible index range with explicit
+// overscan. Same arithmetic as listCoreVisibleRange but takes the
+// buffer rows as an argument so callers can tune for their row height
+// (the internal listCoreVirtualBufferRows of 2 is tuned for ~20-32 px
+// rows, not 150+ px grid cards). Returns (0, -1) for degenerate inputs.
+func ListVisibleRange(itemCount int, rowHeight, listHeight,
+	scrollY float32, overscan int) (int, int) {
+	if itemCount == 0 || rowHeight <= 0 || listHeight <= 0 {
+		return 0, -1
+	}
+	maxIdx := itemCount - 1
+	absScroll := scrollY
+	if absScroll < 0 {
+		absScroll = -absScroll
+	}
+	first := max(0, min(maxIdx, int(absScroll/rowHeight)))
+	visibleRows := int(listHeight/rowHeight) + 1
+	buf := max(0, overscan)
+	firstVisible := max(0, first-buf)
+	lastVisible := min(maxIdx, first+visibleRows+buf)
+	lastVisible = max(lastVisible, firstVisible)
+	return firstVisible, lastVisible
+}
+
 // listCoreRowHeightEstimate estimates row height from text
 // style + padding. No Window needed. Uses the same 1.4×
 // line-height factor as text shape layout.

--- a/gui/window.go
+++ b/gui/window.go
@@ -22,6 +22,24 @@ type TextMeasurer interface {
 	LayoutText(text string, style TextStyle, wrapWidth float32) (glyph.Layout, error)
 }
 
+// FontLister is an optional capability on TextMeasurer backends.
+// Backends that wrap a *glyph.TextSystem opt in; others need no change.
+type FontLister interface {
+	ListFontFamilies() []string
+}
+
+// ListSystemFonts returns font family names from the active text
+// system's catalog, sorted case-insensitively. Returns nil before
+// backend init, on WASM stub backends, or on backends that do not
+// implement FontLister. Includes RegisterAppFont families once those
+// paths have been added to the text system.
+func ListSystemFonts(w *Window) []string {
+	if fl, ok := w.textMeasurer.(FontLister); ok {
+		return fl.ListFontFamilies()
+	}
+	return nil
+}
+
 // windowRender holds render-walk state reset each frame.
 type windowRender struct {
 	// Renderers — flat draw command list, reused via [:0].


### PR DESCRIPTION
## Summary

Adds `examples/fontviewer`: a browsable system-font catalog. A virtualized card grid renders editable sample text in every installed family, with name filtering, a 12–72 px size slider, and click-to-copy. Follows `docs/specs/font-viewer.md`.

Fixed-size cards are windowed to the visible range (`gui.ListVisibleRange`), so per-frame shaping is **O(visible), not O(N)** — important with 300+ families. A `--shape-all` flag drops virtualization to stress all-N main-thread shaping.

## Supporting API (consumed by the example)

- **`gui.ListSystemFonts`** + the optional **`FontLister`** backend capability, surfacing the active text system's family catalog (`window.go`). Backends opt in via a type assertion — no change forced on the mandatory `TextMeasurer` interface.
- **`gui.ListVisibleRange`**: exported visible-range helper taking overscan as an argument, tuned for tall grid cards (`list_core.go`).
- **`ListFontFamilies`** on each text backend (android, gl, ios, metal, web).

## Notes

- Independent of #95 — the example uses `FitFixed` rows, so it does not rely on that fix. Both PRs target `main` and can merge in any order.
- Desktop-only for v1: `ListSystemFonts` returns nil where no `FontLister` backend exists (WASM stub shows the empty state).

## Tests

Layout/state tests for filter, card height, visible-range spacer math, empty catalog, and no-panic view generation. `go build ./...`, `go vet ./...`, `golangci-lint run` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786883740&installation_id=145733661&pr_number=96&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F96&signature=9e1535b5f8fd66295aa186b76a10bb1ffdba05d6ada58d4cb6a70d9955f47e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->