### PR TITLE
examples/process_monitor: add live process monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Process monitor example.** New `examples/process_monitor` — a live task
+  manager: filterable process list with flat/tree views, sortable columns, and
+  per-process CPU/RAM history charts built from plain containers. Data is
+  collected dependency-free (`ps` on macOS/Linux, `tasklist` on Windows;
+  `/proc/meminfo` or `sysctl`+`vm_stat` for system memory), sampled on a
+  background goroutine that publishes under the window lock and refreshes via
+  `Window.UpdateWindow`. Styled entirely from the standard theme tokens.
+  Includes a headless `-once` terminal report. Functional port of the go-shirei
+  example of the same name.
+
 ## [v0.38.1] - 2026-07-17
 
 ### Changed

--- a/examples/process_monitor/README.md
+++ b/examples/process_monitor/README.md
@@ -1,0 +1,89 @@
+# process_monitor
+
+A small live task manager: a filterable process list with flat/tree views,
+sortable columns, and per-process CPU/RAM history charts — built on go-gui's
+immediate-mode pipeline and styled entirely from the standard theme tokens.
+
+It is a functional port of the [go-shirei `process_monitor`][shirei] example.
+The goal is feature parity, not a pixel-for-pixel visual match: the layout takes
+cues from other go-gui examples and the colors come from `gui.ThemeDark` /
+`gui.ThemeLight`, not hand-picked HSL values.
+
+[shirei]: https://go.hasen.dev
+
+## Features
+
+- Live process list: PID, CPU%, RSS, MEM%, USER, STATE, THREADS, NAME.
+- Click a column header to sort; click again to reverse.
+- Select a row for a detail panel with ~60s rolling CPU and RAM charts.
+- Filter box matching name, command line, user, or PID (substring, case-insensitive).
+- Flat list **or** parent/child tree (collapse a subtree with ▸/▾; an active
+  filter keeps matched processes' ancestors visible).
+- Sample-interval selector: 0.5s / 1s / 2s / 5s.
+- Metrics the OS won't report render `--`, never a fake `0`.
+- System memory bar in the header (shown only when the platform reports totals).
+
+## Run it
+
+```shell
+go run ./examples/process_monitor              # open the GUI
+go run ./examples/process_monitor -once        # print one report and exit
+go run ./examples/process_monitor -once -limit 20 -sort mem
+```
+
+Flags: `-once`, `-limit N`, `-sort cpu|mem|pid|name|user|state|threads`,
+`-refresh D` (GUI interval, snapped to the nearest preset).
+
+## How it works
+
+### Dependency-free data collection
+
+go-gui examples share the root module, so this example pulls in no third-party
+process library. It shells out to the OS instead:
+
+- **macOS / Linux** — parse `ps` (`collect_unix.go`). Linux also reports the
+  thread count via `nlwp`; macOS `ps` has no thread column, so THREADS shows
+  `--` there.
+- **Windows** — parse `tasklist` CSV (`collect_windows.go`). No live CPU% is
+  available from one call, so CPU shows `--`.
+- System memory totals come from `/proc/meminfo` (Linux) or `sysctl` + `vm_stat`
+  (macOS); other platforms omit the memory bar.
+
+**CPU% caveat:** on Unix the value is `ps`'s `%cpu`, which is a *lifetime
+average*, not an instantaneous interval rate. It is a real, useful number and
+needs only one sample; a delta-based interval CPU% (two cumulative-CPU-time
+reads) would be the enhancement.
+
+### Background sampling, UI only reads
+
+Sampling spawns a subprocess, so it runs on a background goroutine, off the
+frame path (`startSampler` in `main.go`). Each pass takes a snapshot, then
+publishes it under the window lock and asks for a layout refresh:
+
+```go
+snap, err := Collect()
+w.Lock()
+app.Snapshot = snap
+app.Store.Update(snap, app.Selected)
+w.UpdateWindow() // re-run the view against fresh state, preserving focus/scroll
+w.Unlock()
+```
+
+`UpdateWindow` (not `UpdateView`) re-runs the registered view without clearing
+the state registry, so the filter input keeps focus and the list keeps its
+scroll position across refreshes. The backend's idle poll repaints within
+~100 ms, so no explicit wake is needed at these intervals.
+
+### Stable processes + rolling history
+
+`ProcessStore` (`store.go`) keeps a stable `*Process` per identity so table rows
+and chart history survive across refreshes. Exited processes linger for 60 s
+(so their charts stay visible) and are then evicted — unless they are selected.
+
+### Charts from plain containers
+
+Each history chart (`chart.go`) is a row of bottom-anchored `Rectangle` bars in
+fixed 2-second time buckets — no canvas widget, no chart library.
+`resampleHistory` folds the irregularly-sampled history into those fixed buckets
+(averaging within a slot, linearly interpolating gaps) so the x-axis is always
+"last 60 s," independent of the sample rate.

--- a/examples/process_monitor/chart.go
+++ b/examples/process_monitor/chart.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"time"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+const (
+	historyWindow = 60 * time.Second
+	// 2s buckets over a 60s window give 30 bars across the panel — wide enough
+	// to read as bars rather than hairlines. Each bucket still averages its
+	// samples, so 1s sampling just puts two samples per bar.
+	historyBucket = 2 * time.Second
+
+	chartWidth  float32 = 340
+	chartBarsH  float32 = 56
+	barMinPixel float32 = 1
+)
+
+// HistBucket is one fixed time slot of a resampled history series.
+type HistBucket struct {
+	Value        float64
+	HasData      bool
+	Interpolated bool
+}
+
+// usageChart renders one fixed-window history chart as a row of container
+// bars — no canvas, no chart library. valueFn selects the metric; minScale is
+// the lowest the y-axis top may be (CPU pins at 100, RAM floats to the max
+// seen); fill is the bar color; fmtFn formats the scale readout.
+func usageChart(
+	p *Process,
+	title string,
+	minScale float64,
+	fill gui.Color,
+	valueFn func(ProcessPoint) float64,
+	fmtFn func(float64) string,
+) gui.View {
+	theme := gui.CurrentTheme()
+	buckets := resampleHistory(p.History, historyWindow, historyBucket, valueFn)
+
+	// The y-axis top is the larger of minScale and the biggest real sample.
+	scale := minScale
+	for _, b := range buckets {
+		if b.HasData && b.Value > scale {
+			scale = b.Value
+		}
+	}
+	if scale <= 0 {
+		scale = 1
+	}
+
+	fillDim := fill
+	fillDim.A = 120 // interpolated slots draw lighter
+
+	bars := make([]gui.View, 0, len(buckets))
+	for _, b := range buckets {
+		bars = append(bars, bucketBar(b, scale, fill, fillDim, theme))
+	}
+
+	return gui.Column(gui.ContainerCfg{
+		Width:   chartWidth,
+		Sizing:  gui.FixedFit,
+		Spacing: gui.SomeF(4),
+		Content: []gui.View{
+			gui.Row(gui.ContainerCfg{
+				Sizing:  gui.FillFit,
+				Padding: gui.NoPadding,
+				VAlign:  gui.VAlignMiddle,
+				Spacing: gui.SomeF(8),
+				Content: []gui.View{
+					gui.Text(gui.TextCfg{Text: title, TextStyle: theme.B5}),
+					gui.Text(gui.TextCfg{Text: "scale " + fmtFn(scale), TextStyle: theme.N6}),
+				},
+			}),
+			gui.Row(gui.ContainerCfg{
+				Width:   chartWidth,
+				Height:  chartBarsH,
+				Sizing:  gui.FixedFixed,
+				Clip:    true,
+				Radius:  gui.SomeF(theme.RadiusSmall),
+				Color:   theme.ColorInterior,
+				Padding: gui.SomeP(4, 4, 4, 4),
+				Spacing: gui.SomeF(1),
+				Content: bars,
+			}),
+		},
+	})
+}
+
+// bucketBar renders one time slot: a bottom-anchored bar sized to the metric,
+// or a faint baseline when the slot has no data.
+func bucketBar(b HistBucket, scale float64, fill, fillDim gui.Color, theme gui.Theme) gui.View {
+	if !b.HasData {
+		return gui.Column(gui.ContainerCfg{
+			Sizing:  gui.FillFill,
+			Padding: gui.NoPadding,
+			VAlign:  gui.VAlignBottom,
+			Content: []gui.View{
+				gui.Rectangle(gui.RectangleCfg{
+					Height: barMinPixel,
+					Sizing: gui.FillFixed,
+					Color:  theme.ColorBorder,
+				}),
+			},
+		})
+	}
+
+	ratio := b.Value / scale
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	barH := max(barMinPixel, float32(ratio)*(chartBarsH-8))
+	color := fill
+	if b.Interpolated {
+		color = fillDim
+	}
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		Padding: gui.NoPadding,
+		VAlign:  gui.VAlignBottom,
+		Content: []gui.View{
+			gui.Rectangle(gui.RectangleCfg{
+				Height: barH,
+				Sizing: gui.FillFixed,
+				Color:  color,
+				Radius: 1,
+			}),
+		},
+	})
+}
+
+// resampleHistory buckets raw, irregularly-spaced samples into a fixed number
+// of equal-duration time slots. The rightmost slot ends at the latest sample;
+// slots march left into the past; samples in the same slot are averaged; empty
+// slots between two real slots are linearly interpolated so slow sampling still
+// draws a continuous line. Slots before the first real sample stay empty rather
+// than inventing data.
+func resampleHistory(hist []ProcessPoint, window, bucket time.Duration, valueFn func(ProcessPoint) float64) []HistBucket {
+	n := max(int(window/bucket), 1)
+	buckets := make([]HistBucket, n)
+	if len(hist) == 0 {
+		return buckets
+	}
+
+	// Bucket on fixed wall-clock boundaries so historical bars do not shift as
+	// sub-second samples slide the latest timestamp forward each redraw.
+	bucketNS := bucket.Nanoseconds()
+	if bucketNS <= 0 {
+		bucketNS = int64(time.Second)
+	}
+	latestBucket := hist[len(hist)-1].Time.UnixNano() / bucketNS
+	sums := make([]float64, n)
+	counts := make([]int, n)
+	for _, pt := range hist {
+		ptBucket := pt.Time.UnixNano() / bucketNS
+		fromRight := max(latestBucket-ptBucket, 0)
+		idx := n - 1 - int(fromRight)
+		if idx < 0 || idx >= n {
+			continue
+		}
+		sums[idx] += valueFn(pt)
+		counts[idx]++
+	}
+	for i := range buckets {
+		if counts[i] > 0 {
+			buckets[i].Value = sums[i] / float64(counts[i])
+			buckets[i].HasData = true
+		}
+	}
+
+	// Linearly fill gaps between real slots.
+	prev := -1
+	for i := range n {
+		if !buckets[i].HasData {
+			continue
+		}
+		if prev >= 0 && i-prev > 1 {
+			for k := prev + 1; k < i; k++ {
+				t := float64(k-prev) / float64(i-prev)
+				buckets[k].Value = buckets[prev].Value + (buckets[i].Value-buckets[prev].Value)*t
+				buckets[k].HasData = true
+				buckets[k].Interpolated = true
+			}
+		}
+		prev = i
+	}
+	return buckets
+}
+
+// ramHistoryScale rounds the max RSS in history up to a 500 MiB step so the RAM
+// chart's y-axis is stable and readable.
+func ramHistoryScale(hist []ProcessPoint) float64 {
+	const step = 500 * 1024 * 1024
+	var maxRSS uint64
+	for _, pt := range hist {
+		if pt.RSSBytes > maxRSS {
+			maxRSS = pt.RSSBytes
+		}
+	}
+	if maxRSS == 0 {
+		return float64(step)
+	}
+	scale := ((maxRSS + step - 1) / step) * step
+	return float64(scale)
+}

--- a/examples/process_monitor/chart_test.go
+++ b/examples/process_monitor/chart_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func cpuOf(pt ProcessPoint) float64 { return pt.CPUPercent }
+
+func TestResampleHistoryEmpty(t *testing.T) {
+	t.Parallel()
+	buckets := resampleHistory(nil, 5*time.Second, time.Second, cpuOf)
+	if len(buckets) != 5 {
+		t.Fatalf("bucket count = %d, want 5", len(buckets))
+	}
+	for i, b := range buckets {
+		if b.HasData {
+			t.Fatalf("bucket %d should have no data for empty history", i)
+		}
+	}
+}
+
+func TestResampleHistoryBucketsAndInterpolation(t *testing.T) {
+	t.Parallel()
+	base := time.Unix(1_700_000_000, 0)
+	hist := []ProcessPoint{
+		{Time: base, CPUPercent: 0},
+		{Time: base.Add(2 * time.Second), CPUPercent: 20},
+		{Time: base.Add(4 * time.Second), CPUPercent: 40},
+	}
+	buckets := resampleHistory(hist, 5*time.Second, time.Second, cpuOf)
+	if len(buckets) != 5 {
+		t.Fatalf("bucket count = %d, want 5", len(buckets))
+	}
+
+	// Real samples land in slots 0, 2, 4; the gaps at 1 and 3 are interpolated.
+	want := []struct {
+		value  float64
+		data   bool
+		interp bool
+	}{
+		{0, true, false},
+		{10, true, true},
+		{20, true, false},
+		{30, true, true},
+		{40, true, false},
+	}
+	for i, w := range want {
+		b := buckets[i]
+		if b.HasData != w.data || b.Interpolated != w.interp || b.Value != w.value {
+			t.Fatalf("bucket %d = %+v, want value=%v data=%v interp=%v",
+				i, b, w.value, w.data, w.interp)
+		}
+	}
+}
+
+func TestResampleHistoryNoInterpolationBeforeFirstSample(t *testing.T) {
+	t.Parallel()
+	base := time.Unix(1_700_000_000, 0)
+	// A single sample in the newest slot; older slots must stay empty.
+	hist := []ProcessPoint{{Time: base.Add(4 * time.Second), CPUPercent: 50}}
+	buckets := resampleHistory(hist, 5*time.Second, time.Second, cpuOf)
+	for i := range 4 {
+		if buckets[i].HasData {
+			t.Fatalf("bucket %d should be empty before the first real sample", i)
+		}
+	}
+	if !buckets[4].HasData || buckets[4].Value != 50 {
+		t.Fatalf("newest bucket = %+v, want value=50 data=true", buckets[4])
+	}
+}
+
+func TestRamHistoryScale(t *testing.T) {
+	t.Parallel()
+	const step = 500 * 1024 * 1024
+	cases := []struct {
+		maxRSS uint64
+		want   float64
+	}{
+		{0, step},
+		{300 * 1024 * 1024, step},
+		{600 * 1024 * 1024, 2 * step},
+		{step, step},
+	}
+	for _, c := range cases {
+		hist := []ProcessPoint{{RSSBytes: c.maxRSS}}
+		if got := ramHistoryScale(hist); got != c.want {
+			t.Fatalf("ramHistoryScale(maxRSS=%d) = %v, want %v", c.maxRSS, got, c.want)
+		}
+	}
+}

--- a/examples/process_monitor/collect.go
+++ b/examples/process_monitor/collect.go
@@ -1,0 +1,72 @@
+// The process_monitor example is a small live task manager: a filterable
+// process list with flat/tree views, sortable columns, and per-process
+// CPU/RAM history charts. It is a functional port of the go-shirei
+// process_monitor example, rebuilt on go-gui's immediate-mode pipeline and
+// styled entirely from the standard theme tokens.
+//
+// Data is collected without any third-party dependency: on Unix by parsing
+// `ps`, on Windows by parsing `tasklist`. See collect_unix.go /
+// collect_windows.go. System memory totals come from sysmem_*.go.
+package main
+
+import "time"
+
+// CPUPercentUnknown marks a process whose CPU could not be measured. It sorts
+// below every real reading and renders as "--" rather than a fake 0.
+const CPUPercentUnknown float64 = -1
+
+// ProcInfo is one process as seen in a single sample. Fields that the OS
+// refused to report are left zero with MetricsUnknown set, so the UI can show
+// "--" instead of inventing data.
+type ProcInfo struct {
+	StartTime      time.Time
+	Name           string
+	Cmdline        string
+	User           string
+	State          string
+	RSSBytes       uint64
+	MemPercent     float64
+	CPUPercent     float64 // CPUPercentUnknown when unreadable
+	PID            int
+	PPID           int
+	Threads        int
+	MetricsUnknown bool
+}
+
+// Snapshot is one full sweep of the process table plus system memory.
+type Snapshot struct {
+	Time             time.Time
+	Processes        []ProcInfo
+	TotalMemoryBytes uint64
+	UsedMemoryBytes  uint64
+}
+
+// Collect takes one snapshot of the running processes. The platform-specific
+// collectProcesses (collect_unix.go / collect_windows.go / collect_other.go)
+// does the OS work; this wrapper fills in the memory totals and the derived
+// per-process memory share.
+func Collect() (*Snapshot, error) {
+	procs, err := collectProcesses()
+	if err != nil {
+		return nil, err
+	}
+
+	total, used := systemMemory()
+	snap := &Snapshot{
+		Time:             time.Now(),
+		Processes:        procs,
+		TotalMemoryBytes: total,
+		UsedMemoryBytes:  used,
+	}
+
+	// Derive each process's memory share now that the total is known.
+	if total > 0 {
+		for i := range snap.Processes {
+			p := &snap.Processes[i]
+			if !p.MetricsUnknown {
+				p.MemPercent = float64(p.RSSBytes) / float64(total) * 100
+			}
+		}
+	}
+	return snap, nil
+}

--- a/examples/process_monitor/collect_other.go
+++ b/examples/process_monitor/collect_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux && !windows
+
+package main
+
+import "errors"
+
+// collectProcesses is a stub for platforms without a supported collector. The
+// UI surfaces the error the same way it surfaces any sample failure.
+func collectProcesses() ([]ProcInfo, error) {
+	return nil, errors.New("process listing is not supported on this platform")
+}

--- a/examples/process_monitor/collect_unix.go
+++ b/examples/process_monitor/collect_unix.go
@@ -1,0 +1,155 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// collectProcesses shells out to `ps` and parses one line per process. This
+// keeps the example dependency-free while still working on macOS and Linux.
+//
+// The column list is chosen so every field except the last is a single
+// whitespace-free token; the trailing `args` column (the full command line)
+// absorbs the rest of the line. Linux additionally exposes `nlwp` (thread
+// count); macOS `ps` does not, so threads are reported as unknown there.
+func collectProcesses() ([]ProcInfo, error) {
+	linux := runtime.GOOS == "linux"
+
+	// Field order must match the parsing below. Trailing "=" suppresses the
+	// header line for every column.
+	format := "pid=,ppid=,pcpu=,rss=,state=,user=,args="
+	fixed := 6 // number of leading fixed tokens before args
+	if linux {
+		format = "pid=,ppid=,pcpu=,rss=,nlwp=,state=,user=,args="
+		fixed = 7
+	}
+
+	// #nosec G204 — format is a constant, not user input.
+	cmd := exec.Command("ps", "-axo", format)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var procs []ProcInfo
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), "\n")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		p, ok := parsePSLine(line, linux, fixed)
+		if ok {
+			procs = append(procs, p)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return procs, nil
+}
+
+// parsePSLine splits one `ps` line into its fixed columns plus the free-form
+// command line. Unparseable numeric fields fall back to MetricsUnknown so the
+// row still lists but shows "--" for the missing metric.
+func parsePSLine(line string, linux bool, fixed int) (ProcInfo, bool) {
+	// Fields() collapses runs of spaces; the trailing args column can contain
+	// spaces, so grab the fixed columns first and keep the remainder intact.
+	fields := strings.Fields(line)
+	if len(fields) < fixed {
+		return ProcInfo{}, false
+	}
+
+	pid, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return ProcInfo{}, false
+	}
+	p := ProcInfo{PID: pid}
+	p.PPID, _ = strconv.Atoi(fields[1])
+
+	if cpu, err := strconv.ParseFloat(fields[2], 64); err == nil {
+		p.CPUPercent = cpu
+	} else {
+		p.CPUPercent = CPUPercentUnknown
+		p.MetricsUnknown = true
+	}
+
+	// RSS is reported in KiB.
+	if rssKiB, err := strconv.ParseUint(fields[3], 10, 64); err == nil {
+		p.RSSBytes = rssKiB * 1024
+	} else {
+		p.MetricsUnknown = true
+	}
+
+	idx := 4
+	if linux {
+		if n, err := strconv.Atoi(fields[idx]); err == nil {
+			p.Threads = n
+		} else {
+			p.MetricsUnknown = true
+		}
+		idx++
+	}
+	// macOS ps has no thread column; Threads stays 0 and ThreadsText renders
+	// "--". That is not a metrics failure, so MetricsUnknown is left unset.
+
+	p.State = normalizeState(fields[idx])
+	idx++
+	p.User = fields[idx]
+	idx++
+
+	// The command line is everything from the first args token to end of line.
+	// Recover it from the original string to preserve internal spacing.
+	p.Cmdline = commandTail(line, fields[:idx])
+	p.Name = processName(p.Cmdline)
+	return p, true
+}
+
+// commandTail returns the portion of line following the already-consumed
+// leading tokens, trimmed of leading whitespace.
+func commandTail(line string, consumed []string) string {
+	rest := line
+	for _, tok := range consumed {
+		i := strings.Index(rest, tok)
+		if i < 0 {
+			return strings.TrimSpace(rest)
+		}
+		rest = rest[i+len(tok):]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// processName derives a short display name from a command line: the base name
+// of the executable (first argument).
+func processName(cmdline string) string {
+	if cmdline == "" {
+		return "?"
+	}
+	first := cmdline
+	if before, _, ok := strings.Cut(cmdline, " "); ok {
+		first = before
+	}
+	base := filepath.Base(first)
+	if base == "" || base == "." || base == "/" {
+		return cmdline
+	}
+	return base
+}
+
+// normalizeState keeps the primary process-state letter and drops trailing
+// scheduler flags (e.g. "Ss" -> "S", "R+" -> "R") so the STATE column stays
+// narrow and comparable across platforms.
+func normalizeState(s string) string {
+	if s == "" {
+		return "?"
+	}
+	return s[:1]
+}

--- a/examples/process_monitor/collect_windows.go
+++ b/examples/process_monitor/collect_windows.go
@@ -1,0 +1,87 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/csv"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// collectProcesses parses `tasklist` CSV output on Windows. This lists every
+// process with image name, PID, memory usage, status, and user, keeping the
+// example dependency-free. Live per-interval CPU% is not available from a
+// single tasklist call, so CPU is reported as unknown (renders "--"); a
+// two-sample CPU-time delta would be the enhancement.
+func collectProcesses() ([]ProcInfo, error) {
+	// /v = verbose (adds Status and User Name columns), /fo csv, /nh = no header.
+	// #nosec G204 — all arguments are constants.
+	cmd := exec.Command("tasklist", "/fo", "csv", "/nh", "/v")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	r := csv.NewReader(strings.NewReader(string(out)))
+	r.FieldsPerRecord = -1 // rows vary; be lenient
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	// Verbose column order: Image Name, PID, Session Name, Session#,
+	// Mem Usage, Status, User Name, CPU Time, Window Title.
+	procs := make([]ProcInfo, 0, len(records))
+	for _, rec := range records {
+		if len(rec) < 7 {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(rec[1]))
+		if err != nil {
+			continue
+		}
+		p := ProcInfo{
+			PID:            pid,
+			Name:           imageBase(rec[0]),
+			Cmdline:        rec[0],
+			User:           rec[6],
+			State:          shortStatus(rec[5]),
+			RSSBytes:       parseMemUsage(rec[4]),
+			CPUPercent:     CPUPercentUnknown,
+			MetricsUnknown: true, // no live CPU% / thread count from tasklist
+		}
+		procs = append(procs, p)
+	}
+	return procs, nil
+}
+
+// parseMemUsage turns a "12,345 K" mem-usage string into bytes.
+func parseMemUsage(s string) uint64 {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, " K")
+	s = strings.ReplaceAll(s, ",", "")
+	s = strings.ReplaceAll(s, " ", "") // non-breaking space thousands sep
+	kib, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return kib * 1024
+}
+
+func imageBase(name string) string {
+	base := filepath.Base(strings.TrimSpace(name))
+	if base == "" {
+		return "?"
+	}
+	return base
+}
+
+func shortStatus(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "?"
+	}
+	return s[:1]
+}

--- a/examples/process_monitor/format.go
+++ b/examples/process_monitor/format.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 )
@@ -37,7 +38,7 @@ func (p *ProcInfo) ThreadsText() string {
 
 // formatCPU renders a CPU percentage, with "--" for unreadable values.
 func formatCPU(v float64) string {
-	if v < 0 {
+	if v < 0 || math.IsNaN(v) {
 		return "--"
 	}
 	return fmt.Sprintf("%.1f", v)
@@ -45,7 +46,7 @@ func formatCPU(v float64) string {
 
 // formatCPUPercent is formatCPU with a trailing percent sign.
 func formatCPUPercent(v float64) string {
-	if v < 0 {
+	if v < 0 || math.IsNaN(v) {
 		return "--"
 	}
 	return fmt.Sprintf("%.1f%%", v)

--- a/examples/process_monitor/format.go
+++ b/examples/process_monitor/format.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Metric cell text: "--" when the OS refused the reading, never a fake 0.
+
+// CPUText renders CPU% with one decimal, or "--" when unknown.
+func (p *ProcInfo) CPUText() string { return formatCPU(p.CPUPercent) }
+
+// RSSText renders resident memory, or "--" when unknown.
+func (p *ProcInfo) RSSText() string {
+	if p.MetricsUnknown {
+		return "--"
+	}
+	return formatBytes(p.RSSBytes)
+}
+
+// MemText renders memory share as a percentage, or "--" when unknown.
+func (p *ProcInfo) MemText() string {
+	if p.MetricsUnknown {
+		return "--"
+	}
+	return fmt.Sprintf("%.2f%%", p.MemPercent)
+}
+
+// ThreadsText renders the thread count, or "--" when unknown.
+func (p *ProcInfo) ThreadsText() string {
+	if p.MetricsUnknown || p.Threads <= 0 {
+		return "--"
+	}
+	return strconv.Itoa(p.Threads)
+}
+
+// formatCPU renders a CPU percentage, with "--" for unreadable values.
+func formatCPU(v float64) string {
+	if v < 0 {
+		return "--"
+	}
+	return fmt.Sprintf("%.1f", v)
+}
+
+// formatCPUPercent is formatCPU with a trailing percent sign.
+func formatCPUPercent(v float64) string {
+	if v < 0 {
+		return "--"
+	}
+	return fmt.Sprintf("%.1f%%", v)
+}
+
+// formatBytes renders a byte count with a binary unit suffix.
+func formatBytes(v uint64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+		tb = gb * 1024
+	)
+	switch {
+	case v >= tb:
+		return fmt.Sprintf("%.1fT", float64(v)/tb)
+	case v >= gb:
+		return fmt.Sprintf("%.1fG", float64(v)/gb)
+	case v >= mb:
+		return fmt.Sprintf("%.1fM", float64(v)/mb)
+	case v >= kb:
+		return fmt.Sprintf("%.1fK", float64(v)/kb)
+	default:
+		return fmt.Sprintf("%dB", v)
+	}
+}
+
+// formatCount renders an integer with thousands separators.
+func formatCount(v int) string {
+	s := strconv.Itoa(v)
+	if len(s) <= 3 {
+		return s
+	}
+	var out []byte
+	for i, c := range []byte(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// formatTime renders a timestamp as a clock (today) or short date.
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	if time.Since(t) < 24*time.Hour {
+		return t.Format("15:04:05")
+	}
+	return t.Format("Jan 2 15:04")
+}
+
+// truncate shortens s to at most n runes, appending an ellipsis.
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	if n == 1 {
+		return "…"
+	}
+	return string(r[:n-1]) + "…"
+}

--- a/examples/process_monitor/format_test.go
+++ b/examples/process_monitor/format_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestFormatCPUNegativeAndZero(t *testing.T) {
+	t.Parallel()
+	if got := formatCPU(-1); got != "--" {
+		t.Fatalf("formatCPU(-1) = %q, want \"--\"", got)
+	}
+	if got := formatCPU(0); got != "0.0" {
+		t.Fatalf("formatCPU(0) = %q, want \"0.0\"", got)
+	}
+}
+
+func TestFormatCPUNaN(t *testing.T) {
+	t.Parallel()
+	if got := formatCPU(math.NaN()); got != "--" {
+		t.Fatalf("formatCPU(NaN) = %q, want \"--\"", got)
+	}
+	if got := formatCPUPercent(math.NaN()); got != "--" {
+		t.Fatalf("formatCPUPercent(NaN) = %q, want \"--\"", got)
+	}
+}
+
+func TestFormatCPUPercent(t *testing.T) {
+	t.Parallel()
+	if got := formatCPUPercent(-1); got != "--" {
+		t.Fatalf("formatCPUPercent(-1) = %q, want \"--\"", got)
+	}
+	if got := formatCPUPercent(42.5); got != "42.5%" {
+		t.Fatalf("formatCPUPercent(42.5) = %q, want \"42.5%%\"", got)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		v    uint64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024, "1.0K"},
+		{1536, "1.5K"},
+		{1024 * 1024, "1.0M"},
+		{1024 * 1024 * 1024, "1.0G"},
+		{1024 * 1024 * 1024 * 1024, "1.0T"},
+	}
+	for _, c := range cases {
+		if got := formatBytes(c.v); got != c.want {
+			t.Fatalf("formatBytes(%d) = %q, want %q", c.v, got, c.want)
+		}
+	}
+}
+
+func TestFormatCount(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		v    int
+		want string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1,000"},
+		{1000000, "1,000,000"},
+		{1234567890, "1,234,567,890"},
+	}
+	for _, c := range cases {
+		if got := formatCount(c.v); got != c.want {
+			t.Fatalf("formatCount(%d) = %q, want %q", c.v, got, c.want)
+		}
+	}
+}
+
+func TestFormatTimeZero(t *testing.T) {
+	t.Parallel()
+	if got := formatTime(time.Time{}); got != "unknown" {
+		t.Fatalf("formatTime(zero) = %q, want \"unknown\"", got)
+	}
+}
+
+func TestFormatTimeRecent(t *testing.T) {
+	t.Parallel()
+	now := time.Now().Add(-2 * time.Second)
+	got := formatTime(now)
+	if got == "unknown" {
+		t.Fatal("recent time should not render as unknown")
+	}
+	// The format is HH:MM:SS for recent times.
+	if len(got) != 8 {
+		t.Fatalf("expected clock format (8 chars), got %q", got)
+	}
+}
+
+func TestFormatTimeOld(t *testing.T) {
+	t.Parallel()
+	old := time.Now().Add(-48 * time.Hour)
+	got := formatTime(old)
+	if got == "unknown" {
+		t.Fatal("old time should not render as unknown")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		s    string
+		n    int
+		want string
+	}{
+		{"", 0, ""},
+		{"hello", -1, ""},
+		{"hello", 0, ""},
+		{"h", 1, "h"},
+		{"hello", 1, "…"},
+		{"hello", 5, "hello"},
+		{"hello", 6, "hello"},
+		{"hello world", 7, "hello …"},
+	}
+	for _, c := range cases {
+		if got := truncate(c.s, c.n); got != c.want {
+			t.Fatalf("truncate(%q, %d) = %q, want %q", c.s, c.n, got, c.want)
+		}
+	}
+}
+
+func TestProcInfoCPUText(t *testing.T) {
+	t.Parallel()
+	p := ProcInfo{CPUPercent: -1}
+	if got := p.CPUText(); got != "--" {
+		t.Fatalf("CPUText(unknown) = %q, want \"--\"", got)
+	}
+	p.CPUPercent = 12.3
+	if got := p.CPUText(); got != "12.3" {
+		t.Fatalf("CPUText(12.3) = %q, want \"12.3\"", got)
+	}
+}
+
+func TestProcInfoRSSText(t *testing.T) {
+	t.Parallel()
+	p := ProcInfo{MetricsUnknown: true}
+	if got := p.RSSText(); got != "--" {
+		t.Fatalf("RSSText(unknown) = %q, want \"--\"", got)
+	}
+	p = ProcInfo{RSSBytes: 10 << 20}
+	if got := p.RSSText(); got != "10.0M" {
+		t.Fatalf("RSSText(10MiB) = %q, want \"10.0M\"", got)
+	}
+}
+
+func TestProcInfoMemText(t *testing.T) {
+	t.Parallel()
+	p := ProcInfo{MetricsUnknown: true}
+	if got := p.MemText(); got != "--" {
+		t.Fatalf("MemText(unknown) = %q, want \"--\"", got)
+	}
+	p = ProcInfo{MemPercent: 3.75}
+	if got := p.MemText(); got != "3.75%" {
+		t.Fatalf("MemText(3.75) = %q, want \"3.75%%\"", got)
+	}
+}
+
+func TestProcInfoThreadsText(t *testing.T) {
+	t.Parallel()
+	p := ProcInfo{MetricsUnknown: true}
+	if got := p.ThreadsText(); got != "--" {
+		t.Fatalf("ThreadsText(unknown flags) = %q, want \"--\"", got)
+	}
+	p = ProcInfo{MetricsUnknown: false, Threads: 0}
+	if got := p.ThreadsText(); got != "--" {
+		t.Fatalf("ThreadsText(0 threads) = %q, want \"--\"", got)
+	}
+	p = ProcInfo{Threads: 4}
+	if got := p.ThreadsText(); got != "4" {
+		t.Fatalf("ThreadsText(4) = %q, want \"4\"", got)
+	}
+}

--- a/examples/process_monitor/main.go
+++ b/examples/process_monitor/main.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"flag"
+	"time"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend"
+)
+
+// sortState is threaded through the table header and the row ordering so a
+// header click and the -sort flag pick the same column.
+type sortState struct {
+	Column int
+	Desc   bool
+}
+
+// App is the window's typed state slot. The sampler goroutine writes it under
+// the window lock; the view reads it (the view already runs under that lock).
+type App struct {
+	Snapshot    *Snapshot
+	Err         error
+	Store       *ProcessStore
+	Selected    *Process
+	LastRefresh time.Time
+	Filter      string
+	Interval    time.Duration
+	Sort        sortState
+	TreeMode    bool
+}
+
+// Sample interval presets shown by the toolbar radio group.
+var intervalLabels = []string{"0.5s", "1s", "2s", "5s"}
+
+func main() {
+	once := flag.Bool("once", false, "print one terminal report and exit instead of opening the GUI")
+	limit := flag.Int("limit", 10, "number of processes to print in -once mode")
+	sortBy := flag.String("sort", "cpu", "sort column: cpu, mem, pid, name, user, state, threads")
+	refresh := flag.Duration("refresh", time.Second, "GUI sample interval (snapped to 0.5s/1s/2s/5s)")
+	flag.Parse()
+
+	if *once {
+		runOnce(*limit, *sortBy)
+		return
+	}
+
+	gui.SetTheme(gui.ThemeDark.WithBorders(true))
+
+	col := sortColumnIndex(*sortBy)
+	state := &App{
+		Store:    NewProcessStore(),
+		Interval: snapInterval(*refresh),
+		Sort:     sortState{Column: col, Desc: colDefs[col].desc},
+	}
+
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  state,
+		Title:  "Process Monitor",
+		Width:  1100,
+		Height: 700,
+		OnInit: func(w *gui.Window) {
+			// Register the view once; the sampler re-runs it via UpdateWindow.
+			w.UpdateView(rootView)
+			startSampler(w)
+		},
+	})
+
+	backend.Run(w)
+}
+
+// startSampler launches the background sampling loop. Sampling spawns a
+// subprocess (ps/tasklist), so it must run off the frame thread. Each pass
+// takes a snapshot, then publishes it under the window lock and requests a
+// layout refresh; the backend's idle poll repaints within ~100ms.
+func startSampler(w *gui.Window) {
+	go func() {
+		for {
+			snap, err := Collect()
+
+			w.Lock()
+			app := gui.State[App](w)
+			app.Snapshot = snap
+			app.Err = err
+			if snap != nil {
+				app.LastRefresh = snap.Time
+				app.Store.Update(snap, app.Selected)
+				// Auto-select the top row on the first successful sample.
+				if app.Selected == nil {
+					less := colDefs[app.Sort.Column].less
+					rows := visibleRows(app.Store.Processes(), "", less, app.Sort.Desc, false)
+					if len(rows) > 0 {
+						app.Selected = rows[0]
+					}
+				}
+			}
+			interval := app.Interval
+			// UpdateWindow (not UpdateView) re-runs the view against fresh state
+			// WITHOUT clearing the state registry, so the filter input keeps
+			// focus and the process list keeps its scroll position.
+			w.UpdateWindow()
+			w.Unlock()
+
+			if interval <= 0 {
+				interval = time.Second
+			}
+			time.Sleep(interval)
+		}
+	}()
+}
+
+// sortColumnIndex maps a -sort flag value to a column index.
+func sortColumnIndex(key string) int {
+	switch key {
+	case "pid":
+		return colPID
+	case "mem", "rss":
+		return colRSS
+	case "user":
+		return colUser
+	case "state":
+		return colState
+	case "threads", "thr":
+		return colThreads
+	case "name":
+		return colName
+	default: // "cpu" and anything unrecognized
+		return colCPU
+	}
+}
+
+// snapInterval rounds an arbitrary duration to the nearest toolbar preset so
+// the radio selection always matches the running interval.
+func snapInterval(d time.Duration) time.Duration {
+	presets := []time.Duration{
+		500 * time.Millisecond, time.Second, 2 * time.Second, 5 * time.Second,
+	}
+	if d <= 0 {
+		return time.Second
+	}
+	best, bestDiff := presets[0], absDuration(d-presets[0])
+	for _, p := range presets[1:] {
+		if diff := absDuration(d - p); diff < bestDiff {
+			best, bestDiff = p, diff
+		}
+	}
+	return best
+}
+
+// intervalLabel renders a duration as its preset label.
+func intervalLabel(d time.Duration) string {
+	switch d {
+	case 500 * time.Millisecond:
+		return "0.5s"
+	case 2 * time.Second:
+		return "2s"
+	case 5 * time.Second:
+		return "5s"
+	default:
+		return "1s"
+	}
+}
+
+// intervalFromLabel is the inverse of intervalLabel.
+func intervalFromLabel(s string) time.Duration {
+	switch s {
+	case "0.5s":
+		return 500 * time.Millisecond
+	case "2s":
+		return 2 * time.Second
+	case "5s":
+		return 5 * time.Second
+	default:
+		return time.Second
+	}
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}

--- a/examples/process_monitor/main_test.go
+++ b/examples/process_monitor/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSortColumnIndex(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		key  string
+		want int
+	}{
+		{"pid", colPID},
+		{"cpu", colCPU},
+		{"mem", colRSS},
+		{"rss", colRSS},
+		{"user", colUser},
+		{"state", colState},
+		{"threads", colThreads},
+		{"thr", colThreads},
+		{"name", colName},
+		{"unknown", colCPU}, // default
+		{"", colCPU},        // default
+	}
+	for _, c := range cases {
+		if got := sortColumnIndex(c.key); got != c.want {
+			t.Fatalf("sortColumnIndex(%q) = %d, want %d", c.key, got, c.want)
+		}
+	}
+}
+
+func TestSnapInterval(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		d    time.Duration
+		want time.Duration
+	}{
+		{0, time.Second},                 // zero snaps to 1s
+		{-time.Millisecond, time.Second}, // negative snaps to 1s
+		{400 * time.Millisecond, 500 * time.Millisecond},
+		{700 * time.Millisecond, 500 * time.Millisecond}, // closer to 500ms than 1s
+		{1200 * time.Millisecond, time.Second},
+		{1500 * time.Millisecond, time.Second}, // equidistant to 1s and 2s, first wins
+		{3 * time.Second, 2 * time.Second},
+		{3800 * time.Millisecond, 5 * time.Second},
+		{10 * time.Second, 5 * time.Second},
+	}
+	for _, c := range cases {
+		if got := snapInterval(c.d); got != c.want {
+			t.Fatalf("snapInterval(%v) = %v, want %v", c.d, got, c.want)
+		}
+	}
+}
+
+func TestIntervalLabelRoundtrip(t *testing.T) {
+	t.Parallel()
+	for _, d := range []time.Duration{
+		500 * time.Millisecond, time.Second, 2 * time.Second, 5 * time.Second,
+	} {
+		label := intervalLabel(d)
+		back := intervalFromLabel(label)
+		if back != d {
+			t.Fatalf("interval roundtrip: %v -> %q -> %v", d, label, back)
+		}
+	}
+}
+
+func TestAbsDuration(t *testing.T) {
+	t.Parallel()
+	if got := absDuration(5 * time.Second); got != 5*time.Second {
+		t.Fatalf("absDuration(5s) = %v", got)
+	}
+	if got := absDuration(-3 * time.Second); got != 3*time.Second {
+		t.Fatalf("absDuration(-3s) = %v", got)
+	}
+	if got := absDuration(0); got != 0 {
+		t.Fatalf("absDuration(0) = %v", got)
+	}
+}

--- a/examples/process_monitor/once.go
+++ b/examples/process_monitor/once.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+)
+
+// runOnce prints a single sorted process report to stdout and exits — a quick
+// headless check that needs no window. It relies on the collector's snapshot
+// CPU% (ps pcpu on Unix), so no second sample is required.
+func runOnce(limit int, sortBy string) {
+	snap, err := Collect()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "sample:", err)
+		os.Exit(1)
+	}
+
+	procs := append([]ProcInfo(nil), snap.Processes...)
+	sortProcInfos(procs, sortBy)
+
+	if limit > len(procs) {
+		limit = len(procs)
+	}
+	if limit < 0 {
+		limit = 0
+	}
+
+	fmt.Printf("Top %d processes by %s\n", limit, sortBy)
+	if snap.TotalMemoryBytes > 0 {
+		fmt.Printf("Memory: %s used / %s total\n",
+			formatBytes(snap.UsedMemoryBytes), formatBytes(snap.TotalMemoryBytes))
+	}
+	fmt.Println()
+	fmt.Printf("%-7s %7s %9s %7s %-12s %-5s %5s %s\n",
+		"PID", "CPU%", "RSS", "MEM%", "USER", "STATE", "THR", "NAME")
+	for _, p := range procs[:limit] {
+		fmt.Printf("%-7d %7s %9s %7s %-12.12s %-5s %5s %s\n",
+			p.PID, p.CPUText(), p.RSSText(), p.MemText(),
+			p.User, p.State, p.ThreadsText(), truncate(nameOr(p), 80))
+	}
+}
+
+// nameOr falls back to the command line when the name is empty.
+func nameOr(p ProcInfo) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Cmdline
+}
+
+// sortProcInfos sorts snapshot rows for -once. High-to-low for the numeric
+// metrics, alphabetical for the text columns, with a PID tiebreak.
+func sortProcInfos(procs []ProcInfo, sortBy string) {
+	switch sortColumnIndex(sortBy) {
+	case colPID:
+		sort.SliceStable(procs, func(i, j int) bool { return procs[i].PID < procs[j].PID })
+	case colRSS:
+		sort.SliceStable(procs, func(i, j int) bool {
+			if procs[i].RSSBytes != procs[j].RSSBytes {
+				return procs[i].RSSBytes > procs[j].RSSBytes
+			}
+			return procs[i].PID < procs[j].PID
+		})
+	case colUser:
+		sort.SliceStable(procs, func(i, j int) bool {
+			if procs[i].User != procs[j].User {
+				return procs[i].User < procs[j].User
+			}
+			return procs[i].PID < procs[j].PID
+		})
+	case colState:
+		sort.SliceStable(procs, func(i, j int) bool {
+			if procs[i].State != procs[j].State {
+				return procs[i].State < procs[j].State
+			}
+			return procs[i].PID < procs[j].PID
+		})
+	case colThreads:
+		sort.SliceStable(procs, func(i, j int) bool {
+			if procs[i].Threads != procs[j].Threads {
+				return procs[i].Threads > procs[j].Threads
+			}
+			return procs[i].PID < procs[j].PID
+		})
+	case colName:
+		sort.SliceStable(procs, func(i, j int) bool {
+			if procs[i].Name != procs[j].Name {
+				return procs[i].Name < procs[j].Name
+			}
+			return procs[i].PID < procs[j].PID
+		})
+	default: // colCPU
+		sort.SliceStable(procs, func(i, j int) bool {
+			if procs[i].CPUPercent != procs[j].CPUPercent {
+				return procs[i].CPUPercent > procs[j].CPUPercent
+			}
+			return procs[i].PID < procs[j].PID
+		})
+	}
+}

--- a/examples/process_monitor/store.go
+++ b/examples/process_monitor/store.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	maxHistoryPoints = 240
+	keepStoppedFor   = 60 * time.Second
+)
+
+// ProcessKey identifies a process across samples. Including StartTime guards
+// against PID reuse; our collectors do not populate StartTime yet, so in
+// practice the key is PID-only. Documented limitation (see README).
+type ProcessKey struct {
+	StartTime time.Time
+	PID       int
+}
+
+// ProcessPoint is one history sample for the charts.
+type ProcessPoint struct {
+	Time       time.Time
+	CPUPercent float64
+	RSSBytes   uint64
+}
+
+// Process is a stable, store-owned view of a process: the latest sample plus
+// rolling history and tree-view scratch. Table rows bind to *Process pointers
+// so selection and history survive across refreshes.
+type Process struct {
+	ProcInfo
+	Key       ProcessKey
+	LastSeen  time.Time
+	StoppedAt time.Time
+	History   []ProcessPoint
+
+	// Collapsed hides this process's children in tree view.
+	Collapsed bool
+
+	// Tree scratch, recomputed each time visible rows are built.
+	TreeDepth      int
+	TreeChildCount int
+}
+
+// Running reports whether the process was present in the latest sample.
+func (p *Process) Running() bool { return p.StoppedAt.IsZero() }
+
+// appendHistory pushes one point, capping the ring buffer at maxHistoryPoints.
+func (p *Process) appendHistory(t time.Time, cpu float64, rss uint64) {
+	p.History = append(p.History, ProcessPoint{Time: t, CPUPercent: cpu, RSSBytes: rss})
+	if len(p.History) > maxHistoryPoints {
+		copy(p.History, p.History[len(p.History)-maxHistoryPoints:])
+		p.History = p.History[:maxHistoryPoints]
+	}
+}
+
+// ProcessStore keeps a stable *Process per identity and ages out processes
+// that have exited.
+type ProcessStore struct {
+	ByKey map[ProcessKey]*Process
+}
+
+// NewProcessStore returns an empty store.
+func NewProcessStore() *ProcessStore {
+	return &ProcessStore{ByKey: make(map[ProcessKey]*Process)}
+}
+
+func processKey(info ProcInfo) ProcessKey {
+	return ProcessKey{PID: info.PID, StartTime: info.StartTime}
+}
+
+// Update folds a snapshot into the store: refresh live processes, append
+// history, and mark then eventually evict processes that have disappeared.
+// selected is never evicted so its detail/charts stay visible.
+func (s *ProcessStore) Update(snap *Snapshot, selected *Process) {
+	if snap == nil {
+		return
+	}
+	if s.ByKey == nil {
+		s.ByKey = make(map[ProcessKey]*Process)
+	}
+
+	seen := make(map[ProcessKey]bool, len(snap.Processes))
+	for _, info := range snap.Processes {
+		key := processKey(info)
+		p := s.ByKey[key]
+		if p == nil {
+			p = &Process{Key: key}
+			s.ByKey[key] = p
+		}
+		p.ProcInfo = info
+		p.LastSeen = snap.Time
+		p.StoppedAt = time.Time{}
+		// Unknown CPU charts as a flat 0 line; the row label carries the "--".
+		p.appendHistory(snap.Time, max(info.CPUPercent, 0), info.RSSBytes)
+		seen[key] = true
+	}
+
+	for key, p := range s.ByKey {
+		if seen[key] {
+			continue
+		}
+		if p.StoppedAt.IsZero() {
+			p.StoppedAt = snap.Time
+			p.State = "x"
+			p.CPUPercent = 0
+			p.appendHistory(snap.Time, 0, p.RSSBytes)
+		}
+		if p != selected && snap.Time.Sub(p.StoppedAt) > keepStoppedFor {
+			delete(s.ByKey, key)
+		}
+	}
+}
+
+// Processes returns a snapshot slice of every tracked process (random order).
+func (s *ProcessStore) Processes() []*Process {
+	if s == nil {
+		return nil
+	}
+	out := make([]*Process, 0, len(s.ByKey))
+	for _, p := range s.ByKey {
+		out = append(out, p)
+	}
+	return out
+}
+
+// ActiveCount returns the number of currently-running processes.
+func (s *ProcessStore) ActiveCount() int {
+	if s == nil {
+		return 0
+	}
+	var n int
+	for _, p := range s.ByKey {
+		if p.Running() {
+			n++
+		}
+	}
+	return n
+}
+
+// visibleRows applies the filter and ordering (or tree flattening) to produce
+// the ordered rows the table displays.
+func visibleRows(procs []*Process, filter string, less func(a, b *Process) bool, desc, tree bool) []*Process {
+	needle := strings.ToLower(strings.TrimSpace(filter))
+	if tree {
+		return treeRows(procs, needle, less, desc)
+	}
+	rows := make([]*Process, 0, len(procs))
+	for _, p := range procs {
+		if needle == "" || processMatches(p, needle) {
+			rows = append(rows, p)
+		}
+	}
+	orderProcesses(rows, less, desc)
+	return rows
+}
+
+// orderProcesses sorts in place by the column comparator, honoring direction.
+// A nil comparator keeps the given order.
+func orderProcesses(procs []*Process, less func(a, b *Process) bool, desc bool) {
+	if less == nil {
+		return
+	}
+	sort.SliceStable(procs, func(i, j int) bool {
+		if desc {
+			return less(procs[j], procs[i])
+		}
+		return less(procs[i], procs[j])
+	})
+}
+
+// treeRows arranges processes as a PPID forest flattened depth-first. Sibling
+// order follows the active sort. Collapsed subtrees are hidden. When a filter
+// is active only matching processes and their ancestors are shown, and
+// collapse state is ignored so matches stay visible.
+func treeRows(procs []*Process, needle string, less func(a, b *Process) bool, desc bool) []*Process {
+	byPID := make(map[int]*Process, len(procs))
+	for _, p := range procs {
+		byPID[p.PID] = p
+	}
+
+	parentOf := func(p *Process) *Process {
+		parent, ok := byPID[p.PPID]
+		if !ok || parent == p {
+			return nil
+		}
+		return parent
+	}
+
+	children := make(map[int][]*Process)
+	var roots []*Process
+	for _, p := range procs {
+		if parent := parentOf(p); parent != nil {
+			children[parent.PID] = append(children[parent.PID], p)
+		} else {
+			roots = append(roots, p)
+		}
+	}
+
+	// Filtering: include matches plus their ancestor chain.
+	var visible map[*Process]bool
+	if needle != "" {
+		visible = make(map[*Process]bool)
+		for _, p := range procs {
+			if !processMatches(p, needle) {
+				continue
+			}
+			for cur := p; cur != nil && !visible[cur]; cur = parentOf(cur) {
+				visible[cur] = true
+			}
+		}
+	}
+
+	shownChildren := func(p *Process) []*Process {
+		kids := children[p.PID]
+		if visible == nil {
+			return kids
+		}
+		var out []*Process
+		for _, c := range kids {
+			if visible[c] {
+				out = append(out, c)
+			}
+		}
+		return out
+	}
+
+	orderProcesses(roots, less, desc)
+
+	var rows []*Process
+	seen := make(map[*Process]bool)
+	var walk func(p *Process, depth int)
+	walk = func(p *Process, depth int) {
+		if seen[p] {
+			return // cycle guard
+		}
+		seen[p] = true
+
+		kids := shownChildren(p)
+		orderProcesses(kids, less, desc)
+		p.TreeDepth = depth
+		p.TreeChildCount = len(kids)
+		rows = append(rows, p)
+
+		expanded := !p.Collapsed || visible != nil
+		if expanded {
+			for _, c := range kids {
+				walk(c, depth+1)
+			}
+		}
+	}
+	for _, r := range roots {
+		if visible != nil && !visible[r] {
+			continue
+		}
+		walk(r, 0)
+	}
+	return rows
+}
+
+// processMatches reports whether the process matches the lowercased needle in
+// name, command line, user, or PID.
+func processMatches(p *Process, needle string) bool {
+	return strings.Contains(strings.ToLower(p.Name), needle) ||
+		strings.Contains(strings.ToLower(p.Cmdline), needle) ||
+		strings.Contains(strings.ToLower(p.User), needle) ||
+		strings.Contains(strconv.Itoa(p.PID), needle)
+}

--- a/examples/process_monitor/store_test.go
+++ b/examples/process_monitor/store_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func snapAt(t time.Time, procs ...ProcInfo) *Snapshot {
+	return &Snapshot{Time: t, Processes: procs}
+}
+
+func TestStoreUpdateAddsAndCounts(t *testing.T) {
+	t.Parallel()
+	s := NewProcessStore()
+	t0 := time.Unix(1_700_000_000, 0)
+	s.Update(snapAt(t0,
+		ProcInfo{PID: 1, Name: "init"},
+		ProcInfo{PID: 2, Name: "app"},
+	), nil)
+
+	if got := len(s.ByKey); got != 2 {
+		t.Fatalf("ByKey len = %d, want 2", got)
+	}
+	if got := s.ActiveCount(); got != 2 {
+		t.Fatalf("ActiveCount = %d, want 2", got)
+	}
+}
+
+func TestStoreStablePointerAcrossUpdates(t *testing.T) {
+	t.Parallel()
+	s := NewProcessStore()
+	t0 := time.Unix(1_700_000_000, 0)
+	s.Update(snapAt(t0, ProcInfo{PID: 7, Name: "svc", RSSBytes: 100}), nil)
+	first := s.ByKey[ProcessKey{PID: 7}]
+
+	s.Update(snapAt(t0.Add(time.Second), ProcInfo{PID: 7, Name: "svc", RSSBytes: 200}), nil)
+	second := s.ByKey[ProcessKey{PID: 7}]
+
+	if first != second {
+		t.Fatal("expected the same *Process across updates for a reused PID")
+	}
+	if second.RSSBytes != 200 {
+		t.Fatalf("RSSBytes = %d, want 200 (latest sample)", second.RSSBytes)
+	}
+	if len(second.History) != 2 {
+		t.Fatalf("history len = %d, want 2", len(second.History))
+	}
+}
+
+func TestStoreMarksAndEvictsStopped(t *testing.T) {
+	t.Parallel()
+	s := NewProcessStore()
+	t0 := time.Unix(1_700_000_000, 0)
+	s.Update(snapAt(t0, ProcInfo{PID: 9, Name: "gone"}), nil)
+
+	// Process disappears: first missing sample marks it stopped, not evicted.
+	s.Update(snapAt(t0.Add(time.Second)), nil)
+	p := s.ByKey[ProcessKey{PID: 9}]
+	if p == nil {
+		t.Fatal("stopped process evicted too early")
+	}
+	if p.Running() {
+		t.Fatal("process should be marked stopped")
+	}
+
+	// After the keep window elapses, it is evicted.
+	s.Update(snapAt(t0.Add(keepStoppedFor+2*time.Second)), nil)
+	if _, ok := s.ByKey[ProcessKey{PID: 9}]; ok {
+		t.Fatal("stopped process should have been evicted after keepStoppedFor")
+	}
+}
+
+func TestStoreKeepsSelectedStopped(t *testing.T) {
+	t.Parallel()
+	s := NewProcessStore()
+	t0 := time.Unix(1_700_000_000, 0)
+	s.Update(snapAt(t0, ProcInfo{PID: 9, Name: "gone"}), nil)
+	selected := s.ByKey[ProcessKey{PID: 9}]
+
+	s.Update(snapAt(t0.Add(time.Second)), selected)
+	s.Update(snapAt(t0.Add(keepStoppedFor+2*time.Second)), selected)
+
+	if _, ok := s.ByKey[ProcessKey{PID: 9}]; !ok {
+		t.Fatal("selected stopped process must not be evicted")
+	}
+}
+
+func TestHistoryRingBufferCap(t *testing.T) {
+	t.Parallel()
+	p := &Process{}
+	base := time.Unix(1_700_000_000, 0)
+	for i := range maxHistoryPoints + 60 {
+		p.appendHistory(base.Add(time.Duration(i)*time.Second), float64(i), uint64(i))
+	}
+	if len(p.History) != maxHistoryPoints {
+		t.Fatalf("history len = %d, want %d", len(p.History), maxHistoryPoints)
+	}
+	// The oldest points should have been dropped; the last point is the newest.
+	last := p.History[len(p.History)-1]
+	if last.CPUPercent != float64(maxHistoryPoints+59) {
+		t.Fatalf("newest CPU = %v, want %v", last.CPUPercent, float64(maxHistoryPoints+59))
+	}
+}

--- a/examples/process_monitor/sysmem_darwin.go
+++ b/examples/process_monitor/sysmem_darwin.go
@@ -1,0 +1,101 @@
+//go:build darwin
+
+package main
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// systemMemory reports total and used RAM on macOS. Total comes from
+// `sysctl hw.memsize`; used is total minus an approximation of available
+// memory built from `vm_stat` page counts. On any failure it returns (0, 0)
+// and the header omits the memory bar rather than showing a fake value.
+func systemMemory() (total, used uint64) {
+	total = sysctlUint("hw.memsize")
+	if total == 0 {
+		return 0, 0
+	}
+	avail := availableMemory()
+	if avail == 0 || avail > total {
+		return 0, 0
+	}
+	return total, total - avail
+}
+
+// sysctlUint runs `sysctl -n <name>` and parses the result as a uint64.
+func sysctlUint(name string) uint64 {
+	// #nosec G204 — name is a constant.
+	out, err := exec.Command("sysctl", "-n", name).Output()
+	if err != nil {
+		return 0
+	}
+	v, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// availableMemory sums the reclaimable page classes reported by vm_stat
+// (free + inactive + speculative + purgeable) and multiplies by the page size.
+// This is an approximation adequate for the header's usage bar.
+func availableMemory() uint64 {
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		return 0
+	}
+	pageSize := uint64(4096)
+	var freePages uint64
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if i := strings.Index(line, "page size of"); i >= 0 {
+			// "...(page size of 16384 bytes)"
+			if n := firstUint(line[i:]); n > 0 {
+				pageSize = n
+			}
+			continue
+		}
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "Pages free", "Pages inactive", "Pages speculative",
+			"Pages purgeable":
+			freePages += parseVMStatPages(val)
+		}
+	}
+	return freePages * pageSize
+}
+
+// parseVMStatPages parses a vm_stat count field like "  123456." into a uint.
+func parseVMStatPages(s string) uint64 {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, ".")
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// firstUint extracts the first run of digits in s as a uint64.
+func firstUint(s string) uint64 {
+	start := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return 0
+	}
+	end := start
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	v, _ := strconv.ParseUint(s[start:end], 10, 64)
+	return v
+}

--- a/examples/process_monitor/sysmem_linux.go
+++ b/examples/process_monitor/sysmem_linux.go
@@ -17,7 +17,7 @@ func systemMemory() (total, used uint64) {
 	if err != nil {
 		return 0, 0
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var memTotal, memAvail uint64
 	var haveTotal, haveAvail bool

--- a/examples/process_monitor/sysmem_linux.go
+++ b/examples/process_monitor/sysmem_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// systemMemory reads total and used RAM from /proc/meminfo. Used is derived as
+// MemTotal - MemAvailable, matching what tools like free(1) report. On any
+// error it returns (0, 0) and the header simply omits the memory bar.
+func systemMemory() (total, used uint64) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+
+	var memTotal, memAvail uint64
+	var haveTotal, haveAvail bool
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "MemTotal:"):
+			memTotal, haveTotal = meminfoBytes(line)
+		case strings.HasPrefix(line, "MemAvailable:"):
+			memAvail, haveAvail = meminfoBytes(line)
+		}
+		if haveTotal && haveAvail {
+			break
+		}
+	}
+	if !haveTotal || !haveAvail || memAvail > memTotal {
+		return 0, 0
+	}
+	return memTotal, memTotal - memAvail
+}
+
+// meminfoBytes parses a "Key:   12345 kB" line into bytes.
+func meminfoBytes(line string) (uint64, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0, false
+	}
+	kib, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return kib * 1024, true
+}

--- a/examples/process_monitor/sysmem_other.go
+++ b/examples/process_monitor/sysmem_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package main
+
+// systemMemory has no cheap portable source on other platforms, so it reports
+// zero. The header treats (0, 0) as "unknown" and omits the memory bar.
+func systemMemory() (total, used uint64) {
+	return 0, 0
+}

--- a/examples/process_monitor/tree_test.go
+++ b/examples/process_monitor/tree_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"testing"
+)
+
+// proc builds a *Process with the identity/tree fields the row logic needs.
+func proc(pid, ppid int, name string) *Process {
+	return &Process{ProcInfo: ProcInfo{PID: pid, PPID: ppid, Name: name}}
+}
+
+func byPID(a, b *Process) bool { return a.PID < b.PID }
+
+// names extracts the display order for easy assertions.
+func names(rows []*Process) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func TestTreeRowsHierarchy(t *testing.T) {
+	t.Parallel()
+	procs := []*Process{
+		proc(1, 0, "init"),
+		proc(10, 1, "shell"),
+		proc(11, 10, "editor"),
+		proc(12, 1, "daemon"),
+	}
+	rows := treeRows(procs, "", byPID, false)
+
+	got := names(rows)
+	want := []string{"init", "shell", "editor", "daemon"}
+	if len(got) != len(want) {
+		t.Fatalf("rows = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("rows = %v, want %v", got, want)
+		}
+	}
+
+	depth := map[string]int{}
+	kids := map[string]int{}
+	for _, r := range rows {
+		depth[r.Name] = r.TreeDepth
+		kids[r.Name] = r.TreeChildCount
+	}
+	if depth["init"] != 0 || depth["shell"] != 1 || depth["editor"] != 2 || depth["daemon"] != 1 {
+		t.Fatalf("unexpected depths: %v", depth)
+	}
+	if kids["init"] != 2 || kids["shell"] != 1 || kids["editor"] != 0 {
+		t.Fatalf("unexpected child counts: %v", kids)
+	}
+}
+
+func TestTreeRowsCollapseHidesSubtree(t *testing.T) {
+	t.Parallel()
+	shell := proc(10, 1, "shell")
+	shell.Collapsed = true
+	procs := []*Process{
+		proc(1, 0, "init"),
+		shell,
+		proc(11, 10, "editor"), // hidden under collapsed shell
+	}
+	rows := treeRows(procs, "", byPID, false)
+	for _, r := range rows {
+		if r.Name == "editor" {
+			t.Fatal("editor should be hidden under a collapsed parent")
+		}
+	}
+}
+
+func TestTreeRowsFilterKeepsAncestorsIgnoringCollapse(t *testing.T) {
+	t.Parallel()
+	shell := proc(10, 1, "shell")
+	shell.Collapsed = true // must be ignored while filtering
+	procs := []*Process{
+		proc(1, 0, "init"),
+		shell,
+		proc(11, 10, "editor"),
+		proc(12, 1, "unrelated"),
+	}
+	rows := treeRows(procs, "editor", byPID, false)
+
+	got := names(rows)
+	want := map[string]bool{"init": true, "shell": true, "editor": true}
+	if len(got) != len(want) {
+		t.Fatalf("rows = %v, want ancestors of the match only", got)
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Fatalf("unexpected row %q in %v", n, got)
+		}
+	}
+}
+
+func TestVisibleRowsFlatFilterAndSort(t *testing.T) {
+	t.Parallel()
+	procs := []*Process{
+		proc(3, 0, "cee"),
+		proc(1, 0, "aye"),
+		proc(2, 0, "bee"),
+	}
+	rows := visibleRows(procs, "", colDefs[colName].less, false, false)
+	got := names(rows)
+	want := []string{"aye", "bee", "cee"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sorted rows = %v, want %v", got, want)
+		}
+	}
+
+	filtered := visibleRows(procs, "bee", nil, false, false)
+	if len(filtered) != 1 || filtered[0].Name != "bee" {
+		t.Fatalf("filtered rows = %v, want [bee]", names(filtered))
+	}
+}

--- a/examples/process_monitor/view.go
+++ b/examples/process_monitor/view.go
@@ -1,0 +1,616 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// Column indices. app.Sort.Column indexes colDefs.
+const (
+	colPID = iota
+	colCPU
+	colRSS
+	colMem
+	colUser
+	colState
+	colThreads
+	colName
+)
+
+const rowHeight float32 = 26
+
+// Data-visualization accent colors. The theme supplies no chart/status colors,
+// so these are fixed (and chosen to read on both light and dark panels). All
+// other chrome comes from theme tokens.
+var (
+	accentCPU  = gui.RGB(70, 190, 120) // CPU bars: green
+	accentRAM  = gui.RGB(230, 170, 70) // RAM bars: amber
+	accentMem  = gui.RGB(90, 150, 230) // system memory bar: blue
+	colorAlert = gui.RGB(230, 90, 90)  // stopped / error text: red
+)
+
+// column describes one table column: header label, fixed width (0 = flexible),
+// default sort direction, comparator, and cell renderer.
+type column struct {
+	less  func(a, b *Process) bool
+	cell  func(p *Process, app *App) gui.View
+	label string
+	width float32
+	desc  bool
+}
+
+// colDefs is the process table's column set, in display order. Comparators use
+// a PID tiebreak so equal-keyed rows keep a stable order across refreshes
+// (store iteration order is random).
+var colDefs = []column{
+	{
+		label: "PID", width: 64,
+		less: func(a, b *Process) bool { return a.PID < b.PID },
+		cell: func(p *Process, _ *App) gui.View {
+			return textCell(64, strconv.Itoa(p.PID), gui.CurrentTheme().N5)
+		},
+	},
+	{
+		label: "CPU", width: 118, desc: true,
+		less: func(a, b *Process) bool {
+			if a.CPUPercent != b.CPUPercent {
+				return a.CPUPercent < b.CPUPercent
+			}
+			return a.PID < b.PID
+		},
+		cell: cpuCell,
+	},
+	{
+		label: "RSS", width: 80, desc: true,
+		less: lessRSS,
+		cell: func(p *Process, _ *App) gui.View {
+			return textCell(80, p.RSSText(), gui.CurrentTheme().N5)
+		},
+	},
+	{
+		label: "MEM%", width: 74, desc: true,
+		less: lessRSS,
+		cell: func(p *Process, _ *App) gui.View {
+			return textCell(74, p.MemText(), gui.CurrentTheme().N5)
+		},
+	},
+	{
+		label: "USER", width: 110,
+		less: func(a, b *Process) bool {
+			if a.User != b.User {
+				return a.User < b.User
+			}
+			return a.PID < b.PID
+		},
+		cell: func(p *Process, _ *App) gui.View {
+			return textCell(110, p.User, gui.CurrentTheme().N5)
+		},
+	},
+	{
+		label: "STATE", width: 56,
+		less: func(a, b *Process) bool {
+			if a.State != b.State {
+				return a.State < b.State
+			}
+			return a.PID < b.PID
+		},
+		cell: func(p *Process, _ *App) gui.View {
+			return textCell(56, p.State, gui.CurrentTheme().N5)
+		},
+	},
+	{
+		label: "THR", width: 54, desc: true,
+		less: func(a, b *Process) bool {
+			if a.Threads != b.Threads {
+				return a.Threads < b.Threads
+			}
+			return a.PID < b.PID
+		},
+		cell: func(p *Process, _ *App) gui.View {
+			return textCell(54, p.ThreadsText(), gui.CurrentTheme().N5)
+		},
+	},
+	{
+		label: "NAME", width: 0, // flexible
+		less: func(a, b *Process) bool {
+			if a.Name != b.Name {
+				return a.Name < b.Name
+			}
+			return a.PID < b.PID
+		},
+		cell: nameCell,
+	},
+}
+
+func lessRSS(a, b *Process) bool {
+	if a.RSSBytes != b.RSSBytes {
+		return a.RSSBytes < b.RSSBytes
+	}
+	return a.PID < b.PID
+}
+
+// rootView is registered once in OnInit; the sampler goroutine re-runs it each
+// refresh via Window.UpdateWindow.
+func rootView(w *gui.Window) gui.View {
+	app := gui.State[App](w)
+	ww, wh := w.WindowSize()
+	theme := gui.CurrentTheme()
+
+	return gui.Column(gui.ContainerCfg{
+		Width:   float32(ww),
+		Height:  float32(wh),
+		Sizing:  gui.FixedFixed,
+		Color:   theme.ColorBackground,
+		Padding: gui.NoPadding,
+		Content: []gui.View{
+			headerView(app),
+			toolbarView(app),
+			processTable(app),
+			detailView(app),
+		},
+	})
+}
+
+func headerView(app *App) gui.View {
+	theme := gui.CurrentTheme()
+	content := []gui.View{
+		gui.Row(gui.ContainerCfg{
+			Sizing:  gui.FillFit,
+			Padding: gui.NoPadding,
+			VAlign:  gui.VAlignMiddle,
+			Spacing: gui.SomeF(12),
+			Content: []gui.View{
+				gui.Text(gui.TextCfg{Text: "Process Monitor", TextStyle: theme.B2}),
+			},
+		}),
+	}
+
+	switch {
+	case app.Err != nil:
+		content = append(content, gui.Text(gui.TextCfg{
+			Text:      "sample error: " + app.Err.Error(),
+			TextStyle: styleColor(theme.N5, colorAlert),
+		}))
+	case app.Snapshot == nil:
+		content = append(content, gui.Text(gui.TextCfg{
+			Text: "Collecting process samples…", TextStyle: theme.N5,
+		}))
+	default:
+		content = append(content, statsRow(app))
+	}
+
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Color:   theme.ColorPanel,
+		Padding: gui.SomeP(12, 16, 12, 16),
+		Spacing: gui.SomeF(8),
+		Content: content,
+	})
+}
+
+func statsRow(app *App) gui.View {
+	theme := gui.CurrentTheme()
+	content := []gui.View{
+		statPill("Processes", fmt.Sprintf("%s active / %s kept",
+			formatCount(app.Store.ActiveCount()), formatCount(len(app.Store.ByKey)))),
+		statPill("Updated", formatTime(app.LastRefresh)),
+	}
+
+	// Only show the memory bar when the platform gave us real totals.
+	if app.Snapshot.TotalMemoryBytes > 0 {
+		used, total := app.Snapshot.UsedMemoryBytes, app.Snapshot.TotalMemoryBytes
+		ratio := float32(float64(used) / float64(total))
+		content = append(content, gui.Row(gui.ContainerCfg{
+			Sizing:  gui.FitFit,
+			Padding: gui.NoPadding,
+			VAlign:  gui.VAlignMiddle,
+			Spacing: gui.SomeF(8),
+			Content: []gui.View{
+				gui.Text(gui.TextCfg{Text: "Memory", TextStyle: theme.N6}),
+				usageBar(ratio, 160, 10, accentMem),
+				gui.Text(gui.TextCfg{
+					Text:      fmt.Sprintf("%s / %s", formatBytes(used), formatBytes(total)),
+					TextStyle: theme.N6,
+				}),
+			},
+		}))
+	}
+
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Padding: gui.NoPadding,
+		VAlign:  gui.VAlignMiddle,
+		Spacing: gui.SomeF(18),
+		Content: content,
+	})
+}
+
+func statPill(label, value string) gui.View {
+	theme := gui.CurrentTheme()
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FitFit,
+		Color:   theme.ColorInterior,
+		Radius:  gui.SomeF(theme.RadiusSmall),
+		Padding: gui.SomeP(5, 9, 5, 9),
+		Spacing: gui.SomeF(6),
+		VAlign:  gui.VAlignMiddle,
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{Text: label, TextStyle: theme.N6}),
+			gui.Text(gui.TextCfg{Text: value, TextStyle: theme.B5}),
+		},
+	})
+}
+
+func toolbarView(app *App) gui.View {
+	theme := gui.CurrentTheme()
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Color:   theme.ColorPanel,
+		Padding: gui.SomeP(8, 16, 8, 16),
+		Spacing: gui.SomeF(12),
+		VAlign:  gui.VAlignMiddle,
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{Text: "Filter", TextStyle: theme.B5}),
+			gui.Input(gui.InputCfg{
+				ID:          "pm-filter",
+				Sizing:      gui.FixedFit,
+				Width:       300,
+				Text:        app.Filter,
+				Placeholder: "name, command, user, or PID",
+				OnTextChanged: func(_ *gui.Layout, text string, w *gui.Window) {
+					gui.State[App](w).Filter = text
+				},
+			}),
+			spacer(),
+			gui.Text(gui.TextCfg{Text: "View", TextStyle: theme.B5}),
+			viewModeRadio(app),
+			gui.Text(gui.TextCfg{Text: "Every", TextStyle: theme.B5}),
+			intervalRadio(app),
+		},
+	})
+}
+
+func viewModeRadio(app *App) gui.View {
+	value := "Flat"
+	if app.TreeMode {
+		value = "Tree"
+	}
+	return gui.RadioButtonGroupRow(gui.RadioButtonGroupCfg{
+		ID:    "pm-view",
+		Items: []string{"Flat", "Tree"},
+		Value: value,
+		OnSelect: func(v string, w *gui.Window) {
+			gui.State[App](w).TreeMode = v == "Tree"
+		},
+	})
+}
+
+func intervalRadio(app *App) gui.View {
+	return gui.RadioButtonGroupRow(gui.RadioButtonGroupCfg{
+		ID:    "pm-interval",
+		Items: intervalLabels,
+		Value: intervalLabel(app.Interval),
+		OnSelect: func(v string, w *gui.Window) {
+			gui.State[App](w).Interval = intervalFromLabel(v)
+		},
+	})
+}
+
+func processTable(app *App) gui.View {
+	theme := gui.CurrentTheme()
+	if app.Snapshot == nil {
+		return centered("Waiting for first sample…")
+	}
+
+	// Rows are filtered and ordered here (not by a table widget): tree mode
+	// orders siblings within the hierarchy and the filter keeps ancestors.
+	less := colDefs[app.Sort.Column].less
+	rows := visibleRows(app.Store.Processes(), app.Filter, less, app.Sort.Desc, app.TreeMode)
+
+	var body gui.View
+	if len(rows) == 0 {
+		body = centered("No matching processes")
+	} else {
+		rowViews := make([]gui.View, 0, len(rows))
+		for i, p := range rows {
+			rowViews = append(rowViews, processRow(p, app, i))
+		}
+		body = gui.Column(gui.ContainerCfg{
+			ID:            "pm-scroll",
+			Scrollable:    true,
+			ScrollbarCfgY: &gui.ScrollbarCfg{Overflow: gui.ScrollbarAuto},
+			Sizing:        gui.FillFill,
+			Padding:       gui.NoPadding,
+			Content:       rowViews,
+		})
+	}
+
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		Color:   theme.ColorBackground,
+		Padding: gui.NoPadding,
+		Content: []gui.View{headerRow(app), body},
+	})
+}
+
+func headerRow(app *App) gui.View {
+	theme := gui.CurrentTheme()
+	cells := make([]gui.View, 0, len(colDefs))
+	for i, col := range colDefs {
+		cells = append(cells, headerCell(col, i, app))
+	}
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FillFixed,
+		Height:  rowHeight,
+		Color:   theme.ColorInterior,
+		Padding: gui.NoPadding,
+		VAlign:  gui.VAlignMiddle,
+		Content: cells,
+	})
+}
+
+func headerCell(col column, idx int, app *App) gui.View {
+	theme := gui.CurrentTheme()
+	label := col.label
+	if app.Sort.Column == idx {
+		if app.Sort.Desc {
+			label += " ▼"
+		} else {
+			label += " ▲"
+		}
+	}
+
+	cfg := gui.ContainerCfg{
+		VAlign:  gui.VAlignMiddle,
+		Clip:    true,
+		Padding: gui.SomeP(0, 6, 0, 6),
+		Content: []gui.View{gui.Text(gui.TextCfg{Text: label, TextStyle: theme.B6, Clip: true})},
+		OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+			a := gui.State[App](w)
+			if a.Sort.Column == idx {
+				a.Sort.Desc = !a.Sort.Desc
+			} else {
+				a.Sort.Column = idx
+				a.Sort.Desc = col.desc
+			}
+			e.IsHandled = true
+		},
+	}
+	if col.width == 0 {
+		cfg.Sizing = gui.FillFill
+	} else {
+		cfg.Width = col.width
+		cfg.Sizing = gui.FixedFill
+	}
+	return gui.Row(cfg)
+}
+
+func processRow(p *Process, app *App, i int) gui.View {
+	theme := gui.CurrentTheme()
+	bg := theme.ColorPanel
+	if i%2 == 1 {
+		bg = theme.ColorBackground
+	}
+	if app.Selected == p {
+		bg = theme.ColorSelect
+	}
+
+	cells := make([]gui.View, 0, len(colDefs))
+	for _, col := range colDefs {
+		cells = append(cells, col.cell(p, app))
+	}
+
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FillFixed,
+		Height:  rowHeight,
+		Color:   bg,
+		Padding: gui.NoPadding,
+		VAlign:  gui.VAlignMiddle,
+		Content: cells,
+		OnClick: func(_ *gui.Layout, e *gui.Event, w *gui.Window) {
+			gui.State[App](w).Selected = p
+			e.IsHandled = true
+		},
+	})
+}
+
+func detailView(app *App) gui.View {
+	theme := gui.CurrentTheme()
+	if app.Snapshot == nil || app.Selected == nil {
+		return gui.Column(gui.ContainerCfg{
+			Sizing:  gui.FillFit,
+			Color:   theme.ColorPanel,
+			Padding: gui.SomeP(10, 16, 12, 16),
+			Content: []gui.View{gui.Text(gui.TextCfg{Text: "Select a process", TextStyle: theme.N5})},
+		})
+	}
+
+	p := app.Selected
+	facts := []gui.View{
+		gui.Text(gui.TextCfg{
+			Text: fmt.Sprintf("%s  pid %d", p.Name, p.PID), TextStyle: theme.B4,
+		}),
+		gui.Text(gui.TextCfg{Text: fmt.Sprintf("ppid %d", p.PPID), TextStyle: theme.N6}),
+		gui.Text(gui.TextCfg{Text: "cpu " + formatCPUPercent(p.CPUPercent), TextStyle: theme.N6}),
+		gui.Text(gui.TextCfg{Text: "rss " + p.RSSText(), TextStyle: theme.N6}),
+	}
+	if !p.Running() {
+		facts = append(facts, gui.Text(gui.TextCfg{
+			Text: "stopped " + formatTime(p.StoppedAt), TextStyle: styleColor(theme.N6, colorAlert),
+		}))
+	}
+
+	cmd := p.Cmdline
+	if cmd == "" {
+		cmd = p.Name
+	}
+
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Color:   theme.ColorPanel,
+		Padding: gui.SomeP(10, 16, 12, 16),
+		Spacing: gui.SomeF(6),
+		Content: []gui.View{
+			gui.Row(gui.ContainerCfg{
+				Sizing:  gui.FillFit,
+				Padding: gui.NoPadding,
+				VAlign:  gui.VAlignMiddle,
+				Spacing: gui.SomeF(12),
+				Content: facts,
+			}),
+			gui.Text(gui.TextCfg{Text: truncate(cmd, 160), TextStyle: theme.N6, Clip: true}),
+			historyCharts(p),
+		},
+	})
+}
+
+func historyCharts(p *Process) gui.View {
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FitFit,
+		Padding: gui.NoPadding,
+		Spacing: gui.SomeF(12),
+		Content: []gui.View{
+			usageChart(p, "CPU", 100, accentCPU,
+				func(pt ProcessPoint) float64 { return pt.CPUPercent },
+				func(v float64) string { return fmt.Sprintf("%.0f%%", v) }),
+			usageChart(p, "RAM", ramHistoryScale(p.History), accentRAM,
+				func(pt ProcessPoint) float64 { return float64(pt.RSSBytes) },
+				func(v float64) string { return formatBytes(uint64(v)) }),
+		},
+	})
+}
+
+// --- small view helpers ---
+
+// textCell renders a fixed-width, vertically-centered, clipped text cell.
+func textCell(width float32, s string, style gui.TextStyle) gui.View {
+	return gui.Row(gui.ContainerCfg{
+		Width:   width,
+		Sizing:  gui.FixedFill,
+		VAlign:  gui.VAlignMiddle,
+		Clip:    true,
+		Padding: gui.SomeP(0, 6, 0, 6),
+		Content: []gui.View{gui.Text(gui.TextCfg{Text: s, TextStyle: style, Clip: true})},
+	})
+}
+
+// cpuCell renders the CPU percentage next to a small usage bar.
+func cpuCell(p *Process, _ *App) gui.View {
+	theme := gui.CurrentTheme()
+	ratio := float32(0)
+	if p.CPUPercent > 0 {
+		ratio = float32(p.CPUPercent / 100)
+	}
+	return gui.Row(gui.ContainerCfg{
+		Width:   118,
+		Sizing:  gui.FixedFill,
+		VAlign:  gui.VAlignMiddle,
+		Clip:    true,
+		Padding: gui.SomeP(0, 6, 0, 6),
+		Spacing: gui.SomeF(6),
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{Text: p.CPUText(), TextStyle: theme.N5}),
+			usageBar(ratio, 48, 8, accentCPU),
+		},
+	})
+}
+
+// nameCell renders the process name, prefixed in tree mode by an indent and a
+// collapse chevron for processes that have children.
+func nameCell(p *Process, app *App) gui.View {
+	theme := gui.CurrentTheme()
+	kids := make([]gui.View, 0, 3)
+
+	if app.TreeMode {
+		if depth := min(p.TreeDepth, 8); depth > 0 {
+			kids = append(kids, gui.Rectangle(gui.RectangleCfg{
+				Width: float32(depth) * 14, Sizing: gui.FixedFill, Color: gui.ColorTransparent,
+			}))
+		}
+		if p.TreeChildCount > 0 {
+			marker := "▾"
+			if p.Collapsed {
+				marker = "▸"
+			}
+			kids = append(kids, gui.Row(gui.ContainerCfg{
+				Width:   16,
+				Sizing:  gui.FixedFill,
+				VAlign:  gui.VAlignMiddle,
+				Content: []gui.View{gui.Text(gui.TextCfg{Text: marker, TextStyle: theme.N5})},
+				OnClick: func(_ *gui.Layout, e *gui.Event, _ *gui.Window) {
+					// p is a stable store pointer; toggling under event dispatch
+					// (which holds the window lock) is safe.
+					p.Collapsed = !p.Collapsed
+					e.IsHandled = true
+				},
+			}))
+		} else {
+			kids = append(kids, gui.Rectangle(gui.RectangleCfg{
+				Width: 16, Sizing: gui.FixedFill, Color: gui.ColorTransparent,
+			}))
+		}
+	}
+
+	style := theme.N5
+	if !p.Running() {
+		style = theme.N6 // dim stopped processes
+	}
+	kids = append(kids, gui.Text(gui.TextCfg{Text: p.Name, TextStyle: style, Clip: true}))
+
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		VAlign:  gui.VAlignMiddle,
+		Clip:    true,
+		Padding: gui.SomeP(0, 6, 0, 6),
+		Spacing: gui.SomeF(2),
+		Content: kids,
+	})
+}
+
+// usageBar renders a rounded background track with a proportional fill.
+func usageBar(ratio, width, height float32, fill gui.Color) gui.View {
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	theme := gui.CurrentTheme()
+	return gui.Row(gui.ContainerCfg{
+		Width:   width,
+		Height:  height,
+		Sizing:  gui.FixedFixed,
+		Color:   theme.ColorBorder,
+		Radius:  gui.SomeF(2),
+		Padding: gui.NoPadding,
+		Content: []gui.View{
+			gui.Rectangle(gui.RectangleCfg{
+				Width: width * ratio, Height: height, Sizing: gui.FixedFixed,
+				Color: fill, Radius: 2,
+			}),
+		},
+	})
+}
+
+func centered(msg string) gui.View {
+	theme := gui.CurrentTheme()
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		HAlign:  gui.HAlignCenter,
+		VAlign:  gui.VAlignMiddle,
+		Padding: gui.NoPadding,
+		Content: []gui.View{gui.Text(gui.TextCfg{Text: msg, TextStyle: theme.N4})},
+	})
+}
+
+func spacer() gui.View {
+	return gui.Rectangle(gui.RectangleCfg{Sizing: gui.FillFit, Color: gui.ColorTransparent})
+}
+
+// styleColor returns a copy of style with its color overridden.
+func styleColor(style gui.TextStyle, c gui.Color) gui.TextStyle {
+	style.Color = c
+	return style
+}

--- a/examples/process_monitor/view_test.go
+++ b/examples/process_monitor/view_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// seededApp builds app state from a synthetic snapshot so view tests never
+// shell out to the real process collector.
+func seededApp() *App {
+	app := &App{
+		Store:    NewProcessStore(),
+		Interval: time.Second,
+		Sort:     sortState{Column: colCPU, Desc: true},
+	}
+	snap := &Snapshot{
+		Time:             time.Unix(1_700_000_000, 0),
+		TotalMemoryBytes: 16 << 30,
+		UsedMemoryBytes:  8 << 30,
+		Processes: []ProcInfo{
+			{PID: 1, PPID: 0, Name: "init", User: "root", State: "S", RSSBytes: 10 << 20, Threads: 1},
+			{PID: 100, PPID: 1, Name: "app", User: "me", State: "R", RSSBytes: 200 << 20, CPUPercent: 12.5, MemPercent: 1.2, Threads: 8},
+			{PID: 101, PPID: 100, Name: "child", User: "me", State: "S", RSSBytes: 50 << 20, CPUPercent: 1.0, MemPercent: 0.3, Threads: 2},
+		},
+	}
+	app.Store.Update(snap, nil)
+	app.Snapshot = snap
+	app.LastRefresh = snap.Time
+
+	rows := visibleRows(app.Store.Processes(), "", colDefs[colCPU].less, true, false)
+	if len(rows) > 0 {
+		app.Selected = rows[0]
+	}
+	return app
+}
+
+func buildView(t *testing.T, app *App) gui.Layout {
+	t.Helper()
+	w := gui.NewWindow(gui.WindowCfg{State: app, Width: 1100, Height: 700})
+	// GenerateViewLayout recurses the whole tree, exercising every cell and
+	// chart builder (nil backend: TextMeasurer/SvgParser are nil, as in all
+	// headless example tests).
+	return gui.GenerateViewLayout(rootView(w), w)
+}
+
+func TestRootViewBuildsFlatAndTree(t *testing.T) {
+	t.Parallel()
+	for _, tree := range []bool{false, true} {
+		app := seededApp()
+		app.TreeMode = tree
+		layout := buildView(t, app)
+		if len(layout.Children) == 0 {
+			t.Fatalf("expected a populated layout tree (tree=%v)", tree)
+		}
+	}
+}
+
+func TestRootViewEmptyAndErrorStates(t *testing.T) {
+	t.Parallel()
+
+	// No snapshot yet: the "collecting" / "waiting" placeholders must build.
+	_ = buildView(t, &App{Store: NewProcessStore(), Interval: time.Second})
+
+	// Sample error path.
+	_ = buildView(t, &App{
+		Store:    NewProcessStore(),
+		Interval: time.Second,
+		Err:      errors.New("boom"),
+	})
+}
+
+func TestRootViewFilterNoMatches(t *testing.T) {
+	t.Parallel()
+	app := seededApp()
+	app.Filter = "does-not-exist-xyz"
+	_ = buildView(t, app)
+}


### PR DESCRIPTION
## Summary

New example app — a live process monitor with:
- Flat and tree views with sortable columns (PID, CPU, RSS, MEM%, User, State, Threads, Name)
- Per-process CPU/RAM history charts (60s window, resampled to 2s buckets)
- Filter by name, command, user, or PID
- Selectable refresh interval (0.5s/1s/2s/5s)
- System memory usage bar (macOS + Linux)
- Headless `-once` mode for terminal output
- No third-party dependencies (shells out to `ps`/`tasklist`)

### Files
- `chart.go` — histogram bucketing, resampling with linear interpolation
- `collect.go` — snapshot structs, memory-share derivation
- `collect_unix.go` / `collect_windows.go` / `collect_other.go` — platform collectors
- `format.go` — CPU/RSS/time rendering (NaN-guarded)
- `main.go` — window setup, background sampler goroutine
- `once.go` — headless `-once` mode
- `store.go` — stable process identity across samples with eviction
- `sysmem_darwin.go` / `sysmem_linux.go` / `sysmem_other.go` — system memory totals
- `view.go` — go-gui immediate-mode view tree (table, charts, toolbar)
- `*_test.go` — 33 tests covering store, chart, tree, view, format, and utilities

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786917727&installation_id=145733661&pr_number=100&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F100&signature=feddc461f7dd02b7522ff1f1b3e694c12a28a965812c1fc13437d114ee8b0da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->