### PR TITLE
gui: add BoundedMap.GetOr, migrate ignored-ok Get sites from #54

### DIFF
--- a/gui/bounded_map.go
+++ b/gui/bounded_map.go
@@ -79,6 +79,16 @@ func (m *BoundedMap[K, V]) Get(key K) (V, bool) {
 	return v, ok
 }
 
+// GetOr returns the value for key, or def if the key is absent.
+// Use at call sites that would otherwise ignore Get's ok boolean, so
+// the assumed default is explicit rather than an implicit zero value.
+func (m *BoundedMap[K, V]) GetOr(key K, def V) V {
+	if v, ok := m.data[key]; ok {
+		return v
+	}
+	return def
+}
+
 // Delete removes key from map.
 func (m *BoundedMap[K, V]) Delete(key K) {
 	if _, exists := m.data[key]; !exists {

--- a/gui/bounded_map_test.go
+++ b/gui/bounded_map_test.go
@@ -22,6 +22,25 @@ func TestBoundedMapBasicOperations(t *testing.T) {
 	}
 }
 
+func TestBoundedMapGetOr(t *testing.T) {
+	m := NewBoundedMap[string, int](3)
+	m.Set("a", 1)
+
+	// Present key returns the stored value, not the default.
+	if v := m.GetOr("a", 99); v != 1 {
+		t.Errorf("present: got %d, want 1", v)
+	}
+	// Missing key returns the supplied default.
+	if v := m.GetOr("missing", 99); v != 99 {
+		t.Errorf("missing: got %d, want 99", v)
+	}
+	// Stored zero value is distinguishable from a non-zero default.
+	m.Set("z", 0)
+	if v := m.GetOr("z", 99); v != 0 {
+		t.Errorf("stored zero: got %d, want 0", v)
+	}
+}
+
 func TestBoundedMapEviction(t *testing.T) {
 	m := NewBoundedMap[string, int](3)
 	m.Set("a", 1)

--- a/gui/drag_reorder.go
+++ b/gui/drag_reorder.go
@@ -248,11 +248,12 @@ func dragReorderStart(cfg dragReorderStartCfg, w *Window) {
 
 	var startScrollX, startScrollY float32
 	if scrollID != "" {
+		// Default 0: unscrolled position when no offset recorded yet.
 		if smx := w.scrollXRead(); smx != nil {
-			startScrollX, _ = smx.Get(scrollID)
+			startScrollX = smx.GetOr(scrollID, 0)
 		}
 		if smy := w.scrollYRead(); smy != nil {
-			startScrollY, _ = smy.Get(scrollID)
+			startScrollY = smy.GetOr(scrollID, 0)
 		}
 	}
 
@@ -377,12 +378,13 @@ func dragReorderOnMouseMove(
 	scrolledSinceStart := false
 
 	if state.scrollID != "" {
+		// Default 0: unscrolled position when no offset recorded yet.
 		var scrollVal float32
 		switch axis {
 		case DragReorderVertical:
-			scrollVal, _ = w.scrollY().Get(state.scrollID)
+			scrollVal = w.scrollY().GetOr(state.scrollID, 0)
 		case DragReorderHorizontal:
-			scrollVal, _ = w.scrollX().Get(state.scrollID)
+			scrollVal = w.scrollX().GetOr(state.scrollID, 0)
 		}
 		var startScroll float32
 		switch axis {

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -125,7 +125,8 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 	var scrollY float32
 	dropdownScrollID := cfg.ID + ".dropdown"
 	if cfg.Scrollable {
-		scrollY, _ = w.scrollY().Get(dropdownScrollID)
+		// Default 0: unscrolled dropdown before first scroll event.
+		scrollY = w.scrollY().GetOr(dropdownScrollID, 0)
 	}
 	first, last := listCoreVisibleRange(len(filtered), rowH, listH, scrollY)
 
@@ -318,7 +319,8 @@ func comboboxClose(id string, w *Window) {
 func makeComboboxOnChar(cfgID string) func(*Layout, *Event, *Window) {
 	return func(_ *Layout, e *Event, w *Window) {
 		ss := StateMap[string, bool](w, nsCombobox, capModerate)
-		isOpen, _ := ss.Get(cfgID) // ok ignored: false means "not open"
+		// Default false: absent entry means "not open".
+		isOpen := ss.GetOr(cfgID, false)
 		if !isOpen {
 			return
 		}
@@ -327,8 +329,8 @@ func makeComboboxOnChar(cfgID string) func(*Layout, *Event, *Window) {
 			return
 		}
 		sq := StateMap[string, string](w, nsComboboxQuery, capModerate)
-		// ok ignored: empty string is correct initial query.
-		query, _ := sq.Get(cfgID)
+		// Default "": absent entry means empty initial query.
+		query := sq.GetOr(cfgID, "")
 		query += string(ch)
 		sq.Set(cfgID, query)
 		sh := StateMap[string, int](w, nsComboboxHighlight, capModerate)
@@ -346,7 +348,8 @@ func makeComboboxOnKeyDown(cfgID string, onSelect func(string, *Event, *Window),
 
 func comboboxOnKeyDown(cfgID string, onSelect func(string, *Event, *Window), focusID string, filteredIDs []string, scrollID string, rowH, listH float32, e *Event, w *Window) {
 	ss := StateMap[string, bool](w, nsCombobox, capModerate)
-	isOpen, _ := ss.Get(cfgID) // ok ignored: false means "not open"
+	// Default false: absent entry means "not open".
+	isOpen := ss.GetOr(cfgID, false)
 
 	if !isOpen {
 		if e.KeyCode == KeySpace || e.KeyCode == KeyEnter ||
@@ -365,7 +368,8 @@ func comboboxOnKeyDown(cfgID string, onSelect func(string, *Event, *Window), foc
 
 	if e.KeyCode == KeyBackspace {
 		sq := StateMap[string, string](w, nsComboboxQuery, capModerate)
-		query, _ := sq.Get(cfgID) // ok ignored: empty string, len checked below
+		// Default "": absent entry means empty query, len check below.
+		query := sq.GetOr(cfgID, "")
 		if len(query) > 0 {
 			_, sz := utf8.DecodeLastRuneInString(query)
 			sq.Set(cfgID, query[:len(query)-sz])
@@ -379,7 +383,8 @@ func comboboxOnKeyDown(cfgID string, onSelect func(string, *Event, *Window), foc
 
 	itemCount := len(filteredIDs)
 	sh := StateMap[string, int](w, nsComboboxHighlight, capModerate)
-	cur, _ := sh.Get(cfgID)
+	// Default 0: first item highlighted; bounds-checked before use.
+	cur := sh.GetOr(cfgID, 0)
 	action := listCoreNavigate(e.KeyCode, itemCount)
 
 	if action == listCoreSelectItem {
@@ -406,7 +411,8 @@ func scrollEnsureVisible(
 	id string, idx int, rowH, listH float32, w *Window,
 ) {
 	sm := w.scrollY()
-	scrollY, _ := sm.Get(id)
+	// Default 0: unscrolled list before first scroll event.
+	scrollY := sm.GetOr(id, 0)
 	top := float32(idx) * rowH
 	bottom := top + rowH
 	visible := -scrollY

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -122,7 +122,8 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 	scrollID := cfg.ID + ":scroll"
 	var scrollY float32
 	if cfg.Scrollable {
-		scrollY, _ = w.scrollY().Get(scrollID)
+		// Default 0: unscrolled list before first scroll event.
+		scrollY = w.scrollY().GetOr(scrollID, 0)
 	}
 	first, last := listCoreVisibleRange(len(filtered), rowH, cfg.MaxHeight, scrollY)
 

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -470,7 +470,8 @@ func inputOnClick(scrollID string) func(*Layout, *Event, *Window) {
 		}
 		if scrollID != "" && layout.Parent != nil {
 			sy := w.scrollY()
-			ds.scrollY0, _ = sy.Get(scrollID) // ok ignored: zero offset is correct initial scroll
+			// Default 0: unscrolled input before first scroll event.
+			ds.scrollY0 = sy.GetOr(scrollID, 0)
 			p := layout.Parent.Shape
 			ds.viewTop = p.Y + p.Padding.Top
 			viewH := p.Height - p.paddingHeight()

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -84,7 +84,8 @@ func rtfSelectOnClick(l *Layout, e *Event, w *Window) {
 		if p.Shape != nil && p.Shape.Scrollable {
 			scrollID = p.Shape.ID
 			sy := w.scrollY()
-			dragScrollY0, _ = sy.Get(scrollID)
+			// Default 0: unscrolled container before first scroll event.
+			dragScrollY0 = sy.GetOr(scrollID, 0)
 			sp := p.Shape
 			viewTop = sp.Y + sp.Padding.Top
 			viewH := sp.Height - sp.paddingHeight()


### PR DESCRIPTION
Resolves #54.

Adds `BoundedMap.GetOr(key K, def V) V` so call sites that previously ignored `Get`'s ok boolean state their assumed default explicitly.

Migrated sites (per the issue's list):
- `gui/drag_reorder.go` — drag-start and drag-move scroll offsets (x4)
- `gui/view_combobox.go` — dropdown scroll, open state x2, query x2, highlight index, ensure-visible scroll (x7)
- `gui/view_command_palette.go` — list scroll
- `gui/view_input.go` — drag-start scroll offset
- `gui/view_rtf_select.go` — drag-start scroll offset

Each migrated site carries a one-line comment stating why the default is correct. New `TestBoundedMapGetOr` covers present key, missing key, and stored-zero-vs-default.

Remaining ~105 ignored-ok sites tracked in #101 (same fix pattern).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786919231&installation_id=145733661&pr_number=102&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F102&signature=575405c065a4a4e73a513681374575220f93610f570ca8ec5e2971c982314f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->