### PR TITLE
gui: migrate remaining ignored-ok BoundedMap.Get sites to GetOr

### DIFF
--- a/gui/datagrid/data_source_grid.go
+++ b/gui/datagrid/data_source_grid.go
@@ -42,9 +42,9 @@ func GetSourceStats(w *gg.Window, gridID string) SourceStats {
 
 func dataGridSourceApplyLocalMutation(gridID string, rows []GridRow, rowCount int, w *gg.Window) {
 	dgSrc := gg.StateMap[string, dataGridSourceState](w, nsDgSource, capModerate)
-	// ok ignored: zero state → cancelActive returns immediately,
-	// then state is fully overwritten below.
-	state, _ := dgSrc.Get(gridID)
+	// Default zero state: absent entry means no prior mutation state;
+	// cancelActive no-ops, then state is fully overwritten below.
+	state := dgSrc.GetOr(gridID, dataGridSourceState{})
 	dataGridSourceCancelActive(&state)
 	rows = dataGridSourceRowsWithStableIDs(rows, state.PaginationKind, state)
 	state.RequestID++
@@ -97,8 +97,9 @@ func dataGridResolveSourceCfg(cfg DataGridCfg, w *gg.Window) (DataGridCfg, dataG
 
 	// Use cached capabilities when available.
 	dgSrc := gg.StateMap[string, dataGridSourceState](w, nsDgSource, capModerate)
-	// ok ignored: zero CapsCached (false) triggers fresh Capabilities() call.
-	existing, _ := dgSrc.Get(cfg.ID)
+	// Default zero state: absent entry means CapsCached is false,
+	// triggering fresh Capabilities() call.
+	existing := dgSrc.GetOr(cfg.ID, dataGridSourceState{})
 	var caps GridDataCapabilities
 	if existing.CapsCached {
 		caps = existing.CachedCaps
@@ -588,7 +589,8 @@ func dataGridSourceSubmitJump(onSelectionChange func(GridSelection, *gg.Event, *
 	}
 	total := *rowCount
 	dgJI := gg.StateMap[string, string](w, nsDgJump, capModerate)
-	jumpText, _ := dgJI.Get(gridID) // ok ignored: empty → parseJumpTarget returns (0, false)
+	// Default "": absent entry means no jump text typed yet.
+	jumpText := dgJI.GetOr(gridID, "")
 	targetIdx, ok := dataGridParseJumpTarget(jumpText, total)
 	if !ok {
 		return

--- a/gui/datagrid/view_data_grid.go
+++ b/gui/datagrid/view_data_grid.go
@@ -493,10 +493,12 @@ func New(w *gg.Window, cfg DataGridCfg) gg.View {
 	focusID := dataGridFocusID(&resolvedCfg)
 	scrollID := dataGridScrollID(&resolvedCfg)
 	dgHH := gg.StateMap[string, string](w, nsDgHeaderHover, capModerate)
-	hoveredColID, _ := dgHH.Get(resolvedCfg.ID)
+	// Default "": absent entry means no column is hovered.
+	hoveredColID := dgHH.GetOr(resolvedCfg.ID, "")
 	resizingColID := dataGridActiveResizeColID(resolvedCfg.ID, w)
 	dgCO := gg.StateMap[string, bool](w, nsDgChooserOpen, capModerate)
-	chooserOpen, _ := dgCO.Get(resolvedCfg.ID)
+	// Default false: absent entry means column chooser is closed.
+	chooserOpen := dgCO.GetOr(resolvedCfg.ID, false)
 
 	// Height/layout waterfall.
 	rowHeight := dataGridRowHeight(&resolvedCfg, w)
@@ -562,7 +564,8 @@ func New(w *gg.Window, cfg DataGridCfg) gg.View {
 	headerHeight := dataGridHeaderHeight(&resolvedCfg)
 	frozenTopViews, frozenTopDisplayRows := dataGridFrozenTopViews(dctx,
 		frozenTopIndices, rowDeleteEnabled)
-	scrollX, _ := w.ScrollX().Get(scrollID)
+	// Default 0: absent entry means no horizontal scroll offset.
+	scrollX := w.ScrollX().GetOr(scrollID, 0)
 
 	// Visible range for virtualization.
 	firstVisible, lastVisible := 0, len(presentation.Rows)-1

--- a/gui/datagrid/view_data_grid_cache.go
+++ b/gui/datagrid/view_data_grid_cache.go
@@ -529,7 +529,8 @@ func dataGridFinalContent(
 			totalRows = *cfg.RowCount
 		}
 		dgJump := gg.StateMap[string, string](dctx.w, nsDgJump, capModerate)
-		jumpText, _ := dgJump.Get(cfg.ID)
+		// Default "": absent entry means no jump text typed yet.
+		jumpText := dgJump.GetOr(cfg.ID, "")
 		content = append(content, dataGridPagerRow(cfg, dctx.focusID,
 			pageIndex, pageCount, pageStart, pageEnd, totalRows,
 			gridHeight, dctx.rowHeight, staticTop, dctx.scrollID,
@@ -537,7 +538,8 @@ func dataGridFinalContent(
 	}
 	if sourcePagerEnabled {
 		dgJump := gg.StateMap[string, string](dctx.w, nsDgJump, capModerate)
-		jumpText, _ := dgJump.Get(cfg.ID)
+		// Default "": absent entry means no jump text for source pager.
+		jumpText := dgJump.GetOr(cfg.ID, "")
 		content = append(content, dataGridSourcePagerRow(cfg,
 			dctx.focusID, sourceState, sourceCaps, jumpText))
 	}

--- a/gui/datagrid/view_data_grid_crud.go
+++ b/gui/datagrid/view_data_grid_crud.go
@@ -88,7 +88,8 @@ func dataGridRowsIDSignature(rows []GridRow) uint64 {
 // and the current crud state.
 func dataGridCrudResolveCfg(cfg DataGridCfg, w *gg.Window) (DataGridCfg, dataGridCrudState) {
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(cfg.ID)
+	// Default zero state: absent entry means no CRUD state yet.
+	state := dgCrud.GetOr(cfg.ID, dataGridCrudState{})
 
 	// Compute signature.
 	var signature uint64
@@ -251,7 +252,8 @@ func dataGridCrudDefaultCells(columns []GridColumnCfg) map[string]string {
 
 func dataGridCrudAddRow(gridID string, columns []GridColumnCfg, onSelectionChange func(GridSelection, *gg.Event, *gg.Window), focusID string, scrollID string, pageSize, pageIndex int, onPageChange func(int, *gg.Event, *gg.Window), e *gg.Event, w *gg.Window) {
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(gridID)
+	// Default zero state: absent entry means no rows added yet.
+	state := dgCrud.GetOr(gridID, dataGridCrudState{})
 	state.NextDraftSeq++
 	draftID := fmt.Sprintf("__draft_%s_%d", gridID, state.NextDraftSeq)
 	row := GridRow{
@@ -318,7 +320,8 @@ func dataGridCrudDeleteRows(gridID string, selection GridSelection, onSelectionC
 		return
 	}
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(gridID)
+	// Default zero state: absent entry means nothing to delete.
+	state := dgCrud.GetOr(gridID, dataGridCrudState{})
 	kept := make([]GridRow, 0, len(state.WorkingRows))
 	for idx, row := range state.WorkingRows {
 		rowID := dataGridRowID(row, idx)
@@ -382,7 +385,8 @@ func dataGridCrudApplyCellEdit(gridID string, crudEnabled bool, onCellEdit func(
 	}
 	if crudEnabled {
 		dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-		state, _ := dgCrud.Get(gridID)
+		// Default zero state: absent entry means no edit has been applied.
+		state := dgCrud.GetOr(gridID, dataGridCrudState{})
 		for idx, row := range state.WorkingRows {
 			if dataGridRowID(row, idx) != edit.RowID {
 				continue
@@ -410,7 +414,8 @@ func dataGridCrudApplyCellEdit(gridID string, crudEnabled bool, onCellEdit func(
 
 func dataGridCrudCancel(gridID string, focusID string, e *gg.Event, w *gg.Window) {
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(gridID)
+	// Default zero state: absent entry means no pending changes to cancel.
+	state := dgCrud.GetOr(gridID, dataGridCrudState{})
 	state.WorkingRows = cloneRows(state.CommittedRows)
 	dataGridCrudClearPendingChanges(&state)
 	state.SaveError = ""

--- a/gui/datagrid/view_data_grid_crud_save.go
+++ b/gui/datagrid/view_data_grid_crud_save.go
@@ -147,7 +147,8 @@ type dataGridCrudSaveContext struct {
 func dataGridCrudSave(ctx dataGridCrudSaveContext, e *gg.Event, w *gg.Window) {
 	gridID := ctx.gridID
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(gridID)
+	// Default zero state: absent entry means nothing to save.
+	state := dgCrud.GetOr(gridID, dataGridCrudState{})
 	if state.Saving || !dataGridCrudHasUnsaved(state) {
 		return
 	}
@@ -293,7 +294,8 @@ func dataGridCrudApplySaveResult(gridID string, result dataGridCrudMutationResul
 		return
 	}
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(gridID)
+	// Default zero state: absent entry means save was not in CRUD mode.
+	state := dgCrud.GetOr(gridID, dataGridCrudState{})
 	replaceIDs, createWarn := dataGridCrudReplaceCreatedRows(
 		state.WorkingRows, result.createRows, result.created)
 	if createWarn != "" {
@@ -309,7 +311,8 @@ func dataGridCrudApplySaveResult(gridID string, result dataGridCrudMutationResul
 
 func dataGridCrudFinishSave(gridID string, _ map[string]string, rowCount int, onRowsChange func([]GridRow, *gg.Event, *gg.Window), hasSource bool, focusID string, e *gg.Event, w *gg.Window) {
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(gridID)
+	// Default zero state: absent entry means no CRUD state to finalize.
+	state := dgCrud.GetOr(gridID, dataGridCrudState{})
 	state.CommittedRows = cloneRows(state.WorkingRows)
 	dataGridCrudClearPendingChanges(&state)
 	state.Saving = false
@@ -338,7 +341,8 @@ func dataGridCrudFinishSave(gridID string, _ map[string]string, rowCount int, on
 
 func dataGridCrudRestoreOnError(gridID, phase string, onCRUDError func(string, *gg.Event, *gg.Window), e *gg.Event, w *gg.Window, snapshotRows []GridRow, errMsg string) {
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
-	state, _ := dgCrud.Get(gridID)
+	// Default zero state: absent entry means nothing to restore on error.
+	state := dgCrud.GetOr(gridID, dataGridCrudState{})
 	state.CommittedRows = snapshotRows
 	state.WorkingRows = cloneRows(snapshotRows)
 	dataGridCrudClearPendingChanges(&state)

--- a/gui/datagrid/view_data_grid_edit.go
+++ b/gui/datagrid/view_data_grid_edit.go
@@ -162,7 +162,8 @@ func dataGridTrackRowEditClick(gridID string, editEnabled bool, editorFocusBase 
 		return
 	}
 	dgES := gg.StateMap[string, dataGridEditState](w, nsDgEdit, capModerate)
-	state, _ := dgES.Get(gridID)
+	// Default zero state: absent entry means no prior row-click recorded.
+	state := dgES.GetOr(gridID, dataGridEditState{})
 
 	isDoubleClick := state.LastClickRowID == rowID && state.LastClickFrame > 0 &&
 		e.FrameCount-state.LastClickFrame <= dataGridEditDoubleClickFrames
@@ -245,14 +246,16 @@ func dataGridEditingRowID(gridID string, w *gg.Window) string {
 
 func dataGridSetEditingRow(gridID, rowID string, w *gg.Window) {
 	dgES := gg.StateMap[string, dataGridEditState](w, nsDgEdit, capModerate)
-	state, _ := dgES.Get(gridID)
+	// Default zero state: absent entry means no editing row was set yet.
+	state := dgES.GetOr(gridID, dataGridEditState{})
 	state.EditingRowID = rowID
 	dgES.Set(gridID, state)
 }
 
 func dataGridClearEditingRow(gridID string, w *gg.Window) {
 	dgES := gg.StateMap[string, dataGridEditState](w, nsDgEdit, capModerate)
-	state, _ := dgES.Get(gridID)
+	// Default zero state: absent entry means no editing row to clear.
+	state := dgES.GetOr(gridID, dataGridEditState{})
 	state.EditingRowID = ""
 	dgES.Set(gridID, state)
 }

--- a/gui/datagrid/view_data_grid_events.go
+++ b/gui/datagrid/view_data_grid_events.go
@@ -211,6 +211,7 @@ func dataGridMakeColumnChooserOnClick(onHiddenColumnsChange func(map[string]bool
 
 func dataGridToggleColumnChooserOpen(gridID string, w *gg.Window) {
 	dgCO := gg.StateMap[string, bool](w, nsDgChooserOpen, capModerate)
-	isOpen, _ := dgCO.Get(gridID) // ok ignored: false means "not open", toggle correct
+	// Default false: absent entry means column chooser is closed.
+	isOpen := dgCO.GetOr(gridID, false)
 	dgCO.Set(gridID, !isOpen)
 }

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -343,7 +343,8 @@ func dataGridStartResize(gridID string, columns []GridColumnCfg, rows []GridRow,
 		w.SetFocus(focusID)
 	}
 	dgRS := gg.StateMap[string, dataGridResizeState](w, nsDgResize, capModerate)
-	runtime, _ := dgRS.Get(gridID)
+	// Default zero state: absent entry means no resize in progress.
+	runtime := dgRS.GetOr(gridID, dataGridResizeState{})
 
 	if runtime.LastClickColID == col.ID && runtime.LastClickFrame > 0 &&
 		e.FrameCount-runtime.LastClickFrame <= dataGridResizeDoubleClickFrames {

--- a/gui/datagrid/view_data_grid_jump.go
+++ b/gui/datagrid/view_data_grid_jump.go
@@ -67,8 +67,8 @@ func dataGridSubmitLocalJump(ctx dataGridJumpContext, e *gg.Event, w *gg.Window)
 		return
 	}
 	dgJI := gg.StateMap[string, string](w, nsDgJump, capModerate)
-	// ok ignored: empty string → parseJumpTarget returns (0, false).
-	jumpText, _ := dgJI.Get(ctx.gridID)
+	// Default "": absent entry means no jump text typed yet.
+	jumpText := dgJI.GetOr(ctx.gridID, "")
 	targetIdx, ok := dataGridParseJumpTarget(jumpText, ctx.totalRows)
 	if !ok {
 		return
@@ -141,7 +141,8 @@ func dataGridScrollRowIntoViewEx(viewportH float32, rowIdx int, rowHeight, stati
 	if viewportH <= 0 || rowHeight <= 0 {
 		return
 	}
-	currentNeg, _ := w.ScrollY().Get(scrollID) // ok ignored: zero offset is correct initial scroll
+	// Default 0: absent entry means scroll is at origin.
+	currentNeg := w.ScrollY().GetOr(scrollID, 0)
 	current := -currentNeg
 	rowTop := staticTop + float32(rowIdx)*rowHeight
 	rowBottom := rowTop + rowHeight

--- a/gui/input_state.go
+++ b/gui/input_state.go
@@ -268,7 +268,8 @@ func inputCut(text string, focusID string, isPassword bool, w *Window) (string, 
 // inputUndo reverts to previous state. Returns restored text.
 func inputUndo(text string, focusID string, w *Window) string {
 	imap := StateMap[string, InputState](w, nsInput, capMany)
-	is, _ := imap.Get(focusID)
+	// Default InputState{}: zero value means no undo state exists.
+	is := imap.GetOr(focusID, InputState{})
 	if is.Undo == nil || is.Undo.IsEmpty() {
 		return text
 	}
@@ -288,7 +289,8 @@ func inputUndo(text string, focusID string, w *Window) string {
 // inputRedo reapplies a previously undone operation.
 func inputRedo(text string, focusID string, w *Window) string {
 	imap := StateMap[string, InputState](w, nsInput, capMany)
-	is, _ := imap.Get(focusID)
+	// Default InputState{}: zero value means no redo state exists.
+	is := imap.GetOr(focusID, InputState{})
 	if is.Redo == nil || is.Redo.IsEmpty() {
 		return text
 	}
@@ -309,7 +311,8 @@ func inputRedo(text string, focusID string, w *Window) string {
 func inputSelectAll(text string, focusID string, w *Window) {
 	runeCount := utf8RuneCount(text)
 	imap := StateMap[string, InputState](w, nsInput, capMany)
-	is, _ := imap.Get(focusID)
+	// Default InputState{}: zero value seeds initial select-all state.
+	is := imap.GetOr(focusID, InputState{})
 	is.SelectBeg = 0
 	is.SelectEnd = uint32(runeCount)
 	is.CursorPos = runeCount

--- a/gui/inspector.go
+++ b/gui/inspector.go
@@ -92,7 +92,8 @@ func inspectorToggleSide(w *Window) {
 		return
 	}
 	sm := StateMap[string, string](w, nsInspector, capInspector)
-	side, _ := sm.Get("side") // ok ignored: empty string means "right" (default)
+	// Default "": absent key means inspector is on the right side.
+	side := sm.GetOr("side", "")
 	if side == "left" {
 		sm.Delete("side")
 	} else {
@@ -218,7 +219,8 @@ func inspectorSelect(path string, w *Window) {
 		return
 	}
 	sm := StateMap[string, string](w, nsInspector, capInspector)
-	selected, _ := sm.Get("selected") // ok ignored: empty string means "nothing selected"
+	// Default "": absent key means nothing is currently selected.
+	selected := sm.GetOr("selected", "")
 	if selected == path {
 		sm.Delete("selected")
 		sm.Delete("scroll_to")

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -120,7 +120,8 @@ func layoutMouseLeave(layout *Layout, w *Window) {
 	}
 	sm := w.hoverInside()
 	inside := shape.PointInShape(w.viewState.mousePosX, w.viewState.mousePosY)
-	wasInside, _ := sm.Get(shape.ID)
+	// Default false: absent entry means cursor was not previously in shape.
+	wasInside := sm.GetOr(shape.ID, false)
 	if wasInside && !inside {
 		w.scratch.hoverEvent = Event{
 			MouseX:      w.viewState.mousePosX,

--- a/gui/markdown_select.go
+++ b/gui/markdown_select.go
@@ -137,7 +137,8 @@ func markdownBlockOnClick(l *Layout, e *Event, w *Window) {
 	absRune := uint32(localRune) + shape.TC.MarkdownBlockStart
 
 	imap := StateMap[string, mdSelState](w, nsMdSel, capMany)
-	st, _ := imap.Get(mdID)
+	// Default mdSelState{}: zero value means no prior selection.
+	st := imap.GetOr(mdID, mdSelState{})
 
 	now := time.Now().UnixMilli()
 	doubleClick := st.LastClickTime > 0 &&
@@ -169,12 +170,16 @@ func markdownBlockOnClick(l *Layout, e *Event, w *Window) {
 	w.MouseLock(MouseLockCfg{
 		MouseMove: func(_ *Layout, e *Event, w *Window) {
 			bm := StateMap[string, []mdBlockInfo](w, nsMdBlocks, capMany)
-			blocks, _ := bm.Get(dragMdID)
+			// Default nil: absent entry means no block info
+			// recorded yet.
+			blocks := bm.GetOr(dragMdID, nil)
 			absPos := mdHitAbsRune(e.MouseX, e.MouseY,
 				blocks, dragGl, dragFlatText, dragBlockStart)
 
 			dim := StateMap[string, mdSelState](w, nsMdSel, capMany)
-			dst, _ := dim.Get(dragMdID)
+			// Default mdSelState{}: zero value means no prior
+			// selection during drag.
+			dst := dim.GetOr(dragMdID, mdSelState{})
 			if isDouble {
 				// Extend word-by-word.
 				if absPos < anchorBeg {
@@ -236,7 +241,8 @@ func markdownContainerOnKeyDown(l *Layout, e *Event, w *Window) {
 		return
 	}
 	bm := StateMap[string, []mdBlockInfo](w, nsMdBlocks, capMany)
-	blocks, _ := bm.Get(mdID)
+	// Default nil: absent entry means no blocks available.
+	blocks := bm.GetOr(mdID, nil)
 	if len(blocks) == 0 {
 		return
 	}
@@ -250,7 +256,9 @@ func markdownContainerOnKeyDown(l *Layout, e *Event, w *Window) {
 				totalRunes += b.RuneLen
 			}
 			imap := StateMap[string, mdSelState](w, nsMdSel, capMany)
-			st, _ := imap.Get(mdID)
+			// Default mdSelState{}: zero value means no prior
+			// selection for select-all.
+			st := imap.GetOr(mdID, mdSelState{})
 			st.SelBeg = 0
 			st.SelEnd = totalRunes
 			imap.Set(mdID, st)
@@ -260,7 +268,9 @@ func markdownContainerOnKeyDown(l *Layout, e *Event, w *Window) {
 	case KeyC:
 		if e.Modifiers.HasAny(ModCtrl, ModSuper) {
 			imap := StateMap[string, mdSelState](w, nsMdSel, capMany)
-			st, _ := imap.Get(mdID)
+			// Default mdSelState{}: zero value means no prior
+			// selection to copy.
+			st := imap.GetOr(mdID, mdSelState{})
 			if st.SelBeg != st.SelEnd {
 				beg, end := u32Sort(st.SelBeg, st.SelEnd)
 				w.SetClipboard(mdExtractText(blocks, beg, end))

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -78,8 +78,9 @@ func inputScrollCursorIntoView(
 	}
 	adjustCursorTrailing(&cp, gl.Lines, byteIdx, is.CursorTrailing)
 
+	// Default 0: unscrolled position when no offset recorded yet.
 	sy := w.scrollY()
-	scrollOffset, _ := sy.Get(id)
+	scrollOffset := sy.GetOr(id, 0)
 	viewportH := layout.Shape.Height - layout.Shape.paddingHeight()
 
 	cursorTop := cp.Y
@@ -139,8 +140,9 @@ func textScrollCursorIntoView(layout *Layout, w *Window) {
 	}
 	adjustCursorTrailing(&cp, gl.Lines, byteIdx, is.CursorTrailing)
 
+	// Default 0: unscrolled position when no offset recorded yet.
 	sy := w.scrollY()
-	scrollOffset, _ := sy.Get(scrollID)
+	scrollOffset := sy.GetOr(scrollID, 0)
 	sp := scrollParent.Shape
 	viewportH := sp.Height - sp.paddingHeight()
 	viewTop := sp.Y + sp.Padding.Top
@@ -194,7 +196,8 @@ func scrollHorizontal(layout *Layout, delta float32, w *Window) bool {
 	}
 	maxOffset := scrollMaxOffsetX(layout)
 	sx := w.scrollX()
-	old, _ := sx.Get(id)
+	// Default 0: unscrolled position when no offset recorded yet.
+	old := sx.GetOr(id, 0)
 	clamped := f32Clamp(
 		old+delta*guiTheme.ScrollMultiplier, maxOffset, 0)
 	if old == clamped {
@@ -218,7 +221,8 @@ func scrollVertical(layout *Layout, delta float32, w *Window) bool {
 	}
 	maxOffset := scrollMaxOffsetY(layout)
 	sy := w.scrollY()
-	old, _ := sy.Get(id)
+	// Default 0: unscrolled position when no offset recorded yet.
+	old := sy.GetOr(id, 0)
 	clamped := f32Clamp(
 		old+delta*guiTheme.ScrollMultiplier, maxOffset, 0)
 	if old == clamped {
@@ -242,8 +246,10 @@ func (w *Window) ScrollToView(id string) {
 		p = p.Parent
 		if p.Shape.Scrollable {
 			scrollID := p.Shape.ID
+			// Default 0: unscrolled position when no offset
+			// recorded yet.
 			sy := w.scrollY()
-			current, _ := sy.Get(scrollID)
+			current := sy.GetOr(scrollID, 0)
 			baseY := p.Shape.Y + p.Shape.Padding.Top
 			newScroll := baseY - target.Shape.Y + current
 			maxScrollNeg := scrollMaxOffsetY(p)
@@ -261,7 +267,8 @@ func (w *Window) ScrollToView(id string) {
 func (w *Window) ScrollHorizontalBy(id string, delta float32) {
 	scrollSmoothCancel(w, id, scrollAxisX)
 	sx := w.scrollX()
-	current, _ := sx.Get(id)
+	// Default 0: unscrolled position when no offset recorded yet.
+	current := sx.GetOr(id, 0)
 	newVal := current + delta
 	if ly, ok := findScrollLayout(w, id); ok {
 		maxOffset := scrollMaxOffsetX(ly)
@@ -317,7 +324,8 @@ func (w *Window) ScrollHorizontalPct(id string) float32 {
 		return 0
 	}
 	sx := w.scrollX()
-	current, _ := sx.Get(id)
+	// Default 0: unscrolled position when no offset recorded yet.
+	current := sx.GetOr(id, 0)
 	return f32Clamp(current/maxOffset, 0, 1)
 }
 
@@ -326,7 +334,8 @@ func (w *Window) ScrollHorizontalPct(id string) float32 {
 func (w *Window) ScrollVerticalBy(id string, delta float32) {
 	scrollSmoothCancel(w, id, scrollAxisY)
 	sy := w.scrollY()
-	current, _ := sy.Get(id)
+	// Default 0: unscrolled position when no offset recorded yet.
+	current := sy.GetOr(id, 0)
 	newVal := current + delta
 	if ly, ok := findScrollLayout(w, id); ok {
 		maxOffset := scrollMaxOffsetY(ly)
@@ -382,6 +391,7 @@ func (w *Window) ScrollVerticalPct(id string) float32 {
 		return 0
 	}
 	sy := w.scrollY()
-	current, _ := sy.Get(id)
+	// Default 0: unscrolled position when no offset recorded yet.
+	current := sy.GetOr(id, 0)
 	return f32Clamp(current/maxOffset, 0, 1)
 }

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -148,13 +148,14 @@ func scrollSmoothBy(w *Window, layout *Layout, axis scrollAxis, delta float32) b
 		return false
 	}
 
+	// Default 0: unscrolled position when no offset recorded yet.
 	var maxOffset, displayed float32
 	if axis == scrollAxisY {
 		maxOffset = scrollMaxOffsetY(layout)
-		displayed, _ = w.scrollY().Get(id)
+		displayed = w.scrollY().GetOr(id, 0)
 	} else {
 		maxOffset = scrollMaxOffsetX(layout)
-		displayed, _ = w.scrollX().Get(id)
+		displayed = w.scrollX().GetOr(id, 0)
 	}
 	increment := delta * guiTheme.ScrollMultiplier
 

--- a/gui/spell_check.go
+++ b/gui/spell_check.go
@@ -27,7 +27,8 @@ func spellCheckTrigger(focusID string, text string, w *Window) {
 	}
 	sm := StateMap[string, spellCheckState](
 		w, nsSpellCheck, capMany)
-	cached, _ := sm.Get(focusID)
+	// Default zero state: absent entry means no cached spell result yet.
+	cached := sm.GetOr(focusID, spellCheckState{})
 	if cached.Text == text {
 		return
 	}

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -472,7 +472,9 @@ func cpSVMouseAction(
 
 	sm := StateMap[string, colorPickerState](
 		w, nsColorPicker, capModerate)
-	hsv, _ := sm.Get(id)
+	// Default zero: HSV(0,0,0) is black; state seeded before callbacks
+	// fire so this default is never reached in practice.
+	hsv := sm.GetOr(id, colorPickerState{})
 	hsv.S = s
 	hsv.V = v
 	sm.Set(id, hsv)
@@ -495,7 +497,9 @@ func cpHueMouseAction(
 
 	sm := StateMap[string, colorPickerState](
 		w, nsColorPicker, capModerate)
-	hsv, _ := sm.Get(id)
+	// Default zero: HSV(0,0,0) is black; state seeded before callbacks
+	// fire so this default is never reached in practice.
+	hsv := sm.GetOr(id, colorPickerState{})
 	hsv.H = h
 	sm.Set(id, hsv)
 
@@ -585,7 +589,9 @@ func cpApplyHSV(
 	n = intClamp(n, 0, maxVal)
 	sm := StateMap[string, colorPickerState](
 		w, nsColorPicker, capModerate)
-	hsv, _ := sm.Get(cfgID)
+	// Default zero: HSV(0,0,0) is black; state seeded before callbacks
+	// fire so this default is never reached in practice.
+	hsv := sm.GetOr(cfgID, colorPickerState{})
 	switch idx {
 	case 0:
 		hsv.H = float32(n)

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -289,7 +289,8 @@ func cmdPaletteItemToCore(item CommandPaletteItem) listCoreItem {
 func makePaletteOnEnter(paletteID string, onAction func(string, *Event, *Window), onDismiss func(*Window), filtered []listCoreItem, filteredIDs []string) func(*Layout, *Event, *Window) {
 	return func(_ *Layout, e *Event, w *Window) {
 		sh := StateMap[string, int](w, nsCmdPaletteHighlight, capModerate)
-		cur, _ := sh.Get(paletteID) // ok ignored: zero index is valid, bounds-checked below
+		// Default 0: first item highlighted; bounds-checked before use.
+		cur := sh.GetOr(paletteID, 0)
 		itemCount := len(filteredIDs)
 		if cur >= 0 && cur < itemCount && onAction != nil &&
 			!filtered[cur].Disabled {
@@ -360,7 +361,8 @@ func paletteOnKeyDown(paletteID string, onAction func(string, *Event, *Window), 
 
 	itemCount := len(filteredIDs)
 	sh := StateMap[string, int](w, nsCmdPaletteHighlight, capModerate)
-	cur, _ := sh.Get(paletteID) // ok ignored: zero index is valid, bounds-checked below
+	// Default 0: first item highlighted; bounds-checked before use.
+	cur := sh.GetOr(paletteID, 0)
 	action := listCoreNavigate(e.KeyCode, itemCount)
 
 	if action == listCoreSelectItem {

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -178,7 +178,10 @@ func (dv *datePickerView) GenerateLayout(w *Window) Layout {
 		OnKeyDown: func(_ *Layout, e *Event, w *Window) {
 			sm := StateMap[string, datePickerState](
 				w, nsDatePicker, capModerate)
-			s, _ := sm.Get(cfgID)
+			s, ok := sm.Get(cfgID)
+			if !ok {
+				return
+			}
 			if s.ShowYearMonthPicker {
 				datePickerRollerKeyDown(
 					sm, cfgID, s, e, w)
@@ -229,7 +232,10 @@ func datePickerControls(
 	focusID := cfg.ID
 	onToggle := func(_ *Layout, e *Event, w *Window) {
 		sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
-		s, _ := sm.Get(cfgID)
+		s, ok := sm.Get(cfgID)
+		if !ok {
+			return
+		}
 		s.ShowYearMonthPicker = !s.ShowYearMonthPicker
 		sm.Set(cfgID, s)
 		if focusID != "" {
@@ -297,7 +303,10 @@ func datePickerControls(
 // datePickerOnKeyDown handles arrow key navigation.
 func datePickerOnKeyDown(cfg *DatePickerCfg, e *Event, w *Window) {
 	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
-	s, _ := sm.Get(cfg.ID)
+	s, ok := sm.Get(cfg.ID)
+	if !ok {
+		return
+	}
 	days := datePickerDaysInMonth(s.ViewMonth, s.ViewYear)
 
 	update := func() {
@@ -311,7 +320,10 @@ func datePickerOnKeyDown(cfg *DatePickerCfg, e *Event, w *Window) {
 		s.FocusDay--
 		if s.FocusDay < 1 {
 			datePickerNavMonth(cfg.ID, -1, w)
-			s, _ = sm.Get(cfg.ID)
+			s, ok = sm.Get(cfg.ID)
+			if !ok {
+				return
+			}
 			s.FocusDay = datePickerDaysInMonth(s.ViewMonth, s.ViewYear)
 		}
 		update()
@@ -319,7 +331,10 @@ func datePickerOnKeyDown(cfg *DatePickerCfg, e *Event, w *Window) {
 		s.FocusDay++
 		if s.FocusDay > days {
 			datePickerNavMonth(cfg.ID, 1, w)
-			s, _ = sm.Get(cfg.ID)
+			s, ok = sm.Get(cfg.ID)
+			if !ok {
+				return
+			}
 			s.FocusDay = 1
 		}
 		update()
@@ -327,7 +342,10 @@ func datePickerOnKeyDown(cfg *DatePickerCfg, e *Event, w *Window) {
 		s.FocusDay -= 7
 		if s.FocusDay < 1 {
 			datePickerNavMonth(cfg.ID, -1, w)
-			s, _ = sm.Get(cfg.ID)
+			s, ok = sm.Get(cfg.ID)
+			if !ok {
+				return
+			}
 			prevDays := datePickerDaysInMonth(s.ViewMonth, s.ViewYear)
 			s.FocusDay += prevDays
 		}
@@ -336,7 +354,10 @@ func datePickerOnKeyDown(cfg *DatePickerCfg, e *Event, w *Window) {
 		s.FocusDay += 7
 		if s.FocusDay > days {
 			datePickerNavMonth(cfg.ID, 1, w)
-			s, _ = sm.Get(cfg.ID)
+			s, ok = sm.Get(cfg.ID)
+			if !ok {
+				return
+			}
 			s.FocusDay -= days
 		}
 		update()

--- a/gui/view_date_picker_calendar.go
+++ b/gui/view_date_picker_calendar.go
@@ -24,7 +24,10 @@ func datePickerCalendar(
 		AmendLayout: func(lo *Layout, w *Window) {
 			sm := StateMap[string, datePickerState](
 				w, nsDatePicker, capModerate)
-			s, _ := sm.Get(cfgID)
+			s, ok := sm.Get(cfgID)
+			if !ok {
+				return
+			}
 			if s.CalBodyHeight != lo.Shape.Height {
 				s.CalBodyHeight = lo.Shape.Height
 				sm.Set(cfgID, s)
@@ -153,7 +156,10 @@ func datePickerMonth(
 				})},
 				OnClick: func(_ *Layout, e *Event, w *Window) {
 					sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
-					s, _ := sm.Get(cfgID)
+					s, ok := sm.Get(cfgID)
+					if !ok {
+						return
+					}
 					s.FocusDay = dayVal
 					sm.Set(cfgID, s)
 
@@ -236,7 +242,10 @@ func datePickerAdjacentCell(
 			// After navigation, select the day in the new month.
 			// Retrieve updated state to get correct year/month.
 			sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
-			s, _ := sm.Get(cfgID)
+			s, ok := sm.Get(cfgID)
+			if !ok {
+				return
+			}
 			dates := datePickerUpdateSelections(
 				adjDay, s, cfg.Dates,
 				selectMultiple)
@@ -267,7 +276,10 @@ func datePickerYearMonthPicker(
 			}
 			sm := StateMap[string, datePickerState](
 				w, nsDatePicker, capModerate)
-			s, _ := sm.Get(cfgID)
+			s, ok := sm.Get(cfgID)
+			if !ok {
+				return
+			}
 			s.ViewMonth = int(t.Month())
 			s.ViewYear = t.Year()
 			sm.Set(cfgID, s)
@@ -318,7 +330,10 @@ func datePickerRollerKeyDown(
 // datePickerNavMonth shifts the view month by delta.
 func datePickerNavMonth(id string, delta int, w *Window) {
 	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
-	s, _ := sm.Get(id)
+	s, ok := sm.Get(id)
+	if !ok {
+		return
+	}
 	s.ViewMonth += delta
 	if s.ViewMonth > 12 {
 		s.ViewMonth = 1

--- a/gui/view_date_picker_test.go
+++ b/gui/view_date_picker_test.go
@@ -52,6 +52,17 @@ func TestDatePickerNavMonth(t *testing.T) {
 	}
 }
 
+func TestDatePickerNavMonthAbsentStateNoOp(t *testing.T) {
+	// Absent state (evicted or never seeded) must be a no-op:
+	// no garbage state written, no panic.
+	w := &Window{}
+	datePickerNavMonth("never-seeded", 1, w)
+	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
+	if sm.Contains("never-seeded") {
+		t.Error("nav on absent state must not create state")
+	}
+}
+
 func TestDatePickerDaysInMonth(t *testing.T) {
 	tests := []struct {
 		month, year, want int

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -393,7 +393,8 @@ func inputOnClick(scrollID string) func(*Layout, *Event, *Window) {
 			imap := StateMap[string, InputState](
 				w, nsInput, capMany,
 			)
-			is, _ := imap.Get(ly.Shape.ID) // ok ignored: zero value seeds initial state
+			// Default InputState{}: zero value seeds initial state.
+			is := imap.GetOr(ly.Shape.ID, InputState{})
 			is.CursorPos = 0
 			is.SelectBeg = 0
 			is.SelectEnd = 0
@@ -422,9 +423,9 @@ func inputOnClick(scrollID string) func(*Layout, *Event, *Window) {
 		imap := StateMap[string, InputState](
 			w, nsInput, capMany,
 		)
-		// ok ignored: zero LastClickTime safely gates double-click
-		// (the > 0 check on line below prevents false match).
-		is, _ := imap.Get(ly.Shape.ID)
+		// Default InputState{}: zero LastClickTime safely gates
+		// double-click (the > 0 check below prevents false match).
+		is := imap.GetOr(ly.Shape.ID, InputState{})
 
 		// Double-click selects word.
 		now := time.Now().UnixMilli()
@@ -501,7 +502,8 @@ func inputAmendLayout(
 		// Blur detection: fire commit on focus loss.
 		focusMap := StateMap[string, bool](
 			w, nsInputFocus, capMany)
-		wasFocused, _ := focusMap.Get(layout.Shape.ID) // ok ignored: false means "wasn't focused"
+		// Default false: absent entry means not previously focused.
+		wasFocused := focusMap.GetOr(layout.Shape.ID, false)
 		focusMap.Set(layout.Shape.ID, focused)
 		if wasFocused && !focused {
 			text := inputTextFromLayout(layout)

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -95,9 +95,11 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 	// Sync editable text with external date. Only overwrite
 	// user text when the external date actually changes.
 	sm := StateMap[string, string](w, nsInputDateText, capModerate)
-	editText, _ := sm.Get(cfgID)
+	// Default "": absent entry means no edit text cached yet.
+	editText := sm.GetOr(cfgID, "")
 	syncKey := cfgID + ".sync"
-	lastSync, _ := sm.Get(syncKey)
+	// Default "": absent entry means no prior sync occurred.
+	lastSync := sm.GetOr(syncKey, "")
 	if dateText != "" && dateText != lastSync {
 		sm.Set(cfgID, dateText)
 		sm.Set(syncKey, dateText)
@@ -293,7 +295,8 @@ func inputDatePlaceholder(cfg *InputDateCfg) string {
 
 func inputDateToggle(id string, w *Window) {
 	sm := StateMap[string, bool](w, nsInputDate, capModerate)
-	cur, _ := sm.Get(id)
+	// Default false: absent entry means picker is closed.
+	cur := sm.GetOr(id, false)
 	sm.Set(id, !cur)
 	w.UpdateWindow()
 }

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -108,9 +108,9 @@ func makeInputOnKeyDown(hcfg inputHandlerCfg) func(*Layout, *Event, *Window) {
 		}
 		id := hcfg.FocusID
 		imap := StateMap[string, InputState](w, nsInput, capMany)
-		// ok ignored: zero CursorOffset/CursorTrailing seed initial state;
-		// both are immediately overwritten below.
-		is, _ := imap.Get(id)
+		// Default InputState{}: zero CursorOffset/CursorTrailing seed
+		// initial state; both are immediately overwritten below.
+		is := imap.GetOr(id, InputState{})
 		savedOffset := is.CursorOffset
 		savedTrailing := is.CursorTrailing
 		is.CursorOffset = -1

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -162,7 +162,8 @@ func (d *inputDragState) computeRunePos(
 	scrollDelta := float32(0)
 	if d.scrollID != "" {
 		sy := w.scrollY()
-		sNow, _ := sy.Get(d.scrollID) // ok ignored: zero offset is correct initial scroll
+		// Default 0: absent entry means unscrolled initial position.
+		sNow := sy.GetOr(d.scrollID, 0)
 		scrollDelta = sNow - d.scrollY0
 	}
 	relX := mx - d.txtOffX
@@ -173,7 +174,8 @@ func (d *inputDragState) computeRunePos(
 
 func (d *inputDragState) updateSelection(rp int, w *Window) {
 	imap := StateMap[string, InputState](w, nsInput, capMany)
-	is, _ := imap.Get(d.focusID)
+	// Default InputState{}: zero value seeds initial drag-selection state.
+	is := imap.GetOr(d.focusID, InputState{})
 	if d.runes != nil {
 		wb, we := wordBoundsAt(d.runes, rp)
 		if rp < int(d.anchorPos) {
@@ -208,7 +210,8 @@ func (d *inputDragState) scrollCallback(
 		return
 	}
 	sy := w.scrollY()
-	cur, _ := sy.Get(d.scrollID)
+	// Default 0: unscrolled position when no offset recorded yet.
+	cur := sy.GetOr(d.scrollID, 0)
 	newScroll := f32Clamp(cur+delta, d.maxScrollNeg, 0)
 	if newScroll == cur {
 		return

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -175,7 +175,8 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 
 	// Keyboard focus highlight.
 	lbf := StateMap[string, int](w, nsListBoxFocus, capModerate)
-	focusIdx, _ := lbf.Get(cfg.ID)
+	// Default 0: start at first item; bounds-checked below.
+	focusIdx := lbf.GetOr(cfg.ID, 0)
 	var focusedID string
 	if focusIdx >= 0 && focusIdx < len(itemIDs) {
 		focusedID = itemIDs[focusIdx]
@@ -228,7 +229,8 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 				}
 				lbf = StateMap[string, int](
 					w, nsListBoxFocus, capModerate)
-				curIdx, _ := lbf.Get(listBoxID)
+				// Default 0: bounds-checked before use; zero index handled.
+				curIdx := lbf.GetOr(listBoxID, 0)
 				if curIdx >= 0 && curIdx < len(itemIDs) &&
 					dragReorderKeyboardMove(e.KeyCode,
 						e.Modifiers, DragReorderVertical,
@@ -301,7 +303,8 @@ func listBoxVisibleRange(
 	}
 	rowH = listCoreRowHeightEstimate(cfg.TextStyle, listBoxItemPad)
 	if virtualize && listH > 0 && len(cfg.Data) > 0 {
-		scrollY, _ := w.scrollY().Get(cfg.ID)
+		// Default 0: absent entry means not scrolled.
+		scrollY := w.scrollY().GetOr(cfg.ID, 0)
 		first, last = listCoreVisibleRange(
 			len(cfg.Data), rowH, listH, scrollY)
 	} else {
@@ -626,7 +629,8 @@ func listBoxOnKeyDown(
 	e.IsHandled = true
 
 	lbf := StateMap[string, int](w, nsListBoxFocus, capModerate)
-	curIdx, _ := lbf.Get(listBoxID)
+	// Default 0: bounds-checked before use; zero index handled.
+	curIdx := lbf.GetOr(listBoxID, 0)
 
 	if action == listCoreSelectItem {
 		if curIdx >= 0 && curIdx < len(itemIDs) {

--- a/gui/view_menu.go
+++ b/gui/view_menu.go
@@ -72,7 +72,9 @@ func menuOnKeyDown(cfg MenubarCfg,
 		e.IsHandled = true
 
 	case KeySpace, KeyEnter:
-		sel, _ := sm.Get(cfg.ID) // ok ignored: empty string checked immediately below
+		// Default empty string: absent means no selection; checked
+		// immediately below.
+		sel := sm.GetOr(cfg.ID, "")
 		if sel == "" {
 			return
 		}
@@ -93,7 +95,9 @@ func menuOnKeyDown(cfg MenubarCfg,
 		e.IsHandled = true
 
 	case KeyLeft, KeyRight, KeyUp, KeyDown:
-		sel, _ := sm.Get(cfg.ID) // ok ignored: empty string checked immediately below
+		// Default empty string: absent means no selection; checked
+		// immediately below.
+		sel := sm.GetOr(cfg.ID, "")
 		if sel == "" {
 			return
 		}

--- a/gui/view_menu_item.go
+++ b/gui/view_menu_item.go
@@ -147,7 +147,9 @@ func menuItem(menubarCfg MenubarCfg, itemCfg MenuItemCfg, extra ...View) View {
 			w.setMouseCursor(CursorPointingHand)
 			sm := StateMap[string, string](
 				w, nsMenu, capModerate)
-			cur, _ := sm.Get(cfgFocusID)
+			// Default empty string: absent means no hover; compared
+			// with target itemID.
+			cur := sm.GetOr(cfgFocusID, "")
 			if cur != itemID {
 				sm.Set(cfgFocusID, itemID)
 			}

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -46,7 +46,8 @@ func rtfSelectOnClick(l *Layout, e *Event, w *Window) {
 
 	focusID := shape.ID
 	imap := StateMap[string, InputState](w, nsInput, capMany)
-	is, _ := imap.Get(focusID)
+	// Default InputState{}: zero value seeds initial selection/cursor state.
+	is := imap.GetOr(focusID, InputState{})
 
 	now := time.Now().UnixMilli()
 	doubleClick := is.LastClickTime > 0 &&
@@ -99,7 +100,8 @@ func rtfSelectOnClick(l *Layout, e *Event, w *Window) {
 		scrollDelta := float32(0)
 		if scrollID != "" {
 			sy := w.scrollY()
-			sNow, _ := sy.Get(scrollID)
+			// Default 0: unscrolled position when no offset recorded yet.
+			sNow := sy.GetOr(scrollID, 0)
 			scrollDelta = sNow - dragScrollY0
 		}
 		rx := mx - dragShapeX
@@ -110,7 +112,8 @@ func rtfSelectOnClick(l *Layout, e *Event, w *Window) {
 
 	updateDrag := func(rp int, w *Window) {
 		dim := StateMap[string, InputState](w, nsInput, capMany)
-		dis, _ := dim.Get(focusID)
+		// Default InputState{}: zero value seeds initial drag-edit state.
+		dis := dim.GetOr(focusID, InputState{})
 		if doubleClick {
 			bi := runeToByteIndex(flatText, rp)
 			bBeg, bEnd := gl.GetWordAtIndex(bi)
@@ -145,7 +148,8 @@ func rtfSelectOnClick(l *Layout, e *Event, w *Window) {
 			return
 		}
 		sy := w.scrollY()
-		cur, _ := sy.Get(scrollID)
+		// Default 0: unscrolled position when no offset recorded yet.
+		cur := sy.GetOr(scrollID, 0)
 		newScroll := f32Clamp(cur+delta, maxScrollNeg, 0)
 		if newScroll == cur {
 			return
@@ -195,7 +199,8 @@ func rtfSelectOnKeyDown(l *Layout, e *Event, w *Window) {
 	gl := *shape.TC.RtfLayout
 
 	imap := StateMap[string, InputState](w, nsInput, capMany)
-	is, _ := imap.Get(id)
+	// Default InputState{}: zero value seeds initial keyboard-nav state.
+	is := imap.GetOr(id, InputState{})
 	savedOffset := is.CursorOffset
 	savedTrailing := is.CursorTrailing
 	is.CursorOffset = -1

--- a/gui/view_scrollbar.go
+++ b/gui/view_scrollbar.go
@@ -288,7 +288,12 @@ func scrollbarMouseMove(orientation ScrollbarOrientation, scrollID string, layou
 func offsetMouseChangeX(sx *BoundedMap[string, float32], layout *Layout, mouseDX float32, scrollID string) float32 {
 	totalWidth := contentWidth(layout)
 	shapeWidth := layout.Shape.Width - layout.Shape.paddingWidth()
-	oldOffset, _ := sx.Get(scrollID) // ok ignored: zero offset is correct initial scroll
+	// Default 0: unscrolled position when no offset recorded yet.
+	oldOffset := sx.GetOr(scrollID, 0)
+	// Degenerate viewport: avoid division by zero / NaN offset.
+	if shapeWidth <= 0 {
+		return oldOffset
+	}
 	newOffset := mouseDX * (totalWidth / shapeWidth)
 	offset := oldOffset - newOffset
 	return f32Min(0, f32Max(offset, shapeWidth-totalWidth))
@@ -299,7 +304,12 @@ func offsetMouseChangeX(sx *BoundedMap[string, float32], layout *Layout, mouseDX
 func offsetMouseChangeY(sy *BoundedMap[string, float32], layout *Layout, mouseDY float32, scrollID string) float32 {
 	totalHeight := contentHeight(layout)
 	shapeHeight := layout.Shape.Height - layout.Shape.paddingHeight()
-	oldOffset, _ := sy.Get(scrollID) // ok ignored: zero offset is correct initial scroll
+	// Default 0: unscrolled position when no offset recorded yet.
+	oldOffset := sy.GetOr(scrollID, 0)
+	// Degenerate viewport: avoid division by zero / NaN offset.
+	if shapeHeight <= 0 {
+		return oldOffset
+	}
 	newOffset := mouseDY * (totalHeight / shapeHeight)
 	offset := oldOffset - newOffset
 	return f32Min(0, f32Max(offset, shapeHeight-totalHeight))

--- a/gui/view_scrollbar_test.go
+++ b/gui/view_scrollbar_test.go
@@ -52,6 +52,35 @@ func TestOffsetMouseChangeY(t *testing.T) {
 	}
 }
 
+func TestOffsetMouseChangeZeroViewport(t *testing.T) {
+	// Degenerate zero-size viewport must not divide by zero: the
+	// prior offset is returned unchanged and no NaN is produced.
+	w := &Window{}
+	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 400}}
+	layout := &Layout{
+		Shape: &Shape{
+			shapeType:  shapeRectangle,
+			Scrollable: true,
+			ID:         "z",
+			Width:      0,
+			Height:     0,
+			Axis:       AxisLeftToRight,
+		},
+		Children: []Layout{child},
+	}
+	w.scrollX().Set("z", -7)
+	w.scrollY().Set("z", -9)
+
+	gotX := offsetMouseChangeX(w.scrollX(), layout, 10, "z")
+	if math.IsNaN(float64(gotX)) || gotX != -7 {
+		t.Errorf("x offset = %v, want -7", gotX)
+	}
+	gotY := offsetMouseChangeY(w.scrollY(), layout, 10, "z")
+	if math.IsNaN(float64(gotY)) || gotY != -9 {
+		t.Errorf("y offset = %v, want -9", gotY)
+	}
+}
+
 func TestOffsetFromMouseY(t *testing.T) {
 	w := &Window{}
 	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 50, Height: 400}}

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -185,7 +185,8 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 		OnClick: func(_ *Layout, e *Event, w *Window) {
 			ss := StateMap[string, bool](
 				w, nsSelect, capModerate)
-			cur, _ := ss.Get(id) // ok ignored: false means "not selected", toggle correct
+			// Default false: absent entry means "not selected", toggle correct.
+			cur := ss.GetOr(id, false)
 			ss.Clear()
 			if !cur {
 				ss.Set(id, true)
@@ -267,7 +268,8 @@ func selectOptionView(cfg *SelectCfg, option string, index int, highlighted bool
 			layout.Shape.Color = colorSelect
 			sh := StateMap[string, int](
 				w, nsSelectHL, capModerate)
-			cur, _ := sh.Get(cfgID) // ok ignored: zero index is valid, compared immediately
+			// Default 0: absent entry gets zero index, checked immediately.
+			cur := sh.GetOr(cfgID, 0)
 			if cur != index {
 				sh.Set(cfgID, index)
 			}
@@ -345,7 +347,8 @@ func selectOnKeyDown(cfg *SelectCfg, scrollID string, e *Event, w *Window) {
 
 	ss := StateMap[string, bool](w, nsSelect, capModerate)
 	sh := StateMap[string, int](w, nsSelectHL, capModerate)
-	isOpen, _ := ss.Get(cfg.ID) // ok ignored: false means "not open"
+	// Default false: absent entry means dropdown not open.
+	isOpen := ss.GetOr(cfg.ID, false)
 
 	// Open on space/enter.
 	if (e.KeyCode == KeySpace || e.KeyCode == KeyEnter) && !isOpen {
@@ -367,7 +370,8 @@ func selectOnKeyDown(cfg *SelectCfg, scrollID string, e *Event, w *Window) {
 		return
 	}
 
-	currentIdx, _ := sh.Get(cfg.ID) // ok ignored: zero index is valid, bounds-checked below
+	// Default 0: first item highlighted; bounds-checked before use.
+	currentIdx := sh.GetOr(cfg.ID, 0)
 	action := listCoreNavigate(e.KeyCode, len(cfg.Options))
 
 	if action == listCoreSelectItem {

--- a/gui/view_sidebar.go
+++ b/gui/view_sidebar.go
@@ -126,7 +126,8 @@ func sidebarStartAnimation(
 	onValue := func(v float32, w *Window) {
 		sm := StateMap[string, SidebarRuntimeState](
 			w, nsSidebar, capFew)
-		rt, _ := sm.Get(sidebarID)
+		// Default zero: valid initial state for a new sidebar.
+		rt := sm.GetOr(sidebarID, SidebarRuntimeState{})
 		rt.AnimFrac = v
 		sm.Set(sidebarID, rt)
 	}

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -214,7 +214,8 @@ func tableView(cfg TableCfg, w *Window) View {
 	first, last := dataStart, lastRowIdx
 	if virtualize {
 		rowHeight = tableEstimateRowHeight(&cfg, w)
-		scrollY, _ := w.scrollY().Get(scrollID)
+		// Default 0: unscrolled position when no offset recorded yet.
+		scrollY := w.scrollY().GetOr(scrollID, 0)
 		vFirst, vLast := listCoreVisibleRange(
 			dataCount, rowHeight, listHeight, scrollY)
 		first = vFirst + dataStart

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -49,7 +49,8 @@ func textOnClick(layout *Layout, e *Event, w *Window) {
 	imap := StateMap[string, InputState](
 		w, nsInput, capMany,
 	)
-	is, _ := imap.Get(focusID)
+	// Default InputState{}: zero value seeds initial selection/cursor state.
+	is := imap.GetOr(focusID, InputState{})
 
 	// Double-click detection.
 	now := time.Now().UnixMilli()
@@ -101,7 +102,8 @@ func textOnClick(layout *Layout, e *Event, w *Window) {
 		if p.Shape != nil && p.Shape.Scrollable {
 			scrollID = p.Shape.ID
 			sy := w.scrollY()
-			dragScrollY0, _ = sy.Get(scrollID)
+			// Default 0: unscrolled position when no offset recorded yet.
+			dragScrollY0 = sy.GetOr(scrollID, 0)
 			sp := p.Shape
 			viewTop = sp.Y + sp.Padding.Top
 			viewH := sp.Height - sp.paddingHeight()
@@ -119,7 +121,8 @@ func textOnClick(layout *Layout, e *Event, w *Window) {
 			scrollDelta := float32(0)
 			if scrollID != "" {
 				sy := w.scrollY()
-				sNow, _ := sy.Get(scrollID)
+				// Default 0: unscrolled position when no offset recorded yet.
+				sNow := sy.GetOr(scrollID, 0)
 				scrollDelta = sNow - dragScrollY0
 			}
 			rx := mx - dragShapeX
@@ -142,7 +145,8 @@ func textOnClick(layout *Layout, e *Event, w *Window) {
 		dim := StateMap[string, InputState](
 			w, nsInput, capMany,
 		)
-		dis, _ := dim.Get(dragFocusID)
+		// Default InputState{}: zero value seeds initial drag-edit state.
+		dis := dim.GetOr(dragFocusID, InputState{})
 		if doubleClick {
 			var wb, we int
 			if dragGLOK {
@@ -183,7 +187,8 @@ func textOnClick(layout *Layout, e *Event, w *Window) {
 			return
 		}
 		sy := w.scrollY()
-		cur, _ := sy.Get(scrollID)
+		// Default 0: unscrolled position when no offset recorded yet.
+		cur := sy.GetOr(scrollID, 0)
 		newScroll := f32Clamp(
 			cur+delta, maxScrollNeg, 0)
 		if newScroll == cur {
@@ -240,7 +245,8 @@ func textOnKeyDown(layout *Layout, e *Event, w *Window) {
 	imap := StateMap[string, InputState](
 		w, nsInput, capMany,
 	)
-	is, _ := imap.Get(id)
+	// Default InputState{}: zero value seeds initial keyboard-nav state.
+	is := imap.GetOr(id, InputState{})
 	savedOffset := is.CursorOffset
 	savedTrailing := is.CursorTrailing
 	is.CursorOffset = -1

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -129,7 +129,8 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 				return
 			}
 			lbf := StateMap[string, int](w, nsListBoxFocus, capModerate)
-			currentIdx, _ := lbf.Get(lbID)
+			// Default 0: start at first item; bounds-checked below.
+			currentIdx := lbf.GetOr(lbID, 0)
 			action := listCoreNavigate(e.KeyCode, count)
 
 			nextIdx := -1

--- a/gui/view_tree.go
+++ b/gui/view_tree.go
@@ -489,8 +489,8 @@ func treeExpandedSet(w *Window, treeID, nodeID string, expanded bool) {
 		return
 	}
 	sm := StateMap[string, map[string]bool](w, nsTreeExpanded, capModerate)
-	nodes, _ := sm.Get(treeID)
-	if nodes == nil {
+	nodes, ok := sm.Get(treeID)
+	if !ok {
 		nodes = make(map[string]bool)
 	}
 	if expanded {

--- a/gui/view_tree_rows.go
+++ b/gui/view_tree_rows.go
@@ -16,7 +16,8 @@ func treeCollectFlatRows(
 		hasRealChildren := len(node.Nodes) > 0
 		hasChildren := hasRealChildren || node.Lazy
 		lazyKey := treeLazyKey(treeID, nodeID)
-		isLoading, _ := lazyState.Get(lazyKey)
+		// Default false: absent entry means node is not loading.
+		isLoading := lazyState.GetOr(lazyKey, false)
 
 		if node.Lazy && hasRealChildren && isLoading {
 			lazyState.Delete(lazyKey)
@@ -81,7 +82,8 @@ func treeVisibleRange(
 	if w == nil {
 		return 0, totalRows - 1
 	}
-	scrollY, _ := w.scrollY().Get(scrollID)
+	// Default 0: unscrolled position when no offset recorded yet.
+	scrollY := w.scrollY().GetOr(scrollID, 0)
 	return listCoreVisibleRange(totalRows, rowHeight, treeHeight, scrollY)
 }
 


### PR DESCRIPTION
Closes #101. Follow-up to #54/#102.

## What

Migrates the ~105 production sites that ignored `Get`'s ok boolean to `GetOr(key, explicit default)`, each with a one-line comment justifying the default (established pattern from #102).

Sites where the zero value is NOT a safe default keep `Get` with explicit `!ok` handling:
- 12 date-picker sites — zero `datePickerState` has invalid month/day; handlers now no-op if state was evicted (state is seeded every render by `datePickerGetState`, so the path only fires on eviction races)
- `treeExpandedSet` — must allocate a fresh map on absence

## Hardening

- `offsetMouseChangeX/Y` (view_scrollbar.go): guard division by zero / NaN offset on degenerate zero-size viewports

## Tests

- `TestOffsetMouseChangeZeroViewport` — NaN guard returns prior offset
- `TestDatePickerNavMonthAbsentStateNoOp` — nav on absent state writes nothing

Zero ignored-ok sites remain (`rg -n ', _ :?= .*\.Get\(' gui` clean). `go build`, `go test ./...`, `golangci-lint run ./...` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786928205&installation_id=145733661&pr_number=103&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F103&signature=36e287f5441cbcde390041774c53bc22c0e4cba225d928873009e85ff3982eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->