### PR TITLE
changelog: add v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.39.0] - 2026-07-18
+
 ### Added
 
+- **`BoundedMap.GetOr`.** New method on `BoundedMap` that accepts a constructor
+  function, returning an existing value or publishing a new one without a
+  double lookup. Internal `BoundedMap.Get` callers with ignored-ok returns have
+  been migrated to `GetOr`, hardening the map against lost writes.
 - **Process monitor example.** New `examples/process_monitor` — a live task
   manager: filterable process list with flat/tree views, sortable columns, and
   per-process CPU/RAM history charts built from plain containers. Data is
@@ -18,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Window.UpdateWindow`. Styled entirely from the standard theme tokens.
   Includes a headless `-once` terminal report. Functional port of the go-shirei
   example of the same name.
+
+### Changed
+
+- **Dependency bump.** Updated go-glyph to v1.17.2 (background cache warming
+  for CJK fallback coverage; no API change).
 
 ## [v0.38.1] - 2026-07-17
 


### PR DESCRIPTION
## v0.39.0

### Added
- `BoundedMap.GetOr` — new method accepting a constructor function, returning an existing value or publishing a new one without a double lookup.
- Process monitor example — live task manager with filterable process list, flat/tree views, sortable columns, and per-process CPU/RAM history charts.

### Changed
- Updated go-glyph to v1.17.2 (background cache warming for CJK fallback coverage).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786976236&installation_id=145733661&pr_number=105&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F105&signature=87df917d2af014b6020b99ae8d78b1028f4a1f365b34bd491482d03bfe2b1fdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->