### PR TITLE
gui: stop pre-sizing BoundedMap data map to keep small-map fast path

### DIFF
--- a/gui/bounded_map.go
+++ b/gui/bounded_map.go
@@ -13,14 +13,16 @@ type BoundedMap[K comparable, V any] struct {
 
 // NewBoundedMap creates a BoundedMap with the given max size.
 func NewBoundedMap[K comparable, V any](maxSize int) *BoundedMap[K, V] {
-	dataCap := 0
-	orderCap := 0
-	if maxSize > 0 {
-		dataCap = maxSize
-		orderCap = maxSize
-	}
+	orderCap := max(maxSize, 0)
+	// data is deliberately not pre-sized to maxSize: occupancy is
+	// typically far below capacity (e.g. a handful of scroll containers
+	// against capScroll=200), and a map that stays within one Swiss-table
+	// group (<=8 entries) keeps the runtime's small-map lookup fast path
+	// (~4x faster Get on integer keys; measured in #77). Pre-sizing also
+	// allocates the full table up front per map. Maps that do fill pay
+	// only amortized rehash cost on the way up.
 	return &BoundedMap[K, V]{
-		data:    make(map[K]V, dataCap),
+		data:    make(map[K]V),
 		order:   make([]K, 0, orderCap),
 		maxSize: maxSize,
 	}


### PR DESCRIPTION
## Summary

Investigation of #77 showed the reported 4.5x `BoundedMap[uint32].Get` slowdown is **not** a wrapper or generics penalty — it is a capacity confound in the benchmark, plus a real (small) inefficiency this PR fixes.

### Findings

- `-gcflags=-S` on both a bare generic function and a generic-struct method (same shape as `BoundedMap.Get`): every instantiation, shaped and concrete, emits `CALL runtime.mapaccess2_fast32` — identical to a raw map. No dictionary slow path.
- Controlled bench with capacity as the only variable (M5, go1.26.5):

  | Get, uint32 keys, 8 entries | cap 8   | cap 200 |
  | --------------------------- | ------- | ------- |
  | raw `map[uint32]float32`    | 2.37 ns | 10.2 ns |
  | generic struct method       | 2.38 ns | 10.3 ns |

  Raw map at cap 200 is exactly as slow as `BoundedMap`; `BoundedMap` at cap 8 is exactly as fast as the raw map. The issue's benchmark sized raw maps with `make(map, 8)` but `BoundedMap` at capacity 200.
- Cause: the Go 1.24+ Swiss-table runtime gives maps that fit one group (≤8 slots) a no-hash small-map lookup fast path. Pre-sizing to `maxSize` forfeits it. This also explains the string-parity and Set anomalies noted in the issue (string key comparison dominates either path; assign lacks the same asymmetry).

### Change

`NewBoundedMap` no longer pre-sizes the data map. Occupancy is typically far below capacity (a handful of scroll containers vs `capScroll=200`), so most instances stay on the small-map fast path (~4x faster integer-key Get) and skip the up-front full-table allocation. Maps that do fill pay only amortized rehash on the way up. The `order` slice keeps its capacity hint.

Closes #77

## Testing

- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — clean
- `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786989522&installation_id=145733661&pr_number=106&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F106&signature=7d4c9aad5b0ad7493496e036f2bc43669f67bb4c432ae8b27cb140b16d2783f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->