### PR TITLE
gui: fold buttonView into containerView, pool shapeEffects

### DIFF
--- a/gui/event_handlers_test.go
+++ b/gui/event_handlers_test.go
@@ -746,8 +746,8 @@ func TestMakeContainerEventsOnFileDropAlone(t *testing.T) {
 			called = true
 		},
 	}
-	eh := makeContainerEvents(cfg)
-	if eh == nil {
+	eh, ok := makeContainerEvents(cfg)
+	if !ok {
 		t.Fatal("expected non-nil eventHandlers")
 	}
 	if eh.OnFileDrop == nil {

--- a/gui/scratch_pools.go
+++ b/gui/scratch_pools.go
@@ -134,6 +134,7 @@ type scratchPools struct {
 	viewShapes   scratchObjPool[Shape]
 	buttonColors scratchObjPool[shapeButtonColors]
 	viewEvents   scratchObjPool[eventHandlers]
+	viewEffects  scratchObjPool[shapeEffects]
 
 	// Render-phase pools: reuse heap objects whose addresses are
 	// stored in RenderCmd pointer fields (avoids per-frame escapes).
@@ -181,6 +182,7 @@ func newScratchPools() scratchPools {
 		viewShapes:             scratchObjPool[Shape]{retainMax: 16384, shrinkTo: 1024},
 		buttonColors:           scratchObjPool[shapeButtonColors]{retainMax: 512, shrinkTo: 32},
 		viewEvents:             scratchObjPool[eventHandlers]{retainMax: 4096, shrinkTo: 256},
+		viewEffects:            scratchObjPool[shapeEffects]{retainMax: 4096, shrinkTo: 256},
 		renderTextStyles:       scratchObjPool[TextStyle]{retainMax: 4096, shrinkTo: 256},
 		renderGlyphLayouts:     scratchObjPool[glyph.Layout]{retainMax: 1024, shrinkTo: 64},
 		renderAffineTransforms: scratchObjPool[glyph.AffineTransform]{retainMax: 256, shrinkTo: 16},
@@ -205,6 +207,7 @@ func (p *scratchPools) resetViewPools() {
 	p.viewShapes.reset()
 	p.buttonColors.reset()
 	p.viewEvents.reset()
+	p.viewEffects.reset()
 	if cap(p.layoutChildrenArena) > layoutChildrenRetainMax {
 		p.layoutChildrenArena = make([]Layout, 0, layoutChildrenShrinkTo)
 	} else {

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -73,43 +73,6 @@ type ButtonCfg struct {
 	A11YRole AccessRole
 }
 
-// buttonView wraps a containerView with per-button hover/focus
-// colors, replacing per-frame closure allocations with pooled
-// shapeButtonColors and package-level handler functions.
-type buttonView struct {
-	cv               *containerView
-	userOnHover      func(*Layout, *Event, *Window)
-	userAmendLayout  func(*Layout, *Window)
-	colorHover       Color
-	colorClick       Color
-	colorFocus       Color
-	colorBorderFocus Color
-}
-
-func (bv *buttonView) Content() []View { return bv.cv.Content() }
-
-func (bv *buttonView) GenerateLayout(w *Window) Layout {
-	layout := bv.cv.GenerateLayout(w)
-	if layout.Shape.events != nil {
-		bc := shapeButtonColors{
-			ColorHover:       bv.colorHover,
-			ColorClick:       bv.colorClick,
-			ColorFocus:       bv.colorFocus,
-			ColorBorderFocus: bv.colorBorderFocus,
-			OnHover:          bv.userOnHover,
-			OnAmend:          bv.userAmendLayout,
-		}
-		if w != nil {
-			layout.Shape.bc = w.scratch.buttonColors.alloc(bc)
-		} else {
-			layout.Shape.bc = &bc
-		}
-		layout.Shape.events.AmendLayout = buttonAmendLayout
-		layout.Shape.events.OnHover = buttonOnHover
-	}
-	return layout
-}
-
 func buttonAmendLayout(layout *Layout, w *Window) {
 	if layout.Shape.Disabled ||
 		!layout.Shape.hasEvents() ||
@@ -203,15 +166,15 @@ func Button(cfg ButtonCfg) View {
 		Content:         cfg.Content,
 	}).(*containerView)
 
-	return &buttonView{
-		cv:               cv,
-		colorHover:       cfg.ColorHover,
-		colorClick:       cfg.ColorClick,
-		colorFocus:       cfg.ColorFocus,
-		colorBorderFocus: cfg.ColorBorderFocus,
-		userOnHover:      cfg.OnHover,
-		userAmendLayout:  cfg.AmendLayout,
-	}
+	cv.isButton = true
+	cv.colorHover = cfg.ColorHover
+	cv.colorClick = cfg.ColorClick
+	cv.colorFocus = cfg.ColorFocus
+	cv.colorBorderFocus = cfg.ColorBorderFocus
+	cv.userOnHover = cfg.OnHover
+	cv.userAmendLayout = cfg.AmendLayout
+
+	return cv
 }
 
 // commandButtonIDPrefix namespaces auto-filled CommandButton IDs.

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -104,11 +104,10 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 			}
 		},
 	}
-	col := &containerView{
-		shape:   buildContainerShape(&ccfg),
+	return generateViewLayout(&containerView{
+		cfg:     ccfg,
 		content: content,
-	}
-	return generateViewLayout(col, w)
+	}, w)
 }
 
 // cpSVAndHueRow builds the SV area and hue slider row.

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -286,11 +286,10 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		},
 	}
 	ccfg.ClickButton = MouseLeft
-	outerRow := &containerView{
-		shape:   buildContainerShape(&ccfg),
+	return generateViewLayout(&containerView{
+		cfg:     ccfg,
 		content: content,
-	}
-	return generateViewLayout(outerRow, w)
+	}, w)
 }
 
 func comboboxOpen(id string, focusID string, w *Window) {

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -145,6 +145,7 @@ type ContainerCfg struct {
 
 	// Internal — set by factory functions.
 	axis                 Axis
+	shapeType            shapeType // zero = shapeRectangle
 	scrollbarOrientation ScrollbarOrientation
 }
 
@@ -157,31 +158,51 @@ func applyContainerDefaults(cfg *ContainerCfg) (spacing, sizeBorder, radius floa
 }
 
 // containerView implements View for container-based layouts.
-// Shape is pre-built at factory time so the full ContainerCfg
-// (~400 B) never escapes to heap with the view.
-//
-// IMPORTANT: GenerateLayout shallow-copies the shape on every
-// call. The layout pipeline mutates Shape fields in place
-// (X += offset, Width += childWidth, etc.), so returning the
-// same pointer would let mutations accumulate when a view is
-// cached and reused across frames (combobox/command-palette
-// dropdown caches). The copy keeps the template pristine while
-// still avoiding the per-frame ContainerCfg→Shape build cost.
+// ContainerCfg is stored by value; the Shape is built per
+// GenerateLayout call using pooled allocs (allocShape,
+// allocEventHandlers, allocEffects). This eliminates the
+// factory-phase &Shape{} heap alloc at the cost of rebuilding
+// ~70 fields each frame. Cached views (combobox/command-palette
+// dropdowns) re-pay the build cost without heap allocs.
 type containerView struct {
-	shape       *Shape
-	title       string
-	content     []View
-	titleBG     Color
-	colorBorder Color
-	disabled    bool
+	cfg     ContainerCfg
+	content []View
+
+	// Button-specific fields — set only by Button (step 4 fold-in).
+	isButton         bool
+	userOnHover      func(*Layout, *Event, *Window)
+	userAmendLayout  func(*Layout, *Window)
+	colorHover       Color
+	colorClick       Color
+	colorFocus       Color
+	colorBorderFocus Color
 }
 
 func (cv *containerView) Content() []View { return cv.content }
 
 func (cv *containerView) GenerateLayout(w *Window) Layout {
-	layout := Layout{Shape: w.allocShape(*cv.shape)}
-	addGroupBoxTitle(cv.title, cv.titleBG, cv.colorBorder,
-		cv.disabled, w, &layout)
+	layout := Layout{
+		Shape: w.allocShape(buildContainerShape(&cv.cfg, w)),
+	}
+	if cv.isButton && layout.Shape.events != nil {
+		bc := shapeButtonColors{
+			ColorHover:       cv.colorHover,
+			ColorClick:       cv.colorClick,
+			ColorFocus:       cv.colorFocus,
+			ColorBorderFocus: cv.colorBorderFocus,
+			OnHover:          cv.userOnHover,
+			OnAmend:          cv.userAmendLayout,
+		}
+		if w != nil {
+			layout.Shape.bc = w.scratch.buttonColors.alloc(bc)
+		} else {
+			layout.Shape.bc = &bc
+		}
+		layout.Shape.events.AmendLayout = buttonAmendLayout
+		layout.Shape.events.OnHover = buttonOnHover
+	}
+	addGroupBoxTitle(cv.cfg.Title, cv.cfg.TitleBG, cv.cfg.ColorBorder,
+		cv.cfg.Disabled, w, &layout)
 	return layout
 }
 
@@ -254,32 +275,32 @@ func addGroupBoxTitle(title string, titleBG, colorBorder Color,
 	})
 }
 
-func makeContainerEffects(c *ContainerCfg) *shapeEffects {
+func makeContainerEffects(c *ContainerCfg) (shapeEffects, bool) {
 	if c.Shadow == nil && c.Gradient == nil &&
 		c.BorderGradient == nil && c.Shader == nil &&
 		c.ColorFilter == nil && c.BlurRadius == 0 {
-		return nil
+		return shapeEffects{}, false
 	}
-	return &shapeEffects{
+	return shapeEffects{
 		Shadow:         c.Shadow,
 		Gradient:       c.Gradient,
 		BorderGradient: c.BorderGradient,
 		Shader:         c.Shader,
 		ColorFilter:    c.ColorFilter,
 		BlurRadius:     c.BlurRadius,
-	}
+	}, true
 }
 
-func makeContainerEvents(c *ContainerCfg) *eventHandlers {
+func makeContainerEvents(c *ContainerCfg) (eventHandlers, bool) {
 	if c.OnClick == nil && c.OnChar == nil &&
 		c.OnKeyDown == nil && c.OnKeyUp == nil &&
 		c.OnMouseMove == nil && c.OnMouseUp == nil &&
 		c.OnHover == nil && c.OnGesture == nil &&
 		c.OnFileDrop == nil && c.OnIMECommit == nil &&
 		c.OnScroll == nil && c.AmendLayout == nil {
-		return nil
+		return eventHandlers{}, false
 	}
-	return &eventHandlers{
+	return eventHandlers{
 		OnClick:      c.OnClick,
 		OnChar:       c.OnChar,
 		OnKeyDown:    c.OnKeyDown,
@@ -295,7 +316,7 @@ func makeContainerEvents(c *ContainerCfg) *eventHandlers {
 		ClickButton:  c.ClickButton,
 		ClickOnSpace: c.ClickOnSpace,
 		ClickOnEnter: c.ClickOnEnter,
-	}
+	}, true
 }
 
 func makeContainerA11Y(c *ContainerCfg) *AccessInfo {
@@ -316,12 +337,16 @@ func deriveContainerA11YRole(c *ContainerCfg) AccessRole {
 }
 
 // buildContainerShape constructs a Shape from a ContainerCfg.
-// Used by widgets that build containerView directly.
-func buildContainerShape(cfg *ContainerCfg) *Shape {
+// Uses pooled allocs for effects and events via w.
+func buildContainerShape(cfg *ContainerCfg, w *Window) Shape {
 	RequireScrollID("container", cfg.Scrollable, cfg.ID)
 	spacing, sizeBorder, radius, padding := applyContainerDefaults(cfg)
-	shape := &Shape{
-		shapeType:            shapeRectangle,
+	shapeType := cfg.shapeType
+	if shapeType == shapeNone {
+		shapeType = shapeRectangle
+	}
+	shape := Shape{
+		shapeType:            shapeType,
 		ID:                   cfg.ID,
 		Focusable:            cfg.Focusable,
 		Axis:                 cfg.axis,
@@ -345,7 +370,6 @@ func buildContainerShape(cfg *ContainerCfg) *Shape {
 		TextDir:              cfg.TextDir,
 		Radius:               radius,
 		Color:                cfg.Color,
-		fx:                   makeContainerEffects(cfg),
 		SizeBorder:           sizeBorder,
 		ColorBorder:          cfg.ColorBorder,
 		Disabled:             cfg.Disabled,
@@ -359,7 +383,6 @@ func buildContainerShape(cfg *ContainerCfg) *Shape {
 		Scrollable:           cfg.Scrollable,
 		OverDraw:             cfg.OverDraw,
 		ScrollMode:           cfg.ScrollMode,
-		events:               makeContainerEvents(cfg),
 		Hero:                 cfg.Hero,
 		Wrap:                 cfg.Wrap,
 		Overflow:             cfg.Overflow,
@@ -368,7 +391,13 @@ func buildContainerShape(cfg *ContainerCfg) *Shape {
 		A11YState:            cfg.A11YState,
 		A11Y:                 makeContainerA11Y(cfg),
 	}
-	applyFixedSizingConstraints(shape)
+	if fx, ok := makeContainerEffects(cfg); ok {
+		shape.fx = w.allocEffects(fx)
+	}
+	if ev, ok := makeContainerEvents(cfg); ok {
+		shape.events = w.allocEventHandlers(ev)
+	}
+	applyFixedSizingConstraints(&shape)
 	return shape
 }
 
@@ -396,12 +425,8 @@ func container(cfg ContainerCfg) View {
 	}
 
 	return &containerView{
-		shape:       buildContainerShape(&cfg),
-		content:     content,
-		title:       cfg.Title,
-		titleBG:     cfg.TitleBG,
-		colorBorder: cfg.ColorBorder,
-		disabled:    cfg.Disabled,
+		cfg:     cfg,
+		content: content,
 	}
 }
 
@@ -433,9 +458,8 @@ func Canvas(cfg ContainerCfg) View {
 // Circle creates a circular container.
 func Circle(cfg ContainerCfg) View {
 	cfg.axis = AxisTopToBottom
-	cv := container(cfg).(*containerView)
-	cv.shape.shapeType = shapeCircle
-	return cv
+	cfg.shapeType = shapeCircle
+	return container(cfg)
 }
 
 func appendScrollbar(content []View, override *ScrollbarCfg, orientation ScrollbarOrientation, id string) []View {
@@ -454,13 +478,18 @@ func appendScrollbar(content []View, override *ScrollbarCfg, orientation Scrollb
 	}))
 }
 
-func invisibleContainerView() *containerView {
-	cfg := ContainerCfg{
+// invisibleContainerView provides a singleton immutable
+// invisible placeholder. Since containerView is now
+// cfg-by-value (no mutable template shape), a single instance
+// is safe across the lifetime of the package.
+var invisibleContainerViewSingleton = &containerView{
+	cfg: ContainerCfg{
 		Disabled: true,
 		OverDraw: true,
 		Padding:  NoPadding,
-	}
-	return &containerView{
-		shape: buildContainerShape(&cfg),
-	}
+	},
+}
+
+func invisibleContainerView() *containerView {
+	return invisibleContainerViewSingleton
 }

--- a/gui/view_frame_bench_test.go
+++ b/gui/view_frame_bench_test.go
@@ -58,3 +58,84 @@ func BenchmarkViewFrame(b *testing.B) {
 		})
 	}
 }
+
+// buildButtonFrameView creates a tree of buttons with hover/focus colors
+// set, exercising the buttonColors pool and buttonOnHover/buttonAmendLayout
+// wiring in the folded containerView.GenerateLayout.
+func buildButtonFrameView(buttons int) View {
+	content := make([]View, buttons)
+	for i := range buttons {
+		content[i] = Button(ButtonCfg{
+			ID:      "btn-" + strconv.Itoa(i),
+			Sizing:  FitFill,
+			OnClick: func(_ *Layout, _ *Event, _ *Window) {},
+			Content: []View{
+				Text(TextCfg{Text: "Button " + strconv.Itoa(i)}),
+			},
+		})
+	}
+	return Column(ContainerCfg{
+		ID:      "btn-root",
+		Sizing:  FillFill,
+		Content: content,
+	})
+}
+
+// buildEffectsFrameView creates containers with shadow/gradient effects
+// set, exercising the viewEffects pool.
+func buildEffectsFrameView(containers int) View {
+	shadow := &BoxShadow{Color: Black, OffsetX: 2, OffsetY: 2, BlurRadius: 4}
+	content := make([]View, containers)
+	for i := range containers {
+		content[i] = Row(ContainerCfg{
+			ID:     "fx-" + strconv.Itoa(i),
+			Sizing: FitFit,
+			Shadow: shadow,
+			Color:  LightGray,
+			Content: []View{
+				Text(TextCfg{Text: "Effect " + strconv.Itoa(i)}),
+			},
+		})
+	}
+	return Column(ContainerCfg{
+		ID:      "fx-root",
+		Sizing:  FillFill,
+		Content: content,
+	})
+}
+
+// BenchmarkButtonFrame exercises the Button factory path (folded
+// buttonView) through the full frame pipeline.
+func BenchmarkButtonFrame(b *testing.B) {
+	for _, count := range []int{50, 200} {
+		b.Run("btns_"+strconv.Itoa(count), func(b *testing.B) {
+			w := &Window{scratch: newScratchPools()}
+			w.windowWidth = 1200
+			w.windowHeight = 900
+			b.ReportAllocs()
+			for b.Loop() {
+				w.scratch.resetViewPools()
+				view := buildButtonFrameView(count)
+				_ = generateViewLayout(view, w)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectsFrame exercises containers with shadow/gradient effects
+// through the full frame pipeline, verifying the viewEffects pool.
+func BenchmarkEffectsFrame(b *testing.B) {
+	for _, count := range []int{50, 200} {
+		b.Run("fx_"+strconv.Itoa(count), func(b *testing.B) {
+			w := &Window{scratch: newScratchPools()}
+			w.windowWidth = 1200
+			w.windowHeight = 900
+			b.ReportAllocs()
+			for b.Loop() {
+				w.scratch.resetViewPools()
+				view := buildEffectsFrameView(count)
+				_ = generateViewLayout(view, w)
+			}
+		})
+	}
+}

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -199,11 +199,10 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 		},
 	}
 	ccfg.ClickButton = MouseLeft
-	cv := &containerView{
-		shape:   buildContainerShape(&ccfg),
+	return generateViewLayout(&containerView{
+		cfg:     ccfg,
 		content: content,
-	}
-	return generateViewLayout(cv, w)
+	}, w)
 }
 
 // selectOptionView builds a single option row.

--- a/gui/view_select_test.go
+++ b/gui/view_select_test.go
@@ -92,9 +92,9 @@ func TestSelectOptionViewOnClickFires(t *testing.T) {
 
 	w := &Window{}
 	e := &Event{MouseButton: MouseLeft}
-	// The OnClick is on the containerView's shape events.
-	if cv.shape.events != nil && cv.shape.events.OnClick != nil {
-		cv.shape.events.OnClick(nil, e, w)
+	layout := cv.GenerateLayout(w)
+	if layout.Shape.events != nil && layout.Shape.events.OnClick != nil {
+		layout.Shape.events.OnClick(nil, e, w)
 	}
 	if !fired {
 		t.Error("OnSelect not fired")

--- a/gui/window.go
+++ b/gui/window.go
@@ -464,6 +464,16 @@ func (w *Window) allocEventHandlers(src eventHandlers) *eventHandlers {
 	return w.scratch.viewEvents.alloc(src)
 }
 
+// allocEffects returns a pooled *shapeEffects initialized to src.
+// Pointer valid until the next view-phase pool reset.
+func (w *Window) allocEffects(src shapeEffects) *shapeEffects {
+	if w == nil {
+		cp := src
+		return &cp
+	}
+	return w.scratch.viewEffects.alloc(src)
+}
+
 // SetClipboardFn sets the function used to copy text to the clipboard.
 func (w *Window) SetClipboardFn(fn func(string)) {
 	w.clipboardSetFn = fn


### PR DESCRIPTION
Eliminates the factory-phase `&Shape{}` heap allocation by storing `ContainerCfg` by value in `containerView` and building the `Shape` per `GenerateLayout` call using pooled allocs. Also folds the `buttonView` wrapper struct into `containerView`.

**Changes:**
- `containerView`: `cfg`+`content` replace `shape`+`title`+`titleBG`+`colorBorder`+`disabled`
- `buildContainerShape(cfg, w)`: returns `Shape` by value, uses pooled allocs for `fx` and `events`
- `makeContainerEffects`/`makeContainerEvents`: return `(T, bool)` instead of `*T`
- Add `viewEffects` pool to `scratchPools`; add `Window.allocEffects`
- Inline `containerView` construction in color_picker, combobox, select
- `Circle` sets `cfg.shapeType` instead of mutating a template `Shape`
- `invisibleContainerView` → singleton (safe with cfg-by-value)
- Update tests + add `ButtonFrame`/`EffectsFrame` benchmarks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787055342&installation_id=145733661&pr_number=107&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F107&signature=02856d252cc8f2d838529ae3fba59e06e1ce3cc09ced27385b6b5b6cb68301ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->