### PR TITLE
sidebar: drop children when fully closed to prevent Fixed-width-0 content-resize bug

### DIFF
--- a/gui/view_sidebar.go
+++ b/gui/view_sidebar.go
@@ -67,6 +67,16 @@ func (w *Window) Sidebar(cfg SidebarCfg) View {
 		pad = Some(Padding{})
 	}
 
+	// A Fixed-width box with Width 0 degrades to content sizing in
+	// layoutWidths (issue #94), so a fully closed sidebar that kept
+	// its children would snap back to content width the moment the
+	// close animation lands on exactly 0. Drop the content instead:
+	// childless Fixed-0 boxes still resolve to width 0.
+	content := cfg.Content
+	if animW <= 0 {
+		content = nil
+	}
+
 	return Column(ContainerCfg{
 		ID:              cfg.ID,
 		Sizing:          cfg.Sizing,
@@ -80,7 +90,7 @@ func (w *Window) Sidebar(cfg SidebarCfg) View {
 		A11YRole:        AccessRoleGroup,
 		A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.ID),
 		A11YDescription: cfg.A11YDescription,
-		Content:         cfg.Content,
+		Content:         content,
 	})
 }
 

--- a/gui/view_sidebar_test.go
+++ b/gui/view_sidebar_test.go
@@ -34,6 +34,38 @@ func TestSidebarClosedWidth(t *testing.T) {
 	}
 }
 
+// TestSidebarClosedStaysClosedAfterFitPass guards against the
+// Fixed-width-0 degrade-to-content-sizing rule (issue #94) reopening
+// a fully closed sidebar: layoutWidths grows a Fixed box with Width 0
+// to its content width, so the closed sidebar must render childless.
+// The child here has a definite Fixed width because Text measures 0
+// under the nil test TextMeasurer and would mask the regression.
+func TestSidebarClosedStaysClosedAfterFitPass(t *testing.T) {
+	w := &Window{}
+	v := w.Sidebar(SidebarCfg{
+		ID:    "sb",
+		Open:  false,
+		Width: 200,
+		Content: []View{
+			Column(ContainerCfg{
+				Sizing: FixedFixed,
+				Width:  120,
+				Height: 40,
+			}),
+		},
+	})
+	layout := generateViewLayout(v, w)
+	layoutWidths(&layout)
+	if layout.Shape.Width != 0 {
+		t.Errorf("closed width after fit pass = %f, want 0",
+			layout.Shape.Width)
+	}
+	if len(layout.Children) != 0 {
+		t.Errorf("closed sidebar children = %d, want 0",
+			len(layout.Children))
+	}
+}
+
 func TestSidebarInvisible(t *testing.T) {
 	w := &Window{}
 	v := w.Sidebar(SidebarCfg{
@@ -80,5 +112,173 @@ func TestSidebarRuntimeStateInit(t *testing.T) {
 	}
 	if rt.AnimFrac != 1 {
 		t.Errorf("animFrac = %f, want 1 (open)", rt.AnimFrac)
+	}
+}
+
+func TestSidebarToggleToClosedPreservesState(t *testing.T) {
+	w := &Window{}
+
+	// First frame: sidebar is open.
+	v := w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    true,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+	layout := generateViewLayout(v, w)
+	if layout.Shape.Width != 200 {
+		t.Fatalf("initial open width = %f, want 200", layout.Shape.Width)
+	}
+
+	// Simulate animation completing to closed: manually set state.
+	sm := StateMap[string, SidebarRuntimeState](w, nsSidebar, capFew)
+	sm.Set("sb", SidebarRuntimeState{AnimFrac: 0, PrevOpen: false, Initialized: true})
+
+	// Next frame: sidebar should stay closed.
+	v2 := w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    false,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+	layout2 := generateViewLayout(v2, w)
+	if layout2.Shape.Width != 0 {
+		t.Errorf("closed width = %f, want 0", layout2.Shape.Width)
+	}
+
+	// Verify state is still consistent.
+	rt, _ := sm.Get("sb")
+	if rt.AnimFrac != 0 {
+		t.Errorf("AnimFrac = %f, want 0", rt.AnimFrac)
+	}
+	if rt.PrevOpen != false {
+		t.Errorf("PrevOpen = %v, want false", rt.PrevOpen)
+	}
+}
+
+func TestSidebarReinitAfterClearWithOpenFalse(t *testing.T) {
+	w := &Window{}
+
+	// First frame: sidebar is open, then cleared.
+	_ = w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    true,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+
+	// Clear the state map entirely (simulating clearViewState).
+	w.viewState.registry.Clear()
+
+	// Next frame with Open=false: re-init should produce closed sidebar.
+	v := w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    false,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+	layout := generateViewLayout(v, w)
+	if layout.Shape.Width != 0 {
+		t.Errorf("re-init closed width = %f, want 0", layout.Shape.Width)
+	}
+
+	sm := StateMap[string, SidebarRuntimeState](w, nsSidebar, capFew)
+	rt, ok := sm.Get("sb")
+	if !ok {
+		t.Fatal("state should exist after re-init")
+	}
+	if rt.AnimFrac != 0 {
+		t.Errorf("AnimFrac = %f, want 0", rt.AnimFrac)
+	}
+	if rt.PrevOpen != false {
+		t.Errorf("PrevOpen = %v, want false", rt.PrevOpen)
+	}
+}
+
+func TestSidebarReinitAfterClearWithOpenTrue(t *testing.T) {
+	w := &Window{}
+
+	// First frame: sidebar is open, then cleared.
+	_ = w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    true,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+
+	// Clear the state map entirely.
+	w.viewState.registry.Clear()
+
+	// Next frame with Open=true: re-init should produce open sidebar.
+	v := w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    true,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+	layout := generateViewLayout(v, w)
+	if layout.Shape.Width != 200 {
+		t.Errorf("re-init open width = %f, want 200", layout.Shape.Width)
+	}
+
+	sm := StateMap[string, SidebarRuntimeState](w, nsSidebar, capFew)
+	rt, ok := sm.Get("sb")
+	if !ok {
+		t.Fatal("state should exist after re-init")
+	}
+	if rt.AnimFrac != 1 {
+		t.Errorf("AnimFrac = %f, want 1", rt.AnimFrac)
+	}
+}
+
+func TestSidebarNoDoubleAnimation(t *testing.T) {
+	w := &Window{}
+
+	// Open sidebar.
+	v := w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    true,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+	_ = generateViewLayout(v, w)
+
+	// Simulate closing animation halfway done.
+	sm := StateMap[string, SidebarRuntimeState](w, nsSidebar, capFew)
+	sm.Set("sb", SidebarRuntimeState{AnimFrac: 0.5, PrevOpen: true, Initialized: true})
+
+	// Now toggle closed — should start animation 0.5→0.
+	v2 := w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    false,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+	layout2 := generateViewLayout(v2, w)
+	// Still at 0.5 width (anim hasn't ticked yet).
+	if layout2.Shape.Width != 100 {
+		t.Errorf("width = %f, want 100 (half)", layout2.Shape.Width)
+	}
+
+	// PrevOpen should now be false.
+	rt, _ := sm.Get("sb")
+	if rt.PrevOpen != false {
+		t.Errorf("PrevOpen = %v, want false", rt.PrevOpen)
+	}
+
+	// Same-frame second call (simulating double layout): should NOT restart animation.
+	v3 := w.Sidebar(SidebarCfg{
+		ID:      "sb",
+		Open:    false,
+		Width:   200,
+		Content: []View{Text(TextCfg{Text: "nav"})},
+	})
+	layout3 := generateViewLayout(v3, w)
+	if layout3.Shape.Width != 100 {
+		t.Errorf("second call width = %f, want 100", layout3.Shape.Width)
+	}
+	rt2, _ := sm.Get("sb")
+	if rt2.PrevOpen != false {
+		t.Errorf("PrevOpen after second call = %v, want false", rt2.PrevOpen)
 	}
 }


### PR DESCRIPTION
A Fixed-width box with Width 0 degrades to content sizing in layoutWidths (issue #94), so a fully closed sidebar that kept its children would snap back to content width when the close animation lands on exactly 0. Drop the content when animW <= 0 — childless Fixed-0 boxes still resolve to width 0.

Adds tests for toggle, reinit-after-clear, no-double-animation, and closed-after-fit-pass regression guard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787056645&installation_id=145733661&pr_number=108&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F108&signature=ae0490f62d38e9954ca11108cf5c9dd240e5fbe31bd2d63300620e20cb4b5344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->