### PR TITLE
input: fix batched-event echo and single-line vertical centering; datagrid: fix quick-filter debounce draft rendering

### DIFF
--- a/examples/showcase/docs/widget_data_grid.md
+++ b/examples/showcase/docs/widget_data_grid.md
@@ -96,7 +96,7 @@ datagrid.New(w, datagrid.DataGridCfg{
 | FrozenTopRowIDs        | []string           | Row IDs pinned to top                |
 | DetailExpandedRowIDs   | map[string]bool    | Expanded detail row IDs              |
 | QuickFilterPlaceholder | string             | Quick filter placeholder text        |
-| QuickFilterDebounce    | time.Duration      | Quick filter debounce delay          |
+| QuickFilterDebounce    | time.Duration      | Quick filter debounce delay (200ms with DataSource, 0 otherwise; negative = immediate) |
 | RowHeight              | float32            | Row height in pixels                 |
 | HeaderHeight           | float32            | Header height in pixels              |
 | IDFocus                | uint32             | Tab-order focus ID (> 0 to enable)   |

--- a/gui/datagrid/state.go
+++ b/gui/datagrid/state.go
@@ -12,6 +12,7 @@ const (
 	nsDgCrud         = "gui.dg.crud"
 	nsDgJump         = "gui.dg.jump"
 	nsDgPendingJump  = "gui.dg.pending_jump"
+	nsDgQuickDraft   = "gui.dg.quick_draft"
 	nsDgSource       = "gui.dg.source"
 
 	capModerate = 50

--- a/gui/datagrid/view_data_grid.go
+++ b/gui/datagrid/view_data_grid.go
@@ -223,12 +223,15 @@ type DataGridCfg struct {
 	// precedence over Rows. If Columns is empty, column
 	// definitions are auto-generated from sorted keys of the
 	// first map entry (default width 150px).
-	RowsData            []map[string]string
-	Rows                []GridRow
-	FrozenTopRowIDs     []string
-	PageLimit           int
-	PageSize            int
-	PageIndex           int
+	RowsData        []map[string]string
+	Rows            []GridRow
+	FrozenTopRowIDs []string
+	PageLimit       int
+	PageSize        int
+	PageIndex       int
+	// QuickFilterDebounce delays the quick filter query commit.
+	// Defaults to 200ms on grids with a DataSource, 0 (immediate)
+	// otherwise; negative opts a sourced grid out of debouncing.
 	QuickFilterDebounce time.Duration
 	PaddingCell         gg.Opt[gg.Padding]
 	PaddingHeader       gg.Opt[gg.Padding]
@@ -291,7 +294,11 @@ func applyDataGridDefaults(cfg *DataGridCfg) {
 	if cfg.PageLimit == 0 {
 		cfg.PageLimit = dataGridDefaultPageLimit
 	}
-	if cfg.QuickFilterDebounce == 0 {
+	// Debounce only pays off when filtering triggers async fetches;
+	// on in-memory grids it just delays the query round-trip. A
+	// negative value opts a sourced grid out of debouncing (the
+	// handler treats <= 0 as immediate).
+	if cfg.QuickFilterDebounce == 0 && dataGridHasSource(cfg) {
 		cfg.QuickFilterDebounce = 200 * time.Millisecond
 	}
 	if !cfg.ColorBackground.IsSet() {

--- a/gui/datagrid/view_data_grid_cache.go
+++ b/gui/datagrid/view_data_grid_cache.go
@@ -510,7 +510,7 @@ func dataGridFinalContent(
 	if cfg.ShowQuickFilter {
 		qfHeight := dataGridQuickFilterHeight(cfg)
 		content = append(content, dataGridFrozenTopZone(cfg,
-			[]gg.View{dataGridQuickFilterRow(cfg)},
+			[]gg.View{dataGridQuickFilterRow(cfg, dctx.w)},
 			qfHeight, totalWidth, scrollX))
 	}
 	if boolDefault(cfg.ShowHeader, true) && cfg.FreezeHeader {

--- a/gui/datagrid/view_data_grid_events.go
+++ b/gui/datagrid/view_data_grid_events.go
@@ -3,17 +3,29 @@ package datagrid
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	gg "github.com/go-gui-org/go-gui/gui"
 )
 
 // --- Quick filter ---
 
-func dataGridQuickFilterRow(cfg *DataGridCfg) gg.View {
+func dataGridQuickFilterRow(cfg *DataGridCfg, w *gg.Window) gg.View {
 	h := dataGridQuickFilterHeight(cfg)
 	queryCallback := cfg.OnQueryChange
 	query := cfg.Query
+	gridID := cfg.ID
 	value := query.QuickFilter
+	// While a debounced commit is pending, the committed query lags
+	// what the user typed by the debounce delay. Render the pending
+	// draft instead, so keystrokes echo immediately and the next
+	// keystroke reads current text back out of the layout — without
+	// this, every keystroke rebuilds from the stale committed value
+	// and fast typing collapses to the last character.
+	draftMap := gg.StateMap[string, string](w, nsDgQuickDraft, capModerate)
+	if draft, ok := draftMap.Get(gridID); ok {
+		value = draft
+	}
 	inputID := cfg.ID + ":quick_filter"
 	inputFocusID := inputID
 	matchesText := dataGridQuickFilterMatchesText(cfg)
@@ -54,36 +66,8 @@ func dataGridQuickFilterRow(cfg *DataGridCfg) gg.View {
 				ColorBorder:      cfg.ColorBorder,
 				TextStyle:        cfg.TextStyleFilter,
 				PlaceholderStyle: placeholderStyle,
-				OnTextChanged: func(_ *gg.Layout, text string, w *gg.Window) {
-					if queryCallback == nil {
-						return
-					}
-					if debounce <= 0 {
-						next := GridQueryState{
-							Sorts:       append([]GridSort(nil), query.Sorts...),
-							Filters:     append([]GridFilter(nil), query.Filters...),
-							QuickFilter: text,
-						}
-						e := &gg.Event{}
-						queryCallback(next, e, w)
-						return
-					}
-					sorts := append([]GridSort(nil), query.Sorts...)
-					filters := append([]GridFilter(nil), query.Filters...)
-					w.AnimationAdd(&gg.Animate{
-						AnimID: inputID + ":debounce",
-						Delay:  debounce,
-						Callback: func(_ *gg.Animate, w *gg.Window) {
-							next := GridQueryState{
-								Sorts:       sorts,
-								Filters:     filters,
-								QuickFilter: text,
-							}
-							e := &gg.Event{}
-							queryCallback(next, e, w)
-						},
-					})
-				},
+				OnTextChanged: dataGridQuickFilterOnTextChanged(
+					gridID, inputID, query, queryCallback, debounce),
 			}),
 			gg.Text(gg.TextCfg{
 				Text:      matchesText,
@@ -96,6 +80,8 @@ func dataGridQuickFilterRow(cfg *DataGridCfg) gg.View {
 						return
 					}
 					w.AnimationRemove(inputID + ":debounce")
+					gg.StateMap[string, string](w, nsDgQuickDraft,
+						capModerate).Delete(gridID)
 					next := GridQueryState{
 						Sorts:       append([]GridSort(nil), query.Sorts...),
 						Filters:     append([]GridFilter(nil), query.Filters...),
@@ -109,6 +95,57 @@ func dataGridQuickFilterRow(cfg *DataGridCfg) gg.View {
 				}),
 		},
 	})
+}
+
+// dataGridQuickFilterOnTextChanged builds the quick filter input's
+// text-changed handler. With no debounce the query commits
+// immediately. With a debounce the commit is deferred, so the typed
+// text is parked in nsDgQuickDraft: dataGridQuickFilterRow renders
+// the draft while it is pending, which keeps the input echoing
+// keystrokes even though the committed query lags by the debounce
+// delay. Re-typing replaces both the draft and the pending
+// animation (same AnimID); the commit callback clears the draft to
+// hand display back to the controlled query value.
+func dataGridQuickFilterOnTextChanged(
+	gridID, inputID string,
+	query GridQueryState,
+	queryCallback func(GridQueryState, *gg.Event, *gg.Window),
+	debounce time.Duration,
+) func(*gg.Layout, string, *gg.Window) {
+	return func(_ *gg.Layout, text string, w *gg.Window) {
+		if queryCallback == nil {
+			return
+		}
+		if debounce <= 0 {
+			next := GridQueryState{
+				Sorts:       append([]GridSort(nil), query.Sorts...),
+				Filters:     append([]GridFilter(nil), query.Filters...),
+				QuickFilter: text,
+			}
+			e := &gg.Event{}
+			queryCallback(next, e, w)
+			return
+		}
+		sorts := append([]GridSort(nil), query.Sorts...)
+		filters := append([]GridFilter(nil), query.Filters...)
+		gg.StateMap[string, string](w, nsDgQuickDraft,
+			capModerate).Set(gridID, text)
+		w.AnimationAdd(&gg.Animate{
+			AnimID: inputID + ":debounce",
+			Delay:  debounce,
+			Callback: func(_ *gg.Animate, w *gg.Window) {
+				next := GridQueryState{
+					Sorts:       sorts,
+					Filters:     filters,
+					QuickFilter: text,
+				}
+				e := &gg.Event{}
+				queryCallback(next, e, w)
+				gg.StateMap[string, string](w, nsDgQuickDraft,
+					capModerate).Delete(gridID)
+			},
+		})
+	}
 }
 
 func dataGridQuickFilterMatchesText(cfg *DataGridCfg) string {

--- a/gui/datagrid/view_data_grid_quick_filter_test.go
+++ b/gui/datagrid/view_data_grid_quick_filter_test.go
@@ -1,0 +1,160 @@
+package datagrid
+
+import (
+	"testing"
+	"time"
+
+	gg "github.com/go-gui-org/go-gui/gui"
+)
+
+// --- Quick filter debounce draft ---
+
+func quickFilterDraft(w *gg.Window, gridID string) (string, bool) {
+	return gg.StateMap[string, string](w, nsDgQuickDraft, capModerate).Get(gridID)
+}
+
+// findShapeText walks a layout tree for a text shape whose text
+// matches want. Returns true when found.
+func findShapeText(layout *gg.Layout, want string) bool {
+	if layout.Shape != nil && layout.Shape.TC != nil &&
+		layout.Shape.TC.Text == want {
+		return true
+	}
+	for i := range layout.Children {
+		if findShapeText(&layout.Children[i], want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestQuickFilterDebounceDefaultInMemory(t *testing.T) {
+	cfg := &DataGridCfg{ID: "g1"}
+	applyDataGridDefaults(cfg)
+	if cfg.QuickFilterDebounce != 0 {
+		t.Fatalf("QuickFilterDebounce = %v without DataSource, want 0",
+			cfg.QuickFilterDebounce)
+	}
+}
+
+func TestQuickFilterDebounceDefaultWithSource(t *testing.T) {
+	cfg := &DataGridCfg{
+		ID:         "g1",
+		DataSource: NewInMemoryDataSource(nil),
+	}
+	applyDataGridDefaults(cfg)
+	if cfg.QuickFilterDebounce != 200*time.Millisecond {
+		t.Fatalf("QuickFilterDebounce = %v with DataSource, want 200ms",
+			cfg.QuickFilterDebounce)
+	}
+}
+
+func TestQuickFilterDebounceNegativeOptsOut(t *testing.T) {
+	cfg := &DataGridCfg{
+		ID:                  "g1",
+		DataSource:          NewInMemoryDataSource(nil),
+		QuickFilterDebounce: -1,
+	}
+	applyDataGridDefaults(cfg)
+	if cfg.QuickFilterDebounce != -1 {
+		t.Fatalf("QuickFilterDebounce = %v, want -1 preserved",
+			cfg.QuickFilterDebounce)
+	}
+}
+
+func TestQuickFilterNoDebounceCommitsImmediately(t *testing.T) {
+	w := gg.NewWindow(gg.WindowCfg{})
+	var committed []string
+	handler := dataGridQuickFilterOnTextChanged("g1", "g1:quick_filter",
+		GridQueryState{},
+		func(q GridQueryState, _ *gg.Event, _ *gg.Window) {
+			committed = append(committed, q.QuickFilter)
+		}, 0)
+
+	handler(nil, "a", w)
+	handler(nil, "ab", w)
+
+	if len(committed) != 2 || committed[1] != "ab" {
+		t.Fatalf("committed = %v, want [a ab]", committed)
+	}
+	if _, ok := quickFilterDraft(w, "g1"); ok {
+		t.Fatal("draft set on undebounced path, want none")
+	}
+}
+
+func TestQuickFilterDebounceParksDraft(t *testing.T) {
+	w := gg.NewWindow(gg.WindowCfg{})
+	var committed []string
+	handler := dataGridQuickFilterOnTextChanged("g1", "g1:quick_filter",
+		GridQueryState{},
+		func(q GridQueryState, _ *gg.Event, _ *gg.Window) {
+			committed = append(committed, q.QuickFilter)
+		}, 200*time.Millisecond)
+
+	handler(nil, "a", w)
+
+	if len(committed) != 0 {
+		t.Fatalf("committed = %v before debounce, want none", committed)
+	}
+	draft, ok := quickFilterDraft(w, "g1")
+	if !ok || draft != "a" {
+		t.Fatalf("draft = %q, %t, want %q, true", draft, ok, "a")
+	}
+	if !w.HasAnimation("g1:quick_filter:debounce") {
+		t.Fatal("debounce animation not registered")
+	}
+}
+
+func TestQuickFilterDebounceRetypeReplacesDraft(t *testing.T) {
+	w := gg.NewWindow(gg.WindowCfg{})
+	handler := dataGridQuickFilterOnTextChanged("g1", "g1:quick_filter",
+		GridQueryState{},
+		func(GridQueryState, *gg.Event, *gg.Window) {},
+		200*time.Millisecond)
+
+	// Two keystrokes inside the debounce window: the draft must
+	// track the latest text so the rendered input echoes typing.
+	handler(nil, "a", w)
+	handler(nil, "ab", w)
+
+	draft, ok := quickFilterDraft(w, "g1")
+	if !ok || draft != "ab" {
+		t.Fatalf("draft = %q, %t, want %q, true", draft, ok, "ab")
+	}
+}
+
+func TestQuickFilterRowRendersPendingDraft(t *testing.T) {
+	w := gg.NewWindow(gg.WindowCfg{})
+	cfg := &DataGridCfg{
+		ID:            "g1",
+		Query:         GridQueryState{QuickFilter: "stale"},
+		OnQueryChange: func(GridQueryState, *gg.Event, *gg.Window) {},
+	}
+	applyDataGridDefaults(cfg)
+
+	gg.StateMap[string, string](w, nsDgQuickDraft, capModerate).
+		Set("g1", "fresh")
+
+	layout := gg.GenerateViewLayout(dataGridQuickFilterRow(cfg, w), w)
+	if !findShapeText(&layout, "fresh") {
+		t.Fatal("pending draft text not rendered")
+	}
+	if findShapeText(&layout, "stale") {
+		t.Fatal("stale committed text rendered while draft pending")
+	}
+}
+
+func TestQuickFilterRowRendersCommittedWithoutDraft(t *testing.T) {
+	w := gg.NewWindow(gg.WindowCfg{})
+	cfg := &DataGridCfg{
+		ID:            "g1",
+		Query:         GridQueryState{QuickFilter: "committed"},
+		OnQueryChange: func(GridQueryState, *gg.Event, *gg.Window) {},
+	}
+	applyDataGridDefaults(cfg)
+
+	layout := gg.GenerateViewLayout(dataGridQuickFilterRow(cfg, w), w)
+	if !findShapeText(&layout, "committed") {
+		t.Fatal("committed query text not rendered")
+	}
+}

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -180,6 +180,13 @@ func Input(cfg InputCfg) View {
 	if cfg.Mode == InputMultiline && cfg.Scrollable {
 		txtSizing = FillFit
 		innerSizing = FillFit
+	} else if cfg.Mode != InputMultiline {
+		// Single-line: the text shape must hug its font height so the
+		// inner row's VAlignMiddle can center it. Text renders from
+		// the top of its shape, so a Fill-height text pins the glyphs
+		// to the top of any input taller than the text (visible in
+		// data grid cells, which strip padding and fill the row).
+		txtSizing = FillFit
 	}
 
 	txtContent := []View{
@@ -331,6 +338,11 @@ type inputHandlerCfg struct {
 func (h *inputHandlerCfg) fireTextChanged(
 	layout *Layout, text string, w *Window,
 ) {
+	// Echo the mutation into the layout tree before notifying the
+	// app. Events are drained in batches against the same tree, so
+	// a later event in the batch must see this text, not the text
+	// the last frame rendered (see inputSetTextInLayout).
+	inputSetTextInLayout(layout, text)
 	if h.ReadOnly || h.OnTextChanged == nil {
 		return
 	}

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -27,6 +27,33 @@ func inputTextFromLayout(layout *Layout) string {
 	return txt.Shape.TC.Text
 }
 
+// inputSetTextInLayout writes mutated text back into the input's
+// inner text shape (Column → Row/Column → Text). Backends drain
+// every pending event against the same layout tree before the next
+// frame rebuild, so without this write-back the second key event in
+// a batch reads the pre-mutation text via inputTextFromLayout and
+// silently discards the earlier keystroke (dropped characters when
+// typing fast; backspaces that do not stick). The tree is rebuilt
+// from app state before the next render, so this echo only feeds
+// intra-batch event reads — it never reaches the screen.
+func inputSetTextInLayout(layout *Layout, text string) {
+	if len(layout.Children) == 0 {
+		return
+	}
+	row := &layout.Children[0]
+	if len(row.Children) == 0 {
+		return
+	}
+	txt := &row.Children[0]
+	if txt.Shape == nil || txt.Shape.TC == nil {
+		return
+	}
+	txt.Shape.TC.Text = text
+	// Clear the placeholder flag so a follow-up read returns the
+	// typed text rather than treating it as placeholder content.
+	txt.Shape.TC.TextIsPlaceholder = false
+}
+
 // inputGlyphLayoutFor navigates to the inner text shape of an
 // input layout and returns a glyph Layout for cursor navigation.
 func inputGlyphLayoutFor(layout *Layout, w *Window) (glyph.Layout, bool) {

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -264,6 +264,50 @@ func (c *inputTestCtx) state() InputState {
 	return getInputState(c.w, c.layout.Shape.ID)
 }
 
+// TestInputSingleLineTextCentersVertically renders a single-line
+// input taller than its font and asserts the inner text shape is
+// vertically centered, not pinned to the top. Data grid filter
+// cells (no padding, input fills the row) regressed on this: text
+// sized FillFill defeats the inner row's VAlignMiddle.
+func TestInputSingleLineTextCentersVertically(t *testing.T) {
+	w := &Window{}
+	w.windowWidth = 200
+	w.windowHeight = 40
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+
+	layout := generateViewLayout(Input(InputCfg{
+		ID:      "f700",
+		Text:    "hi",
+		Width:   200,
+		Height:  40,
+		Sizing:  FixedFixed,
+		Padding: NoPadding,
+	}), w)
+	layoutPipeline(&layout, w)
+
+	if len(layout.Children) == 0 || len(layout.Children[0].Children) == 0 {
+		t.Fatal("input layout missing inner text child")
+	}
+	txt := layout.Children[0].Children[0].Shape
+	if txt.TC == nil {
+		t.Fatal("inner child is not a text shape")
+	}
+	// FillFit must hug the stub font height; a Fill text stretches
+	// to the content box (~38 after borders) and pins glyphs to the
+	// top even though its midpoint still matches the input's.
+	if abs32(txt.Height-20) > 1 {
+		t.Fatalf("text height = %.1f, want ~20 (font height)", txt.Height)
+	}
+	// Border (default) insets the content box symmetrically, so the
+	// text midpoint must still sit at the input midpoint.
+	wantMidY := layout.Shape.Y + 20
+	gotMidY := txt.Y + txt.Height/2
+	if abs32(gotMidY-wantMidY) > 1 {
+		t.Fatalf("text midY = %.1f, want ~%.1f (top=%.1f h=%.1f)",
+			gotMidY, wantMidY, txt.Y, txt.Height)
+	}
+}
+
 // --- OnChar tests ---
 
 func TestInputOnCharInsert(t *testing.T) {
@@ -279,6 +323,39 @@ func TestInputOnCharInsertAtMiddle(t *testing.T) {
 	ctx.fireChar('X')
 	if ctx.lastText != "aXb" {
 		t.Fatalf("got %q, want %q", ctx.lastText, "aXb")
+	}
+}
+
+// Batched-event regression tests: backends drain all pending events
+// against the same layout tree before the next frame rebuild. Each
+// mutation must be visible to the next event in the batch via the
+// layout write-back in fireTextChanged, or earlier keystrokes are
+// silently overwritten (dropped chars, backspaces that do not stick).
+
+func TestInputOnCharBatchedCompound(t *testing.T) {
+	ctx := newInputTest("ab", "f502", 2)
+	ctx.fireChar('c')
+	ctx.fireChar('d')
+	if ctx.lastText != "abcd" {
+		t.Fatalf("got %q, want %q", ctx.lastText, "abcd")
+	}
+}
+
+func TestInputOnCharBatchedFromPlaceholder(t *testing.T) {
+	ctx := newInputTest("", "f503", 0)
+	ctx.fireChar('a')
+	ctx.fireChar('b')
+	if ctx.lastText != "ab" {
+		t.Fatalf("got %q, want %q", ctx.lastText, "ab")
+	}
+}
+
+func TestInputKeyDownBatchedBackspace(t *testing.T) {
+	ctx := newInputTest("abcd", "f504", 4)
+	ctx.fireKeyDown(KeyBackspace, 0)
+	ctx.fireKeyDown(KeyBackspace, 0)
+	if ctx.lastText != "ab" {
+		t.Fatalf("got %q, want %q", ctx.lastText, "ab")
 	}
 }
 


### PR DESCRIPTION
### Changes

- **input: batched-event echo** — write mutated text back to layout tree in `fireTextChanged` so batched keystrokes see each other (fixes dropped characters / stuck backspaces on fast typing)
- **input: single-line vertical centering** — single-line mode now uses `FillFit` for inner text shape so `VAlignMiddle` centers glyphs in inputs taller than the font (regression: data grid filter cells with no padding)
- **datagrid: quick-filter debounce draft** — introduce `nsDgQuickDraft` state map to render typed text immediately during the debounce window; default 200ms debounce now only applies to grids with a `DataSource` (in-memory grids commit immediately)
- **datagrid: refactor** — extract `dataGridQuickFilterOnTextChanged`; clear button now cancels draft state
- **tests** — add batched-event compound/placeholder/backspace tests; add input vertical-centering layout test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787059030&installation_id=145733661&pr_number=109&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F109&signature=67082cfcdeee54f310bb162192913432ac65aa6775c315b08878858315e32a6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->