### PR TITLE
metal: drop mouse-down consumed by window resize drag

### DIFF
--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -72,6 +72,11 @@ static int             _evIMELength;
 static int             _evIMEGeneration;   // incremented on each IME event
 static int             _evIMEConsumedGen;  // last generation consumed by poll
 static int             _quitRequested;     // set by quit:/appShouldTerminate: (main thread only)
+// Set by windowWillStartLiveResize:, consumed in metalPollEvent.
+// AppKit's resize tracking loop runs *inside* [NSApp sendEvent:], so
+// this flag tells us — after sendEvent returns — that the mouse-down
+// we already stored was swallowed to drive a window resize.
+static int             _liveResizeStarted;
 
 // ─── Window ID counter ─────────────────────────────────────────
 
@@ -298,6 +303,13 @@ static uint32_t _nextWindowID = 1;
 - (BOOL)canBecomeMainWindow { return YES; }
 
 // ─── NSWindowDelegate ──────────────────────────────────────────
+
+// A resize drag begun on the window border. The press that started it
+// belongs to AppKit, not to the app — see the _liveResizeStarted
+// consumer in metalPollEvent.
+- (void)windowWillStartLiveResize:(NSNotification *)notification {
+    _liveResizeStarted = 1;
+}
 
 - (void)windowDidResize:(NSNotification *)notification {
     // Report content-bounds size, not frame size. The frame
@@ -747,12 +759,28 @@ int metalPollEvent(int timeoutMs) {
     // Store event data for Go accessors.
     storeEvent(event, wid);
 
+    _liveResizeStarted = 0;
+
     // Forward to AppKit for window management and text input.
     // Key events: keyDown: → interpretKeyEvents: → insertText: fires
     // for printable characters, doCommandBySelector: (no-op) for
     // non-printable keys. Go receives EventChar or EventKeyDown.
     // Mouse/scroll: standard AppKit routing (resize, close, focus).
     [NSApp sendEvent:event];
+
+    // Drop a mouse-down that AppKit consumed to resize the window.
+    // The resize grab area overlaps the content view by a few points,
+    // so storeEvent (which runs before sendEvent, with no way to know
+    // where AppKit will route the press) hands Go a plain content-
+    // relative click. A widget filling the window then treats it as a
+    // real press — e.g. a text input starts a drag-selection and calls
+    // MouseLock. The matching mouse-up never arrives because AppKit's
+    // resize tracking loop, which runs to completion inside the
+    // sendEvent above, swallows it, so the drag stays locked forever.
+    if (_liveResizeStarted && _evType == METAL_EVENT_MOUSE_DOWN) {
+        _evType = METAL_EVENT_NONE;
+    }
+    _liveResizeStarted = 0;
 
     // If sendEvent triggered IME callbacks that overwrote _evType
     // to CHAR or IME_COMP, mark this generation as consumed so


### PR DESCRIPTION
AppKit's resize tracking loop runs inside `[NSApp sendEvent:]` and swallows the matching mouse-up. The initial mouse-down — stored by `storeEvent` before `sendEvent` — was reaching Go as a real content click. A widget filling the window then triggers a drag-selection + `MouseLock` that never gets the corresponding release because AppKit consumed the mouse-up.

Listen for `windowWillStartLiveResize:` to detect when AppKit swallowed the press for a resize, and null the event type so Go never sees the bogus mouse-down.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787060465&installation_id=145733661&pr_number=111&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F111&signature=9444c57a6cb993f93e769597caf15e8a4144c333f769dcd25812c6e853775605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->