### PR TITLE
gui: fix Switch focus highlight and Toggle check-box sizing

### DIFF
--- a/gui/styles_widget.go
+++ b/gui/styles_widget.go
@@ -71,9 +71,13 @@ type SwitchStyle struct {
 
 // ToggleStyle defines toggle button visual properties.
 type ToggleStyle struct {
-	TextStyleNormal  TextStyle
-	TextStyleLabel   TextStyle
-	Padding          Padding
+	TextStyleNormal TextStyle
+	TextStyleLabel  TextStyle
+	Padding         Padding
+	// Size is the square edge length of the check box. Fixed on both
+	// axes so the box stays square instead of shrinking to the width
+	// of the check glyph.
+	Size             float32
 	SizeBorder       float32
 	Radius           float32
 	Color            Color
@@ -176,6 +180,7 @@ var (
 		ColorHover:       colorHoverDark,
 		ColorSelect:      colorInteriorDark,
 		Padding:          NewPadding(1, 1, 1, 2),
+		Size:             SizeTextMedium + 4,
 		SizeBorder:       SizeBorderDef,
 		Radius:           RadiusSmall,
 		TextStyleNormal:  DefaultTextStyle,

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -133,6 +133,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			ColorHover:       cfg.ColorHover,
 			ColorSelect:      cfg.ColorInterior,
 			Padding:          NewPadding(1, 1, 1, 2),
+			Size:             ts.Size + 4,
 			SizeBorder:       cfg.SizeBorder,
 			Radius:           cfg.Radius,
 			TextStyleNormal:  ts,

--- a/gui/view_switch.go
+++ b/gui/view_switch.go
@@ -56,8 +56,9 @@ func Switch(cfg SwitchCfg) View {
 	}
 
 	content := make([]View, 0, 2)
+	// No ID here: the focusable outer row owns cfg.ID, and IDs must be
+	// unique per window.
 	content = append(content, Row(ContainerCfg{
-		ID:          cfg.ID,
 		Width:       width,
 		Height:      height,
 		Sizing:      FixedFit,
@@ -90,12 +91,15 @@ func Switch(cfg SwitchCfg) View {
 	}
 
 	return Row(ContainerCfg{
-		ID:              cfg.ID,
-		Focusable:       !cfg.FocusDisabled,
-		Disabled:        cfg.Disabled,
-		Invisible:       cfg.Invisible,
-		SizeBorder:      NoBorder,
-		Padding:         NoPadding,
+		ID:         cfg.ID,
+		Focusable:  !cfg.FocusDisabled,
+		Disabled:   cfg.Disabled,
+		Invisible:  cfg.Invisible,
+		SizeBorder: NoBorder,
+		Padding:    NoPadding,
+		// Centre the pill and its label on the row's cross axis so the
+		// label sits vertically middle-aligned with the switch.
+		VAlign:          VAlignMiddle,
 		A11YRole:        AccessRoleSwitchToggle,
 		A11YState:       a11yState,
 		A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.Label),
@@ -123,9 +127,14 @@ func Switch(cfg SwitchCfg) View {
 				layout.Shape.events.OnClick == nil {
 				return
 			}
+			// Highlight only the pill (child 0), not the outer row —
+			// the outer row also spans the label.
+			if len(layout.Children) == 0 {
+				return
+			}
 			if w.IsFocus(layout.Shape.ID) {
-				layout.Shape.Color = colorFocus
-				layout.Shape.ColorBorder = colorBorderFocus
+				layout.Children[0].Shape.Color = colorFocus
+				layout.Children[0].Shape.ColorBorder = colorBorderFocus
 			}
 		},
 		Content: content,

--- a/gui/view_switch_test.go
+++ b/gui/view_switch_test.go
@@ -6,12 +6,17 @@ func TestSwitchIDPassthrough(t *testing.T) {
 	w := &Window{}
 	layout := generateViewLayout(
 		Switch(SwitchCfg{ID: "sw1", OnClick: noop}), w)
-	// ID is on the inner pill, not outer row.
+	// ID lives on the focusable outer row only; the inner pill must
+	// not duplicate it.
+	if layout.Shape.ID != "sw1" {
+		t.Errorf("outer ID: got %s", layout.Shape.ID)
+	}
 	if len(layout.Children) == 0 {
 		t.Fatal("expected children")
 	}
-	if layout.Children[0].Shape.ID != "sw1" {
-		t.Errorf("ID: got %s", layout.Children[0].Shape.ID)
+	if layout.Children[0].Shape.ID != "" {
+		t.Errorf("pill ID: got %s, want empty",
+			layout.Children[0].Shape.ID)
 	}
 }
 

--- a/gui/view_toggle.go
+++ b/gui/view_toggle.go
@@ -13,9 +13,11 @@ type ToggleCfg struct {
 	A11YLabel       string
 	A11YDescription string
 	Padding         Opt[Padding]
-	SizeBorder      Opt[float32]
-	Radius          Opt[float32]
-	MinWidth        float32
+	// Size overrides the square edge length of the check box.
+	Size       Opt[float32]
+	SizeBorder Opt[float32]
+	Radius     Opt[float32]
+	MinWidth   float32
 	// FocusDisabled opts out of the default-on focus. Focus also
 	// requires a non-empty ID; without one the control is inert.
 	FocusDisabled    bool
@@ -38,6 +40,7 @@ func Toggle(cfg ToggleCfg) View {
 	d := &DefaultToggleStyle
 	sizeBorder := cfg.SizeBorder.Get(d.SizeBorder)
 	radius := cfg.Radius.Get(d.Radius)
+	size := cfg.Size.Get(d.Size)
 
 	boxColor := cfg.Color
 	if cfg.Selected {
@@ -60,6 +63,9 @@ func Toggle(cfg ToggleCfg) View {
 	colorClick := cfg.ColorClick
 
 	content := make([]View, 0, 2)
+	// Fixed square box: without Fixed sizing the box fits the check
+	// glyph, which is narrower than the line height, so it renders as
+	// a tall rectangle. Padding stays for the inner text inset.
 	content = append(content, Row(ContainerCfg{
 		Color:       boxColor,
 		ColorBorder: cfg.ColorBorder,
@@ -68,6 +74,9 @@ func Toggle(cfg ToggleCfg) View {
 		Radius:      Some(radius),
 		Disabled:    cfg.Disabled,
 		Invisible:   cfg.Invisible,
+		Width:       size,
+		Height:      size,
+		Sizing:      FixedFixed,
 		HAlign:      HAlignCenter,
 		VAlign:      VAlignMiddle,
 		Content: []View{

--- a/gui/view_toggle_test.go
+++ b/gui/view_toggle_test.go
@@ -82,3 +82,22 @@ func TestToggleLabelAddsChild(t *testing.T) {
 			len(layout.Children))
 	}
 }
+
+// The check box must be a fixed square; a Fit-sized box collapses to
+// the width of the check glyph and renders as a tall rectangle.
+func TestToggleBoxIsSquare(t *testing.T) {
+	w := &Window{}
+	layout := generateViewLayout(Toggle(ToggleCfg{
+		ID: "cb-sq", OnClick: noop, Size: Some[float32](24),
+	}), w)
+	if len(layout.Children) == 0 {
+		t.Fatal("expected children")
+	}
+	box := layout.Children[0].Shape
+	if box.Width != 24 || box.Height != 24 {
+		t.Errorf("box size: got %vx%v, want 24x24", box.Width, box.Height)
+	}
+	if box.Sizing != FixedFixed {
+		t.Errorf("box sizing: got %v, want FixedFixed", box.Sizing)
+	}
+}

--- a/gui/view_widget_test.go
+++ b/gui/view_widget_test.go
@@ -383,12 +383,18 @@ func TestSwitchClickHoverChangesColor(t *testing.T) {
 
 func TestSwitchFocusBorder(t *testing.T) {
 	w := newTestWindow()
-	v := Switch(SwitchCfg{OnClick: noop, ID: "f5"})
+	v := Switch(SwitchCfg{OnClick: noop, ID: "f5", Label: "on"})
 	layout := generateViewLayout(v, w)
 	w.SetFocus("f5")
 	layout.Shape.events.AmendLayout(&layout, w)
-	if layout.Shape.ColorBorder != DefaultSwitchStyle.ColorBorderFocus {
-		t.Error("focused switch should have focus border color")
+	// Focus paints the pill only; the outer row (which spans the
+	// label) stays untouched.
+	if layout.Children[0].Shape.ColorBorder !=
+		DefaultSwitchStyle.ColorBorderFocus {
+		t.Error("focused pill should have focus border color")
+	}
+	if layout.Shape.ColorBorder == DefaultSwitchStyle.ColorBorderFocus {
+		t.Error("outer row should not be highlighted")
 	}
 }
 


### PR DESCRIPTION
## Changes

### Switch
- Focus highlight now draws on the pill only, not the entire row (the row spans the label, so full-row highlight was visually wrong).
- Added vertical center alignment to the outer row so the switch and label are vertically centred.
- Removed duplicate ID from the inner pill row; ID lives only on the focusable outer wrapper.
- Updated switch focus border and ID passthrough tests accordingly.

### Toggle
- Added configurable `Size` field to ToggleCfg for a fixed-size square check box.
- Check box now uses fixed sizing to render as a square instead of collapsing to the check glyph width (which produced a tall rectangle).
- New test validates square sizing.
- Added Size to DefaultToggleStyle and ThemeMaker.

### Styles
- ToggleStyle gains a Size field with sensible default.