### PR TITLE
Add smooth programmatic scrolling (ScrollVerticalToSmooth / ScrollHorizontalToSmooth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Smooth programmatic scrolling.** New `Window.ScrollVerticalToSmooth` and
+  `Window.ScrollHorizontalToSmooth` ease a scrollable to an absolute offset
+  using the same exponential smoothing as discrete mouse-wheel scrolling.
+  No-op when the scroll id is not found or the target equals the current
+  offset; instant `ScrollVerticalTo`/`ScrollHorizontalTo` still cancel any
+  in-flight ease. The wheel smoother's arm logic is now shared
+  (`scrollSmoothParams`/`scrollSmoothArm`) between relative wheel deltas and
+  absolute targets.
+
 ## [v0.39.0] - 2026-07-18
 
 ### Added

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -294,6 +294,17 @@ func (w *Window) ScrollHorizontalTo(id string, offset float32) {
 	sx.Set(id, offset)
 }
 
+// ScrollHorizontalToSmooth eases the given scrollable to offset
+// (negative) using the same exponential smoothing as discrete
+// mouse-wheel scrolling. No-op if the scroll id is not found or the
+// target equals the current offset. Use ScrollHorizontalTo for an
+// instant jump.
+func (w *Window) ScrollHorizontalToSmooth(id string, offset float32) {
+	if ly, ok := findScrollLayout(w, id); ok {
+		scrollSmoothTo(w, ly, scrollAxisX, offset)
+	}
+}
+
 // ScrollHorizontalToPct scrolls to a horizontal percentage.
 // pct: 0.0 = left, 1.0 = right. Clamped to [0, 1].
 // No-op if the scroll id is not found or content fits viewport.
@@ -359,6 +370,17 @@ func (w *Window) ScrollVerticalTo(id string, offset float32) {
 		return
 	}
 	sy.Set(id, offset)
+}
+
+// ScrollVerticalToSmooth eases the given scrollable to offset
+// (negative) using the same exponential smoothing as discrete
+// mouse-wheel scrolling. No-op if the scroll id is not found or the
+// target equals the current offset. Use ScrollVerticalTo for an
+// instant jump.
+func (w *Window) ScrollVerticalToSmooth(id string, offset float32) {
+	if ly, ok := findScrollLayout(w, id); ok {
+		scrollSmoothTo(w, ly, scrollAxisY, offset)
+	}
 }
 
 // ScrollVerticalToPct scrolls to a vertical percentage.

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -137,19 +137,41 @@ func (s *scrollSmoothAnimation) findEntry(id string, axis scrollAxis) *scrollSmo
 // the displayed offset to the animation. Returns true if a repaint is
 // warranted. Main goroutine only.
 func scrollSmoothBy(w *Window, layout *Layout, axis scrollAxis, delta float32) bool {
+	displayed, maxOffset, ok := scrollSmoothParams(w, layout, axis)
+	if !ok {
+		return false
+	}
+	increment := delta * guiTheme.ScrollMultiplier
+	return scrollSmoothArm(w, layout.Shape.ID, axis, displayed, maxOffset, increment, true)
+}
+
+// scrollSmoothTo arms the smoother toward an absolute offset
+// (negative) for layout's scrollable, easing from the displayed
+// offset with the same exponential lerp as discrete-wheel scrolling.
+// Returns true if an ease was started. Main goroutine only.
+func scrollSmoothTo(w *Window, layout *Layout, axis scrollAxis, offset float32) bool {
+	displayed, maxOffset, ok := scrollSmoothParams(w, layout, axis)
+	if !ok {
+		return false
+	}
+	return scrollSmoothArm(w, layout.Shape.ID, axis, displayed, maxOffset, offset, false)
+}
+
+// scrollSmoothParams validates that layout can ease on axis and
+// returns the displayed offset and scroll bound. Main goroutine only.
+func scrollSmoothParams(w *Window, layout *Layout, axis scrollAxis) (displayed, maxOffset float32, ok bool) {
 	id := layout.Shape.ID
 	if !layout.Shape.Scrollable || id == "" {
-		return false
+		return 0, 0, false
 	}
 	if axis == scrollAxisY && layout.Shape.ScrollMode == ScrollHorizontalOnly {
-		return false
+		return 0, 0, false
 	}
 	if axis == scrollAxisX && layout.Shape.ScrollMode == ScrollVerticalOnly {
-		return false
+		return 0, 0, false
 	}
 
 	// Default 0: unscrolled position when no offset recorded yet.
-	var maxOffset, displayed float32
 	if axis == scrollAxisY {
 		maxOffset = scrollMaxOffsetY(layout)
 		displayed = w.scrollY().GetOr(id, 0)
@@ -157,8 +179,16 @@ func scrollSmoothBy(w *Window, layout *Layout, axis scrollAxis, delta float32) b
 		maxOffset = scrollMaxOffsetX(layout)
 		displayed = w.scrollX().GetOr(id, 0)
 	}
-	increment := delta * guiTheme.ScrollMultiplier
+	return displayed, maxOffset, true
+}
 
+// scrollSmoothArm updates the smoother entry for id+axis toward a new
+// target and (re)arms the animation. When relative, amount is added
+// to the current base (the in-flight target when active, else the
+// displayed offset); otherwise amount is an absolute offset. The
+// result clamps to [maxOffset, 0]. Returns false when the target is
+// non-finite or already in effect. Main goroutine only.
+func scrollSmoothArm(w *Window, id string, axis scrollAxis, displayed, maxOffset, amount float32, relative bool) bool {
 	w.animMu.Lock()
 	defer w.animMu.Unlock()
 	if w.scrollSmooth == nil {
@@ -171,7 +201,11 @@ func scrollSmoothBy(w *Window, layout *Layout, axis scrollAxis, delta float32) b
 	if e.active {
 		base = e.target
 	}
-	newTarget := f32Clamp(base+increment, maxOffset, 0)
+	target := amount
+	if relative {
+		target = base + amount
+	}
+	newTarget := f32Clamp(target, maxOffset, 0)
 	if !f32IsFinite(newTarget) {
 		// NaN delta, multiplier, or displayed offset would poison the
 		// ease into a never-settling animation. Reject the event.

--- a/gui/scroll_smooth_test.go
+++ b/gui/scroll_smooth_test.go
@@ -339,3 +339,164 @@ func TestCommandApplyScrollSmoothNilSafe(t *testing.T) {
 	w := &Window{}
 	commandApplyScrollSmooth(w) // must not panic
 }
+
+func TestScrollVerticalToSmoothEasesToAbsoluteTarget(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	_, w := makeScrollLayout("14", 100, 100, 100, 300)
+	w.scrollY().Set("14", -100)
+
+	w.ScrollVerticalToSmooth("14", 0)
+
+	e := w.scrollSmooth.findEntry("14", scrollAxisY)
+	if e == nil || !e.active {
+		t.Fatal("expected an active entry")
+	}
+	if e.target != 0 {
+		t.Errorf("target = %v, want 0", e.target)
+	}
+	if e.current != -100 {
+		t.Errorf("current = %v, want -100 (displayed offset)", e.current)
+	}
+	// Absolute target must not accumulate on repeat calls.
+	w.ScrollVerticalToSmooth("14", 0)
+	if e.target != 0 {
+		t.Errorf("target after repeat call = %v, want 0", e.target)
+	}
+	driveScrollSmooth(w, 200)
+	if v, _ := w.scrollY().Get("14"); v != 0 {
+		t.Errorf("settled offset = %v, want 0", v)
+	}
+}
+
+func TestScrollVerticalToSmoothClampsAtBounds(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	_, w := makeScrollLayout("15", 100, 100, 100, 300) // maxOffset -200
+
+	w.ScrollVerticalToSmooth("15", -9999)
+	e := w.scrollSmooth.findEntry("15", scrollAxisY)
+	if e == nil || e.target != -200 {
+		t.Fatalf("target = %v, want -200 (clamped)", e.target)
+	}
+	driveScrollSmooth(w, 200)
+	if v, _ := w.scrollY().Get("15"); v != -200 {
+		t.Errorf("settled offset = %v, want -200", v)
+	}
+}
+
+func TestScrollVerticalToSmoothNoOpAtTarget(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	_, w := makeScrollLayout("16", 100, 100, 100, 300)
+
+	// Already at offset 0: nothing to ease, no entry armed.
+	w.ScrollVerticalToSmooth("16", 0)
+	if w.scrollSmooth != nil {
+		if e := w.scrollSmooth.findEntry("16", scrollAxisY); e != nil && e.active {
+			t.Error("expected no active entry when already at target")
+		}
+	}
+}
+
+func TestScrollVerticalToSmoothUnknownID(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	_, w := makeScrollLayout("17", 100, 100, 100, 300)
+
+	w.ScrollVerticalToSmooth("nope", -50) // must not panic or arm
+	if w.scrollSmooth != nil && w.scrollSmooth.findEntry("nope", scrollAxisY) != nil {
+		t.Error("unknown scroll id must not create an entry")
+	}
+}
+
+func TestScrollHorizontalToSmoothEases(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	w := &Window{}
+	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 50}}
+	layout := Layout{
+		Shape: &Shape{
+			shapeType:  shapeRectangle,
+			Scrollable: true,
+			ID:         "18",
+			Width:      100,
+			Height:     50,
+			Axis:       AxisLeftToRight,
+		},
+		Children: []Layout{child},
+	}
+	w.layout = Layout{
+		Shape:    &Shape{shapeType: shapeRectangle},
+		Children: []Layout{layout},
+	}
+
+	w.ScrollHorizontalToSmooth("18", -50)
+	driveScrollSmooth(w, 200)
+	if v, _ := w.scrollX().Get("18"); v != -50 {
+		t.Errorf("horizontal settled = %v, want -50", v)
+	}
+}
+
+func TestScrollVerticalToSmoothCanceledByInstantScroll(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	_, w := makeScrollLayout("19", 100, 100, 100, 300)
+	w.scrollY().Set("19", -100)
+
+	w.ScrollVerticalToSmooth("19", 0)
+	if e := w.scrollSmooth.findEntry("19", scrollAxisY); e == nil || !e.active {
+		t.Fatal("expected active entry before instant scroll")
+	}
+
+	w.ScrollVerticalTo("19", -30)
+	e := w.scrollSmooth.findEntry("19", scrollAxisY)
+	if e.active {
+		t.Error("instant scroll must cancel the in-flight ease")
+	}
+	if v, _ := w.scrollY().Get("19"); v != -30 {
+		t.Errorf("instant offset = %v, want -30", v)
+	}
+}
+
+func TestScrollHorizontalToSmoothCanceledByInstantScroll(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	w := &Window{}
+	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 50}}
+	layout := Layout{
+		Shape: &Shape{
+			shapeType:  shapeRectangle,
+			Scrollable: true,
+			ID:         "20",
+			Width:      100,
+			Height:     50,
+			Axis:       AxisLeftToRight,
+		},
+		Children: []Layout{child},
+	}
+	w.layout = Layout{
+		Shape:    &Shape{shapeType: shapeRectangle},
+		Children: []Layout{layout},
+	}
+	w.scrollX().Set("20", -100)
+
+	w.ScrollHorizontalToSmooth("20", 0)
+	if e := w.scrollSmooth.findEntry("20", scrollAxisX); e == nil || !e.active {
+		t.Fatal("expected active entry before instant scroll")
+	}
+
+	w.ScrollHorizontalTo("20", -30)
+	e := w.scrollSmooth.findEntry("20", scrollAxisX)
+	if e.active {
+		t.Error("instant scroll must cancel the in-flight ease")
+	}
+	if v, _ := w.scrollX().Get("20"); v != -30 {
+		t.Errorf("instant offset = %v, want -30", v)
+	}
+}
+
+func TestScrollVerticalToSmoothRejectsNaN(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+	_, w := makeScrollLayout("21", 100, 100, 100, 300)
+
+	w.ScrollVerticalToSmooth("21", float32(math.NaN()))
+	if w.scrollSmooth != nil {
+		if e := w.scrollSmooth.findEntry("21", scrollAxisY); e != nil && e.active {
+			t.Error("NaN offset must not arm an entry")
+		}
+	}
+}


### PR DESCRIPTION
New Window methods ease a scrollable to an absolute offset using the same exponential smoothing as discrete mouse-wheel scrolling.

- `ScrollVerticalToSmooth(id, offset)` / `ScrollHorizontalToSmooth(id, offset)` — public API
- `scrollSmoothTo` — new internal entry point for absolute-target eases
- `scrollSmoothParams` / `scrollSmoothArm` — shared helpers extracted from `scrollSmoothBy`
- Tests: absolute target, clamp, no-op at target, cancel by instant scroll, NaN rejection, horizontal axis

No-op when the scroll id is not found or the target equals the current offset. Instant `ScrollVerticalTo`/`ScrollHorizontalTo` still cancel any in-flight ease.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787074181&installation_id=145733661&pr_number=113&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F113&signature=d14d78025bdf5d3554eb6d184abc9a62fee55cf9034ded3b2677e441186008e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->