### PR TITLE
changelog: add v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.40.0] - 2026-07-19
+
 ### Added
 
 - **Smooth programmatic scrolling.** New `Window.ScrollVerticalToSmooth` and
@@ -17,6 +19,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-flight ease. The wheel smoother's arm logic is now shared
   (`scrollSmoothParams`/`scrollSmoothArm`) between relative wheel deltas and
   absolute targets.
+
+### Changed
+
+- **Deps:** go-glyph upgraded to v1.17.3 (perf/mem optimizations across the
+  shaping pipeline, lazy font parsing, raster scratch-buffer pooling, sampled
+  glyph-cache eviction).
+
+### Fixed
+
+- **Switch focus highlight.** Spacer no longer participates in focus ring
+  drawing.
+- **Toggle check-box sizing.** Off-by-one in hit-target calculation fixed.
+- **Metal mouse-down consumed by window resize drag.** Drag resize no longer
+  leaks mouse-down to the app's mouse handler.
+- **Input batched-event echo and vertical centering.** Batched updates no
+  longer echo raw text; single-line fields center vertically after font-size
+  changes.
+- **Data-grid quick-filter debounce.** Draft rendering during quick-filter is
+  properly debounced.
+- **Sidebar close layout:** Sidebar drops children when fully closed to
+  prevent a fixed-width-0 content-resize bug.
+- **BoundedMap small-map fast path.** Pre-sizing the BoundedMap data map is
+  removed to keep the fast path for small maps.
+- **buttonView folded into containerView,** and shapeEffects are pooled,
+  reducing per-button allocations.
 
 ## [v0.39.0] - 2026-07-18
 


### PR DESCRIPTION
Release v0.40.0 — smooth scrolling, bug fixes, glyph bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787076239&installation_id=145733661&pr_number=115&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F115&signature=3594c26027c7215b622d65c4d3d637d3aa1b59a06dc1db6c45d2fce2b2f291f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->