### PR TITLE
Add one-shot scroll anchoring API (ScrollAnchor, ScrollAnchorReveal, ScrollVerticalOffset)

### DIFF
--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -27,6 +27,7 @@ func layoutPipeline(layout *Layout, w *Window) {
 	layoutAdjustScrollOffsets(layout, w)
 	fx, fy := floatAttachLayout(layout, w.windowRect())
 	layoutPositions(layout, fx, fy, w)
+	layoutApplyScrollAnchors(layout, w)
 	layoutDisables(layout, false)
 
 	// Post-position passes.

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -400,6 +400,14 @@ func (w *Window) ScrollVerticalToPct(id string, pct float32) {
 	scrollSmoothCancel(w, id, scrollAxisY)
 }
 
+// ScrollVerticalOffset returns the current vertical scroll offset of
+// the given scrollable: <= 0, where 0 is the top. Unknown ids read
+// as 0 (unscrolled).
+func (w *Window) ScrollVerticalOffset(id string) float32 {
+	// Default 0: unscrolled position when no offset recorded yet.
+	return w.scrollY().GetOr(id, 0)
+}
+
 // ScrollVerticalPct returns the current vertical scroll
 // position as a percentage (0.0 = top, 1.0 = bottom).
 // Returns 0 if not found or content fits viewport.

--- a/gui/scroll_anchor.go
+++ b/gui/scroll_anchor.go
@@ -1,0 +1,160 @@
+package gui
+
+// scrollAnchor is a pending one-shot scroll-anchoring request. See
+// Window.ScrollAnchor.
+type scrollAnchor struct {
+	scrollID string
+	anchorID string
+	relY     float32 // anchor top relative to viewport top at request time
+	frame    uint64  // frameCount at request time; stale entries are dropped
+	reveal   bool    // ease to the top after the correction lands
+}
+
+// scrollAnchorMaxAge is how many frames a pending anchor may wait
+// for a layout pass containing its scrollable (passes also run on
+// floating subtrees that don't contain it) before it is dropped as
+// stale — e.g. the scrollable was removed from the view.
+const scrollAnchorMaxAge = 2
+
+// ScrollAnchor requests one-shot vertical scroll anchoring for the
+// scrollable with the given scroll id: on the next layout pass the
+// scroll offset is corrected so the view anchorID keeps the
+// viewport-relative position it has now. Call it just before
+// mutating state that inserts or removes content above the reader's
+// position (typically right before UpdateWindow). The correction
+// happens inside the layout pipeline, before the frame renders, so
+// no intermediate position is ever shown.
+//
+// The request is consumed by the next layout pass containing the
+// scrollable. It is dropped without effect — the view jumps as if
+// no anchor was requested — when either id cannot be resolved, the
+// content fits the viewport, or the corrected offset would fall
+// outside the scrollable range. Last write wins per scrollable.
+// Main goroutine only.
+func (w *Window) ScrollAnchor(scrollID, anchorID string) {
+	w.scrollAnchorRequest(scrollID, anchorID, false)
+}
+
+// ScrollAnchorReveal anchors like [Window.ScrollAnchor], then eases
+// the scrollable to the top with the same smoothing as
+// [Window.ScrollVerticalToSmooth], so content prepended above the
+// anchor glides into view instead of appearing suddenly. The ease
+// must arm after the anchoring correction is in place — an ordering
+// only the layout pipeline can provide, which is why the reveal is
+// part of the request rather than a separate call (an ease armed
+// before the correction would no-op when the reader is already at
+// the top). Main goroutine only.
+func (w *Window) ScrollAnchorReveal(scrollID, anchorID string) {
+	w.scrollAnchorRequest(scrollID, anchorID, true)
+}
+
+// scrollAnchorRequest records a pending anchor, capturing the
+// anchor's viewport-relative position from the last laid-out frame
+// so the next pass can restore it.
+func (w *Window) scrollAnchorRequest(scrollID, anchorID string, reveal bool) {
+	if scrollID == "" || anchorID == "" {
+		return
+	}
+	sc, ok := findScrollLayout(w, scrollID)
+	if !ok {
+		return
+	}
+	target, ok := sc.FindByID(anchorID)
+	if !ok {
+		return
+	}
+	relY := target.Shape.Y - (sc.Shape.Y + sc.Shape.PaddingTop())
+	if !f32IsFinite(relY) {
+		return
+	}
+	a := scrollAnchor{
+		scrollID: scrollID,
+		anchorID: anchorID,
+		relY:     relY,
+		frame:    w.frameCount,
+		reveal:   reveal,
+	}
+	for i := range w.scrollAnchors {
+		if w.scrollAnchors[i].scrollID == scrollID {
+			w.scrollAnchors[i] = a
+			return
+		}
+	}
+	w.scrollAnchors = append(w.scrollAnchors, a)
+}
+
+// layoutApplyScrollAnchors consumes pending scroll anchors after the
+// position pass: for each request whose scrollable is in this tree,
+// the scroll offset is corrected so the anchor view keeps the
+// viewport-relative position captured at request time, and the
+// already positioned children are shifted to match (later passes lay
+// out identically from the stored offset). Requests whose scrollable
+// is not in this tree — e.g. a floating-subtree pass — stay pending
+// briefly for the pass that has it.
+func layoutApplyScrollAnchors(layout *Layout, w *Window) {
+	if len(w.scrollAnchors) == 0 {
+		return
+	}
+	kept := w.scrollAnchors[:0]
+	for _, a := range w.scrollAnchors {
+		sc, ok := FindLayoutByScrollID(layout, a.scrollID)
+		if !ok {
+			if w.frameCount-a.frame <= scrollAnchorMaxAge {
+				kept = append(kept, a)
+			}
+			continue
+		}
+		applyScrollAnchor(a, sc, w)
+	}
+	w.scrollAnchors = kept
+}
+
+// applyScrollAnchor corrects one scrollable's offset so the anchor
+// view keeps its captured viewport-relative position, then shifts
+// the positioned subtree for the current frame and, for reveal
+// requests, arms the ease back to the top.
+func applyScrollAnchor(a scrollAnchor, sc *Layout, w *Window) {
+	target, ok := sc.FindByID(a.anchorID)
+	if !ok {
+		return // anchor left the view; jump
+	}
+	viewTop := sc.Shape.Y + sc.Shape.PaddingTop()
+	delta := target.Shape.Y - (viewTop + a.relY)
+	if delta == 0 {
+		return // anchor did not move; nothing to correct
+	}
+	maxOffset := scrollMaxOffsetY(sc)
+	if maxOffset >= 0 {
+		return // content fits the viewport; nothing to anchor
+	}
+	sy := w.scrollY()
+	old := sy.GetOr(a.scrollID, 0)
+	newOffset := old - delta
+	if !f32IsFinite(newOffset) || newOffset > 0 || newOffset < maxOffset {
+		return // correction would leave the scroll range; jump
+	}
+
+	// Store the corrected offset for later passes and move the
+	// already positioned children to match for this frame (positions
+	// are absolute; moving a parent does not move its children).
+	sy.Set(a.scrollID, newOffset)
+	for i := range sc.Children {
+		scrollAnchorShiftY(&sc.Children[i], -delta)
+	}
+	// Keep any in-flight ease continuous from the corrected offset.
+	scrollSmoothShiftY(w, a.scrollID, -delta)
+	fireOnScroll(sc, w)
+	if a.reveal {
+		scrollSmoothTo(w, sc, scrollAxisY, 0)
+	}
+}
+
+// scrollAnchorShiftY moves a positioned subtree vertically. Every
+// descendant shifts because positions are absolute after the
+// position pass.
+func scrollAnchorShiftY(layout *Layout, dy float32) {
+	layout.Shape.Y += dy
+	for i := range layout.Children {
+		scrollAnchorShiftY(&layout.Children[i], dy)
+	}
+}

--- a/gui/scroll_anchor_test.go
+++ b/gui/scroll_anchor_test.go
@@ -1,0 +1,284 @@
+package gui
+
+import "testing"
+
+// anchorPost is a fixed-height child of the test scrollable.
+type anchorPost struct {
+	id string
+	h  float32
+}
+
+const anchorScrollID = "scroll"
+
+// anchorLayoutTree builds a 100x100 scrollable column containing one
+// fixed-height child per post.
+func anchorLayoutTree(posts []anchorPost) Layout {
+	children := make([]Layout, len(posts))
+	for i, p := range posts {
+		children[i] = Layout{
+			Shape: &Shape{
+				shapeType: shapeRectangle,
+				ID:        p.id,
+				Width:     100,
+				Height:    p.h,
+			},
+		}
+	}
+	scroll := Layout{
+		Shape: &Shape{
+			shapeType:  shapeRectangle,
+			Scrollable: true,
+			ID:         anchorScrollID,
+			Width:      100,
+			Height:     100,
+			Axis:       AxisTopToBottom,
+		},
+		Children: children,
+	}
+	return Layout{
+		Shape:    &Shape{shapeType: shapeRectangle, Width: 100, Height: 100},
+		Children: []Layout{scroll},
+	}
+}
+
+// anchorLayoutPass mimics a frame's relevant pipeline steps for the
+// given posts: clamp offsets, position, then apply pending anchors.
+func anchorLayoutPass(w *Window, posts []anchorPost) {
+	w.layout = anchorLayoutTree(posts)
+	layoutAdjustScrollOffsets(&w.layout, w)
+	layoutPositions(&w.layout, 0, 0, w)
+	layoutApplyScrollAnchors(&w.layout, w)
+}
+
+// anchorWindow builds a window positioned at the given offset over
+// the posts, ready for a ScrollAnchor request.
+func anchorWindow(offset float32, posts []anchorPost) *Window {
+	w := &Window{}
+	w.scrollY().Set(anchorScrollID, offset)
+	w.layout = anchorLayoutTree(posts)
+	layoutAdjustScrollOffsets(&w.layout, w)
+	layoutPositions(&w.layout, 0, 0, w)
+	return w
+}
+
+func anchorChildY(t *testing.T, w *Window, id string) float32 {
+	t.Helper()
+	ly, ok := w.layout.FindByID(id)
+	if !ok {
+		t.Fatalf("child %q not found", id)
+	}
+	return ly.Shape.Y
+}
+
+func TestScrollAnchorHoldsPositionAcrossPrepend(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+	if got := anchorChildY(t, w, "A"); got != -30 {
+		t.Fatalf("pre-anchor A.Y = %v, want -30", got)
+	}
+
+	w.ScrollAnchor(anchorScrollID, "A")
+	anchorLayoutPass(w, append([]anchorPost{{"N", 40}}, posts...))
+
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != -70 {
+		t.Errorf("offset = %v, want -70", got)
+	}
+	// The anchor keeps its viewport position; the prepended post
+	// sits above it, off-screen.
+	if got := anchorChildY(t, w, "A"); got != -30 {
+		t.Errorf("A.Y = %v, want -30", got)
+	}
+	if got := anchorChildY(t, w, "N"); got != -70 {
+		t.Errorf("N.Y = %v, want -70", got)
+	}
+	if len(w.scrollAnchors) != 0 {
+		t.Errorf("anchor not consumed: %d pending", len(w.scrollAnchors))
+	}
+}
+
+func TestScrollAnchorConsumedOnce(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+	w.ScrollAnchor(anchorScrollID, "A")
+
+	grown := append([]anchorPost{{"N", 40}}, posts...)
+	anchorLayoutPass(w, grown)
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != -70 {
+		t.Fatalf("offset = %v, want -70", got)
+	}
+
+	// A second pass over the same content must not re-apply.
+	anchorLayoutPass(w, grown)
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != -70 {
+		t.Errorf("offset after second pass = %v, want -70", got)
+	}
+}
+
+func TestScrollAnchorBailsWhenContentFits(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+	w.ScrollAnchor(anchorScrollID, "A")
+
+	// Content shrinks to fit the viewport: nothing to anchor; the
+	// clamp pass snaps the offset to 0 and the anchor stays out of it.
+	anchorLayoutPass(w, []anchorPost{{"A", 50}, {"B", 30}})
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != 0 {
+		t.Errorf("offset = %v, want 0", got)
+	}
+	if got := anchorChildY(t, w, "A"); got != 0 {
+		t.Errorf("A.Y = %v, want 0 (no shift)", got)
+	}
+}
+
+func TestScrollAnchorBailsWhenCorrectionLeavesRange(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+	w.ScrollAnchor(anchorScrollID, "A")
+
+	// New content 110 high: max offset -10, so the clamp pass moves
+	// the reader to -10 and holding A would need -40. Out of range —
+	// jump instead of anchoring.
+	anchorLayoutPass(w, []anchorPost{{"N", 10}, {"A", 50}, {"B", 50}})
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != -10 {
+		t.Errorf("offset = %v, want -10", got)
+	}
+}
+
+func TestScrollAnchorBailsWhenAnchorGone(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+	w.ScrollAnchor(anchorScrollID, "A")
+
+	anchorLayoutPass(w, []anchorPost{{"N", 40}, {"B", 50}, {"C", 50}})
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != -30 {
+		t.Errorf("offset = %v, want -30 (unchanged)", got)
+	}
+	if len(w.scrollAnchors) != 0 {
+		t.Errorf("anchor not consumed: %d pending", len(w.scrollAnchors))
+	}
+}
+
+func TestScrollAnchorRevealArmsEaseFromTop(t *testing.T) {
+	// The reader is at the very top — the case where arming the ease
+	// before the correction would no-op (target 0 == displayed 0).
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(0, posts)
+
+	w.ScrollAnchorReveal(anchorScrollID, "A")
+	anchorLayoutPass(w, append([]anchorPost{{"N", 40}}, posts...))
+
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != -40 {
+		t.Fatalf("offset = %v, want -40", got)
+	}
+	e := w.scrollSmooth.findEntry(anchorScrollID, scrollAxisY)
+	if e == nil || !e.active {
+		t.Fatal("expected an active ease entry")
+	}
+	if e.target != 0 {
+		t.Errorf("ease target = %v, want 0", e.target)
+	}
+	if e.current != -40 {
+		t.Errorf("ease current = %v, want -40", e.current)
+	}
+
+	// Drive the ease: the new post glides fully into view.
+	driveScrollSmooth(w, 200)
+	if got := w.ScrollVerticalOffset(anchorScrollID); got != 0 {
+		t.Errorf("settled offset = %v, want 0", got)
+	}
+}
+
+func TestScrollAnchorShiftsInFlightEase(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+
+	// An ease toward -10 is mid-flight when the anchor applies.
+	sc, ok := FindLayoutByScrollID(&w.layout, anchorScrollID)
+	if !ok {
+		t.Fatal("scrollable not found")
+	}
+	if !scrollSmoothTo(w, sc, scrollAxisY, -10) {
+		t.Fatal("expected ease to arm")
+	}
+
+	w.ScrollAnchor(anchorScrollID, "A")
+	anchorLayoutPass(w, append([]anchorPost{{"N", 40}}, posts...))
+
+	// The correction moved the displayed offset by -40; the ease
+	// continues from there instead of snapping back to pre-anchor
+	// values on its next tick.
+	e := w.scrollSmooth.findEntry(anchorScrollID, scrollAxisY)
+	if e == nil || !e.active {
+		t.Fatal("expected the ease to stay active")
+	}
+	if e.current != -70 {
+		t.Errorf("ease current = %v, want -70", e.current)
+	}
+	if e.target != -10 {
+		t.Errorf("ease target = %v, want -10", e.target)
+	}
+}
+
+func TestScrollAnchorStaleRequestDropped(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+	w.ScrollAnchor(anchorScrollID, "A")
+
+	// Passes over trees without the scrollable (e.g. floating
+	// subtrees) keep the request pending...
+	other := Layout{Shape: &Shape{shapeType: shapeRectangle}}
+	layoutApplyScrollAnchors(&other, w)
+	if len(w.scrollAnchors) != 1 {
+		t.Fatalf("pending anchors = %d, want 1", len(w.scrollAnchors))
+	}
+
+	// ...but only for scrollAnchorMaxAge frames.
+	w.frameCount += scrollAnchorMaxAge + 1
+	layoutApplyScrollAnchors(&other, w)
+	if len(w.scrollAnchors) != 0 {
+		t.Errorf("stale anchor kept: %d pending", len(w.scrollAnchors))
+	}
+}
+
+func TestScrollAnchorLastWriteWinsPerScrollable(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+	w.ScrollAnchor(anchorScrollID, "A")
+	w.ScrollAnchorReveal(anchorScrollID, "B")
+
+	if len(w.scrollAnchors) != 1 {
+		t.Fatalf("pending anchors = %d, want 1", len(w.scrollAnchors))
+	}
+	a := w.scrollAnchors[0]
+	if a.anchorID != "B" || !a.reveal {
+		t.Errorf("pending anchor = %+v, want anchorID B with reveal", a)
+	}
+	// B sat at -30+50 = 20 relative to the viewport top.
+	if a.relY != 20 {
+		t.Errorf("relY = %v, want 20", a.relY)
+	}
+}
+
+func TestScrollAnchorUnknownIDsNoOp(t *testing.T) {
+	posts := []anchorPost{{"A", 50}, {"B", 50}, {"C", 50}}
+	w := anchorWindow(-30, posts)
+
+	w.ScrollAnchor("", "A")
+	w.ScrollAnchor(anchorScrollID, "")
+	w.ScrollAnchor("nope", "A")
+	w.ScrollAnchor(anchorScrollID, "nope")
+	if len(w.scrollAnchors) != 0 {
+		t.Errorf("pending anchors = %d, want 0", len(w.scrollAnchors))
+	}
+}
+
+func TestScrollVerticalOffset(t *testing.T) {
+	w := &Window{}
+	if got := w.ScrollVerticalOffset("missing"); got != 0 {
+		t.Errorf("missing id offset = %v, want 0", got)
+	}
+	w.scrollY().Set("s", -42)
+	if got := w.ScrollVerticalOffset("s"); got != -42 {
+		t.Errorf("offset = %v, want -42", got)
+	}
+}

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -241,6 +241,25 @@ func scrollSmoothCancel(w *Window, id string, axis scrollAxis) {
 	}
 }
 
+// scrollSmoothShiftY moves any in-flight vertical ease for id by dy,
+// preserving its absolute target. Used by scroll anchoring when it
+// rewrites the displayed offset mid-ease, so the animation continues
+// from the corrected position instead of stomping the correction on
+// its next tick. Main goroutine only.
+func scrollSmoothShiftY(w *Window, id string, dy float32) {
+	w.animMu.Lock()
+	defer w.animMu.Unlock()
+	if w.scrollSmooth == nil {
+		return
+	}
+	if e := w.scrollSmooth.findEntry(id, scrollAxisY); e != nil && e.active {
+		e.current += dy
+		if !f32IsFinite(e.current) {
+			e.active = false
+		}
+	}
+}
+
 // scrollSmoothReset drops all eased-scroll state. Called when the view
 // tree is rebuilt (clearHotMaps), since scroll id keys may change.
 func (w *Window) scrollSmoothReset() {

--- a/gui/window.go
+++ b/gui/window.go
@@ -206,6 +206,10 @@ type Window struct {
 	// target offset. Guarded by animMu (see gui/scroll_smooth.go).
 	scrollSmooth *scrollSmoothAnimation
 
+	// scrollAnchors holds pending one-shot scroll-anchoring requests,
+	// consumed by the layout pipeline. See Window.ScrollAnchor.
+	scrollAnchors []scrollAnchor
+
 	windowToast
 
 	// Embedded concern groups.


### PR DESCRIPTION
## What

- `Window.ScrollAnchor(scrollID, anchorID)` — one-shot request: on the next layout pass, correct the scroll offset so `anchorID` keeps the viewport-relative position it has now. Content inserted/removed above the reader no longer jumps.
- `Window.ScrollAnchorReveal` — anchor, then ease to the top with the existing smooth-scroll, so prepended content glides into view. The ease arms inside the pipeline after the correction lands — arming it beforehand would no-op when the reader is already at the top (`scrollSmoothArm` rejects `target == current`).
- `Window.ScrollVerticalOffset(id)` — read the current offset (≤ 0, 0 = top); previously only `ScrollVerticalPct` existed.

## How

New pipeline pass `layoutApplyScrollAnchors` immediately after `layoutPositions`:
- rewrites the stored offset and shifts the already-positioned subtree for the current frame (`layoutPositions` is additive, so re-running it is not an option; positions are absolute, so the whole subtree moves),
- keeps any in-flight ease continuous (`scrollSmoothShiftY` moves `current`, preserves the absolute target),
- bails to a plain jump when the anchor left the view, content fits the viewport, or the correction would leave the scrollable range,
- requests are one-shot, last-write-wins per scrollable, vertical only; requests whose scrollable is not in the laid-out tree (floating-subtree passes) stay pending for `scrollAnchorMaxAge` frames.

## Motivation

go-kite's timeline hand-rolled all of this in an `AmendLayout` callback (~90 lines of subtree shifting and clamp math). With this API the app-side code reduces to an anchor request plus its at-top/idle policy. Follow-up PR in go-kite removes the old mechanism.

## Testing

11 new tests in `gui/scroll_anchor_test.go` covering hold-across-prepend, one-shot consumption, all three bail paths, reveal-from-top, mid-ease continuity, staleness expiry, and last-write-wins. Full suite + `-race -count=2` green; `make tidy-check vet deps-doc-check large-files generate-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787101406&installation_id=145733661&pr_number=117&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F117&signature=90a83e41f3ae8c5c08a19e513ae6f4101ac2a0a270bf5647aa3900158249a666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->