### PR TITLE
changelog: add v0.41.0 (one-shot scroll anchoring API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.41.0] - 2026-07-20
+
+### Added
+
+- **One-shot scroll anchoring.** New `Window.ScrollAnchor(scrollID, anchorID)`
+  corrects the scroll offset on the next layout pass so the anchor view keeps
+  the viewport-relative position it has now — content inserted or removed
+  above the reader no longer causes a visual jump. The correction runs inside
+  the layout pipeline (new `layoutApplyScrollAnchors` pass after
+  `layoutPositions`), before the frame renders, so no intermediate position is
+  ever shown. Requests are one-shot, last-write-wins per scrollable, vertical
+  only, and bail to a plain jump when the anchor left the view, the content
+  fits the viewport, or the correction would leave the scrollable range.
+- **`Window.ScrollAnchorReveal`** anchors, then eases the scrollable to the
+  top with the same smoothing as `ScrollVerticalToSmooth`, so prepended
+  content glides into view. The ease arms inside the pipeline after the
+  correction lands (arming beforehand would no-op when the reader is already
+  at the top). An in-flight ease stays continuous across an anchoring
+  correction: its displayed position shifts with the content, its absolute
+  target is preserved.
+- **`Window.ScrollVerticalOffset(id)`** returns the current vertical scroll
+  offset (<= 0, 0 = top), complementing the existing percentage-based
+  `ScrollVerticalPct`.
+
 ## [v0.40.0] - 2026-07-19
 
 ### Added


### PR DESCRIPTION
Changelog entry for v0.41.0: one-shot scroll anchoring (`ScrollAnchor`, `ScrollAnchorReveal`, `ScrollVerticalOffset`) from #117. Minor bump — new public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787101868&installation_id=145733661&pr_number=118&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F118&signature=3d193127f43e9e55df1407f641759817dd10ee7bf6bceedd2c50c4b3a963d0cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->