### PR TITLE
Fix command-queue buffer race and lost final scroll-ease value

### DIFF
--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -35,6 +35,7 @@ type scrollSmoothEntry struct {
 	current float32
 	active  bool
 	settled bool // reached target this tick; retire next tick
+	dirty   bool // current changed but not yet applied to the map
 }
 
 // scrollApply is a lock-free snapshot of an entry for the apply pass.
@@ -100,6 +101,7 @@ func (s *scrollSmoothAnimation) Update(_ *Window, _ float32, ac *AnimationComman
 		} else {
 			e.current += diff * scrollSmoothFactor
 		}
+		e.dirty = true
 		anyActive = true
 	}
 	if !anyActive {
@@ -238,6 +240,10 @@ func scrollSmoothCancel(w *Window, id string, axis scrollAxis) {
 	if e := w.scrollSmooth.findEntry(id, axis); e != nil {
 		e.active = false
 		e.settled = false
+		// Drop any unapplied eased value: the direct write that
+		// triggered this cancel must not be overwritten by a stale
+		// apply on the next flush.
+		e.dirty = false
 	}
 }
 
@@ -254,8 +260,10 @@ func scrollSmoothShiftY(w *Window, id string, dy float32) {
 	}
 	if e := w.scrollSmooth.findEntry(id, scrollAxisY); e != nil && e.active {
 		e.current += dy
+		e.dirty = true
 		if !f32IsFinite(e.current) {
 			e.active = false
+			e.dirty = false
 		}
 	}
 }
@@ -284,9 +292,14 @@ func commandApplyScrollSmooth(w *Window) {
 	ss.pending = ss.pending[:0]
 	for i := range ss.entries {
 		e := &ss.entries[i]
-		if !e.active {
+		// Keyed on dirty, not active: a settled entry retires on
+		// the tick after its final value is computed, and a slow
+		// flush must still apply that value instead of ending the
+		// ease fractionally short of its target.
+		if !e.dirty {
 			continue
 		}
+		e.dirty = false
 		ss.pending = append(ss.pending, scrollApply{
 			id: e.id, axis: e.axis, val: e.current,
 		})

--- a/gui/scroll_smooth_live_test.go
+++ b/gui/scroll_smooth_live_test.go
@@ -1,0 +1,62 @@
+package gui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestScrollVerticalToSmoothLiveLoop drives a smooth scroll through
+// the real animation goroutine while the test goroutine plays the
+// main loop's role, flushing commands until the ease settles. This
+// is the production topology (animation goroutine queueing, main
+// goroutine flushing), so the race detector can observe queue/flush
+// interactions — regression cover for the command scratch buffer
+// being handed back to writers while the flush loop still read it.
+func TestScrollVerticalToSmoothLiveLoop(t *testing.T) {
+	guiTheme.ScrollMultiplier = 1
+
+	// NewWindow, not a bare Window: the animation goroutine only
+	// starts when the lifecycle channels exist.
+	w := NewWindow(WindowCfg{Width: 100, Height: 100})
+	t.Cleanup(func() {
+		w.stopAnimationLoop()
+	})
+	child := Layout{
+		Shape: &Shape{shapeType: shapeRectangle, Width: 100, Height: 300},
+	}
+	w.layout = Layout{
+		Shape: &Shape{shapeType: shapeRectangle},
+		Children: []Layout{{
+			Shape: &Shape{
+				shapeType:  shapeRectangle,
+				Scrollable: true,
+				ID:         "live",
+				Width:      100,
+				Height:     100,
+				Axis:       AxisTopToBottom,
+			},
+			Children: []Layout{child},
+		}},
+	}
+
+	if !scrollSmoothTo(w, &w.layout.Children[0], scrollAxisY, -50) {
+		t.Fatal("expected ease to arm")
+	}
+
+	// Flush slower than the 16ms animation tick so ticks land while
+	// the flusher is between flushes — the timing where a reclaimed
+	// scratch buffer is written while the previous flush's reads are
+	// still the latest unsynchronized access.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		time.Sleep(25 * time.Millisecond)
+		w.flushCommands()
+		if v, _ := w.scrollY().Get("live"); v == -50 {
+			return
+		}
+		if time.Now().After(deadline) {
+			v, _ := w.scrollY().Get("live")
+			t.Fatalf("ease did not settle; offset %v", v)
+		}
+	}
+}

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -83,10 +83,13 @@ func (w *Window) flushCommands() {
 		w.commandsMu.Unlock()
 		return
 	}
-	// Swap to avoid holding lock during execution.
+	// Swap to avoid holding lock during execution. toRun's backing
+	// array must NOT be recycled into commandScratch yet: writers
+	// reclaim the scratch buffer (reclaimCommandScratch) and would
+	// append into the array while the loop below still reads it.
 	toRun := w.commands
 	w.commands = w.commandScratch[:0]
-	w.commandScratch = toRun[:0]
+	w.commandScratch = nil
 	w.commandsMu.Unlock()
 
 	for i := range toRun {
@@ -100,6 +103,14 @@ func (w *Window) flushCommands() {
 			cmd.animateFn(cmd.animate, w)
 		}
 	}
+
+	// Iteration done — toRun's backing is safe to hand out for
+	// reuse now (unless a nested flush already installed one).
+	w.commandsMu.Lock()
+	if w.commandScratch == nil {
+		w.commandScratch = toRun[:0]
+	}
+	w.commandsMu.Unlock()
 }
 
 // markLayoutRefresh requests a full layout rebuild next frame.


### PR DESCRIPTION
Two bugs found by resurrecting the live smooth-scroll test:

1. **`flushCommands` data race.** The swap handed `toRun`'s backing array to `commandScratch` before iterating it; when the swap left `w.commands` nil, a concurrent `queueCommand` (animation goroutine) reclaimed the array via `reclaimCommandScratch` and appended into it while the flush loop still read it — losing/duplicating commands. Fix: scratch nils at swap, `toRun`'s backing is returned under the lock after iteration (nested-flush guarded).

2. **Lost final ease value.** `commandApplyScrollSmooth` skipped inactive entries, but settled entries retire one tick after computing the final value — a busy main thread missing that 16ms window ended the ease fractionally short of target. Fix: per-entry `dirty` flag (set on any `current` change, cleared on apply and on cancel), apply pass keys on it.

New `TestScrollVerticalToSmoothLiveLoop` runs the production topology (animation goroutine queueing, test goroutine flushing) at a 25ms flush cadence — slower than the 16ms tick, which reproduced both bugs deterministically: DATA RACE + settle timeout before the fix, green ×5 under `-race` after.

Full race suite 19/19 ok; tidy/vet/deps-doc/large-files/generate gates and golangci-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787103823&installation_id=145733661&pr_number=120&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F120&signature=b28f8e8109901056dc875f4d68f6d845a90886b08d82a2dc1885aca448aa1d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->