### PR TITLE
changelog: add v0.41.1 (command-queue race + final ease value fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.41.1] - 2026-07-20
+
+### Fixed
+
+- **Command-queue buffer race.** `flushCommands` recycled its buffer into the
+  scratch pool before finishing iteration; a concurrent `QueueCommand` from
+  the animation goroutine could reclaim that same array and append into it
+  mid-iteration, losing or duplicating queued commands. The buffer is now
+  handed back only after execution completes.
+- **Smooth scrolling could end fractionally short of its target.** A settled
+  ease retires one animation tick after computing its final value; a main
+  thread that missed that 16ms window dropped the snap-to-target. Entries now
+  carry a dirty flag so the final value survives until the next flush, and a
+  cancel clears it so direct offset writes are never overwritten by a stale
+  eased value.
+
 ## [v0.41.0] - 2026-07-20
 
 ### Added


### PR DESCRIPTION
Changelog for v0.41.1: fixes from #120. Patch bump — bug fixes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787104127&installation_id=145733661&pr_number=121&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F121&signature=0cc6bb6837db7c38e1fee88f241c57c4224ac87249024fd292da7da07bba7977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->