### PR TITLE
ViewFunc: defer window-dependent subtrees with a function adapter

### DIFF
--- a/gui/view.go
+++ b/gui/view.go
@@ -11,6 +11,27 @@ type View interface {
 	GenerateLayout(w *Window) Layout
 }
 
+// ViewFunc adapts a function to a View, deferring construction to
+// layout-generation time so the function can read window state. It is
+// useful inside Content slices when a subtree needs State(*Window)
+// but the enclosing function does not receive w.
+type ViewFunc func(*Window) View
+
+// Content satisfies the View interface. ViewFunc always
+// returns empty content; its GenerateLayout defers to the
+// wrapped function to build the subtree.
+func (f ViewFunc) Content() []View { return nil }
+
+// GenerateLayout calls the wrapped function and recursively
+// builds the full Layout tree from the returned View.
+func (f ViewFunc) GenerateLayout(w *Window) Layout {
+	v := f(w)
+	if v == nil {
+		return Layout{}
+	}
+	return generateViewLayout(v, w)
+}
+
 // ensureLayoutShape normalizes layout nodes so pipeline passes can
 // safely dereference Shape fields.
 func ensureLayoutShape(layout *Layout) {

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -55,65 +55,51 @@ func newDockLayoutCore(cfg *DockLayoutCfg) *dockLayoutCore {
 	}
 }
 
-// dockLayoutView is the View implementation for DockLayout.
-// Custom View struct gives GenerateLayout access to *Window,
-// needed to read dockDragState for ghost rendering.
-type dockLayoutView struct {
-	cfg DockLayoutCfg
-}
-
-func (dv *dockLayoutView) Content() []View { return nil }
-
-func (dv *dockLayoutView) GenerateLayout(w *Window) Layout {
-	cfg := &dv.cfg
-	core := newDockLayoutCore(cfg)
-	drag := dockDragGet(w, cfg.ID)
-
-	content := make([]View, 0, 3)
-	content = append(content, dockNodeView(core, cfg.Root, cfg, drag))
-	content = append(content, dockDragZoneOverlayView(cfg.ColorZonePreview))
-
-	if drag.active {
-		ghostLabel := dockFindPanelLabel(cfg.Panels, drag.panelID)
-		if len(ghostLabel) > 0 {
-			content = append(content, dockDragGhostView(drag, ghostLabel))
-		}
-	}
-
-	dockID := core.id
-	colorZone := core.colorZonePreview
-
-	cv := Canvas(ContainerCfg{
-		ID:       cfg.ID,
-		A11YRole: AccessRoleGroup,
-		Sizing:   cfg.Sizing,
-		Padding:  NoPadding,
-		Spacing:  SomeF(0),
-		Clip:     true,
-		AmendLayout: func(layout *Layout, w *Window) {
-			dockLayoutAmend(dockID, colorZone, layout, w)
-		},
-		OnKeyDown: func(_ *Layout, e *Event, w *Window) {
-			if e.KeyCode == KeyEscape {
-				state := dockDragGet(w, dockID)
-				if state.active {
-					dockDragCancel(dockID, w)
-					e.IsHandled = true
-				}
-			}
-		},
-		Content: content,
-	})
-
-	return generateViewLayout(cv, w)
-}
-
 // DockLayout creates a docking layout component. Renders a tree
 // of splitters and tabbed panel groups. Supports drag-and-drop
 // panel rearrangement.
 func DockLayout(cfg DockLayoutCfg) View {
 	applyDockLayoutDefaults(&cfg)
-	return &dockLayoutView{cfg: cfg}
+	return ViewFunc(func(w *Window) View {
+		core := newDockLayoutCore(&cfg)
+		drag := dockDragGet(w, cfg.ID)
+
+		content := make([]View, 0, 3)
+		content = append(content, dockNodeView(core, cfg.Root, &cfg, drag))
+		content = append(content, dockDragZoneOverlayView(cfg.ColorZonePreview))
+
+		if drag.active {
+			ghostLabel := dockFindPanelLabel(cfg.Panels, drag.panelID)
+			if len(ghostLabel) > 0 {
+				content = append(content, dockDragGhostView(drag, ghostLabel))
+			}
+		}
+
+		dockID := core.id
+		colorZone := core.colorZonePreview
+
+		return Canvas(ContainerCfg{
+			ID:       cfg.ID,
+			A11YRole: AccessRoleGroup,
+			Sizing:   cfg.Sizing,
+			Padding:  NoPadding,
+			Spacing:  SomeF(0),
+			Clip:     true,
+			AmendLayout: func(layout *Layout, w *Window) {
+				dockLayoutAmend(dockID, colorZone, layout, w)
+			},
+			OnKeyDown: func(_ *Layout, e *Event, w *Window) {
+				if e.KeyCode == KeyEscape {
+					state := dockDragGet(w, dockID)
+					if state.active {
+						dockDragCancel(dockID, w)
+						e.IsHandled = true
+					}
+				}
+			},
+			Content: content,
+		})
+	})
 }
 
 func applyDockLayoutDefaults(cfg *DockLayoutCfg) {

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -130,17 +130,9 @@ type tableColWidthCache struct {
 // are auto-sized when a Window is available during layout.
 func Table(cfg TableCfg) View {
 	RequireID("Table", cfg.ID)
-	return &deferredTableView{cfg: cfg}
-}
-
-type deferredTableView struct {
-	cfg TableCfg
-}
-
-func (d *deferredTableView) Content() []View { return nil }
-
-func (d *deferredTableView) GenerateLayout(w *Window) Layout {
-	return generateViewLayout(tableView(d.cfg, w), w)
+	return ViewFunc(func(w *Window) View {
+		return tableView(cfg, w)
+	})
 }
 
 // Table generates a table with text measurement, column width

--- a/gui/view_test.go
+++ b/gui/view_test.go
@@ -244,6 +244,121 @@ func TestGenerateViewLayoutNormalizesNilShape(t *testing.T) {
 	}
 }
 
+// --- ViewFunc tests ---
+
+func TestViewFuncContentReturnsNil(t *testing.T) {
+	f := ViewFunc(func(w *Window) View {
+		return &stubView{id: "inner"}
+	})
+	if content := f.Content(); content != nil {
+		t.Errorf("Content(): got %v, want nil", content)
+	}
+}
+
+func TestViewFuncGenerateLayout(t *testing.T) {
+	f := ViewFunc(func(w *Window) View {
+		return &stubView{id: "inner"}
+	})
+	layout := f.GenerateLayout(&Window{})
+	if layout.Shape.ID != "inner" {
+		t.Errorf("ID: got %q, want inner", layout.Shape.ID)
+	}
+}
+
+func TestViewFuncGenerateLayoutNested(t *testing.T) {
+	f := ViewFunc(func(w *Window) View {
+		return &stubView{
+			id: "parent",
+			children: []View{
+				&stubView{id: "child1"},
+				&stubView{id: "child2"},
+			},
+		}
+	})
+	layout := f.GenerateLayout(&Window{})
+	if layout.Shape.ID != "parent" {
+		t.Errorf("root ID: got %q", layout.Shape.ID)
+	}
+	if len(layout.Children) != 2 {
+		t.Fatalf("children: got %d, want 2", len(layout.Children))
+	}
+	if layout.Children[0].Shape.ID != "child1" {
+		t.Error("child1 ID mismatch")
+	}
+	if layout.Children[1].Shape.ID != "child2" {
+		t.Error("child2 ID mismatch")
+	}
+}
+
+func TestViewFuncNilReturn(t *testing.T) {
+	f := ViewFunc(func(w *Window) View {
+		return nil
+	})
+	layout := f.GenerateLayout(&Window{})
+	// Nil View returns a Layout with no Shape from GenerateLayout.
+	// generateViewLayout normalizes nil Shape to shapeNone.
+	if layout.Shape != nil && layout.Shape.shapeType != shapeNone {
+		t.Errorf("shape type: got %v, want shapeNone or nil", layout.Shape.shapeType)
+	}
+}
+
+func TestViewFuncInContentSlice(t *testing.T) {
+	v := Column(ContainerCfg{
+		ID: "root",
+		Content: []View{
+			ViewFunc(func(w *Window) View {
+				return &stubView{
+					id: "dynamic",
+					children: []View{
+						&stubView{id: "leaf"},
+					},
+				}
+			}),
+		},
+	})
+	layout := generateViewLayout(v, &Window{})
+	if len(layout.Children) != 1 {
+		t.Fatalf("root children: got %d, want 1", len(layout.Children))
+	}
+	dyn := &layout.Children[0]
+	if dyn.Shape.ID != "dynamic" {
+		t.Errorf("dynamic ID: got %q, want dynamic", dyn.Shape.ID)
+	}
+	if len(dyn.Children) != 1 {
+		t.Fatalf("dynamic children: got %d, want 1", len(dyn.Children))
+	}
+	if dyn.Children[0].Shape.ID != "leaf" {
+		t.Error("leaf ID mismatch")
+	}
+}
+
+func TestViewFuncNilInContentSlice(t *testing.T) {
+	v := Column(ContainerCfg{
+		ID: "root",
+		Content: []View{
+			ViewFunc(func(w *Window) View {
+				return nil
+			}),
+		},
+	})
+	layout := generateViewLayout(v, &Window{})
+	// Nil return produces empty Layout; should not appear as child
+	// because generateViewLayout skips nil in Content loop.
+	if layout.Shape.ID != "root" {
+		t.Errorf("root ID: got %q, want root", layout.Shape.ID)
+	}
+}
+
+func TestViewFuncWithNilWindow(t *testing.T) {
+	f := ViewFunc(func(w *Window) View {
+		return &stubView{id: "inner"}
+	})
+	layout := f.GenerateLayout(nil)
+	if layout.Shape.ID != "inner" {
+		t.Errorf("ID: got %q, want inner", layout.Shape.ID)
+	}
+}
+
 // --- Container factory tests ---
 
 func TestColumnSetsAxis(t *testing.T) {


### PR DESCRIPTION
Closes #116

Adds `ViewFunc`, a `func(*Window) View` that satisfies the `View` interface. This lets app code drop a
window-dependent subtree into a `Content` slice without threading `w` through helper functions or writing
a custom `View` struct.

## Changes

- **gui/view.go** — add `ViewFunc` type with nil-safe `GenerateLayout`
- **gui/view_dock_layout.go** — remove `dockLayoutView` struct (~50 lines); rewrite `DockLayout()` to return `ViewFunc`. Keep `dockLayoutCore` for GC-safe closure capture in the dock subsystem.
- **gui/view_table.go** — remove `deferredTableView` struct (already the `ViewFunc` pattern, just implemented as a named type); rewrite `Table()` to return `ViewFunc`
- **gui/view_test.go** — add 7 tests covering nil return, single/nested children, content-slice integration, nil-window, and nil-in-content-slice

## Usage

```go
Column(ContainerCfg{
    Content: []View{
        ViewFunc(func(w *Window) View {
            app := State[AppState](w)
            // ... build subtree using app state ...
        }),
    },
})
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787140481&installation_id=145733661&pr_number=122&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F122&signature=354027298d8b7d609bc8e6f7a59c831dceff84984808ebca46e6de595b0bc2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->