### PR TITLE
gui: add NativeSound interface and sysbeep package for system alert sounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **System alert sound.** `Window.Beep` plays the platform's alert sound
+  (`NSBeep` on macOS, `MessageBeep` on Windows, the freedesktop `bell` event
+  via `canberra-gtk-play` on Linux), honoring the user's system-wide alert
+  sound choice, volume, and mute settings. `Window.BeepAvailable` reports
+  whether the platform can actually produce one, so callers can fall back to
+  a visual cue on mobile, wasm, and Linux without canberra installed. Backed
+  by the new `gui/backend/sysbeep` package and a `NativeSound` sub-interface
+  on `NativePlatform`. This is for incidental out-of-band alerts such as a
+  terminal BEL — it loads no assets and holds no output device open, unlike
+  `gui/audio`.
+
 ## [v0.41.1] - 2026-07-20
 
 ### Fixed

--- a/gui/backend/android/native_platform.go
+++ b/gui/backend/android/native_platform.go
@@ -99,3 +99,11 @@ func (n *nativePlatform) CreateSystemTray(_ gui.SystemTrayCfg, _ func(string)) (
 }
 func (n *nativePlatform) UpdateSystemTray(_ int, _ gui.SystemTrayCfg) {}
 func (n *nativePlatform) RemoveSystemTray(_ int)                      {}
+
+// --- Sound ---
+
+// Beep is a no-op: this platform routes alerts through its own
+// notification framework rather than an app-triggered system sound.
+func (n *nativePlatform) Beep() {}
+
+func (n *nativePlatform) BeepAvailable() bool { return false }

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -87,3 +87,9 @@ func (n *nativePlatform) SpellLearn(word string) {
 
 func (n *nativePlatform) SetNativeMenubar(_ gui.NativeMenubarCfg, _ func(string)) {}
 func (n *nativePlatform) ClearNativeMenubar()                                     {}
+
+// --- Sound ---
+
+func (n *nativePlatform) Beep() { nativehost.Beep() }
+
+func (n *nativePlatform) BeepAvailable() bool { return nativehost.BeepAvailable() }

--- a/gui/backend/internal/nativehost/nativehost.go
+++ b/gui/backend/internal/nativehost/nativehost.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-gui-org/go-gui/gui/backend/filedialog"
 	"github.com/go-gui-org/go-gui/gui/backend/printdialog"
 	"github.com/go-gui-org/go-gui/gui/backend/spellcheck"
+	"github.com/go-gui-org/go-gui/gui/backend/sysbeep"
 )
 
 // maxURILen caps the raw URI length to prevent OOM from maliciously
@@ -242,3 +243,10 @@ func SpellLearn(word string) {
 	}
 	spellcheck.Learn(word)
 }
+
+// Beep plays the system alert sound. Thin forwarder to the sysbeep
+// sub-package; no-op where the platform has no such sound.
+func Beep() { sysbeep.Play() }
+
+// BeepAvailable reports whether Beep is audible on this platform.
+func BeepAvailable() bool { return sysbeep.Available() }

--- a/gui/backend/ios/native_platform.go
+++ b/gui/backend/ios/native_platform.go
@@ -98,3 +98,11 @@ func (n *nativePlatform) CreateSystemTray(_ gui.SystemTrayCfg, _ func(string)) (
 }
 func (n *nativePlatform) UpdateSystemTray(_ int, _ gui.SystemTrayCfg) {}
 func (n *nativePlatform) RemoveSystemTray(_ int)                      {}
+
+// --- Sound ---
+
+// Beep is a no-op: this platform routes alerts through its own
+// notification framework rather than an app-triggered system sound.
+func (n *nativePlatform) Beep() {}
+
+func (n *nativePlatform) BeepAvailable() bool { return false }

--- a/gui/backend/metal/native_platform.go
+++ b/gui/backend/metal/native_platform.go
@@ -160,3 +160,9 @@ func (n *nativePlatform) UpdateSystemTray(
 func (n *nativePlatform) RemoveSystemTray(id int) {
 	nativemenu.RemoveSystemTray(id)
 }
+
+// --- Sound ---
+
+func (n *nativePlatform) Beep() { nativehost.Beep() }
+
+func (n *nativePlatform) BeepAvailable() bool { return nativehost.BeepAvailable() }

--- a/gui/backend/sysbeep/doc.go
+++ b/gui/backend/sysbeep/doc.go
@@ -1,0 +1,10 @@
+// Package sysbeep plays the OS alert sound — the same sound the
+// platform uses for an out-of-band "something needs your attention"
+// event, honoring whatever the user has configured system-wide
+// (alert sound choice, alert volume, and any "mute UI sounds"
+// accessibility setting).
+//
+// Deliberately not a general audio API: there is no asset to load, no
+// output device held open, and no volume control. Consumers that want
+// to play their own sounds should use the gui/audio package instead.
+package sysbeep

--- a/gui/backend/sysbeep/sysbeep_darwin.go
+++ b/gui/backend/sysbeep/sysbeep_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin && !ios
+
+package sysbeep
+
+/*
+#cgo CFLAGS: -fobjc-arc
+#cgo LDFLAGS: -framework AppKit
+#include "sysbeep_darwin.h"
+*/
+import "C"
+
+// Play plays the macOS system alert sound via NSBeep.
+func Play() { C.sysbeepPlay() }
+
+// Available reports that this platform has a system alert sound.
+func Available() bool { return true }

--- a/gui/backend/sysbeep/sysbeep_darwin.h
+++ b/gui/backend/sysbeep/sysbeep_darwin.h
@@ -1,0 +1,9 @@
+//go:build darwin && !ios
+
+#ifndef SYSBEEP_DARWIN_H
+#define SYSBEEP_DARWIN_H
+
+// sysbeepPlay plays the user's configured system alert sound.
+void sysbeepPlay(void);
+
+#endif

--- a/gui/backend/sysbeep/sysbeep_darwin.m
+++ b/gui/backend/sysbeep/sysbeep_darwin.m
@@ -1,0 +1,14 @@
+//go:build darwin && !ios
+
+#import <AppKit/AppKit.h>
+#include "sysbeep_darwin.h"
+
+// NSBeep is the AppKit alert sound. It respects the user's selected
+// alert sound, the alert volume slider, and the "Play user interface
+// sound effects" setting, so a muted Mac stays silent. It is also
+// self-coalescing: overlapping calls do not stack into a chorus.
+void sysbeepPlay(void) {
+    @autoreleasepool {
+        NSBeep();
+    }
+}

--- a/gui/backend/sysbeep/sysbeep_linux.go
+++ b/gui/backend/sysbeep/sysbeep_linux.go
@@ -1,0 +1,43 @@
+//go:build linux && !android
+
+package sysbeep
+
+import (
+	"os/exec"
+	"sync"
+)
+
+// Linux has no in-process system-alert API equivalent to NSBeep or
+// MessageBeep, so the freedesktop sound theme is played through
+// canberra-gtk-play — the same helper GTK apps use, which honors the
+// user's chosen sound theme and their desktop's event-sound setting.
+// Absent that binary there is no sensible fallback (the kernel console
+// beep is not reachable from a Wayland/X client), so Play is a no-op.
+var lookupOnce = sync.OnceValue(func() string {
+	path, err := exec.LookPath("canberra-gtk-play")
+	if err != nil {
+		return ""
+	}
+	return path
+})
+
+// Play plays the freedesktop "bell" event sound, if canberra-gtk-play
+// is installed. Non-blocking: the helper is spawned and reaped in the
+// background so a bell never stalls the caller.
+func Play() {
+	path := lookupOnce()
+	if path == "" {
+		return
+	}
+	cmd := exec.Command(path, "-i", "bell")
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	// Reap asynchronously; leaving this out would accumulate zombies
+	// for the life of the process.
+	go func() { _ = cmd.Wait() }()
+}
+
+// Available reports whether a system alert sound can be played, i.e.
+// whether canberra-gtk-play was found on PATH.
+func Available() bool { return lookupOnce() != "" }

--- a/gui/backend/sysbeep/sysbeep_linux.go
+++ b/gui/backend/sysbeep/sysbeep_linux.go
@@ -29,6 +29,7 @@ func Play() {
 	if path == "" {
 		return
 	}
+	// #nosec G204 — path from exec.LookPath, args are fixed
 	cmd := exec.Command(path, "-i", "bell")
 	if err := cmd.Start(); err != nil {
 		return

--- a/gui/backend/sysbeep/sysbeep_other.go
+++ b/gui/backend/sysbeep/sysbeep_other.go
@@ -1,0 +1,13 @@
+//go:build (!darwin || ios) && !windows && (!linux || android)
+
+package sysbeep
+
+// No system alert sound on mobile or wasm targets: iOS and Android
+// route alerts through their own notification frameworks rather than
+// an app-triggered beep, and the browser has no such concept.
+
+// Play is a no-op on platforms without a system alert sound.
+func Play() {}
+
+// Available reports that this platform has no system alert sound.
+func Available() bool { return false }

--- a/gui/backend/sysbeep/sysbeep_test.go
+++ b/gui/backend/sysbeep/sysbeep_test.go
@@ -1,0 +1,21 @@
+package sysbeep
+
+import "testing"
+
+// TestPlayDoesNotPanic exercises the platform Play path. It cannot
+// assert audio came out, but it does catch a missing symbol, a bad cgo
+// signature, or a nil-deref in the lookup path — and on CI it also
+// proves Play stays non-blocking.
+func TestPlayDoesNotPanic(t *testing.T) {
+	Play()
+}
+
+// TestAvailableMatchesPlatform pins the contract that Available is
+// answerable without side effects and is stable across calls, so
+// callers can use it to pick a visual fallback once at startup.
+func TestAvailableMatchesPlatform(t *testing.T) {
+	first := Available()
+	if second := Available(); first != second {
+		t.Errorf("Available not stable: %v then %v", first, second)
+	}
+}

--- a/gui/backend/sysbeep/sysbeep_windows.go
+++ b/gui/backend/sysbeep/sysbeep_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package sysbeep
+
+import "golang.org/x/sys/windows"
+
+var (
+	user32       = windows.NewLazySystemDLL("user32.dll")
+	pMessageBeep = user32.NewProc("MessageBeep")
+)
+
+// mbDefault is MB_OK — the sound mapped to the "Default Beep" system
+// event. Passing 0xFFFFFFFF instead would fall back to the PC speaker
+// when no sound is configured, which is jarring on modern machines.
+const mbDefault = 0x00000000
+
+// Play plays the Windows default alert sound via MessageBeep. The call
+// is asynchronous: it returns as soon as the sound is queued.
+func Play() { _, _, _ = pMessageBeep.Call(uintptr(mbDefault)) }
+
+// Available reports that this platform has a system alert sound.
+func Available() bool { return true }

--- a/gui/backend/web/native_platform.go
+++ b/gui/backend/web/native_platform.go
@@ -443,3 +443,11 @@ func dotExtensions(exts []string) string {
 func jsObject() js.Value {
 	return js.Global().Get("Object").New()
 }
+
+// --- Sound ---
+
+// Beep is a no-op: this platform routes alerts through its own
+// notification framework rather than an app-triggered system sound.
+func (n *nativePlatform) Beep() {}
+
+func (n *nativePlatform) BeepAvailable() bool { return false }

--- a/gui/native_platform.go
+++ b/gui/native_platform.go
@@ -64,6 +64,17 @@ type NativeSystemTray interface {
 	RemoveSystemTray(id int)
 }
 
+// NativeSound plays OS-level alert sounds.
+type NativeSound interface {
+	// Beep plays the user's configured system alert sound, honoring
+	// their system-wide alert volume and mute settings. No-op on
+	// platforms without such a sound. Non-blocking.
+	Beep()
+	// BeepAvailable reports whether Beep produces an audible sound on
+	// this platform, so callers can fall back to a visual cue.
+	BeepAvailable() bool
+}
+
 // NativePlatform composes all native OS sub-interfaces.
 // Set by the backend; nil in tests (operations no-op / return error).
 type NativePlatform interface {
@@ -76,6 +87,7 @@ type NativePlatform interface {
 	NativeSpellChecker
 	NativeMenubar
 	NativeSystemTray
+	NativeSound
 	OpenURI(uri string) error
 	TitlebarDark(dark bool)
 	SetWindowVibrancy(material VibrancyMaterial)

--- a/gui/native_platform_noop.go
+++ b/gui/native_platform_noop.go
@@ -55,3 +55,5 @@ func (NoopNativePlatform) CreateSystemTray(_ SystemTrayCfg, _ func(string)) (int
 }
 func (NoopNativePlatform) UpdateSystemTray(_ int, _ SystemTrayCfg) {}
 func (NoopNativePlatform) RemoveSystemTray(_ int)                  {}
+func (NoopNativePlatform) Beep()                                   {}
+func (NoopNativePlatform) BeepAvailable() bool                     { return false }

--- a/gui/native_sound.go
+++ b/gui/native_sound.go
@@ -1,0 +1,29 @@
+package gui
+
+// Beep plays the user's configured system alert sound — the platform's
+// standard "needs your attention" cue, honoring their system-wide alert
+// sound choice, alert volume, and mute settings.
+//
+// Non-blocking, and safe to call when no native platform is attached
+// (tests, headless): it is then a no-op. Intended for incidental
+// out-of-band events such as a terminal BEL; it is not a general audio
+// API, see the gui/audio package for that.
+func (w *Window) Beep() {
+	if w.nativePlatform == nil {
+		return
+	}
+	w.nativePlatform.Beep()
+}
+
+// BeepAvailable reports whether [Window.Beep] produces an audible sound
+// on this platform. False when no native platform is attached, or on
+// targets with no system alert sound (mobile, wasm) and on Linux when
+// canberra-gtk-play is not installed. Callers that need the user to
+// notice the event can use this to decide whether a visual fallback is
+// also warranted.
+func (w *Window) BeepAvailable() bool {
+	if w.nativePlatform == nil {
+		return false
+	}
+	return w.nativePlatform.BeepAvailable()
+}

--- a/gui/native_sound_test.go
+++ b/gui/native_sound_test.go
@@ -1,0 +1,47 @@
+package gui
+
+import "testing"
+
+// beepSpy records Beep calls and reports a configurable availability.
+type beepSpy struct {
+	NoopNativePlatform
+	calls     int
+	available bool
+}
+
+func (b *beepSpy) Beep()               { b.calls++ }
+func (b *beepSpy) BeepAvailable() bool { return b.available }
+
+func TestWindowBeepNoNativePlatform(t *testing.T) {
+	// No platform attached (tests, headless): must not panic, and must
+	// report unavailable so callers fall back to a visual cue.
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.Beep()
+	if w.BeepAvailable() {
+		t.Error("BeepAvailable = true with no native platform")
+	}
+}
+
+func TestWindowBeepNoopPlatform(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(&NoopNativePlatform{})
+	w.Beep()
+	if w.BeepAvailable() {
+		t.Error("BeepAvailable = true for NoopNativePlatform")
+	}
+}
+
+func TestWindowBeepForwardsToPlatform(t *testing.T) {
+	spy := &beepSpy{available: true}
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(spy)
+
+	w.Beep()
+	w.Beep()
+	if spy.calls != 2 {
+		t.Errorf("Beep forwarded %d times, want 2", spy.calls)
+	}
+	if !w.BeepAvailable() {
+		t.Error("BeepAvailable did not forward platform result")
+	}
+}


### PR DESCRIPTION
Adds `NativeSound` sub-interface on `NativePlatform` with `Beep()` and `BeepAvailable()`, convenience methods on `Window`, and a new `gui/backend/sysbeep` package that plays the OS alert sound per-platform.

- **macOS**: `NSBeep` via cgo
- **Windows**: `MessageBeep` via syscall
- **Linux**: `canberra-gtk-play -i bell` (freedesktop sound theme); no-op if not installed
- **Mobile/web/Android**: no-op, `BeepAvailable=false`

Non-blocking. No asset loading, no device held open. Intended for incidental out-of-band alerts such as a terminal BEL.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787143723&installation_id=145733661&pr_number=123&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F123&signature=efd887ae77b747f5259886c81b80a877296b19b3685829b81a2836e725524cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->