### PR TITLE
refactor: defer CommandButton construction to layout time via ViewFunc

### DIFF
--- a/examples/command_demo/main.go
+++ b/examples/command_demo/main.go
@@ -132,7 +132,7 @@ func mainView(w *gui.Window) gui.View {
 		Spacing: gui.SomeF(0),
 		Content: []gui.View{
 			menuBar(w),
-			body(w, app, theme),
+			body(app, theme),
 			statusBar(app, theme),
 			gui.CommandPalette(gui.CommandPaletteCfg{
 				ID:         "palette",
@@ -171,7 +171,7 @@ func menuBar(w *gui.Window) gui.View {
 	})
 }
 
-func body(w *gui.Window, app *App, theme gui.Theme) gui.View {
+func body(app *App, theme gui.Theme) gui.View {
 	savedText := "unsaved"
 	if app.Saved {
 		savedText = "saved"
@@ -202,11 +202,11 @@ func body(w *gui.Window, app *App, theme gui.Theme) gui.View {
 				SizeBorder: gui.NoBorder,
 				Padding:    gui.NoPadding,
 				Content: []gui.View{
-					gui.CommandButton(w, "edit.increment",
+					gui.CommandButton("edit.increment",
 						gui.ButtonCfg{}),
-					gui.CommandButton(w, "edit.decrement",
+					gui.CommandButton("edit.decrement",
 						gui.ButtonCfg{}),
-					gui.CommandButton(w, "edit.undo",
+					gui.CommandButton("edit.undo",
 						gui.ButtonCfg{}),
 				},
 			}),
@@ -216,9 +216,9 @@ func body(w *gui.Window, app *App, theme gui.Theme) gui.View {
 				SizeBorder: gui.NoBorder,
 				Padding:    gui.NoPadding,
 				Content: []gui.View{
-					gui.CommandButton(w, "file.new",
+					gui.CommandButton("file.new",
 						gui.ButtonCfg{}),
-					gui.CommandButton(w, "file.save",
+					gui.CommandButton("file.save",
 						gui.ButtonCfg{}),
 				},
 			}),

--- a/examples/showcase/demo_feedback.go
+++ b/examples/showcase/demo_feedback.go
@@ -215,12 +215,12 @@ func demoCommandButton(w *gui.Window) gui.View {
 				Spacing: gui.SomeF(8),
 				Padding: gui.NoPadding,
 				Content: []gui.View{
-					gui.CommandButton(w, "sc.greet", gui.ButtonCfg{ID: "cb-greet"}),
-					gui.CommandButton(w, "sc.count", gui.ButtonCfg{ID: "cb-count"}),
+					gui.CommandButton("sc.greet", gui.ButtonCfg{ID: "cb-greet"}),
+					gui.CommandButton("sc.count", gui.ButtonCfg{ID: "cb-count"}),
 				},
 			}),
 			sectionLabel(t, "Auto-disabled via CanExecute"),
-			gui.CommandButton(w, "sc.disabled", gui.ButtonCfg{ID: "cb-disabled"}),
+			gui.CommandButton("sc.disabled", gui.ButtonCfg{ID: "cb-disabled"}),
 		},
 	})
 }

--- a/gui/command_test.go
+++ b/gui/command_test.go
@@ -269,9 +269,17 @@ func TestKeyNameSpecial(t *testing.T) {
 
 func TestCommandButtonUnknownReturnsErrorView(t *testing.T) {
 	w := NewWindow(WindowCfg{State: new(int)})
-	v := CommandButton(w, "nonexistent", ButtonCfg{})
+	v := CommandButton("nonexistent", ButtonCfg{})
 	if v == nil {
 		t.Fatal("should return error placeholder view")
+	}
+	// Verify the error text appears at layout time.
+	l := v.GenerateLayout(w)
+	if l.Shape == nil {
+		t.Fatal("error view should have a shape")
+	}
+	if l.Shape.TC == nil || l.Shape.TC.Text != "unknown command: nonexistent" {
+		t.Errorf("unexpected error text: %q", l.Shape.TC.Text)
 	}
 }
 
@@ -285,7 +293,7 @@ func TestCommandButtonDefaultsIDToCommandID(t *testing.T) {
 		Execute: func(_ *Event, _ *Window) {},
 	})
 
-	v := CommandButton(w, "edit.increment", ButtonCfg{})
+	v := CommandButton("edit.increment", ButtonCfg{})
 	l := v.GenerateLayout(w)
 	want := commandButtonIDPrefix + "edit.increment"
 	if got := l.Shape.ID; got != want {
@@ -312,7 +320,7 @@ func TestCommandButtonIDDoesNotCollideWithMenuItem(t *testing.T) {
 		Execute: func(_ *Event, _ *Window) {},
 	})
 
-	btn := CommandButton(w, "file.new", ButtonCfg{})
+	btn := CommandButton("file.new", ButtonCfg{})
 	btnID := btn.GenerateLayout(w).Shape.ID
 
 	// A menubar item for the same command renders a shape keyed by the
@@ -332,7 +340,7 @@ func TestCommandButtonExplicitIDWins(t *testing.T) {
 		Execute: func(_ *Event, _ *Window) {},
 	})
 
-	v := CommandButton(w, "edit.undo", ButtonCfg{ID: "custom"})
+	v := CommandButton("edit.undo", ButtonCfg{ID: "custom"})
 	l := v.GenerateLayout(w)
 	if got := l.Shape.ID; got != "custom" {
 		t.Errorf("ID = %q, want %q", got, "custom")
@@ -343,6 +351,182 @@ func TestUnregisterCommandNoOp(_ *testing.T) {
 	w := NewWindow(WindowCfg{State: new(int)})
 	// Should not panic when unregistering a non-existent ID.
 	w.UnregisterCommand("does-not-exist")
+}
+
+func TestCommandButtonAutoLabel(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:       "test.cmd",
+		Label:    "Test",
+		Shortcut: Shortcut{Key: KeyD, Modifiers: ModCtrl},
+		Execute:  func(_ *Event, _ *Window) {},
+	})
+
+	v := CommandButton("test.cmd", ButtonCfg{})
+	l := v.GenerateLayout(w)
+
+	// auto-label should produce a Text child with the command label.
+	if len(l.Children) == 0 || l.Children[0].Shape == nil ||
+		l.Children[0].Shape.TC == nil ||
+		l.Children[0].Shape.TC.Text == "" {
+		t.Fatal("auto-label should set text content in child")
+	}
+}
+
+func TestCommandButtonAutoDisable(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "test.cmd",
+		Label:   "Test",
+		Execute: func(_ *Event, _ *Window) {},
+		CanExecute: func(_ *Window) bool {
+			return false
+		},
+	})
+
+	v := CommandButton("test.cmd", ButtonCfg{})
+	l := v.GenerateLayout(w)
+
+	if !l.Shape.Disabled {
+		t.Error("button should be disabled when CanExecute returns false")
+	}
+}
+
+func TestCommandButtonAutoDisableWhenCanExecuteTrue(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "test.cmd",
+		Label:   "Test",
+		Execute: func(_ *Event, _ *Window) {},
+		CanExecute: func(_ *Window) bool {
+			return true
+		},
+	})
+
+	v := CommandButton("test.cmd", ButtonCfg{})
+	l := v.GenerateLayout(w)
+
+	if l.Shape.Disabled {
+		t.Error("button should not be disabled when CanExecute returns true")
+	}
+}
+
+func TestCommandButtonOnClickWiring(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	executed := false
+	w.RegisterCommand(Command{
+		ID:    "test.cmd",
+		Label: "Test",
+		Execute: func(_ *Event, _ *Window) {
+			executed = true
+		},
+	})
+
+	v := CommandButton("test.cmd", ButtonCfg{})
+	l := v.GenerateLayout(w)
+
+	if l.Shape.events.OnClick == nil {
+		t.Fatal("OnClick should be wired")
+	}
+
+	e := &Event{}
+	l.Shape.events.OnClick(&l, e, w)
+	if !executed {
+		t.Error("OnClick should execute the command")
+	}
+}
+
+func TestCommandButtonOnClickChecksCanExecute(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	executed := false
+	w.RegisterCommand(Command{
+		ID:    "test.cmd",
+		Label: "Test",
+		Execute: func(_ *Event, _ *Window) {
+			executed = true
+		},
+		CanExecute: func(_ *Window) bool {
+			return false
+		},
+	})
+
+	v := CommandButton("test.cmd", ButtonCfg{})
+	l := v.GenerateLayout(w)
+
+	e := &Event{}
+	l.Shape.events.OnClick(&l, e, w)
+	if executed {
+		t.Error("OnClick should not execute when CanExecute returns false")
+	}
+}
+
+func TestCommandButtonUserContentOverridesAutoLabel(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "test.cmd",
+		Label:   "Auto",
+		Execute: func(_ *Event, _ *Window) {},
+	})
+
+	userContent := []View{Text(TextCfg{Text: "Custom"})}
+	v := CommandButton("test.cmd", ButtonCfg{Content: userContent})
+	l := v.GenerateLayout(w)
+
+	// User-provided Content should be preserved, not overwritten.
+	if len(l.Children) == 0 || l.Children[0].Shape == nil ||
+		l.Children[0].Shape.TC == nil ||
+		l.Children[0].Shape.TC.Text != "Custom" {
+		t.Errorf("user content should be preserved, got %q",
+			l.Children[0].Shape.TC.Text)
+	}
+}
+
+func TestCommandButtonUserOnClickOverridesAutoWiring(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	cmdExecuted := false
+	w.RegisterCommand(Command{
+		ID:    "test.cmd",
+		Label: "Test",
+		Execute: func(_ *Event, _ *Window) {
+			cmdExecuted = true
+		},
+	})
+
+	userExecuted := false
+	v := CommandButton("test.cmd", ButtonCfg{
+		OnClick: func(_ *Layout, _ *Event, _ *Window) {
+			userExecuted = true
+		},
+	})
+	l := v.GenerateLayout(w)
+
+	e := &Event{}
+	l.Shape.events.OnClick(&l, e, w)
+	if cmdExecuted {
+		t.Error("command should not execute when user provides OnClick")
+	}
+	if !userExecuted {
+		t.Error("user OnClick should be called")
+	}
+}
+
+func TestCommandButtonViewFuncType(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "test.cmd",
+		Label:   "Test",
+		Execute: func(_ *Event, _ *Window) {},
+	})
+
+	v := CommandButton("test.cmd", ButtonCfg{})
+	if _, ok := v.(ViewFunc); !ok {
+		t.Error("CommandButton should return ViewFunc")
+	}
+
+	// Content() should return nil (ViewFunc never has eager content).
+	if c := v.Content(); c != nil {
+		t.Error("ViewFunc Content() should return nil")
+	}
 }
 
 func TestCommandDispatchNoMatch(t *testing.T) {

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -185,57 +185,61 @@ func Button(cfg ButtonCfg) View {
 const commandButtonIDPrefix = "cmdbtn:"
 
 // CommandButton creates a button wired to a registered
-// command. Auto-fills label from Command.Label when Content
-// is nil. Auto-fills ID from cmdID. Auto-disables via
-// CanExecute. Wires OnClick to Command.Execute.
+// command. Construction is deferred to layout time via ViewFunc
+// so the caller does not need to pass *Window. Auto-fills label
+// from Command.Label when Content is nil. Auto-fills ID from
+// cmdID. Auto-disables via CanExecute. Wires OnClick to
+// Command.Execute.
 //
 // The auto-filled ID is commandButtonIDPrefix + cmdID. Set cfg.ID
 // explicitly when placing two buttons for the same command in one
 // window, otherwise both get the same focus ID.
-func CommandButton(w *Window, cmdID string, cfg ButtonCfg) View {
-	cmd, ok := w.CommandByID(cmdID)
-	if !ok {
-		return Text(TextCfg{
-			Text:      "unknown command: " + cmdID,
-			TextStyle: TextStyle{Color: Red},
-		})
-	}
-
-	// Focus traversal is keyed by ID (see isFocusedTarget), so
-	// Focusable: true is a silent no-op without one.
-	if cfg.ID == "" {
-		cfg.ID = commandButtonIDPrefix + cmdID
-	}
-
-	// Auto-fill content from command label.
-	if cfg.Content == nil && cmd.Label != "" {
-		label := cmd.Label
-		hint := cmd.Shortcut.String()
-		if hint != "" {
-			label += "  " + hint
+func CommandButton(cmdID string, cfg ButtonCfg) View {
+	return ViewFunc(func(w *Window) View {
+		cmd, ok := w.CommandByID(cmdID)
+		if !ok {
+			return Text(TextCfg{
+				Text:      "unknown command: " + cmdID,
+				TextStyle: TextStyle{Color: Red},
+			})
 		}
-		cfg.Content = []View{
-			Text(TextCfg{Text: label}),
-		}
-	}
 
-	// Wire OnClick to command execute.
-	if cfg.OnClick == nil {
-		cmdExec := cmd.Execute
-		cID := cmdID
-		cfg.OnClick = func(_ *Layout, e *Event, w *Window) {
-			if w.CommandCanExecute(cID) && cmdExec != nil {
-				cmdExec(e, w)
+		// Focus traversal is keyed by ID (see isFocusedTarget), so
+		// Focusable: true is a silent no-op without one.
+		if cfg.ID == "" {
+			cfg.ID = commandButtonIDPrefix + cmdID
+		}
+
+		// Auto-fill content from command label.
+		if cfg.Content == nil && cmd.Label != "" {
+			label := cmd.Label
+			hint := cmd.Shortcut.String()
+			if hint != "" {
+				label += "  " + hint
+			}
+			cfg.Content = []View{
+				Text(TextCfg{Text: label}),
 			}
 		}
-	}
 
-	// Auto-disable via CanExecute.
-	if cmd.CanExecute != nil && !cmd.CanExecute(w) {
-		cfg.Disabled = true
-	}
+		// Wire OnClick to command execute.
+		if cfg.OnClick == nil {
+			cmdExec := cmd.Execute
+			cID := cmdID
+			cfg.OnClick = func(_ *Layout, e *Event, w *Window) {
+				if w.CommandCanExecute(cID) && cmdExec != nil {
+					cmdExec(e, w)
+				}
+			}
+		}
 
-	return Button(cfg)
+		// Auto-disable via CanExecute.
+		if cmd.CanExecute != nil && !cmd.CanExecute(w) {
+			cfg.Disabled = true
+		}
+
+		return Button(cfg)
+	})
 }
 
 func applyButtonDefaults(cfg *ButtonCfg) {


### PR DESCRIPTION

<summary>
Removes the *Window parameter from CommandButton by wrapping its body in ViewFunc. Command lookup, auto-label, auto-disable, and OnClick wiring are deferred to GenerateLayout. This is the only factory from the #119 audit that is a clean ViewFunc candidate — menus, tooltips, and animation widgets all have deep Window dependencies.

8 new tests cover auto-label, auto-disable, OnClick wiring, CanExecute guard, user content/OnClick overrides, and ViewFunc type identity.
</summary>

💘 Generated with Crush

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787344342&installation_model_id=426559&pr_number=125&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F125&signature=d7ec759b8f2b349d9c686ab08fb94afe770cf6e33d669c2166f8d5851f6d64c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->