### PR TITLE
fix(metal): pump frames while a nested AppKit runloop blocks the event loop

### DIFF
--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -213,6 +213,7 @@ func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
 	}
 
 	defer func() {
+		C.metalStopFramePump()
 		for _, ws := range states {
 			ws.destroy()
 		}
@@ -690,5 +691,9 @@ func (ws *windowState) useGlyphPipeline() {
 
 // Destroy releases all backend resources.
 func (b *Backend) Destroy() {
+	// App-global, so it belongs here rather than in windowState.destroy:
+	// leaving a live timer behind would keep pumping frames for windows
+	// that no longer exist (and, in tests, across packages' runs).
+	C.metalStopFramePump()
 	b.destroy()
 }

--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -25,10 +25,14 @@ int metalTestMenuAboutExists(void);
 int metalTestWindowsMenuExists(void);
 int metalTestFocusedGUIWindowMatches(void *windowHandle);
 int metalTestApplicationDidBecomeActive(void);
+void metalTestRunModalMode(int ms);
+void metalTestRunDefaultMode(int ms);
+int metalTestFramePumpActive(void);
 */
 import "C"
 import (
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/go-gui-org/go-gui/gui"
@@ -62,6 +66,43 @@ func lookupWindow(id uint32) *windowState {
 	ws := windowRegistry[id]
 	windowRegistryMu.Unlock()
 	return ws
+}
+
+// pumpScratch is the reusable snapshot buffer for goMetalPumpFrames, so a
+// 60 Hz pump allocates nothing. Main-thread only, like the pump itself.
+var pumpScratch []*windowState
+
+// framePumpCount counts goMetalPumpFrames invocations that actually ran
+// (i.e. reached Go from a nested runloop). Tests read it to prove the
+// timer fires in nested modes and stays quiet in the default mode.
+var framePumpCount atomic.Uint64
+
+//export goMetalPumpFrames
+func goMetalPumpFrames() {
+	framePumpCount.Add(1)
+
+	// Snapshot under the lock: PumpFrame runs app code, which may open or
+	// close windows and so mutate the registry.
+	windowRegistryMu.Lock()
+	pumpScratch = pumpScratch[:0]
+	for _, ws := range windowRegistry {
+		pumpScratch = append(pumpScratch, ws)
+	}
+	windowRegistryMu.Unlock()
+
+	for _, ws := range pumpScratch {
+		w := ws.attachedWindow
+		if w == nil || ws.ctx == nil {
+			continue
+		}
+		// PumpFrame, not FrameFn: it declines the frame instead of
+		// deadlocking when the stack that entered the nested runloop
+		// already holds the window lock.
+		if w.PumpFrame() {
+			ws.renderFrame(w)
+		}
+	}
+	clear(pumpScratch) // drop references to destroyed windows
 }
 
 // ─── Test helpers ──────────────────────────────────────────────
@@ -154,6 +195,16 @@ func testFocusedGUIWindowMatches(handle C.GoGuiNSWindow) bool {
 func testApplicationDidBecomeActive() bool {
 	return C.metalTestApplicationDidBecomeActive() != 0
 }
+
+// testFramePumpActive reports whether the nested-runloop frame-pump
+// timer is currently installed.
+func testFramePumpActive() bool { return C.metalTestFramePumpActive() != 0 }
+
+// testRunModalMode spins the main runloop in NSModalPanelRunLoopMode —
+// what AppKit does inside runModal — so the pump timer can fire there.
+// testRunDefaultMode is the negative control.
+func testRunModalMode(ms int)   { C.metalTestRunModalMode(C.int(ms)) }
+func testRunDefaultMode(ms int) { C.metalTestRunDefaultMode(C.int(ms)) }
 
 // ─── C callbacks (weak in metal_window.m, strong here) ───────
 

--- a/gui/backend/metal/frame_pump_test.go
+++ b/gui/backend/metal/frame_pump_test.go
@@ -1,0 +1,78 @@
+//go:build darwin && !ios
+
+package metal
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// TestFramePumpNestedMode is a compile-time guard only; the real check
+// needs Cocoa on the initial main thread and runs from TestMain via
+// runMainThreadTests → runFramePumpMainThreadTests.
+func TestFramePumpNestedMode(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Cocoa requires main thread; tested via TestMain")
+	}
+}
+
+// runFramePumpMainThreadTests verifies the nested-runloop frame pump:
+// the timer must fire (and reach Go) while the main runloop runs in a
+// nested mode, and must stay silent in NSDefaultRunLoopMode where the
+// backend's own event loop owns frame timing.
+//
+// Regression test for windows freezing — no repaint, no command flush,
+// no terminal reflow on resize — for as long as a modal dialog or open
+// menu keeps a nested AppKit runloop on the main thread.
+//
+// Panics on failure, matching runMainThreadTests.
+func runFramePumpMainThreadTests() {
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  new(int),
+		Width:  200,
+		Height: 200,
+	})
+	w.UpdateView(func(_ *gui.Window) gui.View {
+		return gui.Rectangle(gui.RectangleCfg{
+			Width:  100,
+			Height: 50,
+			Color:  gui.Green,
+		})
+	})
+	b, err := New(w)
+	if err != nil {
+		panic("frame pump: metal.New: " + err.Error())
+	}
+
+	// metalAppFinishLaunch arms the pump.
+	testActivateNow()
+	if !testFramePumpActive() {
+		panic("frame pump: timer not installed after metalAppFinishLaunch")
+	}
+
+	// Nested mode: the pump must run. 200 ms is ~12 ticks at 60 Hz, so
+	// this does not depend on precise timer scheduling.
+	before := framePumpCount.Load()
+	testRunModalMode(200)
+	if framePumpCount.Load() == before {
+		panic("frame pump: no frames pumped in NSModalPanelRunLoopMode")
+	}
+
+	// Default mode: the pump must stay out of the way. The timer still
+	// fires here (it is installed in common modes) but the handler must
+	// return before calling into Go.
+	before = framePumpCount.Load()
+	testRunDefaultMode(200)
+	if got := framePumpCount.Load(); got != before {
+		panic("frame pump: pumped in NSDefaultRunLoopMode — frames doubled")
+	}
+
+	// Destroy must retire the timer; a live one would keep pumping
+	// frames for windows that no longer exist.
+	b.Destroy()
+	if testFramePumpActive() {
+		panic("frame pump: timer still valid after Destroy")
+	}
+}

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -134,4 +134,8 @@ func runMainThreadTests() {
 	if ws := lookupWindow(winID); ws != nil {
 		panic("metal.Destroy: window still in windowRegistry after destroy")
 	}
+
+	// 10. Frames must keep flowing while a nested AppKit runloop (modal
+	//     dialog, open menu, live resize) blocks the Go event loop.
+	runFramePumpMainThreadTests()
 }

--- a/gui/backend/metal/metal_window.h
+++ b/gui/backend/metal/metal_window.h
@@ -61,6 +61,10 @@ extern void goMetalWindowFocusChanged(unsigned int windowID,
 // Called when files are dropped on the window.
 extern void goMetalFileDrop(unsigned int windowID, char *path);
 
+// Called from the frame-pump timer while a nested AppKit runloop is
+// running (see metalStartFramePump). Go renders one frame per window.
+extern void goMetalPumpFrames(void);
+
 // ─── Event polling ─────────────────────────────────────────────
 
 // Poll for the next event with an optional timeout.
@@ -184,5 +188,27 @@ void metalAppFinishLaunch(void);
 
 // Set the dock icon from PNG data.
 void metalSetDockIcon(const void *data, int len);
+
+// ─── Frame pump (nested runloops) ──────────────────────────────
+//
+// The Go event loop pumps events and frames from NSDefaultRunLoopMode
+// only. Whenever AppKit runs a nested runloop on the main thread — a
+// modal dialog ([NSAlert/NSSavePanel runModal]), menu tracking, the
+// live-resize tracking loop — that loop is blocked inside sendEvent:
+// and no frames are produced: queued commands never flush and the
+// window stops repainting until the nested loop exits.
+//
+// metalStartFramePump installs a repeating timer in
+// NSRunLoopCommonModes that renders a frame per window while such a
+// nested loop runs. It does nothing in NSDefaultRunLoopMode, where the
+// Go loop owns frame timing.
+//
+// This cannot help when the main thread blocks with no runloop running
+// at all (e.g. a synchronous system API that puts up a TCC permission
+// prompt) — no timer fires in that state.
+void metalStartFramePump(void);
+
+// Stop and release the frame-pump timer. Idempotent.
+void metalStopFramePump(void);
 
 #endif // METAL_WINDOW_H

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -574,6 +574,7 @@ __attribute__((weak)) void goMetalWindowShouldClose(unsigned int wid) {}
 __attribute__((weak)) void goMetalWindowFocusChanged(unsigned int wid,
                                                      int focused) {}
 __attribute__((weak)) void goMetalFileDrop(unsigned int wid, char *path) {}
+__attribute__((weak)) void goMetalPumpFrames(void) {}
 
 // ─── Event polling ─────────────────────────────────────────────
 
@@ -1135,6 +1136,50 @@ void metalAppFinishLaunch(void) {
     // Not guarded by the dispatch_once: every call must re-activate so
     // newly-created windows come to the foreground.
     metalForceActivate();
+
+    // Windows exist now, so frames are meaningful: arm the nested-runloop
+    // frame pump. Idempotent, so the repeat calls for later windows are
+    // harmless.
+    metalStartFramePump();
+}
+
+// ─── Frame pump (nested runloops) ──────────────────────────────
+//
+// Rationale lives in metal_window.h. The short version: the Go event loop
+// only pumps NSDefaultRunLoopMode, so a nested AppKit runloop (modal
+// dialog, menu tracking, live resize) starves every window of frames.
+// This timer is scheduled in NSRunLoopCommonModes, which includes
+// NSEventTrackingRunLoopMode and NSModalPanelRunLoopMode, so it keeps
+// firing exactly when the Go loop cannot.
+
+// Timer interval — 60 Hz. Frames are cheap when nothing is dirty:
+// Window.PumpFrame flushes commands and returns false without rendering
+// unless a refresh is actually pending.
+static const NSTimeInterval kFramePumpInterval = 1.0 / 60.0;
+
+static NSTimer *_framePumpTimer;
+
+void metalStartFramePump(void) {
+    if (_framePumpTimer) return;
+    _framePumpTimer = [NSTimer timerWithTimeInterval:kFramePumpInterval
+                                             repeats:YES
+                                               block:^(NSTimer *timer) {
+        // In the default mode the Go event loop is running and owns frame
+        // timing; pumping here too would double every frame. Only the
+        // nested modes — where that loop is blocked — need this timer.
+        NSString *mode = [[NSRunLoop currentRunLoop] currentMode];
+        if (!mode || [mode isEqualToString:NSDefaultRunLoopMode]) return;
+        goMetalPumpFrames();
+    }];
+    // Common modes, not the default mode: see above.
+    [[NSRunLoop mainRunLoop] addTimer:_framePumpTimer
+                              forMode:NSRunLoopCommonModes];
+}
+
+void metalStopFramePump(void) {
+    if (!_framePumpTimer) return;
+    [_framePumpTimer invalidate];
+    _framePumpTimer = nil;
 }
 
 // ─── Test helpers (called from Go tests via cgo) ─────────────────
@@ -1198,6 +1243,32 @@ void metalTestInjectKeyDown(unsigned short keyCode, unsigned int modifiers) {
     _evKeyCode = keyCode;
     _evModifiers = modifiers;
     _evKeyRepeat = 0;
+}
+
+// Run the main runloop for ms milliseconds in a nested mode, standing in
+// for what AppKit does inside [NSAlert runModal] or menu tracking. The
+// frame-pump timer must fire here (mode != NSDefaultRunLoopMode) and must
+// not fire in the default-mode variant. See TestFramePumpNestedMode.
+// runMode:beforeDate: returns as soon as it services one input source
+// (and immediately when the mode has none), so loop until the deadline.
+static void metalTestRunMode(NSString *mode, int ms) {
+    NSDate *until = [NSDate dateWithTimeIntervalSinceNow:ms / 1000.0];
+    while ([until timeIntervalSinceNow] > 0) {
+        [[NSRunLoop mainRunLoop] runMode:mode beforeDate:until];
+    }
+}
+
+void metalTestRunModalMode(int ms) {
+    metalTestRunMode(NSModalPanelRunLoopMode, ms);
+}
+
+void metalTestRunDefaultMode(int ms) {
+    metalTestRunMode(NSDefaultRunLoopMode, ms);
+}
+
+// Report whether the frame-pump timer is currently installed.
+int metalTestFramePumpActive(void) {
+    return (_framePumpTimer && [_framePumpTimer isValid]) ? 1 : 0;
 }
 
 // Inject a synthetic quit event so Go tests can verify mapMetalEvent

--- a/gui/window.go
+++ b/gui/window.go
@@ -256,6 +256,12 @@ type Window struct {
 	refreshLayout     bool
 	refreshRenderOnly bool
 
+	// pumping guards PumpFrame against re-entry: a nested platform
+	// runloop can fire its frame timer again while the previous pump
+	// is still inside FrameFn (a command callback that itself spins a
+	// runloop, for instance). Main-thread only — no atomic needed.
+	pumping bool
+
 	// Window focus state — backend sets false on unfocus event.
 	focused bool
 }

--- a/gui/window_pump_test.go
+++ b/gui/window_pump_test.go
@@ -1,0 +1,88 @@
+package gui
+
+import "testing"
+
+// PumpFrame is the entry point backends use from a nested platform
+// runloop (modal dialog, menu tracking, live resize), where the backend's
+// own event loop is blocked and delivers no frames. These tests cover the
+// three behaviours that matter there: it does a real frame, it declines
+// rather than deadlocks when the window is already locked up-stack, and
+// it refuses to re-enter itself.
+
+func newPumpTestWindow() *Window {
+	w := NewWindow(WindowCfg{
+		State:  new(int),
+		Width:  100,
+		Height: 100,
+	})
+	w.viewGenerator = func(_ *Window) View {
+		return Text(TextCfg{Text: "x"})
+	}
+	return w
+}
+
+func TestPumpFrameFlushesAndRebuilds(t *testing.T) {
+	w := newPumpTestWindow()
+	w.refreshLayout = false
+	w.refreshRenderOnly = false
+
+	// A command queued while the backend loop is blocked — e.g. a
+	// terminal's debounced resize wake — must still be flushed.
+	flushed := false
+	w.QueueCommand(func(_ *Window) {
+		flushed = true
+		w.markLayoutRefresh()
+	})
+
+	if !w.PumpFrame() {
+		t.Fatal("PumpFrame should report a rebuild after the queued refresh")
+	}
+	if !flushed {
+		t.Error("queued command not flushed")
+	}
+	if w.refreshLayout {
+		t.Error("refreshLayout should be cleared by the pumped frame")
+	}
+}
+
+func TestPumpFrameSkipsWhenLocked(t *testing.T) {
+	w := newPumpTestWindow()
+	w.refreshLayout = true
+
+	// Stand in for a caller further up the stack — an event handler
+	// that opened the modal dialog from inside locked window code.
+	// Blocking here would wedge the main thread.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.PumpFrame() {
+		t.Error("PumpFrame should decline the frame while the window is locked")
+	}
+	if !w.refreshLayout {
+		t.Error("pending refresh must survive a declined pump")
+	}
+}
+
+func TestPumpFrameRejectsReentry(t *testing.T) {
+	w := newPumpTestWindow()
+	w.refreshLayout = true
+
+	// The timer firing again inside a command callback that itself
+	// spins a runloop.
+	var inner, innerRan bool
+	w.QueueCommand(func(_ *Window) {
+		innerRan = true
+		inner = w.PumpFrame()
+	})
+
+	w.PumpFrame()
+	if !innerRan {
+		t.Fatal("queued command did not run")
+	}
+	if inner {
+		t.Error("nested PumpFrame should be rejected")
+	}
+	if w.pumping {
+		t.Error("pumping flag not cleared after the frame")
+	}
+}

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -173,6 +173,38 @@ func (w *Window) FrameFn() bool {
 	return rebuilt
 }
 
+// PumpFrame runs one frame from a *nested* platform runloop — a modal
+// dialog, menu tracking, live resize — where the backend's own event loop
+// is blocked and would otherwise deliver no frames at all. Same work as
+// FrameFn (flush queued commands, rebuild layout/renderers) and the same
+// return value: true when the backend should follow with renderFrame.
+//
+// Two guards make it safe to call from that re-entrant position:
+//
+//   - w.pumping rejects a pump nested inside another pump.
+//   - The TryLock probe rejects the frame when some caller further up the
+//     stack already owns w.mu — e.g. an event handler that opened the
+//     modal dialog from inside Update. Blocking there would deadlock the
+//     main thread, and skipping costs nothing: the next timer tick retries.
+//
+// Main-thread only, like FrameFn.
+func (w *Window) PumpFrame() bool {
+	if w.pumping {
+		return false
+	}
+	// Probe only — the lock is released immediately. On the main thread the
+	// sole possible holder is our own call stack, so a successful TryLock
+	// means FrameFn's own w.mu.Lock cannot deadlock.
+	if !w.mu.TryLock() {
+		return false
+	}
+	w.mu.Unlock()
+
+	w.pumping = true
+	defer func() { w.pumping = false }()
+	return w.FrameFn()
+}
+
 // Update performs a full layout rebuild and re-renders.
 func (w *Window) Update() {
 	w.mu.Lock()


### PR DESCRIPTION
## Problem

The Metal backend's event loop polls and renders from `NSDefaultRunLoopMode` only. Any nested AppKit runloop on the main thread — `[NSAlert/NSSavePanel runModal]`, menu tracking, the live-resize tracking loop — blocks that loop inside `sendEvent:`, so `Window.FrameFn` never runs: queued commands never flush and windows stop repainting until the nested loop exits.

Surfaced as a go-term bug: resizing the window while a macOS dialog was up resized the frame but not the terminal. go-term debounces reflow by 50 ms and relies on a later frame to apply the final size. That frame normally arrives when the tracking loop exits and the poll loop resumes; with a modal loop owning the main thread it never does.

Reproducible without any dialog: run a clock in a go-term window and hold a menu open — output freezes and jumps on release.

## Fix

A 60 Hz `NSTimer` installed in `NSRunLoopCommonModes` (which includes `NSEventTrackingRunLoopMode` and `NSModalPanelRunLoopMode`) renders one frame per window. Its block returns immediately in `NSDefaultRunLoopMode`, where the Go loop already owns frame timing and pumping would double every frame.

`Window.PumpFrame` is the entry point — `FrameFn`'s work, plus two guards for the re-entrant position it is called from:

- declines the frame instead of blocking when a caller up-stack already holds `w.mu` (an event handler that opened the dialog from inside locked code) — the next tick retries;
- rejects a pump nested inside another pump.

Timer is armed from `metalAppFinishLaunch` and retired in `Backend.Destroy` / `RunAppE` teardown.

## Limitation (documented in `metal_window.h`)

No help when the main thread blocks with no runloop running at all — e.g. a synchronous system API putting up a TCC permission prompt. No timer fires in that state.

## Tests

- `gui/window_pump_test.go` — pumped frame flushes a queued command and rebuilds; declines without deadlock while `mu` is held, leaving the pending refresh intact; rejects re-entry.
- `gui/backend/metal/frame_pump_test.go`, wired into `runMainThreadTests` — real window and real timer: frames pumped while the main runloop runs `NSModalPanelRunLoopMode`; none pumped in `NSDefaultRunLoopMode`; timer retired by `Destroy`.

`go test ./... && go vet ./...` clean. Fix confirmed by hand in go-term against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787693692&installation_model_id=426559&pr_number=128&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F128&signature=ffbc223d55ecb84637e68b20a1b43df04ae66433b941b6c87bf29b87c1973a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->