### PR TITLE
changelog: add v0.43.0 (PumpFrame, CommandButton signature, go-glyph v1.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.43.0] - 2026-07-26
+
+### Added
+
+- **`Window.PumpFrame`.** Drives a single frame — flush, rebuild, present —
+  from outside the normal event loop. This is what lets the Metal backend keep
+  rendering while a nested AppKit run loop (a modal sheet, a native menu
+  tracking session) owns the main thread.
+
+### Changed
+
+- **BREAKING: `CommandButton` no longer takes a `*Window`.** The signature is
+  now `CommandButton(cmdID string, cfg ButtonCfg) View`. Command lookup,
+  auto-label, auto-disable, and `OnClick` wiring are deferred to
+  `GenerateLayout` via `ViewFunc`, so the widget no longer needs a window at
+  construction time. Callers drop the first argument:
+  `gui.CommandButton(w, "save", cfg)` → `gui.CommandButton("save", cfg)`.
+- **Dependencies: `go-glyph` bumped to v1.18.0**, picking up
+  `TextSystem.Purge` / `GlyphAtlas.Reset` / `Renderer.PurgeGlyphCache` for
+  mid-session glyph and atlas memory reclamation.
+
+### Fixed
+
+- **Metal: frames no longer freeze under a nested AppKit run loop.** A modal
+  sheet or native menu tracking session blocked the event loop; frames are now
+  pumped for the duration.
+- **Metal: removed an MSL lambda that broke every app on macOS Sonoma.** The
+  shader failed to compile on Sonoma, taking down app startup.
+
 ## [v0.42.0] - 2026-07-20
 
 ### Added


### PR DESCRIPTION
Release changelog for v0.43.0.

**Breaking:** `CommandButton` drops its leading `*Window` parameter (#125).

- Added `Window.PumpFrame` (#128)
- Metal: pump frames under a nested AppKit run loop (#128)
- Metal: remove MSL lambda that broke apps on macOS Sonoma (#127)
- deps: go-glyph v1.18.0 (#129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787695239&installation_model_id=426559&pr_number=130&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F130&signature=efdf64653331552b8d2030bd36edbf57217f135b38ef5df27d7f8f877211afab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->