### PR TITLE
feat(theme): allow apps to override the themed icon font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`ThemeCfg.IconFontFamily`.** Sets the font family used by every
+  theme-driven icon style (`Theme.Icon1`…`Icon6` and
+  `TreeStyle.TextStyleIcon`), so an app that ships its own curated icon font
+  can retarget them all with one field. Mirrors the existing
+  `MonoFontFamily` handling: defaulted to `IconFontName` in `baseCfg()`, and
+  an empty value falls back to `IconFontName`. No behavior change for
+  existing apps — the bundled Feather font stays embedded, registered, and
+  the default.
+- **`gui.RegisterAppFontBytes([]byte)`.** Registers an in-memory font
+  (e.g. one loaded with `go:embed`) alongside the existing path-based
+  `RegisterAppFont`. The text system persists the bytes to its own temp file
+  and removes it on teardown, so callers no longer need to manage one.
+  Consumed by the GL and Metal backends, matching where `AppFontPaths` is
+  consumed today.
+- **`gui.LoadAppFonts(FontRegistrar, string)`.** Registers everything in
+  `AppFontPaths` and `AppFontData` with a text system, logging and skipping
+  fonts that fail to load so one bad font cannot stop the window from coming
+  up. Replaces the per-backend loops the GL and Metal backends each carried,
+  and takes the narrow `gui.FontRegistrar` interface
+  (`AddFontFile`/`AddFontBytes`) so backends yet to adopt it — iOS, Android —
+  can wire it up with one call.
+
 ## [v0.43.0] - 2026-07-26
 
 ### Added

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -13,7 +13,6 @@ package gl
 import (
 	"log"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/go-gl/gl/v3.3-core/gl"
@@ -145,11 +144,7 @@ func (b *Backend) initGLResources(w *gui.Window) error {
 			b.iconFontPath = tmp
 		}
 	}
-	for _, p := range gui.AppFontPaths {
-		if aerr := textSys.AddFontFile(p); aerr != nil {
-			log.Printf("gl: load app font %q: %v", filepath.Base(p), aerr)
-		}
-	}
+	gui.LoadAppFonts(textSys, "gl")
 
 	w.SetTextMeasurer(&textMeasurer{textSys: textSys})
 	w.SetSvgParser(svg.New())

--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"runtime"
 	"unsafe"
 
@@ -568,12 +567,7 @@ func createWindowState(w *gui.Window) (*windowState, error) {
 		}
 	}
 
-	for _, p := range gui.AppFontPaths {
-		if err := textSys.AddFontFile(p); err != nil {
-			log.Printf("metal: load app font %q: %v",
-				filepath.Base(p), err)
-		}
-	}
+	gui.LoadAppFonts(textSys, "metal")
 
 	return ws, nil
 }

--- a/gui/backend/web/backend.go
+++ b/gui/backend/web/backend.go
@@ -328,7 +328,7 @@ func loadIconFont(data []byte) {
 	b64 := base64.StdEncoding.EncodeToString(data)
 	src := "url(data:font/truetype;base64," + b64 + ")"
 
-	ff := js.Global().Get("FontFace").New("feathericon", src)
+	ff := js.Global().Get("FontFace").New(gui.IconFontName, src)
 	promise := ff.Call("load")
 	var thenFn, catchFn js.Func
 	thenFn = js.FuncOf(func(_ js.Value, _ []js.Value) any {

--- a/gui/fonts.go
+++ b/gui/fonts.go
@@ -1,7 +1,10 @@
 package gui
 
 import (
+	"bytes"
 	_ "embed"
+	"log"
+	"path/filepath"
 	"slices"
 )
 
@@ -41,6 +44,78 @@ func RegisterAppFont(path string) {
 		return
 	}
 	AppFontPaths = append(AppFontPaths, path)
+}
+
+// AppFontData lists in-memory application fonts (TTF/OTF) to register
+// with the text system at backend init time. Append via
+// RegisterAppFontBytes before calling backend.RunApp / backend.Run.
+//
+// Use this for fonts embedded in the executable with go:embed — the
+// text system persists the bytes to its own temp file, so the caller
+// does not have to manage one.
+//
+// Consumed by the GL and Metal backends, matching where AppFontPaths is
+// consumed. The iOS, Android and web backends ignore both lists; on web
+// use the browser FontFace API instead.
+//
+// To retarget the themed icon styles at a registered font, set that
+// font's family name in ThemeCfg.IconFontFamily.
+var AppFontData [][]byte
+
+// RegisterAppFontBytes appends data to AppFontData if not already
+// present. Empty data is ignored. Safe to call multiple times with the
+// same font.
+//
+// data is retained by reference, not copied — the caller must not
+// mutate it afterwards. go:embed data satisfies this by construction.
+func RegisterAppFontBytes(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	// slices.Contains needs a comparable element; []byte is not.
+	if slices.ContainsFunc(AppFontData, func(d []byte) bool {
+		return bytes.Equal(d, data)
+	}) {
+		return
+	}
+	AppFontData = append(AppFontData, data)
+}
+
+// FontRegistrar is the font-loading subset of glyph.TextSystem that
+// LoadAppFonts needs. Backends pass their *glyph.TextSystem; tests pass
+// a fake.
+type FontRegistrar interface {
+	AddFontFile(path string) error
+	AddFontBytes(data []byte) error
+}
+
+// LoadAppFonts registers every font in AppFontPaths and AppFontData
+// with ts, naming the calling backend ("gl", "metal") in log lines.
+// Call once per text system during backend init, after the bundled icon
+// font is loaded.
+//
+// A font that fails to load is logged and skipped: one unreadable font
+// must not stop the remaining ones — or the window itself — from coming
+// up. A nil ts is a no-op.
+func LoadAppFonts(ts FontRegistrar, backend string) {
+	if ts == nil {
+		return
+	}
+	for _, p := range AppFontPaths {
+		if err := ts.AddFontFile(p); err != nil {
+			log.Printf("%s: load app font %q: %v",
+				backend, filepath.Base(p), err)
+		}
+	}
+	// AddFontBytes owns the temp file it writes and removes it in Free,
+	// so there is nothing to track here. Byte slices have no name to
+	// report, so identify a failure by index and size.
+	for i, d := range AppFontData {
+		if err := ts.AddFontBytes(d); err != nil {
+			log.Printf("%s: load app font bytes #%d (%d bytes): %v",
+				backend, i, len(d), err)
+		}
+	}
 }
 
 // Icon constants — Feather icon font Unicode mappings.

--- a/gui/fonts_test.go
+++ b/gui/fonts_test.go
@@ -1,6 +1,12 @@
 package gui
 
-import "testing"
+import (
+	"errors"
+	"io"
+	"log"
+	"os"
+	"testing"
+)
 
 func TestIconLookupContainsAllConstants(t *testing.T) {
 	if len(IconLookup) != 255 {
@@ -44,5 +50,141 @@ func TestFontVariantsStruct(t *testing.T) {
 func TestIconFontName(t *testing.T) {
 	if IconFontName != "feathericon" {
 		t.Errorf("IconFontName = %q, want %q", IconFontName, "feathericon")
+	}
+}
+
+func TestRegisterAppFont(t *testing.T) {
+	// Registration lists are process globals; restore them so other
+	// tests (and the backends) see the original state.
+	saved := AppFontPaths
+	t.Cleanup(func() { AppFontPaths = saved })
+	AppFontPaths = nil
+
+	RegisterAppFont("/tmp/a.ttf")
+	RegisterAppFont("/tmp/a.ttf")
+	RegisterAppFont("/tmp/b.ttf")
+	if len(AppFontPaths) != 2 {
+		t.Fatalf("AppFontPaths = %v, want 2 entries", AppFontPaths)
+	}
+	if AppFontPaths[0] != "/tmp/a.ttf" || AppFontPaths[1] != "/tmp/b.ttf" {
+		t.Errorf("AppFontPaths = %v, want [a b] in order", AppFontPaths)
+	}
+}
+
+func TestRegisterAppFontBytes(t *testing.T) {
+	saved := AppFontData
+	t.Cleanup(func() { AppFontData = saved })
+	AppFontData = nil
+
+	RegisterAppFontBytes(nil)
+	RegisterAppFontBytes([]byte{})
+	if len(AppFontData) != 0 {
+		t.Fatalf("empty data registered: %v", AppFontData)
+	}
+
+	RegisterAppFontBytes([]byte("font-a"))
+	// Distinct slice, equal contents — must dedupe by value.
+	RegisterAppFontBytes([]byte("font-a"))
+	RegisterAppFontBytes([]byte("font-b"))
+	if len(AppFontData) != 2 {
+		t.Fatalf("AppFontData has %d entries, want 2", len(AppFontData))
+	}
+	if string(AppFontData[0]) != "font-a" || string(AppFontData[1]) != "font-b" {
+		t.Errorf("AppFontData = %q, want [font-a font-b] in order",
+			AppFontData)
+	}
+}
+
+// fakeRegistrar records what LoadAppFonts asked it to load and fails
+// the entries named in failFiles / failBytes.
+type fakeRegistrar struct {
+	files     []string
+	data      [][]byte
+	failFiles map[string]bool
+	failBytes map[string]bool
+}
+
+func (f *fakeRegistrar) AddFontFile(path string) error {
+	f.files = append(f.files, path)
+	if f.failFiles[path] {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func (f *fakeRegistrar) AddFontBytes(data []byte) error {
+	f.data = append(f.data, data)
+	if f.failBytes[string(data)] {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+// setAppFonts points both registration globals at the given fixtures
+// and restores them when the test ends.
+func setAppFonts(t *testing.T, paths []string, data [][]byte) {
+	t.Helper()
+	savedPaths, savedData := AppFontPaths, AppFontData
+	t.Cleanup(func() { AppFontPaths, AppFontData = savedPaths, savedData })
+	AppFontPaths, AppFontData = paths, data
+}
+
+func TestLoadAppFontsRegistersBothLists(t *testing.T) {
+	setAppFonts(t,
+		[]string{"/tmp/a.ttf", "/tmp/b.ttf"},
+		[][]byte{[]byte("font-c")})
+
+	fake := &fakeRegistrar{}
+	LoadAppFonts(fake, "test")
+
+	if len(fake.files) != 2 ||
+		fake.files[0] != "/tmp/a.ttf" || fake.files[1] != "/tmp/b.ttf" {
+		t.Errorf("AddFontFile calls = %v, want both paths in order",
+			fake.files)
+	}
+	if len(fake.data) != 1 || string(fake.data[0]) != "font-c" {
+		t.Errorf("AddFontBytes calls = %q, want [font-c]", fake.data)
+	}
+}
+
+// A font that fails to load must not stop the ones after it — an
+// unreadable font should cost its own glyphs, not the whole window.
+func TestLoadAppFontsContinuesPastFailures(t *testing.T) {
+	setAppFonts(t,
+		[]string{"/tmp/bad.ttf", "/tmp/good.ttf"},
+		[][]byte{[]byte("bad"), []byte("good")})
+
+	// Failures are logged; keep the test output clean.
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	fake := &fakeRegistrar{
+		failFiles: map[string]bool{"/tmp/bad.ttf": true},
+		failBytes: map[string]bool{"bad": true},
+	}
+	LoadAppFonts(fake, "test")
+
+	if len(fake.files) != 2 || fake.files[1] != "/tmp/good.ttf" {
+		t.Errorf("AddFontFile calls = %v, want the good path still attempted",
+			fake.files)
+	}
+	if len(fake.data) != 2 || string(fake.data[1]) != "good" {
+		t.Errorf("AddFontBytes calls = %q, want the good font still attempted",
+			fake.data)
+	}
+}
+
+func TestLoadAppFontsNilRegistrarNoPanic(t *testing.T) {
+	setAppFonts(t, []string{"/tmp/a.ttf"}, [][]byte{[]byte("font-a")})
+	LoadAppFonts(nil, "test") // must not panic
+}
+
+func TestLoadAppFontsEmptyListsNoCalls(t *testing.T) {
+	setAppFonts(t, nil, nil)
+	fake := &fakeRegistrar{}
+	LoadAppFonts(fake, "test")
+	if len(fake.files) != 0 || len(fake.data) != 0 {
+		t.Errorf("registrar called with empty lists: %v %q",
+			fake.files, fake.data)
 	}
 }

--- a/gui/inspector.go
+++ b/gui/inspector.go
@@ -366,11 +366,10 @@ func inspectorPropsNodes(p inspectorNodeProps) []TreeNodeCfg {
 		Size:  guiTheme.SizeTextXSmall,
 		Color: propColor,
 	}
-	pis := TextStyle{
-		Family: IconFontName,
-		Size:   guiTheme.SizeTextXSmall,
-		Color:  propColor,
-	}
+	// Icon5 is the XSmall themed icon style, so it already carries the
+	// theme's icon family (app-overridable via ThemeCfg.IconFontFamily).
+	pis := guiTheme.Icon5
+	pis.Color = propColor
 
 	nodes := make([]TreeNodeCfg, 0, 16)
 	if p.TextPreview != "" {

--- a/gui/theme.go
+++ b/gui/theme.go
@@ -131,6 +131,16 @@ type ThemeCfg struct {
 
 	MonoFontFamily string // font family for code/mono text
 
+	// IconFontFamily is the font family for the themed icon styles
+	// (Icon1..Icon6, TreeStyle.TextStyleIcon). Defaults to
+	// IconFontName; an app that ships its own icon font sets this to
+	// that font's family name. Empty falls back to IconFontName.
+	//
+	// Setting this only retargets the styles — the font itself must
+	// still be registered with RegisterAppFont or RegisterAppFontBytes
+	// before the backend starts, or icons render as tofu.
+	IconFontFamily string
+
 	Padding Padding
 
 	PaddingSmall  Padding

--- a/gui/theme_defaults.go
+++ b/gui/theme_defaults.go
@@ -26,6 +26,7 @@ const (
 func baseCfg() ThemeCfg {
 	return ThemeCfg{
 		MonoFontFamily:   defaultMonoFontFamily,
+		IconFontFamily:   IconFontName,
 		Padding:          PaddingMedium,
 		PaddingSmall:     PaddingSmall,
 		PaddingMedium:    PaddingMedium,

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"cmp"
 	"time"
 
 	"github.com/go-gui-org/go-glyph"
@@ -14,6 +15,11 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 		s.Size = size
 		return s
 	}
+
+	// Icon family for every theme-driven icon style. A ThemeCfg built
+	// from scratch (not via baseCfg) leaves this empty, so fall back to
+	// the bundled font rather than render icons in the default family.
+	iconFamily := cmp.Or(cfg.IconFontFamily, IconFontName)
 
 	borderFocus := cfg.ColorBorderFocus
 	if borderFocus.Eq(Color{}) {
@@ -182,7 +188,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			TextStyleIcon: TextStyle{
 				Color:  ts.Color,
 				Size:   cfg.SizeTextSmall,
-				Family: IconFontName,
+				Family: iconFamily,
 			},
 			Indent:  25,
 			Spacing: 0,
@@ -565,7 +571,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 
 	// Icon font shortcuts.
 	icon := ts
-	icon.Family = IconFontName
+	icon.Family = iconFamily
 	theme.Icon1 = makeStyle(icon, theme.SizeTextXLarge)
 	theme.Icon2 = makeStyle(icon, theme.SizeTextLarge)
 	theme.Icon3 = makeStyle(icon, theme.SizeTextMedium)

--- a/gui/theme_maker_test.go
+++ b/gui/theme_maker_test.go
@@ -1,0 +1,111 @@
+package gui
+
+import "testing"
+
+// iconStyleFamilies returns every theme-driven icon style family so the
+// tests can assert them as a set.
+func iconStyleFamilies(theme Theme) []string {
+	return []string{
+		theme.Icon1.Family,
+		theme.Icon2.Family,
+		theme.Icon3.Family,
+		theme.Icon4.Family,
+		theme.Icon5.Family,
+		theme.Icon6.Family,
+		theme.TreeStyle.TextStyleIcon.Family,
+	}
+}
+
+func TestThemeMakerIconFamilyDefault(t *testing.T) {
+	theme := ThemeMaker(baseCfg())
+	for i, got := range iconStyleFamilies(theme) {
+		if got != IconFontName {
+			t.Errorf("icon style %d family = %q, want %q",
+				i, got, IconFontName)
+		}
+	}
+}
+
+func TestThemeMakerIconFamilyOverride(t *testing.T) {
+	cfg := baseCfg()
+	cfg.IconFontFamily = "mycustomicons"
+	theme := ThemeMaker(cfg)
+	for i, got := range iconStyleFamilies(theme) {
+		if got != "mycustomicons" {
+			t.Errorf("icon style %d family = %q, want %q",
+				i, got, "mycustomicons")
+		}
+	}
+}
+
+// A ThemeCfg built from scratch has no IconFontFamily; icons must still
+// resolve to the bundled font rather than the default text family.
+func TestThemeMakerIconFamilyEmptyFallsBack(t *testing.T) {
+	theme := ThemeMaker(ThemeCfg{})
+	for i, got := range iconStyleFamilies(theme) {
+		if got != IconFontName {
+			t.Errorf("icon style %d family = %q, want %q",
+				i, got, IconFontName)
+		}
+	}
+}
+
+func TestThemeMakerMonoFamily(t *testing.T) {
+	cfg := baseCfg()
+	cfg.MonoFontFamily = "mycustommono"
+	theme := ThemeMaker(cfg)
+	styles := []TextStyle{
+		theme.M1, theme.M2, theme.M3, theme.M4, theme.M5, theme.M6,
+	}
+	for i, s := range styles {
+		if s.Family != "mycustommono" {
+			t.Errorf("M%d family = %q, want %q",
+				i+1, s.Family, "mycustommono")
+		}
+	}
+}
+
+// The icon family must retarget only the icon styles. A leak into the
+// plain/italic/bold or mono styles renders body text in an icon font —
+// no crash, just unreadable output, so lock it down here.
+func TestThemeMakerIconFamilyDoesNotLeak(t *testing.T) {
+	cfg := baseCfg()
+	cfg.TextStyleDef.Family = "mytextfamily"
+	cfg.MonoFontFamily = "mymonofamily"
+	cfg.IconFontFamily = "myiconfamily"
+	theme := ThemeMaker(cfg)
+
+	text := map[string]TextStyle{
+		"I3": theme.I3, "I6": theme.I6,
+		"BI3": theme.BI3, "BI6": theme.BI6,
+	}
+	for name, s := range text {
+		if s.Family != "mytextfamily" {
+			t.Errorf("%s family = %q, want %q",
+				name, s.Family, "mytextfamily")
+		}
+	}
+	if theme.M3.Family != "mymonofamily" {
+		t.Errorf("M3 family = %q, want %q",
+			theme.M3.Family, "mymonofamily")
+	}
+}
+
+// Every preset theme must resolve icons to the bundled font. A preset
+// added later that builds its ThemeCfg from scratch instead of from
+// baseCfg would otherwise silently lose its icon family.
+func TestPresetThemesIconFamily(t *testing.T) {
+	presets := map[string]Theme{
+		"ThemeDark":  ThemeDark,
+		"ThemeLight": ThemeLight,
+		"ThemeBlue":  ThemeBlue,
+	}
+	for name, theme := range presets {
+		for i, got := range iconStyleFamilies(theme) {
+			if got != IconFontName {
+				t.Errorf("%s icon style %d family = %q, want %q",
+					name, i, got, IconFontName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #131.

## What

Lets an app that ships a curated icon set retarget go-gui's themed icon
styles at its own font, and register that font without managing a temp file.

### 1. `ThemeCfg.IconFontFamily`

An exact mirror of the existing `MonoFontFamily` handling — defaulted to
`IconFontName` in `baseCfg()`, with an empty value falling back to
`IconFontName` so a `ThemeCfg` built from scratch still renders icons rather
than body text. Covers `Theme.Icon1…Icon6` and `TreeStyle.TextStyleIcon`.

`inspector.go` now resolves its icon style from `guiTheme.Icon5` instead of
rebuilding the literal.

### 2. `gui.RegisterAppFontBytes([]byte)`

Registers an in-memory font (e.g. `go:embed`) alongside path-based
`RegisterAppFont`. go-glyph's `AddFontBytes` persists the bytes to its own
temp file and removes it in `Free`, so callers no longer manage one.

### 3. `gui.LoadAppFonts` (not in the issue's proposed shape)

Both font lists now register through one shared function over the narrow
`gui.FontRegistrar` interface, replacing the duplicated loops the GL and
Metal backends each carried (−6 and −7 lines; `path/filepath` drops out of
both import blocks).

The motivation is testability, not tidiness: that logic previously sat behind
a live Metal device or GL context and had no test coverage at all. A fake
registrar now covers ordering, **failure-skipping** (the behavior the
error-handling exists for, previously never exercised), nil registrar, and
empty lists.

## Deviation from the issue

Issue #131 proposed replacing *two* literal `Family: IconFontName` sites.
Only `inspector.go` was changed. `styles_widget_overlay.go:150` is
`DefaultTreeStyle` — the package-level no-theme fallback, with no `cfg` in
scope to resolve a family from. Its literal is correct and stays.

## Resolved open question

Single family, not a fallback stack — as the issue leaned. Can be widened
later without breaking the field.

## Not covered

iOS and Android still ignore `AppFontPaths` / `AppFontData` entirely, so the
override is unusable there. That is a behavior change on platforms needing
device verification — tracked separately in #132.

## Compatibility

No behavior change for existing apps: Feather stays embedded, registered by
every backend, and the default.

## Verification

- `go build ./...` — pass
- `GOOS=js GOARCH=wasm go build ./gui/...` — pass (web backend is in the diff)
- `go test ./...` — 75 packages ok, 0 failures
- `golangci-lint run ./...` — 0 issues
- `gofmt` — clean

New tests: 4 for `LoadAppFonts`, 2 for `RegisterAppFont`/`RegisterAppFontBytes`,
5 for the theme icon family (default, override, empty fallback, no-leak into
text/mono styles, all preset themes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787839310&installation_model_id=426559&pr_number=133&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F133&signature=d528d824eb69f99415ea35dad4544e71f34810c10a4381cbc713e0531160c411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->