### PR TITLE
feat: add OmitAboutItem and IncludeWindowMenu to native menubar config

### DIFF
--- a/gui/backend/nativemenu/menu_darwin.go
+++ b/gui/backend/nativemenu/menu_darwin.go
@@ -233,10 +233,21 @@ func SetMenubar(
 		suppSys = 1
 	}
 
+	omitAbout := C.int(0)
+	if cfg.OmitAboutItem {
+		omitAbout = 1
+	}
+
+	inclWindow := C.int(0)
+	if cfg.IncludeWindowMenu {
+		inclWindow = 1
+	}
+
 	C.nativemenuSetMenubar(cAppName,
 		menusPtr, C.int(len(menuDescs)),
 		itemsPtr, C.int(len(allItems)),
-		inclEdit, suppSys, cAboutID)
+		inclEdit, suppSys, cAboutID,
+		omitAbout, inclWindow)
 }
 
 // ClearMenubar removes the native menubar.

--- a/gui/backend/nativemenu/menu_darwin.h
+++ b/gui/backend/nativemenu/menu_darwin.h
@@ -26,7 +26,9 @@ void nativemenuSetMenubar(const char *appName,
     NativeMenuItemC *allItems, int itemCount,
     int includeEditMenu,
     int suppressSystemEditItems,
-    const char *aboutActionID);
+    const char *aboutActionID,
+    int omitAboutItem,
+    int includeWindowMenu);
 
 // Remove the custom menubar (revert to default).
 void nativemenuClearMenubar(void);

--- a/gui/backend/nativemenu/menu_darwin.m
+++ b/gui/backend/nativemenu/menu_darwin.m
@@ -190,38 +190,43 @@ static NSMenuItem *standardEditMenu(void) {
 // ---------------------------------------------------------------------------
 
 static NSMenuItem *appMenu(const char *appName,
-    const char *aboutActionID) {
+    const char *aboutActionID, int omitAboutItem) {
     NSString *name = appName
         ? [NSString stringWithUTF8String:appName]
         : @"";
 
     NSMenu *menu = [[NSMenu alloc] initWithTitle:name];
 
-    NSString *aboutTitle =
-        [NSString stringWithFormat:@"About %@", name];
-    NSMenuItem *about;
-    if (aboutActionID != NULL && aboutActionID[0] != '\0') {
-        // Route through the user action callback so the app can show
-        // its own About dialog instead of the system About panel.
-        // Deliberate deviation from the AppKit-selector pattern used
-        // by Quit: About content is app-defined, not OS-defined.
-        MenuActionHandler *handler = sharedHandler();
-        about = [[NSMenuItem alloc]
-            initWithTitle:aboutTitle
-            action:@selector(menuItemClicked:)
-            keyEquivalent:@""];
-        about.target = handler;
-        about.representedObject =
-            [NSString stringWithUTF8String:aboutActionID];
-    } else {
-        about = [[NSMenuItem alloc]
-            initWithTitle:aboutTitle
-            action:@selector(orderFrontStandardAboutPanel:)
-            keyEquivalent:@""];
-    }
-    [menu addItem:about];
+    // omitAboutItem leaves the app menu with Quit only — for apps that
+    // place About under their own Help menu. The separator goes with it:
+    // a leading separator above Quit reads as a rendering bug.
+    if (!omitAboutItem) {
+        NSString *aboutTitle =
+            [NSString stringWithFormat:@"About %@", name];
+        NSMenuItem *about;
+        if (aboutActionID != NULL && aboutActionID[0] != '\0') {
+            // Route through the user action callback so the app can show
+            // its own About dialog instead of the system About panel.
+            // Deliberate deviation from the AppKit-selector pattern used
+            // by Quit: About content is app-defined, not OS-defined.
+            MenuActionHandler *handler = sharedHandler();
+            about = [[NSMenuItem alloc]
+                initWithTitle:aboutTitle
+                action:@selector(menuItemClicked:)
+                keyEquivalent:@""];
+            about.target = handler;
+            about.representedObject =
+                [NSString stringWithUTF8String:aboutActionID];
+        } else {
+            about = [[NSMenuItem alloc]
+                initWithTitle:aboutTitle
+                action:@selector(orderFrontStandardAboutPanel:)
+                keyEquivalent:@""];
+        }
+        [menu addItem:about];
 
-    [menu addItem:[NSMenuItem separatorItem]];
+        [menu addItem:[NSMenuItem separatorItem]];
+    }
 
     NSString *quitTitle =
         [NSString stringWithFormat:@"Quit %@", name];
@@ -235,6 +240,37 @@ static NSMenuItem *appMenu(const char *appName,
 
     NSMenuItem *item = [[NSMenuItem alloc]
         initWithTitle:name action:nil keyEquivalent:@""];
+    item.submenu = menu;
+    return item;
+}
+
+// ---------------------------------------------------------------------------
+// Standard Window menu (Close, Minimize, Zoom, Bring All to Front).
+// ---------------------------------------------------------------------------
+
+// windowMenu mirrors the menu the metal backend installs by default, so an
+// app that replaces the default menubar with SetNativeMenubar doesn't silently
+// lose Cmd+W / Cmd+M. Registered with NSApp via setWindowsMenu: by the caller
+// so AppKit appends the open-window list.
+static NSMenuItem *windowMenu(void) {
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Window"];
+
+    NSMenuItem *close = [menu addItemWithTitle:@"Close"
+        action:@selector(performClose:) keyEquivalent:@"w"];
+    close.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+
+    NSMenuItem *min = [menu addItemWithTitle:@"Minimize"
+        action:@selector(performMiniaturize:) keyEquivalent:@"m"];
+    min.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+
+    [menu addItemWithTitle:@"Zoom"
+        action:@selector(performZoom:) keyEquivalent:@""];
+    [menu addItem:[NSMenuItem separatorItem]];
+    [menu addItemWithTitle:@"Bring All to Front"
+        action:@selector(arrangeInFront:) keyEquivalent:@""];
+
+    NSMenuItem *item = [[NSMenuItem alloc]
+        initWithTitle:@"Window" action:nil keyEquivalent:@""];
     item.submenu = menu;
     return item;
 }
@@ -286,13 +322,15 @@ void nativemenuSetMenubar(const char *appName,
     NativeMenuItemC *allItems, int itemCount,
     int includeEditMenu,
     int suppressSystemEditItems,
-    const char *aboutActionID) {
+    const char *aboutActionID,
+    int omitAboutItem,
+    int includeWindowMenu) {
 
     @autoreleasepool {
         NSMenu *bar = [[NSMenu alloc] init];
 
         // App menu.
-        [bar addItem:appMenu(appName, aboutActionID)];
+        [bar addItem:appMenu(appName, aboutActionID, omitAboutItem)];
 
         // User-defined menus.
         MenuActionHandler *handler = sharedHandler();
@@ -319,6 +357,22 @@ void nativemenuSetMenubar(const char *appName,
             // Insert after File if present, or at index 1.
             NSInteger idx = bar.numberOfItems > 1 ? 2 : 1;
             [bar insertItem:standardEditMenu() atIndex:idx];
+        }
+
+        // Standard Window menu. macOS convention puts it second to last,
+        // immediately before Help — so insert before a user-supplied Help
+        // menu when there is one, else append.
+        if (includeWindowMenu) {
+            NSInteger idx = bar.numberOfItems;
+            for (NSInteger i = 0; i < bar.numberOfItems; i++) {
+                if ([[bar itemAtIndex:i].title isEqualToString:@"Help"]) {
+                    idx = i;
+                    break;
+                }
+            }
+            NSMenuItem *wm = windowMenu();
+            [bar insertItem:wm atIndex:idx];
+            [NSApp setWindowsMenu:wm.submenu];
         }
 
         [NSApp setMainMenu:bar];

--- a/gui/native_menu.go
+++ b/gui/native_menu.go
@@ -28,6 +28,15 @@ type NativeMenubarCfg struct {
 	Menus                   []NativeMenuCfg // File, Edit, View, etc.
 	IncludeEditMenu         bool            // auto-wire standard Edit menu
 	SuppressSystemEditItems bool            // remove OS-injected AutoFill/WritingTools/Dictation
+	// OmitAboutItem drops "About <AppName>" (and its separator) from the app
+	// menu, leaving Quit alone. For apps that put About under their own Help
+	// menu. Takes precedence over AboutActionID — no About item is created.
+	OmitAboutItem bool
+	// IncludeWindowMenu auto-wires the standard Window menu (Close, Minimize,
+	// Zoom, Bring All to Front) and registers it with the OS window list.
+	// Installing a menubar replaces the backend's default one, so without
+	// this the app loses Cmd+W / Cmd+M.
+	IncludeWindowMenu bool
 }
 
 // NativeMenuItemsFromMenuItems converts in-app MenuItemCfg

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -310,6 +310,13 @@ func (w *Window) Dialog(cfg DialogCfg) {
 	cfg.visible = true
 	cfg.oldFocusID = w.viewState.focusID
 	w.dialogCfg = cfg
+	// The dialog overlay is built during a full layout pass, so the flag has
+	// to be set explicitly: a caller outside the event path (a native menu
+	// action, a QueueCommand from a worker) leaves the window otherwise idle,
+	// and the render-only frames a blinking cursor produces reuse the existing
+	// layout tree — the dialog would stay invisible until an unrelated event
+	// forced a rebuild.
+	w.markLayoutRefresh()
 	w.SetFocus(dialogFocusID(cfg))
 }
 
@@ -317,6 +324,9 @@ func (w *Window) Dialog(cfg DialogCfg) {
 func (w *Window) DialogDismiss() {
 	oldFocus := w.dialogCfg.oldFocusID
 	w.dialogCfg = DialogCfg{}
+	// Same reasoning as Dialog: without a rebuild the overlay stays on screen
+	// after a programmatic dismiss.
+	w.markLayoutRefresh()
 	w.SetFocus(oldFocus)
 }
 

--- a/gui/view_dialog_test.go
+++ b/gui/view_dialog_test.go
@@ -381,6 +381,36 @@ func TestRetainDialogFocus_DefaultButtonYes(t *testing.T) {
 	}
 }
 
+func TestDialogMarksLayoutRefresh(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.refreshLayout = false
+	w.dialogCfg = DialogCfg{} // visible=false
+
+	w.Dialog(DialogCfg{DialogType: DialogMessage, Title: "Hi"})
+	if !w.refreshLayout {
+		t.Error("Dialog should mark layout refresh")
+	}
+}
+
+func TestDialogDismissMarksLayoutRefresh(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.Dialog(DialogCfg{DialogType: DialogMessage, Title: "Hi"})
+	w.refreshLayout = false
+
+	w.DialogDismiss()
+	if !w.refreshLayout {
+		t.Error("DialogDismiss should mark layout refresh")
+	}
+}
+
+func TestDialogDoubleDismissNoPanic(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	w.Dialog(DialogCfg{DialogType: DialogMessage, Title: "Hi"})
+	w.DialogDismiss()
+	// Second dismiss must not panic.
+	w.DialogDismiss()
+}
+
 func TestDialogConfirmView(t *testing.T) {
 	cfg := DialogCfg{
 		Title:      "Confirm?",


### PR DESCRIPTION
## Summary

Adds two new boolean fields to `NativeMenubarCfg`:

- **`OmitAboutItem`**: drops "About <AppName>" (and its separator) from the app menu, leaving Quit alone. For apps that put About under their own Help menu. Takes precedence over `AboutActionID`.
- **`IncludeWindowMenu`**: auto-wires the standard Window menu (Close, Minimize, Zoom, Bring All to Front) and registers it with the OS window list. Installing a menubar replaces the backend's default one, so without this the app loses Cmd+W / Cmd+M.

Also adds `markLayoutRefresh()` calls in `Dialog` and `DialogDismiss` to ensure programmatic dialog lifecycle changes (triggered outside the event path, e.g. from a native menu action or `QueueCommand`) force a layout rebuild rather than waiting for an unrelated event.

## Files changed

| File | Change |
|------|--------|
| `gui/native_menu.go` | Added `OmitAboutItem`, `IncludeWindowMenu` fields to `NativeMenubarCfg` |
| `gui/backend/nativemenu/menu_darwin.go` | Pass new fields through to C |
| `gui/backend/nativemenu/menu_darwin.h` | Updated C function signature |
| `gui/backend/nativemenu/menu_darwin.m` | Implement `omitAboutItem` guard, `windowMenu()` helper, `includeWindowMenu` wiring |
| `gui/view_dialog.go` | Added `markLayoutRefresh()` to `Dialog` and `DialogDismiss` |
| `gui/view_dialog_test.go` | Added tests for layout refresh flags and double-dismiss safety |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788014726&installation_model_id=426559&pr_number=134&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F134&signature=1bb7d5dfde1709e3f96bc1cba26715b15c9defc5c42b44870f2623ed6176bd2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->