### PR TITLE
changelog: add v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.44.0] - 2026-07-30
+
 ### Added
 
+- **`NativeMenubarCfg.OmitAboutItem`.** Drops "About <AppName>" and its
+  separator from the app menu, leaving Quit alone, for apps that expose About
+  under their own Help menu. Takes precedence over `AboutActionID` — no About
+  item is created at all.
+- **`NativeMenubarCfg.IncludeWindowMenu`.** Auto-wires the standard Window
+  menu (Close, Minimize, Zoom, Bring All to Front) and registers it with the
+  OS window list. Installing a menubar replaces the backend's default one, so
+  without this an app silently loses Cmd+W / Cmd+M.
 - **`ThemeCfg.IconFontFamily`.** Sets the font family used by every
   theme-driven icon style (`Theme.Icon1`…`Icon6` and
   `TreeStyle.TextStyleIcon`), so an app that ships its own curated icon font
@@ -30,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and takes the narrow `gui.FontRegistrar` interface
   (`AddFontFile`/`AddFontBytes`) so backends yet to adopt it — iOS, Android —
   can wire it up with one call.
+
+### Fixed
+
+- **Programmatic `Window.Dialog` / `DialogDismiss` now force a layout
+  rebuild.** The dialog overlay is built during a full layout pass, so a
+  caller outside the event path — a native menu action, a `QueueCommand` from
+  a worker — left the window otherwise idle and the render-only frames a
+  blinking cursor produces reused the existing layout tree. The dialog stayed
+  invisible (or, on dismiss, stayed on screen) until an unrelated event forced
+  a rebuild.
 
 ## [v0.43.0] - 2026-07-26
 


### PR DESCRIPTION
Cuts the v0.44.0 release notes from the accumulated `Unreleased` section and adds the two entries that were missing.

**Added**
- `NativeMenubarCfg.OmitAboutItem` / `IncludeWindowMenu` (#134) — was not in the changelog.
- `ThemeCfg.IconFontFamily`, `gui.RegisterAppFontBytes`, `gui.LoadAppFonts` (#133) — already staged under Unreleased.

**Fixed**
- `Window.Dialog` / `DialogDismiss` force a layout rebuild (#134) — was not in the changelog.

Minor bump: new public API, no breaking changes. Tag v0.44.0 follows on merge; go-term's pending native-menubar work is blocked on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788016153&installation_model_id=426559&pr_number=135&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F135&signature=e0fdc730738190480e72f004a4fb45f53848b2cf4ddd298f17a410118b0e8949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->