### PR TITLE
test: add unit tests for core types with zero direct coverage (#53)

### DIFF
--- a/gui/styles_widget_defaults_test.go
+++ b/gui/styles_widget_defaults_test.go
@@ -1,0 +1,400 @@
+package gui
+
+// Pins the Default*Style package vars declared in
+// styles_widget_control.go and styles_widget_overlay.go.
+//
+// Go-Gui has two sources of widget defaults: these package vars (used
+// when a widget renders without a theme-supplied style) and ThemeMaker
+// (which builds every style from a ThemeCfg). They are maintained by
+// hand and drift apart silently. The tests below pin the package-var
+// side and call out, in comments, each place the two disagree — so a
+// future edit to one has to be a deliberate decision about the other.
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+// SetTheme (theme.go:236) overwrites every Default*Style global from
+// the active theme, and nothing restores them. Any earlier test that
+// switches themes therefore leaves the live vars holding theme values
+// rather than the declared literals, which makes naive assertions
+// order-dependent (and repeat-run dependent under -count=N).
+//
+// These snapshots are package-level vars, so Go initializes them from
+// the declared literals before any test runs. Assert against the
+// snapshot, never the live global.
+var (
+	pristineProgressBarStyle    = DefaultProgressBarStyle
+	pristineSliderStyle         = DefaultSliderStyle
+	pristineTabControlStyle     = DefaultTabControlStyle
+	pristineBreadcrumbStyle     = DefaultBreadcrumbStyle
+	pristineSplitterStyle       = DefaultSplitterStyle
+	pristineTableStyle          = DefaultTableStyle
+	pristineComboboxStyle       = DefaultComboboxStyle
+	pristineCommandPaletteStyle = DefaultCommandPaletteStyle
+	pristineDatePickerStyle     = DefaultDatePickerStyle
+	pristineColorPickerStyle    = DefaultColorPickerStyle
+	pristineSkeletonStyle       = DefaultSkeletonStyle
+	pristineMenubarStyle        = DefaultMenubarStyle
+	pristineBadgeStyle          = DefaultBadgeStyle
+	pristineExpandPanelStyle    = DefaultExpandPanelStyle
+	pristineDialogStyle         = DefaultDialogStyle
+	pristineToastStyle          = DefaultToastStyle
+	pristineTreeStyle           = DefaultTreeStyle
+	pristineDataGridStyle       = DefaultDataGridStyle
+	pristineTextStyle           = DefaultTextStyle
+	pristineListBoxStyle        = DefaultListBoxStyle
+	pristineRadioStyle          = DefaultRadioStyle
+	pristineSwitchStyle         = DefaultSwitchStyle
+	pristineToggleStyle         = DefaultToggleStyle
+	pristineSelectStyle         = DefaultSelectStyle
+	pristineInputStyle          = DefaultInputStyle
+	pristineScrollbarStyle      = DefaultScrollbarStyle
+	pristineTooltipStyle        = DefaultTooltipStyle
+)
+
+// --- styles_widget_control.go ----------------------------------------
+
+func TestDefaultProgressBarStyle(t *testing.T) {
+	s := pristineProgressBarStyle
+	// ThemeMaker drives Size from cfg.SizeProgressBar and never sets
+	// SizeBorder at all; the package var hard-codes both.
+	if s.Size != 20 {
+		t.Errorf("size = %v, want 20", s.Size)
+	}
+	if s.SizeBorder != 0 {
+		t.Errorf("size_border = %v, want 0 (progress bar is borderless)", s.SizeBorder)
+	}
+	if s.Radius != RadiusSmall {
+		t.Errorf("radius = %v, want RadiusSmall %v", s.Radius, RadiusSmall)
+	}
+	if !s.TextShow {
+		t.Error("text_show should default true")
+	}
+	if !s.TextBackground.Eq(ColorTransparent) {
+		t.Errorf("text_background = %v, want transparent", s.TextBackground)
+	}
+}
+
+func TestDefaultSliderStyle(t *testing.T) {
+	s := pristineSliderStyle
+	// Both of these are bare literals, not the SizeBorderDef / Radius*
+	// constants — and ThemeMaker computes Radius as cfg.SizeSlider/2.
+	if s.SizeBorder != 1 {
+		t.Errorf("size_border = %v, want literal 1 (not SizeBorderDef %v)",
+			s.SizeBorder, SizeBorderDef)
+	}
+	if s.Radius != 3 {
+		t.Errorf("radius = %v, want literal 3", s.Radius)
+	}
+	if s.Size != 6 {
+		t.Errorf("size = %v, want 6", s.Size)
+	}
+	if s.ThumbSize != 16 {
+		t.Errorf("thumb_size = %v, want 16", s.ThumbSize)
+	}
+}
+
+func TestDefaultTabControlStyle(t *testing.T) {
+	s := pristineTabControlStyle
+	if s.SizeBorder != SizeBorderDef || s.SizeTabBorder != SizeBorderDef {
+		t.Errorf("borders = %v/%v, want SizeBorderDef %v",
+			s.SizeBorder, s.SizeTabBorder, SizeBorderDef)
+	}
+	if s.Radius != RadiusMedium || s.RadiusTab != RadiusSmall {
+		t.Errorf("radius/radius_tab = %v/%v, want %v/%v",
+			s.Radius, s.RadiusTab, RadiusMedium, RadiusSmall)
+	}
+	if s.SpacingHeader != 2 {
+		t.Errorf("spacing_header = %v, want 2", s.SpacingHeader)
+	}
+	// Disabled text is the normal text color at alpha 130.
+	if s.TextStyleDisabled.Color.A != 130 {
+		t.Errorf("disabled alpha = %d, want 130", s.TextStyleDisabled.Color.A)
+	}
+}
+
+func TestDefaultBreadcrumbStyle(t *testing.T) {
+	s := pristineBreadcrumbStyle
+	if s.Separator != "/" {
+		t.Errorf("separator = %q, want %q", s.Separator, "/")
+	}
+	// Disabled crumbs sit at alpha 130, separators at the lighter 160.
+	if s.TextStyleDisabled.Color.A != 130 {
+		t.Errorf("disabled alpha = %d, want 130", s.TextStyleDisabled.Color.A)
+	}
+	if s.TextStyleSeparator.Color.A != 160 {
+		t.Errorf("separator alpha = %d, want 160", s.TextStyleSeparator.Color.A)
+	}
+	if s.SizeContentBorder != SizeBorderDef {
+		t.Errorf("content border = %v, want %v", s.SizeContentBorder, SizeBorderDef)
+	}
+}
+
+func TestDefaultSplitterStyle(t *testing.T) {
+	s := pristineSplitterStyle
+	if s.HandleSize != 9 {
+		t.Errorf("handle_size = %v, want 9", s.HandleSize)
+	}
+	// Keyboard drag increments: 2% normal, 10% with a modifier.
+	if s.DragStep != 0.02 {
+		t.Errorf("drag_step = %v, want 0.02", s.DragStep)
+	}
+	if s.DragStepLarge != 0.10 {
+		t.Errorf("drag_step_large = %v, want 0.10", s.DragStepLarge)
+	}
+}
+
+func TestDefaultTableStyle(t *testing.T) {
+	s := pristineTableStyle
+	if s.ColumnWidthDefault != 50 {
+		t.Errorf("column_width_default = %v, want 50", s.ColumnWidthDefault)
+	}
+	if s.ColumnWidthMin != 20 {
+		t.Errorf("column_width_min = %v, want 20", s.ColumnWidthMin)
+	}
+	if s.AlignHead != HAlignCenter {
+		t.Errorf("align_head = %v, want center", s.AlignHead)
+	}
+	// Header is bold at the normal text size. ThemeMaker instead
+	// overwrites TextStyleHead with theme.B3 after the struct literal.
+	if s.TextStyleHead.Typeface != glyph.TypefaceBold {
+		t.Errorf("head typeface = %v, want bold", s.TextStyleHead.Typeface)
+	}
+	if s.TextStyleHead.Size != pristineTextStyle.Size {
+		t.Errorf("head size = %v, want %v", s.TextStyleHead.Size, pristineTextStyle.Size)
+	}
+}
+
+func TestDefaultComboboxStyle(t *testing.T) {
+	s := pristineComboboxStyle
+	// Fixed RadiusMedium here; ThemeMaker uses cfg.Radius, so a
+	// square-cornered theme still gets a rounded unthemed combobox.
+	if s.Radius != RadiusMedium {
+		t.Errorf("radius = %v, want RadiusMedium %v", s.Radius, RadiusMedium)
+	}
+	if s.MinWidth != 75 || s.MaxWidth != 200 {
+		t.Errorf("width bounds = %v/%v, want 75/200", s.MinWidth, s.MaxWidth)
+	}
+	if s.MaxDropdownHeight != 200 {
+		t.Errorf("max_dropdown_height = %v, want 200", s.MaxDropdownHeight)
+	}
+	// Placeholder alpha 100 matches ThemeMaker's placeholderColor.
+	if s.PlaceholderStyle.Color.A != 100 {
+		t.Errorf("placeholder alpha = %d, want 100", s.PlaceholderStyle.Color.A)
+	}
+}
+
+func TestDefaultCommandPaletteStyle(t *testing.T) {
+	s := pristineCommandPaletteStyle
+	if s.Width != 500 || s.MaxHeight != 400 {
+		t.Errorf("size = %v x %v, want 500 x 400", s.Width, s.MaxHeight)
+	}
+	// Fixed grey; ThemeMaker derives the detail color from the theme
+	// text color at alpha 140 instead.
+	if !s.DetailStyle.Color.Eq(RGBA(128, 128, 128, 200)) {
+		t.Errorf("detail color = %v, want RGBA(128,128,128,200)", s.DetailStyle.Color)
+	}
+	if !s.BackdropColor.Eq(RGBA(0, 0, 0, 120)) {
+		t.Errorf("backdrop = %v, want RGBA(0,0,0,120)", s.BackdropColor)
+	}
+}
+
+func TestDefaultDatePickerStyle(t *testing.T) {
+	s := pristineDatePickerStyle
+	if s.CellSpacing != 2 {
+		t.Errorf("cell_spacing = %v, want 2", s.CellSpacing)
+	}
+	if s.SizeBorder != SizeBorderDef {
+		t.Errorf("size_border = %v, want %v", s.SizeBorder, SizeBorderDef)
+	}
+	if s.Radius != RadiusMedium || s.RadiusBorder != RadiusMedium {
+		t.Errorf("radius/radius_border = %v/%v, want both %v",
+			s.Radius, s.RadiusBorder, RadiusMedium)
+	}
+}
+
+func TestDefaultColorPickerStyle(t *testing.T) {
+	s := pristineColorPickerStyle
+	if s.SVSize != 200 {
+		t.Errorf("sv_size = %v, want 200", s.SVSize)
+	}
+	if s.SliderHeight != 24 {
+		t.Errorf("slider_height = %v, want 24", s.SliderHeight)
+	}
+	if s.IndicatorSize != 16 {
+		t.Errorf("indicator_size = %v, want 16", s.IndicatorSize)
+	}
+}
+
+// ColorHighlight is the one computed value in the control defaults:
+// colorInteriorDark.Add(RGBA(20,20,20,0)). Assert the resolved color so
+// a change to either the base color or Color.Add saturation shows up.
+func TestDefaultSkeletonStyleHighlightResolved(t *testing.T) {
+	s := pristineSkeletonStyle
+	want := RGBA(94, 94, 94, 255) // 74+20 per channel, alpha unchanged
+	if !s.ColorHighlight.Eq(want) {
+		t.Errorf("color_highlight = %v, want %v", s.ColorHighlight, want)
+	}
+	// The highlight must be lighter than the base or the shimmer is invisible.
+	if s.ColorHighlight.R <= s.Color.R {
+		t.Errorf("highlight R %d not lighter than base R %d",
+			s.ColorHighlight.R, s.Color.R)
+	}
+	if s.Radius != RadiusSmall {
+		t.Errorf("radius = %v, want RadiusSmall %v", s.Radius, RadiusSmall)
+	}
+}
+
+func TestDefaultMenubarStyle(t *testing.T) {
+	s := pristineMenubarStyle
+	if s.WidthSubmenuMin != 50 || s.WidthSubmenuMax != 200 {
+		t.Errorf("submenu width = %v/%v, want 50/200",
+			s.WidthSubmenuMin, s.WidthSubmenuMax)
+	}
+	if s.Spacing != SpacingMedium {
+		t.Errorf("spacing = %v, want SpacingMedium %v", s.Spacing, SpacingMedium)
+	}
+	// Submenu items are flush by default; ThemeMaker uses 1 instead.
+	if s.SpacingSubmenu != 0 {
+		t.Errorf("spacing_submenu = %v, want 0", s.SpacingSubmenu)
+	}
+	if s.Radius != RadiusSmall || s.RadiusBorder != RadiusMedium {
+		t.Errorf("radius/radius_border = %v/%v, want %v/%v",
+			s.Radius, s.RadiusBorder, RadiusSmall, RadiusMedium)
+	}
+}
+
+// --- styles_widget_overlay.go ----------------------------------------
+
+// DefaultBadgeStyle leaves TextStyle at its zero value, unlike
+// ThemeMaker which sets it to B5 with a White color. A badge rendered
+// without a theme therefore inherits size 0 and must be given a style
+// by the caller.
+func TestDefaultBadgeStyle(t *testing.T) {
+	s := pristineBadgeStyle
+	if s.TextStyle != (TextStyle{}) {
+		t.Errorf("text_style = %+v, want zero value", s.TextStyle)
+	}
+	if s.DotSize != 8 {
+		t.Errorf("dot_size = %v, want 8", s.DotSize)
+	}
+	// Semantic colors are hard-coded rather than theme-derived, and
+	// match the toast palette exactly.
+	if !s.ColorSuccess.Eq(pristineToastStyle.ColorSuccess) {
+		t.Errorf("badge success %v != toast success %v",
+			s.ColorSuccess, pristineToastStyle.ColorSuccess)
+	}
+	if !s.ColorWarning.Eq(pristineToastStyle.ColorWarning) {
+		t.Errorf("badge warning %v != toast warning %v",
+			s.ColorWarning, pristineToastStyle.ColorWarning)
+	}
+	if !s.ColorError.Eq(pristineToastStyle.ColorError) {
+		t.Errorf("badge error %v != toast error %v",
+			s.ColorError, pristineToastStyle.ColorError)
+	}
+}
+
+func TestDefaultExpandPanelStyle(t *testing.T) {
+	s := pristineExpandPanelStyle
+	if s.SizeBorder != SizeBorderDef {
+		t.Errorf("size_border = %v, want %v", s.SizeBorder, SizeBorderDef)
+	}
+	if s.Radius != RadiusMedium || s.RadiusBorder != RadiusMedium {
+		t.Errorf("radius/radius_border = %v/%v, want both %v",
+			s.Radius, s.RadiusBorder, RadiusMedium)
+	}
+	if s.Color.Eq(Color{}) {
+		t.Error("color should not be the zero Color")
+	}
+	if s.ColorHover.Eq(s.ColorClick) {
+		t.Error("hover and click colors should differ")
+	}
+}
+
+// ToastAnchor is a bare iota enum with no String and no validation, so
+// its ordering is load-bearing for anything persisting the value.
+func TestToastAnchorConstants(t *testing.T) {
+	anchors := []struct {
+		got  ToastAnchor
+		want ToastAnchor
+		name string
+	}{
+		{ToastTopLeft, 0, "ToastTopLeft"},
+		{ToastTopRight, 1, "ToastTopRight"},
+		{ToastBottomLeft, 2, "ToastBottomLeft"},
+		{ToastBottomRight, 3, "ToastBottomRight"},
+	}
+	for _, a := range anchors {
+		if a.got != a.want {
+			t.Errorf("%s = %d, want %d", a.name, a.got, a.want)
+		}
+	}
+}
+
+// DefaultDialogStyle leaves the width bounds unset while ThemeMaker
+// sets 200/300 — an unthemed dialog is therefore unconstrained.
+func TestDefaultDialogStyleWidthBoundsUnset(t *testing.T) {
+	s := pristineDialogStyle
+	if s.MinWidth != 0 || s.MaxWidth != 0 {
+		t.Errorf("width bounds = %v/%v, want 0/0 (ThemeMaker sets 200/300)",
+			s.MinWidth, s.MaxWidth)
+	}
+}
+
+func TestDefaultTreeStyleIndentAndSpacing(t *testing.T) {
+	s := pristineTreeStyle
+	if s.Indent != 25 {
+		t.Errorf("indent = %v, want 25", s.Indent)
+	}
+	if s.Spacing != 0 {
+		t.Errorf("spacing = %v, want 0", s.Spacing)
+	}
+	// Tree chevrons come from the bundled icon font, not the text font.
+	if s.TextStyleIcon.Family != IconFontName {
+		t.Errorf("icon family = %q, want %q", s.TextStyleIcon.Family, IconFontName)
+	}
+}
+
+// --- styles.go --------------------------------------------------------
+
+// DefaultDataGridStyle is declared with no initializer. That is
+// intentional — the datagrid resolves its style from the theme — but it
+// means the package var is not a usable fallback like its siblings.
+func TestDefaultDataGridStyleIsZeroValue(t *testing.T) {
+	if pristineDataGridStyle != (DataGridStyle{}) {
+		t.Errorf("DefaultDataGridStyle = %+v, want the zero value", pristineDataGridStyle)
+	}
+}
+
+// ToGlyphStyle maps only the subset glyph needs. Align, LineSpacing,
+// RotationRadians, AffineTransform and Gradient are handled by go-gui's
+// own render path — glyph.TextStyle has no counterpart fields at all,
+// so the drop is enforced at compile time. What is worth asserting is
+// that populating those go-gui-only fields does not perturb the fields
+// that do cross.
+func TestToGlyphStyleDropsGoGuiOnlyFields(t *testing.T) {
+	affine := glyph.AffineRotation(1.0)
+	base := TextStyle{
+		Family:        "Menlo",
+		Color:         RGBA(1, 2, 3, 255),
+		Size:          17,
+		LetterSpacing: 1.5,
+		Underline:     true,
+		Typeface:      glyph.TypefaceBold,
+	}
+
+	decorated := base
+	decorated.Align = TextAlignCenter
+	decorated.LineSpacing = 2.5
+	decorated.RotationRadians = 1.0
+	decorated.AffineTransform = &affine
+	decorated.Gradient = &glyph.GradientConfig{}
+
+	if base.ToGlyphStyle() != decorated.ToGlyphStyle() {
+		t.Errorf("go-gui-only fields changed the glyph style:\n plain = %+v\n decorated = %+v",
+			base.ToGlyphStyle(), decorated.ToGlyphStyle())
+	}
+}

--- a/gui/styles_widget_test.go
+++ b/gui/styles_widget_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDefaultInputStyleColors(t *testing.T) {
-	s := DefaultInputStyle
+	s := pristineInputStyle
 	if s.Color.Eq(Color{}) {
 		t.Error("input color should not be zero")
 	}
@@ -17,7 +17,7 @@ func TestDefaultInputStyleColors(t *testing.T) {
 }
 
 func TestDefaultScrollbarStyle(t *testing.T) {
-	s := DefaultScrollbarStyle
+	s := pristineScrollbarStyle
 	if s.Size != 7 {
 		t.Errorf("scrollbar size = %f", s.Size)
 	}
@@ -33,11 +33,11 @@ func TestDefaultWidgetStylesNonZero(t *testing.T) {
 		name   string
 		radius float32
 	}{
-		{"radio", DefaultRadioStyle.SizeBorder},
-		{"switch", DefaultSwitchStyle.SizeBorder},
-		{"toggle", DefaultToggleStyle.SizeBorder},
-		{"select", DefaultSelectStyle.SizeBorder},
-		{"listbox", DefaultListBoxStyle.SizeBorder},
+		{"radio", pristineRadioStyle.SizeBorder},
+		{"switch", pristineSwitchStyle.SizeBorder},
+		{"toggle", pristineToggleStyle.SizeBorder},
+		{"select", pristineSelectStyle.SizeBorder},
+		{"listbox", pristineListBoxStyle.SizeBorder},
 	}
 	for _, s := range styles {
 		if s.radius == 0 {
@@ -47,7 +47,7 @@ func TestDefaultWidgetStylesNonZero(t *testing.T) {
 }
 
 func TestDefaultDialogStyle(t *testing.T) {
-	s := DefaultDialogStyle
+	s := pristineDialogStyle
 	if s.Color.Eq(Color{}) {
 		t.Error("dialog color should not be zero")
 	}
@@ -60,7 +60,7 @@ func TestDefaultDialogStyle(t *testing.T) {
 }
 
 func TestDefaultToastStyle(t *testing.T) {
-	s := DefaultToastStyle
+	s := pristineToastStyle
 	if s.MaxVisible != 5 {
 		t.Errorf("max_visible = %d, want 5", s.MaxVisible)
 	}
@@ -73,7 +73,7 @@ func TestDefaultToastStyle(t *testing.T) {
 }
 
 func TestDefaultTooltipStyle(t *testing.T) {
-	s := DefaultTooltipStyle
+	s := pristineTooltipStyle
 	if s.Delay == 0 {
 		t.Error("delay should not be zero")
 	}
@@ -121,7 +121,7 @@ func TestEffectiveTextTransformDefault(t *testing.T) {
 }
 
 func TestDefaultTreeStyle(t *testing.T) {
-	s := DefaultTreeStyle
+	s := pristineTreeStyle
 	if !s.ColorHover.IsSet() {
 		t.Error("tree hover color should be set")
 	}

--- a/gui/theme_maker_test.go
+++ b/gui/theme_maker_test.go
@@ -109,3 +109,193 @@ func TestPresetThemesIconFamily(t *testing.T) {
 		}
 	}
 }
+
+// --- Derivation branches ---------------------------------------------
+//
+// ThemeMaker computes four values up front (theme_maker.go:22-35) and
+// then fans them out across many widget styles. The tests below pin
+// those derivations rather than re-asserting every consumer.
+
+// borderFocus falls back to ColorSelect only when ColorBorderFocus is
+// the exact zero Color — Color.Eq compares the IsSet flag too, so a
+// deliberately transparent-but-set color does NOT trigger the fallback.
+func TestThemeMakerBorderFocusFallsBackToSelect(t *testing.T) {
+	cfg := baseCfg()
+	cfg.ColorSelect = RGBA(10, 20, 30, 255)
+	cfg.ColorBorderFocus = Color{} // unset
+
+	theme := ThemeMaker(cfg)
+	consumers := map[string]Color{
+		"ButtonStyle": theme.ButtonStyle.ColorBorderFocus,
+		"ToggleStyle": theme.ToggleStyle.ColorBorderFocus,
+		"SliderStyle": theme.SliderStyle.ColorBorderFocus,
+		"TabControl":  theme.TabControlStyle.ColorTabBorderFocus,
+	}
+	for name, got := range consumers {
+		if !got.Eq(cfg.ColorSelect) {
+			t.Errorf("%s.ColorBorderFocus = %v, want ColorSelect %v",
+				name, got, cfg.ColorSelect)
+		}
+	}
+}
+
+func TestThemeMakerBorderFocusExplicitWins(t *testing.T) {
+	cfg := baseCfg()
+	cfg.ColorSelect = RGBA(10, 20, 30, 255)
+	cfg.ColorBorderFocus = RGBA(200, 100, 50, 255)
+
+	theme := ThemeMaker(cfg)
+	if !theme.ButtonStyle.ColorBorderFocus.Eq(cfg.ColorBorderFocus) {
+		t.Errorf("ButtonStyle.ColorBorderFocus = %v, want %v",
+			theme.ButtonStyle.ColorBorderFocus, cfg.ColorBorderFocus)
+	}
+	if !theme.SliderStyle.ColorBorderFocus.Eq(cfg.ColorBorderFocus) {
+		t.Errorf("SliderStyle.ColorBorderFocus = %v, want %v",
+			theme.SliderStyle.ColorBorderFocus, cfg.ColorBorderFocus)
+	}
+}
+
+// The scrollbar radius keys off cfg.Radius, NOT cfg.RadiusSmall — so a
+// square-cornered theme squares the scrollbar even when RadiusSmall is
+// rounded. This is the surprising half of the branch.
+func TestThemeMakerScrollbarRadiusForcedNoneByRadius(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Radius = RadiusNone
+	cfg.RadiusSmall = RadiusSmall // deliberately rounded
+
+	theme := ThemeMaker(cfg)
+	if theme.ScrollbarStyle.Radius != RadiusNone {
+		t.Errorf("ScrollbarStyle.Radius = %v, want RadiusNone", theme.ScrollbarStyle.Radius)
+	}
+	if theme.ScrollbarStyle.RadiusThumb != RadiusNone {
+		t.Errorf("ScrollbarStyle.RadiusThumb = %v, want RadiusNone",
+			theme.ScrollbarStyle.RadiusThumb)
+	}
+}
+
+func TestThemeMakerScrollbarRadiusUsesRadiusSmall(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Radius = RadiusMedium
+	cfg.RadiusSmall = RadiusSmall
+
+	theme := ThemeMaker(cfg)
+	if theme.ScrollbarStyle.Radius != RadiusSmall {
+		t.Errorf("ScrollbarStyle.Radius = %v, want RadiusSmall %v",
+			theme.ScrollbarStyle.Radius, RadiusSmall)
+	}
+	if theme.ScrollbarStyle.RadiusThumb != RadiusSmall {
+		t.Errorf("ScrollbarStyle.RadiusThumb = %v, want RadiusSmall %v",
+			theme.ScrollbarStyle.RadiusThumb, RadiusSmall)
+	}
+}
+
+// Placeholder text reuses the default text RGB with a hard-coded alpha
+// of 100, shared by Input, Select and Combobox.
+func TestThemeMakerPlaceholderColor(t *testing.T) {
+	cfg := baseCfg()
+	cfg.TextStyleDef = TextStyle{Color: RGBA(220, 210, 200, 255), Size: SizeTextMedium}
+
+	theme := ThemeMaker(cfg)
+	want := RGBA(220, 210, 200, 100)
+	placeholders := map[string]TextStyle{
+		"InputStyle":    theme.InputStyle.PlaceholderStyle,
+		"SelectStyle":   theme.SelectStyle.PlaceholderStyle,
+		"ComboboxStyle": theme.ComboboxStyle.PlaceholderStyle,
+	}
+	for name, got := range placeholders {
+		if !got.Color.Eq(want) {
+			t.Errorf("%s.PlaceholderStyle.Color = %v, want %v", name, got.Color, want)
+		}
+		if got.Size != cfg.TextStyleDef.Size {
+			t.Errorf("%s.PlaceholderStyle.Size = %v, want %v",
+				name, got.Size, cfg.TextStyleDef.Size)
+		}
+	}
+}
+
+// TableStyle.TextStyleHead and BadgeStyle.TextStyle are assigned AFTER
+// the struct literal (theme_maker.go:538-540), overwriting whatever the
+// literal set. Pin the final values so a future edit to the literal
+// cannot silently appear to take effect.
+func TestThemeMakerPostLiteralOverwrites(t *testing.T) {
+	cfg := baseCfg()
+	cfg.TextStyleDef = TextStyle{Color: RGBA(200, 200, 200, 255), Size: SizeTextMedium}
+	theme := ThemeMaker(cfg)
+
+	if theme.TableStyle.TextStyleHead != theme.B3 {
+		t.Errorf("TableStyle.TextStyleHead = %+v, want B3 %+v",
+			theme.TableStyle.TextStyleHead, theme.B3)
+	}
+
+	wantBadge := theme.B5
+	wantBadge.Color = White
+	if theme.BadgeStyle.TextStyle != wantBadge {
+		t.Errorf("BadgeStyle.TextStyle = %+v, want B5 with White color %+v",
+			theme.BadgeStyle.TextStyle, wantBadge)
+	}
+	if !theme.BadgeStyle.TextStyle.Color.Eq(White) {
+		t.Errorf("BadgeStyle.TextStyle.Color = %v, want White",
+			theme.BadgeStyle.TextStyle.Color)
+	}
+}
+
+// Sizes derived from cfg rather than copied straight through.
+func TestThemeMakerDerivedSizes(t *testing.T) {
+	cfg := baseCfg()
+	cfg.TextStyleDef = TextStyle{Size: 18}
+	cfg.SizeSlider = 10
+
+	theme := ThemeMaker(cfg)
+	if theme.ToggleStyle.Size != 22 {
+		t.Errorf("ToggleStyle.Size = %v, want TextStyleDef.Size+4 = 22",
+			theme.ToggleStyle.Size)
+	}
+	if theme.SliderStyle.Radius != 5 {
+		t.Errorf("SliderStyle.Radius = %v, want SizeSlider/2 = 5",
+			theme.SliderStyle.Radius)
+	}
+}
+
+// SizeSlider is not clamped: a zero slider size yields a zero radius
+// rather than a default. Documented, not a bug to "fix" here.
+func TestThemeMakerSliderRadiusZeroSizeNotClamped(t *testing.T) {
+	cfg := baseCfg()
+	cfg.SizeSlider = 0
+
+	theme := ThemeMaker(cfg)
+	if theme.SliderStyle.Radius != 0 {
+		t.Errorf("SliderStyle.Radius = %v, want 0 for SizeSlider 0",
+			theme.SliderStyle.Radius)
+	}
+}
+
+// A wholly empty ThemeCfg must still build a Theme without panicking.
+// Every size lands at zero and every color transparent — only the icon
+// family falls back.
+func TestThemeMakerZeroCfg(t *testing.T) {
+	theme := ThemeMaker(ThemeCfg{})
+
+	if theme.Name != "" {
+		t.Errorf("Name = %q, want empty", theme.Name)
+	}
+	for i, got := range iconStyleFamilies(theme) {
+		if got != IconFontName {
+			t.Errorf("icon style %d family = %q, want fallback %q",
+				i, got, IconFontName)
+		}
+	}
+	if theme.ButtonStyle.Radius != 0 || theme.ButtonStyle.SizeBorder != 0 {
+		t.Errorf("ButtonStyle radius/border = %v/%v, want 0/0",
+			theme.ButtonStyle.Radius, theme.ButtonStyle.SizeBorder)
+	}
+	// borderFocus fallback resolves to the (also zero) ColorSelect.
+	if !theme.ButtonStyle.ColorBorderFocus.Eq(Color{}) {
+		t.Errorf("ButtonStyle.ColorBorderFocus = %v, want zero Color",
+			theme.ButtonStyle.ColorBorderFocus)
+	}
+	// Placeholder alpha is unconditional, even over a zero text color.
+	if theme.InputStyle.PlaceholderStyle.Color.A != 100 {
+		t.Errorf("placeholder alpha = %d, want 100",
+			theme.InputStyle.PlaceholderStyle.Color.A)
+	}
+}

--- a/gui/view_form_test.go
+++ b/gui/view_form_test.go
@@ -366,3 +366,431 @@ func TestFormShouldValidate(t *testing.T) {
 		}
 	}
 }
+
+// --- Layout-walking variants -----------------------------------------
+//
+// Only the *ByID entry points were covered; these are the ones widgets
+// actually call from AmendLayout, where the form ID must be recovered
+// from the parent chain.
+
+// formLayoutFixture builds a form -> child parent chain and returns the
+// child, which is what a widget's AmendLayout would hold.
+func formLayoutFixture(formID string) *Layout {
+	parent := &Layout{Shape: &Shape{ID: formLayoutID(formID)}}
+	return &Layout{Shape: &Shape{ID: "input-1"}, Parent: parent}
+}
+
+func TestFormRegisterFieldViaLayout(t *testing.T) {
+	w := newTestWindow()
+	child := formLayoutFixture("layout-form")
+
+	FormRegisterField(w, child, FormFieldAdapterCfg{
+		FieldID: "email",
+		Value:   "a@b.c",
+	})
+
+	fs, ok := w.FormFieldState("layout-form", "email")
+	if !ok {
+		t.Fatal("field not registered against the ancestor form")
+	}
+	if fs.Value != "a@b.c" {
+		t.Errorf("value = %q, want %q", fs.Value, "a@b.c")
+	}
+}
+
+func TestFormRegisterFieldNoOps(t *testing.T) {
+	// Each of these must leave the form state untouched rather than
+	// panic — widgets call this unconditionally from AmendLayout.
+	cases := []struct {
+		name   string
+		layout *Layout
+		cfg    FormFieldAdapterCfg
+	}{
+		{"nil layout", nil, FormFieldAdapterCfg{FieldID: "f"}},
+		{"empty field id", formLayoutFixture("f1"), FormFieldAdapterCfg{}},
+		{
+			"no ancestor form",
+			&Layout{Shape: &Shape{ID: "loose-input"}},
+			FormFieldAdapterCfg{FieldID: "f"},
+		},
+	}
+	for _, tc := range cases {
+		w := newTestWindow()
+		FormRegisterField(w, tc.layout, tc.cfg)
+		if state := formRuntimeRead(w, "f1"); state != nil && len(state.fields) > 0 {
+			t.Errorf("%s: expected no field registration, got %d",
+				tc.name, len(state.fields))
+		}
+	}
+}
+
+func TestFormOnFieldEventViaLayout(t *testing.T) {
+	w := newTestWindow()
+	child := formLayoutFixture("evt-form")
+
+	required := func(f FormFieldSnapshot, _ FormSnapshot) []FormIssue {
+		if f.Value == "" {
+			return []FormIssue{{Msg: "required"}}
+		}
+		return nil
+	}
+	cfg := FormFieldAdapterCfg{
+		FieldID:        "name",
+		Value:          "",
+		SyncValidators: []FormSyncValidator{required},
+	}
+
+	FormRegisterField(w, child, cfg)
+	FormOnFieldEvent(w, child, cfg, FormTriggerBlur)
+
+	issues := w.FormFieldErrors("evt-form", "name")
+	if len(issues) != 1 || issues[0].Msg != "required" {
+		t.Fatalf("expected the sync validator to run, got %v", issues)
+	}
+
+	fs, _ := w.FormFieldState("evt-form", "name")
+	if !fs.Touched {
+		t.Error("blur should mark the field touched")
+	}
+}
+
+func TestFormOnFieldEventNoOps(t *testing.T) {
+	w := newTestWindow()
+	// Empty FieldID and a layout with no ancestor form both return
+	// before touching form state.
+	FormOnFieldEvent(w, formLayoutFixture("f1"), FormFieldAdapterCfg{},
+		FormTriggerBlur)
+	FormOnFieldEvent(w, &Layout{Shape: &Shape{ID: "loose"}},
+		FormFieldAdapterCfg{FieldID: "f"}, FormTriggerBlur)
+
+	if state := formRuntimeRead(w, "f1"); state != nil && len(state.fields) > 0 {
+		t.Errorf("expected no fields, got %d", len(state.fields))
+	}
+}
+
+// --- Submit / reset requests -----------------------------------------
+
+func TestFormRequestSubmitSetsFlag(t *testing.T) {
+	w := newTestWindow()
+	FormRequestSubmit(w, "req-form")
+
+	state := formRuntimeRead(w, "req-form")
+	if state == nil {
+		t.Fatal("expected form state to be created lazily")
+	}
+	if !state.submitReq {
+		t.Error("submitReq not set")
+	}
+}
+
+func TestFormRequestResetSetsFlag(t *testing.T) {
+	w := newTestWindow()
+	FormRequestReset(w, "req-form")
+
+	state := formRuntimeRead(w, "req-form")
+	if state == nil {
+		t.Fatal("expected form state to be created lazily")
+	}
+	if !state.resetReq {
+		t.Error("resetReq not set")
+	}
+}
+
+func TestFormRequestEmptyIDNoOp(t *testing.T) {
+	// An empty ID must not create a state entry under "".
+	w := newTestWindow()
+	FormRequestSubmit(w, "")
+	FormRequestReset(w, "")
+	if state := formRuntimeRead(w, ""); state != nil {
+		t.Error("empty form ID should not create form state")
+	}
+}
+
+// FormSubmit/FormReset are aliases; assert they hit the same flags so a
+// future divergence is caught.
+func TestFormSubmitResetMethodAliases(t *testing.T) {
+	w := newTestWindow()
+	w.FormSubmit("alias-form")
+	w.FormReset("alias-form")
+
+	state := formRuntimeRead(w, "alias-form")
+	if state == nil {
+		t.Fatal("expected form state")
+	}
+	if !state.submitReq {
+		t.Error("FormSubmit did not set submitReq")
+	}
+	if !state.resetReq {
+		t.Error("FormReset did not set resetReq")
+	}
+}
+
+// --- FormRequestSubmitForLayout --------------------------------------
+
+func TestFormRequestSubmitForLayoutSuccess(t *testing.T) {
+	w := newTestWindow()
+	child := formLayoutFixture("enter-form")
+	formApplyCfg(w, "enter-form", FormCfg{ID: "enter-form"}) // submitOnEnter defaults on
+
+	FormRequestSubmitForLayout(w, child)
+
+	state := formRuntimeRead(w, "enter-form")
+	if state == nil || !state.submitReq {
+		t.Fatal("Enter on a field should have requested submit")
+	}
+}
+
+func TestFormRequestSubmitForLayoutSuppressedWhenDisabled(t *testing.T) {
+	w := newTestWindow()
+	child := formLayoutFixture("no-enter-form")
+	formApplyCfg(w, "no-enter-form", FormCfg{
+		ID:              "no-enter-form",
+		NoSubmitOnEnter: true,
+	})
+
+	FormRequestSubmitForLayout(w, child)
+
+	state := formRuntimeRead(w, "no-enter-form")
+	if state == nil {
+		t.Fatal("expected existing form state")
+	}
+	if state.submitReq {
+		t.Error("NoSubmitOnEnter should suppress the submit request")
+	}
+}
+
+func TestFormRequestSubmitForLayoutEarlyReturns(t *testing.T) {
+	// nil layout, nil Shape and no-ancestor all bail before touching
+	// state. The un-applied-cfg case bails on formRuntimeRead == nil:
+	// a form that never rendered has no state, so Enter does nothing
+	// even though the layout chain resolves.
+	w := newTestWindow()
+	FormRequestSubmitForLayout(w, nil)
+	FormRequestSubmitForLayout(w, &Layout{})
+	FormRequestSubmitForLayout(w, &Layout{Shape: &Shape{ID: "loose"}})
+	FormRequestSubmitForLayout(w, formLayoutFixture("never-rendered"))
+
+	if state := formRuntimeRead(w, "never-rendered"); state != nil {
+		t.Error("expected no form state for a form that never applied its cfg")
+	}
+}
+
+// --- Summary / pending -------------------------------------------------
+
+func TestFormSummaryUnknownFormIsValid(t *testing.T) {
+	// An unknown form reads as valid so callers can gate a submit
+	// button before the form has rendered.
+	w := newTestWindow()
+	got := w.FormSummary("nope")
+	if !got.Valid {
+		t.Error("unknown form should read as valid")
+	}
+	if got.Pending || got.InvalidCount != 0 || got.PendingCount != 0 {
+		t.Errorf("unknown form summary = %+v, want zero counts", got)
+	}
+	if got.Issues != nil {
+		t.Errorf("Issues = %v, want nil", got.Issues)
+	}
+}
+
+func TestFormSummaryIssuesNilWhenClean(t *testing.T) {
+	// The Issues map is allocated lazily — a clean form must not pay
+	// for it.
+	w := newTestWindow()
+	FormRegisterFieldByID(w, "clean", FormFieldAdapterCfg{
+		FieldID: "a", Value: "ok",
+	})
+
+	got := w.FormSummary("clean")
+	if !got.Valid {
+		t.Error("form with no errors should be valid")
+	}
+	if got.Issues != nil {
+		t.Errorf("Issues = %v, want nil for a clean form", got.Issues)
+	}
+}
+
+func TestFormSummaryCountsInvalidFields(t *testing.T) {
+	w := newTestWindow()
+	formID := "sum-form"
+	required := func(f FormFieldSnapshot, _ FormSnapshot) []FormIssue {
+		if f.Value == "" {
+			return []FormIssue{{Msg: "required"}}
+		}
+		return nil
+	}
+	for _, id := range []string{"a", "b"} {
+		cfg := FormFieldAdapterCfg{
+			FieldID:        id,
+			Value:          "",
+			SyncValidators: []FormSyncValidator{required},
+		}
+		FormRegisterFieldByID(w, formID, cfg)
+		FormOnFieldEventByID(w, formID, cfg, FormTriggerBlur)
+	}
+
+	got := w.FormSummary(formID)
+	if got.Valid {
+		t.Error("form with two failing fields should be invalid")
+	}
+	if got.InvalidCount != 2 {
+		t.Errorf("InvalidCount = %d, want 2", got.InvalidCount)
+	}
+	if len(got.Issues) != 2 {
+		t.Errorf("Issues has %d entries, want 2", len(got.Issues))
+	}
+}
+
+func TestFormPendingStateUnknownForm(t *testing.T) {
+	w := newTestWindow()
+	got := w.FormPendingState("nope")
+	if got.FormID != "nope" {
+		t.Errorf("FormID = %q, want %q", got.FormID, "nope")
+	}
+	if got.FieldIDs != nil {
+		t.Errorf("FieldIDs = %v, want nil", got.FieldIDs)
+	}
+	if got.PendingCount != 0 {
+		t.Errorf("PendingCount = %d, want 0", got.PendingCount)
+	}
+}
+
+func TestFormPendingStateSortsFieldIDs(t *testing.T) {
+	// Map iteration is random; the ID list must come back sorted so
+	// callers can render a stable "validating…" list.
+	w := newTestWindow()
+	formID := "pending-form"
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+
+	slowVal := func(
+		_ FormFieldSnapshot, _ FormSnapshot, _ *GridAbortSignal,
+	) []FormIssue {
+		<-block
+		return nil
+	}
+
+	for _, id := range []string{"zeta", "alpha", "mid"} {
+		cfg := FormFieldAdapterCfg{
+			FieldID:         id,
+			Value:           "v",
+			AsyncValidators: []FormAsyncValidator{slowVal},
+		}
+		FormRegisterFieldByID(w, formID, cfg)
+		FormOnFieldEventByID(w, formID, cfg, FormTriggerBlur)
+	}
+
+	got := w.FormPendingState(formID)
+	if got.PendingCount != 3 {
+		t.Fatalf("PendingCount = %d, want 3", got.PendingCount)
+	}
+	want := []string{"alpha", "mid", "zeta"}
+	for i, id := range want {
+		if got.FieldIDs[i] != id {
+			t.Errorf("FieldIDs[%d] = %q, want %q", i, got.FieldIDs[i], id)
+		}
+	}
+}
+
+// --- Stale async results ---------------------------------------------
+
+// Every revalidation bumps requestSeq. A result carrying an older
+// requestID belongs to an aborted run and must be dropped, or a slow
+// stale validator would clobber the current field state.
+func TestFormApplyAsyncResultDropsStaleRequest(t *testing.T) {
+	w := newTestWindow()
+	formID := "stale-form"
+
+	cfg := FormFieldAdapterCfg{
+		FieldID: "f",
+		Value:   "v",
+		AsyncValidators: []FormAsyncValidator{
+			func(_ FormFieldSnapshot, _ FormSnapshot, _ *GridAbortSignal) []FormIssue {
+				return nil
+			},
+		},
+	}
+	FormRegisterFieldByID(w, formID, cfg)
+	FormOnFieldEventByID(w, formID, cfg, FormTriggerBlur)
+
+	state := formRuntimeRead(w, formID)
+	field := state.fields["f"]
+	current := field.requestSeq
+
+	formApplyAsyncResult(w, formID, "f", current-1,
+		[]FormIssue{{Msg: "stale"}})
+
+	if len(field.asyncErrors) != 0 {
+		t.Errorf("stale result applied: asyncErrors = %v", field.asyncErrors)
+	}
+	if !field.pending {
+		t.Error("stale result cleared the pending flag")
+	}
+
+	// The in-flight result for the current request still lands.
+	formApplyAsyncResult(w, formID, "f", current,
+		[]FormIssue{{Msg: "fresh"}})
+	if len(field.asyncErrors) != 1 || field.asyncErrors[0].Msg != "fresh" {
+		t.Errorf("current result not applied: %v", field.asyncErrors)
+	}
+	if field.pending {
+		t.Error("current result should have cleared pending")
+	}
+}
+
+func TestFormApplyAsyncResultUnknownTargets(t *testing.T) {
+	// Unknown form and unknown field both return early rather than
+	// creating state — an async result can outlive its form.
+	w := newTestWindow()
+	formApplyAsyncResult(w, "ghost", "f", 1, []FormIssue{{Msg: "x"}})
+	if formRuntimeRead(w, "ghost") != nil {
+		t.Error("async result should not create form state")
+	}
+
+	FormRegisterFieldByID(w, "real", FormFieldAdapterCfg{FieldID: "a", Value: "v"})
+	formApplyAsyncResult(w, "real", "missing", 1, []FormIssue{{Msg: "x"}})
+	if _, ok := w.FormFieldState("real", "missing"); ok {
+		t.Error("async result should not create a field")
+	}
+}
+
+// FormFieldErrors returns the underlying syncErrors/asyncErrors slice
+// whenever one side is empty (formMergeErrors takes that shortcut), and
+// those slices are truncated with [:0] and re-appended in place on the
+// next validation. A retained result therefore aliases live state.
+// Callers must clone before holding across a frame; this test documents
+// the contract so it is not mistaken for a defensive copy.
+func TestFormFieldErrorsAliasesRuntimeSlice(t *testing.T) {
+	w := newTestWindow()
+	formID := "alias-errors"
+
+	msg := "first"
+	validator := func(_ FormFieldSnapshot, _ FormSnapshot) []FormIssue {
+		return []FormIssue{{Msg: msg}}
+	}
+	cfg := FormFieldAdapterCfg{
+		FieldID:        "f",
+		Value:          "v",
+		SyncValidators: []FormSyncValidator{validator},
+	}
+
+	FormRegisterFieldByID(w, formID, cfg)
+	FormOnFieldEventByID(w, formID, cfg, FormTriggerBlur)
+
+	retained := w.FormFieldErrors(formID, "f")
+	if len(retained) != 1 || retained[0].Msg != "first" {
+		t.Fatalf("setup: got %v, want one 'first' issue", retained)
+	}
+
+	// Revalidate with a different message. The runtime reuses the same
+	// backing array, so the retained slice observes the new value.
+	msg = "second"
+	FormOnFieldEventByID(w, formID, cfg, FormTriggerBlur)
+
+	if retained[0].Msg != "second" {
+		t.Errorf("retained[0].Msg = %q, want %q — formMergeErrors is "+
+			"documented to alias the runtime slice; if this now returns "+
+			"a copy, update the doc comment on FormFieldErrors",
+			retained[0].Msg, "second")
+	}
+}

--- a/gui/window.go
+++ b/gui/window.go
@@ -29,11 +29,14 @@ type FontLister interface {
 }
 
 // ListSystemFonts returns font family names from the active text
-// system's catalog, sorted case-insensitively. Returns nil before
-// backend init, on WASM stub backends, or on backends that do not
-// implement FontLister. Includes RegisterAppFont families once those
-// paths have been added to the text system.
+// system's catalog, sorted case-insensitively. Returns nil for a nil
+// window, before backend init, on WASM stub backends, or on backends
+// that do not implement FontLister. Includes RegisterAppFont families
+// once those paths have been added to the text system.
 func ListSystemFonts(w *Window) []string {
+	if w == nil {
+		return nil
+	}
 	if fl, ok := w.textMeasurer.(FontLister); ok {
 		return fl.ListFontFamilies()
 	}

--- a/gui/window_accessors_test.go
+++ b/gui/window_accessors_test.go
@@ -1,0 +1,186 @@
+package gui
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// fontListerMeasurer is a TextMeasurer that also implements FontLister.
+// stubTextMeasurer (layout_pipeline_test.go) deliberately does NOT
+// implement FontLister, so it doubles as the negative case below.
+type fontListerMeasurer struct {
+	stubTextMeasurer
+	families []string
+}
+
+func (m *fontListerMeasurer) ListFontFamilies() []string { return m.families }
+
+func TestListSystemFontsNilMeasurer(t *testing.T) {
+	// Before backend init w.textMeasurer is nil — the type assertion
+	// must fail cleanly rather than panic.
+	w := newTestWindow()
+	if got := ListSystemFonts(w); got != nil {
+		t.Fatalf("ListSystemFonts with nil measurer = %v, want nil", got)
+	}
+}
+
+func TestListSystemFontsNilWindow(t *testing.T) {
+	// Matches the nil-receiver tolerance of TextWidth and Now: a font
+	// picker built before the window exists degrades to an empty list
+	// instead of panicking.
+	if got := ListSystemFonts(nil); got != nil {
+		t.Fatalf("ListSystemFonts(nil) = %v, want nil", got)
+	}
+}
+
+func TestListSystemFontsMeasurerWithoutFontLister(t *testing.T) {
+	// FontLister is an optional capability; a plain measurer opts out.
+	w := newTestWindow()
+	w.SetTextMeasurer(&stubTextMeasurer{charWidth: 10, fontHeight: 20})
+	if got := ListSystemFonts(w); got != nil {
+		t.Fatalf("ListSystemFonts without FontLister = %v, want nil", got)
+	}
+}
+
+func TestListSystemFontsReturnsFamilies(t *testing.T) {
+	want := []string{"Helvetica", "Menlo"}
+	w := newTestWindow()
+	w.SetTextMeasurer(&fontListerMeasurer{families: want})
+
+	got := ListSystemFonts(w)
+	if len(got) != len(want) {
+		t.Fatalf("ListSystemFonts len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("family[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestListSystemFontsEmptyCatalog(t *testing.T) {
+	// A FontLister with nothing registered returns nil, not a panic.
+	w := newTestWindow()
+	w.SetTextMeasurer(&fontListerMeasurer{families: nil})
+	if got := ListSystemFonts(w); got != nil {
+		t.Fatalf("ListSystemFonts with empty catalog = %v, want nil", got)
+	}
+}
+
+func TestWindowTextMeasurerRoundTrip(t *testing.T) {
+	w := newTestWindow()
+	if w.TextMeasurer() != nil {
+		t.Fatal("expected nil measurer on a fresh window")
+	}
+
+	tm := &stubTextMeasurer{charWidth: 7, fontHeight: 14}
+	w.SetTextMeasurer(tm)
+	if w.TextMeasurer() != tm {
+		t.Fatal("TextMeasurer did not return the measurer set by SetTextMeasurer")
+	}
+
+	// Backends may clear the measurer during teardown.
+	w.SetTextMeasurer(nil)
+	if w.TextMeasurer() != nil {
+		t.Fatal("expected nil measurer after SetTextMeasurer(nil)")
+	}
+}
+
+func TestWindowTimingsZeroBeforeFirstFrame(t *testing.T) {
+	// Timings reports the previous frame's numbers; before any frame
+	// has run it must read as the zero value rather than garbage.
+	w := newTestWindow()
+	if got := (w.Timings()); got != (FrameTimings{}) {
+		t.Fatalf("Timings before first frame = %+v, want zero value", got)
+	}
+}
+
+func TestWindowAppNilInSingleWindowMode(t *testing.T) {
+	// A window built without an App parent reports nil; widgets that
+	// reach for multi-window services must nil-check.
+	w := newTestWindow()
+	if got := w.App(); got != nil {
+		t.Fatalf("App() = %v, want nil for a standalone window", got)
+	}
+}
+
+func TestWindowLockUnlockPair(t *testing.T) {
+	// Lock/Unlock are a raw mutex passthrough; a matched pair must not
+	// deadlock and must leave the mutex reacquirable.
+	w := newTestWindow()
+
+	w.Lock()
+	w.windowWidth = 640
+	w.Unlock()
+
+	w.Lock()
+	w.windowHeight = 480
+	w.Unlock()
+
+	if gotW, gotH := w.WindowSize(); gotW != 640 || gotH != 480 {
+		t.Fatalf("WindowSize = %dx%d, want 640x480", gotW, gotH)
+	}
+}
+
+func TestWindowLockExcludesSecondHolder(t *testing.T) {
+	w := newTestWindow()
+
+	var wg sync.WaitGroup
+	acquired := make(chan struct{})
+
+	w.Lock()
+	wg.Go(func() {
+		w.Lock()
+		close(acquired)
+		w.Unlock()
+	})
+
+	// The goroutine must still be blocked while this side holds the lock.
+	select {
+	case <-acquired:
+		t.Fatal("second Lock succeeded while the window mutex was held")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	w.Unlock()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second Lock never acquired after Unlock")
+	}
+	wg.Wait()
+}
+
+func TestClearDrawCanvasCacheEmptyRegistry(t *testing.T) {
+	// Called on every theme change, including before any canvas has
+	// been drawn — an uninitialized registry must be a no-op.
+	w := newTestWindow()
+	w.ClearDrawCanvasCache()
+}
+
+func TestClearDrawCanvasCacheDropsEntries(t *testing.T) {
+	w := newTestWindow()
+
+	sm := StateMap[string, DrawCanvasCache](w, nsDrawCanvas, capModerate)
+	sm.Set("canvas-1", DrawCanvasCache{Version: 7})
+	if _, ok := sm.Get("canvas-1"); !ok {
+		t.Fatal("seeded cache entry not readable")
+	}
+
+	w.ClearDrawCanvasCache()
+
+	// ClearNamespace drops the whole map, so the namespace reads back nil.
+	if got := StateMapRead[string, DrawCanvasCache](w, nsDrawCanvas); got != nil {
+		t.Fatal("expected nsDrawCanvas namespace to be cleared")
+	}
+}
+
+func TestSetWakeMainFnAcceptsNil(t *testing.T) {
+	// Headless/test windows never get a wake fn; clearing it must not
+	// panic. The invocation path is covered by TestQueueCommandWakesMain.
+	w := newTestWindow()
+	w.SetWakeMainFn(func() {})
+	w.SetWakeMainFn(nil)
+}


### PR DESCRIPTION
Closes #53.

## Context

Issue 53 listed six files as having "no dedicated test file". That table was derived from filename matching, not actual coverage — five of the six already had tests. This PR closes the *real* gaps rather than duplicating existing coverage. Details posted on the issue.

| File | Issue claim | Actual |
|------|-------------|--------|
| `gui/window.go` | untested | ~30 tests across 5 files |
| `gui/theme_maker.go` | untested | `theme_maker_test.go` — icon/mono family only |
| `gui/styles.go` | untested | `styles_core_test.go` — 11 tests |
| `gui/styles_widget_control.go` | untested | **genuinely untested** |
| `gui/styles_widget_overlay.go` | untested | 4 of 7 default styles |
| `gui/view_form_process.go` | untested | `view_form_test.go` — ~15 tests |

## New tests (59)

- **`gui/window_accessors_test.go`** (new) — `ListSystemFonts` (the only wholly untested export in `window.go`), `TextMeasurer()`, `Timings()`, `App()`, `Lock`/`Unlock` incl. mutual exclusion, `ClearDrawCanvasCache`, `SetWakeMainFn`.
- **`gui/theme_maker_test.go`** — the four derivation branches at the top of `ThemeMaker` (`borderFocus` fallback, `sbRadius` coupling to `cfg.Radius` rather than `cfg.RadiusSmall`, placeholder alpha), the post-literal `TableStyle.TextStyleHead` / `BadgeStyle.TextStyle` overwrites, derived sizes, zero-`ThemeCfg` contract.
- **`gui/styles_widget_defaults_test.go`** (new) — pins the `Default*Style` package vars from `styles_widget_control.go` plus the overlay gaps, with comments naming each divergence from `ThemeMaker` output (progress bar border, slider literals, menubar submenu spacing, combobox radius, dialog width bounds, badge text style).
- **`gui/view_form_test.go`** — the untested exported surface of `view_form_process.go`: layout-walking `FormRegisterField`/`FormOnFieldEvent`, `FormRequestSubmit`/`Reset`, every `FormRequestSubmitForLayout` early return, `FormSummary`, `FormPendingState`, the `FormSubmit`/`FormReset` aliases, and the stale-`requestID` guard in `formApplyAsyncResult`.

## Two fixes that fall out

- **`SetTheme` (`gui/theme.go:236`) overwrites every `Default*Style` global and nothing restores them**, so any test that switches themes rewrites the package defaults for the rest of the test binary. `TestDefaultWidgetStylesNonZero` already failed under `go test -count=5` on `main`, before this work. Default-style assertions now read init-time snapshots instead of the live globals, making them order- and repeat-independent. The underlying global mutation is untouched — that is a larger design question.
- **`ListSystemFonts` panicked on a nil `*Window`** while its siblings `TextWidth` and `Now` both guard. Guard added (`gui/window.go:36`), doc comment updated.

## Verification

`gofmt` clean · `go vet ./...` clean · `golangci-lint run ./...` 0 issues · `go test ./...` 75 packages ok · `-count=5` and `-shuffle=on` both pass · benchmarks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788029470&installation_model_id=426559&pr_number=136&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F136&signature=2b7110307f2adebde9a470f308e6b8232d1dc62959f80244284dce4418b48c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->