### PR TITLE
feat: DrawContext.ImageClipped — scissored image drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`DrawContext.ImageClipped`.** Draws an image restricted to a
+  sub-rectangle: the texture still maps to the full destination rect, a
+  scissor decides what is visible. `DrawCanvasImageEntry` gained
+  `ClipX`/`ClipY`/`ClipW`/`ClipH` plus a `Clipped` flag to carry it, and the
+  emit path intersects that rect with the canvas clip (`RenderClip` replaces
+  the scissor rather than nesting) and restores the canvas clip afterwards.
+  Consumers that must paint a fragment of an image without cropping the source
+  file — a terminal emulator showing the visible cells of an image whose
+  remaining cells sit behind another pane — could not express that before.
+  Recorders (SVG/PDF export) receive the unclipped image, unchanged.
+
 ## [v0.44.0] - 2026-07-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,11 +137,19 @@ git/mkdir/rm/ls output. `ctx_fetch_and_index` instead of curl/wget/WebFetch.
 
 - **WebGPU Backend** (2026-06): Explored in branch `webgpu-backend` (deleted).
   12 WGSL shader pipelines, device init, render loop all working. Rejected
-  because WebGPU has no native text rendering — font measurement and glyph
-  rasterization require Canvas2D. A hybrid backend defeats the purpose; a
-  pure-Go TTF rasterizer would be needed in go-glyph first. The existing
-  Canvas2D backend already handles every render command correctly. GPU
-  acceleration doesn't address the actual bottleneck (heap allocations).
+  at the time because WebGPU has no native text rendering — font measurement
+  and glyph rasterization require Canvas2D. A hybrid backend defeats the
+  purpose; a pure-Go TTF rasterizer in go-glyph was the missing piece. The
+  existing Canvas2D backend already handles every render command correctly.
+  GPU acceleration doesn't address the actual bottleneck (heap allocations).
+
+  **Update (2026-07):** go-glyph now has a pure-Go text pipeline
+  (`bitmap_puregoft.go` — go-text/typesetting harfbuzz shaping +
+  golang.org/x/image/vector rasterization, no CGo). Combined with
+  [goffi](https://github.com/go-webgpu/goffi) (zero-CGo FFI for calling
+  wgpu-native), a CGo-free WebGPU desktop backend is now technically viable
+  — blocked only by the upfront engineering cost of a full backend rewrite,
+  not by any missing dependencies.
 
 ## Specs
 

--- a/gui/canvas_draw.go
+++ b/gui/canvas_draw.go
@@ -41,12 +41,20 @@ type DrawCanvasTriBatch struct {
 // entry observed for a given URL binds the fetcher for that URL's
 // in-flight download. Consumers wiring two fetchers to overlapping
 // URL namespaces must route via URL prefix themselves.
+// ClipX/ClipY/ClipW/ClipH restrict drawing to a sub-rectangle of the
+// canvas, in the same content-relative coordinates as X/Y/W/H. They
+// are honored only when Clipped is set (a zero rect would otherwise
+// be indistinguishable from "no clip"). Use it to show part of an
+// image without cropping the file: the texture still maps to the
+// full X/Y/W/H rect, the scissor decides what is visible.
 type DrawCanvasImageEntry struct {
-	Fetcher    ImageFetcher
-	Src        string
-	BgOpacity  Opt[float32]
-	X, Y, W, H float32
-	BgColor    Color
+	Fetcher                    ImageFetcher
+	Src                        string
+	BgOpacity                  Opt[float32]
+	X, Y, W, H                 float32
+	ClipX, ClipY, ClipW, ClipH float32
+	BgColor                    Color
+	Clipped                    bool
 }
 
 // DrawRecorder receives high-level draw commands before
@@ -728,6 +736,37 @@ func (dc *DrawContext) ImageWithFetcher(
 		Src: src, BgOpacity: bgOpacity, BgColor: bgColor,
 		Fetcher: fetcher,
 	})
+}
+
+// ImageClipped is Image restricted to a sub-rectangle: the image
+// still maps to the full x/y/w/h rect, but only the part inside
+// clipX/clipY/clipW/clipH is painted. The clip is intersected with
+// the canvas's own clip, and is in the same content-relative
+// coordinates as x/y.
+//
+// It exists for consumers that must show a fragment of an image
+// without cropping the source file — a terminal emulator painting
+// the visible tiles of an image whose remaining cells are scrolled
+// behind another pane, for instance. Recorders (SVG/PDF export) see
+// the unclipped image: they capture structure, not scissor state.
+func (dc *DrawContext) ImageClipped(
+	x, y, w, h float32, src string,
+	bgOpacity Opt[float32], bgColor Color,
+	clipX, clipY, clipW, clipH float32,
+) {
+	if clipW <= 0 || clipH <= 0 ||
+		!isFiniteF(clipX) || !isFiniteF(clipY) ||
+		!isFiniteF(clipW) || !isFiniteF(clipH) {
+		return
+	}
+	before := len(dc.images)
+	dc.ImageWithFetcher(x, y, w, h, src, bgOpacity, bgColor, nil)
+	if len(dc.images) == before {
+		return // rejected (bad geometry) or routed to a recorder
+	}
+	e := &dc.images[len(dc.images)-1]
+	e.ClipX, e.ClipY, e.ClipW, e.ClipH = clipX, clipY, clipW, clipH
+	e.Clipped = true
 }
 
 // isFiniteF reports whether v is a finite float32 (not NaN or Inf).

--- a/gui/canvas_draw_image_test.go
+++ b/gui/canvas_draw_image_test.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -23,7 +24,7 @@ func TestEmitDrawCanvasImagesLocalPath(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: path,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
 
 	found := false
 	for _, r := range w.renderers {
@@ -62,7 +63,7 @@ func TestEmitDrawCanvasImagesHTTPInFlight(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: url,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
 
 	for _, r := range w.renderers {
 		if r.Kind == RenderImage {
@@ -94,7 +95,7 @@ func TestEmitDrawCanvasImagesHTTPCached(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: url,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
 
 	found := false
 	for _, r := range w.renderers {
@@ -116,7 +117,7 @@ func TestEmitDrawCanvasImagesDataURL(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: src,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
 
 	found := false
 	for _, r := range w.renderers {
@@ -126,5 +127,203 @@ func TestEmitDrawCanvasImagesDataURL(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected RenderImage for data URL")
+	}
+}
+
+// testFullClip is a clip rect large enough to contain any test geometry, so
+// emitDrawCanvasImages behaves as if the canvas did not clip.
+var testFullClip = drawClip{X: -1e6, Y: -1e6, Width: 2e6, Height: 2e6}
+
+// A clipped entry must narrow the scissor around its own image and restore
+// the canvas clip afterwards, so the following entry is not clipped by it.
+func TestEmitDrawCanvasImagesClipped(t *testing.T) {
+	w := makeWindowWithScratch()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.png")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []DrawCanvasImageEntry{
+		{
+			X: 0, Y: 0, W: 100, H: 100, Src: path,
+			ClipX: 10, ClipY: 20, ClipW: 30, ClipH: 40, Clipped: true,
+		},
+		{X: 0, Y: 0, W: 100, H: 100, Src: path},
+	}
+	emitDrawCanvasImages(entries, 5, 5, testFullClip, w)
+
+	var kinds []RenderKind
+	var clips []RenderCmd
+	for _, r := range w.renderers {
+		kinds = append(kinds, r.Kind)
+		if r.Kind == RenderClip {
+			clips = append(clips, r)
+		}
+	}
+	want := []RenderKind{RenderClip, RenderImage, RenderClip, RenderImage}
+	if len(kinds) != len(want) {
+		t.Fatalf("cmd kinds = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("cmd kinds = %v, want %v", kinds, want)
+		}
+	}
+	// Origin offset applies to the clip rect exactly as it does to the image.
+	if clips[0].X != 15 || clips[0].Y != 25 ||
+		clips[0].W != 30 || clips[0].H != 40 {
+		t.Errorf("narrowed clip = %v,%v %vx%v, want 15,25 30x40",
+			clips[0].X, clips[0].Y, clips[0].W, clips[0].H)
+	}
+	if clips[1].W != testFullClip.Width {
+		t.Errorf("restored clip width = %v, want %v",
+			clips[1].W, testFullClip.Width)
+	}
+}
+
+func TestIntersectClipsContained(t *testing.T) {
+	a := drawClip{X: 0, Y: 0, Width: 100, Height: 100}
+	b := drawClip{X: 20, Y: 30, Width: 40, Height: 50}
+	got, ok := intersectClips(a, b)
+	if !ok {
+		t.Fatal("expect overlap")
+	}
+	if got != b {
+		t.Errorf("intersection = %+v, want %+v (fully contained)", got, b)
+	}
+}
+
+func TestIntersectClipsPartialOverlap(t *testing.T) {
+	a := drawClip{X: 0, Y: 0, Width: 50, Height: 50}
+	b := drawClip{X: 30, Y: 20, Width: 50, Height: 50}
+	want := drawClip{X: 30, Y: 20, Width: 20, Height: 30}
+	got, ok := intersectClips(a, b)
+	if !ok {
+		t.Fatal("expect overlap")
+	}
+	if got != want {
+		t.Errorf("intersection = %+v, want %+v", got, want)
+	}
+}
+
+func TestIntersectClipsTouchingEdgesNoOverlap(t *testing.T) {
+	a := drawClip{X: 0, Y: 0, Width: 10, Height: 10}
+	b := drawClip{X: 10, Y: 0, Width: 10, Height: 10}
+	_, ok := intersectClips(a, b)
+	if ok {
+		t.Fatal("touching edges should not overlap")
+	}
+}
+
+func TestIntersectClipsDegenerateB(t *testing.T) {
+	a := drawClip{X: 0, Y: 0, Width: 100, Height: 100}
+	tests := []struct {
+		name string
+		b    drawClip
+	}{
+		{"zero width", drawClip{X: 0, Y: 0, Width: 0, Height: 10}},
+		{"zero height", drawClip{X: 0, Y: 0, Width: 10, Height: 0}},
+		{"neg width", drawClip{X: 0, Y: 0, Width: -1, Height: 10}},
+		{"nan x", drawClip{X: float32(math.NaN()), Y: 0, Width: 10, Height: 10}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := intersectClips(a, tc.b)
+			if ok {
+				t.Fatal("degenerate b must not overlap")
+			}
+		})
+	}
+}
+
+func TestEmitDrawCanvasImagesConsecutiveClipped(t *testing.T) {
+	w := makeWindowWithScratch()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.png")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []DrawCanvasImageEntry{
+		{
+			X: 0, Y: 0, W: 100, H: 100, Src: path,
+			ClipX: 10, ClipY: 10, ClipW: 50, ClipH: 50, Clipped: true,
+		},
+		{
+			X: 0, Y: 0, W: 100, H: 100, Src: path,
+			ClipX: 20, ClipY: 20, ClipW: 30, ClipH: 30, Clipped: true,
+		},
+	}
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+
+	var kinds []RenderKind
+	for _, r := range w.renderers {
+		kinds = append(kinds, r.Kind)
+	}
+	// Two clipped entries, each with its own clip: [Clip, Image, Clip, Image, Clip(restore)]
+	want := []RenderKind{RenderClip, RenderImage, RenderClip, RenderImage, RenderClip}
+	if len(kinds) != len(want) {
+		t.Fatalf("cmd kinds = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("cmd kinds[%d] = %v, want %v", i, kinds[i], want[i])
+		}
+	}
+}
+
+func TestEmitDrawCanvasImagesAllClippedRestoreAtEnd(t *testing.T) {
+	w := makeWindowWithScratch()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.png")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []DrawCanvasImageEntry{
+		{
+			X: 0, Y: 0, W: 100, H: 100, Src: path,
+			ClipX: 0, ClipY: 0, ClipW: 40, ClipH: 40, Clipped: true,
+		},
+	}
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+
+	nClips := 0
+	for _, r := range w.renderers {
+		if r.Kind == RenderClip {
+			nClips++
+		}
+	}
+	if nClips != 2 {
+		t.Fatalf("expected 2 clips (narrow + restore), got %d", nClips)
+	}
+}
+
+// A clip rect that does not overlap the canvas clip drops the entry entirely
+// rather than emitting a degenerate scissor.
+func TestEmitDrawCanvasImagesClippedAway(t *testing.T) {
+	w := makeWindowWithScratch()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.png")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []DrawCanvasImageEntry{{
+		X: 0, Y: 0, W: 100, H: 100, Src: path,
+		ClipX: 500, ClipY: 500, ClipW: 10, ClipH: 10, Clipped: true,
+	}}
+	emitDrawCanvasImages(entries, 0, 0,
+		drawClip{X: 0, Y: 0, Width: 100, Height: 100}, w)
+
+	for _, r := range w.renderers {
+		if r.Kind == RenderImage {
+			t.Fatal("image emitted despite non-overlapping clip")
+		}
 	}
 }

--- a/gui/canvas_draw_test.go
+++ b/gui/canvas_draw_test.go
@@ -706,3 +706,97 @@ func TestDrawContextImageForwardsToRecorder(t *testing.T) {
 			len(dc.images))
 	}
 }
+
+func TestDrawContextImageClipped(t *testing.T) {
+	dc := DrawContext{Width: 100, Height: 100}
+	dc.ImageClipped(0, 0, 50, 50, "test.png", Opt[float32]{}, Color{},
+		10, 20, 30, 40)
+	images := dc.Images()
+	if len(images) != 1 {
+		t.Fatalf("images = %d, want 1", len(images))
+	}
+	im := images[0]
+	if !im.Clipped {
+		t.Fatal("expected Clipped = true")
+	}
+	if im.ClipX != 10 || im.ClipY != 20 ||
+		im.ClipW != 30 || im.ClipH != 40 {
+		t.Errorf("clip rect = (%v,%v,%v,%v), want (10,20,30,40)",
+			im.ClipX, im.ClipY, im.ClipW, im.ClipH)
+	}
+	if im.Src != "test.png" {
+		t.Errorf("src = %q, want %q", im.Src, "test.png")
+	}
+	if im.Fetcher != nil {
+		t.Error("ImageClipped must not set Fetcher")
+	}
+}
+
+func TestDrawContextImageClippedRejectsBadClip(t *testing.T) {
+	nan := float32(math.NaN())
+	inf := float32(math.Inf(1))
+	tests := []struct {
+		name                       string
+		clipX, clipY, clipW, clipH float32
+	}{
+		{"zero clipW", 0, 0, 0, 10},
+		{"zero clipH", 0, 0, 10, 0},
+		{"neg clipW", 0, 0, -1, 10},
+		{"neg clipH", 0, 0, 10, -3},
+		{"nan clipX", nan, 0, 10, 10},
+		{"nan clipY", 0, nan, 10, 10},
+		{"nan clipW", 0, 0, nan, 10},
+		{"nan clipH", 0, 0, 10, nan},
+		{"+inf clipX", inf, 0, 10, 10},
+		{"+inf clipY", 0, inf, 10, 10},
+		{"+inf clipW", 0, 0, inf, 10},
+		{"-inf clipX", float32(math.Inf(-1)), 0, 10, 10},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := DrawContext{Width: 100, Height: 100}
+			dc.ImageClipped(0, 0, 50, 50, "test.png",
+				Opt[float32]{}, Color{},
+				tc.clipX, tc.clipY, tc.clipW, tc.clipH)
+			if len(dc.images) != 0 {
+				t.Errorf("%s: images = %d, want 0 (rejected)",
+					tc.name, len(dc.images))
+			}
+		})
+	}
+}
+
+func TestDrawContextImageClippedForwardsUnclippedToRecorder(t *testing.T) {
+	dc := DrawContext{Width: 100, Height: 100}
+	rec := &imageRecorderStub{}
+	dc.SetRecorder(rec)
+	dc.ImageClipped(3, 4, 16, 32, "tile.png", SomeF(0.75), Blue,
+		5, 5, 10, 10)
+	if !rec.called {
+		t.Fatal("recorder.Image not invoked")
+	}
+	if rec.x != 3 || rec.y != 4 || rec.w != 16 || rec.h != 32 {
+		t.Errorf("rect = (%v,%v,%v,%v), want (3,4,16,32)",
+			rec.x, rec.y, rec.w, rec.h)
+	}
+	// Clip info is NOT forwarded — recorders see the unclipped image.
+	if len(dc.images) != 0 {
+		t.Errorf("images = %d, want 0 (recorder owns it)",
+			len(dc.images))
+	}
+}
+
+func TestDrawContextImageClippedRejectsDegenerateGeometry(t *testing.T) {
+	dc := DrawContext{Width: 100, Height: 100}
+	dc.ImageClipped(0, 0, 0, 50, "test.png", Opt[float32]{}, Color{},
+		10, 10, 20, 20)
+	if len(dc.images) != 0 {
+		t.Errorf("degenerate w: images = %d, want 0", len(dc.images))
+	}
+	dc2 := DrawContext{Width: 100, Height: 100}
+	dc2.ImageClipped(0, 0, 50, 0, "test.png", Opt[float32]{}, Color{},
+		10, 10, 20, 20)
+	if len(dc2.images) != 0 {
+		t.Errorf("degenerate h: images = %d, want 0", len(dc2.images))
+	}
+}

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -68,8 +68,10 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	oy := shape.Y + shape.PaddingTop()
 
 	// Clip to content area.
+	effClip := clip
 	if shape.Clip {
-		emitClipCmd(drawClip{X: ox, Y: oy, Width: cw, Height: ch}, w)
+		effClip = drawClip{X: ox, Y: oy, Width: cw, Height: ch}
+		emitClipCmd(effClip, w)
 	}
 
 	// Images emit first so they act as the back layer. DrawContext
@@ -79,7 +81,7 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	// markers / HUD chips / labels *over* tile images in the same
 	// DrawCanvas. Reverse ordering would be correct only if triangles/
 	// text were meant as backgrounds — which no in-tree consumer wants.
-	emitDrawCanvasImages(cached.Images, ox, oy, w)
+	emitDrawCanvasImages(cached.Images, ox, oy, effClip, w)
 
 	for _, batch := range cached.Batches {
 		emitRenderer(RenderCmd{
@@ -152,9 +154,21 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 // via ResolveImageSrc; an in-flight download returns "" and the
 // emit is skipped this frame. The window redraws when the
 // download completes.
+//
+// clip is the clip rect in effect for the canvas — the content box
+// when the shape clips, otherwise the parent's. An entry drawn via
+// ImageClipped narrows it to that entry's own rect (intersected,
+// since RenderClip *replaces* the scissor rather than nesting) and
+// restores clip afterwards, so a clipped entry cannot leak its
+// scissor onto the entries that follow.
 func emitDrawCanvasImages(
-	images []DrawCanvasImageEntry, ox, oy float32, w *Window,
+	images []DrawCanvasImageEntry, ox, oy float32, clip drawClip, w *Window,
 ) {
+	// narrowed tracks whether the scissor currently in the command stream is
+	// one entry's own clip rather than the canvas clip, so the restore is
+	// emitted exactly once — before the next unclipped entry, or after the
+	// loop — instead of once per clipped entry.
+	narrowed := false
 	for i := range images {
 		im := &images[i]
 		if !isFiniteF(im.X) || !isFiniteF(im.Y) ||
@@ -177,6 +191,20 @@ func emitDrawCanvasImages(
 				bg = bg.WithOpacity(op)
 			}
 		}
+		if im.Clipped {
+			sub, ok := intersectClips(clip, drawClip{
+				X: ox + im.ClipX, Y: oy + im.ClipY,
+				Width: im.ClipW, Height: im.ClipH,
+			})
+			if !ok {
+				continue // clipped away entirely
+			}
+			emitClipCmd(sub, w)
+			narrowed = true
+		} else if narrowed {
+			emitClipCmd(clip, w)
+			narrowed = false
+		}
 		emitRenderer(RenderCmd{
 			Kind:     RenderImage,
 			X:        ox + im.X,
@@ -187,4 +215,25 @@ func emitDrawCanvasImages(
 			Resource: resource,
 		}, w)
 	}
+	if narrowed {
+		emitClipCmd(clip, w)
+	}
+}
+
+// intersectClips returns the overlap of two clip rects. Reports false when
+// they do not overlap, or when either is degenerate.
+func intersectClips(a, b drawClip) (drawClip, bool) {
+	if !isFiniteF(b.X) || !isFiniteF(b.Y) ||
+		!isFiniteF(b.Width) || !isFiniteF(b.Height) ||
+		b.Width <= 0 || b.Height <= 0 {
+		return drawClip{}, false
+	}
+	x := f32Max(a.X, b.X)
+	y := f32Max(a.Y, b.Y)
+	right := f32Min(a.X+a.Width, b.X+b.Width)
+	bottom := f32Min(a.Y+a.Height, b.Y+b.Height)
+	if right <= x || bottom <= y {
+		return drawClip{}, false
+	}
+	return drawClip{X: x, Y: y, Width: right - x, Height: bottom - y}, true
 }


### PR DESCRIPTION
Adds `ImageClipped(x, y, w, h, src, bgOpacity, bgColor, clipX, clipY, clipW, clipH)` to `DrawContext`.

The image still maps to the full destination rect; a scissor decides what is visible. For consumers that must paint a fragment of an image without cropping the source file (e.g. a terminal showing visible cells of an image whose remaining cells sit behind another pane).

- `DrawCanvasImageEntry` gets `ClipX`/`ClipY`/`ClipW`/`ClipH` + `Clipped` flag
- `emitDrawCanvasImages` narrows the scissor per clipped entry then restores
- `intersectClips` helper computes rect intersection, rejects degenerate/NaN rects
- Recorders (SVG/PDF) receive the unclipped image unchanged
- 12 new test cases covering valid/invalid clip params, intersection edge cases, and narrowed state machine behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788100792&installation_model_id=426559&pr_number=138&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F138&signature=faea62e1a6d97c1bc5a147288c0634c121928486fdc870a7822ee97735dfb77d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->