### PR TITLE
docs: supersede WebGPU "technically viable" note with #137 findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,17 @@ git/mkdir/rm/ls output. `ctx_fetch_and_index` instead of curl/wget/WebFetch.
   — blocked only by the upfront engineering cost of a full backend rewrite,
   not by any missing dependencies.
 
+  **Superseded (2026-07-31, issue #137):** viable but the wrong instrument.
+  `gui/backend/gl/` has no cgo at all — X11 via xgb, EGL via purego, Win32
+  via syscall. The sole CGo dependency on Linux/Windows is
+  `github.com/go-gl/gl` (55 functions, 47 constants), and its proc-address
+  loader is already pure Go. Swapping that one dispatch layer for purego
+  bindings gets CGo-free Linux+Windows for ~600 lines; wgpu is a superset
+  that also ships 10–40 MB of runtime shared libs, supplies none of
+  `NativePlatform` (10 sub-interfaces), and leaves macOS (the only real CGo
+  backend, 5.9k lines ObjC) untouched. Full assessment:
+  `docs/specs/cgo-free-backend-feasibility.md`.
+
 ## Specs
 
 - Specs should be written to docs/specs folder.


### PR DESCRIPTION
Records the outcome of the issue #137 feasibility assessment in `CLAUDE.md`'s
Rejected Approaches section, correcting the 2026-07 update that called a
CGo-free WebGPU backend "technically viable — blocked only by the upfront
engineering cost."

Viable, but the wrong instrument. Key findings:

- `gui/backend/gl/` has **no cgo at all** — X11 via `jezek/xgb`, EGL via
  `purego`, Win32/WGL via `x/sys` syscall.
- Both `CGO_ENABLED=0` cross-builds (linux, windows) fail with exactly one
  error: `github.com/go-gl/gl`. Its footprint in this repo is **55 functions
  and 47 constants**, and the proc-address loader that binds them is already
  pure Go (`platform_x11.go:287` → `InitWithProcAddrFunc(eglProc)`).
- So CGo-free Linux+Windows is a ~600-line purego binding swap, not a
  4–8k-line rewrite with 12 WGSL pipelines.
- wgpu is a superset of that work: it ships 10–40 MB of runtime shared libs
  (a distribution regression over today's dlopen-the-system-libGL design),
  supplies none of `NativePlatform`'s 10 sub-interfaces, and leaves macOS —
  the only real CGo backend, 5,924 lines of ObjC — untouched.

Full assessment lives at `docs/specs/cgo-free-backend-feasibility.md`, which is
gitignored (`.gitignore:76`) and therefore not in this diff. The condensed
version is posted on #137.

Docs only — no code changes.

Refs #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788103626&installation_model_id=426559&pr_number=140&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F140&signature=fe5a94c35a40042860a526e500642aa715dc9066c6b0b5629e80e0287d7c3f64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->