### PR TITLE
fix: pin main thread from init() across metal, gl, and ios backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Metal backend: AppKit calls could land on a non-main thread.** The Go
+  runtime starts the main goroutine on thread 0 but does not keep it there —
+  any blocking syscall or cgo call before the backend starts (config load,
+  font registration, reading a file named on the command line) can let the
+  scheduler resume `main` on another M. `backend.New` / `backend.RunApp` then
+  called `runtime.LockOSThread` on the *wrong* thread and the first AppKit
+  call aborted with `API misuse: setting the main menu on a non-main thread`.
+  The metal package now calls `runtime.LockOSThread` from `init`, which runs
+  while the main goroutine is still on thread 0. Importing the backend is
+  sufficient; embedders need no init boilerplate.
+- **Same main-thread pin applied to the `gl` (X11/Win32) and `ios` backends.**
+  Latent rather than fatal there, but the same migration applies: an OpenGL
+  context is current on one thread at a time, Win32 delivers a window's
+  messages only to the thread that created it, and UIKit has AppKit's
+  main-thread rule. All three now lock from `init` instead of relying on the
+  late `LockOSThread` in `New` / `RunAppE` / `Run`.
+
 ## [v0.45.0] - 2026-07-31
 
 ### Added
@@ -620,8 +641,6 @@ Documentation-only release. No code or behavior changes; no migration needed.
   a focus-claiming widget (one that re-asserts `SetIDFocus` every view
   rebuild) tries to steal it, so Tab/Esc/Enter keep working. Apps no longer
   need to guard their own `SetIDFocus` with `DialogIsVisible`. (#18)
-
-## [Unreleased]
 
 ## [v0.29.0] - 2026-06-28
 

--- a/gui/backend/gl/mainthread.go
+++ b/gui/backend/gl/mainthread.go
@@ -1,0 +1,34 @@
+//go:build (linux && !js && !android) || (windows && !js)
+
+package gl
+
+import "runtime"
+
+// Pin the main goroutine to the process's initial thread before main()
+// runs.
+//
+// The Go runtime starts the main goroutine on thread 0 but does not
+// keep it there: any blocking syscall or cgo call before the backend
+// starts (config load, font registration, reading a file named on the
+// command line) can let the scheduler resume main on a different M.
+// The LockOSThread calls in New / RunAppE then pin whichever thread
+// main happens to be on by that point, which is not necessarily the
+// one the platform expects.
+//
+// That matters here for two reasons. An OpenGL context is current on
+// one thread at a time, so every GL call — window creation through
+// swap-buffers — must stay on the thread that made the context
+// current. On Win32, a window's messages are delivered only to the
+// thread that created it, so the create call and the message pump have
+// to agree on a thread. Locking from init, while the main goroutine is
+// still on thread 0, makes that thread deterministic instead of
+// whatever the scheduler picked.
+//
+// See gui/backend/metal/mainthread.go, where the same migration caused
+// a hard AppKit abort rather than a latent inconsistency.
+//
+// The lock is never released; the main goroutine stays on thread 0 for
+// the process lifetime, which is what the event loop needs.
+func init() {
+	runtime.LockOSThread()
+}

--- a/gui/backend/ios/mainthread.go
+++ b/gui/backend/ios/mainthread.go
@@ -1,0 +1,31 @@
+//go:build ios
+
+package ios
+
+import "runtime"
+
+// Pin the main goroutine to the process's initial thread before main()
+// runs.
+//
+// UIKit has the same rule as AppKit: UIApplicationMain and every
+// UIView / CAMetalLayer call must happen on the process's initial
+// thread. The Go runtime starts the main goroutine on thread 0 but
+// does not keep it there — any blocking syscall or cgo call before the
+// backend starts can let the scheduler resume main on a different M,
+// after which the LockOSThread in Run pins the wrong thread and
+// C.iosStartApp enters UIApplicationMain off the main thread.
+//
+// Locking from init runs while the main goroutine is still on thread
+// 0, so the lock captures the actual main thread. This covers the
+// Go-driven pattern (backend.Run). The Swift-driven c-archive pattern
+// is unaffected: there the host app owns the main thread and Go is
+// entered from it.
+//
+// See gui/backend/metal/mainthread.go for the macOS case that made
+// this concrete.
+//
+// The lock is never released; the main goroutine stays on thread 0 for
+// the process lifetime.
+func init() {
+	runtime.LockOSThread()
+}

--- a/gui/backend/metal/mainthread.go
+++ b/gui/backend/metal/mainthread.go
@@ -1,0 +1,29 @@
+//go:build darwin && !ios
+
+package metal
+
+import "runtime"
+
+// AppKit requires every NSApplication / NSMenu / NSWindow call to
+// happen on the process's initial thread (thread 0). The Go runtime
+// starts the main goroutine on that thread, but does NOT keep it
+// there: any blocking syscall, cgo call, or preemption point before
+// the backend starts can let the scheduler resume main on a different
+// M. Reaching backend.New / backend.RunApp from a migrated main
+// goroutine makes the LockOSThread call there pin the *wrong* thread,
+// and the first AppKit call aborts with:
+//
+//	API misuse: setting the main menu on a non-main thread
+//
+// Locking here instead is what makes the guarantee real: package init
+// runs on the main goroutine before main(), while it is still on
+// thread 0, so the lock captures the actual main thread. Importing
+// this backend is therefore sufficient — no init boilerplate is
+// required in the embedding program.
+//
+// The lock is never released; the main goroutine stays on thread 0
+// for the process lifetime, which is exactly what an AppKit event
+// loop needs.
+func init() {
+	runtime.LockOSThread()
+}


### PR DESCRIPTION
The Go runtime may resume the main goroutine on a different M after a blocking syscall or cgo call before the backend starts. Calling runtime.LockOSThread in backend init() — before any such migration — ensures AppKit (metal), UIKit (ios), X11/Win32 (gl) all see the correct thread.

Fixes "API misuse: setting the main menu on a non-main thread" on macOS when config loading, font registration, or command-line file reads execute before the backend's LockOSThread call in New/RunAppE/Run.

- Metal backend: LockOSThread in init (was in New)
- GL backend: LockOSThread in init (was in RunAppE)  
- iOS backend: LockOSThread in init (was in Run)
- Changelog entry for all three

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788120963&installation_model_id=426559&pr_number=142&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F142&signature=e8835005eec8c71dadf924c64eb8f0a92f270d4109efb220f786d3b104b2d662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->