### PR TITLE
feat: add X11 PRIMARY selection support (select-to-copy, middle-click paste)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **X11 PRIMARY selection.** `Window.SetPrimary`/`GetPrimary` (with the
+  matching `SetPrimaryFn`/`SetPrimaryGetFn` backend hooks) expose the
+  select-to-copy buffer that middle-click pastes on Unix — independent of
+  CLIPBOARD, so an app can hold two different values at once. The X11 backend
+  already owned selections for CLIPBOARD; PRIMARY reuses that machinery via a
+  shared `selectionState` mapping, and `SelectionClear` now releases only the
+  selection actually lost instead of both. Other backends leave the hooks nil,
+  so `GetPrimary` returns `""` and `SetPrimary` is a no-op on macOS, Windows,
+  web, and mobile.
+
 ## [v0.45.1] - 2026-07-31
 
 ### Fixed

--- a/gui/backend/gl/clipboard_x11.go
+++ b/gui/backend/gl/clipboard_x11.go
@@ -13,28 +13,53 @@ import (
 // selection owner cannot hang the UI thread.
 const clipReadTimeout = time.Second
 
-// setClipboard takes ownership of the X11 CLIPBOARD selection and caches
-// the text so incoming SelectionRequest events can be served.
-func setClipboard(p *platformState, s string) {
-	p.clipboardText = s
-	if p.atomClipboard == 0 {
+// selectionState returns pointers to the cached text and owner flag backing
+// sel, so the set/get/serve paths can treat CLIPBOARD and PRIMARY uniformly.
+// Reports false for any other selection (e.g. SECONDARY), which we neither
+// own nor serve.
+func (p *platformState) selectionState(sel xproto.Atom) (text *string, owns *bool, ok bool) {
+	// atomClipboard is 0 until the atoms are interned; without this an
+	// uninitialized platformState would match a zero selection atom as
+	// CLIPBOARD and claim ownership of nothing.
+	if sel == 0 {
+		return nil, nil, false
+	}
+	switch sel {
+	case p.atomClipboard:
+		return &p.clipboardText, &p.ownsClipboard, true
+	case xproto.AtomPrimary:
+		return &p.primaryText, &p.ownsPrimary, true
+	}
+	return nil, nil, false
+}
+
+// setSelection takes ownership of sel and caches the text so incoming
+// SelectionRequest events can be served. Selections we do not model are
+// ignored rather than claimed.
+func setSelection(p *platformState, sel xproto.Atom, s string) {
+	text, owns, ok := p.selectionState(sel)
+	if !ok {
 		return
 	}
-	p.ownsClipboard = true
-	xproto.SetSelectionOwner(p.conn, p.window, p.atomClipboard,
-		xproto.TimeCurrentTime)
+	*text = s
+	*owns = true
+	xproto.SetSelectionOwner(p.conn, p.window, sel, xproto.TimeCurrentTime)
 	p.conn.Sync() // flush so the server records ownership immediately
 }
 
-// getClipboard returns the current CLIPBOARD text. When this process owns
-// the selection the cached text is returned directly; otherwise the value
-// is requested from the current owner over a dedicated connection so the
+// getSelection returns the current text of sel. When this process owns the
+// selection the cached text is returned directly; otherwise the value is
+// requested from the current owner over a dedicated connection so the
 // round-trip does not reenter the main event loop.
-func getClipboard(p *platformState) string {
-	if p.ownsClipboard {
-		return p.clipboardText
+func getSelection(p *platformState, sel xproto.Atom) string {
+	text, owns, ok := p.selectionState(sel)
+	if !ok {
+		return ""
 	}
-	if p.atomClipboard == 0 || p.atomUTF8 == 0 || p.atomClipProp == 0 {
+	if *owns {
+		return *text
+	}
+	if p.atomUTF8 == 0 || p.atomClipProp == 0 {
 		return ""
 	}
 	if !p.ensureClipReadConn() {
@@ -42,7 +67,7 @@ func getClipboard(p *platformState) string {
 	}
 	conn, win := p.clipReadConn, p.clipReadWin
 
-	xproto.ConvertSelection(conn, win, p.atomClipboard, p.atomUTF8,
+	xproto.ConvertSelection(conn, win, sel, p.atomUTF8,
 		p.atomClipProp, xproto.TimeCurrentTime)
 	conn.Sync()
 
@@ -51,6 +76,21 @@ func getClipboard(p *platformState) string {
 	}
 	return readClipProperty(conn, win, p.atomClipProp)
 }
+
+// setClipboard publishes s as the CLIPBOARD selection (explicit copy).
+func setClipboard(p *platformState, s string) { setSelection(p, p.atomClipboard, s) }
+
+// getClipboard returns the current CLIPBOARD text.
+func getClipboard(p *platformState) string { return getSelection(p, p.atomClipboard) }
+
+// setPrimary publishes s as the PRIMARY selection — the select-to-copy buffer
+// pasted with the middle mouse button, independent of CLIPBOARD. PRIMARY is a
+// predefined atom, so unlike CLIPBOARD it needs no interning and works even
+// before setupAtoms has run.
+func setPrimary(p *platformState, s string) { setSelection(p, xproto.AtomPrimary, s) }
+
+// getPrimary returns the current PRIMARY selection text.
+func getPrimary(p *platformState) string { return getSelection(p, xproto.AtomPrimary) }
 
 // ensureClipReadConn lazily opens the dedicated read connection and its
 // requestor window. Returns false if either could not be created.
@@ -121,9 +161,18 @@ func readClipProperty(conn *xgb.Conn, win xproto.Window, prop xproto.Atom) strin
 	return string(out)
 }
 
-// serveSelectionRequest answers a SelectionRequest for the CLIPBOARD we
-// own, honoring the TARGETS and UTF8_STRING/STRING targets per ICCCM.
+// serveSelectionRequest answers a SelectionRequest for a selection we own,
+// honoring the TARGETS and UTF8_STRING/STRING targets per ICCCM. The value
+// served depends on which selection was asked for — CLIPBOARD and PRIMARY
+// hold different text — so a requestor pasting one never receives the other.
 func (p *platformState) serveSelectionRequest(e xproto.SelectionRequestEvent) {
+	text, _, ok := p.selectionState(e.Selection)
+	if !ok {
+		// A selection we never owned. Refuse rather than answering with
+		// whatever happens to be in the clipboard cache.
+		p.refuseSelectionRequest(e)
+		return
+	}
 	prop := e.Property
 	if prop == 0 { // obsolete client: fall back to the target atom
 		prop = e.Target
@@ -136,12 +185,25 @@ func (p *platformState) serveSelectionRequest(e xproto.SelectionRequestEvent) {
 		xproto.ChangeProperty(p.conn, xproto.PropModeReplace, e.Requestor,
 			prop, xproto.AtomAtom, 32, 2, data)
 	case p.atomUTF8, xproto.AtomString:
-		b := []byte(p.clipboardText)
+		b := []byte(*text)
 		xproto.ChangeProperty(p.conn, xproto.PropModeReplace, e.Requestor,
 			prop, e.Target, 8, uint32(len(b)), b)
 	default:
 		prop = 0 // refuse unsupported targets
 	}
+	p.sendSelectionNotify(e, prop)
+}
+
+// refuseSelectionRequest answers a request we cannot satisfy. ICCCM requires
+// a SelectionNotify either way; Property 0 signals refusal, and omitting it
+// would leave the requestor blocked until its own timeout expires.
+func (p *platformState) refuseSelectionRequest(e xproto.SelectionRequestEvent) {
+	p.sendSelectionNotify(e, 0)
+}
+
+// sendSelectionNotify replies to a SelectionRequest, naming the property the
+// value was written to (or 0 for refusal).
+func (p *platformState) sendSelectionNotify(e xproto.SelectionRequestEvent, prop xproto.Atom) {
 	notify := xproto.SelectionNotifyEvent{
 		Time:      e.Time,
 		Requestor: e.Requestor,

--- a/gui/backend/gl/clipboard_x11_test.go
+++ b/gui/backend/gl/clipboard_x11_test.go
@@ -68,44 +68,30 @@ func newClipTestState(t *testing.T) (*platformState, func()) {
 	return p, cleanup
 }
 
-// TestClipboardGetFromXclip verifies getClipboard reads text set by an
-// external selection owner (xclip).
-func TestClipboardGetFromXclip(t *testing.T) {
-	requireXClip(t)
-	want := "gogui read αβγ 42"
-
-	cmd := exec.Command("xclip", "-selection", "clipboard", "-in")
-	cmd.Stdin = strings.NewReader(want)
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("xclip -in: %v", err)
-	}
-	time.Sleep(50 * time.Millisecond) // let xclip fork and take ownership
-
-	p, cleanup := newClipTestState(t)
-	defer cleanup()
-	if got := getClipboard(p); got != want {
-		t.Errorf("getClipboard() = %q, want %q", got, want)
-	}
+// selCases enumerates the two selections the backend owns, so every
+// round-trip test runs against both. xclipName is what `xclip -selection`
+// calls them.
+var selCases = []struct {
+	name      string
+	xclipName string
+	set       func(*platformState, string)
+	get       func(*platformState) string
+}{
+	{"clipboard", "clipboard", setClipboard, getClipboard},
+	{"primary", "primary", setPrimary, getPrimary},
 }
 
-// TestClipboardSetServesXclip verifies setClipboard takes ownership and
-// serveSelectionRequest answers an external requestor (xclip -out).
-func TestClipboardSetServesXclip(t *testing.T) {
-	requireXClip(t)
-	p, cleanup := newClipTestState(t)
-	defer cleanup()
-
-	want := "gogui write 12345"
-	setClipboard(p, want)
-
-	// Serve incoming SelectionRequest events while xclip pulls the value.
-	stop := make(chan struct{})
+// serveRequests answers SelectionRequest events in the background for as long
+// as the returned stop function has not been called. Standing in for the main
+// event loop, which these tests do not run.
+func serveRequests(p *platformState) (stop func()) {
+	stopCh := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for {
 			select {
-			case <-stop:
+			case <-stopCh:
 				return
 			default:
 			}
@@ -122,14 +108,141 @@ func TestClipboardSetServesXclip(t *testing.T) {
 			}
 		}
 	}()
-
-	out, err := exec.Command("xclip", "-selection", "clipboard", "-out").Output()
-	close(stop)
-	<-done
-	if err != nil {
-		t.Fatalf("xclip -out: %v", err)
+	return func() {
+		close(stopCh)
+		<-done
 	}
-	if got := string(out); got != want {
-		t.Errorf("xclip read %q, want %q", got, want)
+}
+
+// TestSelectionGetFromXclip verifies get{Clipboard,Primary} read text set by
+// an external selection owner (xclip).
+func TestSelectionGetFromXclip(t *testing.T) {
+	requireXClip(t)
+	for _, tc := range selCases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := "gogui read αβγ 42 " + tc.name
+
+			cmd := exec.Command("xclip", "-selection", tc.xclipName, "-in")
+			cmd.Stdin = strings.NewReader(want)
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("xclip -in: %v", err)
+			}
+			time.Sleep(50 * time.Millisecond) // let xclip fork and take ownership
+
+			p, cleanup := newClipTestState(t)
+			defer cleanup()
+			if got := tc.get(p); got != want {
+				t.Errorf("get() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestSelectionSetServesXclip verifies set{Clipboard,Primary} takes ownership
+// and serveSelectionRequest answers an external requestor (xclip -out).
+func TestSelectionSetServesXclip(t *testing.T) {
+	requireXClip(t)
+	for _, tc := range selCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, cleanup := newClipTestState(t)
+			defer cleanup()
+
+			want := "gogui write 12345 " + tc.name
+			tc.set(p, want)
+
+			stop := serveRequests(p)
+			out, err := exec.Command("xclip", "-selection", tc.xclipName, "-out").Output()
+			stop()
+			if err != nil {
+				t.Fatalf("xclip -out: %v", err)
+			}
+			if got := string(out); got != want {
+				t.Errorf("xclip read %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestSelectionsAreIndependent is the point of PRIMARY: holding both at once
+// must yield two different values, and serving a request for one must never
+// answer with the other's text.
+func TestSelectionsAreIndependent(t *testing.T) {
+	requireXClip(t)
+	p, cleanup := newClipTestState(t)
+	defer cleanup()
+
+	const clip = "value-on-clipboard"
+	const prim = "value-on-primary"
+	setClipboard(p, clip)
+	setPrimary(p, prim)
+
+	stop := serveRequests(p)
+	gotClip, errClip := exec.Command("xclip", "-selection", "clipboard", "-out").Output()
+	gotPrim, errPrim := exec.Command("xclip", "-selection", "primary", "-out").Output()
+	stop()
+	if errClip != nil || errPrim != nil {
+		t.Fatalf("xclip -out: %v / %v", errClip, errPrim)
+	}
+	if string(gotClip) != clip {
+		t.Errorf("clipboard = %q, want %q", gotClip, clip)
+	}
+	if string(gotPrim) != prim {
+		t.Errorf("primary = %q, want %q", gotPrim, prim)
+	}
+}
+
+// TestSelectionStateRouting covers the selection→cache mapping without an X
+// server, including the zero-atom guard that keeps an uninitialized
+// platformState from mistaking a nil selection for CLIPBOARD.
+func TestSelectionStateRouting(t *testing.T) {
+	p := &platformState{atomClipboard: 400}
+	p.clipboardText, p.primaryText = "clip", "prim"
+
+	tests := []struct {
+		name string
+		sel  xproto.Atom
+		want string // "" means the selection must be rejected
+	}{
+		{"clipboard", 400, "clip"},
+		{"primary", xproto.AtomPrimary, "prim"},
+		{"secondary rejected", xproto.AtomSecondary, ""},
+		{"zero rejected", 0, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text, owns, ok := p.selectionState(tc.sel)
+			if tc.want == "" {
+				if ok {
+					t.Fatalf("selectionState(%d) accepted an unowned selection", tc.sel)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("selectionState(%d) rejected a known selection", tc.sel)
+			}
+			if *text != tc.want {
+				t.Errorf("text = %q, want %q", *text, tc.want)
+			}
+			// The owner flag must alias the right field: flipping it through
+			// the pointer is how SelectionClear releases one selection only.
+			*owns = true
+		})
+	}
+	if !p.ownsClipboard || !p.ownsPrimary {
+		t.Errorf("owner flags did not alias: clipboard=%v primary=%v",
+			p.ownsClipboard, p.ownsPrimary)
+	}
+}
+
+// TestSelectionStateZeroAtomGuard pins the uninitialized case: before the
+// atoms are interned, atomClipboard is 0 and a zero selection must not route
+// to the clipboard cache.
+func TestSelectionStateZeroAtomGuard(t *testing.T) {
+	p := &platformState{} // atoms not yet interned
+	if _, _, ok := p.selectionState(0); ok {
+		t.Error("zero selection routed to clipboard on an uninitialized state")
+	}
+	if _, _, ok := p.selectionState(xproto.AtomPrimary); !ok {
+		t.Error("PRIMARY is a predefined atom and must resolve before interning")
 	}
 }

--- a/gui/backend/gl/events_x11.go
+++ b/gui/backend/gl/events_x11.go
@@ -154,7 +154,12 @@ func (b *Backend) handleXEvent(ev xgb.Event) {
 		b.plat.serveSelectionRequest(e)
 
 	case xproto.SelectionClearEvent:
-		b.plat.ownsClipboard = false
+		// Only the selection actually taken from us is released. Clearing
+		// both would make a getClipboard after losing PRIMARY go out to the
+		// server for text we still own.
+		if _, owns, ok := b.plat.selectionState(e.Selection); ok {
+			*owns = false
+		}
 
 	case xproto.ExposeEvent:
 		// Damage is repainted by the next frame; nothing to do.

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -58,13 +58,19 @@ type platformState struct {
 	keymap     *xproto.GetKeyboardMappingReply
 	minKeycode xproto.Keycode
 
-	// Clipboard (X11 CLIPBOARD selection).
+	// Selections. X11 has two independent text buffers: CLIPBOARD (explicit
+	// copy/paste) and PRIMARY (filled by selecting text, pasted with the
+	// middle button). Both are served by the same ownership machinery, so
+	// each keeps its own cached text and owner flag while sharing the atoms
+	// and the read connection below.
 	atomClipboard xproto.Atom
 	atomUTF8      xproto.Atom
 	atomTargets   xproto.Atom
 	atomClipProp  xproto.Atom
 	clipboardText string
 	ownsClipboard bool
+	primaryText   string
+	ownsPrimary   bool
 	clipReadConn  *xgb.Conn     // dedicated connection for reads
 	clipReadWin   xproto.Window // requestor window on clipReadConn
 
@@ -309,6 +315,8 @@ func New(w *gui.Window) (*Backend, error) {
 	w.SetTitleFn(func(t string) { setWindowTitle(conn, win, t) })
 	w.SetClipboardFn(func(s string) { setClipboard(&b.plat, s) })
 	w.SetClipboardGetFn(func() string { return getClipboard(&b.plat) })
+	w.SetPrimaryFn(func(s string) { setPrimary(&b.plat, s) })
+	w.SetPrimaryGetFn(func() string { return getPrimary(&b.plat) })
 
 	return b, nil
 }

--- a/gui/window.go
+++ b/gui/window.go
@@ -84,6 +84,12 @@ type windowBackend struct {
 	nativePlatform NativePlatform
 	clipboardSetFn func(string)
 	clipboardGetFn func() string
+	// primarySetFn/primaryGetFn drive the X11 PRIMARY selection — the
+	// implicit, select-to-copy / middle-click-to-paste buffer that is
+	// independent of CLIPBOARD. Only the X11 backend wires these; every
+	// other platform leaves them nil, so GetPrimary yields "" there.
+	primarySetFn func(string)
+	primaryGetFn func() string
 	// setTitleFn updates the OS window title. Set by backend; nil-safe.
 	setTitleFn func(string)
 	// wakeMainFn wakes the main thread from WaitEventTimeout.
@@ -508,6 +514,38 @@ func (w *Window) SetClipboardGetFn(fn func() string) {
 func (w *Window) GetClipboard() string {
 	if w.clipboardGetFn != nil {
 		return w.clipboardGetFn()
+	}
+	return ""
+}
+
+// SetPrimaryFn sets the function used to publish text as the PRIMARY
+// selection.
+func (w *Window) SetPrimaryFn(fn func(string)) {
+	w.primarySetFn = fn
+}
+
+// SetPrimary publishes text as the X11 PRIMARY selection — the buffer filled
+// by selecting text and pasted with the middle mouse button. It is entirely
+// separate from the clipboard, so SetPrimary does not disturb whatever
+// SetClipboard last stored. A no-op on platforms without PRIMARY (macOS,
+// Windows, web, mobile).
+func (w *Window) SetPrimary(text string) {
+	if w.primarySetFn != nil {
+		w.primarySetFn(text)
+	}
+}
+
+// SetPrimaryGetFn sets the function used to read the PRIMARY selection.
+func (w *Window) SetPrimaryGetFn(fn func() string) {
+	w.primaryGetFn = fn
+}
+
+// GetPrimary returns the current X11 PRIMARY selection, or "" on platforms
+// that have no such concept. Callers wanting a paste that works everywhere
+// should fall back to GetClipboard on an empty result.
+func (w *Window) GetPrimary() string {
+	if w.primaryGetFn != nil {
+		return w.primaryGetFn()
 	}
 	return ""
 }

--- a/gui/window_lifecycle_test.go
+++ b/gui/window_lifecycle_test.go
@@ -543,6 +543,30 @@ func TestGetClipboardNilSafe(t *testing.T) {
 	}
 }
 
+func TestSetPrimary(t *testing.T) {
+	w := &Window{}
+	var got string
+	w.SetPrimaryFn(func(s string) { got = s })
+	w.SetPrimary("hello")
+	if got != "hello" {
+		t.Errorf("primary = %q, want hello", got)
+	}
+}
+
+func TestSetPrimaryNilSafe(t *testing.T) {
+	w := &Window{}
+	// Should not panic when no fn set.
+	w.SetPrimary("ignored")
+}
+
+func TestGetPrimaryNilSafe(t *testing.T) {
+	w := &Window{}
+	got := w.GetPrimary()
+	if got != "" {
+		t.Errorf("GetPrimary = %q, want empty for nil fn", got)
+	}
+}
+
 func TestUpdateProducesRenderers(t *testing.T) {
 	w := NewWindow(WindowCfg{
 		State:  new(int),


### PR DESCRIPTION
Unified CLIPBOARD and PRIMARY through a shared `selectionState` dispatch, so set/get/serve paths treat both selections uniformly. Each selection keeps independent cached text and owner flags.

- `selectionState` routes CLIPBOARD and PRIMARY to their own caches, rejects unknown selections (zero-atom guard for uninitialized state)
- `SelectionClear` now only releases the selection that was actually taken — losing PRIMARY no longer drops cache for text we still own from a prior clipboard copy
- `serveSelectionRequest` refuses requests for selections we never owned (ICCCM-compliant refusal with Property 0) instead of answering with whatever happened to be in the clipboard cache
- Adds `SetPrimary` / `GetPrimary` to the Window API (nil-safe — no-op on macOS, Windows, web, mobile; only X11 backend wires them)
- Tests: xclip round-trip for both selections, independence test, selectionState routing, zero-atom guard

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788187196&installation_model_id=426559&pr_number=144&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F144&signature=0c9841e90cd82055a397359a21bc1ebb883260833970e2de114d8bc34e6696f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->