### PR TITLE
feat(gui): export IBeam, NotAllowed and diagonal-resize cursor setters

### DIFF
--- a/gui/view_test.go
+++ b/gui/view_test.go
@@ -1067,15 +1067,15 @@ func TestCursorHelpers(t *testing.T) {
 		want MouseCursor
 	}{
 		{"Arrow", (*Window).SetMouseCursorArrow, CursorArrow},
-		{"IBeam", (*Window).setMouseCursorIBeam, CursorIBeam},
+		{"IBeam", (*Window).SetMouseCursorIBeam, CursorIBeam},
 		{"Crosshair", (*Window).SetMouseCursorCrosshair, CursorCrosshair},
 		{"PointingHand", (*Window).SetMouseCursorPointingHand, CursorPointingHand},
 		{"All", (*Window).SetMouseCursorAll, CursorResizeAll},
 		{"NS", (*Window).SetMouseCursorNS, CursorResizeNS},
 		{"EW", (*Window).SetMouseCursorEW, CursorResizeEW},
-		{"NESW", (*Window).setMouseCursorResizeNESW, CursorResizeNESW},
-		{"NWSE", (*Window).setMouseCursorResizeNWSE, CursorResizeNWSE},
-		{"NotAllowed", (*Window).setMouseCursorNotAllowed, CursorNotAllowed},
+		{"NESW", (*Window).SetMouseCursorResizeNESW, CursorResizeNESW},
+		{"NWSE", (*Window).SetMouseCursorResizeNWSE, CursorResizeNWSE},
+		{"NotAllowed", (*Window).SetMouseCursorNotAllowed, CursorNotAllowed},
 	}
 	for _, tt := range tests {
 		w := &Window{}

--- a/gui/window_cursor.go
+++ b/gui/window_cursor.go
@@ -1,6 +1,13 @@
 package gui
 
 // window_cursor.go — mouse cursor management.
+//
+// Every MouseCursor the backends implement has an exported setter. The set is
+// deliberately complete rather than as-needed: an embedder driving the cursor
+// from an external protocol (a terminal widget honoring OSC 22, a canvas app
+// with its own hit regions) has no way to add one, and falling back to Arrow
+// for a shape every backend already loads is a worse result than the platform
+// can give.
 
 // setMouseCursor sets the mouse cursor shape.
 func (w *Window) setMouseCursor(cursor MouseCursor) {
@@ -10,8 +17,8 @@ func (w *Window) setMouseCursor(cursor MouseCursor) {
 // SetMouseCursorArrow sets the cursor to the default arrow.
 func (w *Window) SetMouseCursorArrow() { w.setMouseCursor(CursorArrow) }
 
-// setMouseCursorIBeam sets the cursor to a text I-beam.
-func (w *Window) setMouseCursorIBeam() { w.setMouseCursor(CursorIBeam) }
+// SetMouseCursorIBeam sets the cursor to a text I-beam.
+func (w *Window) SetMouseCursorIBeam() { w.setMouseCursor(CursorIBeam) }
 
 // SetMouseCursorCrosshair sets the cursor to a crosshair.
 func (w *Window) SetMouseCursorCrosshair() { w.setMouseCursor(CursorCrosshair) }
@@ -28,11 +35,11 @@ func (w *Window) SetMouseCursorNS() { w.setMouseCursor(CursorResizeNS) }
 // SetMouseCursorEW sets the cursor to an east-west resize.
 func (w *Window) SetMouseCursorEW() { w.setMouseCursor(CursorResizeEW) }
 
-// setMouseCursorResizeNESW sets the cursor to a NE-SW resize.
-func (w *Window) setMouseCursorResizeNESW() { w.setMouseCursor(CursorResizeNESW) }
+// SetMouseCursorResizeNESW sets the cursor to a NE-SW diagonal resize.
+func (w *Window) SetMouseCursorResizeNESW() { w.setMouseCursor(CursorResizeNESW) }
 
-// setMouseCursorResizeNWSE sets the cursor to a NW-SE resize.
-func (w *Window) setMouseCursorResizeNWSE() { w.setMouseCursor(CursorResizeNWSE) }
+// SetMouseCursorResizeNWSE sets the cursor to a NW-SE diagonal resize.
+func (w *Window) SetMouseCursorResizeNWSE() { w.setMouseCursor(CursorResizeNWSE) }
 
-// setMouseCursorNotAllowed sets the cursor to a not-allowed indicator.
-func (w *Window) setMouseCursorNotAllowed() { w.setMouseCursor(CursorNotAllowed) }
+// SetMouseCursorNotAllowed sets the cursor to a not-allowed indicator.
+func (w *Window) SetMouseCursorNotAllowed() { w.setMouseCursor(CursorNotAllowed) }


### PR DESCRIPTION
## Problem

`gui/window_cursor.go` exports 6 of the 10 `MouseCursor` shapes. The other four
are lowercase:

| unexported | enum | backend support |
| --- | --- | --- |
| `setMouseCursorIBeam` | `CursorIBeam` | metal `backend.go:368`, x11 `XC_xterm`, win32 `IDC_IBEAM`, web `"text"` |
| `setMouseCursorNotAllowed` | `CursorNotAllowed` | all |
| `setMouseCursorResizeNESW` | `CursorResizeNESW` | all |
| `setMouseCursorResizeNWSE` | `CursorResizeNWSE` | all |

All four are fully wired end to end and already covered by `TestCursorHelpers`.
They stayed unexported because go-gui's own widgets were the only callers —
`view_input.go:268` sets IBeam on text-field hover — so the set grew as-needed
rather than to completion.

An embedder driving the cursor from an external protocol cannot reach them.
go-term needs IBeam, NotAllowed and both diagonals for OSC 22 (mouse cursor
shape), where `text`/`xterm` is the single most common shape an application
requests. Falling back to Arrow for a cursor the platform already loads is a
worse result than the backend can give.

## Change

Pure rename plus doc comments matching the existing six, and a file-level
comment recording why the set is complete rather than as-needed. No backend
change, no behavior change, additive API only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788191652&installation_model_id=426559&pr_number=146&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F146&signature=4966f3e9a63820ed98ac33995ea39331469d08458e63c29c48d80e0fe828100c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->