### PR TITLE
fix(gui): guard FindByID against an unbuilt layout tree

### DIFF
--- a/gui/layout_query.go
+++ b/gui/layout_query.go
@@ -72,7 +72,14 @@ func FindLayoutByScrollID(layout *Layout, id string) (*Layout, bool) {
 }
 
 // FindByID searches the layout tree for a layout with the given ID.
+// A nil Shape means the layout tree has not been built yet (no frame
+// has been laid out), so there is nothing to find. Guarding here rather
+// than in each caller matches findScrollLayout, which already treats a
+// nil root Shape as "not found".
 func (layout *Layout) FindByID(id string) (*Layout, bool) {
+	if layout.Shape == nil {
+		return nil, false
+	}
 	if layout.Shape.ID == id {
 		return layout, true
 	}

--- a/gui/layout_query_test.go
+++ b/gui/layout_query_test.go
@@ -271,6 +271,25 @@ func TestFindByIDNilChildShape(t *testing.T) {
 	}
 }
 
+// An unbuilt child must be skipped, not abort the search: siblings
+// after it must still be reachable.
+func TestFindByIDSkipsNilChildContinuesSearch(t *testing.T) {
+	root := &Layout{
+		Shape: &Shape{ID: "root"},
+		Children: []Layout{
+			{}, // unbuilt subtree
+			{Shape: &Shape{ID: "after"}},
+		},
+	}
+	ly, ok := root.FindByID("after")
+	if !ok {
+		t.Fatal("should find sibling after unbuilt child")
+	}
+	if ly.Shape.ID != "after" {
+		t.Errorf("ID = %q, want after", ly.Shape.ID)
+	}
+}
+
 // ScrollToView is the caller that can reach FindByID before any layout
 // pass — a scroll request issued while the overlay owning the target is
 // still being built. It must be a no-op, not a panic.

--- a/gui/layout_query_test.go
+++ b/gui/layout_query_test.go
@@ -231,3 +231,50 @@ func TestNextPreviousFocusableNilWindow(t *testing.T) {
 		t.Fatalf("prev nil window: got %v, want ID f30", prev)
 	}
 }
+
+func TestFindByIDFound(t *testing.T) {
+	root := &Layout{
+		Shape: &Shape{ID: "root"},
+		Children: []Layout{
+			{Shape: &Shape{ID: "child1"}},
+			{Shape: &Shape{ID: "child2"}},
+		},
+	}
+	ly, ok := root.FindByID("child2")
+	if !ok {
+		t.Fatal("should find child2")
+	}
+	if ly.Shape.ID != "child2" {
+		t.Errorf("ID = %q, want child2", ly.Shape.ID)
+	}
+}
+
+// A Layout with a nil Shape is what Window.layout holds before the
+// first frame is laid out. FindByID must report "not found" rather
+// than dereferencing it.
+func TestFindByIDNilShape(t *testing.T) {
+	root := &Layout{}
+	if _, ok := root.FindByID("anything"); ok {
+		t.Error("nil Shape should not match")
+	}
+}
+
+// Children can also be unbuilt while the parent is not; the recursive
+// step must survive that too.
+func TestFindByIDNilChildShape(t *testing.T) {
+	root := &Layout{
+		Shape:    &Shape{ID: "root"},
+		Children: []Layout{{}},
+	}
+	if _, ok := root.FindByID("missing"); ok {
+		t.Error("should not find missing id")
+	}
+}
+
+// ScrollToView is the caller that can reach FindByID before any layout
+// pass — a scroll request issued while the overlay owning the target is
+// still being built. It must be a no-op, not a panic.
+func TestScrollToViewBeforeLayout(t *testing.T) {
+	var w Window
+	w.ScrollToView("some-id")
+}


### PR DESCRIPTION
Window.layout` holds a zero-value `Layout` until the first frame is laid out, so `Layout.Shape` is nil. `FindByID` dereferenced it unconditionally (`gui/layout_query.go:76`), which crashes any caller that can run before that first pass.

`ScrollToView` is the one such caller today. It is the only `FindByID` user not driven by an input event on an already-laid-out tree, so a scroll request issued while the view owning the target is still being built segfaults instead of no-opping:

```
panic: runtime error: invalid memory address or nil pointer dereference
	gui/layout_query.go:76  (*Layout).FindByID
	gui/scroll.go:240       (*Window).ScrollToView
```

The other thirteen `FindByID` callers (splitters, dock drag, colour picker, scroll anchors) are safe only by accident of timing, so the guard goes in `FindByID` rather than at each call site. That also matches `findScrollLayout` (`gui/scroll.go:7`), which already treats a nil root `Shape` as "not found".

## Found by

Building a command palette and a virtualised theme list in go-term. Both want "scroll the keyboard cursor back into view", and both can issue that scroll on the frame that first builds the overlay — before any layout pass exists. go-term works around it by computing the reveal from cached row geometry using only the nil-safe `ScrollVerticalOffset`/`ScrollVerticalTo`, and will keep doing so: `ScrollToView` top-aligns the target unconditionally (`newScroll := baseY - target.Shape.Y + current`), with no "already visible" or bottom-edge case, which is not the semantics a cursor reveal wants. This PR is only about the crash.

## Tests

Four added to `gui/layout_query_test.go`: nil root `Shape`, nil child `Shape`, the found path (previously uncovered), and `ScrollToView` on a zero-value `Window`. `TestFindByIDNilShape` panics on `main` and passes here.

`go vet ./...` and `go test ./...` clean.

No CHANGELOG entry — the repo adds those in a separate `changelog:` commit at release time. Worth noting the file currently has an empty `## [Unreleased]` heading sitting between v0.46.0 and v0.45.1 (`CHANGELOG.md:37`), which looks misplaced; left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788363844&installation_model_id=426559&pr_number=147&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F147&signature=5ab311ddc43f02553bcef7df02ef0b18559c0e76eb81a2598b86d3fefe6a0b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->