### PR TITLE
fix(gui): FindByID must not match an empty id

### DIFF
--- a/gui/layout_query.go
+++ b/gui/layout_query.go
@@ -72,11 +72,17 @@ func FindLayoutByScrollID(layout *Layout, id string) (*Layout, bool) {
 }
 
 // FindByID searches the layout tree for a layout with the given ID.
+// An empty id never matches — a widget without an ID cannot be
+// addressed — matching the id != "" guards in FindLayoutByScrollID and
+// FindLayoutByFocusID.
 // A nil Shape means the layout tree has not been built yet (no frame
 // has been laid out), so there is nothing to find. Guarding here rather
 // than in each caller matches findScrollLayout, which already treats a
 // nil root Shape as "not found".
 func (layout *Layout) FindByID(id string) (*Layout, bool) {
+	if id == "" {
+		return nil, false
+	}
 	if layout.Shape == nil {
 		return nil, false
 	}

--- a/gui/layout_query_test.go
+++ b/gui/layout_query_test.go
@@ -290,6 +290,19 @@ func TestFindByIDSkipsNilChildContinuesSearch(t *testing.T) {
 	}
 }
 
+// An empty id cannot address a widget, so it must never match — not
+// even a shape whose ID is also empty. Mirrors the id != "" guards in
+// FindLayoutByScrollID and FindLayoutByFocusID.
+func TestFindByIDEmptyIDNeverMatches(t *testing.T) {
+	root := &Layout{
+		Shape:    &Shape{ID: ""},
+		Children: []Layout{{Shape: &Shape{ID: "child"}}},
+	}
+	if _, ok := root.FindByID(""); ok {
+		t.Error(`FindByID("") must not match an empty-ID shape`)
+	}
+}
+
 // ScrollToView is the caller that can reach FindByID before any layout
 // pass — a scroll request issued while the overlay owning the target is
 // still being built. It must be a no-op, not a panic.


### PR DESCRIPTION
## What

`FindByID("")` previously matched the first shape whose ID was also empty — typically the root, or the first widget that never got an ID — instead of reporting not-found.

## Why

An empty id cannot address a widget. `FindLayoutByScrollID` and `FindLayoutByFocusID` both guard `id != ""`; `FindByID` was the odd one out.

## Change

- Early `id == ""` guard in `FindByID` (gui/layout_query.go), before touching the tree
- `TestFindByIDEmptyIDNeverMatches`: a root with an empty ID must not match `FindByID("")`

Follow-up to #147 (which made the same function nil-safe against unbuilt layout trees).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788366032&installation_model_id=426559&pr_number=148&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F148&signature=411ad3dba2945a85bbf1e0110fd208aebb43e6bf9c086d3595b9f3f84b118a59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->