### PR TITLE
fix(ime): queue macOS text-input events, fix converted commits (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,93 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Metal backend dropped IME commit events (#149).** Text-input callbacks
+  wrote a single global event slot, so when one `[NSApp sendEvent:]` fired
+  several `NSTextInputClient` callbacks — the normal CJK sequence of
+  `insertText:` (commit) immediately followed by `setMarkedText:` (residual
+  composition) — each overwrote the previous and only the last reached Go.
+  Committing Japanese produced zero characters; preedit rendering was
+  unaffected. Text events now go through a FIFO drained one per
+  `metalPollEvent`, so every callback is delivered, in order. The
+  `_evIMEGeneration`/`_evIMEConsumedGen` pair is gone — an empty queue
+  encodes the same signal.
+- **Japanese converted text could never be committed on macOS.** After the
+  IME converted a composition (Space, or picking from the candidate window),
+  Enter did nothing at all: no `insertText:`, no callback of any kind, and the
+  preedit stayed on screen forever. Two `NSTextInputClient` methods were
+  stubbed in ways the input method treats as "this client has no document":
+  `selectedRange` returned `{NSNotFound, 0}` — which IMK then used as the base
+  for its range arithmetic, producing garbage queries like
+  `{NSNotFound - 30, 30}` — and `attributedSubstringForProposedRange:`
+  returned `nil`, though a converted commit asks for the text it is replacing.
+  `selectedRange` now reports the selection the IME last set inside the
+  composition, and `attributedSubstringForProposedRange:` serves the
+  composition text (clamped, `nil` only when genuinely out of range).
+  `validAttributesForMarkedText` now advertises the standard marked-text
+  attributes instead of an empty list. Reproduced and fixed against a plain
+  AppKit program with no go-gui code in it, so this was protocol conformance,
+  not an event-loop problem. Unconverted kana commits were unaffected, which
+  is why plain `nihongo` + Enter always worked.
+- **Keys the input method owns no longer also reach the widget on macOS.**
+  While a composition is live the IME owns the keyboard — arrows move between
+  conversion clauses, Enter commits, Escape reverts — but the raw
+  `EventKeyDown` was delivered as well, so the field's caret (and the preedit
+  drawn at it) slid sideways under the arrow keys, and Enter could fire a
+  widget action mid-composition. `keyDown:` now marks a keystroke as claimed
+  when a composition was in progress or the key started one, and
+  `metalPollEvent` drops it; the visible effect arrives as the queued
+  composition or commit instead.
+- **Placeholder text no longer stays visible during IME composition.** The
+  preedit was inserted into the placeholder rather than replacing it, so the
+  hint was pushed out to the right of the composing text ("かんEnter a name").
+  A placeholder is a hint, not content, so a composition now replaces it
+  outright; a field with real text still gets the preedit inserted at the
+  cursor. Applies to every backend, not just macOS.
+- **Metal backend now reports the end of an IME composition.** An empty
+  `setMarkedText:` (composition cancelled) previously wrote no event at all,
+  leaving the preedit on screen. It is delivered as an `EventIMEComposition`
+  with empty `IMEText`, which `Window.imeUpdate` already treats as "clear".
+- **IME composition offsets are clamped to the preedit.** `IMEStart` and
+  `IMELength` cross a platform boundary — Cocoa's `NSRange`, the Android
+  bridge's `int64`, the browser's composition events — and fed slice
+  arithmetic in the render path unchecked. `NSNotFound` in particular
+  truncates to `-1` in the event's `int32`. `Window.imeUpdate` now clamps both
+  to the composition's rune range, so a confused or hostile input method can
+  mis-place an underline but cannot panic the renderer.
+- **Web backend: keys the input method owns no longer reach the widget.** The
+  browser fires `keydown` for arrows, Enter and Escape during a composition
+  (`key == "Process"`, `isComposing == true`); the handler mapped the physical
+  `code` and delivered an `EventKeyDown` anyway, so the caret slid out from
+  under the preedit and Enter could fire a widget action mid-composition. The
+  same class of bug as the macOS fix above. Composing keydowns are now
+  ignored.
+- **Web backend: a cancelled composition now reports its end.**
+  `compositionend` with empty data (Escape) returned without emitting
+  anything, relying on a preceding `compositionupdate` to clear the state — a
+  browser/IME-dependent assumption. It now emits an `EventIMEComposition` with
+  empty `IMEText` directly.
+
+### Changed
+
+- **macOS now emits `EventKeyDown` for printable keys**, followed by
+  `EventChar`, matching X11, win32 and web. The KeyDown was previously
+  swallowed by the same single-slot overwrite. Text input is unaffected
+  (insertion runs on the Char path only), but two consequences are worth
+  noting for macOS apps: a `Command` registered with a modifier-less
+  `Shortcut` (e.g. `Shortcut{Key: KeyA}`) now fires on plain typing, as it
+  already did on Linux/Windows; and `InputCfg.OnKeyDown` now fires for
+  printable keys. Space-activated `OnKeyDown` handlers (select, combobox,
+  listbox, tree, date picker, menu) become live on macOS — previously dead.
+
+### Documentation
+
+- `Event.CharCode` documents that it carries only the first rune of an IME
+  commit; the full string is in `IMEText`.
+
 ## [v0.47.0] - 2026-08-01
 
 ### Added

--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -28,6 +28,13 @@ int metalTestApplicationDidBecomeActive(void);
 void metalTestRunModalMode(int ms);
 void metalTestRunDefaultMode(int ms);
 int metalTestFramePumpActive(void);
+void metalTestPushIMECommit(const char *utf8);
+void metalTestPushIMEComposition(const char *utf8, int start, int len);
+int metalTestIMEQueueDepth(void);
+void metalTestResetIMEQueue(void);
+int metalTestPopTextEvent(void);
+int metalTestIMEClientConformance(void *windowHandle);
+int metalTestIMEKeySuppressedWhileComposing(void *windowHandle);
 */
 import "C"
 import (
@@ -137,6 +144,20 @@ func testWindowDelegateExists(handle C.GoGuiNSWindow) bool {
 	return C.metalTestWindowDelegateExists(unsafe.Pointer(handle)) != 0
 }
 
+// testIMEClientConformance checks the NSTextInputClient answers a
+// Japanese IME needs to commit converted text. Needs a real window, so
+// it runs from runMainThreadTests.
+func testIMEClientConformance(handle C.GoGuiNSWindow) bool {
+	return C.metalTestIMEClientConformance(unsafe.Pointer(handle)) != 0
+}
+
+// testIMEKeySuppressedWhileComposing checks that a key the input
+// method owns does not also reach the widget.
+func testIMEKeySuppressedWhileComposing(handle C.GoGuiNSWindow) bool {
+	return C.metalTestIMEKeySuppressedWhileComposing(
+		unsafe.Pointer(handle)) != 0
+}
+
 func testWindowID(handle C.GoGuiNSWindow) uint32 {
 	return uint32(C.metalWindowGetID(handle))
 }
@@ -159,6 +180,49 @@ func testInjectKeyDown(keyCode uint16, modifiers uint32) {
 // tested without a running event loop.
 func testInjectQuitEvent() {
 	C.metalTestInjectQuitEvent()
+}
+
+// testPushIMECommit queues a committed-text event exactly as
+// insertText: does, so tests can simulate several IME callbacks
+// landing inside one sendEvent:.
+func testPushIMECommit(text string) {
+	ctext := C.CString(text)
+	defer C.free(unsafe.Pointer(ctext))
+	C.metalTestPushIMECommit(ctext)
+}
+
+// testPushIMEComposition queues a preedit-update event as
+// setMarkedText: does. An empty text is the composition-end signal.
+func testPushIMEComposition(text string, start, length int) {
+	ctext := C.CString(text)
+	defer C.free(unsafe.Pointer(ctext))
+	C.metalTestPushIMEComposition(ctext, C.int(start), C.int(length))
+}
+
+// testIMEQueueDepth reports how many text events are still queued.
+func testIMEQueueDepth() int {
+	return int(C.metalTestIMEQueueDepth())
+}
+
+// testResetIMEQueue drops queued text events so one test cannot
+// leak state into the next.
+func testResetIMEQueue() {
+	C.metalTestResetIMEQueue()
+}
+
+// testPopTextEvent drains one queued text event into the C event
+// globals, bypassing metalPollEvent. Used where the queue may be
+// empty: metalPollEvent would then fall through to NSApp, which is
+// main-thread-only.
+func testPopTextEvent() bool {
+	return C.metalTestPopTextEvent() != 0
+}
+
+// testPollEvent runs the real metalPollEvent drain path. Only safe to
+// call with a non-empty text queue — the drain returns before any
+// NSApp access.
+func testPollEvent() bool {
+	return C.metalPollEvent(0) != 0
 }
 
 func testQuitActionSetsQuitEvent() bool {

--- a/gui/backend/metal/events_test.go
+++ b/gui/backend/metal/events_test.go
@@ -279,6 +279,144 @@ func TestMapMetalEvent_PlainKeyDown_ReturnsKeyDown(t *testing.T) {
 	}
 }
 
+// ─── IME text-event queue ──────────────────────────────────────
+
+// A single sendEvent: can fire insertText: then setMarkedText:. With
+// the old single event slot the commit was overwritten and lost —
+// Japanese input produced zero characters (issue #149). Both events
+// must survive, in order.
+func TestIMEQueue_CommitThenComposition_BothDelivered(t *testing.T) {
+	testResetIMEQueue()
+	defer testResetIMEQueue()
+
+	testPushIMECommit("日本語")
+	testPushIMEComposition("ん", 1, 0)
+
+	if !testPollEvent() {
+		t.Fatal("first poll: got no event, want the commit")
+	}
+	evt, cont := mapMetalEvent()
+	if !cont {
+		t.Fatal("commit should continue the event loop")
+	}
+	if evt.Type != gui.EventChar {
+		t.Fatalf("first event: got %v, want EventChar", evt.Type)
+	}
+	if evt.IMEText != "日本語" {
+		t.Fatalf("commit text: got %q, want %q", evt.IMEText, "日本語")
+	}
+
+	if !testPollEvent() {
+		t.Fatal("second poll: got no event, want the composition")
+	}
+	evt, cont = mapMetalEvent()
+	if !cont {
+		t.Fatal("composition should continue the event loop")
+	}
+	if evt.Type != gui.EventIMEComposition {
+		t.Fatalf("second event: got %v, want EventIMEComposition", evt.Type)
+	}
+	if evt.IMEText != "ん" {
+		t.Fatalf("composition text: got %q, want %q", evt.IMEText, "ん")
+	}
+	if evt.IMEStart != 1 {
+		t.Fatalf("composition start: got %d, want 1", evt.IMEStart)
+	}
+}
+
+// A drained queue must not hand the same event back on the next poll.
+func TestIMEQueue_DrainedQueueDoesNotRedeliver(t *testing.T) {
+	testResetIMEQueue()
+	defer testResetIMEQueue()
+
+	testPushIMECommit("a")
+	if !testPopTextEvent() {
+		t.Fatal("pop: got nothing, want the queued commit")
+	}
+	if d := testIMEQueueDepth(); d != 0 {
+		t.Fatalf("queue depth after drain: got %d, want 0", d)
+	}
+	if testPopTextEvent() {
+		t.Fatal("pop on empty queue: got an event, want none")
+	}
+}
+
+// Empty marked text is the IME's composition-end signal. It must reach
+// Go as an empty composition so the preedit can be cleared.
+func TestIMEQueue_CompositionEnd_DeliversEmptyComposition(t *testing.T) {
+	testResetIMEQueue()
+	defer testResetIMEQueue()
+
+	testPushIMEComposition("", 0, 0)
+
+	if !testPollEvent() {
+		t.Fatal("poll: got no event, want the composition end")
+	}
+	evt, cont := mapMetalEvent()
+	if !cont {
+		t.Fatal("composition end should continue the event loop")
+	}
+	if evt.Type != gui.EventIMEComposition {
+		t.Fatalf("got %v, want EventIMEComposition", evt.Type)
+	}
+	if evt.IMEText != "" {
+		t.Fatalf("composition end text: got %q, want empty", evt.IMEText)
+	}
+}
+
+// A queued commit may be delivered a poll or more after the key event
+// that produced it, by which point the shared modifier global has moved
+// on. The entry must carry its own snapshot.
+func TestIMEQueue_ModifiersSurviveDeferredPop(t *testing.T) {
+	testResetIMEQueue()
+	defer testResetIMEQueue()
+
+	const modCmd = uint32(1 << 20) // NSEventModifierFlagCommand
+
+	// Key-down sets the modifier global; the commit is queued with it.
+	testInjectKeyDown(0x00, modCmd)
+	testPushIMECommit("a")
+
+	// A later event clobbers the global before the queue is drained.
+	testInjectKeyDown(0x00, 0)
+
+	if !testPopTextEvent() {
+		t.Fatal("pop: got nothing, want the queued commit")
+	}
+	evt, _ := mapMetalEvent()
+	if evt.Type != gui.EventChar {
+		t.Fatalf("got %v, want EventChar", evt.Type)
+	}
+	if !evt.Modifiers.Has(gui.ModSuper) {
+		t.Fatalf("modifiers: got %v, want ModSuper from push time",
+			evt.Modifiers)
+	}
+}
+
+// Overflow must stay bounded rather than grow or corrupt the ring.
+func TestIMEQueue_OverflowIsBounded(t *testing.T) {
+	testResetIMEQueue()
+	defer testResetIMEQueue()
+
+	const queueCap = 32 // TEXT_EVENT_CAP
+	for range queueCap + 4 {
+		testPushIMECommit("x")
+	}
+	if d := testIMEQueueDepth(); d != queueCap {
+		t.Fatalf("queue depth after overflow: got %d, want %d", d, queueCap)
+	}
+
+	// The newest entries are the ones kept.
+	for i := range queueCap {
+		if !testPopTextEvent() {
+			t.Fatalf("pop %d: got nothing, want an entry", i)
+		}
+	}
+	if d := testIMEQueueDepth(); d != 0 {
+		t.Fatalf("queue depth after full drain: got %d, want 0", d)
+	}
+}
+
 // ─── Cursor bounds guard ────────────────────────────────────────
 
 func TestCursorBoundsCheck(t *testing.T) {

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -113,6 +113,22 @@ func runMainThreadTests() {
 		panic("metal.New: window not registered in windowRegistry")
 	}
 
+	// 7b. NSTextInputClient must answer what an input method needs to
+	//     commit converted text. selectedRange returning NSNotFound or
+	//     attributedSubstringForProposedRange: returning nil makes the
+	//     Japanese IME abandon the commit and strand the composition.
+	if !testIMEClientConformance(b.window) {
+		panic("NSTextInputClient: IME conformance check failed")
+	}
+
+	// 7c. A key the input method consumed must not also reach the
+	//     widget: arrows move between conversion clauses, and a raw
+	//     arrow would drag the field's caret out from under the
+	//     preedit.
+	if !testIMEKeySuppressedWhileComposing(b.window) {
+		panic("IME key suppression: raw key leaked while composing")
+	}
+
 	// 8. metalAppFinishLaunch must not crash — validates the C function
 	//    exists, links, and can be called from Go. Regression test
 	//    for the activation call added before the event loop.

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -69,14 +69,92 @@ static int             _evKeyRepeat;
 static char           *_evText;           // malloc'd, freed on next event
 static int             _evIMEStart;
 static int             _evIMELength;
-static int             _evIMEGeneration;   // incremented on each IME event
-static int             _evIMEConsumedGen;  // last generation consumed by poll
 static int             _quitRequested;     // set by quit:/appShouldTerminate: (main thread only)
 // Set by windowWillStartLiveResize:, consumed in metalPollEvent.
 // AppKit's resize tracking loop runs *inside* [NSApp sendEvent:], so
 // this flag tells us — after sendEvent returns — that the mouse-down
 // we already stored was swallowed to drive a window resize.
 static int             _liveResizeStarted;
+// Set by keyDown: when an input method owned the keystroke, consumed in
+// metalPollEvent. While a composition is live the IME owns the keyboard
+// — arrows move between conversion clauses, Enter commits, Escape
+// reverts — so the raw key must not also reach the widget, or the
+// field's own caret moves under the preedit.
+static int             _imeConsumedKey;
+
+// ─── Text-input event queue (IME) ──────────────────────────────
+//
+// A single [NSApp sendEvent:] can fire several NSTextInputClient
+// callbacks synchronously — for CJK, insertText: (the commit)
+// immediately followed by setMarkedText: (a residual composition).
+// The _ev* globals above are one slot, so the earlier callback used
+// to be overwritten and silently lost.  Queue the text events instead
+// and let metalPollEvent hand them to Go one per call.
+//
+// Main thread only: every writer is an AppKit callback and the only
+// reader is metalPollEvent, so no locking is needed.
+
+typedef struct {
+    int          type;       // METAL_EVENT_CHAR | METAL_EVENT_IME_COMP
+    unsigned int windowID;
+    char        *text;       // malloc'd, owned by the entry
+    int          imeStart;
+    int          imeLength;
+    unsigned int modifiers;  // snapshot: _evModifiers moves on before the pop
+} TextEvent;
+
+#define TEXT_EVENT_CAP 32
+
+static TextEvent _textQ[TEXT_EVENT_CAP];
+static int       _textQHead;   // index of the oldest entry
+static int       _textQCount;
+
+// Append a text event.  `utf8` may be NULL or empty (an empty
+// composition is how the IME reports "preedit ended").
+static void pushTextEvent(int type, const char *utf8, unsigned int wid,
+                          int start, int len) {
+    // Full queue: drop the oldest entry rather than the new one, so the
+    // most recent input state always survives.  Unreachable in practice —
+    // the queue drains on every poll and one sendEvent yields a handful.
+    if (_textQCount == TEXT_EVENT_CAP) {
+        TextEvent *oldest = &_textQ[_textQHead];
+        if (oldest->text) free(oldest->text);
+        _textQHead = (_textQHead + 1) % TEXT_EVENT_CAP;
+        _textQCount--;
+    }
+
+    TextEvent *e = &_textQ[(_textQHead + _textQCount) % TEXT_EVENT_CAP];
+    e->type      = type;
+    e->windowID  = wid;
+    e->text      = strdup(utf8 ? utf8 : "");
+    e->imeStart  = start;
+    e->imeLength = len;
+    e->modifiers = _evModifiers;
+    _textQCount++;
+}
+
+// Move the oldest queued text event into the _ev* globals so the Go
+// accessors see it.  Returns 1 if an event was delivered, 0 if empty.
+static int popTextEvent(void) {
+    if (_textQCount == 0) return 0;
+
+    TextEvent *e = &_textQ[_textQHead];
+    _textQHead = (_textQHead + 1) % TEXT_EVENT_CAP;
+    _textQCount--;
+
+    // Same ownership rule as storeEvent: the globals own _evText and
+    // free it before taking the next one.  Go copies via C.GoString
+    // immediately after the poll returns.
+    if (_evText) free(_evText);
+    _evText      = e->text;
+    e->text      = NULL;
+    _evType      = e->type;
+    _evWindowID  = e->windowID;
+    _evIMEStart  = e->imeStart;
+    _evIMELength = e->imeLength;
+    _evModifiers = e->modifiers;
+    return 1;
+}
 
 // ─── Window ID counter ─────────────────────────────────────────
 
@@ -91,6 +169,7 @@ static uint32_t _nextWindowID = 1;
 @property (nonatomic, assign) NSRect      imeCursorRect;
 @property (nonatomic, copy)   NSAttributedString *markedText;
 @property (nonatomic, assign) NSRange     markedRange;
+@property (nonatomic, assign) NSRange     selRange;
 @end
 
 @implementation MetalContentView
@@ -116,6 +195,7 @@ static uint32_t _nextWindowID = 1;
         _imeActive = NO;
         _imeCursorRect = NSZeroRect;
         _markedRange = NSMakeRange(NSNotFound, 0);
+        _selRange = NSMakeRange(0, 0);
 
         self.wantsLayer = YES;
         self.layer = metalLayer;
@@ -150,7 +230,14 @@ static uint32_t _nextWindowID = 1;
 // insertText: fires for printable characters. Non-printable
 // keys (arrows, etc.) return to Go as EventKeyDown.
 - (void)keyDown:(NSEvent *)event {
+    // A composition already in progress means the input method owns
+    // this key. So does a key that starts one: it produced a preedit,
+    // not a command.
+    BOOL wasComposing = (_markedText != nil);
     [self interpretKeyEvents:@[event]];
+    if (wasComposing || _markedText != nil) {
+        _imeConsumedKey = 1;
+    }
 }
 
 - (void)keyUp:(NSEvent *)event {
@@ -170,17 +257,16 @@ static uint32_t _nextWindowID = 1;
 // ─── NSTextInputClient (IME) ───────────────────────────────────
 
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange {
-    // Free previous event text.
-    if (_evText) { free(_evText); _evText = NULL; }
-
+    NSString *committed = nil;
     if ([string isKindOfClass:[NSAttributedString class]]) {
-        _evText = strdup([[(NSAttributedString *)string string] UTF8String]);
+        committed = [(NSAttributedString *)string string];
     } else if ([string isKindOfClass:[NSString class]]) {
-        _evText = strdup([(NSString *)string UTF8String]);
+        committed = (NSString *)string;
     }
-    _evType = METAL_EVENT_CHAR;
-    _evWindowID = _windowID;
-    _evIMEGeneration++; // new IME text to deliver
+
+    // Queued, not written straight to the globals: a CJK commit is
+    // routinely followed by setMarkedText: inside the same sendEvent:.
+    pushTextEvent(METAL_EVENT_CHAR, [committed UTF8String], _windowID, 0, 0);
 
     [self unmarkText];
 }
@@ -188,8 +274,6 @@ static uint32_t _nextWindowID = 1;
 - (void)setMarkedText:(id)string
         selectedRange:(NSRange)selectedRange
      replacementRange:(NSRange)replacementRange {
-    if (_evText) { free(_evText); _evText = NULL; }
-
     if ([string isKindOfClass:[NSAttributedString class]]) {
         _markedText = [(NSAttributedString *)string copy];
     } else if ([string isKindOfClass:[NSString class]]) {
@@ -197,22 +281,42 @@ static uint32_t _nextWindowID = 1;
     }
 
     if (_markedText && [_markedText length] > 0) {
-        _evText = strdup([[_markedText string] UTF8String]);
         _markedRange = NSMakeRange(0, [_markedText length]);
-        _evIMEStart = (int)selectedRange.location;
-        _evIMELength = (int)selectedRange.length;
-        _evType = METAL_EVENT_IME_COMP;
-        _evWindowID = _windowID;
-        _evIMEGeneration++; // new IME composition to deliver
+        // Selection inside the composition, read back via
+        // selectedRange while converting. Kept verbatim (length and
+        // all — conversion selects a whole clause), guarding only
+        // against a location the composition cannot hold.
+        _selRange = selectedRange;
+        if (_selRange.location == NSNotFound ||
+            _selRange.location > [_markedText length]) {
+            _selRange = NSMakeRange([_markedText length], 0);
+        }
+        // Subtraction, not a sum: unsigned range members wrap.
+        if (_selRange.length > [_markedText length] - _selRange.location) {
+            _selRange.length = [_markedText length] - _selRange.location;
+        }
+        // Report the clamped range, not the raw one: NSNotFound
+        // truncates to -1 in an int and would reach the renderer as a
+        // negative caret offset.
+        pushTextEvent(METAL_EVENT_IME_COMP, [[_markedText string] UTF8String],
+                      _windowID, (int)_selRange.location,
+                      (int)_selRange.length);
     } else {
         _markedText = nil;
         _markedRange = NSMakeRange(NSNotFound, 0);
+        _selRange = NSMakeRange(0, 0);
+        // Empty marked text means the IME ended the composition (cancel,
+        // or commit handled by insertText:).  Deliver it as an empty
+        // composition so Go can clear the preedit; unmarkText stays
+        // silent so a commit does not emit a second one.
+        pushTextEvent(METAL_EVENT_IME_COMP, "", _windowID, 0, 0);
     }
 }
 
 - (void)unmarkText {
     _markedText = nil;
     _markedRange = NSMakeRange(NSNotFound, 0);
+    _selRange = NSMakeRange(0, 0);
 }
 
 - (BOOL)hasMarkedText {
@@ -223,13 +327,41 @@ static uint32_t _nextWindowID = 1;
     return _markedRange;
 }
 
+// The input method does range arithmetic against this value and
+// abandons a commit when it is NSNotFound — a converted commit has to
+// replace text at the insertion point. go-gui keeps the document text
+// on the Go side, so the range is expressed against the composition
+// alone: marked text always starts at 0, and _selRange tracks the
+// caret the IME last reported inside it.
 - (NSRange)selectedRange {
-    return NSMakeRange(NSNotFound, 0);
+    return _selRange;
 }
 
+// Returning nil here makes the input method abandon a converted
+// commit — it asks for the text it is about to replace. go-gui keeps
+// the document on the Go side, so the composition itself stands in as
+// the document: marked text always starts at 0, which is the same
+// coordinate space markedRange and selectedRange report.
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)range
                                                 actualRange:(NSRangePointer)actualRange {
-    return nil;
+    NSString *doc = [_markedText string];
+    if (!doc) doc = @"";
+
+    NSRange r = range;
+    if (r.location == NSNotFound || r.location > [doc length]) {
+        if (actualRange) *actualRange = NSMakeRange(NSNotFound, 0);
+        return nil;
+    }
+    // Subtract rather than compare location + length: NSRange members
+    // are unsigned, and IMK does send lengths near NSUIntegerMax, which
+    // would wrap the sum and slip past a comparison into a crash inside
+    // substringWithRange:.
+    if (r.length > [doc length] - r.location) {
+        r.length = [doc length] - r.location;
+    }
+    if (actualRange) *actualRange = r;
+    return [[NSAttributedString alloc]
+        initWithString:[doc substringWithRange:r]];
 }
 
 - (NSRect)firstRectForCharacterRange:(NSRange)range
@@ -246,8 +378,13 @@ static uint32_t _nextWindowID = 1;
     return 0;
 }
 
+// The attributes a text client advertises for marked text. An empty
+// list tells the input method the client cannot render clause
+// segments, which degrades conversion behavior.
 - (NSArray<NSAttributedStringKey> *)validAttributesForMarkedText {
-    return @[];
+    return @[NSUnderlineStyleAttributeName,
+             NSUnderlineColorAttributeName,
+             NSMarkedClauseSegmentAttributeName];
 }
 
 @end
@@ -710,14 +847,11 @@ int metalPollEvent(int timeoutMs) {
         return 1;
     }
 
-    // Check for unconsumed IME events (char / composition) stored
-    // by NSTextInputClient callbacks during the previous sendEvent.
-    // Uses a generation counter so stale _evType values are not
-    // re-delivered across successive poll calls.
-    if (_evIMEConsumedGen < _evIMEGeneration) {
-        _evIMEConsumedGen = _evIMEGeneration;
-        return 1;
-    }
+    // Drain text-input events queued by NSTextInputClient callbacks
+    // during a previous sendEvent before touching the NSEvent queue.
+    // This is what keeps a multi-callback keystroke (CJK commit +
+    // residual composition) in order and intact.
+    if (popTextEvent()) return 1;
 
     // Non-blocking dequeue.
     event = [NSApp nextEventMatchingMask:ALL_EVENTS
@@ -740,13 +874,9 @@ int metalPollEvent(int timeoutMs) {
     }
 
     if (!event) {
-        // Check if IME left us an event during the blocking wait
-        // (e.g., from a concurrent dispatch). Same generation
-        // check as above.
-        if (_evIMEConsumedGen < _evIMEGeneration) {
-            _evIMEConsumedGen = _evIMEGeneration;
-            return 1;
-        }
+        // IME callbacks can fire during the blocking wait — the
+        // candidate window runs the runloop — so check the queue again.
+        if (popTextEvent()) return 1;
         return 0;
     }
 
@@ -761,6 +891,7 @@ int metalPollEvent(int timeoutMs) {
     storeEvent(event, wid);
 
     _liveResizeStarted = 0;
+    _imeConsumedKey = 0;
 
     // Forward to AppKit for window management and text input.
     // Key events: keyDown: → interpretKeyEvents: → insertText: fires
@@ -783,11 +914,21 @@ int metalPollEvent(int timeoutMs) {
     }
     _liveResizeStarted = 0;
 
-    // If sendEvent triggered IME callbacks that overwrote _evType
-    // to CHAR or IME_COMP, mark this generation as consumed so
-    // the next poll call doesn't re-deliver it.
-    if (_evType == METAL_EVENT_CHAR || _evType == METAL_EVENT_IME_COMP) {
-        _evIMEConsumedGen = _evIMEGeneration;
+    // Drop a key the input method claimed. Its visible effect arrives
+    // as the queued composition or commit instead.
+    if (_imeConsumedKey && _evType == METAL_EVENT_KEY_DOWN) {
+        _evType = METAL_EVENT_NONE;
+    }
+    _imeConsumedKey = 0;
+
+    // sendEvent may have queued text events (insertText:/setMarkedText:).
+    // Return the NSEvent-derived event now and let the drain at the top
+    // of the next poll deliver them, so a printable key yields KEY_DOWN
+    // followed by CHAR — the order X11, win32 and web already use. If
+    // the NSEvent produced nothing of its own, deliver a queued event
+    // straight away rather than handing Go an empty poll.
+    if (_evType == METAL_EVENT_NONE) {
+        popTextEvent();
     }
 
     return 1;
@@ -1186,7 +1327,7 @@ void metalStopFramePump(void) {
 //
 // These live in the production file, not a separate _test.m, on
 // purpose: they reach file-static state — the event globals (_evType,
-// _quitRequested, _evIMEGeneration…), metalCursorInContentBounds, and
+// _quitRequested…), the text-event queue, metalCursorInContentBounds, and
 // metalFocusedGUIWindow. C `static` is translation-unit-local, so a
 // split would force exposing those symbols via the header, widening
 // the production surface just to relocate test code. Keeping the
@@ -1243,6 +1384,152 @@ void metalTestInjectKeyDown(unsigned short keyCode, unsigned int modifiers) {
     _evKeyCode = keyCode;
     _evModifiers = modifiers;
     _evKeyRepeat = 0;
+}
+
+// Push onto the text-event queue exactly as insertText: /
+// setMarkedText: do, so Go tests can drive the IME path (and the
+// multi-event-per-sendEvent case behind issue #149) without a running
+// event loop or a real input method.
+void metalTestPushIMECommit(const char *utf8) {
+    pushTextEvent(METAL_EVENT_CHAR, utf8, 0, 0, 0);
+}
+
+void metalTestPushIMEComposition(const char *utf8, int start, int len) {
+    pushTextEvent(METAL_EVENT_IME_COMP, utf8, 0, start, len);
+}
+
+int metalTestIMEQueueDepth(void) { return _textQCount; }
+
+// Forward declaration: the conformance helpers below reset the queue
+// they dirty, and the definition sits after them.
+void metalTestResetIMEQueue(void);
+
+// Drive keyDown: with a composition in progress and report whether the
+// raw key was claimed by the input method. A key that reaches the
+// widget while composing moves the field's caret out from under the
+// preedit and can fire Enter/Escape actions the user never meant.
+int metalTestIMEKeySuppressedWhileComposing(void *windowHandle) {
+    if (!windowHandle) return 0;
+    GoGuiWindow *gw = (GoGuiWindow *)windowHandle;
+    if (!gw->nsWindow) return 0;
+    NSView *cv = gw->nsWindow.contentView;
+    if (![cv isKindOfClass:[MetalContentView class]]) return 0;
+    MetalContentView *view = (MetalContentView *)cv;
+
+    NSEvent *key = [NSEvent keyEventWithType:NSEventTypeKeyDown
+                                    location:NSZeroPoint
+                               modifierFlags:0
+                                   timestamp:0
+                                windowNumber:[gw->nsWindow windowNumber]
+                                     context:nil
+                                  characters:@""
+                 charactersIgnoringModifiers:@""
+                                   isARepeat:NO
+                                     keyCode:123]; // left arrow
+    if (!key) return 0;
+
+    // Composing: the key belongs to the input method.
+    [view setMarkedText:@"あい"
+          selectedRange:NSMakeRange(0, 2)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+    _imeConsumedKey = 0;
+    [view keyDown:key];
+    int suppressed = _imeConsumedKey;
+
+    // Not composing: the key is the widget's to handle.
+    [view unmarkText];
+    _imeConsumedKey = 0;
+    [view keyDown:key];
+    int deliveredWhenIdle = (_imeConsumedKey == 0);
+
+    _imeConsumedKey = 0;
+    metalTestResetIMEQueue();
+    return (suppressed && deliveredWhenIdle) ? 1 : 0;
+}
+
+// Verify the NSTextInputClient answers an input method needs to commit
+// converted text. Returning NSNotFound from selectedRange, or nil from
+// attributedSubstringForProposedRange:, makes the Japanese IME abandon
+// the commit after conversion — the composition stays marked forever
+// and nothing reaches the app. Reproduced in a plain AppKit program
+// with no go-gui code in it, so the contract is AppKit's, not go-gui's.
+// Empty validAttributesForMarkedText tells the IME the client cannot
+// render clause segments.
+int metalTestIMEClientConformance(void *windowHandle) {
+    if (!windowHandle) return 0;
+    GoGuiWindow *gw = (GoGuiWindow *)windowHandle;
+    if (!gw->nsWindow) return 0;
+    NSView *cv = gw->nsWindow.contentView;
+    if (![cv isKindOfClass:[MetalContentView class]]) return 0;
+    MetalContentView *view = (MetalContentView *)cv;
+
+    int ok = 1;
+
+    // Compose "あい" with the whole clause selected, as conversion does.
+    [view setMarkedText:@"あい"
+          selectedRange:NSMakeRange(0, 2)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+
+    NSRange sel = [view selectedRange];
+    if (sel.location == NSNotFound || sel.location + sel.length > 2) ok = 0;
+
+    NSRange actual = NSMakeRange(NSNotFound, 0);
+    NSAttributedString *sub =
+        [view attributedSubstringForProposedRange:NSMakeRange(0, 2)
+                                      actualRange:&actual];
+    if (!sub || ![[sub string] isEqualToString:@"あい"]) ok = 0;
+
+    // An out-of-range request must degrade to nil, not crash or lie.
+    NSAttributedString *bad =
+        [view attributedSubstringForProposedRange:NSMakeRange(99, 2)
+                                      actualRange:NULL];
+    if (bad != nil) ok = 0;
+
+    // A length near NSUIntegerMax must clamp, not wrap past the guard
+    // into substringWithRange: — IMK really does ask for these.
+    NSAttributedString *huge =
+        [view attributedSubstringForProposedRange:
+                  NSMakeRange(1, NSUIntegerMax)
+                                      actualRange:NULL];
+    if (!huge || ![[huge string] isEqualToString:@"い"]) ok = 0;
+
+    if ([[view validAttributesForMarkedText] count] == 0) ok = 0;
+
+    // The queued composition must carry the clamped selection, not the
+    // raw one: NSNotFound truncates to -1 in the int the event holds,
+    // and Go would draw the clause underline from a negative offset.
+    metalTestResetIMEQueue();
+    [view setMarkedText:@"あい"
+          selectedRange:NSMakeRange(NSNotFound, 0)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+    if (!popTextEvent()) {
+        ok = 0;
+    } else if (_evIMEStart != 2 || _evIMELength != 0) {
+        ok = 0;
+    }
+
+    [view unmarkText];
+    if ([view selectedRange].location == NSNotFound) ok = 0;
+
+    metalTestResetIMEQueue();
+    return ok;
+}
+
+// Drain one entry without going through metalPollEvent.  Used for the
+// empty-queue assertions: metalPollEvent would fall through to
+// [NSApp nextEventMatchingMask:…], which is main-thread-only and must
+// not be called from the ordinary (non-main-thread) test binary.
+int metalTestPopTextEvent(void) { return popTextEvent(); }
+
+// Drop every queued entry so one test cannot leak state into the next.
+void metalTestResetIMEQueue(void) {
+    while (_textQCount > 0) {
+        TextEvent *e = &_textQ[_textQHead];
+        if (e->text) { free(e->text); e->text = NULL; }
+        _textQHead = (_textQHead + 1) % TEXT_EVENT_CAP;
+        _textQCount--;
+    }
+    _evType = METAL_EVENT_NONE;
 }
 
 // Run the main runloop for ms milliseconds in a nested mode, standing in

--- a/gui/backend/web/events.go
+++ b/gui/backend/web/events.go
@@ -120,6 +120,19 @@ func (b *Backend) registerEvents(w *gui.Window) {
 
 	reg(doc, "keydown", func(_ js.Value, args []js.Value) any {
 		e := args[0]
+
+		// While a composition is live the input method owns the
+		// keyboard — arrows move between clauses, Enter commits,
+		// Escape reverts — and the browser still fires keydown for
+		// those keys (key == "Process", isComposing == true). Let
+		// them through and the field's own caret moves out from
+		// under the preedit, or Enter submits mid-composition.
+		// Truthy, not Bool: Bool panics on a browser that predates
+		// the property and leaves it undefined.
+		if e.Get("isComposing").Truthy() {
+			return nil
+		}
+
 		code := e.Get("code").String()
 		key := e.Get("key").String()
 		mods := mapModifiers(e)
@@ -187,6 +200,11 @@ func (b *Backend) registerEvents(w *gui.Window) {
 			e := args[0]
 			text := e.Get("data").String()
 			if len(text) == 0 {
+				// Cancelled composition (Escape). Report the end
+				// so the preedit clears; without it the overlay
+				// can outlive the composition.
+				*evt = gui.Event{Type: gui.EventIMEComposition}
+				w.EventFn(evt)
 				return nil
 			}
 			// CharCode carries only the first rune; the full

--- a/gui/event.go
+++ b/gui/event.go
@@ -301,6 +301,11 @@ type TouchPoint struct {
 }
 
 // Event holds input event data.
+//
+// CharCode carries only the FIRST rune of the typed text. An IME
+// commit routinely delivers several runes in one event (CJK), and the
+// full string lives only in IMEText — read IMEText whenever the text
+// may come from an input method.
 type Event struct {
 	IMEText           string
 	FilePath          string

--- a/gui/ime.go
+++ b/gui/ime.go
@@ -9,15 +9,23 @@ type ime struct {
 }
 
 // imeUpdate sets composition state from an IME composition event.
+//
+// The offsets are clamped here rather than in each backend: they cross
+// a platform boundary (Cocoa's NSRange, the Android bridge's int64,
+// the browser's composition events), a hostile or merely confused
+// input method can report anything, and the values feed slice
+// arithmetic in the render path, which runs every frame.
 func (w *Window) imeUpdate(e *Event) {
 	if len(e.IMEText) == 0 {
 		w.imeClear()
 		return
 	}
+	n := utf8RuneCount(e.IMEText)
+	cursor := min(max(int(e.IMEStart), 0), n)
 	w.ime.composing = true
 	w.ime.compText = e.IMEText
-	w.ime.compCursor = int(e.IMEStart)
-	w.ime.compSelLen = int(e.IMELength)
+	w.ime.compCursor = cursor
+	w.ime.compSelLen = min(max(int(e.IMELength), 0), n-cursor)
 }
 
 // imeClear resets composition state (called on commit or focus

--- a/gui/ime_test.go
+++ b/gui/ime_test.go
@@ -34,6 +34,41 @@ func TestIMEClearResetsState(t *testing.T) {
 	}
 }
 
+// The offsets arrive from a platform input method and index the
+// preedit for slice arithmetic in the render path, so they must land
+// inside the composition whatever the IME reports. Counted in runes:
+// "かん" is two.
+func TestIMEUpdateClampsOffsets(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		start, length          int32
+		wantCursor, wantSelLen int
+	}{
+		{"in range", 1, 1, 1, 1},
+		{"negative start", -5, 2, 0, 2},
+		{"start past end", 9, 0, 2, 0},
+		{"negative length", 0, -3, 0, 0},
+		{"length past end", 1, 9, 1, 1},
+		{"NSNotFound truncated to -1", -1, -1, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newTestWindow()
+			w.imeUpdate(&Event{
+				Type:      EventIMEComposition,
+				IMEText:   "かん",
+				IMEStart:  tc.start,
+				IMELength: tc.length,
+			})
+			if got := w.IMECompCursor(); got != tc.wantCursor {
+				t.Errorf("cursor: got %d, want %d", got, tc.wantCursor)
+			}
+			if got := w.IMECompSelLen(); got != tc.wantSelLen {
+				t.Errorf("sel len: got %d, want %d", got, tc.wantSelLen)
+			}
+		})
+	}
+}
+
 func TestIMEUpdateEmptyTextClears(t *testing.T) {
 	w := newTestWindow()
 	w.imeUpdate(&Event{
@@ -78,4 +113,82 @@ func TestIMESetRectNoopWithoutPlatform(_ *testing.T) {
 	w := newTestWindow()
 	// Should not panic with nil nativePlatform.
 	w.IMESetRect(10, 20, 30, 40)
+}
+
+// renderIMEPreedit composes "かん" into a focused text field and
+// returns the string the renderer emitted. cursor is the field's caret
+// position; placeholder marks the field text as a hint rather than
+// content.
+func renderIMEPreedit(t *testing.T, text string, cursor int,
+	placeholder bool,
+) string {
+	t.Helper()
+
+	const id = "ime-field"
+	w := makeWindowWithScratch()
+	w.viewState.focusID = id
+	StateMap[string, InputState](w, nsInput, capMany).Set(
+		id, InputState{CursorPos: cursor})
+	w.imeUpdate(&Event{Type: EventIMEComposition, IMEText: "かん"})
+
+	style := DefaultTextStyle
+	renderText(&Shape{
+		shapeType: shapeText,
+		Focusable: true, ID: id,
+		Width: 200, Height: 20,
+		Opacity: 1.0,
+		TC: &ShapeTextConfig{
+			Text:              text,
+			TextStyle:         &style,
+			TextIsPlaceholder: placeholder,
+		},
+	}, makeClip(0, 0, 400, 400), w)
+
+	for _, r := range w.renderers {
+		if r.Kind == RenderText {
+			return r.Text
+		}
+	}
+	t.Fatal("no text command emitted")
+	return ""
+}
+
+// A composition replaces the placeholder rather than being inserted
+// into it. Inserting pushed the placeholder out to the right of the
+// preedit, leaving the hint visible while the user typed.
+func TestRenderTextIMEReplacesPlaceholder(t *testing.T) {
+	if got := renderIMEPreedit(t, "Enter a name", 0, true); got != "かん" {
+		t.Fatalf("composing over a placeholder rendered %q, want %q",
+			got, "かん")
+	}
+}
+
+// The same composition in a field with real text is still inserted at
+// the cursor, not substituted for the content.
+func TestRenderTextIMEInsertsIntoRealText(t *testing.T) {
+	if got := renderIMEPreedit(t, "abcd", 2, false); got != "abかんcd" {
+		t.Fatalf("preedit at cursor rendered %q, want %q",
+			got, "abかんcd")
+	}
+}
+
+// A cursor outside the text must not panic the render path: the
+// preedit is drawn every frame, so a bad offset would take the whole
+// app down rather than mis-draw one string.
+func TestRenderTextIMEOutOfRangeCursorNoPanic(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cursor int
+		want   string
+	}{
+		{"negative", -5, "かんabcd"},
+		{"past end", 99, "abcdかん"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderIMEPreedit(t, "abcd", tc.cursor, false)
+			if got != tc.want {
+				t.Fatalf("rendered %q, want %q", got, tc.want)
+			}
+		})
+	}
 }

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -63,7 +63,15 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 		is := StateReadOr(w, nsInput, shape.ID,
 			InputState{})
 		runes := []rune(text)
-		compInsertPos = min(is.CursorPos, len(runes))
+		if tc.TextIsPlaceholder {
+			// The placeholder is a hint, not content: a composition
+			// replaces it outright. Inserting into it would push the
+			// hint out to the right of the preedit.
+			runes = nil
+		}
+		// Clamped both ways: the slices below panic on a cursor
+		// outside the text, and the preedit is drawn every frame.
+		compInsertPos = min(max(is.CursorPos, 0), len(runes))
 		var sb strings.Builder
 		sb.Grow(len(text) + len(compText))
 		sb.WriteString(string(runes[:compInsertPos]))


### PR DESCRIPTION
Fixes the Metal backend dropping IME commits, plus three defects that surfaced once the commits started arriving.

Closes #149.

## The reported bug

Every event lived in a single set of C globals. One `[NSApp sendEvent:]` can fire several `NSTextInputClient` callbacks — for CJK, `insertText:` (the commit) immediately followed by `setMarkedText:` (a residual composition) — so each overwrote the previous and only the last reached Go. Committing Japanese produced zero characters.

Text-input callbacks now push onto a bounded FIFO (32 entries, oldest dropped on overflow) that `metalPollEvent` drains one per call. `_evIMEGeneration`/`_evIMEConsumedGen` are gone; an empty queue encodes the same signal. Each entry snapshots its own modifiers, since `_evModifiers` moves on before a deferred pop.

## Three defects found while verifying it

**Converted text could never be committed — this had never worked.** After conversion (Space, or picking a candidate), Enter did nothing at all: no `insertText:`, no callback of any kind, preedit stranded on screen. Two client methods were stubbed in ways IMK reads as "this client has no document": `selectedRange` returned `{NSNotFound, 0}`, which IMK then used as the base for range arithmetic (producing queries like `{NSNotFound - 30, 30}`), and `attributedSubstringForProposedRange:` returned `nil` even though a converted commit asks for the text it is replacing. Reproduced in a plain AppKit program with no go-gui code in it, so this is protocol conformance, not the event loop. Unconverted kana commits were unaffected, which is why plain `nihongo` + Enter always worked.

**Keys the input method owned also reached the widget.** Arrows dragged the field's caret out from under the preedit; Enter could fire a widget action mid-composition. `keyDown:` now marks such a keystroke claimed and `metalPollEvent` drops it. The web backend had the identical bug via the browser's `isComposing` flag — fixed there too.

**Placeholder text stayed visible while composing.** The preedit was inserted *into* the hint rather than replacing it, rendering `かんEnter a name`. Backend-independent fix in `renderText`.

Composition end (empty `setMarkedText:`, and `compositionend` with empty data on web) now reports an empty `EventIMEComposition` so the preedit clears.

## Hardening

IME offsets are clamped in `Window.imeUpdate` — the one place all four backends pass through. They cross a platform boundary (Cocoa `NSRange`, the Android bridge's `int64`, browser composition events) and fed slice arithmetic in the render path unchecked, where `NSNotFound` truncated to `-1` panicked the renderer. `attributedSubstringForProposedRange:` also compared `location + length` on unsigned range members; IMK sends lengths near `NSUIntegerMax`, which wrapped past the guard into a crash. Now a subtraction.

## Behavior change

**macOS now emits `EventKeyDown` for printable keys**, followed by `EventChar`, matching X11, win32 and web — the KeyDown was previously swallowed by the same single-slot overwrite. Text input is unaffected (insertion runs on the Char path only), but two consequences for macOS apps: a `Command` registered with a modifier-less `Shortcut` now fires on plain typing, as it already did on Linux/Windows; and `InputCfg.OnKeyDown` fires for printable keys. Space-activated `OnKeyDown` handlers (select, combobox, listbox, tree, date picker, menu) become live on macOS — previously dead.

## Testing

Five Go tests for the queue (ordering, no re-delivery, composition end, modifier snapshot, bounded overflow), two C conformance helpers run from `runMainThreadTests` (client answers + key suppression, both needing a real window), and Go tests for the placeholder, out-of-range cursor, and offset clamping. Every one was verified to fail against the unfixed code before being kept.

`go build ./...`, `go test ./...`, `golangci-lint run ./...` clean, plus `GO_GUI_MAIN_THREAD_TESTS=1` for the metal package and the wasm web suite under the Node runner.

**Not covered by tests:** the two web fixes. The wasm test binary runs under Node, which has no DOM, so the listeners cannot be registered or dispatched to.

## Follow-ups filed

- #150 — X11 has no IME support at all; CJK input does not work on Linux
- #151 — Android `imeCommit` emits per-rune `EventChar` with empty `IMEText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788405123&installation_model_id=426559&pr_number=152&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F152&signature=51b55c87da9e0d271adcd94abb8bc7ac41623ab41838de70d6eada0f8d42b452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->