### PR TITLE
fix(ime): android imeCommit emits one EventChar with IMEText (#151)

### DIFF
--- a/gui/backend/android/events.go
+++ b/gui/backend/android/events.go
@@ -2,7 +2,11 @@
 
 package android
 
-import "github.com/go-gui-org/go-gui/gui"
+import (
+	"unicode/utf8"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
 
 // imeComposition dispatches an IME preedit composition event.
 func imeComposition(text string, cursor, selLen int32) {
@@ -18,19 +22,25 @@ func imeComposition(text string, cursor, selLen int32) {
 	androidWindow.EventFn(&evt)
 }
 
-// imeCommit dispatches committed text as individual EventChar
-// events, one per rune.
+// imeCommit dispatches committed text as a single EventChar carrying
+// the whole string in IMEText, matching macOS and web. CharCode holds
+// only the first rune; consumers read IMEText for the full commit.
 func imeCommit(text string) {
-	if androidWindow == nil {
+	if androidWindow == nil || len(text) == 0 {
 		return
 	}
-	for _, r := range text {
-		evt := gui.Event{
-			Type:     gui.EventChar,
-			CharCode: uint32(r),
-		}
-		androidWindow.EventFn(&evt)
+	// Drop invalid UTF-8 coming across the JNI boundary rather than
+	// dispatching a RuneError char.
+	r, sz := utf8.DecodeRuneInString(text)
+	if r == utf8.RuneError && sz == 1 {
+		return
 	}
+	evt := gui.Event{
+		Type:     gui.EventChar,
+		CharCode: uint32(r),
+		IMEText:  text,
+	}
+	androidWindow.EventFn(&evt)
 }
 
 // touchEvent dispatches a raw touch event to the window's event

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -1103,6 +1103,37 @@ func TestInputReadOnlyBlocksIMEText(t *testing.T) {
 	}
 }
 
+// TestInputCharIMETextInsertsWholeCommit pins the contract every
+// backend now follows for IME commits: one EventChar carries the whole
+// committed string in IMEText, with CharCode holding only the first
+// rune. The handler must insert IMEText, not string(CharCode) — Android
+// relied on a per-rune event loop before this was enforced.
+func TestInputCharIMETextInsertsWholeCommit(t *testing.T) {
+	ctx := newInputTest("", "ime_commit", 0)
+	e := &Event{Type: EventChar, CharCode: 'か', IMEText: "かんじ"}
+	ctx.layout.Shape.events.OnChar(&ctx.layout, e, ctx.w)
+	if ctx.lastText != "かんじ" {
+		t.Fatalf("IME commit inserted %q, want %q",
+			ctx.lastText, "かんじ")
+	}
+	if !e.IsHandled {
+		t.Fatal("IME commit event not marked handled")
+	}
+}
+
+// TestInputCharEmptyIMETextFallsBackToCharCode covers the plain typing
+// path: backends that emit a bare key char leave IMEText empty, so the
+// handler must fall back to CharCode.
+func TestInputCharEmptyIMETextFallsBackToCharCode(t *testing.T) {
+	ctx := newInputTest("ab", "ime_fallback", 2)
+	e := &Event{Type: EventChar, CharCode: 'c'}
+	ctx.layout.Shape.events.OnChar(&ctx.layout, e, ctx.w)
+	if ctx.lastText != "abc" {
+		t.Fatalf("plain char insert produced %q, want %q",
+			ctx.lastText, "abc")
+	}
+}
+
 func TestInputReadOnlyBlocksDeleteKeys(t *testing.T) {
 	for _, key := range []struct {
 		name string


### PR DESCRIPTION
Fixes #151.

## Problem

`imeCommit` (`gui/backend/android/events.go`) split committed text into
one `EventChar` per rune and never set `IMEText` — Android was the only
backend leaving `IMEText` empty on a text event.

`Event.IMEText` is the documented way to read committed text
(`CharCode` carries only the first rune), and `charHandler` prefers it,
so text still landed via the `string(rune(CharCode))` fallback. But any
consumer following the documented contract got nothing on Android, and
a phrase commit cost one layout-tree walk plus one time-travel snapshot
per rune.

## Change

Emit a single `EventChar` with `CharCode` = first rune and `IMEText` =
the whole string, matching macOS (`metal`) and web. Guards added for
empty input and for invalid UTF-8 arriving over the JNI boundary — the
same first-rune `RuneError` check metal uses.

Note: control characters inside a commit now behave as they already do
on macOS/web (a leading control char drops the commit; an embedded
newline inserts verbatim) rather than being filtered per-rune. That is
the shared cross-backend contract; nothing in `gui/` sanitizes control
chars out of `IMEText` on any platform.

## Tests

The android package is `//go:build android` with no test files, and CI
only cross-compiles `go vet` for it — an android-tagged test would
never execute. Coverage instead lands where it runs, in `gui/`:

- `TestInputCharIMETextInsertsWholeCommit` — a multi-rune `IMEText`
  commit inserts the whole string, not just the first rune. Fails if
  the handler regresses to `CharCode`-only.
- `TestInputCharEmptyIMETextFallsBackToCharCode` — plain typing still
  works when `IMEText` is empty.

`go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean.
Device/emulator behavior is unverified — no hardware run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788438925&installation_model_id=426559&pr_number=153&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F153&signature=c468d1a80cc76eb839cf06e3eb5ac34b6f707b21031b9828eb6c719d31b4620f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->