### PR TITLE
fix(fonts): wire iOS and Android backends into gui.LoadAppFonts (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **App fonts were ignored on iOS and Android (#132).** Both backends
+  loaded the bundled icon font but never called `gui.LoadAppFonts`, so
+  `RegisterAppFont` / `RegisterAppFontBytes` were a silent no-op there.
+  That also made `ThemeCfg.IconFontFamily` unusable on those platforms —
+  retargeting the themed icon styles at a font that never loaded rendered
+  tofu. Both now register the app-font lists right after the icon font, as
+  the GL and Metal backends already did.
 - **Metal backend dropped IME commit events (#149).** Text-input callbacks
   wrote a single global event slot, so when one `[NSApp sendEvent:]` fired
   several `NSTextInputClient` callbacks — the normal CJK sequence of

--- a/gui/backend/android/backend.go
+++ b/gui/backend/android/backend.go
@@ -228,6 +228,7 @@ func initBackend(w, h int32, scale float32) {
 			b.iconFontPath = tmp
 		}
 	}
+	gui.LoadAppFonts(textSys, "android")
 
 	// Set injected interfaces on gui Window.
 	androidWindow.SetTextMeasurer(

--- a/gui/backend/ios/backend.go
+++ b/gui/backend/ios/backend.go
@@ -160,6 +160,7 @@ func initBackend(layerPtr unsafe.Pointer,
 			b.iconFontPath = tmp
 		}
 	}
+	gui.LoadAppFonts(textSys, "ios")
 
 	// Set injected interfaces on gui Window.
 	iosWindow.SetTextMeasurer(&textMeasurer{textSys: textSys})

--- a/gui/fonts.go
+++ b/gui/fonts.go
@@ -54,9 +54,9 @@ func RegisterAppFont(path string) {
 // text system persists the bytes to its own temp file, so the caller
 // does not have to manage one.
 //
-// Consumed by the GL and Metal backends, matching where AppFontPaths is
-// consumed. The iOS, Android and web backends ignore both lists; on web
-// use the browser FontFace API instead.
+// Consumed by the GL, Metal, iOS and Android backends, matching where
+// AppFontPaths is consumed. Only the web backend ignores both lists; on
+// web use the browser FontFace API instead.
 //
 // To retarget the themed icon styles at a registered font, set that
 // font's family name in ThemeCfg.IconFontFamily.
@@ -90,7 +90,8 @@ type FontRegistrar interface {
 }
 
 // LoadAppFonts registers every font in AppFontPaths and AppFontData
-// with ts, naming the calling backend ("gl", "metal") in log lines.
+// with ts, naming the calling backend ("gl", "metal", "ios", "android")
+// in log lines.
 // Call once per text system during backend init, after the bundled icon
 // font is loaded.
 //


### PR DESCRIPTION
Closes #132.

## Problem

`gui.LoadAppFonts` centralizes app-font registration behind the narrow `gui.FontRegistrar` interface. The GL and Metal backends call it; the iOS and Android backends never did, so `RegisterAppFont` / `RegisterAppFontBytes` were a **silent no-op** on those platforms.

That also made `ThemeCfg.IconFontFamily` unusable there — retargeting the themed icon styles at a custom icon font that never loads renders tofu.

## Change

One call per mobile backend, placed exactly where GL/Metal place it (immediately after the bundled icon font is registered):

- `gui/backend/ios/backend.go` — `gui.LoadAppFonts(textSys, "ios")`
- `gui/backend/android/backend.go` — `gui.LoadAppFonts(textSys, "android")`

`*glyph.TextSystem` already satisfies `gui.FontRegistrar`; no new plumbing.

Plus the two `gui/fonts.go` doc comments that asserted the old behavior (`AppFontData` said iOS/Android/web ignore both lists — now only web; `LoadAppFonts` now names all four backends in its log-prefix doc), and a CHANGELOG entry.

## No new tests

`gui/fonts_test.go` already covers the shared helper (both lists in order, failures skipped, nil registrar, empty lists). Both mobile packages are behind `//go:build ios` / `//go:build android` and are not compiled by `go test ./...` on darwin/linux — a test placed there would never run.

## Verification

Locally:

- `gofmt -l gui/` clean; `go build ./...`; `go test ./...` (0 failures); `golangci-lint run ./...` (0 issues)
- Both CI iOS recipes reproduced: `examples/ios_demo` `c-archive` build and `go vet -tags ios ./gui/backend/ios/...` under the iphoneos sysroot, exit 0

Not verified locally:

- **Android** — no NDK installed on this machine, so `gomobile bind` / `go vet ./gui/backend/android/...` could not run. The CI `android` job is the compile proof for that side.
- **On-device behavior** on either platform. The issue flags this as needing a device; the remaining risk is init-time only, and `LoadAppFonts` logs-and-skips per-font failures rather than aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788440258&installation_model_id=426559&pr_number=154&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F154&signature=16ddbd8bf46259fb3077c67c4599eec34be080037465ff8cc148c307832d2408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->