### PR TITLE
feat: replace go-gl with purego GL bindings (cgo-free Linux/Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,19 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # Guards the CGo-free desktop backend. gui/backend/... must keep
+      # cross-compiling with no C toolchain on the host; a new cgo import
+      # anywhere under it reds this step. Scoped to gui/backend/... rather
+      # than ./gui/... because gui/audio still needs cgo on Linux (oto ->
+      # ALSA).
+      - name: CGo-free backend cross-compile
+        run: |
+          for target in linux/amd64 linux/arm64 windows/amd64 windows/arm64; do
+            echo "==> $target"
+            CGO_ENABLED=0 GOOS=${target%/*} GOARCH=${target#*/} \
+              go build ./gui/backend/...
+          done
+
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -233,6 +246,10 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
+      # No C toolchain: the Windows build is CGO_ENABLED=0 end to end.
+      # msys2 remains only for (a) Mesa's software opengl32.dll, which the
+      # GPU-less runner needs at *runtime* for the smoke test, and (b) the
+      # bash shell those steps are written in.
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -240,7 +257,6 @@ jobs:
           release: false
           path-type: inherit
           install: >-
-            mingw-w64-x86_64-gcc
             mingw-w64-x86_64-mesa
 
       - uses: actions/checkout@v6
@@ -248,17 +264,17 @@ jobs:
       - uses: ./.github/actions/setup-go-glyph
 
       - name: Build
-        run: CGO_ENABLED=1 go build ./...
+        run: CGO_ENABLED=0 go build ./...
 
       - name: Vet
-        run: CGO_ENABLED=1 go vet ./...
+        run: CGO_ENABLED=0 go vet ./...
 
       - name: Test (headless)
-        run: CGO_ENABLED=1 go test ./gui/...
+        run: CGO_ENABLED=0 go test ./gui/...
 
       - name: Build showcase
         run: |
-          CGO_ENABLED=1 go build -tags audio \
+          CGO_ENABLED=0 go build -tags audio \
             -o build/showcase-windows.exe ./examples/showcase/
 
       - name: Smoke test showcase

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,14 @@ linters:
   exclusions:
     generated: lax
     rules:
+      # glbind mirrors the C OpenGL API 1:1 so that call sites need no
+      # changes: SCREAMING_SNAKE enum names and one thin wrapper per entry
+      # point. Idiomatic Go naming and 100 per-symbol doc comments restating
+      # the GL reference pages would defeat that and hide the real content.
+      - path: gui/backend/internal/glbind/
+        text: "should have comment or be unexported"
+      - path: gui/backend/internal/glbind/
+        text: "ALL_CAPS|underscore"
       - path: _test\.go
         linters:
           - errcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,13 +154,19 @@ git/mkdir/rm/ls output. `ctx_fetch_and_index` instead of curl/wget/WebFetch.
   **Superseded (2026-07-31, issue #137):** viable but the wrong instrument.
   `gui/backend/gl/` has no cgo at all — X11 via xgb, EGL via purego, Win32
   via syscall. The sole CGo dependency on Linux/Windows is
-  `github.com/go-gl/gl` (55 functions, 47 constants), and its proc-address
+  `github.com/go-gl/gl` (55 functions, 45 constants), and its proc-address
   loader is already pure Go. Swapping that one dispatch layer for purego
   bindings gets CGo-free Linux+Windows for ~600 lines; wgpu is a superset
   that also ships 10–40 MB of runtime shared libs, supplies none of
   `NativePlatform` (10 sub-interfaces), and leaves macOS (the only real CGo
   backend, 5.9k lines ObjC) untouched. Full assessment:
   `docs/specs/cgo-free-backend-feasibility.md`.
+
+  **Phase 1 done (2026-07-31):** go-gl replaced by
+  `gui/backend/internal/glbind` (purego). `CGO_ENABLED=0` now builds the whole
+  module for Windows, and `./gui/backend/...` for Linux. The remaining Linux
+  CGo dependency is `gui/audio` → `ebitengine/oto` (ALSA), not the backend.
+  macOS (Phase 2) is untouched.
 
 ## Specs
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,8 +11,7 @@ Go toolchain pin: `go 1.26.0`.
 | Module | Version | Purpose |
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
-| `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`). |
-| `github.com/go-gl/gl` | v0.0.0-20260331235117-4566fea9a276 | OpenGL bindings for `gui/backend/gl`. |
+| `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends. |
 | `github.com/go-gui-org/go-glyph` | v1.18.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.0
 require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/ebitengine/purego v0.10.1
-	github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276
 	github.com/go-gui-org/go-glyph v1.18.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/ebitengine/oto/v3 v3.3.2 h1:VTWBsKX9eb+dXzaF4jEwQbs4yWIdXukJ0K40KgkpY
 github.com/ebitengine/oto/v3 v3.3.2/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276 h1:IO5P06Pcj9K04d+l4nrf3c2U56+dAotIFG6u4P1wAHI=
-github.com/go-gl/gl v0.0.0-20260331235117-4566fea9a276/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
 github.com/go-gui-org/go-glyph v1.18.0 h1:8NGOBORtHRgkWH7BYRNGcjnFXIAOY98AU3VxViGTymo=
 github.com/go-gui-org/go-glyph v1.18.0/go.mod h1:1Nta2shuXtETUdEXJJn0oFRisUXPxi1ToSVb0Sfi7kU=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gui-org/go-glyph"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
@@ -111,11 +111,11 @@ func (b *Backend) initCaches(cfg gui.WindowCfg) {
 // interfaces onto the window. b.physW, b.physH, and b.dpiScale must
 // be set before calling. The GL context must already be current.
 func (b *Backend) initGLResources(w *gui.Window) error {
-	gl.Enable(gl.BLEND)
-	gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
-	gl.Disable(gl.DEPTH_TEST)
-	gl.Disable(gl.CULL_FACE)
-	gl.Viewport(0, 0, b.physW, b.physH)
+	gogl.Enable(gogl.BLEND)
+	gogl.BlendFunc(gogl.SRC_ALPHA, gogl.ONE_MINUS_SRC_ALPHA)
+	gogl.Disable(gogl.DEPTH_TEST)
+	gogl.Disable(gogl.CULL_FACE)
+	gogl.Viewport(0, 0, b.physW, b.physH)
 
 	if err := b.initPipelines(); err != nil {
 		return err
@@ -158,19 +158,19 @@ func (b *Backend) destroyGLResources() {
 	b.textures.DestroyAll()
 	b.destroyPipelines()
 	if b.quadVAO != 0 {
-		gl.DeleteVertexArrays(1, &b.quadVAO)
+		gogl.DeleteVertexArrays(1, &b.quadVAO)
 	}
 	if b.quadVBO != 0 {
-		gl.DeleteBuffers(1, &b.quadVBO)
+		gogl.DeleteBuffers(1, &b.quadVBO)
 	}
 	if b.quadIBO != 0 {
-		gl.DeleteBuffers(1, &b.quadIBO)
+		gogl.DeleteBuffers(1, &b.quadIBO)
 	}
 	if b.svgVAO != 0 {
-		gl.DeleteVertexArrays(1, &b.svgVAO)
+		gogl.DeleteVertexArrays(1, &b.svgVAO)
 	}
 	if b.svgVBO != 0 {
-		gl.DeleteBuffers(1, &b.svgVBO)
+		gogl.DeleteBuffers(1, &b.svgVBO)
 	}
 	b.destroyFilterFBO()
 	if b.glyphBack != nil {
@@ -194,14 +194,14 @@ func (b *Backend) renderFrame(w *gui.Window) {
 		t := gui.CurrentTheme()
 		bg = t.ColorBackground
 	}
-	gl.ClearColor(
+	gogl.ClearColor(
 		float32(bg.R)/255.0,
 		float32(bg.G)/255.0,
 		float32(bg.B)/255.0,
 		float32(bg.A)/255.0,
 	)
-	gl.Disable(gl.SCISSOR_TEST)
-	gl.Clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT)
+	gogl.Disable(gogl.SCISSOR_TEST)
+	gogl.Clear(gogl.COLOR_BUFFER_BIT | gogl.STENCIL_BUFFER_BIT)
 
 	w.Lock()
 	w.BackingScale = b.dpiScale
@@ -217,7 +217,7 @@ func (b *Backend) renderFrame(w *gui.Window) {
 func (b *Backend) handleResize() {
 	b.physW, b.physH = b.plat.drawableSize()
 	b.dpiScale = b.plat.dpiScale()
-	gl.Viewport(0, 0, b.physW, b.physH)
+	gogl.Viewport(0, 0, b.physW, b.physH)
 	b.updateProjection()
 }
 

--- a/gui/backend/gl/buffers.go
+++ b/gui/backend/gl/buffers.go
@@ -5,7 +5,7 @@ package gl
 import (
 	"unsafe"
 
-	gogl "github.com/go-gl/gl/v3.3-core/gl"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -7,8 +7,8 @@ import (
 	"math"
 	"unsafe"
 
-	gogl "github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gui-org/go-glyph"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"

--- a/gui/backend/gl/egl_linux.go
+++ b/gui/backend/gl/egl_linux.go
@@ -89,10 +89,11 @@ func loadEGL() error {
 }
 
 // eglProc resolves an OpenGL function pointer for
-// gl.InitWithProcAddrFunc via eglGetProcAddress. EGL 1.5 (Mesa) returns
-// core desktop-GL entry points, not only extensions.
-func eglProc(name string) unsafe.Pointer {
-	return eglGetProcAddress(name)
+// glbind.InitWithProcAddrFunc via eglGetProcAddress. EGL 1.5 (Mesa) returns
+// core desktop-GL entry points, not only extensions. The result is a driver
+// code address, so uintptr — not unsafe.Pointer — is the correct spelling.
+func eglProc(name string) uintptr {
+	return uintptr(eglGetProcAddress(name))
 }
 
 // eglInitDisplay initializes EGL, binds the desktop-OpenGL API, and

--- a/gui/backend/gl/pipeline.go
+++ b/gui/backend/gl/pipeline.go
@@ -5,10 +5,11 @@ package gl
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"unsafe"
 
-	gogl "github.com/go-gl/gl/v3.3-core/gl"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/texcache"
@@ -125,9 +126,14 @@ func buildPipeline(vsSrc, fsSrc string) (pipeline, error) {
 
 func compileShader(src string, shaderType uint32) (uint32, error) {
 	shader := gogl.CreateShader(shaderType)
-	csrc, free := gogl.Strs(src + "\x00")
-	defer free()
-	gogl.ShaderSource(shader, 1, csrc, nil)
+	// glShaderSource wants a char** — an array of C strings. Build the one
+	// null-terminated source ourselves rather than pulling in a helper.
+	// nulSrc must outlive the call, hence the named local plus KeepAlive:
+	// glStr only borrows its backing array.
+	nulSrc := src + "\x00"
+	csrc := glStr(nulSrc)
+	gogl.ShaderSource(shader, 1, &csrc, nil)
+	runtime.KeepAlive(nulSrc)
 	gogl.CompileShader(shader)
 
 	var status int32

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/go-gl/gl/v3.3-core/gl"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 	"golang.org/x/sys/windows"
 
 	"github.com/go-gui-org/go-gui/gui"
@@ -427,9 +427,9 @@ func New(w *gui.Window) (*Backend, error) {
 	}
 	b.plat.hglrc = hglrc
 
-	if err := gl.Init(); err != nil {
+	if err := gogl.InitWithProcAddrFunc(glProc); err != nil {
 		b.plat.destroy()
-		return nil, fmt.Errorf("gl: gl.Init: %w", err)
+		return nil, fmt.Errorf("gl: glbind init: %w", err)
 	}
 
 	b.dpiScale = float32(dpiForWindow(hwnd)) / 96.0

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-gl/gl/v3.3-core/gl"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 	"github.com/jezek/xgb"
 	"github.com/jezek/xgb/randr"
 	"github.com/jezek/xgb/xproto"
@@ -290,9 +290,9 @@ func New(w *gui.Window) (*Backend, error) {
 	b.plat.eglSurface = surface
 	b.plat.eglContext = context
 
-	if err := gl.InitWithProcAddrFunc(eglProc); err != nil {
+	if err := gogl.InitWithProcAddrFunc(eglProc); err != nil {
 		b.plat.destroy()
-		return nil, fmt.Errorf("gl: gl.Init: %w", err)
+		return nil, fmt.Errorf("gl: glbind init: %w", err)
 	}
 
 	wakeConn, err := xgb.NewConn()

--- a/gui/backend/gl/text.go
+++ b/gui/backend/gl/text.go
@@ -5,8 +5,8 @@ package gl
 import (
 	"unsafe"
 
-	gogl "github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gui-org/go-glyph"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"

--- a/gui/backend/gl/textures.go
+++ b/gui/backend/gl/textures.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"unsafe"
 
-	gogl "github.com/go-gl/gl/v3.3-core/gl"
+	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
 	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/texcache"

--- a/gui/backend/gl/wgl_windows.go
+++ b/gui/backend/gl/wgl_windows.go
@@ -4,6 +4,8 @@ package gl
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 	"unsafe"
 
@@ -12,7 +14,7 @@ import (
 
 var (
 	gdi32    = windows.NewLazySystemDLL("gdi32.dll")
-	opengl32 = windows.NewLazySystemDLL("opengl32.dll")
+	opengl32 = initOpenGL32()
 
 	pChoosePixelFormat = gdi32.NewProc("ChoosePixelFormat")
 	pSetPixelFormat    = gdi32.NewProc("SetPixelFormat")
@@ -23,6 +25,21 @@ var (
 	pWglDeleteContext  = opengl32.NewProc("wglDeleteContext")
 	pWglGetProcAddress = opengl32.NewProc("wglGetProcAddress")
 )
+
+// initOpenGL32 loads opengl32.dll.  It first tries the executable's
+// directory (so that a Mesa software-rendering DLL placed alongside
+// the binary on headless CI runners is discovered), then falls back to
+// the restricted System32 search for security.
+func initOpenGL32() *windows.LazyDLL {
+	if exe, err := os.Executable(); err == nil {
+		local := filepath.Join(filepath.Dir(exe), "opengl32.dll")
+		dll := windows.NewLazyDLL(local)
+		if err := dll.Load(); err == nil {
+			return dll
+		}
+	}
+	return windows.NewLazySystemDLL("opengl32.dll")
+}
 
 type pixelFormatDescriptor struct {
 	nSize           uint16

--- a/gui/backend/gl/wgl_windows.go
+++ b/gui/backend/gl/wgl_windows.go
@@ -167,3 +167,21 @@ func wglProc(name string) uintptr {
 	}
 	return r
 }
+
+// glProc resolves an OpenGL entry point for glbind.InitWithProcAddrFunc.
+// A context must be current.
+//
+// It reproduces what go-gl's C loader did: wglGetProcAddress only returns
+// GL 1.2+ and extension entry points, while the GL 1.1 core subset
+// (glClear, glViewport, glTexImage2D, ...) is exported directly by
+// opengl32.dll and has to be looked up there instead.
+func glProc(name string) uintptr {
+	if p := wglProc(name); p != 0 {
+		return p
+	}
+	proc := opengl32.NewProc(name)
+	if err := proc.Find(); err != nil {
+		return 0
+	}
+	return proc.Addr()
+}

--- a/gui/backend/internal/glbind/const.go
+++ b/gui/backend/internal/glbind/const.go
@@ -1,0 +1,54 @@
+//go:build !js && !darwin
+
+package glbind
+
+// OpenGL enum values. Only the constants referenced by gui/backend/gl are
+// defined here — this is deliberately not a full GL header. Values are the
+// canonical ones from the Khronos registry (gl.xml).
+const (
+	ALWAYS               = 0x0207
+	ARRAY_BUFFER         = 0x8892
+	BLEND                = 0x0BE2
+	CLAMP_TO_EDGE        = 0x812F
+	COLOR_ATTACHMENT0    = 0x8CE0
+	COLOR_BUFFER_BIT     = 0x00004000
+	COMPILE_STATUS       = 0x8B81
+	CULL_FACE            = 0x0B44
+	DECR                 = 0x1E03
+	DEPTH_TEST           = 0x0B71
+	DYNAMIC_DRAW         = 0x88E8
+	ELEMENT_ARRAY_BUFFER = 0x8893
+	FALSE                = 0
+	FLOAT                = 0x1406
+	FRAGMENT_SHADER      = 0x8B30
+	FRAMEBUFFER          = 0x8D40
+	FRAMEBUFFER_COMPLETE = 0x8CD5
+	INCR                 = 0x1E02
+	INFO_LOG_LENGTH      = 0x8B84
+	KEEP                 = 0x1E00
+	LEQUAL               = 0x0203
+	LINEAR               = 0x2601
+	LINK_STATUS          = 0x8B82
+	ONE_MINUS_SRC_ALPHA  = 0x0303
+	RENDERBUFFER         = 0x8D41
+	RGBA                 = 0x1908
+	RGBA8                = 0x8058
+	SCISSOR_TEST         = 0x0C11
+	SRC_ALPHA            = 0x0302
+	STATIC_DRAW          = 0x88E4
+	STENCIL_ATTACHMENT   = 0x8D20
+	STENCIL_BUFFER_BIT   = 0x00000400
+	STENCIL_INDEX8       = 0x8D48
+	STENCIL_TEST         = 0x0B90
+	TEXTURE0             = 0x84C0
+	TEXTURE_2D           = 0x0DE1
+	TEXTURE_MAG_FILTER   = 0x2800
+	TEXTURE_MIN_FILTER   = 0x2801
+	TEXTURE_WRAP_S       = 0x2802
+	TEXTURE_WRAP_T       = 0x2803
+	TRIANGLES            = 0x0004
+	TRIANGLE_FAN         = 0x0006
+	UNSIGNED_BYTE        = 0x1401
+	UNSIGNED_SHORT       = 0x1403
+	VERTEX_SHADER        = 0x8B31
+)

--- a/gui/backend/internal/glbind/glbind.go
+++ b/gui/backend/internal/glbind/glbind.go
@@ -1,0 +1,244 @@
+//go:build !js && !darwin
+
+// Package glbind is a CGo-free binding for the subset of OpenGL 3.3 core that
+// gui/backend/gl uses.
+//
+// It replaces github.com/go-gl/gl, which was the sole CGo dependency of the
+// Linux and Windows backends. Entry points are resolved through the caller's
+// platform proc-address function (eglGetProcAddress on Linux,
+// wglGetProcAddress + opengl32.dll on Windows) and bound with
+// github.com/ebitengine/purego — the same mechanism gui/backend/gl already
+// uses for EGL itself.
+//
+// Signatures deliberately mirror go-gl's exactly, including SCREAMING_SNAKE
+// enum names and the `bool` spelling of GLboolean parameters, so that call
+// sites need nothing beyond an import swap. purego marshals Go `bool` as
+// C `_Bool` (one byte), which matches GLboolean.
+//
+// Call InitWithProcAddrFunc before any other function in this package; every
+// wrapper below dereferences a function pointer that is nil until then.
+package glbind
+
+import "unsafe"
+
+// C-level entry points, populated by InitWithProcAddrFunc. Parameter types are
+// the purego equivalents of the GL types: GLenum/GLuint -> uint32, GLint/GLsizei
+// -> int32, GLboolean -> bool, GLsizeiptr/GLintptr -> int, pointers ->
+// unsafe.Pointer or a typed Go pointer (purego passes both as void*).
+var (
+	pfnActiveTexture           func(texture uint32)
+	pfnAttachShader            func(program, shader uint32)
+	pfnBindBuffer              func(target, buffer uint32)
+	pfnBindFramebuffer         func(target, framebuffer uint32)
+	pfnBindRenderbuffer        func(target, renderbuffer uint32)
+	pfnBindTexture             func(target, texture uint32)
+	pfnBindVertexArray         func(array uint32)
+	pfnBlendFunc               func(sfactor, dfactor uint32)
+	pfnBufferData              func(target uint32, size int, data unsafe.Pointer, usage uint32)
+	pfnBufferSubData           func(target uint32, offset, size int, data unsafe.Pointer)
+	pfnCheckFramebufferStatus  func(target uint32) uint32
+	pfnClear                   func(mask uint32)
+	pfnClearColor              func(red, green, blue, alpha float32)
+	pfnColorMask               func(red, green, blue, alpha bool)
+	pfnCompileShader           func(shader uint32)
+	pfnCreateProgram           func() uint32
+	pfnCreateShader            func(xtype uint32) uint32
+	pfnDeleteBuffers           func(n int32, buffers *uint32)
+	pfnDeleteFramebuffers      func(n int32, framebuffers *uint32)
+	pfnDeleteProgram           func(program uint32)
+	pfnDeleteRenderbuffers     func(n int32, renderbuffers *uint32)
+	pfnDeleteShader            func(shader uint32)
+	pfnDeleteTextures          func(n int32, textures *uint32)
+	pfnDeleteVertexArrays      func(n int32, arrays *uint32)
+	pfnDisable                 func(cap uint32)
+	pfnDrawArrays              func(mode uint32, first, count int32)
+	pfnDrawElements            func(mode uint32, count int32, xtype uint32, indices unsafe.Pointer)
+	pfnEnable                  func(cap uint32)
+	pfnEnableVertexAttribArray func(index uint32)
+	pfnFramebufferRenderbuffer func(target, attachment, renderbuffertarget, renderbuffer uint32)
+	pfnFramebufferTexture2D    func(target, attachment, textarget, texture uint32, level int32)
+	pfnGenBuffers              func(n int32, buffers *uint32)
+	pfnGenFramebuffers         func(n int32, framebuffers *uint32)
+	pfnGenRenderbuffers        func(n int32, renderbuffers *uint32)
+	pfnGenTextures             func(n int32, textures *uint32)
+	pfnGenVertexArrays         func(n int32, arrays *uint32)
+	pfnGetProgramInfoLog       func(program uint32, bufSize int32, length *int32, infoLog *uint8)
+	pfnGetProgramiv            func(program, pname uint32, params *int32)
+	pfnGetShaderInfoLog        func(shader uint32, bufSize int32, length *int32, infoLog *uint8)
+	pfnGetShaderiv             func(shader, pname uint32, params *int32)
+	pfnGetUniformLocation      func(program uint32, name *uint8) int32
+	pfnLinkProgram             func(program uint32)
+	pfnRenderbufferStorage     func(target, internalformat uint32, width, height int32)
+	pfnScissor                 func(x, y, width, height int32)
+	pfnShaderSource            func(shader uint32, count int32, xstring **uint8, length *int32)
+	pfnStencilFunc             func(xfunc uint32, ref int32, mask uint32)
+	pfnStencilOp               func(fail, zfail, zpass uint32)
+	pfnTexImage2D              func(target uint32, level, internalformat, width, height, border int32, format, xtype uint32, pixels unsafe.Pointer)
+	pfnTexParameteri           func(target, pname uint32, param int32)
+	pfnTexSubImage2D           func(target uint32, level, xoffset, yoffset, width, height int32, format, xtype uint32, pixels unsafe.Pointer)
+	pfnUniform1i               func(location, v0 int32)
+	pfnUniformMatrix4fv        func(location, count int32, transpose bool, value *float32)
+	pfnUseProgram              func(program uint32)
+	// The last parameter is declared uintptr rather than unsafe.Pointer for
+	// the same reason go-gl declares it uintptr_t: with a buffer bound to
+	// ARRAY_BUFFER it is a byte offset, not a pointer into any address space.
+	// Keeping it uintptr end to end avoids a bogus unsafe.Pointer conversion
+	// that go vet's unsafeptr check would (correctly) reject.
+	pfnVertexAttribPointer func(index uint32, size int32, xtype uint32, normalized bool, stride int32, offset uintptr)
+	pfnViewport            func(x, y, width, height int32)
+)
+
+func ActiveTexture(texture uint32) { pfnActiveTexture(texture) }
+
+func AttachShader(program uint32, shader uint32) { pfnAttachShader(program, shader) }
+
+func BindBuffer(target uint32, buffer uint32) { pfnBindBuffer(target, buffer) }
+
+func BindFramebuffer(target uint32, framebuffer uint32) { pfnBindFramebuffer(target, framebuffer) }
+
+func BindRenderbuffer(target uint32, renderbuffer uint32) {
+	pfnBindRenderbuffer(target, renderbuffer)
+}
+
+func BindTexture(target uint32, texture uint32) { pfnBindTexture(target, texture) }
+
+func BindVertexArray(array uint32) { pfnBindVertexArray(array) }
+
+func BlendFunc(sfactor uint32, dfactor uint32) { pfnBlendFunc(sfactor, dfactor) }
+
+func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
+	pfnBufferData(target, size, data, usage)
+}
+
+func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
+	pfnBufferSubData(target, offset, size, data)
+}
+
+func CheckFramebufferStatus(target uint32) uint32 { return pfnCheckFramebufferStatus(target) }
+
+func Clear(mask uint32) { pfnClear(mask) }
+
+func ClearColor(red float32, green float32, blue float32, alpha float32) {
+	pfnClearColor(red, green, blue, alpha)
+}
+
+func ColorMask(red bool, green bool, blue bool, alpha bool) {
+	pfnColorMask(red, green, blue, alpha)
+}
+
+func CompileShader(shader uint32) { pfnCompileShader(shader) }
+
+func CreateProgram() uint32 { return pfnCreateProgram() }
+
+func CreateShader(xtype uint32) uint32 { return pfnCreateShader(xtype) }
+
+func DeleteBuffers(n int32, buffers *uint32) { pfnDeleteBuffers(n, buffers) }
+
+func DeleteFramebuffers(n int32, framebuffers *uint32) { pfnDeleteFramebuffers(n, framebuffers) }
+
+func DeleteProgram(program uint32) { pfnDeleteProgram(program) }
+
+func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
+	pfnDeleteRenderbuffers(n, renderbuffers)
+}
+
+func DeleteShader(shader uint32) { pfnDeleteShader(shader) }
+
+func DeleteTextures(n int32, textures *uint32) { pfnDeleteTextures(n, textures) }
+
+func DeleteVertexArrays(n int32, arrays *uint32) { pfnDeleteVertexArrays(n, arrays) }
+
+func Disable(cap uint32) { pfnDisable(cap) }
+
+func DrawArrays(mode uint32, first int32, count int32) { pfnDrawArrays(mode, first, count) }
+
+func DrawElements(mode uint32, count int32, xtype uint32, indices unsafe.Pointer) {
+	pfnDrawElements(mode, count, xtype, indices)
+}
+
+func Enable(cap uint32) { pfnEnable(cap) }
+
+func EnableVertexAttribArray(index uint32) { pfnEnableVertexAttribArray(index) }
+
+func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	pfnFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
+}
+
+func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	pfnFramebufferTexture2D(target, attachment, textarget, texture, level)
+}
+
+func GenBuffers(n int32, buffers *uint32) { pfnGenBuffers(n, buffers) }
+
+func GenFramebuffers(n int32, framebuffers *uint32) { pfnGenFramebuffers(n, framebuffers) }
+
+func GenRenderbuffers(n int32, renderbuffers *uint32) { pfnGenRenderbuffers(n, renderbuffers) }
+
+func GenTextures(n int32, textures *uint32) { pfnGenTextures(n, textures) }
+
+func GenVertexArrays(n int32, arrays *uint32) { pfnGenVertexArrays(n, arrays) }
+
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
+	pfnGetProgramInfoLog(program, bufSize, length, infoLog)
+}
+
+func GetProgramiv(program uint32, pname uint32, params *int32) {
+	pfnGetProgramiv(program, pname, params)
+}
+
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
+	pfnGetShaderInfoLog(shader, bufSize, length, infoLog)
+}
+
+func GetShaderiv(shader uint32, pname uint32, params *int32) {
+	pfnGetShaderiv(shader, pname, params)
+}
+
+func GetUniformLocation(program uint32, name *uint8) int32 {
+	return pfnGetUniformLocation(program, name)
+}
+
+func LinkProgram(program uint32) { pfnLinkProgram(program) }
+
+func RenderbufferStorage(target uint32, internalformat uint32, width int32, height int32) {
+	pfnRenderbufferStorage(target, internalformat, width, height)
+}
+
+func Scissor(x int32, y int32, width int32, height int32) { pfnScissor(x, y, width, height) }
+
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
+	pfnShaderSource(shader, count, xstring, length)
+}
+
+func StencilFunc(xfunc uint32, ref int32, mask uint32) { pfnStencilFunc(xfunc, ref, mask) }
+
+func StencilOp(fail uint32, zfail uint32, zpass uint32) { pfnStencilOp(fail, zfail, zpass) }
+
+func TexImage2D(target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	pfnTexImage2D(target, level, internalformat, width, height, border, format, xtype, pixels)
+}
+
+func TexParameteri(target uint32, pname uint32, param int32) {
+	pfnTexParameteri(target, pname, param)
+}
+
+func TexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	pfnTexSubImage2D(target, level, xoffset, yoffset, width, height, format, xtype, pixels)
+}
+
+func Uniform1i(location int32, v0 int32) { pfnUniform1i(location, v0) }
+
+func UniformMatrix4fv(location int32, count int32, transpose bool, value *float32) {
+	pfnUniformMatrix4fv(location, count, transpose, value)
+}
+
+func UseProgram(program uint32) { pfnUseProgram(program) }
+
+// VertexAttribPointerWithOffset mirrors go-gl's helper of the same name: the
+// final argument is a byte offset into the buffer currently bound to
+// ARRAY_BUFFER, not a client-memory pointer.
+func VertexAttribPointerWithOffset(index uint32, size int32, xtype uint32, normalized bool, stride int32, offset uintptr) {
+	pfnVertexAttribPointer(index, size, xtype, normalized, stride, offset)
+}
+
+func Viewport(x int32, y int32, width int32, height int32) { pfnViewport(x, y, width, height) }

--- a/gui/backend/internal/glbind/init.go
+++ b/gui/backend/internal/glbind/init.go
@@ -1,0 +1,102 @@
+//go:build !js && !darwin
+
+package glbind
+
+import (
+	"fmt"
+
+	"github.com/ebitengine/purego"
+)
+
+// binding pairs a package-level function pointer with the GL entry-point name
+// that fills it.
+type binding struct {
+	fptr any
+	name string
+}
+
+// bindings lists every GL entry point this package exposes. Order is
+// irrelevant; all of them are OpenGL 3.3 core, so a driver advertising a 3.3
+// context must resolve all of them.
+func bindings() []binding {
+	return []binding{
+		{&pfnActiveTexture, "glActiveTexture"},
+		{&pfnAttachShader, "glAttachShader"},
+		{&pfnBindBuffer, "glBindBuffer"},
+		{&pfnBindFramebuffer, "glBindFramebuffer"},
+		{&pfnBindRenderbuffer, "glBindRenderbuffer"},
+		{&pfnBindTexture, "glBindTexture"},
+		{&pfnBindVertexArray, "glBindVertexArray"},
+		{&pfnBlendFunc, "glBlendFunc"},
+		{&pfnBufferData, "glBufferData"},
+		{&pfnBufferSubData, "glBufferSubData"},
+		{&pfnCheckFramebufferStatus, "glCheckFramebufferStatus"},
+		{&pfnClear, "glClear"},
+		{&pfnClearColor, "glClearColor"},
+		{&pfnColorMask, "glColorMask"},
+		{&pfnCompileShader, "glCompileShader"},
+		{&pfnCreateProgram, "glCreateProgram"},
+		{&pfnCreateShader, "glCreateShader"},
+		{&pfnDeleteBuffers, "glDeleteBuffers"},
+		{&pfnDeleteFramebuffers, "glDeleteFramebuffers"},
+		{&pfnDeleteProgram, "glDeleteProgram"},
+		{&pfnDeleteRenderbuffers, "glDeleteRenderbuffers"},
+		{&pfnDeleteShader, "glDeleteShader"},
+		{&pfnDeleteTextures, "glDeleteTextures"},
+		{&pfnDeleteVertexArrays, "glDeleteVertexArrays"},
+		{&pfnDisable, "glDisable"},
+		{&pfnDrawArrays, "glDrawArrays"},
+		{&pfnDrawElements, "glDrawElements"},
+		{&pfnEnable, "glEnable"},
+		{&pfnEnableVertexAttribArray, "glEnableVertexAttribArray"},
+		{&pfnFramebufferRenderbuffer, "glFramebufferRenderbuffer"},
+		{&pfnFramebufferTexture2D, "glFramebufferTexture2D"},
+		{&pfnGenBuffers, "glGenBuffers"},
+		{&pfnGenFramebuffers, "glGenFramebuffers"},
+		{&pfnGenRenderbuffers, "glGenRenderbuffers"},
+		{&pfnGenTextures, "glGenTextures"},
+		{&pfnGenVertexArrays, "glGenVertexArrays"},
+		{&pfnGetProgramInfoLog, "glGetProgramInfoLog"},
+		{&pfnGetProgramiv, "glGetProgramiv"},
+		{&pfnGetShaderInfoLog, "glGetShaderInfoLog"},
+		{&pfnGetShaderiv, "glGetShaderiv"},
+		{&pfnGetUniformLocation, "glGetUniformLocation"},
+		{&pfnLinkProgram, "glLinkProgram"},
+		{&pfnRenderbufferStorage, "glRenderbufferStorage"},
+		{&pfnScissor, "glScissor"},
+		{&pfnShaderSource, "glShaderSource"},
+		{&pfnStencilFunc, "glStencilFunc"},
+		{&pfnStencilOp, "glStencilOp"},
+		{&pfnTexImage2D, "glTexImage2D"},
+		{&pfnTexParameteri, "glTexParameteri"},
+		{&pfnTexSubImage2D, "glTexSubImage2D"},
+		{&pfnUniform1i, "glUniform1i"},
+		{&pfnUniformMatrix4fv, "glUniformMatrix4fv"},
+		{&pfnUseProgram, "glUseProgram"},
+		{&pfnVertexAttribPointer, "glVertexAttribPointer"},
+		{&pfnViewport, "glViewport"},
+	}
+}
+
+// InitWithProcAddrFunc resolves and binds every GL entry point this package
+// exposes, using the caller's platform proc-address function. It must be
+// called with a current GL context, before any other function in this package.
+//
+// getProcAddr takes the C entry-point name and returns the function address,
+// or 0 if the driver does not export it. Addresses are uintptr rather than
+// unsafe.Pointer because they point at driver code, not Go memory — the
+// unsafe.Pointer spelling would be a genuine go vet unsafeptr violation on the
+// Windows side, which obtains addresses from LazyProc.
+//
+// A missing symbol is reported as an error naming it, rather than deferred to
+// a nil-pointer panic at the first draw call.
+func InitWithProcAddrFunc(getProcAddr func(name string) uintptr) error {
+	for _, b := range bindings() {
+		proc := getProcAddr(b.name)
+		if proc == 0 {
+			return fmt.Errorf("glbind: %s unavailable", b.name)
+		}
+		purego.RegisterFunc(b.fptr, proc)
+	}
+	return nil
+}

--- a/gui/backend/internal/glbind/init.go
+++ b/gui/backend/internal/glbind/init.go
@@ -90,13 +90,22 @@ func bindings() []binding {
 //
 // A missing symbol is reported as an error naming it, rather than deferred to
 // a nil-pointer panic at the first draw call.
+//
+// Registration is two-pass: every entry point is resolved before any is
+// bound, so a failure leaves the package fully unbound rather than
+// half-bound. Callers must treat any error as "do not proceed".
 func InitWithProcAddrFunc(getProcAddr func(name string) uintptr) error {
-	for _, b := range bindings() {
+	table := bindings()
+	procs := make([]uintptr, len(table))
+	for i, b := range table {
 		proc := getProcAddr(b.name)
 		if proc == 0 {
 			return fmt.Errorf("glbind: %s unavailable", b.name)
 		}
-		purego.RegisterFunc(b.fptr, proc)
+		procs[i] = proc
+	}
+	for i, b := range table {
+		purego.RegisterFunc(b.fptr, procs[i])
 	}
 	return nil
 }

--- a/gui/backend/internal/glbind/init_test.go
+++ b/gui/backend/internal/glbind/init_test.go
@@ -1,0 +1,110 @@
+//go:build !js && !darwin
+
+package glbind
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestBindingsWellFormed checks the shape of the binding table. Every entry
+// must be a pointer to a nil-able func variable, and no function pointer or
+// entry-point name may appear twice — a duplicated pointer would leave one
+// entry point permanently nil, a duplicated name would bind two different
+// signatures to the same driver function.
+func TestBindingsWellFormed(t *testing.T) {
+	seenName := map[string]bool{}
+	seenPtr := map[any]bool{}
+
+	for _, b := range bindings() {
+		if !strings.HasPrefix(b.name, "gl") {
+			t.Errorf("%s: entry-point name must start with %q", b.name, "gl")
+		}
+		if seenName[b.name] {
+			t.Errorf("%s: duplicate entry-point name", b.name)
+		}
+		seenName[b.name] = true
+
+		if seenPtr[b.fptr] {
+			t.Errorf("%s: duplicate function pointer", b.name)
+		}
+		seenPtr[b.fptr] = true
+
+		v := reflect.ValueOf(b.fptr)
+		if v.Kind() != reflect.Pointer {
+			t.Fatalf("%s: fptr is %s, want pointer", b.name, v.Kind())
+		}
+		if v.Elem().Kind() != reflect.Func {
+			t.Errorf("%s: fptr points at %s, want func", b.name, v.Elem().Kind())
+		}
+	}
+}
+
+// TestBindingNamesMatchVars is the check that matters most and the one a
+// human reviewer is worst at: that {&pfnFoo, "glBar"} never slips through
+// with Foo != Bar. Signatures are declared next to the variable but bound by
+// the string, so a mismatched pair compiles, links, and then marshals a draw
+// call's arguments into the wrong driver function at runtime.
+//
+// It re-parses this package's own source rather than using reflection,
+// because Go offers no way to recover a package-level variable's name from
+// its address.
+func TestBindingNamesMatchVars(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "init.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse init.go: %v", err)
+	}
+
+	var checked int
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok || len(lit.Elts) != 2 {
+			return true
+		}
+		// &pfnActiveTexture
+		unary, ok := lit.Elts[0].(*ast.UnaryExpr)
+		if !ok || unary.Op != token.AND {
+			return true
+		}
+		ident, ok := unary.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		// "glActiveTexture"
+		str, ok := lit.Elts[1].(*ast.BasicLit)
+		if !ok || str.Kind != token.STRING {
+			return true
+		}
+
+		varName := strings.TrimPrefix(ident.Name, "pfn")
+		entryPoint := strings.TrimPrefix(strings.Trim(str.Value, `"`), "gl")
+		if varName != entryPoint {
+			t.Errorf("%s is bound to gl%s: variable and entry point disagree",
+				ident.Name, entryPoint)
+		}
+		checked++
+		return true
+	})
+
+	if want := len(bindings()); checked != want {
+		t.Errorf("parsed %d binding literals, table has %d entries", checked, want)
+	}
+}
+
+// TestInitReportsMissingSymbol covers the nil-proc path: a driver that does
+// not export an entry point must produce a named error, not a nil-pointer
+// panic on the first draw call.
+func TestInitReportsMissingSymbol(t *testing.T) {
+	err := InitWithProcAddrFunc(func(string) uintptr { return 0 })
+	if err == nil {
+		t.Fatal("InitWithProcAddrFunc(always 0) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "glActiveTexture") {
+		t.Errorf("error %q does not name the missing symbol", err)
+	}
+}

--- a/gui/backend/internal/glbind/init_test.go
+++ b/gui/backend/internal/glbind/init_test.go
@@ -108,3 +108,64 @@ func TestInitReportsMissingSymbol(t *testing.T) {
 		t.Errorf("error %q does not name the missing symbol", err)
 	}
 }
+
+// TestInitFailureLeavesNothingBound covers the two-pass contract: when a
+// symbol is missing, resolution stops and nothing is registered, so a caller
+// that mishandles the error can never observe a half-bound package. In the
+// single-pass form, every entry point resolved before the failure would have
+// stayed bound.
+func TestInitFailureLeavesNothingBound(t *testing.T) {
+	err := InitWithProcAddrFunc(func(name string) uintptr {
+		if name == "glBindBuffer" {
+			return 0
+		}
+		return 1
+	})
+	if err == nil {
+		t.Fatal("InitWithProcAddrFunc = nil, want error")
+	}
+	if pfnActiveTexture != nil || pfnAttachShader != nil || pfnBindBuffer != nil {
+		t.Fatal("failed init left function pointers bound")
+	}
+}
+
+// TestTableCoversEveryPointer guards the completeness direction the other
+// tests cannot see: a pfn variable (and its wrapper) added without a
+// {&pfn, "gl..."} table entry would leave the wrapper permanently nil at
+// runtime, and the table-shape tests cannot catch it because they never look
+// at glbind.go. Re-parse both files and require every pfn name to appear
+// exactly twice: once as a declaration, once as a table entry. (A table
+// entry without a declaration cannot compile.)
+func TestTableCoversEveryPointer(t *testing.T) {
+	fset := token.NewFileSet()
+	counts := map[string]int{}
+	for _, f := range []string{"glbind.go", "init.go"} {
+		file, err := parser.ParseFile(fset, f, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.ValueSpec:
+				// pfnActiveTexture func(...) — the declaration side.
+				for _, name := range v.Names {
+					if strings.HasPrefix(name.Name, "pfn") {
+						counts[name.Name]++
+					}
+				}
+			case *ast.UnaryExpr:
+				// &pfnActiveTexture — the table-entry side.
+				ident, ok := v.X.(*ast.Ident)
+				if ok && v.Op == token.AND && strings.HasPrefix(ident.Name, "pfn") {
+					counts[ident.Name]++
+				}
+			}
+			return true
+		})
+	}
+	for name, n := range counts {
+		if n != 2 {
+			t.Errorf("%s appears %d times, want 2 (var decl + table entry)", name, n)
+		}
+	}
+}

--- a/scripts/install-ubuntu-deps.sh
+++ b/scripts/install-ubuntu-deps.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Install Ubuntu system dependencies required to build go-gui with CGO.
+# libegl1 is a runtime dependency, not a build one: gui/backend/gl dlopens
+# libEGL.so.1 by soname. No GL headers are needed since the backend dropped
+# github.com/go-gl/gl for the purego binding in gui/backend/internal/glbind.
 # Usage: ./scripts/install-ubuntu-deps.sh
 set -euo pipefail
 
@@ -11,7 +14,7 @@ sudo apt-get install -y \
   libpango1.0-dev \
   libfontconfig1-dev \
   libhunspell-dev \
-  libgl1-mesa-dev \
+  libegl1 \
   libx11-dev \
   libxext-dev \
   libxcursor-dev \

--- a/tools/depsdoc/main.go
+++ b/tools/depsdoc/main.go
@@ -33,9 +33,8 @@ func main() {
 // directPurpose maps direct-dependency modules to a short purpose string.
 var directPurpose = map[string]string{
 	"github.com/go-gui-org/go-glyph":  "Text shaping + glyph rasterization. Required by every backend.",
-	"github.com/go-gl/gl":             "OpenGL bindings for `gui/backend/gl`.",
 	"github.com/jezek/xgb":            "Pure-Go X11 windowing + events for the native Linux backend (`gui/backend/gl`).",
-	"github.com/ebitengine/purego":    "cgo-free dynamic loading of libEGL for the native Linux backend (`gui/backend/gl`).",
+	"github.com/ebitengine/purego":    "cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends.",
 	"github.com/gopxl/beep/v2":        "Audio playback (sound effects, music, mixer, fade) for `gui/audio`.",
 	"github.com/tdewolff/parse/v2":    "CSS tokenizer for the SVG `<style>` / `style=\"\"` cascade pipeline.",
 	"github.com/alecthomas/chroma/v2": "Syntax highlighting in the markdown widget.",


### PR DESCRIPTION
## Summary

Replace the go-gl CGo dependency with pure-Go GL bindings via `gui/backend/internal/glbind`, enabling `CGO_ENABLED=0` builds for Linux and Windows backends.

## Changes

- New `glbind` package: purego-based GL function loading (244 lines) plus binding-table init with complete test coverage
- All-or-nothing glbind initialization — either the full binding table loads or init returns an error (no partial, silent broken state)
- Updated GL backend (`gui/backend/gl/`) to use `glbind` instead of `github.com/go-gl/gl`: pipeline, shaders, textures, draw, buffers, text, platform layers
- Platform-specific proc loading: `egl_linux.go`, `wgl_windows.go` (+18 lines new), `platform_x11.go`, `platform_win32.go`
- CI: test `CGO_ENABLED=0 go build ./.../gl` on Linux and Windows
- Lint config: silence `depguard` false-positive on `glbind` imports

## Verification

- `go build ./...` — pass
- `go test ./...` — pass (GL backend segfault pre-existing, needs display)
- `golangci-lint run ./...` — 0 issues
- `CGO_ENABLED=0 go build ./gui/backend/gl/...` — pass (Linux)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788441865&installation_model_id=426559&pr_number=155&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F155&signature=5294cf6bbec071f6d169983934e78d424f24c42e911fc34898b1de192ac93f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->