### PR TITLE
fix(ime): SetFocus must not clear composition when already focused (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Re-focusing an already-focused widget destroyed the IME composition
+  (#156).** `SetFocus` was not idempotent: it cleared the preedit and
+  re-activated the platform input context even when the requested ID was
+  already the focused one. Consumers legitimately re-assert focus from
+  inside their `View` function, which runs on every layout rebuild — i.e.
+  after every keystroke — so a CJK composition was torn down between each
+  update. The preedit flashed and never accumulated, leaving CJK input
+  unusable end to end. `imeClear` and the `IMEStart`/`IMEStop` pair now run
+  only on a real focus change. Text-selection clearing and the cursor-blink
+  reset are unchanged, so callers that re-focus to reset a selection still
+  work.
 - **App fonts were ignored on iOS and Android (#132).** Both backends
   loaded the bundled icon font but never called `gui.LoadAppFonts`, so
   `RegisterAppFont` / `RegisterAppFontBytes` were a silent no-op there.

--- a/gui/ime_test.go
+++ b/gui/ime_test.go
@@ -109,6 +109,89 @@ func TestIMEClearedOnFocusChange(t *testing.T) {
 	}
 }
 
+// imeSpyPlatform counts IME activation calls so a test can assert that
+// re-focusing an already-focused widget does not cycle the platform
+// input context.
+type imeSpyPlatform struct {
+	NoopNativePlatform
+	starts int
+	stops  int
+}
+
+func (p *imeSpyPlatform) IMEStart() { p.starts++ }
+func (p *imeSpyPlatform) IMEStop()  { p.stops++ }
+
+// Regression for go-gui-org/go-gui#156. Consumers re-assert focus from
+// inside their View function, which runs on every layout rebuild — i.e.
+// after every keystroke. That must not clear a live composition, or the
+// preedit flashes away between each update and CJK input is unusable.
+func TestIMEPreservedOnRefocusSameID(t *testing.T) {
+	w := newTestWindow()
+	w.SetFocus("f1")
+	w.imeUpdate(&Event{
+		Type:      EventIMEComposition,
+		IMEText:   "にほん",
+		IMEStart:  3,
+		IMELength: 0,
+	})
+	w.SetFocus("f1")
+	if !w.IMEComposing() {
+		t.Fatal("composition dropped by refocusing the same id")
+	}
+	if got := w.IMECompText(); got != "にほん" {
+		t.Fatalf("comp text = %q, want %q", got, "にほん")
+	}
+	if got := w.IMECompCursor(); got != 3 {
+		t.Fatalf("comp cursor = %d, want 3", got)
+	}
+}
+
+// The other half of #156: re-focusing must not re-activate the platform
+// input context either, which on macOS re-ran makeFirstResponder:
+// mid-composition.
+func TestIMEStartNotRepeatedOnRefocusSameID(t *testing.T) {
+	w := newTestWindow()
+	spy := &imeSpyPlatform{}
+	w.SetNativePlatform(spy)
+
+	w.SetFocus("f1")
+	if spy.starts != 1 {
+		t.Fatalf("IMEStart calls after first focus = %d, want 1",
+			spy.starts)
+	}
+	for range 5 {
+		w.SetFocus("f1")
+	}
+	if spy.starts != 1 {
+		t.Fatalf("IMEStart calls after refocus = %d, want 1", spy.starts)
+	}
+	if spy.stops != 0 {
+		t.Fatalf("IMEStop calls after refocus = %d, want 0", spy.stops)
+	}
+
+	// A real focus change still cycles the input context.
+	w.SetFocus("f2")
+	if spy.stops != 1 || spy.starts != 2 {
+		t.Fatalf("after focus change: starts=%d stops=%d, want 2 and 1",
+			spy.starts, spy.stops)
+	}
+}
+
+// A genuine focus change must still drop the composition — the preedit
+// belongs to the widget that was being typed into.
+func TestIMEClearedOnFocusChangeToDifferentID(t *testing.T) {
+	w := newTestWindow()
+	w.SetFocus("f1")
+	w.imeUpdate(&Event{
+		Type:    EventIMEComposition,
+		IMEText: "字",
+	})
+	w.SetFocus("f2")
+	if w.IMEComposing() {
+		t.Fatal("expected composing=false after focus moved to f2")
+	}
+}
+
 func TestIMESetRectNoopWithoutPlatform(_ *testing.T) {
 	w := newTestWindow()
 	// Should not panic with nil nativePlatform.

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -28,7 +28,16 @@ func (w *Window) ClearFocus() {
 func (w *Window) setFocusLocked(id string) {
 	prev := w.viewState.focusID
 	w.clearInputSelections()
-	w.imeClear()
+	// Re-focusing the widget that already has focus must leave an
+	// in-flight IME composition alone. Consumers legitimately re-assert
+	// focus from inside their View function, which runs on every layout
+	// rebuild — i.e. after every keystroke — so an unconditional clear
+	// here wiped the preedit between each composition update, and the
+	// IMEStart below re-activated the platform input context
+	// mid-composition. See go-gui-org/go-gui#156.
+	if id != prev {
+		w.imeClear()
+	}
 	w.viewState.focusID = id
 	if id != "" {
 		w.viewState.inputCursorOn.Store(true)
@@ -36,8 +45,11 @@ func (w *Window) setFocusLocked(id string) {
 			w.animationAddLocked(NewBlinkCursorAnimation())
 		}
 	}
-	if np := w.nativePlatform; np != nil {
-		if prev != "" && id != prev {
+	// Same reasoning: only a real focus *change* touches the platform
+	// IME. prev != "" alone suffices for the stop — the enclosing
+	// id != prev already rules out a no-op transition.
+	if np := w.nativePlatform; np != nil && id != prev {
+		if prev != "" {
 			np.IMEStop()
 		}
 		if id != "" {


### PR DESCRIPTION
## Problem

`setFocusLocked` was not idempotent: it cleared the IME preedit and
re-activated the platform input context even when the requested ID was
already the focused one.

Consumers legitimately re-assert focus from inside their `View` function,
which runs on every layout rebuild — i.e. after every keystroke. So every
CJK composition update was immediately followed by a clear, the preedit
never accumulated, and CJK input was unusable end to end.

## Diagnosis

Confirmed with two-sided ObjC+Go tracing (`gui/backend/CLAUDE.md`) driving
go-term with the macOS Japanese IME. Before the fix, typing 7 keys:

```
[objc] setMarkedText: hadMarked=1 new="ミニ" sel=(2,0)
[go]   imeUpdate text="ミニ" start=2 len=0
[go]   setFocusLocked prev="term-1" id="term-1" same=true
[go]   imeClear WHILE COMPOSING text="ミニ" from ...setFocusLocked:32
```

7 `setMarkedText:` calls, 7 clears, **zero** empty `setMarkedText:` pushes.

This disproves the cause hypothesised in #156. The empty-marked-text branch
at `metal_window_darwin.m:312` never fired; `hasMarkedText` stayed true
throughout and the content view was already first responder on every
`IMESetActive`, so the ObjC marked-text session was never torn down. The
whole defect was on the Go side.

## Fix

`imeClear` and the `IMEStop`/`IMEStart` pair now run only on a real focus
change. `clearInputSelections` and the cursor-blink reset stay
unconditional, so callers that re-focus to reset a selection
(`view_rtf_select.go:39`) are unaffected.

## Verification

Same traced repro after the fix: **0 clears** across 12 keystrokes, the
composition accumulating monotonically, and `IMESetActive` firing once
instead of once per keystroke.

Three regression tests in `gui/ime_test.go`, including an `imeSpyPlatform`
asserting that five repeat `SetFocus("f1")` calls produce exactly one
`IMEStart`, and that a genuine change to `"f2"` still cycles stop/start.

`go build ./...`, `go test ./...` (0 failures), `golangci-lint run ./...`
(0 issues).

## Note on the second symptom in #156

The issue also reported the composition *content* being garbled
(`ミニ倉みきら` for `nihongo`). That is not a go-gui defect — the machine's
enabled Japanese input source was `com.apple.inputmethod.Kotoeri.KanaTyping`
with `JIMPrefTypingMethodKey = 1` (Kana, not Romaji). On the JIS kana layout
`n`→み `i`→に `h`→く `o`→ら `n`→み `g`→き `o`→ら. Reproduced identically in
TextEdit, so Cocoa hands go-gui that string already formed. No code change
warranted.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788445628&installation_model_id=426559&pr_number=157&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F157&signature=135cc310ea847e39558c9681f13c46e84e32af9d71aeaec286c3873dd5f8ffb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->