### PR TITLE
changelog: add v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.48.0] - 2026-08-04
+
 ### Fixed
 
 - **Re-focusing an already-focused widget destroyed the IME composition
@@ -95,6 +97,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **GL backend no longer needs cgo (#155).** The `github.com/go-gl/gl`
+  dependency is replaced by `gui/backend/internal/glbind`, which loads the GL
+  entry points through purego, so the Linux and Windows backends build with
+  `CGO_ENABLED=0`. Loading is all-or-nothing — the full binding table resolves
+  or init returns an error — so there is no partial, silently broken GL state.
+  Proc loading is per-platform (`egl_linux.go`, `wgl_windows.go`). No API
+  change for embedders; the macOS/Metal and web backends are untouched.
 - **macOS now emits `EventKeyDown` for printable keys**, followed by
   `EventChar`, matching X11, win32 and web. The KeyDown was previously
   swallowed by the same single-slot overwrite. Text input is unaffected
@@ -138,8 +147,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   selection actually lost instead of both. Other backends leave the hooks nil,
   so `GetPrimary` returns `""` and `SetPrimary` is a no-op on macOS, Windows,
   web, and mobile.
-
-## [Unreleased]
 
 ## [v0.45.1] - 2026-07-31
 


### PR DESCRIPTION
Cuts **v0.48.0**. Minor, not patch: `#155` replaces the go-gl cgo dependency
with purego bindings, giving `CGO_ENABLED=0` Linux/Windows builds — well past a
bugfix, so the minor digit moves.

Contents, all previously merged and already in the Unreleased section:

- IME commit path on macOS — `#152` (FIFO for text-input callbacks, the
  single-slot overwrite dropped commits), `#157` (`SetFocus` was not
  idempotent and tore down the composition on every keystroke), `#153`
  (Android `imeCommit` emits one `EventChar` with `IMEText`).
- `#154` — app fonts wired into the iOS and Android backends.
- `#147`/`#148` — `FindByID` guards.

This PR also adds the missing changelog entry for `#155` and removes a stray
empty `## [Unreleased]` heading that had been left between v0.46.0 and v0.45.1.

Downstream: go-term#134 (CJK input unusable) is blocked on this tag.

Gate run locally with `GOWORK=off`: `tidy-check vet deps-doc-check large-files
generate-check`, plus build/test — all clean, no regenerated file left dirty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788447297&installation_model_id=426559&pr_number=158&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F158&signature=3d77f1b30bb2f12dd0a6a06fd05ed3b2276622957fe29b960cb702793c8fd567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->