### PR TITLE
fix(metal): restore key repeat by disabling press-and-hold

### DIFF
--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -28,6 +28,7 @@ int metalTestApplicationDidBecomeActive(void);
 void metalTestRunModalMode(int ms);
 void metalTestRunDefaultMode(int ms);
 int metalTestFramePumpActive(void);
+int metalTestPressAndHoldRegistered(void);
 void metalTestPushIMECommit(const char *utf8);
 void metalTestPushIMEComposition(const char *utf8, int start, int len);
 int metalTestIMEQueueDepth(void);
@@ -263,6 +264,14 @@ func testApplicationDidBecomeActive() bool {
 // testFramePumpActive reports whether the nested-runloop frame-pump
 // timer is currently installed.
 func testFramePumpActive() bool { return C.metalTestFramePumpActive() != 0 }
+
+// testPressAndHoldRegistered reports ApplePressAndHoldEnabled as
+// registered by metalAppInit: 0 off, 1 on, -1 never registered.
+// Press-and-hold suppresses the insertText: calls that back key repeat,
+// so the fix registers it off.
+func testPressAndHoldRegistered() int {
+	return int(C.metalTestPressAndHoldRegistered())
+}
 
 // testRunModalMode spins the main runloop in NSModalPanelRunLoopMode —
 // what AppKit does inside runModal — so the pump timer can fire there.

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -46,6 +46,15 @@ func runMainThreadTests() {
 		panic("metalAppInit: activation policy not Regular")
 	}
 
+	// 2b. Press-and-hold must be registered off. With it on (the macOS
+	//    default), AppKit stops calling insertText: for auto-repeat
+	//    keyDown: events, so a held key types exactly one character and
+	//    key repeat is dead everywhere in the toolkit.
+	if got := testPressAndHoldRegistered(); got != 0 {
+		panic("metalAppInit: ApplePressAndHoldEnabled not registered off " +
+			"(key repeat delivers no characters)")
+	}
+
 	// 3. Menu bar must be fully wired — delegate, main menu, and
 	//    Quit wired to delegate. Regression test for Cmd+Q silently
 	//    failing.

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -1197,6 +1197,26 @@ void metalAppInit(void) {
     if (activated) return;
     activated = YES;
 
+    // Restore key repeat.  macOS press-and-hold (on by default) hands a
+    // held key to the accent-palette machinery after the first
+    // insertText:, and stops calling insertText: for the auto-repeat
+    // keyDown: events that follow.  Every repeat then arrives as a bare
+    // EventKeyDown with no EventChar behind it, so holding a letter types
+    // one character, holding Backspace deletes one character, and a
+    // terminal pane echoes nothing while the key is down.
+    //
+    // Registered rather than written: the registration domain sits at the
+    // bottom of the defaults search order, so a user who genuinely wants
+    // the accent palette keeps the escape hatch
+    //
+    //     defaults write -g ApplePressAndHoldEnabled -bool true
+    //
+    // which lives in NSGlobalDomain and outranks this.  Must run before
+    // sharedApplication so AppKit reads it during its own setup.
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+        @"ApplePressAndHoldEnabled": @NO,
+    }];
+
     [GUIApplication sharedApplication];
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 
@@ -1551,6 +1571,19 @@ void metalTestRunModalMode(int ms) {
 
 void metalTestRunDefaultMode(int ms) {
     metalTestRunMode(NSDefaultRunLoopMode, ms);
+}
+
+// Report ApplePressAndHoldEnabled as it stands in the registration
+// domain: 0 registered off, 1 registered on, -1 not registered at all.
+// Deliberately not the *effective* value — a developer who set
+// NSGlobalDomain themselves would otherwise fail this test for holding a
+// preference the fix intentionally leaves them.
+int metalTestPressAndHoldRegistered(void) {
+    NSDictionary *reg = [[NSUserDefaults standardUserDefaults]
+                             volatileDomainForName:NSRegistrationDomain];
+    id v = reg[@"ApplePressAndHoldEnabled"];
+    if (v == nil) return -1;
+    return [v boolValue] ? 1 : 0;
 }
 
 // Report whether the frame-pump timer is currently installed.


### PR DESCRIPTION
## Problem

macOS press-and-hold is on by default. After the first `insertText:`, AppKit hands the held key to the accent-palette machinery and stops calling `insertText:` for the auto-repeat `keyDown:` events that follow. Every repeat reached Go as a bare `EventKeyDown` with no `EventChar` behind it.

Consequences across the toolkit: holding a letter types one character, holding Backspace deletes one character, and a go-term pane echoes nothing for the entire hold.

Surfaced while diagnosing a reported echo delay in the go-term falcon terminal. Measured with a probe app — holding `a` produced 14 repeat keydowns over 1.1s and **zero** char events:

```
6716.346ms keydown  key=65   <- initial press
6716.472ms char     a        <- 126us later, correct
7227.257ms keydown  key=65   <- repeat, no char
7298.943ms keydown  key=65   <- repeat, no char
... 14 repeats, not one char ...
8371.285ms keyup
```

## Fix

`metalAppInit` registers `ApplePressAndHoldEnabled=NO` before `sharedApplication`, so AppKit reads it during its own setup.

`registerDefaults` rather than `setBool:forKey:` on purpose: the registration domain sits at the bottom of the defaults search order, so nothing is persisted to disk and a user who genuinely wants the accent palette keeps a working escape hatch —

```
defaults write -g ApplePressAndHoldEnabled -bool true
```

— which lives in NSGlobalDomain and outranks it.

## Trade-off

This disables the press-and-hold accent palette toolkit-wide in exchange for key repeat. Key repeat is the near-universal expectation, and the palette silently breaking repeat in text inputs is the worse of the two bugs. Same choice GLFW and SDL make.

## Test

`metalTestPressAndHoldRegistered()` reads the **registration domain** specifically (0 off / 1 on / -1 unregistered), asserted in `runMainThreadTests`. Reading the effective value instead would fail on any machine where the developer set NSGlobalDomain themselves — punishing them for a preference this fix deliberately leaves intact.

Verified the assertion is not vacuous: removing the fix makes it panic with the expected message.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean
- Full metal suite passes under `GO_GUI_MAIN_THREAD_TESTS=1`
- Confirmed by hand in the go-term falcon terminal: key repeat works, including Backspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788450540&installation_model_id=426559&pr_number=159&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F159&signature=c265760220db19b7d0fe9a6110040f02086be292dd62ea57e0edaa0d823591ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->