### PR TITLE
changelog: add v0.48.1 (macOS key repeat restored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.48.1] - 2026-08-04
+
+### Fixed
+
+- **Key repeat delivered no characters on macOS (#159).** macOS
+  press-and-hold is on by default. After the first `insertText:`, AppKit
+  hands the held key to the accent-palette machinery and stops calling
+  `insertText:` for the auto-repeat `keyDown:` events that follow, so every
+  repeat reached the toolkit as a bare `EventKeyDown` with no `EventChar`
+  behind it. Holding a letter typed one character, holding Backspace
+  deleted one character, and a terminal pane echoed nothing for the whole
+  hold. `metalAppInit` now registers `ApplePressAndHoldEnabled=NO` before
+  `sharedApplication`. Registered rather than written: the registration
+  domain sits at the bottom of the defaults search order, so nothing is
+  persisted to disk and `defaults write -g ApplePressAndHoldEnabled -bool
+  true` — which lives in NSGlobalDomain and outranks it — still restores
+  the accent palette for anyone who wants it over key repeat.
+
 ## [v0.48.0] - 2026-08-04
 
 ### Fixed


### PR DESCRIPTION
Release changelog for v0.48.1.

Sole change since v0.48.0 is #159 — `metalAppInit` registers `ApplePressAndHoldEnabled=NO`, restoring key repeat on macOS. Bug fix only, no API change, so patch.

Tag follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788451814&installation_model_id=426559&pr_number=160&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F160&signature=29fef43c1d156a6c686365e7dfec469378504f77669f1eae9b98f4855f68eede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->