### PR TITLE
feat(ime): X11 IME support via IBus over D-Bus (#150)

### DIFF
--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -148,7 +148,7 @@ func (b *Backend) initGLResources(w *gui.Window) error {
 
 	w.SetTextMeasurer(&textMeasurer{textSys: textSys})
 	w.SetSvgParser(svg.New())
-	w.SetNativePlatform(&nativePlatform{})
+	w.SetNativePlatform(&nativePlatform{b: b})
 	return nil
 }
 

--- a/gui/backend/gl/events_x11.go
+++ b/gui/backend/gl/events_x11.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jezek/xgb/xproto"
 
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/ibus"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/x11key"
 )
 
@@ -51,20 +52,37 @@ func (b *Backend) handleXEvent(ev xgb.Event) {
 	w := b.plat.w
 	switch e := ev.(type) {
 	case xproto.KeyPressEvent:
+		col := 0
+		if e.State&xproto.KeyButMaskShift != 0 {
+			col = 1
+		}
+		// A key the input method claims belongs entirely to it: while a
+		// composition is live the engine owns the arrows, Return and
+		// Backspace too, so neither the key event nor the character may
+		// also reach the widget.
+		if b.imeProcessKey(b.plat.keysym(e.Detail, col), e.Detail, e.State) {
+			return
+		}
 		b.emit(gui.Event{
 			Type:      gui.EventKeyDown,
 			KeyCode:   x11key.MapKeySym(b.plat.keysym(e.Detail, 0)),
 			Modifiers: x11key.MapModifiers(e.State),
 		})
-		col := 0
-		if e.State&xproto.KeyButMaskShift != 0 {
-			col = 1
-		}
 		if r := x11key.KeysymToRune(b.plat.keysym(e.Detail, col)); r >= 0x20 && r != 0x7f {
 			b.emitChar(r, e.State)
 		}
 
 	case xproto.KeyReleaseEvent:
+		// Releases are forwarded but never suppress the key-up: engines
+		// use them for modifier-only toggles (Shift to switch kana, say)
+		// and nothing else depends on the result.
+		if b.plat.ime != nil {
+			b.plat.ime.ProcessKeyRelease(
+				b.plat.keysym(e.Detail, 0),
+				uint32(e.Detail)-x11KeycodeOffset,
+				uint32(e.State),
+			)
+		}
 		b.emit(gui.Event{
 			Type:      gui.EventKeyUp,
 			KeyCode:   x11key.MapKeySym(b.plat.keysym(e.Detail, 0)),
@@ -118,6 +136,12 @@ func (b *Backend) handleXEvent(ev xgb.Event) {
 
 	case xproto.ConfigureNotifyEvent:
 		scaleChanged := b.maybeRescaleDPI()
+		if !b.plat.haveRandr {
+			// maybeRescaleDPI refreshes the cached root position only
+			// when RandR is present. Without it, invalidate here so the
+			// IME caret rect is recomputed against the new position.
+			b.plat.haveLastPos = false
+		}
 		nw, nh := int32(e.Width), int32(e.Height)
 		if !scaleChanged && nw == b.plat.physW && nh == b.plat.physH {
 			return
@@ -209,8 +233,137 @@ func (b *Backend) emitChar(r rune, state uint16) {
 	})
 }
 
-// --- IME (stub; KeyPress still yields EventChar for printable keys) ---
+// --- IME ---
+//
+// Input methods are reached over D-Bus (see gui/backend/ibus) rather
+// than through XIM. When no input method is running plat.ime is nil and
+// every call below is a no-op, leaving the keysym path above untouched.
 
-func (n *nativePlatform) IMEStart()                   {}
-func (n *nativePlatform) IMEStop()                    {}
-func (n *nativePlatform) IMESetRect(_, _, _, _ int32) {}
+// x11KeycodeOffset converts an X11 keycode to the evdev code IBus wants.
+const x11KeycodeOffset = 8
+
+// imeProcessKey offers a key press to the input method and reports
+// whether it was consumed.
+//
+// The queue is drained on both sides of the call so composition results
+// interleave with key events in the order the user produced them: a
+// commit queued by the previous keystroke must not land after this one.
+func (b *Backend) imeProcessKey(keyval uint32, code xproto.Keycode, state uint16) bool {
+	if b.plat.ime == nil {
+		return false
+	}
+	b.drainIME()
+	consumed := b.plat.ime.ProcessKey(
+		keyval, uint32(code)-x11KeycodeOffset, uint32(state),
+	)
+	b.drainIME()
+	return consumed
+}
+
+// drainIME turns queued input-method results into gui events. The queue
+// is filled from a D-Bus goroutine; this must only run on the main
+// thread, where EventFn is safe to call.
+func (b *Backend) drainIME() {
+	if b.plat.ime == nil {
+		return
+	}
+	b.plat.imeBuf = b.plat.ime.Drain(b.plat.imeBuf[:0])
+	b.plat.imeEvts = imeEvents(b.plat.imeBuf, b.plat.imeEvts[:0])
+	for i := range b.plat.imeEvts {
+		b.emit(b.plat.imeEvts[i])
+	}
+}
+
+// imeEvents converts input-method results to gui events, appending to
+// dst. Kept separate from dispatch so the mapping is testable without
+// an X connection or a running input method.
+func imeEvents(in []ibus.Event, dst []gui.Event) []gui.Event {
+	for i := range in {
+		ev := &in[i]
+		switch ev.Kind {
+		case ibus.KindPreedit:
+			dst = append(dst, gui.Event{
+				Type:      gui.EventIMEComposition,
+				IMEText:   ev.Text,
+				IMEStart:  ev.Cursor,
+				IMELength: ev.SelLen,
+			})
+
+		case ibus.KindCommit:
+			// Committed text is plain input: no modifiers apply, and a
+			// decoding failure upstream must not reach the widget.
+			for _, r := range ev.Text {
+				if r == 0xFFFD {
+					continue
+				}
+				dst = append(dst, gui.Event{
+					Type:     gui.EventChar,
+					CharCode: uint32(r),
+					IMEText:  string(r),
+				})
+			}
+
+		case ibus.KindForwardKey:
+			state := uint16(ev.State & 0xffff)
+			dst = append(dst, gui.Event{
+				Type:      gui.EventKeyDown,
+				KeyCode:   x11key.MapKeySym(ev.Keyval),
+				Modifiers: x11key.MapModifiers(state),
+			})
+			if r := x11key.KeysymToRune(ev.Keyval); r >= 0x20 && r != 0x7f {
+				dst = append(dst, gui.Event{
+					Type:      gui.EventChar,
+					CharCode:  uint32(r),
+					IMEText:   string(r),
+					Modifiers: x11key.MapModifiers(state),
+				})
+			}
+		}
+	}
+	return dst
+}
+
+// rootOrigin returns the window's origin in root coordinates, the frame
+// the caret rect must be reported in. maybeRescaleDPI keeps the cached
+// value fresh on every move, so this normally costs nothing.
+func (b *Backend) rootOrigin() (int16, int16) {
+	if !b.plat.haveLastPos {
+		t, err := xproto.TranslateCoordinates(
+			b.plat.conn, b.plat.window, b.plat.root, 0, 0,
+		).Reply()
+		if err == nil && t != nil {
+			b.plat.lastRootX, b.plat.lastRootY = t.DstX, t.DstY
+			b.plat.haveLastPos = true
+		}
+	}
+	return b.plat.lastRootX, b.plat.lastRootY
+}
+
+func (n *nativePlatform) IMEStart() { n.b.plat.ime.FocusIn() }
+
+// IMEStop drops the input method's focus. No composition event is
+// emitted here: the gui layer already clears its own state on a focus
+// change (Window.setFocusID), and re-entering EventFn from inside an
+// event handler would clobber the event being dispatched.
+func (n *nativePlatform) IMEStop() { n.b.plat.ime.FocusOut() }
+
+// IMESetRect reports the caret rect so the candidate window can anchor
+// to it. The gui layer works in logical points relative to the window;
+// IBus wants physical pixels relative to the root.
+func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
+	b := n.b
+	if b.plat.ime == nil {
+		return
+	}
+	s := b.dpiScale
+	if s <= 0 {
+		s = 1
+	}
+	rx, ry := b.rootOrigin()
+	b.plat.ime.SetCursorLocation(
+		int32(rx)+int32(float32(x)*s),
+		int32(ry)+int32(float32(y)*s),
+		int32(float32(w)*s),
+		int32(float32(h)*s),
+	)
+}

--- a/gui/backend/gl/ime_x11_test.go
+++ b/gui/backend/gl/ime_x11_test.go
@@ -1,0 +1,123 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/ibus"
+)
+
+func TestIMEEventsPreedit(t *testing.T) {
+	got := imeEvents([]ibus.Event{
+		{Kind: ibus.KindPreedit, Text: "にほん", Cursor: 2, SelLen: 1},
+	}, nil)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1", len(got))
+	}
+	e := got[0]
+	if e.Type != gui.EventIMEComposition || e.IMEText != "にほん" ||
+		e.IMEStart != 2 || e.IMELength != 1 {
+		t.Errorf("preedit mapped to %+v", e)
+	}
+}
+
+// An empty preedit is how a composition ends; it must still produce an
+// event, otherwise the widget keeps rendering stale text.
+func TestIMEEventsEmptyPreedit(t *testing.T) {
+	got := imeEvents([]ibus.Event{{Kind: ibus.KindPreedit}}, nil)
+	if len(got) != 1 || got[0].Type != gui.EventIMEComposition ||
+		got[0].IMEText != "" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestIMEEventsCommit(t *testing.T) {
+	got := imeEvents([]ibus.Event{
+		{Kind: ibus.KindCommit, Text: "日本"},
+	}, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want one per rune", len(got))
+	}
+	for i, want := range []rune{'日', '本'} {
+		e := got[i]
+		if e.Type != gui.EventChar || e.CharCode != uint32(want) ||
+			e.IMEText != string(want) {
+			t.Errorf("rune %d mapped to %+v", i, e)
+		}
+		if e.Modifiers != 0 {
+			t.Errorf("rune %d carried modifiers %v", i, e.Modifiers)
+		}
+	}
+}
+
+func TestIMEEventsCommitDropsReplacementChar(t *testing.T) {
+	got := imeEvents([]ibus.Event{
+		{Kind: ibus.KindCommit, Text: "a�b"},
+	}, nil)
+	if len(got) != 2 || got[0].CharCode != 'a' || got[1].CharCode != 'b' {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+// A forwarded key is one the engine declined after all, so it has to
+// come out exactly like an unconsumed key press: key down plus, for a
+// printable keysym, a character.
+func TestIMEEventsForwardKey(t *testing.T) {
+	got := imeEvents([]ibus.Event{
+		{Kind: ibus.KindForwardKey, Keyval: 'a', Keycode: 38},
+	}, nil)
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[0].Type != gui.EventKeyDown {
+		t.Errorf("first event is %v, want EventKeyDown", got[0].Type)
+	}
+	if got[1].Type != gui.EventChar || got[1].CharCode != 'a' {
+		t.Errorf("second event is %+v", got[1])
+	}
+}
+
+// Non-printable keysyms yield a key down only.
+func TestIMEEventsForwardKeyNonPrintable(t *testing.T) {
+	const xkReturn = 0xff0d
+	got := imeEvents([]ibus.Event{
+		{Kind: ibus.KindForwardKey, Keyval: xkReturn},
+	}, nil)
+	if len(got) != 1 || got[0].Type != gui.EventKeyDown {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+// drainIME reuses both buffers, so the conversion must append rather
+// than assume an empty destination.
+func TestIMEEventsAppends(t *testing.T) {
+	dst := []gui.Event{{Type: gui.EventResized}}
+	dst = imeEvents([]ibus.Event{{Kind: ibus.KindCommit, Text: "x"}}, dst)
+	if len(dst) != 2 || dst[0].Type != gui.EventResized ||
+		dst[1].CharCode != 'x' {
+		t.Fatalf("got %+v", dst)
+	}
+}
+
+func TestIMEEventsEmptyInput(t *testing.T) {
+	if got := imeEvents(nil, nil); len(got) != 0 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+// With no input method present the backend must behave exactly as
+// before: no client, no queue, and the key path untouched.
+func TestNoIMEClientIsInert(t *testing.T) {
+	b := &Backend{}
+	b.drainIME()
+	if b.imeProcessKey('a', 38, 0) {
+		t.Error("imeProcessKey consumed a key with no input method")
+	}
+	if b.plat.imeEvts != nil {
+		t.Error("drainIME allocated with no input method")
+	}
+}

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -8,7 +8,10 @@ import (
 )
 
 // nativePlatform implements gui.NativePlatform for the GL backend.
-type nativePlatform struct{}
+//
+// b is the owning backend: IME calls have to reach per-window platform
+// state. Everything else here is process-wide and ignores it.
+type nativePlatform struct{ b *Backend }
 
 // --- URI ---
 

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jezek/xgb/xproto"
 
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/ibus"
 )
 
 // Selected X11 event mask for top-level windows.
@@ -87,6 +88,13 @@ type platformState struct {
 	physW, physH int32
 	scale        float32
 
+	// Input method. ime is nil when none is reachable, in which case
+	// key presses keep going straight through the keysym path. imeBuf
+	// is reused by drainIME to keep the handoff allocation-free.
+	ime     *ibus.Client
+	imeBuf  []ibus.Event
+	imeEvts []gui.Event
+
 	w   *gui.Window
 	evt gui.Event // reused per event to avoid per-event allocation
 }
@@ -139,6 +147,10 @@ func (p *platformState) wake() {
 }
 
 func (p *platformState) destroy() {
+	if p.ime != nil {
+		p.ime.Close()
+		p.ime = nil
+	}
 	if p.eglDpy != 0 {
 		eglMakeCurrent(p.eglDpy, 0, 0, 0)
 		if p.eglContext != 0 {
@@ -302,6 +314,10 @@ func New(w *gui.Window) (*Backend, error) {
 	}
 	b.plat.wakeConn = wakeConn
 
+	// Needs wakeConn and wakeAtom: the client calls wake from a D-Bus
+	// goroutine to bring the event loop round to drainIME.
+	b.plat.ime = ibus.New("go-gui", b.plat.wake)
+
 	b.dpiScale = scale
 	b.physW = physW
 	b.physH = physH
@@ -350,6 +366,7 @@ func (b *Backend) Run(w *gui.Window) {
 				}
 				b.handleXEvent(ev)
 			default:
+				b.drainIME()
 				return true
 			}
 		}
@@ -486,6 +503,9 @@ func RunAppE(app *gui.App, initialWindows ...*gui.Window) error {
 					log.Printf("gl: open window: %v", err)
 				}
 			default:
+				for _, b := range backends {
+					b.drainIME()
+				}
 				drained = true
 			}
 		}

--- a/gui/backend/ibus/doc.go
+++ b/gui/backend/ibus/doc.go
@@ -1,0 +1,12 @@
+// Package ibus is a minimal IBus input-method client spoken over D-Bus.
+//
+// It exists so the X11 backend can support IME (CJK and anything else
+// driven by an input method) without XIM, which has no pure-Go
+// implementation. Both ibus and fcitx5 expose this interface, the
+// latter directly and through the IBus portal, so one client covers
+// nearly every Linux IME user.
+//
+// Only the input-context half of the IBus API is implemented: enough to
+// forward key events, receive preedit and commit, and tell the panel
+// where the caret is. Candidate windows are left to the IME panel.
+package ibus

--- a/gui/backend/ibus/ibus_it_test.go
+++ b/gui/backend/ibus/ibus_it_test.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package ibus
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Integration tests against the input method actually running on this
+// machine. Gated like the X11 and clipboard tests: a build machine has
+// no ibus-daemon, and a developer machine's engine list is unknown.
+func requireIBus(t *testing.T) *Client {
+	t.Helper()
+	if os.Getenv("GOGUI_IBUS_IT") != "1" {
+		t.Skip("set GOGUI_IBUS_IT=1 to run the live input-method tests")
+	}
+	c := New("go-gui-test", nil)
+	if c == nil {
+		t.Fatal("New: no input method reachable")
+	}
+	t.Cleanup(c.Close)
+	return c
+}
+
+func TestLiveConnect(t *testing.T) {
+	c := requireIBus(t)
+	if c.disabled.Load() {
+		t.Fatal("client latched off during setup")
+	}
+}
+
+// A round trip through the daemon: focus the context, offer a key, and
+// confirm the transport survived. Whether the key is consumed depends
+// on the engine the user has active, so only the transport is asserted.
+func TestLiveProcessKey(t *testing.T) {
+	c := requireIBus(t)
+	c.FocusIn()
+	c.SetCursorLocation(100, 200, 2, 20)
+
+	const xkA, evdevA = 0x61, 30
+	consumed := c.ProcessKey(xkA, evdevA, 0)
+	c.ProcessKeyRelease(xkA, evdevA, 0)
+	t.Logf("engine consumed 'a': %v", consumed)
+
+	if c.disabled.Load() {
+		t.Fatal("client latched off: the daemon rejected a call")
+	}
+	c.FocusOut()
+	if c.disabled.Load() {
+		t.Fatal("client latched off during FocusOut")
+	}
+}
+
+// Signals have to reach the queue and fire the wake callback. Only runs
+// meaningfully with a composing engine selected; with a latin engine
+// nothing is produced and the test reports that rather than failing.
+func TestLiveSignals(t *testing.T) {
+	if os.Getenv("GOGUI_IBUS_IT") != "1" {
+		t.Skip("set GOGUI_IBUS_IT=1 to run the live input-method tests")
+	}
+	var wakes atomic.Int32
+	c := New("go-gui-test", func() { wakes.Add(1) })
+	if c == nil {
+		t.Fatal("New: no input method reachable")
+	}
+	defer c.Close()
+
+	c.FocusIn()
+	// "nihon" on a kana engine composes; on a latin engine it does not.
+	for _, k := range []struct{ keyval, code uint32 }{
+		{'n', 49}, {'i', 23}, {'h', 35}, {'o', 24}, {'n', 49},
+	} {
+		c.ProcessKey(k.keyval, k.code, 0)
+		c.ProcessKeyRelease(k.keyval, k.code, 0)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	evs := c.Drain(nil)
+	if len(evs) == 0 {
+		t.Skip("no composition: the active engine is not a composing one")
+	}
+	for _, e := range evs {
+		t.Logf("kind=%d text=%q cursor=%d", e.Kind, e.Text, e.Cursor)
+	}
+	if wakes.Load() == 0 {
+		t.Error("events were queued but wake was never called")
+	}
+	c.FocusOut()
+}

--- a/gui/backend/ibus/ibus_linux.go
+++ b/gui/backend/ibus/ibus_linux.go
@@ -219,7 +219,9 @@ func socketAddress() string {
 }
 
 func readSocketFile(path string) string {
-	data, err := os.ReadFile(path) //nolint:gosec // path is derived from the user's own config dir
+	// #nosec G304 — path is the caller's own ibus config dir joined with
+	// a name that came from globbing that same dir; no external input.
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
@@ -242,6 +244,7 @@ func readSocketFile(path string) string {
 
 func machineID() string {
 	for _, p := range []string{"/etc/machine-id", "/var/lib/dbus/machine-id"} {
+		// #nosec G304 — p iterates two compile-time constants.
 		if data, err := os.ReadFile(p); err == nil {
 			if id := strings.TrimSpace(string(data)); id != "" {
 				return id

--- a/gui/backend/ibus/ibus_linux.go
+++ b/gui/backend/ibus/ibus_linux.go
@@ -1,0 +1,435 @@
+//go:build linux
+
+package ibus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	ifaceBus     = "org.freedesktop.IBus"
+	ifaceContext = "org.freedesktop.IBus.InputContext"
+
+	nameDirect = "org.freedesktop.IBus"
+	namePortal = "org.freedesktop.portal.IBus"
+	pathBus    = "/org/freedesktop/IBus"
+
+	// IBus capability bits. Only preedit and focus are claimed: go-gui
+	// renders the preedit itself but has no candidate-list UI, so the
+	// lookup-table, auxiliary-text and property bits are deliberately
+	// left unset and the IME panel keeps drawing its own candidate
+	// window. Surrounding text is not implemented either.
+	capPreeditText = 1 << 0
+	capFocus       = 1 << 3
+
+	// IBusModifierType release bit, set on the state word so the engine
+	// can tell key release from key press.
+	releaseMask = 1 << 30
+
+	// A key press must not stall the frame. The daemon is on a local
+	// socket, so this is generous; exceeding it means something is
+	// wrong and the client latches off rather than hanging the UI.
+	callTimeout = 100 * time.Millisecond
+)
+
+// Kind classifies an event produced by the input method.
+type Kind int
+
+const (
+	// KindPreedit carries an updated (possibly empty) preedit string.
+	KindPreedit Kind = iota
+	// KindCommit carries text the input method has committed.
+	KindCommit
+	// KindForwardKey carries a key the engine declined after all.
+	KindForwardKey
+)
+
+// Event is one input-method result, queued for the main thread.
+type Event struct {
+	Text                   string
+	Cursor, SelLen         int32
+	Keyval, Keycode, State uint32
+	Kind                   Kind
+}
+
+// Client is an IBus input context. A nil *Client is inert: every method
+// is safe to call on it, so callers need only the one nil check that
+// distinguishes "no input method on this system" from "have one".
+type Client struct {
+	conn *dbus.Conn
+	ctx  dbus.BusObject
+	wake func()
+
+	signals chan *dbus.Signal
+
+	mu      sync.Mutex
+	queue   []Event
+	preedit string // last preedit, replayed by ShowPreeditText
+
+	// disabled latches on the first transport failure. Recovering a
+	// half-dead input method is not worth the complexity: dropping back
+	// to the raw keysym path keeps plain typing working, which is the
+	// behaviour that must never regress.
+	disabled atomic.Bool
+}
+
+// New connects to an input method and creates an input context for it.
+// It returns nil when no input method is reachable, which is the normal
+// case on a system without one; the caller then keeps decoding keysyms
+// directly.
+//
+// wake is called from a D-Bus goroutine whenever events are queued. It
+// must be safe off the main thread and should make the event loop come
+// round to Drain.
+func New(clientName string, wake func()) *Client {
+	conn, dest := connect()
+	if conn == nil {
+		return nil
+	}
+
+	var ctxPath dbus.ObjectPath
+	err := conn.Object(dest, pathBus).
+		Call(ifaceBus+".CreateInputContext", 0, clientName).
+		Store(&ctxPath)
+	if err != nil {
+		_ = conn.Close()
+		return nil
+	}
+
+	c := &Client{
+		conn:    conn,
+		ctx:     conn.Object(dest, ctxPath),
+		wake:    wake,
+		signals: make(chan *dbus.Signal, 32),
+	}
+
+	// A failed match rule is not fatal on a direct peer connection,
+	// where signals arrive regardless.
+	_ = conn.AddMatchSignal(
+		dbus.WithMatchObjectPath(ctxPath),
+		dbus.WithMatchInterface(ifaceContext),
+	)
+	conn.Signal(c.signals)
+	go c.readSignals()
+
+	c.call("SetCapabilities", uint32(capPreeditText|capFocus))
+	return c
+}
+
+// connect finds an input method and returns a private connection to it
+// along with the bus name to address. The connection is always private
+// so Close cannot disturb the shared session bus used by atspi and sni.
+func connect() (*dbus.Conn, string) {
+	if addr := os.Getenv("IBUS_ADDRESS"); addr != "" {
+		if conn := dialPrivate(addr); conn != nil {
+			return conn, nameDirect
+		}
+	}
+	if addr := socketAddress(); addr != "" {
+		if conn := dialPrivate(addr); conn != nil {
+			return conn, nameDirect
+		}
+	}
+	// fcitx5 owns org.freedesktop.IBus on the session bus; the portal
+	// name is what a sandboxed session sees.
+	conn, err := dbus.SessionBusPrivate()
+	if err != nil {
+		return nil, ""
+	}
+	if err = conn.Auth(nil); err != nil {
+		_ = conn.Close()
+		return nil, ""
+	}
+	if err = conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, ""
+	}
+	for _, name := range []string{nameDirect, namePortal} {
+		var has bool
+		if e := conn.BusObject().Call(
+			"org.freedesktop.DBus.NameHasOwner", 0, name,
+		).Store(&has); e == nil && has {
+			return conn, name
+		}
+	}
+	_ = conn.Close()
+	return nil, ""
+}
+
+func dialPrivate(addr string) *dbus.Conn {
+	conn, err := dbus.Dial(addr)
+	if err != nil {
+		return nil
+	}
+	if err = conn.Auth(nil); err != nil {
+		_ = conn.Close()
+		return nil
+	}
+	if err = conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil
+	}
+	return conn
+}
+
+// socketAddress reads the address ibus-daemon publishes under the user
+// config directory. The file outlives the daemon, so the recorded pid
+// is checked before its address is trusted.
+func socketAddress() string {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".config")
+	}
+	dir = filepath.Join(dir, "ibus", "bus")
+
+	id := machineID()
+	if id == "" {
+		return ""
+	}
+	// The exact name encodes the display, which is reconstructed the
+	// same way ibus does it. Globbing covers the cases where that
+	// reconstruction disagrees (a renamed host, IBUS_DISPLAY set for
+	// the daemon but not for us).
+	names := []string{id + "-" + displaySuffix()}
+	if matches, err := filepath.Glob(filepath.Join(dir, id+"-*")); err == nil {
+		for _, m := range matches {
+			names = append(names, filepath.Base(m))
+		}
+	}
+	for _, name := range names {
+		if addr := readSocketFile(filepath.Join(dir, name)); addr != "" {
+			return addr
+		}
+	}
+	return ""
+}
+
+func readSocketFile(path string) string {
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from the user's own config dir
+	if err != nil {
+		return ""
+	}
+	var addr string
+	alive := false
+	for line := range strings.SplitSeq(string(data), "\n") {
+		switch key, val, _ := strings.Cut(strings.TrimSpace(line), "="); key {
+		case "IBUS_ADDRESS":
+			addr = val
+		case "IBUS_DAEMON_PID":
+			pid, err2 := strconv.Atoi(val)
+			alive = err2 == nil && pid > 0 && syscall.Kill(pid, 0) == nil
+		}
+	}
+	if !alive {
+		return ""
+	}
+	return addr
+}
+
+func machineID() string {
+	for _, p := range []string{"/etc/machine-id", "/var/lib/dbus/machine-id"} {
+		if data, err := os.ReadFile(p); err == nil {
+			if id := strings.TrimSpace(string(data)); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// displaySuffix rebuilds the "<host>-<number>" part of the socket file
+// name from DISPLAY, matching ibus_get_socket_path.
+func displaySuffix() string {
+	disp := os.Getenv("IBUS_DISPLAY")
+	if disp == "" {
+		disp = os.Getenv("DISPLAY")
+	}
+	host, rest, found := strings.Cut(disp, ":")
+	if !found {
+		return "unix-0"
+	}
+	if host == "" {
+		host = "unix"
+	}
+	num, _, _ := strings.Cut(rest, ".")
+	if num == "" {
+		num = "0"
+	}
+	return host + "-" + num
+}
+
+// --- input context ---
+
+// ProcessKey offers a key to the input method and reports whether it was
+// consumed. A consumed key must not also be handled by the caller: the
+// engine owns navigation and editing keys while a composition is live.
+func (c *Client) ProcessKey(keyval, keycode, state uint32) bool {
+	if c == nil || c.disabled.Load() {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+
+	var consumed bool
+	err := c.ctx.CallWithContext(
+		ctx, ifaceContext+".ProcessKeyEvent", 0, keyval, keycode, state,
+	).Store(&consumed)
+	if err != nil {
+		c.disabled.Store(true)
+		return false
+	}
+	return consumed
+}
+
+// ProcessKeyRelease offers a key release to the input method. The result
+// is ignored: releases never suppress the caller's own handling.
+func (c *Client) ProcessKeyRelease(keyval, keycode, state uint32) {
+	if c == nil {
+		return
+	}
+	c.ProcessKey(keyval, keycode, state|releaseMask)
+}
+
+// FocusIn tells the input method this context is now active.
+func (c *Client) FocusIn() { c.call("FocusIn") }
+
+// FocusOut abandons any live composition and tells the input method
+// this context is no longer active. The reset comes first so a
+// half-composed string cannot survive the focus change.
+func (c *Client) FocusOut() {
+	c.call("Reset")
+	c.call("FocusOut")
+}
+
+// SetCursorLocation reports the caret rect in root window pixels so the
+// candidate window can anchor to it.
+func (c *Client) SetCursorLocation(x, y, w, h int32) {
+	c.call("SetCursorLocation", x, y, w, h)
+}
+
+// Close destroys the input context and drops the connection.
+func (c *Client) Close() {
+	if c == nil {
+		return
+	}
+	c.disabled.Store(true)
+	c.call("Destroy")
+	_ = c.conn.Close()
+}
+
+// call invokes a fire-and-forget input-context method, latching the
+// client off if the transport fails.
+func (c *Client) call(method string, args ...any) {
+	if c == nil || c.disabled.Load() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+	if err := c.ctx.CallWithContext(
+		ctx, ifaceContext+"."+method, 0, args...,
+	).Err; err != nil {
+		c.disabled.Store(true)
+	}
+}
+
+// --- signals ---
+
+// readSignals translates input-method signals into queued events. It
+// exits when the connection closes, which godbus signals by closing the
+// channel; that also latches the client off.
+func (c *Client) readSignals() {
+	for sig := range c.signals {
+		switch sig.Name {
+		case ifaceContext + ".UpdatePreeditText",
+			ifaceContext + ".UpdatePreeditTextWithMode":
+			text, cursor, visible, ok := decodePreedit(sig.Body)
+			if !ok {
+				continue
+			}
+			if !visible {
+				text = ""
+			}
+			c.setPreedit(text, int32(cursor)) //nolint:gosec // clamped in gui.imeUpdate
+
+		case ifaceContext + ".ShowPreeditText":
+			c.mu.Lock()
+			text := c.preedit
+			c.mu.Unlock()
+			c.push(Event{Kind: KindPreedit, Text: text})
+
+		case ifaceContext + ".HidePreeditText":
+			c.setPreedit("", 0)
+
+		case ifaceContext + ".CommitText":
+			if len(sig.Body) == 0 {
+				continue
+			}
+			text, ok := decodeText(sig.Body[0])
+			if !ok || text == "" {
+				continue
+			}
+			// The preedit is consumed by the commit; clear it first so
+			// the caller never renders both.
+			c.setPreedit("", 0)
+			c.push(Event{Kind: KindCommit, Text: text})
+
+		case ifaceContext + ".ForwardKeyEvent":
+			keyval, keycode, state, ok := decodeForwardKey(sig.Body)
+			if !ok || state&releaseMask != 0 {
+				continue
+			}
+			c.push(Event{
+				Kind:   KindForwardKey,
+				Keyval: keyval, Keycode: keycode, State: state,
+			})
+		}
+	}
+	c.disabled.Store(true)
+}
+
+// setPreedit caches the preedit for ShowPreeditText to replay and queues
+// it for the caller.
+func (c *Client) setPreedit(text string, cursor int32) {
+	c.mu.Lock()
+	c.preedit = text
+	c.mu.Unlock()
+	c.push(Event{Kind: KindPreedit, Text: text, Cursor: cursor})
+}
+
+// push queues an event and wakes the event loop.
+func (c *Client) push(e Event) {
+	c.mu.Lock()
+	c.queue = append(c.queue, e)
+	c.mu.Unlock()
+	if c.wake != nil {
+		c.wake()
+	}
+}
+
+// Drain appends the queued events to dst and returns it. The queue's
+// backing array is reused, so callers should pass a scratch slice back
+// each time to keep this allocation-free. Main thread only.
+func (c *Client) Drain(dst []Event) []Event {
+	if c == nil {
+		return dst
+	}
+	c.mu.Lock()
+	dst = append(dst, c.queue...)
+	c.queue = c.queue[:0]
+	c.mu.Unlock()
+	return dst
+}

--- a/gui/backend/ibus/ibus_other.go
+++ b/gui/backend/ibus/ibus_other.go
@@ -1,0 +1,51 @@
+//go:build !linux
+
+package ibus
+
+// Kind classifies an event produced by the input method.
+type Kind int
+
+const (
+	// KindPreedit carries an updated (possibly empty) preedit string.
+	KindPreedit Kind = iota
+	// KindCommit carries text the input method has committed.
+	KindCommit
+	// KindForwardKey carries a key the engine declined after all.
+	KindForwardKey
+)
+
+// Event is one input-method result, queued for the main thread.
+type Event struct {
+	Text                   string
+	Cursor, SelLen         int32
+	Keyval, Keycode, State uint32
+	Kind                   Kind
+}
+
+// Client is an IBus input context. IBus is Linux-only, so this build
+// has none: New always returns nil and every method is inert.
+type Client struct{}
+
+// New reports that no input method is available.
+func New(_ string, _ func()) *Client { return nil }
+
+// ProcessKey never consumes a key on this platform.
+func (c *Client) ProcessKey(_, _, _ uint32) bool { return false }
+
+// ProcessKeyRelease does nothing on this platform.
+func (c *Client) ProcessKeyRelease(_, _, _ uint32) {}
+
+// FocusIn does nothing on this platform.
+func (c *Client) FocusIn() {}
+
+// FocusOut does nothing on this platform.
+func (c *Client) FocusOut() {}
+
+// SetCursorLocation does nothing on this platform.
+func (c *Client) SetCursorLocation(_, _, _, _ int32) {}
+
+// Close does nothing on this platform.
+func (c *Client) Close() {}
+
+// Drain returns dst unchanged on this platform.
+func (c *Client) Drain(dst []Event) []Event { return dst }

--- a/gui/backend/ibus/queue_test.go
+++ b/gui/backend/ibus/queue_test.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+package ibus
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDrainIsFIFOAndReusesBuffer(t *testing.T) {
+	c := &Client{}
+	for i := range 3 {
+		c.push(Event{Kind: KindCommit, Text: string(rune('a' + i))})
+	}
+
+	buf := c.Drain(nil)
+	if len(buf) != 3 || buf[0].Text != "a" || buf[2].Text != "c" {
+		t.Fatalf("drain order wrong: %+v", buf)
+	}
+	if got := c.Drain(buf[:0]); len(got) != 0 {
+		t.Fatalf("second drain returned %d events, want 0", len(got))
+	}
+
+	c.push(Event{Kind: KindPreedit, Text: "z"})
+	if got := c.Drain(buf[:0]); len(got) != 1 || got[0].Text != "z" {
+		t.Fatalf("after refill got %+v", got)
+	}
+}
+
+func TestPushWakes(t *testing.T) {
+	var wakes atomic.Int32
+	c := &Client{wake: func() { wakes.Add(1) }}
+	c.push(Event{Kind: KindPreedit})
+	c.push(Event{Kind: KindCommit})
+	if wakes.Load() != 2 {
+		t.Fatalf("wake called %d times, want 2", wakes.Load())
+	}
+}
+
+// TestConcurrentPushDrain is here for the race detector: signals are
+// pushed from a D-Bus goroutine while the event loop drains on the main
+// thread, which is the one genuinely concurrent path in this package.
+func TestConcurrentPushDrain(t *testing.T) {
+	const n = 200
+	c := &Client{}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range n {
+			c.push(Event{Kind: KindCommit, Cursor: int32(i)})
+		}
+	})
+
+	var buf []Event
+	got := 0
+	for got < n {
+		buf = c.Drain(buf[:0])
+		got += len(buf)
+	}
+	wg.Wait()
+	if rest := c.Drain(nil); len(rest) != 0 {
+		t.Fatalf("%d events left after draining all %d", len(rest), n)
+	}
+}
+
+func TestNilClientIsInert(t *testing.T) {
+	var c *Client
+	if c.ProcessKey(1, 2, 3) {
+		t.Error("nil client consumed a key")
+	}
+	c.ProcessKeyRelease(1, 2, 3)
+	c.FocusIn()
+	c.FocusOut()
+	c.SetCursorLocation(0, 0, 1, 1)
+	c.Close()
+	if got := c.Drain(nil); got != nil {
+		t.Errorf("nil client drained %v", got)
+	}
+}
+
+func TestDisabledClientStopsConsuming(t *testing.T) {
+	c := &Client{}
+	c.disabled.Store(true)
+	if c.ProcessKey(0x61, 38, 0) {
+		t.Error("disabled client consumed a key")
+	}
+	// call must not dereference the nil connection while disabled.
+	c.FocusIn()
+	c.SetCursorLocation(1, 2, 3, 4)
+}

--- a/gui/backend/ibus/text.go
+++ b/gui/backend/ibus/text.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package ibus
+
+import "github.com/godbus/dbus/v5"
+
+// IBus marshals its objects as IBusSerializable, whose base layout is
+// (name, attachments) followed by the subtype's own fields. IBusText is
+// therefore (sa{sv}sv): name, attachments, text, attribute list. godbus
+// decodes a struct with no static target type into []any, so the text
+// sits at index 2.
+const (
+	textFieldName = 0
+	textFieldText = 2
+	textFields    = 3
+)
+
+// decodeText extracts the string from a marshalled IBusText.
+//
+// The value crosses an untyped D-Bus boundary from a process go-gui does
+// not control, so every step is checked rather than asserted: a
+// malformed or unexpected shape returns false and the caller drops the
+// signal instead of panicking in the render path.
+func decodeText(v any) (string, bool) {
+	switch t := v.(type) {
+	case dbus.Variant:
+		return decodeText(t.Value())
+	case string:
+		// Not a shape IBus sends, but harmless to accept.
+		return t, true
+	case []any:
+		if len(t) < textFields {
+			return "", false
+		}
+		if name, ok := t[textFieldName].(string); !ok || name != "IBusText" {
+			return "", false
+		}
+		s, ok := t[textFieldText].(string)
+		return s, ok
+	default:
+		return "", false
+	}
+}
+
+// decodePreedit reads the body of an UpdatePreeditText or
+// UpdatePreeditTextWithMode signal. Both carry (text, cursorPos,
+// visible); the WithMode variant appends a mode argument that go-gui
+// does not use, so the two are handled by the same path.
+func decodePreedit(body []any) (text string, cursor uint32, visible, ok bool) {
+	if len(body) < 3 {
+		return "", 0, false, false
+	}
+	text, ok = decodeText(body[0])
+	if !ok {
+		return "", 0, false, false
+	}
+	cursor, ok = body[1].(uint32)
+	if !ok {
+		return "", 0, false, false
+	}
+	visible, ok = body[2].(bool)
+	if !ok {
+		return "", 0, false, false
+	}
+	return text, cursor, visible, true
+}
+
+// decodeForwardKey reads the body of a ForwardKeyEvent signal, which the
+// engine sends for keys it declined to consume after all.
+func decodeForwardKey(body []any) (keyval, keycode, state uint32, ok bool) {
+	if len(body) < 3 {
+		return 0, 0, 0, false
+	}
+	keyval, ok = body[0].(uint32)
+	if !ok {
+		return 0, 0, 0, false
+	}
+	keycode, ok = body[1].(uint32)
+	if !ok {
+		return 0, 0, 0, false
+	}
+	state, ok = body[2].(uint32)
+	if !ok {
+		return 0, 0, 0, false
+	}
+	return keyval, keycode, state, true
+}

--- a/gui/backend/ibus/text_test.go
+++ b/gui/backend/ibus/text_test.go
@@ -1,0 +1,106 @@
+//go:build linux
+
+package ibus
+
+import (
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// ibusText builds the []any shape godbus produces for a marshalled
+// IBusText when there is no static target type to decode into.
+func ibusText(s string) []any {
+	return []any{
+		"IBusText",
+		map[string]dbus.Variant{},
+		s,
+		dbus.MakeVariant([]any{"IBusAttrList", map[string]dbus.Variant{}, []dbus.Variant{}}),
+	}
+}
+
+func TestDecodeText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+		ok   bool
+	}{
+		{"variant wrapped", dbus.MakeVariant(ibusText("日本語")), "日本語", true},
+		{"bare struct", ibusText("hello"), "hello", true},
+		{"empty text", ibusText(""), "", true},
+		{"bare string", "plain", "plain", true},
+		{"too short", []any{"IBusText", map[string]dbus.Variant{}}, "", false},
+		{"wrong name", []any{"IBusAttrList", map[string]dbus.Variant{}, "x"}, "", false},
+		{"text not a string", []any{"IBusText", map[string]dbus.Variant{}, 42}, "", false},
+		{"name not a string", []any{7, map[string]dbus.Variant{}, "x"}, "", false},
+		{"unexpected type", uint32(3), "", false},
+		{"nil", nil, "", false},
+		{"nested variant", dbus.MakeVariant(dbus.MakeVariant(ibusText("x"))), "x", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := decodeText(tc.in)
+			if ok != tc.ok || got != tc.want {
+				t.Errorf("decodeText(%v) = %q, %v; want %q, %v",
+					tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestDecodePreedit(t *testing.T) {
+	text := dbus.MakeVariant(ibusText("にほん"))
+
+	t.Run("three arg form", func(t *testing.T) {
+		s, cur, vis, ok := decodePreedit([]any{text, uint32(2), true})
+		if !ok || s != "にほん" || cur != 2 || !vis {
+			t.Fatalf("got %q, %d, %v, %v", s, cur, vis, ok)
+		}
+	})
+
+	t.Run("four arg with mode", func(t *testing.T) {
+		s, cur, vis, ok := decodePreedit([]any{text, uint32(0), false, uint32(1)})
+		if !ok || s != "にほん" || cur != 0 || vis {
+			t.Fatalf("got %q, %d, %v, %v", s, cur, vis, ok)
+		}
+	})
+
+	bad := []struct {
+		name string
+		body []any
+	}{
+		{"empty", nil},
+		{"too short", []any{text, uint32(0)}},
+		{"bad text", []any{dbus.MakeVariant(uint32(1)), uint32(0), true}},
+		{"cursor not uint32", []any{text, int32(0), true}},
+		{"visible not bool", []any{text, uint32(0), uint32(1)}},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, _, ok := decodePreedit(tc.body); ok {
+				t.Errorf("decodePreedit(%v) accepted a malformed body", tc.body)
+			}
+		})
+	}
+}
+
+func TestDecodeForwardKey(t *testing.T) {
+	kv, kc, st, ok := decodeForwardKey([]any{uint32(0x61), uint32(38), uint32(4)})
+	if !ok || kv != 0x61 || kc != 38 || st != 4 {
+		t.Fatalf("got %d, %d, %d, %v", kv, kc, st, ok)
+	}
+
+	bad := [][]any{
+		nil,
+		{uint32(1), uint32(2)},
+		{int32(1), uint32(2), uint32(3)},
+		{uint32(1), "2", uint32(3)},
+		{uint32(1), uint32(2), true},
+	}
+	for _, body := range bad {
+		if _, _, _, ok := decodeForwardKey(body); ok {
+			t.Errorf("decodeForwardKey(%v) accepted a malformed body", body)
+		}
+	}
+}


### PR DESCRIPTION
Closes #150.

CJK text input did not work on Linux at all. `gui/backend/gl/events_x11.go`
stubbed the entire `NativeIME` side of `NativePlatform` and decoded
keysyms straight to `emitChar`, so `EventIMEComposition` was never
emitted, composed text never committed, and `IMESetRect` was a no-op.

## Why IBus rather than XIM

The issue proposed XIM/XIC via xgb. XIM is a legacy protocol tunnelled
over X properties and ClientMessages with no pure-Go implementation — the
transport alone would dwarf the task. IBus speaks D-Bus, `godbus` is
already a dependency (atspi, sni, file portal), and fcitx5 exposes the
IBus interface and the IBus portal, so one client covers nearly every
Linux IME user.

**No cgo and no new dependency.** `CGO_ENABLED=0 go build ./...` stays
green; godbus's only `import "C"` is DragonFly-gated.

Wayland was considered as an alternative and rejected: an X11 app under a
Wayland session gets IME through this same path via XWayland, so this
helps those users today, while a Wayland backend is a from-scratch port
of window creation, input, clipboard, decorations, fractional scale and a
pure-Go xkb keymap parser, with `zwp_text_input_v3` still to write on
top.

## What landed

New `gui/backend/ibus/` (mirrors `atspi/`, `sni/`):

- **Discovery**, first hit wins: `IBUS_ADDRESS` → the ibus socket file
  under the config dir (recorded pid checked for liveness) → session bus
  `org.freedesktop.IBus` → `org.freedesktop.portal.IBus`. The connection
  is always private so `Close` cannot disturb the shared session bus that
  atspi and sni use.
- **`ProcessKeyEvent` is synchronous** under a 100 ms timeout. The daemon
  is on a local socket; async would need a key replay queue and
  back-pressure on in-flight X key events, which is where ordering bugs
  live. Any transport failure latches the client off permanently and the
  raw keysym path takes over — plain typing never regresses.
- **Threading**: signals arrive on a godbus goroutine, are queued, and
  wake the loop through the existing `_GOGUI_WAKE` mechanism. `drainIME`
  is main-thread only and runs on both sides of each key, so a commit
  queued by the previous keystroke cannot land after the current one.
- Decoding is defensive at every step — the payload crosses an untyped
  D-Bus boundary from a process go-gui does not control, and the values
  feed slice arithmetic in the render path.

In `gui/backend/gl/`: `platformState` gains the client and its buffers,
`nativePlatform` gains a `*Backend` so IME calls reach per-window state,
and the three stubs become real `FocusIn`/`FocusOut`/`SetCursorLocation`.
Consumed keys suppress **both** `EventKeyDown` and `EventChar` — the
engine owns arrows, Return and Backspace during composition.
`IMESetRect` maps logical window points to root physical pixels so the
candidate window tracks the caret.

Two deviations from the plan, both avoiding real hazards:

- `IMEStop` emits nothing. `Window.setFocusID` already calls `imeClear`,
  and re-entering `EventFn` from inside a handler would clobber the
  in-flight event via the shared `plat.evt`. It calls `Reset` before
  `FocusOut` so a half-composed string cannot survive a focus change.
- Event mapping is a pure `imeEvents` function rather than a test-only
  interface on the key path.

## Verification

Driven end to end against **ibus-mozc** in `examples/multiline_input`
with xdotool, screenshots inspected:

| stage | result |
|---|---|
| inline preedit | にほんご renders underlined in the widget |
| romaji → kana | incremental: ｎ → に → にほ → にほんご, cursor tracks |
| conversion | space → 日本語, still preedit |
| commit | Return → underline clears, text persists **exactly once** |
| candidate window | anchors directly under the caret |

Also: `go build ./...`, `golangci-lint run ./...` (0 issues), `gofmt`
clean, `CGO_ENABLED=0 go build ./...` for Linux and Windows, and
`GOOS=darwin` for the new package. New tests — 21 decode, 5 queue
(including `-race` concurrent push/drain), 9 event-mapping — plus live
integration tests gated behind `GOGUI_IBUS_IT=1`, matching the existing
`GOGUI_CLIPBOARD_IT` / `GOGUI_X11_IT` pattern.

## Known-red locally, not from this change

`go test ./...` exits 1 on this machine: `gui/backend/gl` segfaults at
process exit. That is #162 — pre-existing, reproduced identically on
unmodified `main` @ 0ab7587, cgo-dependent, and it does not occur under
`CGO_ENABLED=0` (full suite exit 0, all 26 gl tests pass). CI is headless
so the test that triggers it takes its skip branch.

## Follow-ups

- #163 — selected-clause highlighting. `SelLen` is left 0 here. The
  design question is already resolved on that issue with real mozc data:
  `cursor_pos` equals the start of the highlighted range, so no core API
  change is needed.
- #164 — Win32 inline preedit, the same stub shape.
- #162 — the segfault above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788471140&installation_model_id=426559&pr_number=165&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F165&signature=fbd313c38b34a316c20e6fc6bc2f8d659887c87e4c8d141e676a9e38706592d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->