### PR TITLE
fix(ibus): close race-free, bound queue, match release keysym column

### DIFF
--- a/gui/backend/gl/events_x11.go
+++ b/gui/backend/gl/events_x11.go
@@ -52,10 +52,7 @@ func (b *Backend) handleXEvent(ev xgb.Event) {
 	w := b.plat.w
 	switch e := ev.(type) {
 	case xproto.KeyPressEvent:
-		col := 0
-		if e.State&xproto.KeyButMaskShift != 0 {
-			col = 1
-		}
+		col := keysymColumn(e.State)
 		// A key the input method claims belongs entirely to it: while a
 		// composition is live the engine owns the arrows, Return and
 		// Backspace too, so neither the key event nor the character may
@@ -75,10 +72,12 @@ func (b *Backend) handleXEvent(ev xgb.Event) {
 	case xproto.KeyReleaseEvent:
 		// Releases are forwarded but never suppress the key-up: engines
 		// use them for modifier-only toggles (Shift to switch kana, say)
-		// and nothing else depends on the result.
+		// and nothing else depends on the result. The keysym uses the
+		// same shift column as the press so the engine sees matching
+		// press/release pairs.
 		if b.plat.ime != nil {
 			b.plat.ime.ProcessKeyRelease(
-				b.plat.keysym(e.Detail, 0),
+				b.plat.keysym(e.Detail, keysymColumn(e.State)),
 				uint32(e.Detail)-x11KeycodeOffset,
 				uint32(e.State),
 			)
@@ -241,6 +240,15 @@ func (b *Backend) emitChar(r rune, state uint16) {
 
 // x11KeycodeOffset converts an X11 keycode to the evdev code IBus wants.
 const x11KeycodeOffset = 8
+
+// keysymColumn returns the shift column for the given modifier state:
+// column 0 is the unshifted keysym, column 1 the shifted one.
+func keysymColumn(state uint16) int {
+	if state&xproto.KeyButMaskShift != 0 {
+		return 1
+	}
+	return 0
+}
 
 // imeProcessKey offers a key press to the input method and reports
 // whether it was consumed.

--- a/gui/backend/ibus/discovery_test.go
+++ b/gui/backend/ibus/discovery_test.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+package ibus
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestDisplaySuffix(t *testing.T) {
+	tests := []struct {
+		name        string
+		ibusDisplay string
+		display     string
+		want        string
+	}{
+		{"no display", "", "", "unix-0"},
+		{"local display", "", ":0", "unix-0"},
+		{"display with screen", "", ":0.0", "unix-0"},
+		{"remote host", "", "host:1", "host-1"},
+		{"remote with screen", "", "host:2.1", "host-2"},
+		{"colon only", "", ":", "unix-0"},
+		{"ibus overrides", "host:3", ":0", "host-3"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("IBUS_DISPLAY", tc.ibusDisplay)
+			t.Setenv("DISPLAY", tc.display)
+			if got := displaySuffix(); got != tc.want {
+				t.Errorf("displaySuffix() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadSocketFile(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("live daemon", func(t *testing.T) {
+		p := writeSocketFile(t, dir, "unix:path=/run/ibus", os.Getpid())
+		if got := readSocketFile(p); got != "unix:path=/run/ibus" {
+			t.Errorf("readSocketFile = %q, want the recorded address", got)
+		}
+	})
+
+	t.Run("dead daemon", func(t *testing.T) {
+		// kill(pid, 0) on a pid no process can have.
+		p := writeSocketFile(t, dir, "unix:path=/run/ibus", 1<<30)
+		if got := readSocketFile(p); got != "" {
+			t.Errorf("readSocketFile = %q, want empty for a dead pid", got)
+		}
+	})
+
+	t.Run("no pid line", func(t *testing.T) {
+		p := filepath.Join(dir, "nopid")
+		writeFile(t, p, "IBUS_ADDRESS=unix:path=/run/ibus\n")
+		if got := readSocketFile(p); got != "" {
+			t.Errorf("readSocketFile = %q, want empty without a pid", got)
+		}
+	})
+
+	t.Run("bogus pid", func(t *testing.T) {
+		p := filepath.Join(dir, "bogus")
+		writeFile(t, p, "IBUS_DAEMON_PID=abc\n")
+		if got := readSocketFile(p); got != "" {
+			t.Errorf("readSocketFile = %q, want empty for a bogus pid", got)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		if got := readSocketFile(filepath.Join(dir, "nope")); got != "" {
+			t.Errorf("readSocketFile = %q, want empty", got)
+		}
+	})
+}
+
+func writeSocketFile(t *testing.T, dir, addr string, pid int) string {
+	t.Helper()
+	p := filepath.Join(dir, "bus")
+	writeFile(t, p, "IBUS_ADDRESS="+addr+"\nIBUS_DAEMON_PID="+strconv.Itoa(pid)+"\n")
+	return p
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/gui/backend/ibus/ibus_linux.go
+++ b/gui/backend/ibus/ibus_linux.go
@@ -40,6 +40,12 @@ const (
 	// socket, so this is generous; exceeding it means something is
 	// wrong and the client latches off rather than hanging the UI.
 	callTimeout = 100 * time.Millisecond
+
+	// queueLimit bounds the queue when the event loop stalls. Preedit
+	// updates are transient state the engine resends on the next key,
+	// so they are the first thing dropped; a commit is never discarded
+	// while an old preedit can be evicted instead.
+	queueLimit = 256
 )
 
 // Kind classifies an event produced by the input method.
@@ -71,6 +77,7 @@ type Client struct {
 	wake func()
 
 	signals chan *dbus.Signal
+	wg      sync.WaitGroup // readSignals, joined by Close
 
 	mu      sync.Mutex
 	queue   []Event
@@ -120,6 +127,7 @@ func New(clientName string, wake func()) *Client {
 		dbus.WithMatchInterface(ifaceContext),
 	)
 	conn.Signal(c.signals)
+	c.wg.Add(1)
 	go c.readSignals()
 
 	c.call("SetCapabilities", uint32(capPreeditText|capFocus))
@@ -325,6 +333,11 @@ func (c *Client) SetCursorLocation(x, y, w, h int32) {
 }
 
 // Close destroys the input context and drops the connection.
+//
+// It waits for the signal goroutine to exit before returning: wake is
+// called from that goroutine, and the caller tears down the resources
+// it touches (the X wake connection) right after this returns, so no
+// wake may be in flight.
 func (c *Client) Close() {
 	if c == nil {
 		return
@@ -332,6 +345,7 @@ func (c *Client) Close() {
 	c.disabled.Store(true)
 	c.call("Destroy")
 	_ = c.conn.Close()
+	c.wg.Wait()
 }
 
 // call invokes a fire-and-forget input-context method, latching the
@@ -355,6 +369,7 @@ func (c *Client) call(method string, args ...any) {
 // exits when the connection closes, which godbus signals by closing the
 // channel; that also latches the client off.
 func (c *Client) readSignals() {
+	defer c.wg.Done()
 	for sig := range c.signals {
 		switch sig.Name {
 		case ifaceContext + ".UpdatePreeditText",
@@ -413,9 +428,36 @@ func (c *Client) setPreedit(text string, cursor int32) {
 	c.push(Event{Kind: KindPreedit, Text: text, Cursor: cursor})
 }
 
-// push queues an event and wakes the event loop.
+// push queues an event and wakes the event loop. A latched-off client
+// stops queueing, and a stalled loop must not grow the queue without
+// bound, so both are defended here rather than at the call sites.
 func (c *Client) push(e Event) {
 	c.mu.Lock()
+	if c.disabled.Load() {
+		c.mu.Unlock()
+		return
+	}
+	if len(c.queue) >= queueLimit {
+		// Full. Preedit is transient state, so an incoming preedit is
+		// dropped outright and a commit evicts the oldest preedit
+		// instead of being lost. If nothing is evictable the new event
+		// is dropped too: the queue must never grow past the bound.
+		if e.Kind == KindPreedit {
+			c.mu.Unlock()
+			return
+		}
+		for i := range c.queue {
+			if c.queue[i].Kind == KindPreedit {
+				copy(c.queue[i:], c.queue[i+1:])
+				c.queue = c.queue[:len(c.queue)-1]
+				break
+			}
+		}
+		if len(c.queue) >= queueLimit {
+			c.mu.Unlock()
+			return
+		}
+	}
 	c.queue = append(c.queue, e)
 	c.mu.Unlock()
 	if c.wake != nil {

--- a/gui/backend/ibus/queue_test.go
+++ b/gui/backend/ibus/queue_test.go
@@ -89,3 +89,64 @@ func TestDisabledClientStopsConsuming(t *testing.T) {
 	c.FocusIn()
 	c.SetCursorLocation(1, 2, 3, 4)
 }
+
+// A stalled event loop must not grow the queue without bound. Preedit
+// updates are transient — the engine resends them on the next key — so
+// they are dropped first, while a commit evicts the oldest preedit
+// rather than being lost.
+func TestPushQueueLimit(t *testing.T) {
+	c := &Client{}
+
+	for range queueLimit {
+		c.push(Event{Kind: KindPreedit, Text: "x"})
+	}
+	if n := len(c.Drain(nil)); n != queueLimit {
+		t.Fatalf("queue holds %d events, want %d", n, queueLimit)
+	}
+
+	// An incoming preedit at the limit is dropped outright.
+	for range queueLimit {
+		c.push(Event{Kind: KindPreedit, Text: "x"})
+	}
+	c.push(Event{Kind: KindPreedit, Text: "x"})
+	if n := len(c.Drain(nil)); n != queueLimit {
+		t.Fatalf("preedit not dropped at the limit: %d events queued", n)
+	}
+
+	// A commit at the limit evicts the oldest preedit instead.
+	for range queueLimit {
+		c.push(Event{Kind: KindPreedit, Text: "x"})
+	}
+	c.push(Event{Kind: KindCommit, Text: "keep"})
+	evs := c.Drain(nil)
+	if len(evs) != queueLimit || evs[queueLimit-1].Kind != KindCommit {
+		t.Fatalf("commit not kept: %d events, last = %+v", len(evs), evs[queueLimit-1])
+	}
+	if evs[0].Kind != KindPreedit {
+		t.Fatalf("oldest preedit not evicted, first = %+v", evs[0])
+	}
+
+	// With nothing evictable left the queue stays bounded.
+	for range queueLimit {
+		c.push(Event{Kind: KindCommit, Text: "x"})
+	}
+	c.push(Event{Kind: KindCommit, Text: "x"})
+	if n := len(c.Drain(nil)); n != queueLimit {
+		t.Fatalf("queue grew past the limit: %d", n)
+	}
+}
+
+// A latched-off client stops queueing: nothing may be pushed and no
+// wake may fire once Close has started.
+func TestPushDropsAfterClose(t *testing.T) {
+	var wakes atomic.Int32
+	c := &Client{wake: func() { wakes.Add(1) }}
+	c.disabled.Store(true)
+	c.push(Event{Kind: KindCommit, Text: "x"})
+	if n := len(c.Drain(nil)); n != 0 {
+		t.Fatalf("latched client queued %d events", n)
+	}
+	if wakes.Load() != 0 {
+		t.Fatalf("wake called %d times after latch", wakes.Load())
+	}
+}

--- a/gui/backend/ibus/text.go
+++ b/gui/backend/ibus/text.go
@@ -21,24 +21,30 @@ const (
 // not control, so every step is checked rather than asserted: a
 // malformed or unexpected shape returns false and the caller drops the
 // signal instead of panicking in the render path.
+//
+// Variant wrapping is unwrapped iteratively rather than recursively: a
+// hostile daemon can nest wrappers arbitrarily deep, and recursion
+// would grow the stack without bound.
 func decodeText(v any) (string, bool) {
-	switch t := v.(type) {
-	case dbus.Variant:
-		return decodeText(t.Value())
-	case string:
-		// Not a shape IBus sends, but harmless to accept.
-		return t, true
-	case []any:
-		if len(t) < textFields {
+	for {
+		switch t := v.(type) {
+		case dbus.Variant:
+			v = t.Value()
+		case string:
+			// Not a shape IBus sends, but harmless to accept.
+			return t, true
+		case []any:
+			if len(t) < textFields {
+				return "", false
+			}
+			if name, ok := t[textFieldName].(string); !ok || name != "IBusText" {
+				return "", false
+			}
+			s, ok := t[textFieldText].(string)
+			return s, ok
+		default:
 			return "", false
 		}
-		if name, ok := t[textFieldName].(string); !ok || name != "IBusText" {
-			return "", false
-		}
-		s, ok := t[textFieldText].(string)
-		return s, ok
-	default:
-		return "", false
 	}
 }
 


### PR DESCRIPTION
Follow-up quality pass over the IBus IME support landed in #165.

## What changed

- **Teardown race → goroutine hang (`Client.Close`).** A signal in flight
  when `Close()` ran could `push` → `wake()` after the backend closed the
  X wake connection; `SendEventChecked` on a closed xgb connection blocks
  forever on the request channel. `Close` now waits for the signal
  goroutine to exit (`sync.WaitGroup`) — godbus closes the signal channel
  before `conn.Close()` returns, so the wait is bounded. Also a genuine
  data race on `platformState.wakeConn` (reads from the D-Bus goroutine,
  nil write on teardown) under `-race`.
- **Unbounded queue (`push`).** A stalled event loop plus a chatty engine
  could grow the queue without bound. Now latched off with the rest of
  the client, and capped at 256: incoming preedits dropped when full
  (transient state — the engine resends on the next key), commits evict
  the oldest preedit rather than being lost; hard bound either way.
- **Keysym column mismatch on release.** Presses offered `keysym(code,
  shift-column)` to the engine but releases used column 0, so a shifted
  key's release arrived with the wrong keysym. Both now share
  `keysymColumn`, matching IBus convention (GTK sends the same keysym
  for press and release).
- **Recursive `dbus.Variant` unwrap in `decodeText`.** A hostile daemon
  can nest wrappers arbitrarily deep within D-Bus message size limits;
  now unwrapped iteratively, bounding the stack.

## Tests

New: `TestDisplaySuffix`, `TestReadSocketFile` (live pid via
`os.Getpid()`), `TestPushQueueLimit` (cap + eviction policy),
`TestPushDropsAfterClose`. All linux-tagged like the existing suite;
`go test` on CI covers them.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` green;
gofmt clean. The quality pass that produced these changes also verified
darwin/linux/cgo-free linux/windows builds and `GOOS=linux` lint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788476387&installation_model_id=426559&pr_number=167&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F167&signature=d048342731872dd87891222655bc51734da4d6ca3751499f3a5ce5533a299118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->