### PR TITLE
fix(ibus): highlight selected clause from IBusAttrList (#163)

### DIFF
--- a/gui/backend/ibus/debug_linux.go
+++ b/gui/backend/ibus/debug_linux.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package ibus
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// Setting GOGUI_IBUS_DEBUG dumps every raw UpdatePreeditText body to
+// stderr.
+//
+// Which IBusAttribute marks the focused clause is engine convention
+// rather than specification, so the only way to know what an engine
+// actually sends is to watch it compose. The attribute shapes in
+// text_test.go were captured this way from ibus-mozc; the next engine
+// that renders wrongly is diagnosed the same way, which is why this
+// outlives the issue that prompted it.
+var debugPreedit = sync.OnceValue(func() bool {
+	return os.Getenv("GOGUI_IBUS_DEBUG") != ""
+})
+
+func debugDumpPreedit(body []any) {
+	if !debugPreedit() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "IBUS preedit body: %#v\n", body)
+}

--- a/gui/backend/ibus/ibus_linux.go
+++ b/gui/backend/ibus/ibus_linux.go
@@ -79,9 +79,12 @@ type Client struct {
 	signals chan *dbus.Signal
 	wg      sync.WaitGroup // readSignals, joined by Close
 
-	mu      sync.Mutex
-	queue   []Event
-	preedit string // last preedit, replayed by ShowPreeditText
+	mu    sync.Mutex
+	queue []Event
+	// last preedit, replayed by ShowPreeditText
+	preedit       string
+	preeditCursor int32
+	preeditSelLen int32
 
 	// disabled latches on the first transport failure. Recovering a
 	// half-dead input method is not worth the complexity: dropping back
@@ -374,23 +377,38 @@ func (c *Client) readSignals() {
 		switch sig.Name {
 		case ifaceContext + ".UpdatePreeditText",
 			ifaceContext + ".UpdatePreeditTextWithMode":
-			text, cursor, visible, ok := decodePreedit(sig.Body)
+			debugDumpPreedit(sig.Body)
+			p, ok := decodePreedit(sig.Body)
 			if !ok {
 				continue
 			}
-			if !visible {
+			text := p.text
+			if !p.visible {
 				text = ""
 			}
-			c.setPreedit(text, int32(cursor)) //nolint:gosec // clamped in gui.imeUpdate
+			// The clause is read from the attributes rather than
+			// cursorPos: the cursor gives at best the clause start and
+			// never its length, and the range is what IBus actually
+			// specifies. Fall back to the cursor when no clause is
+			// marked, which is what plain unconverted typing sends.
+			cursor, selLen := p.cursor, uint32(0)
+			if p.selEnd > p.selStart {
+				cursor, selLen = p.selStart, p.selEnd-p.selStart
+			}
+			//nolint:gosec // clamped in gui.imeUpdate
+			c.setPreedit(text, int32(cursor), int32(selLen))
 
 		case ifaceContext + ".ShowPreeditText":
 			c.mu.Lock()
-			text := c.preedit
+			text, cursor, selLen := c.preedit, c.preeditCursor, c.preeditSelLen
 			c.mu.Unlock()
-			c.push(Event{Kind: KindPreedit, Text: text})
+			c.push(Event{
+				Kind: KindPreedit, Text: text,
+				Cursor: cursor, SelLen: selLen,
+			})
 
 		case ifaceContext + ".HidePreeditText":
-			c.setPreedit("", 0)
+			c.setPreedit("", 0, 0)
 
 		case ifaceContext + ".CommitText":
 			if len(sig.Body) == 0 {
@@ -402,7 +420,7 @@ func (c *Client) readSignals() {
 			}
 			// The preedit is consumed by the commit; clear it first so
 			// the caller never renders both.
-			c.setPreedit("", 0)
+			c.setPreedit("", 0, 0)
 			c.push(Event{Kind: KindCommit, Text: text})
 
 		case ifaceContext + ".ForwardKeyEvent":
@@ -420,12 +438,18 @@ func (c *Client) readSignals() {
 }
 
 // setPreedit caches the preedit for ShowPreeditText to replay and queues
-// it for the caller.
-func (c *Client) setPreedit(text string, cursor int32) {
+// it for the caller. The clause range is cached with the text: replaying
+// without it would drop the clause highlight on every show.
+func (c *Client) setPreedit(text string, cursor, selLen int32) {
 	c.mu.Lock()
 	c.preedit = text
+	c.preeditCursor = cursor
+	c.preeditSelLen = selLen
 	c.mu.Unlock()
-	c.push(Event{Kind: KindPreedit, Text: text, Cursor: cursor})
+	c.push(Event{
+		Kind: KindPreedit, Text: text,
+		Cursor: cursor, SelLen: selLen,
+	})
 }
 
 // push queues an event and wakes the event loop. A latched-off client

--- a/gui/backend/ibus/text.go
+++ b/gui/backend/ibus/text.go
@@ -9,66 +9,185 @@ import "github.com/godbus/dbus/v5"
 // therefore (sa{sv}sv): name, attachments, text, attribute list. godbus
 // decodes a struct with no static target type into []any, so the text
 // sits at index 2.
+//
+// The attribute list is optional here: only a minimum of three fields is
+// required, so an engine that omits it still yields its text.
 const (
-	textFieldName = 0
-	textFieldText = 2
-	textFields    = 3
+	textFieldName  = 0
+	textFieldText  = 2
+	textFieldAttrs = 3
+	textFields     = 3
 )
 
+// The attribute list is IBusAttrList, (sa{sv}av): name, attachments,
+// attributes. Each element is an IBusAttribute, (sa{sv}uuuu): name,
+// attachments, type, value, start index, end index. The indices are
+// character offsets, matching the rune-based clamping in gui.imeUpdate.
+const (
+	attrListFieldName  = 0
+	attrListFieldAttrs = 2
+	attrListFields     = 3
+
+	attrFieldName  = 0
+	attrFieldType  = 2
+	attrFieldValue = 3
+	attrFieldStart = 4
+	attrFieldEnd   = 5
+	attrFields     = 6
+
+	attrTypeUnderline  = 1
+	attrTypeBackground = 3
+
+	attrUnderlineDouble = 2
+)
+
+// unwrap strips variant wrappers.
+//
+// Iteratively rather than recursively: a hostile daemon can nest
+// wrappers arbitrarily deep, and recursion would grow the stack without
+// bound.
+func unwrap(v any) any {
+	for {
+		t, isVariant := v.(dbus.Variant)
+		if !isVariant {
+			return v
+		}
+		v = t.Value()
+	}
+}
+
 // decodeText extracts the string from a marshalled IBusText.
+func decodeText(v any) (string, bool) {
+	s, _, _, ok := decodeTextSel(v)
+	return s, ok
+}
+
+// decodeTextSel extracts the string from a marshalled IBusText along
+// with the range of the selected clause, if the engine marked one.
+// A zero-width range means no clause is selected.
 //
 // The value crosses an untyped D-Bus boundary from a process go-gui does
 // not control, so every step is checked rather than asserted: a
 // malformed or unexpected shape returns false and the caller drops the
-// signal instead of panicking in the render path.
+// signal instead of panicking in the render path. A malformed *attribute
+// list* is weaker than that — the text is still good, so it only costs
+// the clause highlight.
+func decodeTextSel(v any) (text string, selStart, selEnd uint32, ok bool) {
+	switch t := unwrap(v).(type) {
+	case string:
+		// Not a shape IBus sends, but harmless to accept.
+		return t, 0, 0, true
+	case []any:
+		if len(t) < textFields {
+			return "", 0, 0, false
+		}
+		if name, isStr := t[textFieldName].(string); !isStr || name != "IBusText" {
+			return "", 0, 0, false
+		}
+		text, ok = t[textFieldText].(string)
+		if !ok {
+			return "", 0, 0, false
+		}
+		if len(t) > textFieldAttrs {
+			selStart, selEnd, _ = decodeAttrSel(t[textFieldAttrs])
+		}
+		return text, selStart, selEnd, true
+	default:
+		return "", 0, 0, false
+	}
+}
+
+// decodeAttrSel finds the range of the selected clause in an
+// IBusAttrList.
 //
-// Variant wrapping is unwrapped iteratively rather than recursively: a
-// hostile daemon can nest wrappers arbitrarily deep, and recursion
-// would grow the stack without bound.
-func decodeText(v any) (string, bool) {
-	for {
-		switch t := v.(type) {
-		case dbus.Variant:
-			v = t.Value()
-		case string:
-			// Not a shape IBus sends, but harmless to accept.
-			return t, true
-		case []any:
-			if len(t) < textFields {
-				return "", false
-			}
-			if name, ok := t[textFieldName].(string); !ok || name != "IBusText" {
-				return "", false
-			}
-			s, ok := t[textFieldText].(string)
-			return s, ok
-		default:
-			return "", false
+// Which attribute marks it is engine convention, not specification.
+// ibus-mozc emits both a background attribute and a double underline
+// over the focused segment, so background wins and a lone double
+// underline serves as the fallback for engines that use only that.
+// Anything else — the single underline mozc puts over the unconverted
+// remainder, foreground colour — is not a selection marker.
+func decodeAttrSel(v any) (start, end uint32, ok bool) {
+	list, isSlice := unwrap(v).([]any)
+	if !isSlice || len(list) < attrListFields {
+		return 0, 0, false
+	}
+	if name, isStr := list[attrListFieldName].(string); !isStr || name != "IBusAttrList" {
+		return 0, 0, false
+	}
+	attrs, isSlice := unwrap(list[attrListFieldAttrs]).([]dbus.Variant)
+	if !isSlice {
+		return 0, 0, false
+	}
+
+	var underStart, underEnd uint32
+	haveUnder := false
+	for _, a := range attrs {
+		typ, val, s, e, valid := decodeAttr(a)
+		if !valid || e <= s {
+			continue
+		}
+		switch {
+		case typ == attrTypeBackground:
+			return s, e, true
+		case typ == attrTypeUnderline && val == attrUnderlineDouble && !haveUnder:
+			underStart, underEnd, haveUnder = s, e, true
 		}
 	}
+	if haveUnder {
+		return underStart, underEnd, true
+	}
+	return 0, 0, false
+}
+
+// decodeAttr reads one IBusAttribute.
+func decodeAttr(v any) (typ, val, start, end uint32, ok bool) {
+	f, isSlice := unwrap(v).([]any)
+	if !isSlice || len(f) < attrFields {
+		return 0, 0, 0, 0, false
+	}
+	if name, isStr := f[attrFieldName].(string); !isStr || name != "IBusAttribute" {
+		return 0, 0, 0, 0, false
+	}
+	fields := [4]uint32{}
+	for i, idx := range [4]int{
+		attrFieldType, attrFieldValue, attrFieldStart, attrFieldEnd,
+	} {
+		fields[i], ok = f[idx].(uint32)
+		if !ok {
+			return 0, 0, 0, 0, false
+		}
+	}
+	return fields[0], fields[1], fields[2], fields[3], true
+}
+
+// preedit is one decoded UpdatePreeditText body.
+type preedit struct {
+	text             string
+	cursor           uint32
+	selStart, selEnd uint32
+	visible          bool
 }
 
 // decodePreedit reads the body of an UpdatePreeditText or
 // UpdatePreeditTextWithMode signal. Both carry (text, cursorPos,
 // visible); the WithMode variant appends a mode argument that go-gui
 // does not use, so the two are handled by the same path.
-func decodePreedit(body []any) (text string, cursor uint32, visible, ok bool) {
+func decodePreedit(body []any) (preedit, bool) {
 	if len(body) < 3 {
-		return "", 0, false, false
+		return preedit{}, false
 	}
-	text, ok = decodeText(body[0])
-	if !ok {
-		return "", 0, false, false
+	p := preedit{}
+	var ok bool
+	if p.text, p.selStart, p.selEnd, ok = decodeTextSel(body[0]); !ok {
+		return preedit{}, false
 	}
-	cursor, ok = body[1].(uint32)
-	if !ok {
-		return "", 0, false, false
+	if p.cursor, ok = body[1].(uint32); !ok {
+		return preedit{}, false
 	}
-	visible, ok = body[2].(bool)
-	if !ok {
-		return "", 0, false, false
+	if p.visible, ok = body[2].(bool); !ok {
+		return preedit{}, false
 	}
-	return text, cursor, visible, true
+	return p, true
 }
 
 // decodeForwardKey reads the body of a ForwardKeyEvent signal, which the

--- a/gui/backend/ibus/text_test.go
+++ b/gui/backend/ibus/text_test.go
@@ -10,12 +10,44 @@ import (
 
 // ibusText builds the []any shape godbus produces for a marshalled
 // IBusText when there is no static target type to decode into.
-func ibusText(s string) []any {
+func ibusText(s string, attrs ...dbus.Variant) []any {
 	return []any{
 		"IBusText",
 		map[string]dbus.Variant{},
 		s,
-		dbus.MakeVariant([]any{"IBusAttrList", map[string]dbus.Variant{}, []dbus.Variant{}}),
+		dbus.MakeVariant([]any{"IBusAttrList", map[string]dbus.Variant{}, attrs}),
+	}
+}
+
+// ibusAttr builds one IBusAttribute, (sa{sv}uuuu).
+func ibusAttr(typ, val, start, end uint32) dbus.Variant {
+	return dbus.MakeVariant([]any{
+		"IBusAttribute", map[string]dbus.Variant{},
+		typ, val, start, end,
+	})
+}
+
+// mozcClause1 and mozcClause2 are the attribute lists ibus-mozc emits
+// for "今日はいい天気ですね" (今日は / いい天気ですね) as the focus moves
+// between the two clauses, captured from live UpdatePreeditText signals.
+// The focused clause carries a background, a double underline and a
+// foreground over the same range; the rest carries a single underline.
+// The indices are rune offsets — 今日は is 3 runes but 9 bytes.
+func mozcClause1() []dbus.Variant {
+	return []dbus.Variant{
+		ibusAttr(attrTypeUnderline, attrUnderlineDouble, 0, 3),
+		ibusAttr(attrTypeBackground, 0xd1eaff, 0, 3),
+		ibusAttr(2 /* foreground */, 0x000000, 0, 3),
+		ibusAttr(attrTypeUnderline, 1 /* single */, 3, 10),
+	}
+}
+
+func mozcClause2() []dbus.Variant {
+	return []dbus.Variant{
+		ibusAttr(attrTypeUnderline, 1 /* single */, 0, 3),
+		ibusAttr(attrTypeUnderline, attrUnderlineDouble, 3, 10),
+		ibusAttr(attrTypeBackground, 0xd1eaff, 3, 10),
+		ibusAttr(2 /* foreground */, 0x000000, 3, 10),
 	}
 }
 
@@ -53,16 +85,41 @@ func TestDecodePreedit(t *testing.T) {
 	text := dbus.MakeVariant(ibusText("にほん"))
 
 	t.Run("three arg form", func(t *testing.T) {
-		s, cur, vis, ok := decodePreedit([]any{text, uint32(2), true})
-		if !ok || s != "にほん" || cur != 2 || !vis {
-			t.Fatalf("got %q, %d, %v, %v", s, cur, vis, ok)
+		p, ok := decodePreedit([]any{text, uint32(2), true})
+		if !ok || p.text != "にほん" || p.cursor != 2 || !p.visible {
+			t.Fatalf("got %+v, %v", p, ok)
 		}
 	})
 
 	t.Run("four arg with mode", func(t *testing.T) {
-		s, cur, vis, ok := decodePreedit([]any{text, uint32(0), false, uint32(1)})
-		if !ok || s != "にほん" || cur != 0 || vis {
-			t.Fatalf("got %q, %d, %v, %v", s, cur, vis, ok)
+		p, ok := decodePreedit([]any{text, uint32(0), false, uint32(1)})
+		if !ok || p.text != "にほん" || p.cursor != 0 || p.visible {
+			t.Fatalf("got %+v, %v", p, ok)
+		}
+	})
+
+	t.Run("first clause focused", func(t *testing.T) {
+		conv := dbus.MakeVariant(ibusText("今日はいい天気ですね", mozcClause1()...))
+		p, ok := decodePreedit([]any{conv, uint32(0), true})
+		if !ok || p.selStart != 0 || p.selEnd != 3 {
+			t.Fatalf("got %+v, %v; want clause [0,3)", p, ok)
+		}
+	})
+
+	t.Run("second clause focused", func(t *testing.T) {
+		conv := dbus.MakeVariant(ibusText("今日はいい天気ですね", mozcClause2()...))
+		p, ok := decodePreedit([]any{conv, uint32(3), true})
+		if !ok || p.selStart != 3 || p.selEnd != 10 {
+			t.Fatalf("got %+v, %v; want clause [3,10)", p, ok)
+		}
+	})
+
+	t.Run("unconverted has no clause", func(t *testing.T) {
+		raw := dbus.MakeVariant(ibusText("きょう",
+			ibusAttr(attrTypeUnderline, 1, 0, 3)))
+		p, ok := decodePreedit([]any{raw, uint32(3), true})
+		if !ok || p.selStart != 0 || p.selEnd != 0 {
+			t.Fatalf("got %+v, %v; want no clause", p, ok)
 		}
 	})
 
@@ -78,8 +135,98 @@ func TestDecodePreedit(t *testing.T) {
 	}
 	for _, tc := range bad {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, _, _, ok := decodePreedit(tc.body); ok {
+			if _, ok := decodePreedit(tc.body); ok {
 				t.Errorf("decodePreedit(%v) accepted a malformed body", tc.body)
+			}
+		})
+	}
+}
+
+func TestDecodeAttrSel(t *testing.T) {
+	attrList := func(attrs ...dbus.Variant) any {
+		return dbus.MakeVariant([]any{
+			"IBusAttrList", map[string]dbus.Variant{}, attrs,
+		})
+	}
+
+	tests := []struct {
+		name       string
+		in         any
+		start, end uint32
+		ok         bool
+	}{
+		{"mozc clause 1", attrList(mozcClause1()...), 0, 3, true},
+		{"mozc clause 2", attrList(mozcClause2()...), 3, 10, true},
+		{
+			"background wins over double underline", attrList(
+				ibusAttr(attrTypeUnderline, attrUnderlineDouble, 0, 2),
+				ibusAttr(attrTypeBackground, 0xd1eaff, 4, 9),
+			), 4, 9, true,
+		},
+		{
+			"double underline alone", attrList(
+				ibusAttr(attrTypeUnderline, attrUnderlineDouble, 2, 5),
+			), 2, 5, true,
+		},
+		{
+			"single underline only", attrList(
+				ibusAttr(attrTypeUnderline, 1, 0, 4),
+			), 0, 0, false,
+		},
+		{"no attributes", attrList(), 0, 0, false},
+		{
+			"empty range", attrList(
+				ibusAttr(attrTypeBackground, 0xd1eaff, 3, 3),
+			), 0, 0, false,
+		},
+		{
+			"inverted range", attrList(
+				ibusAttr(attrTypeBackground, 0xd1eaff, 5, 2),
+			), 0, 0, false,
+		},
+		{
+			"skips malformed, keeps good", attrList(
+				dbus.MakeVariant([]any{"IBusAttribute", map[string]dbus.Variant{}}),
+				ibusAttr(attrTypeBackground, 0xd1eaff, 1, 4),
+			), 1, 4, true,
+		},
+		{
+			"wrong attribute name", attrList(
+				dbus.MakeVariant([]any{
+					"IBusText", map[string]dbus.Variant{},
+					attrTypeBackground, uint32(0), uint32(0), uint32(3),
+				}),
+			), 0, 0, false,
+		},
+		{
+			"index not uint32", attrList(
+				dbus.MakeVariant([]any{
+					"IBusAttribute", map[string]dbus.Variant{},
+					attrTypeBackground, uint32(0), int32(0), uint32(3),
+				}),
+			), 0, 0, false,
+		},
+		{"wrong list name", dbus.MakeVariant(
+			[]any{"IBusText", map[string]dbus.Variant{}, []dbus.Variant{}},
+		), 0, 0, false},
+		{"list too short", dbus.MakeVariant(
+			[]any{"IBusAttrList", map[string]dbus.Variant{}},
+		), 0, 0, false},
+		{"attrs not a slice", dbus.MakeVariant(
+			[]any{"IBusAttrList", map[string]dbus.Variant{}, "nope"},
+		), 0, 0, false},
+		{"not a struct", dbus.MakeVariant(uint32(7)), 0, 0, false},
+		{"nil", nil, 0, 0, false},
+		{"deeply nested variant", dbus.MakeVariant(dbus.MakeVariant(
+			attrList(ibusAttr(attrTypeBackground, 0xd1eaff, 0, 3)),
+		)), 0, 3, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := decodeAttrSel(tc.in)
+			if start != tc.start || end != tc.end || ok != tc.ok {
+				t.Errorf("decodeAttrSel = %d, %d, %v; want %d, %d, %v",
+					start, end, ok, tc.start, tc.end, tc.ok)
 			}
 		})
 	}

--- a/gui/event.go
+++ b/gui/event.go
@@ -306,6 +306,12 @@ type TouchPoint struct {
 // commit routinely delivers several runes in one event (CJK), and the
 // full string lives only in IMEText — read IMEText whenever the text
 // may come from an input method.
+//
+// IMEStart and IMELength delimit the selected clause within IMEText, in
+// characters. They are an absolute range, not a caret plus a length:
+// IMEStart is where the clause begins, which a backend must not assume
+// is the insertion point. IMELength == 0 means no clause is selected,
+// and IMEStart is then whatever the platform calls the cursor.
 type Event struct {
 	IMEText           string
 	FilePath          string

--- a/gui/ime.go
+++ b/gui/ime.go
@@ -47,8 +47,9 @@ func (w *Window) IMECompText() string {
 	return w.ime.compText
 }
 
-// IMECompCursor returns the cursor offset within the preedit
-// string (in characters).
+// IMECompCursor returns the start of the selected clause within the
+// preedit string (in characters), or the cursor offset when no clause
+// is selected. See Event.IMEStart.
 func (w *Window) IMECompCursor() int {
 	return w.ime.compCursor
 }

--- a/gui/ime_test.go
+++ b/gui/ime_test.go
@@ -69,6 +69,25 @@ func TestIMEUpdateClampsOffsets(t *testing.T) {
 	}
 }
 
+// A clause that starts partway into the preedit must survive the clamp
+// intact: the offsets are an absolute range, not a caret plus a length.
+// The values are ibus-mozc's second clause of 今日はいい天気ですね.
+func TestIMEUpdateKeepsOffsetClause(t *testing.T) {
+	w := newTestWindow()
+	w.imeUpdate(&Event{
+		Type:      EventIMEComposition,
+		IMEText:   "今日はいい天気ですね",
+		IMEStart:  3,
+		IMELength: 7,
+	})
+	if got := w.IMECompCursor(); got != 3 {
+		t.Errorf("cursor: got %d, want 3", got)
+	}
+	if got := w.IMECompSelLen(); got != 7 {
+		t.Errorf("sel len: got %d, want 7", got)
+	}
+}
+
 func TestIMEUpdateEmptyTextClears(t *testing.T) {
 	w := newTestWindow()
 	w.imeUpdate(&Event{


### PR DESCRIPTION
Closes #163.

`ibus.Event.SelLen` was never assigned, so `gui.Event.IMELength` was always 0
on X11 and the thick clause underline in `renderIMEPreeditUnderline` never
drew. A multi-clause conversion rendered as one uniform underline with no
indication of the active clause.

## Changes

- **`gui/backend/ibus/text.go`** — parses field 3 of `IBusText`, the
  `IBusAttrList`, previously ignored. A background attribute marks the focused
  clause; a lone double underline is the fallback for engines that use only
  that. `decodePreedit` now returns a `preedit` struct rather than a 6-tuple.
- **`gui/backend/ibus/ibus_linux.go`** — emits `Cursor`/`SelLen` from the
  attribute range, falling back to `cursor_pos` with `SelLen 0` when no clause
  is marked, which is what plain unconverted typing sends. **Also fixes a
  second bug:** `ShowPreeditText` replayed only the text, dropping `Cursor` and
  `SelLen` on every show.
- **`gui/backend/ibus/debug_linux.go`** — `GOGUI_IBUS_DEBUG` dumps raw preedit
  bodies. Which attribute marks the focused clause is engine convention, not
  specification, so watching an engine compose is the only way to know what it
  sends; this is how the test data was obtained.
- **`gui/event.go`, `gui/ime.go`** — document the offsets as an absolute range.

## No API change

#163 anticipated needing to widen `IMEStart`/`IMELength` into a real range,
which would have touched metal and android. Not required: `compCursor` is read
in exactly one place, as the clause start at `render_text.go:349`, and is never
drawn as a caret — the candidate rect uses `rects[0]`. The pair already was an
absolute range. metal and android are untouched.

## Verification

`ibus-mozc` installed and made active, composing 今日はいい天気ですね
(今日は / いい天気ですね) with arrow-key navigation between clauses. Captured
signals:

| focused clause | cursor_pos | attributes |
|---|---|---|
| 今日は | 0 | ul-DOUBLE + **background** + fg over [0,3); ul-SINGLE [3,10) |
| いい天気ですね | 3 | ul-SINGLE [0,3); ul-DOUBLE + **background** + fg over [3,10) |

Indices are rune offsets — 今日は is 3 runes but 9 bytes. Unconverted typing
carries only ul-SINGLE with no background, so `SelLen` stays 0 and existing
behavior is preserved. Tests use these captured shapes for both clauses rather
than invented ones.

Confirmed visually in `examples/multiline_input`: the thick underline tracks
the focused segment and moves with each arrow key.

`go build ./...`, `go test ./...` (5630 tests, 88 packages),
`golangci-lint run ./...` (0 issues), `gofmt` clean, and
`CGO_ENABLED=0 go build ./...` all pass.

## Follow-up

#169 filed separately: macOS reports these offsets in UTF-16 code units while
`gui/ime.go` counts runes. Pre-existing, unrelated to this change, and the
IBus path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788524523&installation_model_id=426559&pr_number=170&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F170&signature=a9cb0466bbade77fa5f38cd8c5f66cdd72fd675bac0320dac5436aebea41345a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->