### PR TITLE
changelog: add v0.49.0 (X11 IME, cgo-free audio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.49.0] - 2026-08-05
+
+### Added
+
+- **X11 IME support via IBus over D-Bus (#150).** Linux windows can now
+  compose text with an input method: IBus connects over D-Bus, receives
+  pre-edit clauses, and delivers committed text to the focused widget.
+  Pre-edit display is hooked into the standard composition path, the
+  selected clause is highlighted from `IBusAttrList` (#163), and the
+  connection closes race-free with a bounded queue that matches the
+  release keysym column (#167).
+
 ### Changed
 
 - **Linux audio is now cgo-free by default (#141).** `gui/audio` decoded
@@ -24,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backend for direct-ALSA or maximum hardware compatibility. The public
   `gui/audio` API is unchanged, and Windows/macOS still use oto. The
   CGo-free CI cross-compile widened from `./gui/backend/...` to `./...`.
+- **Dependencies: go-glyph bumped to v1.18.1.**
+- **Test: GL backend smoke test skips when cgo is linked (#168).** The
+  smoke test needs the cgo-free dispatch path; when the binary is built
+  with cgo the load fails, so the test now skips instead of failing.
+- **Docs: C toolchain requirement scoped to macOS only.**
 
 ## [v0.48.1] - 2026-08-04
 


### PR DESCRIPTION
Release prep for v0.49.0: X11 IME via IBus, cgo-free Linux audio, glyph v1.18.1 bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788528415&installation_model_id=426559&pr_number=172&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F172&signature=0f2ad393dec7aaec080c5c1f9c57b4782d8ff2f639cc72133d3a315a2ce25a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->