### PR TITLE
changelog: add v0.49.1 (go-glyph v1.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.49.1] - 2026-08-05
+
+### Changed
+
+- **Dependency: `go-glyph` v1.18.1 → v1.18.2.** Picks up the atlas fix where
+  glyph uploads now precede textured draws, eliminating the one-frame blank
+  lag on first glyph appearance.
+
 ## [v0.49.0] - 2026-08-05
 
 ### Added


### PR DESCRIPTION
Changelog entry for v0.49.1: dependency bump go-glyph v1.18.1 → v1.18.2 (atlas uploads precede textured draws).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788533829&installation_model_id=426559&pr_number=174&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F174&signature=25c1bfe378da56fa3c365fb518c4afec79a54e9c1c627cfe7e23941d404fefe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->