### PR TITLE
fix(gl): set window icon and WM_CLASS on X11 and Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Window icons on Linux and Windows.** The GL backend now publishes
+  `WindowCfg.IconPNG` (or the go-gui default) as `_NET_WM_ICON` on X11 and
+  as the big/small window icons via `WM_SETICON` on Windows, so the taskbar
+  and alt-tab show the app's icon instead of the window manager's default.
+  New `WindowCfg.WMClass` sets the X11 `WM_CLASS` property (both slots) for
+  window grouping and `.desktop`-file matching. The Windows tray icon path
+  moves into `gui/backend/internal/hicon`, shared with the GL backend.
+
 ## [v0.49.1] - 2026-08-05
 
 ### Changed

--- a/gui/backend/gl/icon_x11.go
+++ b/gui/backend/gl/icon_x11.go
@@ -1,0 +1,135 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image/png"
+	"log"
+	"math"
+	"unsafe"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+)
+
+// maxWindowIconDim caps the decoded _NET_WM_ICON size. App icons are
+// typically 512x512; anything larger is rejected rather than letting a
+// bogus PNG balloon memory.
+const maxWindowIconDim = 1024
+
+// maxNetWMIconPixels is the largest _NET_WM_ICON that fits one X11
+// request. The protocol's request-length field is 16 bits in 4-byte
+// units (65535 units ≈ 256 KiB), and xgb truncates a larger write,
+// desyncing the connection. An icon needs 2 CARDINALs of header plus
+// w*h pixels, so 255x255 is the largest square that fits.
+const maxNetWMIconPixels = 65535 - 6
+
+// setWindowIcon publishes cfg.IconPNG (or the go-gui default) as
+// _NET_WM_ICON, the property window managers read for the taskbar and
+// alt-tab icon. Without it the WM falls back to its default icon.
+func setWindowIcon(conn *xgb.Conn, win xproto.Window, cfg gui.WindowCfg) {
+	icon := cfg.IconPNG
+	if len(icon) == 0 {
+		icon = gui.DefaultIconPNG
+	}
+	w, h, argb, err := decodeIconARGB(icon, maxWindowIconDim)
+	if err != nil {
+		log.Printf("gl: window icon: %v", err)
+		return
+	}
+	// The WM downscales to its taskbar size anyway, so shrink
+	// oversized artwork to fit a single protocol request.
+	if 2+w*h > maxNetWMIconPixels {
+		scale := maxNetWMIconPixels - 2
+		// Keep aspect: scale both dims by sqrt(scale/(w*h)).
+		f := math.Sqrt(float64(scale) / float64(w*h))
+		tw := int(float64(w) * f)
+		th := int(float64(h) * f)
+		if tw < 1 {
+			tw = 1
+		}
+		if th < 1 {
+			th = 1
+		}
+		argb = scaleARGB(argb, w, h, tw, th)
+		w, h = tw, th
+	}
+	atom := internAtom(conn, "_NET_WM_ICON")
+	if atom == 0 {
+		return
+	}
+	// _NET_WM_ICON is [width, height, argb...] with one CARDINAL per
+	// pixel in the client's byte order. Client and server share a
+	// machine here (local X connection), so native endianness is the
+	// de-facto encoding every WM expects.
+	data := make([]uint32, 2, len(argb)+2)
+	data[0], data[1] = uint32(w), uint32(h)
+	data = append(data, argb...)
+	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
+		atom, xproto.AtomCardinal, 32,
+		uint32(len(data)),
+		unsafe.Slice((*byte)(unsafe.Pointer(&data[0])), len(data)*4))
+}
+
+// scaleARGB shrinks a w*h ARGB32 image to tw*th with nearest-neighbor
+// sampling.
+func scaleARGB(src []uint32, w, h, tw, th int) []uint32 {
+	dst := make([]uint32, tw*th)
+	for y := range th {
+		sy := y * h / th
+		for x := range tw {
+			dst[y*tw+x] = src[sy*w+x*w/tw]
+		}
+	}
+	return dst
+}
+
+// decodeIconARGB decodes a PNG into straight (non-premultiplied)
+// ARGB32 pixels, the format _NET_WM_ICON expects.
+func decodeIconARGB(pngData []byte, maxDim int) (w, h int, argb []uint32, err error) {
+	img, err := png.Decode(bytes.NewReader(pngData))
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	bounds := img.Bounds()
+	w, h = bounds.Dx(), bounds.Dy()
+	if w <= 0 || h <= 0 {
+		return 0, 0, nil, errors.New("empty icon")
+	}
+	if w > maxDim || h > maxDim {
+		return 0, 0, nil, fmt.Errorf(
+			"icon too large: %dx%d (max %d)", w, h, maxDim)
+	}
+	argb = make([]uint32, w*h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			r, g, b, a := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
+			argb[y*w+x] = uint32(a>>8)<<24 | uint32(r>>8)<<16 |
+				uint32(g>>8)<<8 | uint32(b>>8)
+		}
+	}
+	return w, h, argb, nil
+}
+
+// setWMClass sets the WM_CLASS property — two NUL-terminated strings,
+// instance and class, both from the same configured name. Window
+// managers use it to group windows and to match a .desktop file's
+// StartupWMClass.
+func setWMClass(conn *xgb.Conn, win xproto.Window, s string) {
+	if s == "" {
+		return
+	}
+	buf := append([]byte(s), 0)
+	buf = append(buf, s...)
+	buf = append(buf, 0)
+	atom := internAtom(conn, "WM_CLASS")
+	if atom == 0 {
+		return
+	}
+	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
+		atom, xproto.AtomString, 8, uint32(len(buf)), buf)
+}

--- a/gui/backend/gl/icon_x11_test.go
+++ b/gui/backend/gl/icon_x11_test.go
@@ -1,0 +1,80 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+func TestDecodeIconARGB(t *testing.T) {
+	// 3x1 PNG: opaque red, green, blue. Opaque pixels roundtrip
+	// losslessly (the encoder premultiplies translucent NRGBA
+	// sources, which would corrupt the byte-exact assertions) and
+	// exercise every byte of the AARRGGBB layout.
+	img := image.NewNRGBA(image.Rect(0, 0, 3, 1))
+	img.Set(0, 0, color.NRGBA{R: 0xFF, G: 0x00, B: 0x00, A: 0xFF})
+	img.Set(1, 0, color.NRGBA{R: 0x00, G: 0xFF, B: 0x00, A: 0xFF})
+	img.Set(2, 0, color.NRGBA{R: 0x00, G: 0x00, B: 0xFF, A: 0xFF})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png encode: %v", err)
+	}
+
+	w, h, argb, err := decodeIconARGB(buf.Bytes(), 1024)
+	if err != nil {
+		t.Fatalf("decodeIconARGB: %v", err)
+	}
+	if w != 3 || h != 1 {
+		t.Errorf("dims = %dx%d, want 3x1", w, h)
+	}
+	want := []uint32{
+		0xFFFF0000, // AARRGGBB: alpha sits in the high byte
+		0xFF00FF00,
+		0xFF0000FF,
+	}
+	for i, v := range want {
+		if argb[i] != v {
+			t.Errorf("pixel %d = %08x, want %08x", i, argb[i], v)
+		}
+	}
+}
+
+func TestDecodeIconARGBRejects(t *testing.T) {
+	if _, _, _, err := decodeIconARGB([]byte("not a png"), 1024); err == nil {
+		t.Error("bad PNG accepted")
+	}
+
+	img := image.NewNRGBA(image.Rect(0, 0, 32, 32))
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png encode: %v", err)
+	}
+	if _, _, _, err := decodeIconARGB(buf.Bytes(), 16); err == nil {
+		t.Error("oversized icon accepted")
+	}
+}
+
+func TestScaleARGB(t *testing.T) {
+	// 2x1 → 1x1 keeps the sampled pixel.
+	src := []uint32{0xFF0000FF, 0xFF00FF00}
+	dst := scaleARGB(src, 2, 1, 1, 1)
+	if len(dst) != 1 || dst[0] != 0xFF0000FF {
+		t.Errorf("scale 2x1→1x1 = %x, want ff0000ff", dst[0])
+	}
+	// 4x4 → 2x2 samples the four corners.
+	src = make([]uint32, 16)
+	for i := range src {
+		src[i] = uint32(i)
+	}
+	dst = scaleARGB(src, 4, 4, 2, 2)
+	want := []uint32{0, 2, 8, 10}
+	for i, v := range want {
+		if dst[i] != v {
+			t.Errorf("scaled pixel %d = %d, want %d", i, dst[i], v)
+		}
+	}
+}

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/hicon"
 	"golang.org/x/sys/windows"
 
 	"github.com/go-gui-org/go-gui/gui"
@@ -59,6 +60,7 @@ var (
 	pEmptyClipboard   = user32.NewProc("EmptyClipboard")
 	pGetClipboardData = user32.NewProc("GetClipboardData")
 	pSetClipboardData = user32.NewProc("SetClipboardData")
+	pSendMessageW     = user32.NewProc("SendMessageW")
 )
 
 const (
@@ -74,6 +76,10 @@ const (
 	swShow       = 5
 	pmRemove     = 0x0001
 	cwUseDefault = 0x80000000
+
+	wmSetIcon = 0x0080
+	iconBig   = 1 // ICON_BIG: alt-tab
+	iconSmall = 0 // ICON_SMALL: titlebar, taskbar
 
 	qsAllInput         = 0x04FF
 	mwmoInputAvailable = 0x0004
@@ -179,6 +185,7 @@ type platformState struct {
 	hwnd      uintptr
 	hdc       uintptr
 	hglrc     uintptr
+	hIcon     uintptr
 	cursors   [11]uintptr
 	curCursor uintptr
 	w         *gui.Window
@@ -247,6 +254,10 @@ func (p *platformState) destroy() {
 		pDestroyWindow.Call(p.hwnd)
 		p.hwnd = 0
 	}
+	if p.hIcon != 0 {
+		hicon.Destroy(p.hIcon)
+		p.hIcon = 0
+	}
 }
 
 // --- helpers ---
@@ -255,6 +266,28 @@ func clientSize(hwnd uintptr) (int32, int32) {
 	var r rectW
 	pGetClientRect.Call(hwnd, uintptr(unsafe.Pointer(&r)))
 	return r.right - r.left, r.bottom - r.top
+}
+
+// maxWindowIconDim caps the window icon size. 512x512 icons are
+// common (app artwork); anything beyond that is a mistake.
+const maxWindowIconDim = 1024
+
+// setWindowIcon installs cfg.IconPNG (or the go-gui default) as the
+// window's big and small icons via WM_SETICON. The HICON is owned by
+// p and released in destroy.
+func setWindowIcon(hwnd uintptr, cfg gui.WindowCfg, p *platformState) {
+	icon := cfg.IconPNG
+	if len(icon) == 0 {
+		icon = gui.DefaultIconPNG
+	}
+	h, err := hicon.FromPNG(icon, maxWindowIconDim)
+	if err != nil {
+		log.Printf("gl: window icon: %v", err)
+		return
+	}
+	pSendMessageW.Call(hwnd, wmSetIcon, iconBig, h)
+	pSendMessageW.Call(hwnd, wmSetIcon, iconSmall, h)
+	p.hIcon = h
 }
 
 func dpiForWindow(hwnd uintptr) uint32 {
@@ -412,6 +445,7 @@ func New(w *gui.Window) (*Backend, error) {
 	b := &Backend{}
 	b.plat.hwnd = hwnd
 	registerWindow(hwnd, b)
+	setWindowIcon(hwnd, cfg, &b.plat)
 
 	hdc, _, _ := pGetDC.Call(hwnd)
 	if hdc == 0 {

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -4,6 +4,7 @@ package gl
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"image/png"
 	"log"
@@ -642,9 +643,9 @@ func setWindowIcon(conn *xgb.Conn, win xproto.Window, cfg gui.WindowCfg) {
 // sampling.
 func scaleARGB(src []uint32, w, h, tw, th int) []uint32 {
 	dst := make([]uint32, tw*th)
-	for y := 0; y < th; y++ {
+	for y := range th {
 		sy := y * h / th
-		for x := 0; x < tw; x++ {
+		for x := range tw {
 			dst[y*tw+x] = src[sy*w+x*w/tw]
 		}
 	}
@@ -661,7 +662,7 @@ func decodeIconARGB(pngData []byte, maxDim int) (w, h int, argb []uint32, err er
 	bounds := img.Bounds()
 	w, h = bounds.Dx(), bounds.Dy()
 	if w <= 0 || h <= 0 {
-		return 0, 0, nil, fmt.Errorf("empty icon")
+		return 0, 0, nil, errors.New("empty icon")
 	}
 	if w > maxDim || h > maxDim {
 		return 0, 0, nil, fmt.Errorf(

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -3,12 +3,16 @@
 package gl
 
 import (
+	"bytes"
 	"fmt"
+	"image/png"
 	"log"
+	"math"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 	"github.com/jezek/xgb"
@@ -278,6 +282,10 @@ func New(w *gui.Window) (*Backend, error) {
 	b.plat.curCrtc = crtc
 
 	setWindowTitle(conn, win, title)
+	setWindowIcon(conn, win, cfg)
+	if cfg.WMClass != "" {
+		setWMClass(conn, win, cfg.WMClass)
+	}
 	b.plat.wmDelete = setupCloseProtocol(conn, win)
 	b.plat.wakeAtom = internAtom(conn, "_GOGUI_WAKE")
 	b.plat.atomClipboard = internAtom(conn, "CLIPBOARD")
@@ -569,6 +577,124 @@ func setWindowTitle(conn *xgb.Conn, win xproto.Window, title string) {
 	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
 		xproto.AtomWmName, xproto.AtomString, 8,
 		uint32(len(title)), []byte(title))
+}
+
+// maxWindowIconDim caps the decoded _NET_WM_ICON size. App icons are
+// typically 512x512; anything larger is rejected rather than letting a
+// bogus PNG balloon memory.
+const maxWindowIconDim = 1024
+
+// maxNetWMIconPixels is the largest _NET_WM_ICON that fits one X11
+// request. The protocol's request-length field is 16 bits in 4-byte
+// units (65535 units ≈ 256 KiB), and xgb truncates a larger write,
+// desyncing the connection. An icon needs 2 CARDINALs of header plus
+// w*h pixels, so 255x255 is the largest square that fits.
+const maxNetWMIconPixels = 65535 - 6
+
+// setWindowIcon publishes cfg.IconPNG (or the go-gui default) as
+// _NET_WM_ICON, the property window managers read for the taskbar and
+// alt-tab icon. Without it the WM falls back to its default icon.
+func setWindowIcon(conn *xgb.Conn, win xproto.Window, cfg gui.WindowCfg) {
+	icon := cfg.IconPNG
+	if len(icon) == 0 {
+		icon = gui.DefaultIconPNG
+	}
+	w, h, argb, err := decodeIconARGB(icon, maxWindowIconDim)
+	if err != nil {
+		log.Printf("gl: window icon: %v", err)
+		return
+	}
+	// The WM downscales to its taskbar size anyway, so shrink
+	// oversized artwork to fit a single protocol request.
+	if 2+w*h > maxNetWMIconPixels {
+		scale := maxNetWMIconPixels - 2
+		// Keep aspect: scale both dims by sqrt(scale/(w*h)).
+		f := math.Sqrt(float64(scale) / float64(w*h))
+		tw := int(float64(w) * f)
+		th := int(float64(h) * f)
+		if tw < 1 {
+			tw = 1
+		}
+		if th < 1 {
+			th = 1
+		}
+		argb = scaleARGB(argb, w, h, tw, th)
+		w, h = tw, th
+	}
+	atom := internAtom(conn, "_NET_WM_ICON")
+	if atom == 0 {
+		return
+	}
+	// _NET_WM_ICON is [width, height, argb...] with one CARDINAL per
+	// pixel in the client's byte order. Client and server share a
+	// machine here (local X connection), so native endianness is the
+	// de-facto encoding every WM expects.
+	data := make([]uint32, 2, len(argb)+2)
+	data[0], data[1] = uint32(w), uint32(h)
+	data = append(data, argb...)
+	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
+		atom, xproto.AtomCardinal, 32,
+		uint32(len(data)),
+		unsafe.Slice((*byte)(unsafe.Pointer(&data[0])), len(data)*4))
+}
+
+// scaleARGB shrinks a w*h ARGB32 image to tw*th with nearest-neighbor
+// sampling.
+func scaleARGB(src []uint32, w, h, tw, th int) []uint32 {
+	dst := make([]uint32, tw*th)
+	for y := 0; y < th; y++ {
+		sy := y * h / th
+		for x := 0; x < tw; x++ {
+			dst[y*tw+x] = src[sy*w+x*w/tw]
+		}
+	}
+	return dst
+}
+
+// decodeIconARGB decodes a PNG into straight (non-premultiplied)
+// ARGB32 pixels, the format _NET_WM_ICON expects.
+func decodeIconARGB(pngData []byte, maxDim int) (w, h int, argb []uint32, err error) {
+	img, err := png.Decode(bytes.NewReader(pngData))
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	bounds := img.Bounds()
+	w, h = bounds.Dx(), bounds.Dy()
+	if w <= 0 || h <= 0 {
+		return 0, 0, nil, fmt.Errorf("empty icon")
+	}
+	if w > maxDim || h > maxDim {
+		return 0, 0, nil, fmt.Errorf(
+			"icon too large: %dx%d (max %d)", w, h, maxDim)
+	}
+	argb = make([]uint32, w*h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			r, g, b, a := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
+			argb[y*w+x] = uint32(a>>8)<<24 | uint32(r>>8)<<16 |
+				uint32(g>>8)<<8 | uint32(b>>8)
+		}
+	}
+	return w, h, argb, nil
+}
+
+// setWMClass sets the WM_CLASS property — two NUL-terminated strings,
+// instance and class, both from the same configured name. Window
+// managers use it to group windows and to match a .desktop file's
+// StartupWMClass.
+func setWMClass(conn *xgb.Conn, win xproto.Window, s string) {
+	if s == "" {
+		return
+	}
+	buf := append([]byte(s), 0)
+	buf = append(buf, s...)
+	buf = append(buf, 0)
+	atom := internAtom(conn, "WM_CLASS")
+	if atom == 0 {
+		return
+	}
+	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
+		atom, xproto.AtomString, 8, uint32(len(buf)), buf)
 }
 
 // setupCloseProtocol registers WM_DELETE_WINDOW so the window manager's

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -3,17 +3,12 @@
 package gl
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
-	"image/png"
 	"log"
-	"math"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 	"github.com/jezek/xgb"
@@ -578,124 +573,6 @@ func setWindowTitle(conn *xgb.Conn, win xproto.Window, title string) {
 	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
 		xproto.AtomWmName, xproto.AtomString, 8,
 		uint32(len(title)), []byte(title))
-}
-
-// maxWindowIconDim caps the decoded _NET_WM_ICON size. App icons are
-// typically 512x512; anything larger is rejected rather than letting a
-// bogus PNG balloon memory.
-const maxWindowIconDim = 1024
-
-// maxNetWMIconPixels is the largest _NET_WM_ICON that fits one X11
-// request. The protocol's request-length field is 16 bits in 4-byte
-// units (65535 units ≈ 256 KiB), and xgb truncates a larger write,
-// desyncing the connection. An icon needs 2 CARDINALs of header plus
-// w*h pixels, so 255x255 is the largest square that fits.
-const maxNetWMIconPixels = 65535 - 6
-
-// setWindowIcon publishes cfg.IconPNG (or the go-gui default) as
-// _NET_WM_ICON, the property window managers read for the taskbar and
-// alt-tab icon. Without it the WM falls back to its default icon.
-func setWindowIcon(conn *xgb.Conn, win xproto.Window, cfg gui.WindowCfg) {
-	icon := cfg.IconPNG
-	if len(icon) == 0 {
-		icon = gui.DefaultIconPNG
-	}
-	w, h, argb, err := decodeIconARGB(icon, maxWindowIconDim)
-	if err != nil {
-		log.Printf("gl: window icon: %v", err)
-		return
-	}
-	// The WM downscales to its taskbar size anyway, so shrink
-	// oversized artwork to fit a single protocol request.
-	if 2+w*h > maxNetWMIconPixels {
-		scale := maxNetWMIconPixels - 2
-		// Keep aspect: scale both dims by sqrt(scale/(w*h)).
-		f := math.Sqrt(float64(scale) / float64(w*h))
-		tw := int(float64(w) * f)
-		th := int(float64(h) * f)
-		if tw < 1 {
-			tw = 1
-		}
-		if th < 1 {
-			th = 1
-		}
-		argb = scaleARGB(argb, w, h, tw, th)
-		w, h = tw, th
-	}
-	atom := internAtom(conn, "_NET_WM_ICON")
-	if atom == 0 {
-		return
-	}
-	// _NET_WM_ICON is [width, height, argb...] with one CARDINAL per
-	// pixel in the client's byte order. Client and server share a
-	// machine here (local X connection), so native endianness is the
-	// de-facto encoding every WM expects.
-	data := make([]uint32, 2, len(argb)+2)
-	data[0], data[1] = uint32(w), uint32(h)
-	data = append(data, argb...)
-	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
-		atom, xproto.AtomCardinal, 32,
-		uint32(len(data)),
-		unsafe.Slice((*byte)(unsafe.Pointer(&data[0])), len(data)*4))
-}
-
-// scaleARGB shrinks a w*h ARGB32 image to tw*th with nearest-neighbor
-// sampling.
-func scaleARGB(src []uint32, w, h, tw, th int) []uint32 {
-	dst := make([]uint32, tw*th)
-	for y := range th {
-		sy := y * h / th
-		for x := range tw {
-			dst[y*tw+x] = src[sy*w+x*w/tw]
-		}
-	}
-	return dst
-}
-
-// decodeIconARGB decodes a PNG into straight (non-premultiplied)
-// ARGB32 pixels, the format _NET_WM_ICON expects.
-func decodeIconARGB(pngData []byte, maxDim int) (w, h int, argb []uint32, err error) {
-	img, err := png.Decode(bytes.NewReader(pngData))
-	if err != nil {
-		return 0, 0, nil, err
-	}
-	bounds := img.Bounds()
-	w, h = bounds.Dx(), bounds.Dy()
-	if w <= 0 || h <= 0 {
-		return 0, 0, nil, errors.New("empty icon")
-	}
-	if w > maxDim || h > maxDim {
-		return 0, 0, nil, fmt.Errorf(
-			"icon too large: %dx%d (max %d)", w, h, maxDim)
-	}
-	argb = make([]uint32, w*h)
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			r, g, b, a := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
-			argb[y*w+x] = uint32(a>>8)<<24 | uint32(r>>8)<<16 |
-				uint32(g>>8)<<8 | uint32(b>>8)
-		}
-	}
-	return w, h, argb, nil
-}
-
-// setWMClass sets the WM_CLASS property — two NUL-terminated strings,
-// instance and class, both from the same configured name. Window
-// managers use it to group windows and to match a .desktop file's
-// StartupWMClass.
-func setWMClass(conn *xgb.Conn, win xproto.Window, s string) {
-	if s == "" {
-		return
-	}
-	buf := append([]byte(s), 0)
-	buf = append(buf, s...)
-	buf = append(buf, 0)
-	atom := internAtom(conn, "WM_CLASS")
-	if atom == 0 {
-		return
-	}
-	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
-		atom, xproto.AtomString, 8, uint32(len(buf)), buf)
 }
 
 // setupCloseProtocol registers WM_DELETE_WINDOW so the window manager's

--- a/gui/backend/internal/hicon/hicon.go
+++ b/gui/backend/internal/hicon/hicon.go
@@ -1,0 +1,158 @@
+//go:build windows
+
+// Package hicon converts PNG data to Win32 HICON handles, shared by
+// the SNI tray backend and the GL window backend.
+package hicon
+
+import (
+	"bytes"
+	"fmt"
+	"image/png"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	user32 = syscall.NewLazyDLL("user32.dll")
+	gdi32  = syscall.NewLazyDLL("gdi32.dll")
+
+	procDestroyIcon        = user32.NewProc("DestroyIcon")
+	procGetDC              = user32.NewProc("GetDC")
+	procReleaseDC          = user32.NewProc("ReleaseDC")
+	procCreateDIBSection   = gdi32.NewProc("CreateDIBSection")
+	procDeleteObject       = gdi32.NewProc("DeleteObject")
+	procCreateIconIndirect = user32.NewProc("CreateIconIndirect")
+)
+
+const (
+	biRGB        = 0
+	dibRGBColors = 0
+)
+
+type bitmapV5Header struct {
+	bV5Size          uint32
+	bV5Width         int32
+	bV5Height        int32
+	bV5Planes        uint16
+	bV5BitCount      uint16
+	bV5Compression   uint32
+	bV5SizeImage     uint32
+	bV5XPelsPerMeter int32
+	bV5YPelsPerMeter int32
+	bV5ClrUsed       uint32
+	bV5ClrImportant  uint32
+	bV5RedMask       uint32
+	bV5GreenMask     uint32
+	bV5BlueMask      uint32
+	bV5AlphaMask     uint32
+	bV5CSType        uint32
+	bV5Endpoints     [36]byte
+	bV5GammaRed      uint32
+	bV5GammaGreen    uint32
+	bV5GammaBlue     uint32
+	bV5Intent        uint32
+	bV5ProfileData   uint32
+	bV5ProfileSize   uint32
+	bV5Reserved      uint32
+}
+
+type iconInfo struct {
+	fIcon    int32
+	xHotspot uint32
+	yHotspot uint32
+	hbmMask  uintptr
+	hbmColor uintptr
+}
+
+// FromPNG decodes pngData and creates a HICON. maxDim rejects
+// oversized icons to prevent GDI memory blowup. The caller owns the
+// returned handle and must release it with Destroy.
+func FromPNG(pngData []byte, maxDim int) (uintptr, error) {
+	img, err := png.Decode(bytes.NewReader(pngData))
+	if err != nil {
+		return 0, fmt.Errorf("png decode: %w", err)
+	}
+	bounds := img.Bounds()
+	w := bounds.Dx()
+	h := bounds.Dy()
+	if w <= 0 || h <= 0 {
+		return 0, fmt.Errorf("empty icon")
+	}
+	if w > maxDim || h > maxDim {
+		return 0, fmt.Errorf("icon too large: %dx%d (max %d)",
+			w, h, maxDim)
+	}
+
+	// Build 32-bit BGRA pixel buffer (GDI expects BGR order).
+	stride := w * 4
+	pixels := make([]byte, stride*h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			r, g, b, a := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
+			off := y*stride + x*4
+			pixels[off+0] = byte(b >> 8)
+			pixels[off+1] = byte(g >> 8)
+			pixels[off+2] = byte(r >> 8)
+			pixels[off+3] = byte(a >> 8)
+		}
+	}
+
+	// Get screen DC for DIB creation.
+	hdc, _, _ := procGetDC.Call(0)
+	if hdc == 0 {
+		return 0, fmt.Errorf("GetDC failed")
+	}
+	defer procReleaseDC.Call(0, hdc)
+
+	// Create 32-bit DIB section.
+	bmi := bitmapV5Header{
+		bV5Size:        uint32(unsafe.Sizeof(bitmapV5Header{})),
+		bV5Width:       int32(w),
+		bV5Height:      int32(-h), // negative = top-down
+		bV5Planes:      1,
+		bV5BitCount:    32,
+		bV5Compression: biRGB,
+		bV5AlphaMask:   0xFF000000,
+		bV5RedMask:     0x00FF0000,
+		bV5GreenMask:   0x0000FF00,
+		bV5BlueMask:    0x000000FF,
+	}
+	var bits unsafe.Pointer
+	hbm, _, _ := procCreateDIBSection.Call(
+		hdc,
+		uintptr(unsafe.Pointer(&bmi)),
+		dibRGBColors,
+		uintptr(unsafe.Pointer(&bits)),
+		0, 0)
+	if hbm == 0 {
+		return 0, fmt.Errorf("CreateDIBSection failed")
+	}
+	defer procDeleteObject.Call(hbm)
+
+	// Copy pixels into the DIB section.
+	dst := unsafe.Slice((*byte)(bits), len(pixels))
+	copy(dst, pixels)
+
+	// Create icon from bitmap (nil mask = use alpha channel).
+	ii := iconInfo{
+		fIcon:    1, // TRUE
+		xHotspot: 0,
+		yHotspot: 0,
+		hbmColor: hbm,
+		hbmMask:  0, // NULL — alpha in color bitmap
+	}
+	hIcon, _, _ := procCreateIconIndirect.Call(
+		uintptr(unsafe.Pointer(&ii)))
+	if hIcon == 0 {
+		return 0, fmt.Errorf("CreateIconIndirect failed")
+	}
+
+	return hIcon, nil
+}
+
+// Destroy releases a handle returned by FromPNG. No-op on 0.
+func Destroy(h uintptr) {
+	if h != 0 {
+		procDestroyIcon.Call(h)
+	}
+}

--- a/gui/backend/sni/tray_windows.go
+++ b/gui/backend/sni/tray_windows.go
@@ -5,22 +5,20 @@
 package sni
 
 import (
-	"bytes"
 	"crypto/rand"
 	"fmt"
-	"image/png"
 	"sync"
 	"syscall"
 	"unsafe"
 
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/hicon"
 )
 
 // Win32 DLLs.
 var (
 	shell32 = syscall.NewLazyDLL("shell32.dll")
 	user32  = syscall.NewLazyDLL("user32.dll")
-	gdi32   = syscall.NewLazyDLL("gdi32.dll")
 
 	procShellNotifyIconW    = shell32.NewProc("Shell_NotifyIconW")
 	procCreateWindowExW     = user32.NewProc("CreateWindowExW")
@@ -36,12 +34,6 @@ var (
 	procAppendMenuW         = user32.NewProc("AppendMenuW")
 	procTrackPopupMenu      = user32.NewProc("TrackPopupMenu")
 	procDestroyMenu         = user32.NewProc("DestroyMenu")
-	procDestroyIcon         = user32.NewProc("DestroyIcon")
-	procGetDC               = user32.NewProc("GetDC")
-	procReleaseDC           = user32.NewProc("ReleaseDC")
-	procCreateDIBSection    = gdi32.NewProc("CreateDIBSection")
-	procDeleteObject        = gdi32.NewProc("DeleteObject")
-	procCreateIconIndirect  = user32.NewProc("CreateIconIndirect")
 	procGetCursorPos        = user32.NewProc("GetCursorPos")
 	procSetForegroundWindow = user32.NewProc("SetForegroundWindow")
 )
@@ -88,12 +80,6 @@ const (
 const (
 	tpmRightButton = 0x0002
 	tpmBottomAlign = 0x0020
-)
-
-// DIB constants.
-const (
-	biRGB        = 0
-	dibRGBColors = 0
 )
 
 // notifyIconDataW mirrors the Win32 NOTIFYICONDATAW structure.
@@ -144,42 +130,11 @@ type wndClassExW struct {
 	hIconSm       uintptr
 }
 
-type bitmapV5Header struct {
-	bV5Size          uint32
-	bV5Width         int32
-	bV5Height        int32
-	bV5Planes        uint16
-	bV5BitCount      uint16
-	bV5Compression   uint32
-	bV5SizeImage     uint32
-	bV5XPelsPerMeter int32
-	bV5YPelsPerMeter int32
-	bV5ClrUsed       uint32
-	bV5ClrImportant  uint32
-	bV5RedMask       uint32
-	bV5GreenMask     uint32
-	bV5BlueMask      uint32
-	bV5AlphaMask     uint32
-	bV5CSType        uint32
-	bV5Endpoints     [36]byte
-	bV5GammaRed      uint32
-	bV5GammaGreen    uint32
-	bV5GammaBlue     uint32
-	bV5Intent        uint32
-	bV5ProfileData   uint32
-	bV5ProfileSize   uint32
-	bV5Reserved      uint32
-}
-
-type iconInfo struct {
-	fIcon    int32
-	xHotspot uint32
-	yHotspot uint32
-	hbmMask  uintptr
-	hbmColor uintptr
-}
-
 // --- Tray implementation ---
+
+// maxTrayIconDim caps tray icon size: tray icons render small and
+// oversized PNGs waste GDI memory.
+const maxTrayIconDim = 256
 
 // Tray manages Windows system tray entries.
 type Tray struct {
@@ -405,7 +360,7 @@ func (t *Tray) Create(
 	var hIcon uintptr
 	if len(cfg.IconPNG) > 0 {
 		var iconErr error
-		hIcon, iconErr = pngToHICON(cfg.IconPNG)
+		hIcon, iconErr = hicon.FromPNG(cfg.IconPNG, maxTrayIconDim)
 		if iconErr != nil {
 			return 0, fmt.Errorf("sni: icon: %w", iconErr)
 		}
@@ -449,7 +404,7 @@ func (t *Tray) Create(
 		uintptr(unsafe.Pointer(&nid)))
 	if r == 0 {
 		if hIcon != 0 {
-			procDestroyIcon.Call(hIcon)
+			hicon.Destroy(hIcon)
 		}
 		if hMenu != 0 {
 			procDestroyMenu.Call(hMenu)
@@ -489,7 +444,7 @@ func (t *Tray) Update(id int, cfg gui.SystemTrayCfg) {
 
 	var hIcon uintptr
 	if len(cfg.IconPNG) > 0 {
-		if newIcon, err := pngToHICON(cfg.IconPNG); err == nil {
+		if newIcon, err := hicon.FromPNG(cfg.IconPNG, maxTrayIconDim); err == nil {
 			hIcon = newIcon
 		}
 	}
@@ -526,7 +481,7 @@ func (t *Tray) Update(id int, cfg gui.SystemTrayCfg) {
 
 	// Clean up old GDI resources.
 	if oldIcon != 0 {
-		procDestroyIcon.Call(oldIcon)
+		hicon.Destroy(oldIcon)
 	}
 	if oldMenu != 0 {
 		procDestroyMenu.Call(oldMenu)
@@ -554,7 +509,7 @@ func (t *Tray) Remove(id int) {
 		uintptr(unsafe.Pointer(&nid)))
 
 	if e.hIcon != 0 {
-		procDestroyIcon.Call(e.hIcon)
+		hicon.Destroy(e.hIcon)
 	}
 	if e.hMenu != 0 {
 		procDestroyMenu.Call(e.hMenu)
@@ -659,93 +614,4 @@ func appendMenuNodeItems(
 			n.childCount = len(item.Submenu)
 		}
 	}
-}
-
-// --- PNG → HICON conversion ---
-
-// maxIconDim rejects oversized icons to prevent GDI memory blowup.
-const maxIconDim = 256
-
-func pngToHICON(pngData []byte) (uintptr, error) {
-	img, err := png.Decode(bytes.NewReader(pngData))
-	if err != nil {
-		return 0, fmt.Errorf("png decode: %w", err)
-	}
-	bounds := img.Bounds()
-	w := bounds.Dx()
-	h := bounds.Dy()
-	if w <= 0 || h <= 0 {
-		return 0, fmt.Errorf("empty icon")
-	}
-	if w > maxIconDim || h > maxIconDim {
-		return 0, fmt.Errorf("icon too large: %dx%d (max %d)",
-			w, h, maxIconDim)
-	}
-
-	// Build 32-bit BGRA pixel buffer (GDI expects BGR order).
-	stride := w * 4
-	pixels := make([]byte, stride*h)
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			r, g, b, a := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
-			off := y*stride + x*4
-			pixels[off+0] = byte(b >> 8)
-			pixels[off+1] = byte(g >> 8)
-			pixels[off+2] = byte(r >> 8)
-			pixels[off+3] = byte(a >> 8)
-		}
-	}
-
-	// Get screen DC for DIB creation.
-	hdc, _, _ := procGetDC.Call(0)
-	if hdc == 0 {
-		return 0, fmt.Errorf("GetDC failed")
-	}
-	defer procReleaseDC.Call(0, hdc)
-
-	// Create 32-bit DIB section.
-	bmi := bitmapV5Header{
-		bV5Size:        uint32(unsafe.Sizeof(bitmapV5Header{})),
-		bV5Width:       int32(w),
-		bV5Height:      int32(-h), // negative = top-down
-		bV5Planes:      1,
-		bV5BitCount:    32,
-		bV5Compression: biRGB,
-		bV5AlphaMask:   0xFF000000,
-		bV5RedMask:     0x00FF0000,
-		bV5GreenMask:   0x0000FF00,
-		bV5BlueMask:    0x000000FF,
-	}
-
-	var bits unsafe.Pointer
-	hbm, _, _ := procCreateDIBSection.Call(
-		hdc,
-		uintptr(unsafe.Pointer(&bmi)),
-		dibRGBColors,
-		uintptr(unsafe.Pointer(&bits)),
-		0, 0)
-	if hbm == 0 {
-		return 0, fmt.Errorf("CreateDIBSection failed")
-	}
-	defer procDeleteObject.Call(hbm)
-
-	// Copy pixels into the DIB section.
-	dst := unsafe.Slice((*byte)(bits), len(pixels))
-	copy(dst, pixels)
-
-	// Create icon from bitmap (nil mask = use alpha channel).
-	ii := iconInfo{
-		fIcon:    1, // TRUE
-		xHotspot: 0,
-		yHotspot: 0,
-		hbmColor: hbm,
-		hbmMask:  0, // NULL — alpha in color bitmap
-	}
-	hIcon, _, _ := procCreateIconIndirect.Call(
-		uintptr(unsafe.Pointer(&ii)))
-	if hIcon == 0 {
-		return 0, fmt.Errorf("CreateIconIndirect failed")
-	}
-
-	return hIcon, nil
 }

--- a/gui/window_cfg.go
+++ b/gui/window_cfg.go
@@ -33,6 +33,11 @@ type WindowCfg struct {
 	// IconPNG is optional PNG-encoded icon data for the window.
 	// The backend sets this as the window icon when supported.
 	IconPNG []byte
+	// WMClass sets the X11 WM_CLASS property, used for both the
+	// instance and class slots. Window managers group windows and
+	// match .desktop files by it. Only the X11 backend reads it;
+	// empty omits the property.
+	WMClass string
 	Width   int
 	Height  int
 	// MaxImageBytes caps source image file size for decoded image


### PR DESCRIPTION
Closes the "taskbar shows default gear icon" symptom for CLI-launched
apps (falcon): `WindowCfg.IconPNG` was only honored by the darwin
backend.

## Changes

- **X11 (gl backend)**: publish `IconPNG` (fallback `gui.DefaultIconPNG`)
  as `_NET_WM_ICON`, and new `WindowCfg.WMClass` as `WM_CLASS` (both
  instance and class slots).
- **Windows (gl backend)**: convert `IconPNG` to a HICON and install it
  via `WM_SETICON` (big + small); the handle is released in `destroy()`.
- **Internal**: PNG→HICON conversion extracted from `gui/backend/sni` into
  `gui/backend/internal/hicon`, shared with the GL backend.
- **Tests**: headless unit tests for the ARGB packing and the
  protocol-limit downscale; live verification on X11 confirmed
  `WM_CLASS = "Falcon", "Falcon"` and a 255×255 `_NET_WM_ICON`.

## Notable landmine

The X11 protocol request-length field is 16 bits (~256 KiB max per
request). `jezek/xgb` silently truncates a larger `ChangeProperty`
length, corrupting the connection stream (manifested as spurious
`BadRequest` errors and missing subsequent properties). A 512×512 icon
exceeds the limit, so oversized artwork is downscaled to fit (255×255
max), which is invisible in practice since the WM downscales anyway.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788537773&installation_model_id=426559&pr_number=175&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F175&signature=dbe9b3359c1834572127a791bb14b2bdf494f5ec576a2b91d97eb1a6139dc8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->