### PR TITLE
fix(scroll): give Event.ScrollY a defined unit, honour Windows wheel setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`Event.ScrollX`/`ScrollY` now have a defined unit.** For a discrete mouse
+  wheel (`ScrollPrecise` false) they carry **lines of text**, and every
+  backend converts its native representation to the platform's lines-per-
+  notch — roughly three on all of them. Precise/trackpad deltas are unchanged
+  and still carry pre-scaled points of finger travel; consumers that care must
+  branch on `ScrollPrecise`. The field previously had no documented unit and
+  each backend picked its own: Metal pre-scaled a notch to 2.5 while Win32 and
+  X11 emitted a bare 1.0, so the same gesture scrolled 2.5x further on macOS
+  than on Windows or Linux. Embedders that scaled `ScrollY` by their own
+  constant (rather than by `Theme.ScrollMultiplier`) should re-check their
+  factor.
+
+### Fixed
+
+- **Mouse wheel ignored the Windows scroll-speed setting.** The Win32 backend
+  reported a bare notch count and never read `SPI_GETWHEELSCROLLLINES`
+  (Control Panel → Mouse → Wheel, three lines by default), so an embedder
+  scaling by its own per-unit constant scrolled a fraction of what the user
+  asked for. The setting is now honoured, including the "one screen at a time"
+  (`WHEEL_PAGESCROLL`) sentinel, and re-read per event so a change applies
+  without a restart. `WM_MOUSEHWHEEL` gained the matching
+  `SPI_GETWHEELSCROLLCHARS` handling.
+- **X11 wheel buttons carried no magnitude.** Buttons 4–7 now report three
+  lines per notch, matching GTK, Qt, and the Windows default.
+
 ## [v0.50.0] - 2026-08-05
 
 ### Added

--- a/gui/backend/gl/events_win32.go
+++ b/gui/backend/gl/events_win32.go
@@ -39,6 +39,19 @@ const (
 	sizeMinimized = 1
 	wheelDelta    = 120
 	keyRepeatBit  = 0x40000000 // lParam bit 30: previous key state
+
+	// Wheel-speed settings. Windows exposes lines-per-notch (vertical) and
+	// chars-per-notch (horizontal) as user preferences; the defaults match
+	// a fresh Windows install.
+	spiGetWheelScrollLines = 0x0068
+	spiGetWheelScrollChars = 0x006C
+	defaultScrollLines     = 3
+	defaultScrollChars     = 3
+
+	// wheelPageScroll is the SPI_GETWHEELSCROLLLINES sentinel for "scroll
+	// one screen per notch" (WHEEL_PAGESCROLL == UINT_MAX).
+	wheelPageScroll = 0xFFFFFFFF
+	linesPerPage    = 25
 )
 
 func loWordS(v uintptr) int32 { return int32(int16(v & 0xFFFF)) }
@@ -97,9 +110,9 @@ func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
 		return b.mouseButton(gui.EventMouseUp, gui.MouseMiddle, lparam, false)
 
 	case wmMouseWheel:
-		return b.mouseWheel(0, float32(hiWordS(wparam))/wheelDelta, lparam)
+		return b.mouseWheel(0, notchesToLines(hiWordS(wparam)), lparam)
 	case wmMouseHWheel:
-		return b.mouseWheel(float32(hiWordS(wparam))/wheelDelta, 0, lparam)
+		return b.mouseWheel(notchesToChars(hiWordS(wparam)), 0, lparam)
 
 	case wmKeyDown, wmSysKeyDown:
 		b.emit(gui.Event{
@@ -185,6 +198,51 @@ func (b *Backend) mouseButton(t gui.EventType, btn gui.MouseButton,
 		Modifiers:   winkey.ModState(),
 	})
 	return 0, true
+}
+
+// notchesToLines converts a WM_MOUSEWHEEL delta into gui.Event's scroll
+// unit: lines of text. Windows reports wheel travel in 1/120ths of a
+// notch and leaves the lines-per-notch multiplier to the app, which must
+// read it from SPI_GETWHEELSCROLLLINES (Control Panel → Mouse → Wheel;
+// three by default). Skipping that step is what made one notch scroll a
+// single line-equivalent instead of the three the user asked for.
+func notchesToLines(delta int32) float32 {
+	lines := wheelScrollLines()
+	if lines == wheelPageScroll {
+		// The user selected "one screen at a time". No viewport height is
+		// available here, so approximate a page — consumers clamp to their
+		// own bounds anyway.
+		lines = linesPerPage
+	}
+	return float32(delta) / wheelDelta * float32(lines)
+}
+
+// notchesToChars is the horizontal counterpart, using the separate
+// SPI_GETWHEELSCROLLCHARS setting. It has no page-scroll sentinel.
+func notchesToChars(delta int32) float32 {
+	return float32(delta) / wheelDelta * float32(wheelScrollChars())
+}
+
+// wheelScrollLines reads SPI_GETWHEELSCROLLLINES, falling back to the
+// Windows default when the call fails.
+func wheelScrollLines() uint32 { return sysParamUint(spiGetWheelScrollLines, defaultScrollLines) }
+
+// wheelScrollChars reads SPI_GETWHEELSCROLLCHARS, falling back to the
+// Windows default when the call fails.
+func wheelScrollChars() uint32 { return sysParamUint(spiGetWheelScrollChars, defaultScrollChars) }
+
+// sysParamUint fetches a uint-valued SystemParametersInfo action. The
+// settings are re-read per event rather than cached: they change while
+// the app runs (Control Panel, or a WM_SETTINGCHANGE broadcast), and a
+// wheel message is far too rare for the syscall to matter.
+func sysParamUint(action uintptr, fallback uint32) uint32 {
+	var v uint32
+	r, _, _ := pSysParamsInfoW.Call(
+		action, 0, uintptr(unsafe.Pointer(&v)), 0)
+	if r == 0 || v == 0 {
+		return fallback
+	}
+	return v
 }
 
 func (b *Backend) mouseWheel(sx, sy float32, lparam uintptr) (uintptr, bool) {

--- a/gui/backend/gl/events_win32_test.go
+++ b/gui/backend/gl/events_win32_test.go
@@ -104,3 +104,41 @@ func TestLoHiWordSSignedExtraction(t *testing.T) {
 		t.Errorf("hiWordS = %d, want 800", got)
 	}
 }
+
+// TestNotchesToLines_HonoursSystemSetting pins the wheel-speed fix: a
+// WM_MOUSEWHEEL delta must be converted to gui.Event's line unit using
+// SPI_GETWHEELSCROLLLINES, not emitted as a bare notch count. Reporting
+// 1.0 per notch is what made the terminal grid crawl a quarter of a row
+// per notch on Windows while macOS moved 2.5x further for the same
+// gesture.
+func TestNotchesToLines_HonoursSystemSetting(t *testing.T) {
+	lines := wheelScrollLines()
+	if lines == wheelPageScroll {
+		t.Skip("system set to page-scroll; per-line math not exercised")
+	}
+	if lines == 0 {
+		t.Fatal("wheelScrollLines returned 0; fallback did not apply")
+	}
+	// One notch up.
+	if got, want := notchesToLines(wheelDelta), float32(lines); got != want {
+		t.Errorf("one notch = %v lines, want %v", got, want)
+	}
+	// Direction is preserved.
+	if got, want := notchesToLines(-wheelDelta), -float32(lines); got != want {
+		t.Errorf("one notch down = %v lines, want %v", got, want)
+	}
+	// A partial (high-resolution) notch scales proportionally rather than
+	// rounding away, so precision wheels stay smooth.
+	if got, want := notchesToLines(wheelDelta/2), float32(lines)/2; got != want {
+		t.Errorf("half notch = %v lines, want %v", got, want)
+	}
+}
+
+// TestSysParamUint_FallsBackOnBogusAction verifies the fallback path: an
+// unknown SystemParametersInfo action must yield the documented default
+// rather than zero, which would make the wheel completely dead.
+func TestSysParamUint_FallsBackOnBogusAction(t *testing.T) {
+	if got := sysParamUint(0xFFFF, defaultScrollLines); got != defaultScrollLines {
+		t.Errorf("fallback = %d, want %d", got, defaultScrollLines)
+	}
+}

--- a/gui/backend/gl/events_x11.go
+++ b/gui/backend/gl/events_x11.go
@@ -93,13 +93,13 @@ func (b *Backend) handleXEvent(ev xgb.Event) {
 	case xproto.ButtonPressEvent:
 		switch e.Detail {
 		case 4:
-			b.emitScroll(0, 1, e.EventX, e.EventY, e.State)
+			b.emitScroll(0, x11ScrollLines, e.EventX, e.EventY, e.State)
 		case 5:
-			b.emitScroll(0, -1, e.EventX, e.EventY, e.State)
+			b.emitScroll(0, -x11ScrollLines, e.EventX, e.EventY, e.State)
 		case 6:
-			b.emitScroll(1, 0, e.EventX, e.EventY, e.State)
+			b.emitScroll(x11ScrollLines, 0, e.EventX, e.EventY, e.State)
 		case 7:
-			b.emitScroll(-1, 0, e.EventX, e.EventY, e.State)
+			b.emitScroll(-x11ScrollLines, 0, e.EventX, e.EventY, e.State)
 		default:
 			x, y := b.logicalXY(int32(e.EventX), int32(e.EventY))
 			b.emit(gui.Event{
@@ -212,6 +212,14 @@ func focusRealChange(mode, detail byte) bool {
 	}
 	return true
 }
+
+// x11ScrollLines is the lines-per-notch reported for core X11 wheel
+// buttons 4–7. Unlike Windows (SPI_GETWHEELSCROLLLINES) and macOS
+// (AppKit acceleration), core X11 button events carry no magnitude and
+// the toolkit is expected to supply one — three lines is both the
+// Windows default and what GTK and Qt use, so it is what gui.Event's
+// line unit means here.
+const x11ScrollLines float32 = 3
 
 func (b *Backend) emitScroll(sx, sy float32, px, py int16, state uint16) {
 	x, y := b.logicalXY(int32(px), int32(py))

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -61,6 +61,7 @@ var (
 	pGetClipboardData = user32.NewProc("GetClipboardData")
 	pSetClipboardData = user32.NewProc("SetClipboardData")
 	pSendMessageW     = user32.NewProc("SendMessageW")
+	pSysParamsInfoW   = user32.NewProc("SystemParametersInfoW")
 )
 
 const (

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -21,11 +21,16 @@
 static const float kPreciseScrollScale = 0.075f;
 
 // Scale applied to AppKit line-based (discrete mouse wheel) scrolling
-// deltas. A notch reports ~1 line; combined with gui's ScrollMultiplier
-// (20) this lands one notch at ~50px, which the gui side then eases
-// into place (exponential smoothing). Was 10.0 (net ~200px/notch),
-// which felt far too fast and abrupt.
-static const float kWheelScrollScale = 2.5f;
+// deltas, converting them to gui.Event's line unit. AppKit reports ~1
+// line per notch (more once acceleration kicks in); the platform
+// convention every other backend also reports is three lines per notch,
+// so that is the factor. Combined with gui's ScrollMultiplier (20) this
+// lands one notch at ~60px, which the gui side then eases into place
+// (exponential smoothing). Was 2.5 (~50px/notch) back when the unit was
+// undefined and each backend picked its own — Win32 and X11 reported a
+// bare 1.0, so macOS scrolled 2.5x faster than either for the same
+// gesture. Was 10.0 before that (~200px/notch), which felt far too fast.
+static const float kWheelScrollScale = 3.0f;
 
 // Event mask covering all event types the app needs to receive.
 // MouseEntered/Exited are required by AppKit's internal tracking-

--- a/gui/backend/web/events.go
+++ b/gui/backend/web/events.go
@@ -9,15 +9,19 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
-// Wheel delta normalization constants. Converts browser delta
-// values to approximate scroll "notches":
-//   - DOM_DELTA_PIXEL: ~53px per trackpad notch
-//   - DOM_DELTA_LINE: ~3 lines per discrete wheel notch
-//   - DOM_DELTA_PAGE: each page maps to ~10 notches
+// Wheel delta normalization constants. Converts browser delta values to
+// gui.Event's scroll unit, lines of text (see Event.ScrollY):
+//   - DOM_DELTA_PIXEL: ~17.7px per line, so a 53px trackpad notch stays
+//     the three lines every other backend reports
+//   - DOM_DELTA_LINE: already lines; passed through
+//   - DOM_DELTA_PAGE: a page is ~30 lines
+//
+// The ratios are unchanged from when this produced "notches" — only the
+// unit is scaled, so web scrolling feels exactly as it did.
 const (
-	wheelPixelDivisor   = 53
-	wheelLineDivisor    = 3
-	wheelPageMultiplier = 10
+	wheelPixelDivisor   = 17.7
+	wheelLineDivisor    = 1
+	wheelPageMultiplier = 30
 )
 
 // registerEvents attaches DOM event listeners to the canvas and

--- a/gui/event.go
+++ b/gui/event.go
@@ -328,27 +328,36 @@ type Event struct {
 	MouseY            float32
 	MouseDX           float32
 	MouseDY           float32
-	ScrollX           float32
-	ScrollY           float32
-	Modifiers         Modifier
-	CharCode          uint32
-	IMEStart          int32
-	IMELength         int32
-	GestureDX         float32 // pan/swipe delta from previous
-	GestureDY         float32
-	VelocityX         float32 // px/s at gesture end
-	VelocityY         float32
-	PinchScale        float32 // cumulative scale (1.0 = unchanged)
-	GestureRotation   float32 // cumulative radians
-	CentroidX         float32 // center of active touches
-	CentroidY         float32
-	KeyCode           KeyCode
-	MouseButton       MouseButton
-	Type              EventType
-	GestureType       GestureType
-	GesturePhase      GesturePhase
-	KeyRepeat         bool
-	IsHandled         bool
+	// ScrollX and ScrollY carry scroll distance in one of two units,
+	// selected by ScrollPrecise. For a discrete mouse wheel
+	// (ScrollPrecise false) the unit is LINES OF TEXT: every backend
+	// converts its native notch representation to the platform's
+	// lines-per-notch, so one notch reports ~3 on all of them. For a
+	// precise/trackpad delta (ScrollPrecise true) the unit is points of
+	// finger travel, pre-scaled by the backend. Consumers that care about
+	// the distinction — a terminal grid scrolling whole rows, say — must
+	// branch on ScrollPrecise rather than assuming one unit.
+	ScrollX         float32
+	ScrollY         float32
+	Modifiers       Modifier
+	CharCode        uint32
+	IMEStart        int32
+	IMELength       int32
+	GestureDX       float32 // pan/swipe delta from previous
+	GestureDY       float32
+	VelocityX       float32 // px/s at gesture end
+	VelocityY       float32
+	PinchScale      float32 // cumulative scale (1.0 = unchanged)
+	GestureRotation float32 // cumulative radians
+	CentroidX       float32 // center of active touches
+	CentroidY       float32
+	KeyCode         KeyCode
+	MouseButton     MouseButton
+	Type            EventType
+	GestureType     GestureType
+	GesturePhase    GesturePhase
+	KeyRepeat       bool
+	IsHandled       bool
 	// ScrollPrecise is true for high-res / trackpad scroll deltas
 	// (already carrying OS momentum). False for discrete mouse-wheel
 	// notches, which the gui side eases via scrollSmoothAnimation.


### PR DESCRIPTION
## Problem

`Event.ScrollX`/`ScrollY` had no documented unit, so every backend invented its own:

| Backend | ScrollY per discrete notch |
|---|---|
| Metal | `scrollingDeltaY x 2.5` |
| Win32 | `hiWord/120` = **1.0** |
| X11 | **1.0** |

The same physical gesture scrolled 2.5x further on macOS than on Windows or Linux. Any consumer scaling by its own per-unit constant — rather than by `Theme.ScrollMultiplier` — could be correct on at most one platform. go-term hit exactly this: its wheel factor was tuned against Metal's 2.5, so on Windows a notch moved 5px against an ~18px cell, about a quarter of a row.

Separately, the Win32 backend never read `SPI_GETWHEELSCROLLLINES` — the user's Control Panel → Mouse → Wheel setting — so that preference was silently discarded.

## Change

Non-precise (discrete wheel) deltas now carry **lines of text**, documented on the field. Each backend converts from its native representation:

- **Win32** — reads `SPI_GETWHEELSCROLLLINES` (default 3), including the `WHEEL_PAGESCROLL` "one screen at a time" sentinel. Re-read per event, so a Control Panel change applies without a restart; a wheel message is far too rare for the syscall to matter. `WM_MOUSEHWHEEL` gets the matching `SPI_GETWHEELSCROLLCHARS`.
- **X11** — buttons 4-7 report three lines. Core X11 button events carry no magnitude, and the toolkit is expected to supply one; three is what GTK and Qt use.
- **Metal** — `kWheelScrollScale` 2.5 -> 3.0, agreeing with the others while landing gui's own scroll containers at ~60px/notch (was ~50), so the tuning intent from #22 survives.
- **Web** — divisors rescaled by exactly 3x, so its feel is unchanged under the new unit.

Precise/trackpad deltas are untouched and still carry pre-scaled points of finger travel. Consumers that care must branch on `ScrollPrecise`.

## Compatibility

Embedders that scaled `ScrollY` by their own constant should re-check their factor. Anything using `Theme.ScrollMultiplier` is unaffected in relative terms; on Windows and Linux it simply scrolls the three lines the platform was always asking for, and on macOS the change is 50px -> 60px per notch.

## Testing

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` clean on Windows (pre-existing `errcheck`/`ineffassign` findings in `_win32` files are untouched and not linted by the Linux CI runner).
- New `TestNotchesToLines_HonoursSystemSetting` pins the notch->line conversion, direction, and proportional partial-notch scaling; `TestSysParamUint_FallsBackOnBogusAction` pins the fallback, since a zero would make the wheel completely dead.
- Verified by hand on Windows 10 via go-term: wheel scrolling now travels the expected distance.
- Metal and web changes are unbuildable on the machine used here; both are constant rescales that preserve existing ratios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/go-gui-org/codesmith/go-gui/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788566965&installation_model_id=426559&pr_number=179&repository=go-gui-org%2Fgo-gui&return_to=https%3A%2F%2Fgithub.com%2Fgo-gui-org%2Fgo-gui%2Fpull%2F179&signature=14d5870c969c97a498dfe425972fc7247734142d10d1eb0aab3540174f8c4234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->