### PR TITLE
changelog: add v0.52.1 (eventctx method-value fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.52.1] - 2026-08-07
+
+### Fixed
+
+- **`tools/eventctx` converts callbacks declared as methods.** The rewriter
+  skipped every `func` with a receiver, so a repo that wires its callbacks as
+  method values (`fv.internalClick`) got a converted call site and an
+  unconverted declaration — go-charts hit 109 unresolvable build errors. The
+  scanner now classifies methods alongside plain functions, the value-use scan
+  ignores the method name in a call's selector, and the call folder accepts a
+  selector callee. Tools-only: no shipped library code changed, so v0.52.0 and
+  v0.52.1 are identical for anyone who is not running the migration.
+
 ## [v0.52.0] - 2026-08-07
 
 ### Changed


### PR DESCRIPTION
Cuts v0.52.1 for #186.

Tools-only release: `tools/eventctx` now converts callbacks declared as
methods. No shipped library code differs from v0.52.0 — the tag exists so
`go run github.com/go-gui-org/go-gui/tools/eventctx@v0.52.1` pulls a
rewriter that handles method values, which v0.52.0's does not (go-charts
hit 109 unresolvable build errors on it).

Tag will be pushed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)