### PR TITLE
feat(debug): add the gui.Debug diagnostics gate; delete RequireFocusID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`gui.Debug(bool)` dev-mode diagnostics gate** (developer-ergonomics §4.1,
+  phase 1). Generalizes the focus-only `GOGUI_FOCUS_DEBUG` check into one gate
+  that audits each composed frame for identity defects the library otherwise
+  reports in no way at all: two shapes sharing an `ID`, a focusable shape with
+  no `ID` (renders and clicks, never joins the tab order), and a scrollable
+  shape with no `ID` (shares one scroll offset with every other ID-less
+  scrollable in the window). Findings go to stderr **once per finding per
+  window** — these run per frame, so an undeduplicated warning would emit at the
+  frame rate and be a reason to turn the gate back off. Cycling the gate off and
+  on clears that memory, so a re-enabled gate reports current state. Set at
+  startup by `GOGUI_DEBUG=1`; `GOGUI_FOCUS_DEBUG=1` still works. The flag is an
+  `atomic.Bool` because `Debug` makes it mutable at runtime and the checks read
+  it from the frame goroutine. Measured cost when off: no change in
+  `BenchmarkViewFrame` allocs (202 / 802 allocs/op unchanged) or ns/op.
+
+### Changed
+
+- **`State[T]` names both types when it panics.** A window holding the wrong
+  state type still panics — that is a programmer error discoverable on the first
+  frame, not a runtime condition worth threading through every view function —
+  but the message now reports the type held alongside the type requested instead
+  of Go's bare interface-conversion text.
+
+### Removed
+
+- **`RequireFocusID`** (developer-ergonomics §4.2). Dead exported guard: zero
+  call sites in go-gui, tests included, and zero across all five sibling repos,
+  despite fourteen files exposing a `Focusable bool` field. Retaining it implied
+  a check that never ran, which reads like coverage. Its static case belongs to
+  the `requiredid` analyzer, which reports at build time with the `Cfg` type
+  named; its dynamic case belongs to `RequireID` and the new debug gate. No
+  consumer action required.
+
 ## [v0.52.1] - 2026-08-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -158,6 +158,45 @@ platform-specific instructions.
 
 ---
 
+## Debugging
+
+A few widget mistakes are silent by construction, because they produce no error
+and no visual difference:
+
+- Two widgets sharing an `ID`. `ID` is the identity key for focus, scroll
+  offsets, and per-widget state, so the two collapse onto one identity.
+- A focusable widget with no `ID`. It renders and it clicks, but focus traversal
+  is keyed by `ID`, so it never joins the tab order.
+- A scrollable widget with no `ID`. Every ID-less scrollable in a window shares
+  the key `""`, so they scroll in lockstep.
+
+`gui.Debug(true)` — or `GOGUI_DEBUG=1` in the environment — audits every frame
+for these and writes findings to stderr, once per finding per window:
+
+```go
+gui.Debug(true)
+// gui: focusable shape at 0/2/1 has no ID; focus traversal is keyed by
+// ID, so it renders and clicks but never joins the tab order
+```
+
+Leave it off in production: the checks walk the whole layout tree each frame and
+allocate while doing it.
+
+For the mistakes that are visible in the source, `requiredid` reports them at
+build time instead, naming the `Cfg` type:
+
+```fish
+go run github.com/go-gui-org/go-gui/tools/requiredid/cmd/requiredid ./...
+```
+
+`go vet -vettool=` and a golangci-lint custom plugin work equally well. The tool
+is offered, not required — it is an internal tool whose rules may tighten
+between releases, so nothing breaks if you never run it. Without it, a widget
+that needs an `ID` and has none panics on its first render rather than failing
+your build.
+
+---
+
 ## Contributing
 
 1. Install **Go 1.26+** (a C toolchain too if developing on macOS, see

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -3,10 +3,9 @@
 Status: accepted after three independent reviews; ready to implement.
 One breaking phase (§4.3, §4.4, §4.7) targeting v0.53.0; 18
 sibling call sites affected (§7). §4.2 is entirely non-breaking and
-lands in phase 1. Phases 1–3 ship as v0.52.x. §9 Q1–Q7
-resolved; Q6 is a phase-2 gate on phase 4, and Q8 — whether `requiredid`
-becomes supported surface — is open and due before phase 1.
-Base: `main` @ `80715d1`
+lands in phase 1. Phases 1–3 ship as v0.52.x. §9 Q1–Q8 all
+resolved; Q6 remains a phase-2 gate on phase 4.
+Base: `main` @ `80715d1`. Phase progress: §6.1.
 
 ## Context
 
@@ -827,6 +826,26 @@ choice.
 Phase 4 must be a single release. Three breaking event refactors in
 consecutive versions is worse for consumers than one larger one.
 
+### 6.1 Progress
+
+Phase 1 ships as a series of PRs rather than one, so the 111 mechanical
+`ID` insertions land isolated from the hand-written changes instead of
+burying them in the same diff.
+
+| Phase | Item                                     | Status |
+| ----- | ---------------------------------------- | ------ |
+| 1     | §4.1 `gui.Debug` gate                    | done   |
+| 1     | §4.2 delete `RequireFocusID`             | done   |
+| 1     | §5.3 `State[T]` panic message            | done   |
+| 1     | §8 `ergoaudit -fix` codemod              | todo   |
+| 1     | §4.2 fix 12 first-party a11y defects     | todo   |
+| 1     | §4.9 fix `view_select.go` scroll defect  | todo   |
+| 1     | §4.2 tag 9 `Cfg`s + wire `RequireID`     | todo   |
+| 1     | §4.9 tag `Container`/`Input`, wire scroll| todo   |
+| 1     | §4.9 `checkScrollableID` analyzer rule   | todo   |
+| 1     | §8 README: running `requiredid` (Q8)     | todo   |
+| 2–5   | —                                        | todo   |
+
 ## 7. Sibling impact
 
 All five siblings pin `go-gui v0.52.0`; `main` is v0.52.1, so these
@@ -964,7 +983,7 @@ numbers track the code — and the per-file scan that once misreported
 Two independent reviews agreed with every recommendation below, so Q1–Q7
 are decisions rather than questions. Q6 remains a **phase gate**: agreed
 in approach, but it must be discharged by work in phase 2 before phase 4
-can proceed. Q8 is the one item genuinely unresolved.
+can proceed. Q8 was resolved on 2026-08-07, before phase 1 shipped.
 
 | #   | Topic                    | Decision                             |
 | --- | ------------------------ | ------------------------------------ |
@@ -975,7 +994,7 @@ can proceed. Q8 is the one item genuinely unresolved.
 | 5   | `ColorSet` zero value    | `Opt[Color]`                         |
 | 6   | Nested `OnMouseScroll`   | **gate** — test first, in phase 2    |
 | 7   | Breaking release target  | v0.53.0                              |
-| 8   | `requiredid` for authors | **open** — documented vs. supported  |
+| 8   | `requiredid` for authors | **documented only** (2026-08-07)     |
 
 Detail where the decision carries a constraint:
 
@@ -1010,11 +1029,18 @@ Detail where the decision carries a constraint:
    scroll propagation should not both be in motion at once.
 7. **v0.53.0** for the breaking phase; phases 1–3 as `v0.52.x`. All 29
    sibling edits land in one release; see §6.
-8. **`requiredid` for app authors — open.** Phase 1 makes
-   `gui:"required"` load-bearing, but it is enforcement only where the
-   analyzer runs, and today that is this repo alone (§4.2). Documenting
-   the one-line invocation (§8) is agreed and cheap. What is not
-   decided is whether the analyzer becomes **supported** surface:
+8. **`requiredid` for app authors — resolved 2026-08-07: documented
+   only.** It stays a `tools/` binary that authors may invoke. The
+   README carries the one-line invocation and the `go vet -vettool=`
+   and golangci-lint alternatives, plus one sentence on what an author
+   gets without it: a `RequireID` panic on first render rather than a
+   build failure. The analyzer's rules stay free to tighten, because
+   nothing promises they will not. The consequence accepted with this
+   choice is that most consumers sit on the `RequireID`-panic path by
+   default, and §4.2's static-enforcement claim remains true for this
+   repo alone.
+
+   The alternatives, recorded because the trade is not obvious:
 
    - **Documented only.** It stays a `tools/` binary that authors may
      invoke. Its rules can tighten freely, because nothing promises
@@ -1027,10 +1053,12 @@ Detail where the decision carries a constraint:
      then breaks somebody's build on a patch bump, which is exactly
      the failure mode `deps-doc` and the alloc gates exist to avoid.
 
-   Not resolved here because it is a support-commitment question, not a
-   technical one, and it does not block any phase: the documentation
-   deliverable is the same either way. Decide before phase 1 ships,
-   since that is the release the tag starts mattering in.
+   Chosen "documented only" because the support commitment buys
+   little that the `RequireID` panic does not already buy loudly, and
+   costs the freedom to tighten a rule without reding somebody's build
+   on a patch bump — the failure mode `deps-doc` and the alloc gates
+   exist to avoid. Revisit if a sibling adopts the analyzer and asks
+   for a stability promise.
 
 ## 10. Counting rules
 

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -1,0 +1,221 @@
+package gui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Dev-mode diagnostics.
+//
+// A family of defects in this library are silent by construction: a
+// focusable widget without an ID renders and clicks but never joins
+// the tab order, a scrollable widget without an ID shares the key ""
+// with every other ID-less scrollable in the window, and a duplicate
+// ID collapses two widgets onto one identity. None of these produce
+// an error, a panic, or a visual difference.
+//
+// The debug gate turns them into messages on stderr. It is off by
+// default and costs one atomic load per frame when off.
+
+// debugEnabled gates every check in this file. It is an atomic.Bool
+// rather than a plain bool because [Debug] makes it mutable at
+// runtime, and the checks read it from the frame goroutine while an
+// application may flip it from another. atomic.Bool.Load compiles to
+// a plain load on amd64 and arm64, so the mutability is the reason,
+// not the lookup cost.
+var debugEnabled atomic.Bool
+
+// debugGen increments on every false -> true transition of the gate.
+// Per-window warn-once state carries the generation it was built
+// under and is discarded when the generation moves, so re-enabling
+// the gate after fixing something reports the current state rather
+// than staying silent.
+var debugGen atomic.Uint64
+
+// debugOut is where findings are written. A variable so tests can
+// capture it; never reassigned at runtime.
+var debugOut io.Writer = os.Stderr
+
+func init() {
+	// GOGUI_DEBUG is the general gate. GOGUI_FOCUS_DEBUG is the
+	// original focus-only spelling, still honoured so existing
+	// workflows keep working.
+	if envTruthy("GOGUI_DEBUG") || envTruthy("GOGUI_FOCUS_DEBUG") {
+		debugEnabled.Store(true)
+		debugGen.Store(1)
+	}
+}
+
+// envTruthy reports whether an environment variable is set to
+// something a developer would read as "on".
+func envTruthy(name string) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(strings.TrimSpace(v))
+	return err == nil && b
+}
+
+// Debug turns dev-mode diagnostics on or off. When on, each frame is
+// checked for widgets whose identity is broken in a way that produces
+// no error otherwise:
+//
+//   - two shapes sharing one ID
+//   - a focusable shape with no ID (never keyboard-reachable)
+//   - a scrollable shape with no ID (scroll offset shared with every
+//     other ID-less scrollable in the window)
+//
+// Findings go to stderr, once per finding per window. Turning the
+// gate off and on again clears that memory, so a re-enabled gate
+// reports the state of the frame in front of it.
+//
+// The gate is also set at startup by GOGUI_DEBUG=1.
+//
+// Not for production: the checks walk the whole layout tree every
+// frame and allocate while doing it.
+func Debug(on bool) {
+	if on && debugEnabled.CompareAndSwap(false, true) {
+		debugGen.Add(1)
+		return
+	}
+	debugEnabled.Store(on)
+}
+
+// DebugEnabled reports whether dev-mode diagnostics are on.
+func DebugEnabled() bool { return debugEnabled.Load() }
+
+// debugCheck identifies one class of finding. Warn-once state is
+// keyed by (check, subject), so a window reports each distinct defect
+// once rather than at the frame rate.
+type debugCheck uint8
+
+const (
+	debugCheckDupID debugCheck = iota
+	debugCheckFocusNoID
+	debugCheckScrollNoID
+)
+
+// debugWarnKey is the warn-once key. For the ID-less checks the
+// subject is the shape's path in the layout tree ("0/3/1"), because
+// an empty ID is precisely what is being reported and cannot
+// distinguish two findings.
+type debugWarnKey struct {
+	subject string
+	check   debugCheck
+}
+
+// debugState is a window's warn-once memory. Zero value is ready.
+type debugState struct {
+	warned map[debugWarnKey]struct{}
+	gen    uint64
+}
+
+// debugAudit runs the dev-mode checks over one frame's composed
+// layout tree. No-op unless [Debug] is on.
+//
+// Called from updateLayoutLocked after composeLayout, so it sees the
+// same tree the renderer does, including floating and overlay layers.
+func (w *Window) debugAudit(root *Layout) {
+	if !debugEnabled.Load() {
+		return
+	}
+	// Discard warn-once memory built under an older generation of the
+	// gate, so Debug(false) then Debug(true) re-reports.
+	if gen := debugGen.Load(); w.debug.gen != gen {
+		w.debug.gen = gen
+		w.debug.warned = nil
+	}
+	// ids maps an ID to the path of the shape that claimed it first,
+	// so a duplicate can name both sites. Frame-scoped, unlike
+	// w.debug.warned.
+	ids := make(map[string]string)
+	var path []int
+	w.debugWalk(root, &path, ids)
+}
+
+// debugWalk is the depth-first audit. path is the index chain from
+// the root to layout, maintained in place to keep the walk to one
+// allocation.
+func (w *Window) debugWalk(layout *Layout, path *[]int, ids map[string]string) {
+	if s := layout.Shape; s != nil {
+		w.debugCheckShape(s, *path, ids)
+	}
+	for i := range layout.Children {
+		*path = append(*path, i)
+		w.debugWalk(&layout.Children[i], path, ids)
+		*path = (*path)[:len(*path)-1]
+	}
+}
+
+// debugCheckShape runs the per-shape checks. path is the shape's
+// index chain from the root; ids records which path first claimed
+// each ID this frame.
+func (w *Window) debugCheckShape(s *Shape, path []int, ids map[string]string) {
+	if s.ID != "" {
+		if first, dup := ids[s.ID]; dup {
+			w.debugWarn(debugCheckDupID, s.ID,
+				"duplicate ID %q at %s, first claimed at %s; ID is the "+
+					"identity key for focus, scroll, and per-widget state, so "+
+					"the two collapse to one tab stop and one state slot",
+				s.ID, debugPath(path), first)
+		} else {
+			ids[s.ID] = debugPath(path)
+		}
+		return
+	}
+	// An ID-less shape is ordinary unless it claims a feature that is
+	// keyed by ID. Render the path only when there is something to
+	// report.
+	focusBad := s.Focusable && !s.FocusSkip && !s.Disabled
+	if !focusBad && !s.Scrollable {
+		return
+	}
+	p := debugPath(path)
+	if focusBad {
+		w.debugWarn(debugCheckFocusNoID, p,
+			"focusable shape at %s has no ID; focus traversal is keyed by "+
+				"ID, so it renders and clicks but never joins the tab order", p)
+	}
+	if s.Scrollable {
+		w.debugWarn(debugCheckScrollNoID, p,
+			"scrollable shape at %s has no ID; scroll offsets are keyed by "+
+				"ID, so it shares one offset with every other ID-less "+
+				"scrollable in this window", p)
+	}
+}
+
+// debugWarn prints a finding to stderr the first time this window
+// sees it. subject is the warn-once discriminator within check.
+func (w *Window) debugWarn(check debugCheck, subject, format string, args ...any) {
+	key := debugWarnKey{check: check, subject: subject}
+	if _, seen := w.debug.warned[key]; seen {
+		return
+	}
+	if w.debug.warned == nil {
+		w.debug.warned = make(map[debugWarnKey]struct{})
+	}
+	w.debug.warned[key] = struct{}{}
+	// Diagnostics are best-effort; a failed write to stderr is not
+	// something a GUI frame can act on.
+	_, _ = fmt.Fprintf(debugOut, "gui: "+format+"\n", args...)
+}
+
+// debugPath renders a tree path as "0/3/1". The root is "root".
+func debugPath(path []int) string {
+	if len(path) == 0 {
+		return "root"
+	}
+	var b strings.Builder
+	for i, n := range path {
+		if i > 0 {
+			b.WriteByte('/')
+		}
+		b.WriteString(strconv.Itoa(n))
+	}
+	return b.String()
+}

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -1,0 +1,231 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+)
+
+// captureDebug turns the gate on, redirects findings to a buffer, and
+// restores both on cleanup. Returns the buffer.
+func captureDebug(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	prevOut := debugOut
+	prevOn := debugEnabled.Load()
+	debugOut = &buf
+	Debug(true)
+	t.Cleanup(func() {
+		debugOut = prevOut
+		Debug(prevOn)
+	})
+	return &buf
+}
+
+// debugTree builds a two-level layout from the given shapes: root
+// with each shape as a direct child.
+func debugTree(shapes ...*Shape) Layout {
+	root := Layout{Shape: &Shape{}}
+	for _, s := range shapes {
+		root.Children = append(root.Children, Layout{Shape: s})
+	}
+	return root
+}
+
+func TestDebugAuditFocusableWithoutID(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{Focusable: true})
+
+	w.debugAudit(&tree)
+
+	got := buf.String()
+	if !strings.Contains(got, "focusable shape at 0 has no ID") {
+		t.Fatalf("want focusable-no-ID finding, got %q", got)
+	}
+}
+
+// A focusable shape excluded from tab traversal is not a defect:
+// FocusSkip is how Text/Rtf keep click-focus without a tab stop.
+func TestDebugAuditFocusSkipAndDisabledAreQuiet(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(
+		&Shape{Focusable: true, FocusSkip: true},
+		&Shape{Focusable: true, Disabled: true},
+	)
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+func TestDebugAuditScrollableWithoutID(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{Scrollable: true})
+
+	w.debugAudit(&tree)
+
+	got := buf.String()
+	if !strings.Contains(got, "scrollable shape at 0 has no ID") {
+		t.Fatalf("want scrollable-no-ID finding, got %q", got)
+	}
+}
+
+// The duplicate-ID check covers every shape, not only focusable ones,
+// because ID is also the key for scroll offsets and per-widget state.
+func TestDebugAuditDuplicateIDCoversNonFocusable(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{ID: "dup"}, &Shape{ID: "dup"})
+
+	w.debugAudit(&tree)
+
+	got := buf.String()
+	if !strings.Contains(got, `duplicate ID "dup" at 1, first claimed at 0`) {
+		t.Fatalf("want duplicate-ID finding naming both sites, got %q", got)
+	}
+}
+
+// Distinct IDs on a nested tree must stay quiet, and the path must
+// reflect the full index chain.
+func TestDebugAuditNestedPath(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	inner := Layout{Shape: &Shape{ID: "outer"}}
+	inner.Children = []Layout{
+		{Shape: &Shape{ID: "ok"}},
+		{Shape: &Shape{Focusable: true}},
+	}
+	tree := Layout{Shape: &Shape{}, Children: []Layout{inner}}
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); !strings.Contains(got, "focusable shape at 0/1 has no ID") {
+		t.Fatalf("want path 0/1, got %q", got)
+	}
+}
+
+// Findings are per-frame checks, so without dedupe one broken button
+// emits at the frame rate. Warn once per (check, subject) per window.
+func TestDebugAuditWarnsOncePerWindow(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{Focusable: true})
+
+	w.debugAudit(&tree)
+	first := buf.String()
+	w.debugAudit(&tree)
+
+	if buf.String() != first {
+		t.Fatalf("second audit re-reported: %q", buf.String())
+	}
+	// A second window has its own memory.
+	other := &Window{}
+	other.debugAudit(&tree)
+	if buf.String() == first {
+		t.Fatal("want a fresh window to report independently")
+	}
+}
+
+// Re-enabling the gate must report the current state rather than
+// staying silent on everything it already warned about.
+func TestDebugToggleResetsWarnOnce(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{Focusable: true})
+
+	w.debugAudit(&tree)
+	first := buf.String()
+	if first == "" {
+		t.Fatal("want a finding on the first audit")
+	}
+
+	Debug(false)
+	Debug(true)
+	w.debugAudit(&tree)
+
+	if buf.String() == first {
+		t.Fatal("want the finding re-reported after the gate is cycled")
+	}
+}
+
+func TestDebugAuditNoopWhenOff(t *testing.T) {
+	buf := captureDebug(t)
+	Debug(false)
+	w := &Window{}
+	tree := debugTree(&Shape{Focusable: true}, &Shape{ID: "d"}, &Shape{ID: "d"})
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("gate off must be silent, got %q", got)
+	}
+	if DebugEnabled() {
+		t.Fatal("DebugEnabled must report false")
+	}
+}
+
+func TestDebugPath(t *testing.T) {
+	tests := []struct {
+		want string
+		path []int
+	}{
+		{want: "root"},
+		{path: []int{0}, want: "0"},
+		{path: []int{0, 3, 1}, want: "0/3/1"},
+	}
+	for _, tc := range tests {
+		if got := debugPath(tc.path); got != tc.want {
+			t.Errorf("debugPath(%v) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestEnvTruthy(t *testing.T) {
+	tests := []struct {
+		val  string
+		want bool
+	}{
+		{val: "1", want: true},
+		{val: "true", want: true},
+		{val: " 1 ", want: true},
+		{val: "0", want: false},
+		{val: "", want: false},
+		{val: "yes", want: false},
+	}
+	for _, tc := range tests {
+		t.Setenv("GOGUI_DEBUG_TEST", tc.val)
+		if got := envTruthy("GOGUI_DEBUG_TEST"); got != tc.want {
+			t.Errorf("envTruthy(%q) = %v, want %v", tc.val, got, tc.want)
+		}
+	}
+	if envTruthy("GOGUI_DEBUG_TEST_UNSET") {
+		t.Error("unset variable must be false")
+	}
+}
+
+// State panics with both types named, so the message says what the
+// window actually holds rather than only what was asked for.
+func TestStatePanicNamesBothTypes(t *testing.T) {
+	type held struct{}
+	type want struct{}
+	w := &Window{state: &held{}}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("want a panic on a state type mismatch")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("want a string panic value, got %T", r)
+		}
+		if !strings.Contains(msg, "held") || !strings.Contains(msg, "want") {
+			t.Fatalf("want both type names in %q", msg)
+		}
+	}()
+	State[want](w)
+}

--- a/gui/layout_query.go
+++ b/gui/layout_query.go
@@ -1,23 +1,5 @@
 package gui
 
-import (
-	"fmt"
-	"os"
-)
-
-// focusDebug enables dev-mode focus diagnostics (duplicate focusable
-// IDs). Enable with GOGUI_FOCUS_DEBUG=1.
-var focusDebug = os.Getenv("GOGUI_FOCUS_DEBUG") == "1"
-
-// focusDupWarn reports a duplicate focusable ID in dev mode. Duplicate
-// IDs collapse to a single tab stop; the extra widget is skipped.
-func focusDupWarn(id string) {
-	if focusDebug {
-		fmt.Fprintf(os.Stderr,
-			"gui: duplicate focusable ID %q; collapsing to one tab stop\n", id)
-	}
-}
-
 // FindShape walks the layout depth-first until predicate is satisfied.
 func (layout *Layout) FindShape(predicate func(Layout) bool) (*Shape, bool) {
 	for i := range layout.Children {
@@ -105,9 +87,10 @@ type focusCandidate struct {
 func collectFocusCandidates(layout *Layout, candidates *[]focusCandidate, seen map[string]struct{}) {
 	s := layout.Shape
 	if s.Focusable && !s.FocusSkip && !s.Disabled && s.ID != "" {
-		if _, ok := seen[s.ID]; ok {
-			focusDupWarn(s.ID)
-		} else {
+		// A duplicate ID collapses to a single tab stop; the extra
+		// widget is skipped. Reported by the debug gate's duplicate-ID
+		// check (debug.go), which sees every ID, not only focusable ones.
+		if _, ok := seen[s.ID]; !ok {
 			seen[s.ID] = struct{}{}
 			*candidates = append(*candidates, focusCandidate{
 				id:    s.ID,

--- a/gui/state_registry.go
+++ b/gui/state_registry.go
@@ -128,15 +128,6 @@ func RequireID(widget, id string) {
 	}
 }
 
-// RequireFocusID panics if a Focusable widget has an empty ID. Focus
-// identity and per-widget input state are keyed by Cfg.ID, so a
-// focusable widget must supply one.
-func RequireFocusID(widget string, focusable bool, id string) {
-	if focusable && id == "" {
-		panic("gui: " + widget + " with Focusable:true requires a non-empty Cfg.ID")
-	}
-}
-
 // RequireScrollID panics if a Scrollable widget has an empty ID.
 // Scroll identity and offset state are keyed by Cfg.ID, so a
 // scrollable widget must supply one.

--- a/gui/window.go
+++ b/gui/window.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -273,6 +274,10 @@ type Window struct {
 
 	// Window focus state — backend sets false on unfocus event.
 	focused bool
+
+	// debug is warn-once state for the dev-mode diagnostics in
+	// debug.go. Untouched unless Debug is on.
+	debug debugState
 }
 
 // MouseLockCfg stores callbacks for mouse event handling in a
@@ -316,8 +321,18 @@ type ViewState struct {
 }
 
 // State returns a typed pointer to the user-supplied state.
+//
+// Panics if the window holds a different state type. That is a
+// programmer error discoverable on the first frame, not a runtime
+// condition worth threading through every view function.
 func State[T any](w *Window) *T {
-	return w.state.(*T)
+	s, ok := w.state.(*T)
+	if !ok {
+		var want *T
+		panic(fmt.Sprintf(
+			"gui: State[%T] requested but window holds %T", want, w.state))
+	}
+	return s
 }
 
 // SetState sets the user state for the window.

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -277,6 +277,8 @@ func (w *Window) Update() {
 	}
 
 	w.layout = composeLayout(layers, w)
+	// Dev-mode identity checks. One atomic load when the gate is off.
+	w.debugAudit(&w.layout)
 	w.buildRenderers(w.Config.BgColor, w.windowRect())
 	if t {
 		t3 := time.Now()


### PR DESCRIPTION
Phase 1 of `docs/specs/developer-ergonomics.md`, **PR 1 of 5**.

## What

Three widget defects in this library are silent by construction — no error, no panic, no visual difference:

- two shapes sharing an `ID` (it is the identity key for focus, scroll offsets, and per-widget state, so they collapse onto one identity)
- a focusable shape with no `ID` — renders and clicks, never joins the tab order
- a scrollable shape with no `ID` — shares one offset with every other ID-less scrollable in the window

`gui.Debug(bool)` audits the composed tree once per frame and reports all three to stderr. `GOGUI_DEBUG=1` sets it at startup; `GOGUI_FOCUS_DEBUG=1`, the focus-only spelling this generalizes, still works.

## Design notes

- **`atomic.Bool`, not a plain bool.** `Debug()` makes the flag mutable and `debugAudit` reads it from the frame goroutine, so a plain bool would race a `Debug(true)` from elsewhere. The mutability is the reason, not the lookup cost.
- **Warn once per `(check, subject)` per window.** The checks run per frame, so an undeduplicated warning for one ID-less button emits at the frame rate — that is a reason to turn the gate back off, which defeats it. A `false → true` transition bumps a generation counter and discards the per-window memory, so re-enabling after a fix reports current state rather than staying silent.
- **ID-less checks key on tree path** (`0/3/1`), since `""` is precisely what they report and cannot discriminate two findings.
- **The duplicate-ID check moved off focus-candidate collection**, so it now sees *every* ID rather than only focusable ones.

## Also here

- **`RequireFocusID` deleted** (spec §4.2). Zero call sites in go-gui, tests included, and zero across all five sibling repos, despite fourteen files exposing a `Focusable bool` field. A dead exported guard implies a check that runs — that reads like coverage and is worse than no guard. Its static case belongs to `requiredid` (build time, `Cfg` type named); its dynamic case to `RequireID` and the new gate.
- **`State[T]` names both types when it panics** (spec §5.3). The panic stays — wrong state type is a programmer error found on the first frame. Only the message improves.
- **Spec Q8 resolved: "documented only."** `requiredid` stays a `tools/` binary authors may invoke, rules free to tighten. The accepted consequence is written down: consumers sit on the `RequireID`-panic path, and §4.2's static-enforcement claim holds for this repo alone.

## Verification

`gofmt` clean · `go vet ./...` clean · `golangci-lint run ./...` 0 issues · `requiredid` clean · full `go test ./...` passes.

Cost when off was measured, not asserted — `BenchmarkViewFrame` at `count=5` before and after:

| | allocs/op | B/op |
| --- | --- | --- |
| rows_50 | 202 → 202 | 79809 → 79809 |
| rows_200 | 802 → 802 | 317586 → 317586 |

ns/op within noise.

## Not in this PR

The gate *reports* the 126 known ID defects; fixing them is PRs 2–5 (`ergoaudit -fix`, the 12 first-party a11y defects and the `Select` scroll bug, tagging the 9 `Cfg`s, then `checkScrollableID`). Progress table is in spec §6.1. Phase 1 releases once, after PR 5 — no tag off this merge.

No sibling action: phase 1's sibling cost is 3 call sites, deferred to phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)