### PR TITLE
fix(a11y): give twelve first-party widgets keyboard-reachable buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **Twelve first-party widgets shipped buttons no keyboard user could reach**
+  (developer-ergonomics §4.2, phase 1). Focus traversal is keyed by `ID`, so a
+  focusable widget without one renders, clicks, and silently never joins the tab
+  order. Each of these carried an `OnClick` and had no `ID`: the toast action
+  and dismiss buttons, the date picker's month toggle and prev/next arrows, the
+  date input's calendar button, the markdown code-block copy button, the
+  overflow panel's trigger, the time-travel freeze button, and the DataGrid's
+  header, CRUD, pager, filter-clear, column-chooser, and source-paging controls.
+
+  IDs are **namespaced by the owning widget's own ID** rather than fixed
+  strings, because these widgets can appear more than once in a window — two
+  toasts, two date pickers, two grids. A constant `ID` would have replaced an
+  unreachable button with a duplicate one, collapsing both onto a single tab
+  stop and a single state slot. New `toastBtnID` helper;
+  `dataGridIndicatorButton`, `dataGridOrderButton`, and `ttButton` take an `id`
+  parameter.
+
+  Those three take `id` as a parameter rather than deriving it from their
+  `label` because the labels are not stable identity: DataGrid's come from
+  `gg.ActiveLocale`, and the freeze button's alternates between "Pause" and
+  "Resume". An ID tracking the label would move the widget's focus and state on
+  a locale switch or a state change.
+
+  One case went the other way: the date picker's out-of-month calendar cell is
+  blank, disabled, and handler-less, so it now sets `FocusDisabled: true` rather
+  than being given an ID for empty space. That is the decorative case the
+  opt-out exists for.
+
 ### Added
 
 - **`ergoaudit -fix` codemod** (developer-ergonomics §8, phase 1). Tools-only;

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -45,7 +45,7 @@ several figures depend on dedupe and scope choices.
 | Focusable-by-default `Cfg`s           | 15    | `FocusDisabled` opt-out           |
 | — of those, `ID` **not** required     | 9     | unguarded; see §4.2               |
 | Literals of those 9, all repos        | 408   | `go/ast` walk; see §4.2, §10      |
-| — focusable but ID-less (broken)      | 126   | 12 in go-gui's own widgets        |
+| — focusable but ID-less (broken)      | 126   | 12 in go-gui's own widgets; fixed |
 | — using `FocusDisabled` opt-out       | **1** | decorative case is theoretical    |
 | Tests in `examples/*/main_test.go`    | 63    | 98 lines are no-panic assertions  |
 | `Cfg`s exposing `Scrollable bool`     | 7     | scroll state keyed by ID (§4.9)   |
@@ -717,9 +717,19 @@ Current coverage of the 7 `Cfg`s exposing `Scrollable bool`:
 `RequireFocusID` was — it has exactly one caller. So finish wiring it
 rather than deleting it. The analyzer has zero `Scrollable` references.
 
-One live defect found: `gui/view_select.go:145` builds the dropdown
-container with `Scrollable: true` and no ID. Open two `Select`s in one
-window, scroll one, and the other's offset follows.
+**Correction (2026-08-07, phase 1).** An earlier draft claimed one live
+defect here: "`gui/view_select.go:145` builds the dropdown container
+with `Scrollable: true` and no ID." That is **false**, and it was false
+at this spec's own base commit. The literal sets
+`ID: dropdownScrollID` (= `cfg.ID + ".dropdown"`) at line 130;
+`Scrollable: true` sits fifteen lines below it at line 145, and the
+original reading took the second line without the first.
+
+Re-checked every `Scrollable: true` literal in `gui/` — command
+palette, inspector, table, theme picker, select, datagrid body — and
+**all six already carry an ID**. There are zero live scroll defects.
+The rest of this section still stands as a guard: the contract is
+unenforced even though nothing currently violates it.
 
 Proposed, all additive except the tag:
 
@@ -729,10 +739,8 @@ Proposed, all additive except the tag:
   `checkFocusableID` — same shape, small diff.
 - Add the `Scrollable && ID == ""` check to the §4.1 debug gate, which
   catches internal shapes the analyzer never sees.
-- Fix `gui/view_select.go:145`.
-
-Phase 1, alongside the focus work: same mechanism, same audit, and the
-`Select` defect is live today.
+Phase 1, alongside the focus work: same mechanism, same audit. Note
+that this is now purely preventive — see the correction above.
 
 `ContainerCfg` is the only type that is both opt-in-focusable and
 scrollable (`Focusable` :97, `Scrollable` :102, `ID` :67). With §4.2's
@@ -838,8 +846,8 @@ burying them in the same diff.
 | 1     | §4.2 delete `RequireFocusID`             | done   |
 | 1     | §5.3 `State[T]` panic message            | done   |
 | 1     | §8 `ergoaudit -fix` codemod              | done   |
-| 1     | §4.2 fix 12 first-party a11y defects     | todo   |
-| 1     | §4.9 fix `view_select.go` scroll defect  | todo   |
+| 1     | §4.2 fix 12 first-party a11y defects     | done   |
+| 1     | §4.9 `Select` scroll defect              | n/a — did not exist |
 | 1     | §4.2 tag 9 `Cfg`s + wire `RequireID`     | todo   |
 | 1     | §4.9 tag `Container`/`Input`, wire scroll| todo   |
 | 1     | §4.9 `checkScrollableID` analyzer rule   | todo   |

--- a/gui/datagrid/data_source_grid.go
+++ b/gui/datagrid/data_source_grid.go
@@ -646,7 +646,7 @@ func dataGridSourcePagerRow(cfg *DataGridCfg, focusID string, state dataGridSour
 	content := make([]gg.View, 0, 10)
 
 	// Prev button.
-	content = append(content, dataGridIndicatorButton("\u25C0", cfg.TextStyleHeader, cfg.ColorHeaderHover,
+	content = append(content, dataGridIndicatorButton(gridID+":src_prev", "\u25C0", cfg.TextStyleHeader, cfg.ColorHeaderHover,
 		state.Loading || !hasPrev, dataGridHeaderControlWidth+10, func(ctx gg.EventCtx) {
 			dataGridSourcePrevPage(gridID, kind, pageLimit, ctx.Window)
 			if focusID != "" {
@@ -661,7 +661,7 @@ func dataGridSourcePagerRow(cfg *DataGridCfg, focusID string, state dataGridSour
 		TextStyle: cfg.TextStyleFilter,
 	}))
 	// Next button.
-	content = append(content, dataGridIndicatorButton("\u25B6", cfg.TextStyleHeader, cfg.ColorHeaderHover,
+	content = append(content, dataGridIndicatorButton(gridID+":src_next", "\u25B6", cfg.TextStyleHeader, cfg.ColorHeaderHover,
 		state.Loading || !hasNext, dataGridHeaderControlWidth+10, func(ctx gg.EventCtx) {
 			dataGridSourceNextPage(gridID, kind, pageLimit, ctx.Window)
 			if focusID != "" {
@@ -677,6 +677,7 @@ func dataGridSourcePagerRow(cfg *DataGridCfg, focusID string, state dataGridSour
 	// Retry button on error.
 	if state.LoadError != "" {
 		content = append(content, gg.Button(gg.ButtonCfg{
+			ID:          gridID + ":src_retry",
 			Sizing:      gg.FitFill,
 			Padding:     gg.NoPadding,
 			SizeBorder:  gg.SomeF(0),

--- a/gui/datagrid/view_data_grid_crud.go
+++ b/gui/datagrid/view_data_grid_crud.go
@@ -188,17 +188,17 @@ func dataGridCrudToolbarRow(cfg *DataGridCfg, state dataGridCrudState, caps Grid
 		Spacing:     gg.SomeF(6),
 		VAlign:      gg.VAlignMiddle,
 		Content: []gg.View{
-			dataGridIndicatorButton(gg.ActiveLocale.StrAdd, cfg.TextStyleFilter, cfg.ColorHeaderHover,
+			dataGridIndicatorButton(gridID+":crud_add", gg.ActiveLocale.StrAdd, cfg.TextStyleFilter, cfg.ColorHeaderHover,
 				!canCreate || state.Saving, 0, func(ctx gg.EventCtx) {
 					dataGridCrudAddRow(gridID, columns, onSelectionChange, focusID,
 						scrollID, pageSize, pageIndex, onPageChange, ctx.Event, ctx.Window)
 				}),
-			dataGridIndicatorButton(gg.ActiveLocale.StrDelete, cfg.TextStyleFilter, cfg.ColorHeaderHover,
+			dataGridIndicatorButton(gridID+":crud_delete", gg.ActiveLocale.StrDelete, cfg.TextStyleFilter, cfg.ColorHeaderHover,
 				!canDelete || selectedCount == 0 || state.Saving, 0, func(ctx gg.EventCtx) {
 					dataGridCrudDeleteSelected(gridID, selection, onSelectionChange,
 						focusID, ctx.Event, ctx.Window)
 				}),
-			dataGridIndicatorButton(gg.ActiveLocale.StrSave, cfg.TextStyleFilter, cfg.ColorHeaderHover,
+			dataGridIndicatorButton(gridID+":crud_save", gg.ActiveLocale.StrSave, cfg.TextStyleFilter, cfg.ColorHeaderHover,
 				!hasUnsaved || state.Saving, 0, func(ctx gg.EventCtx) {
 					dataGridCrudSave(dataGridCrudSaveContext{
 						gridID:            gridID,
@@ -213,7 +213,7 @@ func dataGridCrudToolbarRow(cfg *DataGridCfg, state dataGridCrudState, caps Grid
 						focusID:           focusID,
 					}, ctx.Event, ctx.Window)
 				}),
-			dataGridIndicatorButton(gg.ActiveLocale.StrCancel, cfg.TextStyleFilter, cfg.ColorHeaderHover,
+			dataGridIndicatorButton(gridID+":crud_cancel", gg.ActiveLocale.StrCancel, cfg.TextStyleFilter, cfg.ColorHeaderHover,
 				(!hasUnsaved && state.SaveError == "") || state.Saving, 0, func(ctx gg.EventCtx) {
 					dataGridCrudCancel(gridID, focusID, ctx.Event, ctx.Window)
 				}),

--- a/gui/datagrid/view_data_grid_events.go
+++ b/gui/datagrid/view_data_grid_events.go
@@ -73,7 +73,7 @@ func dataGridQuickFilterRow(cfg *DataGridCfg, w *gg.Window) gg.View {
 				Mode:      gg.TextModeSingleLine,
 				TextStyle: dataGridIndicatorTextStyle(cfg.TextStyleFilter),
 			}),
-			dataGridIndicatorButton(gg.ActiveLocale.StrClear, cfg.TextStyleFilter, cfg.ColorHeaderHover,
+			dataGridIndicatorButton(gridID+":filter_clear", gg.ActiveLocale.StrClear, cfg.TextStyleFilter, cfg.ColorHeaderHover,
 				clearDisabled, 0, func(ctx gg.EventCtx) {
 					if queryCallback == nil {
 						return
@@ -181,7 +181,7 @@ func dataGridColumnChooserRow(cfg *DataGridCfg, isOpen bool, focusID string) gg.
 		Spacing: gg.SomeF(6),
 		VAlign:  gg.VAlignMiddle,
 		Content: []gg.View{
-			dataGridIndicatorButton(chooserLabel, cfg.TextStyleFilter, cfg.ColorHeaderHover,
+			dataGridIndicatorButton(gridID+":column_chooser", chooserLabel, cfg.TextStyleFilter, cfg.ColorHeaderHover,
 				false, 0, func(ctx gg.EventCtx) {
 					dataGridToggleColumnChooserOpen(gridID, ctx.Window)
 					if focusID != "" {

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -209,25 +209,32 @@ func dataGridReorderControls(cfg *DataGridCfg, col GridColumnCfg) gg.View {
 		Width:   dataGridHeaderControlsWidth(true, false, false),
 		Sizing:  gg.FixedFill,
 		Content: []gg.View{
-			dataGridOrderButton(leftArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, reorderCB(-1)),
-			dataGridOrderButton(rightArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, reorderCB(1)),
+			dataGridOrderButton(cfg.ID+":reorder_left:"+colID, leftArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, reorderCB(-1)),
+			dataGridOrderButton(cfg.ID+":reorder_right:"+colID, rightArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, reorderCB(1)),
 		},
 	})
 }
 
-func dataGridOrderButton(label string, baseStyle gg.TextStyle, hoverColor gg.Color, cb func(*gg.Event, *gg.Window)) gg.View {
-	return dataGridIndicatorButton(label, baseStyle, hoverColor, false, dataGridHeaderControlWidth,
+func dataGridOrderButton(id, label string, baseStyle gg.TextStyle, hoverColor gg.Color, cb func(*gg.Event, *gg.Window)) gg.View {
+	return dataGridIndicatorButton(id, label, baseStyle, hoverColor, false, dataGridHeaderControlWidth,
 		func(ctx gg.EventCtx) {
 			cb(ctx.Event, ctx.Window)
 		})
 }
 
-func dataGridIndicatorButton(label string, baseStyle gg.TextStyle, hoverColor gg.Color, disabled bool, width float32, onClick func(gg.EventCtx)) gg.View {
+// dataGridIndicatorButton builds one header/toolbar control.
+//
+// id is a parameter rather than derived from label because label is a
+// locale string (gg.ActiveLocale.StrAdd and friends). An ID that
+// tracked the label would change identity on a locale switch, moving
+// the button's focus and per-widget state with it.
+func dataGridIndicatorButton(id, label string, baseStyle gg.TextStyle, hoverColor gg.Color, disabled bool, width float32, onClick func(gg.EventCtx)) gg.View {
 	sizing := gg.FitFill
 	if width > 0 {
 		sizing = gg.FixedFill
 	}
 	return gg.Button(gg.ButtonCfg{
+		ID:          id,
 		Width:       width,
 		Sizing:      sizing,
 		Padding:     gg.NoPadding,
@@ -264,7 +271,7 @@ func dataGridPinControl(cfg *DataGridCfg, col GridColumnCfg) gg.View {
 	colID := col.ID
 	colPin := col.Pin
 
-	return dataGridIndicatorButton(label, cfg.TextStyleHeader, cfg.ColorHeaderHover,
+	return dataGridIndicatorButton(cfg.ID+":pin:"+col.ID, label, cfg.TextStyleHeader, cfg.ColorHeaderHover,
 		false, dataGridHeaderControlWidth, func(ctx gg.EventCtx) {
 			if onColumnPinChange == nil {
 				return

--- a/gui/datagrid/view_data_grid_header_test.go
+++ b/gui/datagrid/view_data_grid_header_test.go
@@ -244,10 +244,31 @@ func TestHeaderControlStateWithPadding(t *testing.T) {
 // --- dataGridOrderButton ---
 
 func TestOrderButtonReturnsView(t *testing.T) {
-	v := dataGridOrderButton("◀", gg.DefaultTextStyle, gg.RGBA(200, 200, 200, 255),
+	v := dataGridOrderButton("grid:reorder_left:col1", "◀",
+		gg.DefaultTextStyle, gg.RGBA(200, 200, 200, 255),
 		func(_ *gg.Event, _ *gg.Window) {})
 	if v == nil {
 		t.Fatal("order button should return a view")
+	}
+}
+
+// The header controls are keyed by grid and column, so two grids —
+// or two columns in one grid — never share a tab stop.
+func TestOrderButtonIDIsPerGridAndColumn(t *testing.T) {
+	style := gg.DefaultTextStyle
+	hover := gg.RGBA(200, 200, 200, 255)
+	cb := func(_ *gg.Event, _ *gg.Window) {}
+
+	a := dataGridOrderButton("gridA:reorder_left:col1", "◀", style, hover, cb)
+	b := dataGridOrderButton("gridB:reorder_left:col1", "◀", style, hover, cb)
+
+	idA := a.GenerateLayout(nil).Shape.ID
+	idB := b.GenerateLayout(nil).Shape.ID
+	if idA == "" || idB == "" {
+		t.Fatalf("header control has no ID: %q, %q", idA, idB)
+	}
+	if idA == idB {
+		t.Errorf("two grids share the header-control ID %q", idA)
 	}
 }
 

--- a/gui/datagrid/view_data_grid_pager.go
+++ b/gui/datagrid/view_data_grid_pager.go
@@ -92,7 +92,7 @@ func dataGridPagerArrows() (string, string) {
 }
 
 func dataGridPagerPrevButton(cfg *DataGridCfg, onPageChange func(int, gg.EventCtx), pageIndex int, focusID string, isFirst bool, prevArrow string) gg.View {
-	return dataGridIndicatorButton(prevArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover,
+	return dataGridIndicatorButton(cfg.ID+":pager_prev", prevArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover,
 		onPageChange == nil || isFirst, dataGridHeaderControlWidth+10,
 		func(ctx gg.EventCtx) {
 			if onPageChange == nil {
@@ -108,7 +108,7 @@ func dataGridPagerPrevButton(cfg *DataGridCfg, onPageChange func(int, gg.EventCt
 }
 
 func dataGridPagerNextButton(cfg *DataGridCfg, onPageChange func(int, gg.EventCtx), pageIndex, pageCount int, focusID string, isLast bool, nextArrow string) gg.View {
-	return dataGridIndicatorButton(nextArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover,
+	return dataGridIndicatorButton(cfg.ID+":pager_next", nextArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover,
 		onPageChange == nil || isLast, dataGridHeaderControlWidth+10,
 		func(ctx gg.EventCtx) {
 			if onPageChange == nil {

--- a/gui/focus_defects_test.go
+++ b/gui/focus_defects_test.go
@@ -1,0 +1,154 @@
+package gui
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// Regression tests for the first-party focus defects found by
+// ergoaudit (developer-ergonomics §4.2). Each of these widgets shipped
+// a button carrying an OnClick that no keyboard user could reach,
+// because focus traversal is keyed by ID and the button had none.
+//
+// The assertions run through the gui.Debug gate rather than poking at
+// shapes directly: the gate is the thing that decides what counts as a
+// focus defect, so a test that agreed with it by reimplementing it
+// would not notice the two drifting apart.
+
+// assertNoFocusDefects renders v and fails if the debug gate reports
+// anything. captureDebug (debug_test.go) turns the gate on and
+// redirects its output for the duration of the test.
+//
+// Uses generateViewLayout, not v.GenerateLayout: the latter builds one
+// node, and every button under test is a descendant reached through
+// Content().
+func assertNoFocusDefects(t *testing.T, w *Window, v View) Layout {
+	t.Helper()
+	buf := captureDebug(t)
+	layout := generateViewLayout(v, w)
+	w.debugAudit(&layout)
+	if got := buf.String(); got != "" {
+		t.Errorf("debug gate reported defects:\n%s", got)
+	}
+	return layout
+}
+
+// focusableIDs collects the ID of every shape that joins the tab
+// order, in tree order.
+func focusableIDs(layout *Layout) []string {
+	var out []string
+	var walk func(*Layout)
+	walk = func(l *Layout) {
+		if s := l.Shape; s != nil && s.Focusable && !s.FocusSkip && !s.Disabled {
+			out = append(out, s.ID)
+		}
+		for i := range l.Children {
+			walk(&l.Children[i])
+		}
+	}
+	walk(layout)
+	return out
+}
+
+// Two toasts on screen at once is the case a fixed ID would break:
+// both dismiss buttons would claim one identity, collapsing them to a
+// single tab stop sharing one state slot.
+func TestToastButtonsGetPerToastIDs(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, animFrac: 1, cfg: ToastCfg{
+			Title: "A", ActionLabel: "Undo", OnAction: func(*Window) {},
+		}},
+		{id: 2, animFrac: 1, cfg: ToastCfg{
+			Title: "B", ActionLabel: "Undo", OnAction: func(*Window) {},
+		}},
+	}
+
+	layout := assertNoFocusDefects(t, w, toastContainerView(w))
+
+	ids := focusableIDs(&layout)
+	want := []string{
+		"toast_1:action", "toast_1:dismiss",
+		"toast_2:action", "toast_2:dismiss",
+	}
+	for _, id := range want {
+		if !slices.Contains(ids, id) {
+			t.Errorf("missing focusable %q; got %v", id, ids)
+		}
+	}
+	assertUnique(t, ids)
+}
+
+// A toast with no action label ships only a dismiss button, and it
+// must still be reachable.
+func TestToastDismissOnlyIsReachable(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 7, animFrac: 1, cfg: ToastCfg{Title: "Saved"}},
+	}
+
+	layout := assertNoFocusDefects(t, w, toastContainerView(w))
+
+	if ids := focusableIDs(&layout); !slices.Contains(ids, "toast_7:dismiss") {
+		t.Errorf("dismiss button not keyboard-reachable; got %v", ids)
+	}
+}
+
+func TestToastBtnIDIsPerToast(t *testing.T) {
+	t.Parallel()
+	if a, b := toastBtnID(1, "dismiss"), toastBtnID(2, "dismiss"); a == b {
+		t.Fatalf("two toasts share the button ID %q", a)
+	}
+	if got := toastBtnID(3, "action"); !strings.Contains(got, "3") {
+		t.Errorf("toastBtnID lost the toast number: %q", got)
+	}
+}
+
+// The overflow panel's trigger is namespaced by the panel's own ID, so
+// a toolbar holding several panels keeps them distinct.
+func TestOverflowPanelTriggerIsReachable(t *testing.T) {
+	w := &Window{}
+	v := OverflowPanel(w, OverflowPanelCfg{
+		ID: "toolbar",
+		Items: []OverflowItem{
+			{View: Text(TextCfg{Text: "one"})},
+		},
+	})
+
+	layout := assertNoFocusDefects(t, w, v)
+
+	if ids := focusableIDs(&layout); !slices.Contains(ids, "toolbar:trigger") {
+		t.Errorf("overflow trigger not keyboard-reachable; got %v", ids)
+	}
+}
+
+// The out-of-month calendar cell is blank, disabled, and has no
+// handler. It opts out of focus rather than inventing an ID for empty
+// space — the decorative case FocusDisabled exists for.
+func TestDatePickerBlankCellOptsOutOfFocus(t *testing.T) {
+	t.Parallel()
+	v := Button(ButtonCfg{
+		FocusDisabled: true,
+		Disabled:      true,
+		Content:       []View{Text(TextCfg{Text: " "})},
+	})
+	w := &Window{}
+	layout := v.GenerateLayout(w)
+	if layout.Shape.Focusable {
+		t.Error("FocusDisabled must clear Focusable on the shape")
+	}
+}
+
+// assertUnique fails on a repeated ID. Duplicates are the failure mode
+// a per-instance namespace exists to prevent.
+func assertUnique(t *testing.T, ids []string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, id := range ids {
+		if seen[id] {
+			t.Errorf("duplicate focusable ID %q in %v", id, ids)
+		}
+		seen[id] = true
+	}
+}

--- a/gui/time_travel_view.go
+++ b/gui/time_travel_view.go
@@ -199,7 +199,7 @@ func (c *TimeTravelController) View(w *Window) View {
 				Sizing:   FillFixed,
 				OnChange: c.onSliderChange,
 			}),
-			ttButton(freezeLabel(c.App), c.ToggleFreeze),
+			ttButton(ttFreezeID, freezeLabel(c.App), c.ToggleFreeze),
 		},
 	})
 }
@@ -235,6 +235,7 @@ func (c *TimeTravelController) onSliderChange(v float32, _ EventCtx) {
 const (
 	ttSliderHeight = 20
 	ttSliderID     = "gui.time_travel.slider"
+	ttFreezeID     = "gui.time_travel.freeze"
 )
 
 // ttDebugFocusID is the focus ID for the debug window's root
@@ -270,8 +271,14 @@ func (c *TimeTravelController) handleKey(ctx EventCtx) {
 
 // ttButton builds a labelled scrubber button whose click
 // handler invokes the given zero-arg function.
-func ttButton(label string, fn func()) View {
+//
+// id is a parameter rather than derived from label because the
+// label is not stable: the freeze button reads "Pause" or
+// "Resume" depending on state, and an ID that changed with it
+// would move the widget's focus and state identity mid-session.
+func ttButton(id, label string, fn func()) View {
 	return Button(ButtonCfg{
+		ID:      id,
 		Content: []View{Text(TextCfg{Text: label})},
 		OnClick: func(ctx EventCtx) { fn() },
 	})

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -267,6 +267,9 @@ func datePickerControls(
 		Sizing:     FillFit,
 		Content: []View{
 			Button(ButtonCfg{
+				// Namespaced by the picker's ID so two date pickers in
+				// one window keep separate focus and state identities.
+				ID:          cfgID + ":month",
 				Color:       ColorTransparent,
 				ColorBorder: ColorTransparent,
 				OnClick:     onToggle,
@@ -276,6 +279,7 @@ func datePickerControls(
 			}),
 			Rectangle(RectangleCfg{Sizing: FillFit}),
 			Button(ButtonCfg{
+				ID:          cfgID + ":prev",
 				Disabled:    state.ShowYearMonthPicker,
 				Color:       ColorTransparent,
 				ColorBorder: ColorTransparent,
@@ -286,6 +290,7 @@ func datePickerControls(
 				})},
 			}),
 			Button(ButtonCfg{
+				ID:          cfgID + ":next",
 				Disabled:    state.ShowYearMonthPicker,
 				Color:       ColorTransparent,
 				ColorBorder: ColorTransparent,

--- a/gui/view_date_picker_calendar.go
+++ b/gui/view_date_picker_calendar.go
@@ -97,15 +97,20 @@ func datePickerMonth(
 					cells = append(cells, datePickerAdjacentCell(
 						cfg, state, d, daysInMonth, cellSize))
 				} else {
+					// Blank spacer for a day outside the month: no
+					// label, no handler, nothing to focus. This is the
+					// decorative case FocusDisabled exists for, so opt
+					// out rather than invent an ID for empty space.
 					cells = append(cells, Button(ButtonCfg{
-						Color:       ColorTransparent,
-						ColorBorder: ColorTransparent,
-						Disabled:    true,
-						MinWidth:    cellSize,
-						MaxWidth:    cellSize,
-						MaxHeight:   cellSize,
-						Padding:     Some(paddingThree),
-						Content:     []View{Text(TextCfg{Text: " "})},
+						FocusDisabled: true,
+						Color:         ColorTransparent,
+						ColorBorder:   ColorTransparent,
+						Disabled:      true,
+						MinWidth:      cellSize,
+						MaxWidth:      cellSize,
+						MaxHeight:     cellSize,
+						Padding:       Some(paddingThree),
+						Content:       []View{Text(TextCfg{Text: " "})},
 					}))
 				}
 				continue

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -119,6 +119,9 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 			Content: []View{
 				inputDateTextField(cfg, cfgID, isOpen, editText),
 				Button(ButtonCfg{
+					// Namespaced by the field's ID: a form can hold
+					// several date inputs.
+					ID:         cfgID + ":calendar",
 					Disabled:   cfg.Disabled || cfg.ReadOnly,
 					Padding:    NoPadding,
 					SizeBorder: NoBorder,

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -164,6 +164,9 @@ func mdCopyButton(
 	}
 
 	return Button(ButtonCfg{
+		// animID already identifies this code block uniquely (it keys
+		// the check-mark animation), so it namespaces the button too.
+		ID:           animID + ":copy",
 		Float:        true,
 		FloatAnchor:  FloatTopRight,
 		FloatTieOff:  FloatTopRight,

--- a/gui/view_overflow_panel.go
+++ b/gui/view_overflow_panel.go
@@ -58,6 +58,9 @@ func OverflowPanel(w *Window, cfg OverflowPanelCfg) View {
 
 	id := cfg.ID
 	content = append(content, Button(ButtonCfg{
+		// Namespaced by the panel's ID: a toolbar can hold several
+		// overflow panels, each with its own trigger.
+		ID:       id + ":trigger",
 		Color:    ColorTransparent,
 		Padding:  cfg.Padding,
 		Disabled: cfg.Disabled,

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -168,6 +168,7 @@ func toastItemView(toast *toastNotification, style ToastStyle) View {
 	if toast.cfg.ActionLabel != "" && toast.cfg.OnAction != nil {
 		onAction := toast.cfg.OnAction
 		buttons = append(buttons, Button(ButtonCfg{
+			ID:      toastBtnID(id, "action"),
 			Color:   ColorTransparent,
 			Content: []View{Text(TextCfg{Text: toast.cfg.ActionLabel, TextStyle: style.TextStyle})},
 			OnClick: func(ctx EventCtx) {
@@ -177,6 +178,7 @@ func toastItemView(toast *toastNotification, style ToastStyle) View {
 		}))
 	}
 	buttons = append(buttons, Button(ButtonCfg{
+		ID:         toastBtnID(id, "dismiss"),
 		Color:      ColorTransparent,
 		SizeBorder: NoBorder,
 		Content:    []View{Text(TextCfg{Text: "\u00d7", TextStyle: style.TextStyle})},
@@ -396,6 +398,13 @@ func toastA11YLabel(t *toastNotification) string {
 }
 
 // toastAnimID generates a unique animation ID for toast anims.
+// toastBtnID keys a toast's buttons by the toast's own numeric ID.
+// Several toasts can be on screen at once, so a fixed ID would
+// collapse their action buttons onto one focus and state identity.
+func toastBtnID(id uint64, part string) string {
+	return "toast_" + strconv.FormatUint(id, 10) + ":" + part
+}
+
 func toastAnimID(prefix string, id uint64) string {
 	return prefix + "_toast_" + strconv.FormatUint(id, 10)
 }


### PR DESCRIPTION
Phase 1 of `docs/specs/developer-ergonomics.md`, **PR 3 of 5**.

## The defect

Focus traversal is keyed by `ID`, so a focusable widget without one renders, clicks, and **silently never joins the tab order**. Twelve buttons in go-gui's own widgets were in that state, each carrying an `OnClick`:

| Widget | Controls |
| --- | --- |
| Toast | action, dismiss |
| Date picker | month toggle, prev, next |
| Date input | calendar |
| Markdown | code-block copy |
| Overflow panel | trigger |
| Time travel | freeze |
| DataGrid | header reorder/pin, CRUD add/delete/save/cancel, pager prev/next, filter clear, column chooser, source paging + retry |

## Why the IDs are namespaced, not fixed

These widgets can appear more than once in a window — two toasts, two date pickers, two grids. A constant `ID` would have swapped an unreachable button for a **duplicate** one, collapsing both onto a single tab stop and a single state slot. That is the worse failure: it looks fine until two are on screen.

So IDs derive from the owning widget's own ID, matching the existing house convention (`cfg.ID + ":quick_filter"`, `gridID + ":resize:" + col.ID`). New `toastBtnID` helper; `dataGridIndicatorButton`, `dataGridOrderButton`, and `ttButton` gain an `id` parameter.

**Those three take `id` rather than deriving it from `label`** because the labels are not stable identity: DataGrid's come from `gg.ActiveLocale`, and the freeze button alternates between "Pause" and "Resume". An ID tracking the label would move focus and per-widget state on a locale switch or a state change.

One case went the other way: the date picker's out-of-month calendar cell is blank, disabled, and handler-less, so it sets `FocusDisabled: true` rather than being handed an ID for empty space — the decorative case the opt-out exists for, and only the second real instance of it in 408 literals.

## Two spec corrections

Both checked against the code, both now recorded in the spec:

1. **§4.9's "one live defect" does not exist.** It claimed `gui/view_select.go:145` builds the dropdown container with `Scrollable: true` and no ID. That is false, and was false at the spec's own base commit: the literal sets `ID: dropdownScrollID` at line **130**, and `Scrollable: true` sits fifteen lines below at **145**. The original reading took the second line without the first. I repeated the error earlier in this work before checking properly.

2. **There are zero live scroll defects at all.** Re-checked every `Scrollable: true` literal in `gui/` — command palette, inspector, table, theme picker, select, datagrid body — and all six already carry an ID. §4.9's remaining work (tags, analyzer rule) still stands as a guard on an unenforced contract, but it is preventive, not a bug fix.

The audit's other figure held: 12 library sites, exactly as reported.

## Testing

Assertions run **through the `gui.Debug` gate** from PR 1 rather than reimplementing its rules, so the test and the gate cannot drift apart. The multi-instance case is covered directly: two toasts must yield four distinct focusable IDs.

Mutation-checked — reverting the toast fix makes both the gate assertion and the ID assertions fail, and restoring it makes them pass.

`ergoaudit -mode focus` now reports **zero** broken literals in `gui/`.

## Verification

`gofmt` clean · `go vet ./...` clean · `golangci-lint run ./...` 0 issues · `requiredid` clean · `make gosec` 0 issues · full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)