### PR TITLE
feat(debug): add checkScrollableID and an OnMouseLeave identity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,28 @@ and this project adheres to
 
 ### Added
 
+- **Two preventive identity checks** (developer-ergonomics §4.9 and §4.1, phase
+  1). Both found **zero** live defects in this repo, which is the point of
+  landing them: the twelve a11y defects above all reached release because
+  nothing looked.
+
+  `tools/requiredid` gained `checkScrollableID`, reporting a literal that sets
+  `Scrollable: true` with no `ID`. Scroll offsets are keyed by `ID`, so every
+  ID-less scrollable in a window shares the key `""` and they scroll in lockstep
+  — visible only once a second one exists, which is how it survives review. It
+  mirrors `checkFocusableID` and keys on the field in the literal rather than a
+  tag: a scrollable container is the exception, and a `gui:"required"` tag on
+  `ContainerCfg.ID` would invert the default and flag the common case. The
+  runtime half, `RequireScrollID`, was already wired.
+
+  The `gui.Debug` gate gained an `OnMouseLeave`-without-`ID` check. This is a
+  fourth ID-keyed behaviour the spec did not enumerate: `layoutMouseLeave`
+  tracks the cursor through a map keyed by `ID` and, unlike the focus path, has
+  **no `Focusable` precondition**. A `FocusDisabled` control carrying an
+  `OnMouseLeave` is therefore still silently broken — the decorative opt-out
+  covers focus, not identity — and neither the focus check nor `requireFocusID`
+  catches it.
+
 - **`ergoaudit -fix` codemod** (developer-ergonomics §8, phase 1). Tools-only;
   no shipped library code changes. Mode `focus` can now rewrite the literals it
   reports, inserting a generated `ID` into each. Phase 1 tags nine `Cfg` types

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ and no visual difference:
   is keyed by `ID`, so it never joins the tab order.
 - A scrollable widget with no `ID`. Every ID-less scrollable in a window shares
   the key `""`, so they scroll in lockstep.
+- An `OnMouseLeave` on a widget with no `ID`. Leave tracking is keyed by `ID`,
+  so the callback never fires. This one survives `FocusDisabled: true` — opting
+  out of focus does not opt out of needing an identity.
 
 `gui.Debug(true)` — or `GOGUI_DEBUG=1` in the environment — audits every frame
 for these and writes findings to stderr, once per finding per window:

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -851,9 +851,9 @@ burying them in the same diff.
 | 1     | §4.2 tag 9 `Cfg`s + wire `RequireID`     | done   |
 | 1     | §8 run the codemod over the 111 literals | done   |
 | 1     | §8 README: running `requiredid` (Q8)     | done   |
-| 1     | §4.9 tag `Container`, wire scroll guard  | todo   |
-| 1     | §4.9 `checkScrollableID` analyzer rule   | todo   |
-| 1     | §4.1 `OnMouseLeave` gate check           | todo   |
+| 1     | §4.9 tag `Container`, wire scroll guard  | n/a — see below |
+| 1     | §4.9 `checkScrollableID` analyzer rule   | done   |
+| 1     | §4.1 `OnMouseLeave` gate check           | done   |
 | 2–5   | —                                        | todo   |
 
 Two corrections to §4.2 arising from the implementation.
@@ -876,6 +876,22 @@ control carrying an `OnMouseLeave` is therefore still silently broken,
 and neither `ergoaudit -mode focus` nor the §4.1 gate looks for it.
 Added to the table above as a §4.1 check rather than widening the
 runtime guard, since the opt-out is otherwise correct.
+
+**§4.9's tag is struck, not deferred.** Two of its three items do not
+apply as written. The runtime guard already exists —
+`RequireScrollID("container", cfg.Scrollable, cfg.ID)` has been wired
+in `buildContainerShape` all along; `ergoaudit` listed `ContainerCfg`
+as unguarded because it judges by tag, not by call site. And tagging
+`ContainerCfg.ID` would be wrong: most containers legitimately have no
+ID, so a `required` tag on a normally-absent field inverts the default
+and flags the common case. The rule is conditional on
+`Scrollable: true`, which is exactly how `checkFocusableID` already
+handles `Focusable: true` — keyed on the field in the literal, no tag.
+So §4.9 reduces to the analyzer rule, which is what shipped.
+
+`InputCfg` also dropped out of the scrollable gap on its own: phase 1
+made its `ID` unconditionally required, which subsumes the scroll case.
+`ContainerCfg` was the only remaining entry.
 
 **Codemod scope note.** The 111 figure included one false positive:
 `CommandButton(cmdID, ButtonCfg{})` fills the `ID` in itself, so the

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -14,9 +14,10 @@ import (
 // A family of defects in this library are silent by construction: a
 // focusable widget without an ID renders and clicks but never joins
 // the tab order, a scrollable widget without an ID shares the key ""
-// with every other ID-less scrollable in the window, and a duplicate
-// ID collapses two widgets onto one identity. None of these produce
-// an error, a panic, or a visual difference.
+// with every other ID-less scrollable in the window, an OnMouseLeave
+// on an ID-less shape never fires, and a duplicate ID collapses two
+// widgets onto one identity. None of these produce an error, a panic,
+// or a visual difference.
 //
 // The debug gate turns them into messages on stderr. It is off by
 // default and costs one atomic load per frame when off.
@@ -69,6 +70,7 @@ func envTruthy(name string) bool {
 //   - a focusable shape with no ID (never keyboard-reachable)
 //   - a scrollable shape with no ID (scroll offset shared with every
 //     other ID-less scrollable in the window)
+//   - a shape with an OnMouseLeave and no ID (the callback never fires)
 //
 // Findings go to stderr, once per finding per window. Turning the
 // gate off and on again clears that memory, so a re-enabled gate
@@ -98,6 +100,7 @@ const (
 	debugCheckDupID debugCheck = iota
 	debugCheckFocusNoID
 	debugCheckScrollNoID
+	debugCheckMouseLeaveNoID
 )
 
 // debugWarnKey is the warn-once key. For the ID-less checks the
@@ -172,7 +175,12 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids map[string]string) {
 	// keyed by ID. Render the path only when there is something to
 	// report.
 	focusBad := s.Focusable && !s.FocusSkip && !s.Disabled
-	if !focusBad && !s.Scrollable {
+	// OnMouseLeave is tracked through a map keyed by ID
+	// (layoutMouseLeave, layout_pipeline.go), and that guard has no
+	// Focusable precondition — so this fires on shapes the focus check
+	// deliberately passes over, including FocusDisabled controls.
+	leaveBad := !s.Disabled && s.events != nil && s.events.OnMouseLeave != nil
+	if !focusBad && !s.Scrollable && !leaveBad {
 		return
 	}
 	p := debugPath(path)
@@ -186,6 +194,11 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids map[string]string) {
 			"scrollable shape at %s has no ID; scroll offsets are keyed by "+
 				"ID, so it shares one offset with every other ID-less "+
 				"scrollable in this window", p)
+	}
+	if leaveBad {
+		w.debugWarn(debugCheckMouseLeaveNoID, p,
+			"shape at %s has an OnMouseLeave but no ID; leave tracking is "+
+				"keyed by ID, so the callback never fires", p)
 	}
 }
 

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -229,3 +229,79 @@ func TestStatePanicNamesBothTypes(t *testing.T) {
 	}()
 	State[want](w)
 }
+
+// An OnMouseLeave is tracked through a map keyed by ID, and that guard
+// has no Focusable precondition — so this defect exists on shapes the
+// focus check passes over, and needs its own finding.
+func TestDebugAuditMouseLeaveWithoutID(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{
+		events: &eventHandlers{OnMouseLeave: func(EventCtx) {}},
+	})
+
+	w.debugAudit(&tree)
+
+	got := buf.String()
+	if !strings.Contains(got, "has an OnMouseLeave but no ID") {
+		t.Fatalf("want mouseleave-no-ID finding, got %q", got)
+	}
+	// The shape is not focusable, so the focus check must stay quiet:
+	// two findings for one shape would misdescribe the defect.
+	if strings.Contains(got, "focusable shape") {
+		t.Errorf("focus check fired on a non-focusable shape: %q", got)
+	}
+}
+
+// The decorative opt-out covers focus, not leave tracking. A
+// FocusDisabled control with an OnMouseLeave is still broken, and this
+// is the case neither the focus check nor the requireFocusID guard
+// catches.
+func TestDebugAuditMouseLeaveOnFocusDisabledShape(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	// FocusDisabled has already been resolved into Focusable: false by
+	// the time a shape exists, which is why the focus check misses it.
+	tree := debugTree(&Shape{
+		Focusable: false,
+		events:    &eventHandlers{OnMouseLeave: func(EventCtx) {}},
+	})
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); !strings.Contains(got, "has an OnMouseLeave but no ID") {
+		t.Fatalf("want mouseleave-no-ID finding, got %q", got)
+	}
+}
+
+func TestDebugAuditMouseLeaveWithIDIsQuiet(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{
+		ID:     "panel",
+		events: &eventHandlers{OnMouseLeave: func(EventCtx) {}},
+	})
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("want silence for an ID'd shape, got %q", got)
+	}
+}
+
+// Disabled shapes never reach the leave-tracking code, so reporting
+// them would be a false positive.
+func TestDebugAuditMouseLeaveDisabledIsQuiet(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+	tree := debugTree(&Shape{
+		Disabled: true,
+		events:   &eventHandlers{OnMouseLeave: func(EventCtx) {}},
+	})
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("want silence for a disabled shape, got %q", got)
+	}
+}

--- a/tools/ergoaudit/focus.go
+++ b/tools/ergoaudit/focus.go
@@ -116,7 +116,7 @@ func runFocus(guiRoot string, repos []string, fix, dry bool, only, skip *regexp.
 		return fmt.Errorf("scanning %s: %w", guiRoot, err)
 	}
 
-	var unguarded, guarded, optIn, scrollUnguarded []string
+	var unguarded, guarded, optIn, scrollCovered []string
 	for name, c := range contracts {
 		switch {
 		case c.defaultOn && c.hasID && !c.idRequired:
@@ -128,21 +128,28 @@ func runFocus(guiRoot string, repos []string, fix, dry bool, only, skip *regexp.
 		}
 		// Scroll offsets are keyed by Shape.ID (gui/layout_position.go),
 		// so every ID-less scrollable shares the key "" and they scroll
-		// in lockstep. Report the same contract gap for Scrollable.
-		if c.scrollable && c.hasID && !c.idRequired {
-			scrollUnguarded = append(scrollUnguarded, name)
+		// in lockstep.
+		//
+		// A tag cannot express this contract: most containers have no
+		// ID and need none, so `gui:"required"` on ContainerCfg.ID
+		// would flag the common case. It is enforced instead by
+		// requiredid's checkScrollableID, which keys on Scrollable in
+		// the literal — so every Cfg here is covered whether or not its
+		// ID carries a tag, and the list is inventory, not a gap.
+		if c.scrollable && c.hasID {
+			scrollCovered = append(scrollCovered, name)
 		}
 	}
 	sort.Strings(unguarded)
 	sort.Strings(guarded)
 	sort.Strings(optIn)
-	sort.Strings(scrollUnguarded)
+	sort.Strings(scrollCovered)
 
 	fmt.Printf("focus contracts derived from %s/gui\n\n", guiRoot)
 	fmt.Printf("  opt-in (Focusable bool):            %d\n", len(optIn))
 	fmt.Printf("  default-on, ID required:            %d  %s\n", len(guarded), strings.Join(guarded, " "))
 	fmt.Printf("  default-on, ID NOT required:        %d  %s\n", len(unguarded), strings.Join(unguarded, " "))
-	fmt.Printf("  scrollable, ID NOT required:        %d  %s\n\n", len(scrollUnguarded), strings.Join(scrollUnguarded, " "))
+	fmt.Printf("  scrollable, ID enforced statically: %d  %s\n\n", len(scrollCovered), strings.Join(scrollCovered, " "))
 
 	if len(unguarded) == 0 {
 		fmt.Println("no unguarded Cfgs: nothing to audit")

--- a/tools/requiredid/requiredid.go
+++ b/tools/requiredid/requiredid.go
@@ -6,9 +6,10 @@
 // for literals that set FocusDisabled: true, the opt-out for a
 // decorative control that never joins focus traversal.
 //
-// It also flags Cfg literals that set Focusable: true without an ID.
-// Focus traversal is keyed by ID, so such a widget is silently
-// unreachable by keyboard.
+// It also flags Cfg literals that set Focusable: true without an ID,
+// which focus traversal skips, leaving the widget silently unreachable
+// by keyboard; and literals that set Scrollable: true without an ID,
+// which share one scroll offset with every other ID-less scrollable.
 package requiredid
 
 import (
@@ -63,6 +64,7 @@ func run(pass *analysis.Pass) (any, error) {
 			}
 			checkRequired(pass, lit, named, st)
 			checkFocusableID(pass, lit, named, st)
+			checkScrollableID(pass, lit, named, st)
 			return true
 		})
 	}
@@ -113,6 +115,35 @@ func checkFocusableID(
 	pass.Reportf(lit.Pos(),
 		"%s sets Focusable: true without an ID; focus traversal is keyed "+
 			"by ID, so the widget is not keyboard-reachable",
+		named.Obj().Name())
+}
+
+// checkScrollableID reports literals that set Scrollable: true but
+// leave ID unset or empty. Scroll offsets are keyed by Shape.ID, so
+// every ID-less scrollable in a window shares the key "" and they
+// scroll in lockstep — visibly wrong, but only once a second one
+// exists, which is why it survives review.
+//
+// Mirrors checkFocusableID: keyed on the field in the literal rather
+// than a tag, because a scrollable container is the exception. Most
+// containers have no ID and need none, so a gui:"required" tag on
+// ContainerCfg.ID would invert the default and flag the common case.
+func checkScrollableID(
+	pass *analysis.Pass, lit *ast.CompositeLit,
+	named *types.Named, st *types.Struct,
+) {
+	if !hasTrueField(lit, "Scrollable") {
+		return
+	}
+	if !hasField(st, "ID") {
+		return
+	}
+	if hasNonEmptyField(lit, "ID") {
+		return
+	}
+	pass.Reportf(lit.Pos(),
+		"%s sets Scrollable: true without an ID; scroll offsets are keyed "+
+			"by ID, so it shares one offset with every other ID-less scrollable",
 		named.Obj().Name())
 }
 

--- a/tools/requiredid/testdata/src/widgets/widgets.go
+++ b/tools/requiredid/testdata/src/widgets/widgets.go
@@ -43,18 +43,32 @@ type UnscopedCfg struct {
 	FocusDisabled bool
 }
 
+// ScrollCfg mirrors ContainerCfg: no tag on ID, because most
+// containers need none. The rule keys on Scrollable in the literal.
+type ScrollCfg struct {
+	ID         string
+	Scrollable bool
+}
+
+// ScrollNoIDCfg is scrollable with no ID field to set.
+type ScrollNoIDCfg struct {
+	Scrollable bool
+}
+
 type S struct{}
 
 func (S) Widget(_ WidgetCfg) {}
 
-func Widget(_ WidgetCfg)     {}
-func helper(_ WidgetCfg)     {}
-func useN(_ NoReqCfg)        {}
-func Focus(_ FocusCfg)       {}
-func NoID(_ NoIDCfg)         {}
-func Flip(_ FlipCfg)         {}
-func Scoped(_ ScopedCfg)     {}
-func Unscoped(_ UnscopedCfg) {}
+func Widget(_ WidgetCfg)         {}
+func helper(_ WidgetCfg)         {}
+func useN(_ NoReqCfg)            {}
+func Focus(_ FocusCfg)           {}
+func NoID(_ NoIDCfg)             {}
+func Flip(_ FlipCfg)             {}
+func Scoped(_ ScopedCfg)         {}
+func Unscoped(_ UnscopedCfg)     {}
+func Scroll(_ ScrollCfg)         {}
+func ScrollNoID(_ ScrollNoIDCfg) {}
 
 func good() {
 	Widget(WidgetCfg{ID: "ok", Name: "x"})
@@ -164,4 +178,35 @@ func flippedCfgSilent() {
 	Flip(FlipCfg{})
 	Flip(FlipCfg{ID: "ok"})
 	Flip(FlipCfg{FocusDisabled: true})
+}
+
+// --- Scrollable ---
+
+func scrollableNoID() {
+	Scroll(ScrollCfg{Scrollable: true}) // want `ScrollCfg sets Scrollable: true without an ID`
+}
+
+func scrollableEmptyID() {
+	Scroll(ScrollCfg{ID: "", Scrollable: true}) // want `ScrollCfg sets Scrollable: true without an ID`
+}
+
+func scrollableWithID() {
+	Scroll(ScrollCfg{ID: "ok", Scrollable: true})
+}
+
+// A non-scrollable container needs no ID: the common case, and the
+// reason this rule keys on the literal rather than a tag.
+func notScrollableNoID() {
+	Scroll(ScrollCfg{})
+}
+
+// Scrollable is not statically true; stay quiet.
+func scrollableComputedFlag() {
+	on := true
+	Scroll(ScrollCfg{Scrollable: on})
+}
+
+// No ID field to set: an unfixable diagnostic would be noise.
+func scrollableNoIDField() {
+	ScrollNoID(ScrollNoIDCfg{Scrollable: true})
 }


### PR DESCRIPTION
Phase 1 of `docs/specs/developer-ergonomics.md`, PR 5 of 5 — **completes the phase**. Follows #189, #190, #191, #192.

Both checks find **zero** live defects in this repo. That is the point of landing them: the twelve a11y defects fixed in #191 all reached release because nothing looked.

## `checkScrollableID` (§4.9)

`requiredid` now reports a literal that sets `Scrollable: true` with no `ID`. Scroll offsets are keyed by `Shape.ID`, so every ID-less scrollable in a window shares the key `""` and they scroll in lockstep — visible only once a second one exists, which is how it survives review.

**§4.9's other two items are struck, not deferred.** The spec records why:

- **The runtime guard already exists.** `RequireScrollID("container", cfg.Scrollable, cfg.ID)` has been wired in `buildContainerShape` all along. `ergoaudit` listed `ContainerCfg` as unguarded because it judges by tag, not by call site.
- **Tagging `ContainerCfg.ID` would be wrong.** Most containers legitimately have no `ID`, so a `required` tag on a normally-absent field inverts the default and flags the common case. The rule is conditional on `Scrollable: true` — exactly how `checkFocusableID` already handles `Focusable: true`: keyed on the field in the literal, no tag involved.

`InputCfg` dropped out of the scrollable gap on its own once #192 made its `ID` unconditionally required. `ContainerCfg` was the last entry.

## `OnMouseLeave` gate check (§4.1)

A fourth ID-keyed behaviour the spec does not enumerate. `layoutMouseLeave` tracks the cursor through a map keyed by `ID` and, unlike the focus path, has **no `Focusable` precondition**.

So a `FocusDisabled` control carrying an `OnMouseLeave` is still silently broken — the decorative opt-out covers focus, not identity — and neither the focus check nor `requireFocusID` catches it. There is a test for exactly that shape.

## `ergoaudit`

The `scrollable, ID NOT required` line became a permanent false alarm once the tag was ruled out as the wrong instrument: it would report `ContainerCfg` forever, and a tool that always says "1 gap" trains people to ignore it. Relabelled `ID enforced statically` and widened to list every scrollable `Cfg`, since `checkScrollableID` covers them all whether or not their `ID` carries a tag. Inventory, not a gap.

```
  default-on, ID required:            15  ButtonCfg ColorPickerCfg …
  default-on, ID NOT required:        0
  scrollable, ID enforced statically: 7   ComboboxCfg CommandPaletteCfg ContainerCfg …
```

## Verification

`gofmt`, `go vet`, `golangci-lint` (0 issues), `make gosec` (0 issues), `requiredid` clean against the repo, full `go test ./...` passing.

Both checks were mutation-tested — inverting each makes its tests fail rather than pass quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)