### PR TITLE
changelog: add v0.53.0 (developer-ergonomics phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.53.0] - 2026-08-07
+
+Developer-ergonomics phase 1 (`docs/specs/developer-ergonomics.md`), shipped as
+PRs #189–#193.
+
+A missing widget `ID` used to be invisible: the widget rendered, it clicked, and
+it silently never joined the tab order. This release makes that a panic at
+construction, a build-time diagnostic, and a runtime gate — and fixes the twelve
+places the library itself got it wrong.
+
+**Upgrading:** the nine input factories listed under _Changed_ now panic on an
+empty `Cfg.ID`. Give each control a window-unique `ID`, or set
+`FocusDisabled: true` on a control that is genuinely decorative. Measured
+against the five sibling repos, this forces three edits in total (go-charts 1,
+go-map 2), all in example code.
 
 ### Fixed
 


### PR DESCRIPTION
Release commit for developer-ergonomics phase 1 (#189, #190, #191, #192, #193).

**Minor bump, not a patch.** The nine input factories now panic on an empty `Cfg.ID` — a breaking change for any caller relying on the old silent inertness.

## What the release actually changes

A missing widget `ID` used to be invisible: the widget rendered, it clicked, and it silently never joined the tab order. It is now a panic at construction, a build-time diagnostic, and a runtime gate — plus the twelve places the library itself got this wrong are fixed.

## Sibling impact

Measured against this commit rather than taken from the spec, by running `requiredid` in each sibling with a temporary `go.work` pointing at go-gui `main`:

| Repo | Forced edits |
|---|---|
| go-charts | 1 (`examples/basic_line/main.go:86`) |
| go-map | 2 (`examples/full-map/main.go:126,139`) |
| go-edit, go-kite, go-term | 0 |

All three are in example code; no sibling library code is affected. This matches §7's estimate exactly. Nothing breaks on merge — every sibling is pinned to v0.52.0 — so each can bump and fix in a single PR after the tag exists.

Follow-up after this merges: tag `v0.53.0`, which triggers `.github/workflows/release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)