### PR TITLE
feat(testing): app-testing API + Q6 nested-scroll gate (ergonomics phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Developer-ergonomics phase 2 (`docs/specs/developer-ergonomics.md` §4.6): an
+app-testing API. Additive.
+
+### Added
+
+- **App-testing API in package `gui`.** `NewTestWindow` builds a backendless
+  window; `TestRender`, `TestClick`, `TestFocus`, `TestKey`, `TestType`,
+  `TestTab`, `TestScroll` and `TestScrollOffset` drive it by widget `ID`. Each
+  synthesizes a real `Event` and pushes it through `Window.EventFn`, then
+  settles a frame — so a test observes hit-testing, focus traversal and scroll
+  clamping, not just the callback. Failures are returned as errors
+  (`ErrTestNoSuchID`, `ErrTestDisabled`, `ErrTestNotFocusable`,
+  `ErrTestNoHandler`, `ErrTestNotVisible`, `ErrTestUnhandled`), because in a
+  test they are assertion failures, not programmer errors. See
+  [Testing your app](README.md#testing-your-app).
+
+  It lives in `gui` rather than a `guitest` subpackage because driving a click
+  requires `Shape.events`, and a sibling package could only reach it by
+  exporting that field permanently.
+
+- **Nested-scroll regression gate** (`gui/scroll_nested_test.go`). Pins the
+  current contract: an inner scrollable pinned at its limit declines the scroll
+  so it cascades to the enclosing container. This is the one place the planned
+  one-event-class collapse changes behavior with no compile error, and it was
+  untestable before `TestScroll`/`TestScrollOffset` existed.
+
 ## [v0.53.0] - 2026-08-07
 
 Developer-ergonomics phase 1 (`docs/specs/developer-ergonomics.md`), shipped as

--- a/README.md
+++ b/README.md
@@ -225,6 +225,66 @@ option — those key state by `ID` regardless of focus.
 
 ---
 
+## Testing your app
+
+`NewTestWindow` builds a window with no backend, no platform, and no run loop,
+and the `Test*` methods drive it the way a user would. Widgets are addressed by
+`ID`.
+
+```go
+func TestIncrement(t *testing.T) {
+    w := gui.NewTestWindow(gui.WindowCfg{State: &App{}})
+    w.TestRender(view)
+
+    if err := w.TestClick("increment"); err != nil {
+        t.Fatal(err)
+    }
+    if got := gui.State[App](w).Count; got != 1 {
+        t.Fatalf("Count = %d, want 1", got)
+    }
+}
+```
+
+| Method                   | Does                                                |
+| ------------------------ | --------------------------------------------------- |
+| `TestRender(view)`       | Runs one frame; returns the root `*Layout`          |
+| `TestClick(id)`          | Left press + release at the widget's visible center |
+| `TestFocus(id)`          | Moves keyboard focus                                |
+| `TestKey(id, key, mods)` | Focuses, then presses and releases a key            |
+| `TestType(id, text)`     | Focuses, then types the text one rune at a time     |
+| `TestTab(dir)`           | Tab / Shift-Tab; returns the newly focused `ID`     |
+| `TestScroll(id, dx, dy)` | Scrolls over the widget                             |
+| `TestScrollOffset(id)`   | Reads a scroll container's current offset           |
+
+Each method synthesizes a real `Event` and pushes it through the same dispatch
+the backend uses, then settles a frame. That is deliberate: it means a test sees
+the widget never joining the tab order, an overlay swallowing the click, or a
+container clamping the scroll — the failures that only exist between the widget
+and the event system. It also means the tree is rebuilt after every action, so a
+`*Layout` captured before one must not be read after it; call `TestRender(nil)`
+to get the current tree.
+
+Failures are returned as errors, not panics — an unknown `ID`, a disabled
+widget, a widget with no matching handler, or an event nothing handled. Match
+them with `errors.Is` against `gui.ErrTestNoSuchID` and friends.
+
+Two behaviors worth knowing before writing assertions:
+
+- **A nil return from `TestClick` does not prove the target fired.** Dispatch
+  does not report which shape it delivered to, so a click absorbed by an overlay
+  is indistinguishable from one the target handled. Assert on the state the
+  click was supposed to change.
+- **`TestScroll` sends a precise/trackpad scroll, not a wheel notch.** The
+  discrete-wheel path eases the offset over later frames via the animation
+  goroutine, which a headless test does not run. The precise path writes the
+  offset synchronously, which is the only thing a test can assert on.
+
+Injected interfaces (`TextMeasurer`, `SvgParser`, `NativePlatform`) stay nil, so
+text extents are approximations. Assert on structure, state and focus — not on
+pixel widths.
+
+---
+
 ## Contributing
 
 1. Install **Go 1.26+** (a C toolchain too if developing on macOS, see

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -643,6 +643,41 @@ from coordinates or targets the ID directly. Hit-testing is the more
 faithful simulation and would also catch overlay and z-order bugs;
 ID-targeting is simpler and sufficient for state-transition tests.
 
+#### 4.6.1 Corrections from the implementation (2026-08-07)
+
+Shipped in `gui/testing.go`. Three things §4.6 got wrong or left out.
+
+**The hit-testing/ID-targeting choice was a false dichotomy.** §9 Q2
+frames them as alternatives. They are orthogonal: the ID picks a
+coordinate, and dispatch then runs full hit-testing from the window
+root. `TestClick` does both. The parts of hit-testing worth having —
+z-order, clipping, disabled subtrees — come free, because the
+synthesized event goes through `Window.EventFn` rather than reaching
+into `Shape.events`. `TestClickAt(x, y)` is still a separate future
+name, but it buys only the ability to click a coordinate that no
+widget's ID names.
+
+**Overlay obstruction is not detectable, and §4.6 implied it was.** An
+overlay that covers the target consumes the click and marks the event
+handled, so `TestClick` returns nil. Dispatch does not record which
+shape it delivered to, so "the target handled it" and "something on
+top of the target handled it" are the same observation from outside.
+`ErrTestUnhandled` therefore catches only total non-delivery.
+Documented on the method and pinned by
+`TestTestClickBlockedByOverlay`. Closing the gap properly means having
+dispatch report its recipient — a change on the hottest event path,
+for a testing feature, and not worth it at this stage.
+
+**`TestScroll` must send a precise scroll, not a wheel notch.** Not a
+preference. The discrete-wheel path does not move the offset at all:
+`scrollSmoothBy` arms an exponential ease that lands over later frames
+driven by the animation goroutine, which no headless test runs — and
+`clearHotMaps` calls `scrollSmoothReset` on every view rebuild, so
+settling a frame would discard the in-flight ease regardless. Only
+`scrollVertical`/`scrollHorizontal`, the precise/trackpad path, write
+synchronously. Consequence for callers: a widget branching on
+`Event.ScrollPrecise` sees the trackpad branch under test.
+
 ### 4.7 Naming: `RTF` / `RtfCfg` casing split
 
 `RTF(cfg RtfCfg)` (`gui/view_rtf.go:212`) is the only factory whose
@@ -881,7 +916,9 @@ burying them in the same diff.
 | 1     | §4.9 tag `Container`, wire scroll guard  | n/a — see below |
 | 1     | §4.9 `checkScrollableID` analyzer rule   | done   |
 | 1     | §4.1 `OnMouseLeave` gate check           | done   |
-| 2–5   | —                                        | todo   |
+| 2     | §4.6 test API in package `gui`           | done   |
+| 2     | Q6 nested-scroll gate written as a test  | done   |
+| 3–5   | —                                        | todo   |
 
 Two corrections to §4.2 arising from the implementation.
 
@@ -1072,7 +1109,7 @@ can proceed. Q8 was resolved on 2026-08-07, before phase 1 shipped.
 | 3   | Nested focus             | unexported `Shape` helper            |
 | 4   | Focusable without ID     | proceed; mandatory `ID`              |
 | 5   | `ColorSet` zero value    | `Opt[Color]`                         |
-| 6   | Nested `OnMouseScroll`   | **gate** — test first, in phase 2    |
+| 6   | Nested `OnMouseScroll`   | gate written 2026-08-07; see below   |
 | 7   | Breaking release target  | v0.54.0 (revised; see §6)            |
 | 8   | `requiredid` for authors | **documented only** (2026-08-07)     |
 
@@ -1107,6 +1144,21 @@ Detail where the decision carries a constraint:
    can be injected but not asserted, and the gate cannot be discharged.
    This is also why §4.9 belongs in phase 1: scroll-state keying and
    scroll propagation should not both be in motion at once.
+
+   **Written 2026-08-07** as `gui/scroll_nested_test.go`. The current
+   contract holds: an inner scrollable pinned at its limit declines the
+   scroll, and traversal unwinds to the enclosing container in the same
+   gesture. Verified to fire by mutation — forcing `IsHandled = true`
+   on a scrollable under the cursor reds
+   `TestNestedScrollCascadesToParentAtLimit` with a message naming Q6.
+   Phase 4 now has something concrete to break, and breaking it is a
+   decision that has to be argued here rather than a silent behavior
+   change.
+
+   One incidental finding: the cascade is not assertable after the
+   fact. Once the outer container scrolls, the inner one is carried out
+   of view and has no clip to aim a follow-up scroll at, so the test
+   must assert across the single gesture where the handoff happens.
 7. **v0.54.0** for the §4.3/§4.4/§4.7 breaking phase; phases 2–3 as
    `v0.53.x`. Revised from the original "v0.53.0, one breaking
    release" — phase 1 turned out to be breaking and consumed that

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -1,10 +1,11 @@
 # Developer ergonomics: assessment and improvement plan
 
 Status: accepted after three independent reviews; ready to implement.
-One breaking phase (§4.3, §4.4, §4.7) targeting v0.53.0; 18
-sibling call sites affected (§7). §4.2 is entirely non-breaking and
-lands in phase 1. Phases 1–3 ship as v0.52.x. §9 Q1–Q8 all
-resolved; Q6 remains a phase-2 gate on phase 4.
+Two breaking phases: phase 1 (§4.2) shipped as v0.53.0, and §4.3/§4.4/
+§4.7 target v0.54.0 with 18 sibling call sites affected (§7). Phases
+2–3 ship as v0.53.x. §9 Q1–Q8 all resolved; Q6 remains a phase-2 gate
+on phase 4. The original single-breaking-release plan and why it was
+wrong: see the correction in §6.
 Base: `main` @ `80715d1`. Phase progress: §6.1.
 
 ## Context
@@ -422,7 +423,10 @@ originally written only *warns* about these defects; there is no reason
 to wait to fix them.
 
 With the opt-in collapse cut, **§4.2 is entirely phase 1** and contains
-no breaking change at all. Nothing here waits for v0.53.0.
+no breaking change at all. Nothing here waits for the §4.3 release.
+
+(Both claims were wrong: §4.2 wires `RequireID` into nine factories,
+which is a runtime break. See the correction in §6.)
 
 ### 4.3 One combined breaking release: events + callbacks
 
@@ -800,12 +804,33 @@ report the type held and the type requested (§4.1).
 |       | removal (§4.4)                    |          |                     |
 | 5     | §4.8 example audit                | no       | 45 files            |
 
-**Versions.** Phases 1–3 are additive and ship as `v0.52.x` point
-releases — siblings pick them up on a routine bump with no action.
-Phase 4 is the single breaking release, **v0.53.0**. Phase 5 touches
-only `examples/`, so it rides whatever release follows. Stated
-explicitly because release-consumer decisions hang off which bumps
-siblings see, and the header names only v0.53.0.
+**Versions — superseded, see the correction below.** The original plan:
+phases 1–3 are additive and ship as `v0.52.x` point releases, phase 4
+is the single breaking release **v0.53.0**, and phase 5 rides whatever
+follows.
+
+**Correction (2026-08-07).** Phase 1 shipped as **v0.53.0** and it is
+breaking. Two errors above:
+
+1. **Phase 1 is not non-breaking.** The footnote below reasons only
+   about the `gui:"required"` tag being inert in a repo that does not
+   invoke the analyzer. That much is true and was verified. But §4.2
+   also wires `RequireID` into the same nine factories, and a panic in
+   `Button` is breaking whether or not anyone runs the tool. Measured
+   rather than argued: go-charts and go-map each had example code that
+   panics at runtime on a routine bump — 3 sites, exactly the count
+   §7 predicted, reached by a mechanism §6 said could not reach them.
+2. **v0.53.0 is consumed.** Phase 4 needs **v0.54.0**.
+
+Revised: phase 1 = v0.53.0 (breaking, shipped). Phases 2–3 additive as
+`v0.53.x`. Phase 4 = v0.54.0, the second breaking release. Phase 5
+rides whatever follows.
+
+The two breaking releases are not a regression against "one breaking
+release": phase 1's break is a runtime panic on a config that was
+already broken, and phase 4's is a compile-time signature change.
+Bundling them would have delayed the a11y fix behind the event
+refactor.
 
 §4.6 moves ahead of the cosmetic work deliberately: a color-set
 refactor (§4.4) and an event-model change (§4.3) both alter behavior
@@ -813,7 +838,9 @@ that apps currently cannot assert on. Landing the test API first means
 the later phases ship with regression coverage instead of hoping the
 examples still look right.
 
-\* Phase 1 is non-breaking **for consumers**. It removes one exported
+\* **Wrong — see the correction above.** Retained because the reasoning
+about the analyzer is sound and worth keeping; the conclusion it feeds
+is not. Phase 1 is non-breaking **for consumers**. It removes one exported
 symbol with zero call sites anywhere (pre-1.0, no compatibility promise
 below v1), and adding `gui:"required"` to the 9 `Cfg`s breaks only
 go-gui's own callers — 111 of them, all in this repo's tests and
@@ -1046,7 +1073,7 @@ can proceed. Q8 was resolved on 2026-08-07, before phase 1 shipped.
 | 4   | Focusable without ID     | proceed; mandatory `ID`              |
 | 5   | `ColorSet` zero value    | `Opt[Color]`                         |
 | 6   | Nested `OnMouseScroll`   | **gate** — test first, in phase 2    |
-| 7   | Breaking release target  | v0.53.0                              |
+| 7   | Breaking release target  | v0.54.0 (revised; see §6)            |
 | 8   | `requiredid` for authors | **documented only** (2026-08-07)     |
 
 Detail where the decision carries a constraint:
@@ -1080,8 +1107,11 @@ Detail where the decision carries a constraint:
    can be injected but not asserted, and the gate cannot be discharged.
    This is also why §4.9 belongs in phase 1: scroll-state keying and
    scroll propagation should not both be in motion at once.
-7. **v0.53.0** for the breaking phase; phases 1–3 as `v0.52.x`. All 29
-   sibling edits land in one release; see §6.
+7. **v0.54.0** for the §4.3/§4.4/§4.7 breaking phase; phases 2–3 as
+   `v0.53.x`. Revised from the original "v0.53.0, one breaking
+   release" — phase 1 turned out to be breaking and consumed that
+   version. The 18 remaining sibling edits still land in one release;
+   see §6.
 8. **`requiredid` for app authors — resolved 2026-08-07: documented
    only.** It stays a `tools/` binary that authors may invoke. The
    README carries the one-line invocation and the `go vet -vettool=`

--- a/gui/scroll_nested_test.go
+++ b/gui/scroll_nested_test.go
@@ -1,0 +1,153 @@
+package gui
+
+import "testing"
+
+// Q6 phase gate (developer-ergonomics spec §9.6).
+//
+// §4.3 proposes collapsing the two event classes into one rule. Nested
+// scroll is the one case where that collapse changes behavior with no
+// compile error: OnMouseScroll is notify-class today, and an inner
+// scrollable that has reached its limit stops consuming so the event
+// cascades to the enclosing scrollable. Under a consume-by-default rule
+// the inner container would swallow it and the outer would freeze —
+// a silent regression of exactly the class §7.2 describes.
+//
+// These tests pin the current contract so phase 4 has something to
+// break. If a change to the propagation model reds them, that is the
+// gate firing, not a flaky test: the behavior below is the decision,
+// and changing it is a deliberate act that needs its own justification
+// in the spec.
+//
+// Written against the phase-2 test API (TestScroll/TestScrollOffset),
+// which is why the gate could not be discharged before now.
+
+// newNestedScrollWindow builds an outer scrollable containing a short
+// inner scrollable plus enough sibling filler that the outer can scroll
+// too. Both are taller than their viewports, so both have somewhere to
+// go and "who moved" is unambiguous.
+func newNestedScrollWindow(t *testing.T) *Window {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(_ *Window) View {
+		rows := func(n int) []View {
+			out := make([]View, 0, n)
+			for range n {
+				out = append(out, Column(ContainerCfg{
+					Sizing: FillFixed,
+					Height: 20,
+				}))
+			}
+			return out
+		}
+		return Column(ContainerCfg{
+			ID:         "outer",
+			Scrollable: true,
+			Sizing:     FixedFixed,
+			Width:      300,
+			Height:     200,
+			Content: []View{
+				Column(ContainerCfg{
+					ID:         "inner",
+					Scrollable: true,
+					Sizing:     FixedFixed,
+					Width:      280,
+					Height:     100,
+					Content:    rows(20),
+				}),
+				// Filler below the inner box, so the outer has content
+				// well past its own 200px viewport and room to receive
+				// a cascaded scroll.
+				Column(ContainerCfg{
+					Sizing:  FillFit,
+					Content: rows(40),
+				}),
+			},
+		})
+	})
+	return w
+}
+
+// Baseline: a scroll over the inner container moves the inner one and
+// leaves the outer alone. Without this, the cascade test below could
+// pass for the wrong reason (inner never receiving anything).
+func TestNestedScrollInnerConsumesWhileItCan(t *testing.T) {
+	w := newNestedScrollWindow(t)
+	if err := w.TestScroll("inner", 0, -5); err != nil {
+		t.Fatalf("TestScroll(inner) = %v, want nil", err)
+	}
+	_, inner, err := w.TestScrollOffset("inner")
+	if err != nil {
+		t.Fatalf("TestScrollOffset(inner) = %v, want nil", err)
+	}
+	_, outer, err := w.TestScrollOffset("outer")
+	if err != nil {
+		t.Fatalf("TestScrollOffset(outer) = %v, want nil", err)
+	}
+	if inner >= 0 {
+		t.Fatalf("inner offset = %v, want < 0", inner)
+	}
+	if outer != 0 {
+		t.Fatalf("outer offset = %v, want 0 — the inner had room and "+
+			"should have absorbed the scroll", outer)
+	}
+}
+
+// The gate itself. The scroll that the inner container can no longer
+// absorb must reach the outer container in the same gesture.
+//
+// Asserted at the transition rather than after it. Once the outer
+// scrolls, the inner box (100px at the top of a 200px viewport) is
+// carried out of view, its clip goes empty, and a follow-up TestScroll
+// aimed at it has no coordinate to use. So the loop watches for the
+// first gesture the inner declines and checks the outer across exactly
+// that gesture.
+func TestNestedScrollCascadesToParentAtLimit(t *testing.T) {
+	w := newNestedScrollWindow(t)
+
+	var innerEnd, outerBefore, outerAfter float32
+	cascaded := false
+	for range 100 {
+		// Snapshot both offsets, then scroll. The gesture of interest
+		// is the one after which the inner has not moved.
+		_, innerBefore, err := w.TestScrollOffset("inner")
+		if err != nil {
+			t.Fatalf("TestScrollOffset(inner) = %v, want nil", err)
+		}
+		_, ob, err := w.TestScrollOffset("outer")
+		if err != nil {
+			t.Fatalf("TestScrollOffset(outer) = %v, want nil", err)
+		}
+		// Errors are not assertable here: once the inner declines, the
+		// outer accepts, so the event is still handled and the return is
+		// still nil. The offsets are the signal.
+		if err = w.TestScroll("inner", 0, -20); err != nil {
+			t.Fatalf("TestScroll(inner) = %v, want nil", err)
+		}
+		_, innerNow, err := w.TestScrollOffset("inner")
+		if err != nil {
+			t.Fatalf("TestScrollOffset(inner) = %v, want nil", err)
+		}
+		if innerNow != innerBefore {
+			continue // inner still had room; keep going
+		}
+		_, oa, err := w.TestScrollOffset("outer")
+		if err != nil {
+			t.Fatalf("TestScrollOffset(outer) = %v, want nil", err)
+		}
+		innerEnd, outerBefore, outerAfter = innerNow, ob, oa
+		cascaded = true
+		break
+	}
+	if !cascaded {
+		t.Fatal("inner container never reached its end")
+	}
+	if innerEnd >= 0 {
+		t.Fatalf("inner offset = %v at its end, want < 0", innerEnd)
+	}
+	if outerAfter >= outerBefore {
+		t.Fatalf("outer offset %v -> %v: the pinned inner container did "+
+			"not cascade the scroll to its parent. If this is intentional, "+
+			"Q6 in docs/specs/developer-ergonomics.md is the decision "+
+			"being changed", outerBefore, outerAfter)
+	}
+}

--- a/gui/testing.go
+++ b/gui/testing.go
@@ -1,0 +1,408 @@
+package gui
+
+import (
+	"errors"
+	"fmt"
+)
+
+// This file is the app-testing API (developer-ergonomics spec §4.6).
+//
+// Why it lives in package gui rather than a gui/guitest subpackage:
+// driving a click means reaching Shape.events, which is unexported and
+// should stay that way. A sibling package could only get there if the
+// field were exported permanently, for the benefit of tests, on the
+// single hottest struct in the library. §9 Q1 resolved this as
+// "package gui".
+//
+// Why these drive Window.EventFn rather than calling the callback
+// directly: the callback is the easy half. The interesting failures are
+// in the other half — the widget never joined focus traversal, an
+// overlay swallowed the click, the container clamped the scroll offset.
+// Synthesizing an Event and pushing it through real dispatch exercises
+// all of that; reaching into Shape.events would test only the part that
+// was never broken.
+//
+// Targeting is by ID (§9 Q2). A coordinate-based TestClickAt is a
+// separate future name, not an overload of these.
+
+// Errors reported by the Test* methods. All are returned wrapped with
+// the offending ID, so callers should match with errors.Is.
+var (
+	// ErrTestNoSuchID means no layout in the current tree carries the
+	// requested ID. Usually one of: the view never rendered, the ID is
+	// misspelled, or the widget is inside a collapsed/hidden branch that
+	// the view function did not emit this frame.
+	ErrTestNoSuchID = errors.New("gui: no widget with that ID")
+
+	// ErrTestDisabled means the widget exists but is Disabled. Event
+	// traversal skips disabled subtrees entirely (isChildEnabled), so
+	// synthesizing the event would silently do nothing.
+	ErrTestDisabled = errors.New("gui: widget is disabled")
+
+	// ErrTestNotFocusable means the widget cannot hold focus, so a
+	// keyboard event addressed to it can never be delivered. Requires
+	// both Focusable and a non-empty ID (isFocusedTarget), and tab
+	// order additionally requires !FocusSkip.
+	ErrTestNotFocusable = errors.New("gui: widget is not focusable")
+
+	// ErrTestNoHandler means the widget has no handler that could
+	// respond to the synthesized event.
+	ErrTestNoHandler = errors.New("gui: widget has no handler for that event")
+
+	// ErrTestNotVisible means the widget has an empty clip rectangle, so
+	// no coordinate hits it. A widget scrolled out of view, sized to
+	// zero, or clipped away by an ancestor lands here.
+	ErrTestNotVisible = errors.New("gui: widget has no visible area")
+
+	// ErrTestUnhandled means the event was dispatched and reached the
+	// end of traversal with nothing claiming it. The widget is present
+	// and hittable, but something above it in z-order absorbed the
+	// event, or the handler called ctx.Bubble() all the way out.
+	ErrTestUnhandled = errors.New("gui: event was not handled by any widget")
+)
+
+// TabDirection selects forward or backward traversal for TestTab.
+type TabDirection int
+
+const (
+	// TabForward is plain Tab.
+	TabForward TabDirection = iota
+	// TabBackward is Shift-Tab.
+	TabBackward
+)
+
+// testWindowSize is the default viewport for a test window. Arbitrary,
+// but large enough that a FillFill root does not clip typical content
+// down to nothing — a zero-size window would make every TestClick fail
+// with ErrTestNotVisible for reasons that have nothing to do with the
+// widget under test.
+const testWindowSize = 800
+
+// NewTestWindow builds a Window suitable for headless tests: no
+// backend, no platform, no run loop.
+//
+// Differences from NewWindow, both of which exist because there is no
+// backend to do the work:
+//
+//   - Width and Height default to testWindowSize when zero, so a
+//     FillFill root has something to fill.
+//   - cfg.OnInit is invoked before returning. The backend normally calls
+//     it at window-open time, and an app that installs its view there
+//     would otherwise render nothing.
+//
+// The injected interfaces (TextMeasurer, SvgParser, NativePlatform) stay
+// nil, exactly as in the existing package tests. Layout therefore uses
+// the no-measurer fallbacks: text extents are approximations, so assert
+// on structure, state and focus, not on pixel widths.
+func NewTestWindow(cfg WindowCfg) *Window {
+	if cfg.Width == 0 {
+		cfg.Width = testWindowSize
+	}
+	if cfg.Height == 0 {
+		cfg.Height = testWindowSize
+	}
+	w := NewWindow(cfg)
+	if cfg.OnInit != nil {
+		cfg.OnInit(w)
+	}
+	return w
+}
+
+// TestRender installs view as the window's view generator and runs one
+// full frame: view function, layout arrange, renderer build. It returns
+// the composed root layout.
+//
+// Passing nil re-runs the frame with whatever generator is already
+// installed — the usual way to observe the tree after a Test* action
+// has changed state.
+//
+// The returned pointer is only valid until the next frame. Every Test*
+// action below settles a frame when the event dirtied the window, which
+// rebuilds the tree in place, so a *Layout captured before an action
+// must not be read after it. Call TestRender(nil) again instead.
+func (w *Window) TestRender(view func(*Window) View) *Layout {
+	if view != nil {
+		w.UpdateView(view)
+	}
+	w.markLayoutRefresh()
+	w.Update()
+	return &w.layout
+}
+
+// settle rebuilds the frame if the event just dispatched dirtied the
+// window. EventFn always ends with UpdateWindow, and the backend would
+// pick that up on the next FrameFn; with no backend running, nothing
+// would. Without this the caller observes pre-event geometry, and —
+// more subtly — scroll offsets stay unclamped, because the clamp lives
+// in layoutAdjustScrollOffsets during arrange, not in the scroll
+// handler.
+func (w *Window) settle() {
+	if w.refreshLayout {
+		w.Update()
+		return
+	}
+	if w.refreshRenderOnly {
+		w.updateRenderOnly()
+	}
+}
+
+// testTarget resolves id to a layout and rejects the two states in
+// which dispatching any event is meaningless.
+func (w *Window) testTarget(id string) (*Layout, error) {
+	ly, ok := w.layout.FindByID(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrTestNoSuchID, id)
+	}
+	if ly.Shape == nil {
+		return nil, fmt.Errorf("%w: %q", ErrTestNoSuchID, id)
+	}
+	if ly.Shape.Disabled {
+		return nil, fmt.Errorf("%w: %q", ErrTestDisabled, id)
+	}
+	return ly, nil
+}
+
+// testHitPoint returns a coordinate guaranteed to hit ly, or an error
+// when no such coordinate exists.
+//
+// The center of shapeClip, not of the shape: PointInShape tests the
+// clip rectangle, so a widget partly scrolled out of its container has
+// a shape center that misses and a clip center that does not.
+func testHitPoint(ly *Layout, id string) (x, y float32, err error) {
+	c := ly.Shape.shapeClip
+	if c.Width <= 0 || c.Height <= 0 {
+		return 0, 0, fmt.Errorf("%w: %q", ErrTestNotVisible, id)
+	}
+	return c.X + c.Width/2, c.Y + c.Height/2, nil
+}
+
+// TestClick synthesizes a left-button press and release at the center of
+// the widget's visible area, dispatched from the window root exactly as
+// the backend would.
+//
+// Hit-testing, not the ID, decides who receives it. The ID only picks
+// the coordinate. If a floating overlay covers the target, the overlay
+// gets the click — which is the real behavior, and the reason this
+// drives dispatch instead of calling the callback.
+//
+// Known gap: when the overlay consumes the click, this returns nil, not
+// an error. Dispatch does not report which shape it delivered to, so
+// "handled by the target" and "handled by something on top of the
+// target" are indistinguishable from here. ErrTestUnhandled therefore
+// catches only total non-delivery. Assert on the state the click was
+// supposed to change; do not read a nil return as proof the target
+// fired.
+//
+// OnClick fires on press (see mouseDownHandler), so the release is sent
+// only for the benefit of OnMouseUp handlers and drag-end logic.
+//
+// Returns ErrTestNoHandler when the widget has neither an OnClick nor
+// focusability, since a click on such a widget cannot have any effect
+// worth asserting on.
+func (w *Window) TestClick(id string) error {
+	ly, err := w.testTarget(id)
+	if err != nil {
+		return err
+	}
+	hasClick := ly.Shape.hasEvents() && ly.Shape.events.OnClick != nil
+	if !hasClick && !ly.Shape.Focusable {
+		return fmt.Errorf("%w: %q has no OnClick and is not focusable",
+			ErrTestNoHandler, id)
+	}
+	x, y, err := testHitPoint(ly, id)
+	if err != nil {
+		return err
+	}
+	down := Event{
+		Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	w.EventFn(&down)
+	// Re-resolve rather than reuse ly: the press may have changed state
+	// (focus, popup dismissal), and settling rebuilds the tree, so the
+	// release must be aimed at the post-press geometry.
+	w.settle()
+	up := Event{
+		Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	w.EventFn(&up)
+	w.settle()
+	if !down.IsHandled {
+		return fmt.Errorf("%w: click on %q", ErrTestUnhandled, id)
+	}
+	return nil
+}
+
+// testFocusable resolves id and rejects it unless it can actually hold
+// focus. Both conditions are required by isFocusedTarget; a widget with
+// Focusable set but no ID is the silent no-op the requiredid analyzer
+// and the RequireID panic exist to prevent.
+func (w *Window) testFocusable(id string) (*Layout, error) {
+	ly, err := w.testTarget(id)
+	if err != nil {
+		return nil, err
+	}
+	if !ly.Shape.Focusable {
+		return nil, fmt.Errorf("%w: %q", ErrTestNotFocusable, id)
+	}
+	return ly, nil
+}
+
+// TestFocus moves keyboard focus to the widget, as clicking it or
+// tabbing to it would.
+//
+// FocusSkip is not rejected: a skipped widget is out of tab order but
+// can still be focused programmatically, which is what this does.
+func (w *Window) TestFocus(id string) error {
+	if _, err := w.testFocusable(id); err != nil {
+		return err
+	}
+	w.SetFocus(id)
+	w.settle()
+	return nil
+}
+
+// TestKey focuses the widget and delivers one key press and release.
+//
+// Unlike TestClick this does not report ErrTestUnhandled. A focused
+// widget legitimately ignores most keys, and keydownHandler also feeds
+// global commands, tab traversal and container scrolling — "nothing
+// consumed it" is normal, not a defect. Assert on the state change
+// instead.
+func (w *Window) TestKey(id string, key KeyCode, mods Modifier) error {
+	if err := w.TestFocus(id); err != nil {
+		return err
+	}
+	down := Event{Type: EventKeyDown, KeyCode: key, Modifiers: mods}
+	w.EventFn(&down)
+	w.settle()
+	up := Event{Type: EventKeyUp, KeyCode: key, Modifiers: mods}
+	w.EventFn(&up)
+	w.settle()
+	return nil
+}
+
+// TestType focuses the widget and delivers text one rune at a time as
+// character events, the same granularity the backend produces.
+//
+// Character events, not key events: typing is EventChar, and an input
+// that only handled EventKeyDown would wrongly appear to work if this
+// sent key codes. Empty text focuses the widget and delivers nothing.
+func (w *Window) TestType(id string, text string) error {
+	if err := w.TestFocus(id); err != nil {
+		return err
+	}
+	for _, r := range text {
+		e := Event{Type: EventChar, CharCode: uint32(r)}
+		w.EventFn(&e)
+		w.settle()
+	}
+	return nil
+}
+
+// TestTab presses Tab (or Shift-Tab) and returns the ID that holds focus
+// afterwards.
+//
+// Sent as a real key event rather than by calling NextFocusable, so a
+// widget whose OnKeyDown swallows Tab is observed swallowing it: the
+// returned ID is then unchanged, which is the bug the test is looking
+// for.
+//
+// An empty returned ID means nothing is focused — typically no widget in
+// the tree qualifies for tab order (Focusable, non-empty ID, !FocusSkip,
+// !Disabled).
+func (w *Window) TestTab(dir TabDirection) (focusedID string, err error) {
+	mods := Modifier(0)
+	if dir == TabBackward {
+		mods = ModShift
+	}
+	e := Event{Type: EventKeyDown, KeyCode: KeyTab, Modifiers: mods}
+	w.EventFn(&e)
+	w.settle()
+	return w.FocusID(), nil
+}
+
+// TestScroll synthesizes a scroll over the widget and applies it
+// immediately. Positive dy scrolls up. The delta is multiplied by the
+// theme's ScrollMultiplier, exactly as a real scroll is.
+//
+// Sent as a precise/trackpad scroll (ScrollPrecise true), not a discrete
+// wheel, and that is not a detail a test can ignore: the discrete path
+// does not move the offset at all. It arms an exponential ease
+// (scrollSmoothBy) that lands over subsequent frames driven by the
+// animation goroutine, which no headless test runs — and even if one
+// did, clearHotMaps calls scrollSmoothReset on every view rebuild, so
+// settling a frame would discard the in-flight ease. The precise path
+// (scrollVertical/scrollHorizontal) writes the offset synchronously,
+// which is the only behavior a test can assert on. A widget that
+// branches on Event.ScrollPrecise will therefore see the trackpad
+// branch here.
+//
+// The widget under the cursor is not guaranteed to receive it.
+// mouseScrollHandler offers the event to the focused element's
+// OnMouseScroll first and only then falls back to the shape under the
+// cursor, so a focused scrollable elsewhere in the tree wins. Real
+// behavior, faithfully reproduced; clear focus first if the test means
+// to isolate the container.
+//
+// Returns ErrTestNoHandler when the widget is neither Scrollable nor has
+// an OnMouseScroll, and ErrTestUnhandled when the event reached no one —
+// including the case where it fell through to a scrollable already
+// pinned at its limit.
+func (w *Window) TestScroll(id string, dx, dy float32) error {
+	ly, err := w.testTarget(id)
+	if err != nil {
+		return err
+	}
+	hasScroll := ly.Shape.hasEvents() && ly.Shape.events.OnMouseScroll != nil
+	if !ly.Shape.Scrollable && !hasScroll {
+		return fmt.Errorf("%w: %q is not Scrollable and has no OnMouseScroll",
+			ErrTestNoHandler, id)
+	}
+	x, y, err := testHitPoint(ly, id)
+	if err != nil {
+		return err
+	}
+	e := Event{
+		Type:          EventMouseScroll,
+		ScrollPrecise: true, // instant path; see the doc comment
+		MouseX:        x, MouseY: y, ScrollX: dx, ScrollY: dy,
+	}
+	w.EventFn(&e)
+	w.settle()
+	if !e.IsHandled {
+		return fmt.Errorf("%w: scroll on %q", ErrTestUnhandled, id)
+	}
+	return nil
+}
+
+// TestScrollOffset reads a scroll container's current offset.
+//
+// Values are the raw stored offsets, which are zero or negative: the
+// offset is added to child positions, so scrolling down moves content up
+// and y goes negative. layoutAdjustScrollOffsets clamps them during
+// arrange, so what this returns is already bounded by content size.
+//
+// Returns ErrTestNoHandler when the widget is not Scrollable, since a
+// non-scrollable widget has no offset rather than an offset of zero, and
+// silently reporting 0 would make an over-scroll assertion pass for the
+// wrong reason.
+func (w *Window) TestScrollOffset(id string) (x, y float32, err error) {
+	ly, err := w.testTarget(id)
+	if err != nil {
+		return 0, 0, err
+	}
+	if !ly.Shape.Scrollable {
+		return 0, 0, fmt.Errorf("%w: %q is not Scrollable", ErrTestNoHandler, id)
+	}
+	// Read-only accessors: a query must not allocate the state maps as a
+	// side effect of being asked about a container that never scrolled.
+	if sx := w.scrollXRead(); sx != nil {
+		x = sx.GetOr(id, 0)
+	}
+	if sy := w.scrollYRead(); sy != nil {
+		y = sy.GetOr(id, 0)
+	}
+	return x, y, nil
+}

--- a/gui/testing_test.go
+++ b/gui/testing_test.go
@@ -1,0 +1,468 @@
+package gui
+
+import (
+	"errors"
+	"testing"
+)
+
+// These tests exercise the app-testing API against real dispatch. They
+// are deliberately written the way an app author would write them —
+// build a view, act, assert on state — because the API's whole claim is
+// that this style now works. §4.6 measured 63 example test functions of
+// which zero assert that clicking changed anything.
+
+// counterState is a minimal app state: one typed slot per window.
+type counterState struct {
+	count int
+	text  string
+	keys  []KeyCode
+}
+
+// newCounterWindow builds a window whose view is two buttons and an
+// input, all with IDs. Returns the window with one frame already
+// rendered.
+func newCounterWindow(t *testing.T) *Window {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(w *Window) View {
+		app := State[counterState](w)
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Button(ButtonCfg{
+					ID:      "inc",
+					Content: []View{Text(TextCfg{Text: "Increment"})},
+					OnClick: func(ctx EventCtx) {
+						State[counterState](ctx.Window).count++
+					},
+				}),
+				Button(ButtonCfg{
+					ID:      "dec",
+					Content: []View{Text(TextCfg{Text: "Decrement"})},
+					OnClick: func(ctx EventCtx) {
+						State[counterState](ctx.Window).count--
+					},
+				}),
+				Input(InputCfg{
+					ID:   "name",
+					Text: app.text,
+					OnKeyDown: func(ctx EventCtx) {
+						a := State[counterState](ctx.Window)
+						a.keys = append(a.keys, ctx.Event.KeyCode)
+					},
+				}),
+			},
+		})
+	})
+	return w
+}
+
+func TestTestClickInvokesOnClick(t *testing.T) {
+	w := newCounterWindow(t)
+	app := State[counterState](w)
+
+	if err := w.TestClick("inc"); err != nil {
+		t.Fatalf("TestClick(inc) = %v, want nil", err)
+	}
+	if app.count != 1 {
+		t.Fatalf("count = %d after one click, want 1", app.count)
+	}
+	// Twice more, to prove the frame settled between actions rather
+	// than the first click happening to work on a stale tree.
+	if err := w.TestClick("inc"); err != nil {
+		t.Fatalf("TestClick(inc) second = %v, want nil", err)
+	}
+	if err := w.TestClick("dec"); err != nil {
+		t.Fatalf("TestClick(dec) = %v, want nil", err)
+	}
+	if app.count != 1 {
+		t.Fatalf("count = %d after +1+1-1, want 1", app.count)
+	}
+}
+
+func TestTestClickUnknownID(t *testing.T) {
+	w := newCounterWindow(t)
+	err := w.TestClick("nope")
+	if !errors.Is(err, ErrTestNoSuchID) {
+		t.Fatalf("TestClick(nope) = %v, want ErrTestNoSuchID", err)
+	}
+}
+
+func TestTestClickDisabled(t *testing.T) {
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		return Button(ButtonCfg{
+			ID:       "off",
+			Disabled: true,
+			Content:  []View{Text(TextCfg{Text: "Off"})},
+			OnClick:  func(_ EventCtx) { t.Error("disabled button fired") },
+		})
+	})
+	err := w.TestClick("off")
+	if !errors.Is(err, ErrTestDisabled) {
+		t.Fatalf("TestClick(off) = %v, want ErrTestDisabled", err)
+	}
+}
+
+func TestTestClickNoHandler(t *testing.T) {
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		// A plain container: no OnClick, not focusable. Clicking it
+		// cannot do anything, so asking to click it is a test bug.
+		return Column(ContainerCfg{
+			ID:      "plain",
+			Sizing:  FixedFixed,
+			Width:   100,
+			Height:  50,
+			Content: []View{Text(TextCfg{Text: "inert"})},
+		})
+	})
+	err := w.TestClick("plain")
+	if !errors.Is(err, ErrTestNoHandler) {
+		t.Fatalf("TestClick(plain) = %v, want ErrTestNoHandler", err)
+	}
+}
+
+// A widget behind an overlay does not receive the click — the overlay
+// does. This separates driving real dispatch from calling
+// Shape.events.OnClick directly: the latter would fire the buried
+// button and report success on an app the user cannot operate.
+//
+// Also pins TestClick's documented gap: the return is nil, because
+// dispatch does not say who it delivered to and something did handle
+// the event. A test must assert on state, not on the nil.
+func TestTestClickBlockedByOverlay(t *testing.T) {
+	var fired, overFired bool
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FixedFixed,
+			Width:  400,
+			Height: 400,
+			Content: []View{
+				Button(ButtonCfg{
+					ID:      "under",
+					Sizing:  FillFill,
+					Content: []View{Text(TextCfg{Text: "Under"})},
+					OnClick: func(_ EventCtx) { fired = true },
+				}),
+				// Float + OverDraw lifts this out of the column's
+				// sizing and draws it on top. Sized explicitly: a
+				// floating shape has no parent to Fill against, so
+				// FillFill would collapse it to nothing and it would
+				// cover the button in name only.
+				Column(ContainerCfg{
+					ID:       "over",
+					Float:    true,
+					OverDraw: true,
+					Sizing:   FixedFixed,
+					Width:    400,
+					Height:   400,
+					OnClick:  func(_ EventCtx) { overFired = true },
+					Color:    Hex(0x000000),
+				}),
+			},
+		})
+	})
+	if err := w.TestClick("under"); err != nil {
+		t.Fatalf("TestClick(under) = %v, want nil (the overlay handled it)", err)
+	}
+	if fired {
+		t.Fatal("covered button fired; overlay did not absorb the click")
+	}
+	if !overFired {
+		t.Fatal("overlay did not receive the click either")
+	}
+}
+
+func TestTestClickFocusesFocusableWidget(t *testing.T) {
+	w := newCounterWindow(t)
+	if err := w.TestClick("name"); err != nil {
+		t.Fatalf("TestClick(name) = %v, want nil", err)
+	}
+	if got := w.FocusID(); got != "name" {
+		t.Fatalf("FocusID = %q after clicking the input, want %q", got, "name")
+	}
+}
+
+func TestTestFocusMovesFocus(t *testing.T) {
+	w := newCounterWindow(t)
+	if err := w.TestFocus("name"); err != nil {
+		t.Fatalf("TestFocus(name) = %v, want nil", err)
+	}
+	if got := w.FocusID(); got != "name" {
+		t.Fatalf("FocusID = %q, want %q", got, "name")
+	}
+}
+
+// KeyF5 rather than a navigation key: Input consumes every key it
+// handles itself (Home, End, arrows, editing keys) and only forwards
+// the leftovers to Cfg.OnKeyDown. Testing with Home would assert
+// nothing about delivery.
+func TestTestKeyReachesOnKeyDown(t *testing.T) {
+	w := newCounterWindow(t)
+	app := State[counterState](w)
+	if err := w.TestKey("name", KeyF5, 0); err != nil {
+		t.Fatalf("TestKey = %v, want nil", err)
+	}
+	if len(app.keys) != 1 || app.keys[0] != KeyF5 {
+		t.Fatalf("keys = %v, want [KeyF5]", app.keys)
+	}
+}
+
+// The complement: a key the widget handles internally must drive the
+// widget's own state, not the app callback. This is what proves TestKey
+// goes through real dispatch rather than poking a callback.
+func TestTestKeyDrivesWidgetState(t *testing.T) {
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(w *Window) View {
+		app := State[counterState](w)
+		return Input(InputCfg{
+			ID:     "name",
+			Sizing: FillFit,
+			Text:   app.text,
+			OnTextChanged: func(s string, ctx EventCtx) {
+				State[counterState](ctx.Window).text = s
+			},
+		})
+	})
+	if err := w.TestType("name", "abc"); err != nil {
+		t.Fatalf("TestType = %v, want nil", err)
+	}
+	if got := getInputState(w, "name").CursorPos; got != 3 {
+		t.Fatalf("CursorPos = %d after typing \"abc\", want 3", got)
+	}
+	if err := w.TestKey("name", KeyHome, 0); err != nil {
+		t.Fatalf("TestKey(Home) = %v, want nil", err)
+	}
+	if got := getInputState(w, "name").CursorPos; got != 0 {
+		t.Fatalf("CursorPos = %d after Home, want 0", got)
+	}
+}
+
+func TestTestFocusNotFocusable(t *testing.T) {
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			ID:      "plain",
+			Sizing:  FillFill,
+			Content: []View{Text(TextCfg{Text: "x"})},
+		})
+	})
+	err := w.TestFocus("plain")
+	if !errors.Is(err, ErrTestNotFocusable) {
+		t.Fatalf("TestFocus(plain) = %v, want ErrTestNotFocusable", err)
+	}
+}
+
+func TestTestTypeEntersText(t *testing.T) {
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(w *Window) View {
+		app := State[counterState](w)
+		return Input(InputCfg{
+			ID:     "name",
+			Sizing: FillFit,
+			Text:   app.text,
+			OnTextChanged: func(s string, ctx EventCtx) {
+				State[counterState](ctx.Window).text = s
+			},
+		})
+	})
+	if err := w.TestType("name", "héllo"); err != nil {
+		t.Fatalf("TestType = %v, want nil", err)
+	}
+	app := State[counterState](w)
+	if app.text != "héllo" {
+		t.Fatalf("text = %q, want %q", app.text, "héllo")
+	}
+}
+
+func TestTestTabTraversesInOrder(t *testing.T) {
+	w := newCounterWindow(t)
+	// Nothing focused yet, so the first Tab lands on the first
+	// candidate in DFS order.
+	got, err := w.TestTab(TabForward)
+	if err != nil {
+		t.Fatalf("TestTab = %v, want nil", err)
+	}
+	if got != "inc" {
+		t.Fatalf("first Tab focused %q, want %q", got, "inc")
+	}
+	if got, _ = w.TestTab(TabForward); got != "dec" {
+		t.Fatalf("second Tab focused %q, want %q", got, "dec")
+	}
+	if got, _ = w.TestTab(TabForward); got != "name" {
+		t.Fatalf("third Tab focused %q, want %q", got, "name")
+	}
+	// Shift-Tab walks back.
+	if got, _ = w.TestTab(TabBackward); got != "dec" {
+		t.Fatalf("Shift-Tab focused %q, want %q", got, "dec")
+	}
+}
+
+// A widget with Focusable but no ID never joins tab order. This is the
+// silent no-op phase 1 made impossible for the nine input factories;
+// containers can still express it, and TestTab must show it.
+func TestTestTabSkipsIDlessFocusable(t *testing.T) {
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					Focusable: true, // no ID: inert
+					Sizing:    FixedFixed,
+					Width:     50,
+					Height:    20,
+				}),
+				Button(ButtonCfg{
+					ID:      "real",
+					Content: []View{Text(TextCfg{Text: "Real"})},
+					OnClick: func(_ EventCtx) {},
+				}),
+			},
+		})
+	})
+	if got, _ := w.TestTab(TabForward); got != "real" {
+		t.Fatalf("Tab focused %q, want %q — ID-less focusable joined tab order",
+			got, "real")
+	}
+}
+
+// newScrollWindow builds a short scrollable container holding content
+// taller than it, so scrolling has somewhere to go.
+func newScrollWindow(t *testing.T) *Window {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		rows := make([]View, 0, 40)
+		for range 40 {
+			rows = append(rows, Column(ContainerCfg{
+				Sizing: FillFixed,
+				Height: 20,
+			}))
+		}
+		return Column(ContainerCfg{
+			ID:         "list",
+			Scrollable: true,
+			Sizing:     FixedFixed,
+			Width:      200,
+			Height:     100,
+			Content:    rows,
+		})
+	})
+	return w
+}
+
+func TestTestScrollMovesOffset(t *testing.T) {
+	w := newScrollWindow(t)
+	x, y, err := w.TestScrollOffset("list")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if x != 0 || y != 0 {
+		t.Fatalf("initial offset = (%v, %v), want (0, 0)", x, y)
+	}
+	// Negative dy scrolls down; the stored offset goes negative.
+	if err = w.TestScroll("list", 0, -3); err != nil {
+		t.Fatalf("TestScroll = %v, want nil", err)
+	}
+	_, y, err = w.TestScrollOffset("list")
+	if err != nil {
+		t.Fatalf("TestScrollOffset after scroll = %v, want nil", err)
+	}
+	if y >= 0 {
+		t.Fatalf("offset y = %v after scrolling down, want < 0", y)
+	}
+}
+
+// Scrolling past the end must stop at the content bound. Asserted as a
+// fixed point rather than against a hand-computed offset: the exact
+// bound depends on row spacing and container padding, so hard-coding it
+// would test the arithmetic in this test rather than the clamp.
+func TestTestScrollClampsAtEnd(t *testing.T) {
+	w := newScrollWindow(t)
+	for range 200 {
+		// Ignore the error: once pinned at the limit the handler stops
+		// consuming, which is the state this test is driving toward.
+		_ = w.TestScroll("list", 0, -30)
+	}
+	_, end, err := w.TestScrollOffset("list")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if end >= 0 {
+		t.Fatalf("offset y = %v after scrolling to the end, want < 0", end)
+	}
+	// Already pinned: more scrolling must be a no-op, and the handler
+	// must stop claiming the event so it can cascade to an ancestor.
+	err = w.TestScroll("list", 0, -30)
+	if !errors.Is(err, ErrTestUnhandled) {
+		t.Fatalf("TestScroll past the end = %v, want ErrTestUnhandled", err)
+	}
+	_, after, err := w.TestScrollOffset("list")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if after != end {
+		t.Fatalf("offset y moved from %v to %v past the end, want clamped",
+			end, after)
+	}
+	// Scrolling back up is not clamped away.
+	if err = w.TestScroll("list", 0, 30); err != nil {
+		t.Fatalf("TestScroll back up = %v, want nil", err)
+	}
+	_, up, err := w.TestScrollOffset("list")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if up <= end {
+		t.Fatalf("offset y = %v after scrolling up from %v, want greater",
+			up, end)
+	}
+}
+
+func TestTestScrollOffsetNotScrollable(t *testing.T) {
+	w := newCounterWindow(t)
+	_, _, err := w.TestScrollOffset("inc")
+	if !errors.Is(err, ErrTestNoHandler) {
+		t.Fatalf("TestScrollOffset(inc) = %v, want ErrTestNoHandler", err)
+	}
+}
+
+func TestTestScrollNotScrollable(t *testing.T) {
+	w := newCounterWindow(t)
+	err := w.TestScroll("inc", 0, -3)
+	if !errors.Is(err, ErrTestNoHandler) {
+		t.Fatalf("TestScroll(inc) = %v, want ErrTestNoHandler", err)
+	}
+}
+
+func TestNewTestWindowRunsOnInit(t *testing.T) {
+	var called bool
+	w := NewTestWindow(WindowCfg{
+		State:  &counterState{},
+		OnInit: func(_ *Window) { called = true },
+	})
+	if !called {
+		t.Fatal("OnInit not called by NewTestWindow")
+	}
+	if w.windowWidth != testWindowSize || w.windowHeight != testWindowSize {
+		t.Fatalf("size = %dx%d, want %dx%d",
+			w.windowWidth, w.windowHeight, testWindowSize, testWindowSize)
+	}
+}
+
+func TestTestRenderNilReusesGenerator(t *testing.T) {
+	w := newCounterWindow(t)
+	if err := w.TestClick("inc"); err != nil {
+		t.Fatalf("TestClick = %v, want nil", err)
+	}
+	root := w.TestRender(nil)
+	if root == nil {
+		t.Fatal("TestRender(nil) returned nil")
+	}
+	if _, ok := root.FindByID("inc"); !ok {
+		t.Fatal("TestRender(nil) lost the tree; generator was not reused")
+	}
+}


### PR DESCRIPTION
Phase 2 of `docs/specs/developer-ergonomics.md` (§4.6). Additive.

## The problem

§4.6 measured 63 test functions across `examples/*/main_test.go`. Zero assert that clicking a widget changed anything. That was not negligence — there was no way to write the test. Reaching a widget's `OnClick` means reaching `Shape.events`, which is unexported.

## What lands

`NewTestWindow` plus `TestRender` / `TestClick` / `TestFocus` / `TestKey` / `TestType` / `TestTab` / `TestScroll` / `TestScrollOffset`, addressing widgets by `ID`.

```go
w := gui.NewTestWindow(gui.WindowCfg{State: &App{}})
w.TestRender(view)
if err := w.TestClick("increment"); err != nil { t.Fatal(err) }
if got := gui.State[App](w).Count; got != 1 { t.Fatalf("Count = %d, want 1", got) }
```

In package `gui`, not a `guitest` subpackage (§9 Q1): the alternative is exporting `Shape.events` permanently to serve testing.

Every method synthesizes a real `Event` and pushes it through `Window.EventFn`, then settles a frame. That is the design, not an implementation detail — the failures worth catching live *between* the widget and the event system: the widget that never joined tab order, the overlay that ate the click, the container that clamped the scroll. Calling the callback directly would exercise only the half that was never broken.

Failures return errors, not panics: in a test they are assertion failures, not programmer errors at a render site.

## Q6 gate discharged

`gui/scroll_nested_test.go` pins the current nested-scroll contract — an inner scrollable at its limit declines the scroll so it cascades to the enclosing container. This is the one place §4.3's one-event-class collapse changes behavior with **no compile error**, and it was unwritable before `TestScroll`/`TestScrollOffset` existed.

Verified to actually fire: forcing `IsHandled = true` on a scrollable under the cursor reds `TestNestedScrollCascadesToParentAtLimit` with a message naming Q6. (A first mutation attempt was ineffective — the `switch` overwrites `IsHandled` — and was redone after it.)

## Three spec claims corrected (§4.6.1)

1. **Hit-testing vs ID-targeting was a false dichotomy.** §9 Q2 frames them as alternatives. They are orthogonal: the ID picks a coordinate, dispatch then hit-tests from the root. `TestClick` does both.
2. **Overlay obstruction is *not* detectable** — §4.6 implied it was. Dispatch does not report which shape it delivered to, so a click absorbed by an overlay is indistinguishable from one the target handled, and `TestClick` returns nil. `ErrTestUnhandled` catches only total non-delivery. Documented on the method and pinned by `TestTestClickBlockedByOverlay`. Closing it means having dispatch record its recipient — a change on the hottest event path, for a testing feature.
3. **`TestScroll` must send a precise scroll, not a wheel notch.** Not a preference: the discrete path does not move the offset at all. `scrollSmoothBy` arms an ease that lands over later frames via the animation goroutine, which no headless test runs — and `scrollSmoothReset` discards it on the next view rebuild regardless.

Also folds in the release-sequencing correction from the previous turn: phase 1 shipped as v0.53.0 and *was* breaking, so phase 4 moves to **v0.54.0** (Q7 updated).

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run ./...` — clean
- `go test ./...` — all pass
- 15 new API tests + 2 gate tests
- Prettier-formatted markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)