### PR TITLE
feat(color): ColorSet + Flat, Opt rule and audit (ergonomics phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,23 @@ and this project adheres to
 
 ## [Unreleased]
 
-Developer-ergonomics phase 2 (`docs/specs/developer-ergonomics.md` §4.6): an
-app-testing API. Additive.
+Developer-ergonomics phases 2 and 3 (`docs/specs/developer-ergonomics.md`
+§4.4–§4.6): an app-testing API and the `ColorSet` collapse. Additive.
 
 ### Added
+
+- **`ColorSet` and `Flat`** (`gui/color_set.go`), on `ButtonCfg` as the `Colors`
+  field. Groups `Base`, `Hover`, `Click`, `Focus`, `Border` and `BorderFocus`
+  into one value; `Flat(c)` pins all six for a widget that should not react to
+  the pointer. `Base` backs the three interactive states, `BorderFocus` falls
+  back to `Border`, and anything still unset falls through to the theme. An
+  assigned flat `Color*` field takes precedence over the set, so existing code
+  keeps its appearance. `examples/todo`'s accent button drops from six color
+  lines to one. See [Styling widgets](README.md#styling-widgets).
+
+  Fields are plain `Color`, reversing the spec's Q5: `Color` already carries its
+  own set flag, so `Opt[Color]` would have added a second, competing notion of
+  unset.
 
 - **App-testing API in package `gui`.** `NewTestWindow` builds a backendless
   window; `TestRender`, `TestClick`, `TestFocus`, `TestKey`, `TestType`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,32 @@ The `requiredid` analyzer flags this. IDs must be unique per window: menu items
 are keyed by raw command ID, so `CommandButton` namespaces its auto-filled ID
 with `cmdbtn:`.
 
+#### `Opt[T]` vs plain fields
+
+**Rule: `Opt[T]` when the zero value is a legitimate user choice that must be
+distinguishable from "unset". A plain field everywhere else.**
+
+`SizeBorder` is the worked example: a border width of `0` is something a caller
+means, so a plain `float32` cannot tell "no border" from "not specified" and
+silently applies the theme default. The same holds for `Padding`, `Radius`,
+`Spacing`, `Opacity`, and enum fields whose zero is a real member
+(`HAlignLeft == 0`). Where zero is not meaningful — most widths, heights,
+counts, and indices — `Opt` costs a wrapper call and buys nothing.
+
+Decide this when authoring the field, not by copying whichever neighbor was
+nearest.
+
+#### Colors on `Cfg` structs
+
+Use plain `Color`, never `Opt[Color]`. `Color` carries its own `set` flag
+(`gui/color.go`), so `Color{}` is unset and `ColorTransparent` is an explicit
+fully-transparent choice — the distinction `Opt` would add already exists, and
+wrapping gives the field two independent notions of unset.
+
+`ColorSet` (`gui/color_set.go`) groups the per-state colors; `Flat(c)` is the
+"keep one appearance" case. **Precedence: an assigned flat `Color*` field wins
+over the `ColorSet`**, so existing code keeps its appearance when a set arrives.
+
 ### External Dependencies
 
 - `glyph` — text shaping/rendering lib. Consumed as versioned module; a

--- a/README.md
+++ b/README.md
@@ -225,6 +225,41 @@ option — those key state by `ID` regardless of focus.
 
 ---
 
+## Styling widgets
+
+A widget that should keep one appearance through hover, press and focus used to
+mean assigning six `Color*` fields. `ColorSet` groups them, and `Flat` covers
+that case in a line:
+
+```go
+gui.Button(gui.ButtonCfg{
+    ID:     "add-todo",
+    Colors: gui.Flat(colorAccent),
+})
+```
+
+`ColorSet` has six fields — `Base`, `Hover`, `Click`, `Focus`, `Border`,
+`BorderFocus`. `Base` backs the three interactive states when they are unset, so
+`ColorSet{Base: c}` gives a widget that does not react to the pointer while
+keeping its themed border. `Flat(c)` additionally pins both borders, which is
+what makes it visually inert rather than merely uniform.
+
+Anything left unset falls through to the theme, and an unassigned `ColorSet`
+changes nothing.
+
+Two rules worth knowing:
+
+- **An assigned flat `Color*` field wins over the `ColorSet`.** The direction is
+  deliberate: code that sets flat fields today must keep its current appearance
+  when a `ColorSet` arrives from a preset or a half-finished edit.
+- **Colors are plain `Color`, not `Opt[Color]`.** `Color` already tracks whether
+  it was set, so `gui.ColorTransparent` is a real choice and `Color{}` means
+  "unspecified".
+
+`ColorSet` is on `ButtonCfg` today; other widgets still take the flat fields.
+
+---
+
 ## Testing your app
 
 `NewTestWindow` builds a window with no backend, no platform, and no run loop,

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -535,6 +535,42 @@ danger) may remove more lines than `ColorSet` alone, and the two
 compose — `ColorSet` is the mechanism, presets are the vocabulary. Ship
 `ColorSet` first; presets are a separate additive proposal.
 
+#### 4.4.1 Corrections from the implementation (2026-08-07)
+
+**Q5 is reversed: `ColorSet` uses plain `Color`, not `Opt[Color]`.** Q5's
+premise — "`Color` has no reserved zero, so a plain field cannot
+distinguish 'unset, inherit from `Base`' from 'deliberately
+transparent'" — is false against the code. `Color` carries its own
+unexported `set` flag (`gui/color.go:11`), `Color{}` is unset, and
+`ColorTransparent = Color{0, 0, 0, 0, true}` (`gui/color.go:40`) is an
+explicitly-set transparent color. The distinction `Opt` was proposed to
+add already exists, and every widget in the repo already branches on
+`Color.IsSet()`.
+
+Wrapping would have given the field two independent notions of unset,
+where `Some(Color{})` reads as "set to unset" — the same
+two-conventions defect §3.1 objects to in `InputCfg`. Pinned by
+`TestColorSetTransparentIsNotUnset`.
+
+**`Base` does not back the border fields.** §4.4 says "unset states
+fall back to `Base`". Applied literally to `Border` that produces a
+border the same color as the fill, which reads as *no* border — not a
+plausible meaning for omitting the field. `Base` backs `Hover`,
+`Click` and `Focus`; `Border` and `BorderFocus` fall through to the
+theme, and `BorderFocus` falls back to `Border` first. `Flat(c)` still
+pins all six, which is what makes it the "visually inert" case rather
+than merely "uniform fill".
+
+**Scoped to `ButtonCfg` in phase 3.** §4.4's phase-4 deletion list
+names only `gui/view_button.go:52-61`, so that is the one `Cfg` that
+gains `Colors`. `InputCfg` is the obvious next adopter — the same
+`examples/todo` view sets four of its color fields — but widening the
+additive change beyond what the measurement covered buys nothing before
+phase 4 removes the flat fields.
+
+The `examples/todo` button is now `Colors: gui.Flat(colorAccent)`, one
+line replacing six, which is the saving §4.4 predicted.
+
 ### 4.5 `Opt[T]` consistency pass and value shorthands
 
 110 `Opt[T]` fields coexist with plain-value fields under no documented
@@ -564,6 +600,43 @@ the current wrappers do — these are unaffected by the decision above:
 gui.PadAll(12)  // == gui.SomeP(12, 12, 12, 12)
 gui.PadXY(8, 4)
 ```
+
+#### 4.5.1 Corrections from the implementation (2026-08-07)
+
+**The shorthands already exist, with different return types.**
+`PadAll(p) Padding` and `PadTBLR(tb, lr) Padding` are at
+`gui/padding.go:56` and `:61`. Redefining `PadAll` to return
+`Opt[Padding]` is a breaking change to an exported function used at
+nine internal sites plus the siblings, and `PadXY(x, y)` inverts
+`PadTBLR`'s argument order — a silent swap for anyone who reaches for
+the familiar name. `Some(PadAll(12))` already says it with no new API,
+so nothing was added. Dropped from phase 3 rather than deferred.
+
+**The field count is 165, not 110.** `grep` for `Opt[` field
+declarations in non-test files under `gui/` returns 165. The figure is
+worth restating because §4.5 uses it to size the work, and the audit
+below shows the work is smaller than either number implies.
+
+**Audit result: the large majority already satisfy the rule.** Grouped
+by field family, with counts:
+
+| Family                                            | Count | Verdict |
+| ------------------------------------------------- | ----- | ------- |
+| `Padding*`, `*Padding`, `CellSpacing`             | ~45   | keep — zero padding is a real choice, `NoPadding` exists |
+| `SizeBorder`, `Size*Border`                       | ~30   | keep — the worked example; zero means "no border" |
+| `Radius*`                                         | ~35   | keep — zero means square corners, theme default is not zero |
+| `Spacing*`                                        | ~11   | keep — `NoSpacing` exists |
+| `Opacity`, `BgOpacity`, `ParamA/B/D`              | 6     | keep — zero is meaningful |
+| `HAlign`, `VAlign`, `Anchor`, `TieOff`, `Mode`    | 7     | keep — enum zero is a real member (`HAlignLeft == 0`) |
+| `Value`, `Min`, `Max`, `Ratio`, `DragStep*`       | 6     | keep — zero is a legitimate slider value |
+| `Size` (text), `Width*`, `Height`, `Min/MaxWidth` | ~11   | **plain in phase 4** — zero is not a meaningful size |
+| `OffsetX/Y`, `HandleSize`, `DotSize`              | 4     | borderline; zero is expressible but equals the default anyway |
+
+So §4.5's phase-4 work is roughly **11 fields, not 165**. That is a
+materially smaller change than the section implies, and it is the
+reason the rule is worth documenting even though almost nothing has to
+move: the value is in deciding new fields correctly, not in the
+cleanup.
 
 ### 4.6 App-testing API — largest additive gap
 
@@ -918,7 +991,11 @@ burying them in the same diff.
 | 1     | §4.1 `OnMouseLeave` gate check           | done   |
 | 2     | §4.6 test API in package `gui`           | done   |
 | 2     | Q6 nested-scroll gate written as a test  | done   |
-| 3–5   | —                                        | todo   |
+| 3     | §4.4 `ColorSet` + `Flat`, on `ButtonCfg` | done   |
+| 3     | §4.5 `Opt` rule documented in `CLAUDE.md` | done  |
+| 3     | §4.5 audit of the existing `Opt` fields  | done   |
+| 3     | §4.5 `PadAll` / `PadXY` shorthands       | n/a — already exist |
+| 4–5   | —                                        | todo   |
 
 Two corrections to §4.2 arising from the implementation.
 
@@ -1108,7 +1185,7 @@ can proceed. Q8 was resolved on 2026-08-07, before phase 1 shipped.
 | 2   | Click model              | ID-targeting v1; `TestClickAt` later |
 | 3   | Nested focus             | unexported `Shape` helper            |
 | 4   | Focusable without ID     | proceed; mandatory `ID`              |
-| 5   | `ColorSet` zero value    | `Opt[Color]`                         |
+| 5   | `ColorSet` zero value    | plain `Color` (reversed; see §4.4.1) |
 | 6   | Nested `OnMouseScroll`   | gate written 2026-08-07; see below   |
 | 7   | Breaking release target  | v0.54.0 (revised; see §6)            |
 | 8   | `requiredid` for authors | **documented only** (2026-08-07)     |
@@ -1127,13 +1204,15 @@ Detail where the decision carries a constraint:
    that mark an internal child focusable get an internal path to
    propagate an ID derived from the parent's, so `Cfg.ID` stays the
    only public spelling.
-5. **`Opt[Color]` for `ColorSet`.** `Color` has no reserved zero, so a
-   plain field cannot distinguish "unset, inherit from `Base`" from
-   "deliberately transparent" — and fallback is the entire point of the
-   type. Keep literals short with `Flat(c)` for the all-states case and
-   a `Some`-style constructor for individual fields; if
-   `ColorSet{Base: gui.Some(c)}` proves noisy in practice, add a
-   `gui.Col(...)` shorthand rather than dropping `Opt`.
+5. **~~`Opt[Color]` for `ColorSet`.~~ Reversed 2026-08-07 during
+   implementation — see §4.4.1.** The original reasoning was: "`Color`
+   has no reserved zero, so a plain field cannot distinguish 'unset,
+   inherit from `Base`' from 'deliberately transparent' — and fallback
+   is the entire point of the type." That premise is false against the
+   code. `Color` has carried its own `set` flag all along, so the
+   distinction exists without a wrapper and adding one would give the
+   field two competing notions of unset. Shipped as plain `Color`;
+   `Flat(c)` survives unchanged as the all-states shorthand.
 6. **Nested scroll is the one real risk.** Under the one-rule collapse a
    nested scrollable that today relies on notify-class propagation to
    hand an unconsumed scroll to its parent changes behavior with **no

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -157,16 +157,13 @@ func composerView(w *gui.Window) gui.View {
 				},
 			}),
 			gui.Button(gui.ButtonCfg{
-				ID:               "add-todo",
-				Color:            colorAccent,
-				ColorHover:       colorAccent,
-				ColorClick:       colorAccent,
-				ColorFocus:       colorAccent,
-				ColorBorder:      colorAccent,
-				ColorBorderFocus: colorAccent,
-				Radius:           gui.SomeF(20),
-				Padding:          gui.SomeP(18, 28, 18, 28),
-				MinWidth:         140,
+				ID: "add-todo",
+				// The button keeps one appearance through hover,
+				// press and focus; Flat says that in a line.
+				Colors:   gui.Flat(colorAccent),
+				Radius:   gui.SomeF(20),
+				Padding:  gui.SomeP(18, 28, 18, 28),
+				MinWidth: 140,
 				Content: []gui.View{
 					gui.Text(gui.TextCfg{
 						Text: "ADD",

--- a/gui/color_set.go
+++ b/gui/color_set.go
@@ -1,0 +1,121 @@
+package gui
+
+// ColorSet groups the per-state colors of an interactive widget into
+// one value, so a caller who wants a single consistent appearance says
+// it once instead of assigning five or six flat Color* fields.
+//
+// Zero value is "nothing specified": every field falls back, and a
+// ColorSet a caller never touches changes nothing.
+//
+// Why plain Color and not Opt[Color]: Color already carries its own
+// set flag (see Color.IsSet), and ColorTransparent is an explicitly-set
+// fully-transparent color, so "unset" and "deliberately transparent"
+// are already distinguishable without a wrapper. Wrapping would give
+// the type two independent notions of unset — Some(Color{}) would mean
+// "set to unset" — and every existing widget already branches on
+// Color.IsSet.
+type ColorSet struct {
+	// Base is the resting background color. It is also the fallback
+	// for Hover, Click and Focus when those are unset.
+	Base Color
+
+	// Hover, Click and Focus are the background colors for the three
+	// interactive states. Unset means "same as Base".
+	Hover Color
+	Click Color
+	Focus Color
+
+	// Border is the border color. It does NOT fall back to Base —
+	// a border the same color as the fill reads as no border at all,
+	// which is not what omitting the field should mean. Unset falls
+	// through to the theme.
+	Border Color
+
+	// BorderFocus is the border color while keyboard-focused. Unset
+	// falls back to Border, then to the theme.
+	BorderFocus Color
+}
+
+// Flat returns a ColorSet whose every field is c, including the two
+// border fields. This is the "do not react" case: a widget that keeps
+// one appearance through hover, press and focus.
+//
+// Flat is not the same as ColorSet{Base: c}. Base only backs the three
+// interactive states; Flat also pins the borders, which is what makes
+// the widget visually inert rather than merely uniform in its fill.
+func Flat(c Color) ColorSet {
+	return ColorSet{
+		Base:        c,
+		Hover:       c,
+		Click:       c,
+		Focus:       c,
+		Border:      c,
+		BorderFocus: c,
+	}
+}
+
+// IsSet reports whether any field of the set was specified. Used by
+// widgets to skip resolution entirely for the common zero-value case.
+func (cs ColorSet) IsSet() bool {
+	return cs.Base.IsSet() || cs.Hover.IsSet() || cs.Click.IsSet() ||
+		cs.Focus.IsSet() || cs.Border.IsSet() || cs.BorderFocus.IsSet()
+}
+
+// resolve returns the set with its internal fallbacks applied: the
+// three interactive states default to Base, and BorderFocus defaults
+// to Border. Fields still unset after this have nothing to say and are
+// left for the theme.
+func (cs ColorSet) resolve() ColorSet {
+	if cs.Base.IsSet() {
+		if !cs.Hover.IsSet() {
+			cs.Hover = cs.Base
+		}
+		if !cs.Click.IsSet() {
+			cs.Click = cs.Base
+		}
+		if !cs.Focus.IsSet() {
+			cs.Focus = cs.Base
+		}
+	}
+	if !cs.BorderFocus.IsSet() && cs.Border.IsSet() {
+		cs.BorderFocus = cs.Border
+	}
+	return cs
+}
+
+// applyTo fills each of the six flat Color* destinations from the set,
+// but only where the destination is still unset.
+//
+// That ordering is the precedence rule, and it is deliberately the
+// unintuitive direction: a flat field that the caller assigned wins
+// over the ColorSet. The reason is migration safety. Existing code
+// assigns flat fields; when a ColorSet arrives — from a preset, a
+// shared style value, or a half-finished edit — that code must keep
+// the appearance it has today rather than silently changing color.
+// The newer, more specific-looking API is the one that yields.
+//
+// Fields left unset by both are untouched, so the caller's theme
+// defaults still apply afterwards.
+// Written as straight-line assignments rather than a table because
+// this runs once per styled widget per frame, and the table form puts
+// a composite literal on the view path for no readability gain.
+func (cs ColorSet) applyTo(
+	base, hover, click, focus, border, borderFocus *Color,
+) {
+	r := cs.resolve()
+	setIfUnset(base, r.Base)
+	setIfUnset(hover, r.Hover)
+	setIfUnset(click, r.Click)
+	setIfUnset(focus, r.Focus)
+	setIfUnset(border, r.Border)
+	setIfUnset(borderFocus, r.BorderFocus)
+}
+
+// setIfUnset assigns src to *dst only when dst holds no explicit color
+// and src has one. Nil dst is tolerated so a widget can pass nil for a
+// state it does not have.
+func setIfUnset(dst *Color, src Color) {
+	if dst != nil && !dst.IsSet() && src.IsSet() {
+		*dst = src
+	}
+}

--- a/gui/color_set_test.go
+++ b/gui/color_set_test.go
@@ -1,0 +1,124 @@
+package gui
+
+import "testing"
+
+func TestColorSetZeroValueIsUnset(t *testing.T) {
+	var cs ColorSet
+	if cs.IsSet() {
+		t.Fatal("zero ColorSet reports IsSet() = true, want false")
+	}
+}
+
+// Base backs the three interactive states but deliberately not the
+// borders — see the field comments on ColorSet.Border.
+func TestColorSetBaseBacksStatesNotBorders(t *testing.T) {
+	r := ColorSet{Base: Blue}.resolve()
+	for name, got := range map[string]Color{
+		"Hover": r.Hover,
+		"Click": r.Click,
+		"Focus": r.Focus,
+	} {
+		if got != Blue {
+			t.Errorf("%s = %v, want Blue (fallback to Base)", name, got)
+		}
+	}
+	if r.Border.IsSet() {
+		t.Errorf("Border = %v, want unset — Base must not back it", r.Border)
+	}
+	if r.BorderFocus.IsSet() {
+		t.Errorf("BorderFocus = %v, want unset", r.BorderFocus)
+	}
+}
+
+func TestColorSetBorderFocusFallsBackToBorder(t *testing.T) {
+	r := ColorSet{Border: Red}.resolve()
+	if r.BorderFocus != Red {
+		t.Fatalf("BorderFocus = %v, want Red", r.BorderFocus)
+	}
+}
+
+// Flat differs from ColorSet{Base: c} precisely in pinning the borders.
+func TestFlatPinsEveryFieldIncludingBorders(t *testing.T) {
+	cs := Flat(Green)
+	if cs.Base != Green || cs.Hover != Green || cs.Click != Green ||
+		cs.Focus != Green || cs.Border != Green ||
+		cs.BorderFocus != Green {
+		t.Fatalf("Flat(Green) = %+v, want every field Green", cs)
+	}
+	if base := (ColorSet{Base: Green}).resolve(); base.Border.IsSet() {
+		t.Fatal("ColorSet{Base:} resolved a Border; Flat must be the " +
+			"only way to pin borders")
+	}
+}
+
+// An explicitly transparent color is a real choice, not an omission.
+// This is the case Opt[Color] was proposed to handle, and the reason
+// it is not needed: Color already tracks it.
+func TestColorSetTransparentIsNotUnset(t *testing.T) {
+	cs := ColorSet{Base: ColorTransparent}
+	if !cs.IsSet() {
+		t.Fatal("ColorSet{Base: ColorTransparent}.IsSet() = false")
+	}
+	dst := Color{}
+	cs.applyTo(&dst, nil, nil, nil, nil, nil)
+	if dst != ColorTransparent {
+		t.Fatalf("dst = %v, want ColorTransparent", dst)
+	}
+}
+
+// The precedence rule: an assigned flat field beats the ColorSet.
+func TestColorSetApplyToLetsFlatFieldWin(t *testing.T) {
+	flat := Red
+	unset := Color{}
+	Flat(Blue).applyTo(&flat, &unset, nil, nil, nil, nil)
+	if flat != Red {
+		t.Errorf("assigned flat field = %v, want Red — ColorSet must "+
+			"not overwrite it", flat)
+	}
+	if unset != Blue {
+		t.Errorf("unassigned flat field = %v, want Blue", unset)
+	}
+}
+
+func TestColorSetApplyToToleratesNilDestinations(t *testing.T) {
+	// A widget without, say, a click color passes nil for it.
+	Flat(Blue).applyTo(nil, nil, nil, nil, nil, nil)
+}
+
+// End to end through the widget: the six-line "don't react" literal
+// collapses to one field and produces the same flat colors.
+func TestButtonColorSetReachesFlatFields(t *testing.T) {
+	cfg := ButtonCfg{ID: "b", Colors: Flat(Blue)}
+	applyButtonDefaults(&cfg)
+	if cfg.Color != Blue || cfg.ColorHover != Blue ||
+		cfg.ColorClick != Blue || cfg.ColorFocus != Blue ||
+		cfg.ColorBorder != Blue || cfg.ColorBorderFocus != Blue {
+		t.Fatalf("Flat(Blue) did not reach every flat field: %+v", cfg)
+	}
+}
+
+// Theme defaults still apply to whatever the ColorSet left unspecified.
+func TestButtonColorSetLeavesThemeDefaultsForUnsetFields(t *testing.T) {
+	cfg := ButtonCfg{ID: "b", Colors: ColorSet{Base: Blue}}
+	applyButtonDefaults(&cfg)
+	if cfg.Color != Blue {
+		t.Fatalf("Color = %v, want Blue", cfg.Color)
+	}
+	if cfg.ColorBorder != DefaultButtonStyle.ColorBorder {
+		t.Fatalf("ColorBorder = %v, want the theme default %v",
+			cfg.ColorBorder, DefaultButtonStyle.ColorBorder)
+	}
+}
+
+// Existing code that sets only flat fields must be unaffected by the
+// new field's existence.
+func TestButtonWithoutColorSetIsUnchanged(t *testing.T) {
+	withSet := ButtonCfg{ID: "b", ColorHover: Red}
+	applyButtonDefaults(&withSet)
+	if withSet.ColorHover != Red {
+		t.Fatalf("ColorHover = %v, want Red", withSet.ColorHover)
+	}
+	if withSet.Color != DefaultButtonStyle.Color {
+		t.Fatalf("Color = %v, want theme default", withSet.Color)
+	}
+}

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -48,6 +48,15 @@ type ButtonCfg struct {
 	A11YState AccessState
 	Color     Color
 
+	// Colors sets the per-state colors as one value. Use it instead of
+	// assigning the flat Color* fields below individually; Flat(c)
+	// covers the common "keep one appearance" case in a single line.
+	//
+	// Precedence: any flat Color* field the caller assigned wins over
+	// the corresponding field here. See ColorSet.applyTo for why the
+	// newer API is the one that yields.
+	Colors ColorSet
+
 	// ColorHover is the background color on mouse hover.
 	ColorHover Color
 
@@ -244,6 +253,16 @@ func CommandButton(cmdID string, cfg ButtonCfg) View {
 }
 
 func applyButtonDefaults(cfg *ButtonCfg) {
+	// ColorSet resolves first so the theme fallbacks below see it as
+	// already-specified. Flat fields the caller set are left alone by
+	// applyTo, which is the documented precedence.
+	if cfg.Colors.IsSet() {
+		cfg.Colors.applyTo(
+			&cfg.Color, &cfg.ColorHover, &cfg.ColorClick,
+			&cfg.ColorFocus, &cfg.ColorBorder, &cfg.ColorBorderFocus,
+		)
+	}
+
 	d := &DefaultButtonStyle
 	if !cfg.Color.IsSet() {
 		cfg.Color = d.Color


### PR DESCRIPTION
Developer-ergonomics phase 3 (`docs/specs/developer-ergonomics.md` §4.4, §4.5). Additive — no breaking changes.

## §4.4 `ColorSet`

`ColorSet` groups `Base`, `Hover`, `Click`, `Focus`, `Border`, `BorderFocus`; `Flat(c)` pins all six. Added to `ButtonCfg` as `Colors`. `examples/todo`'s accent button drops from six color lines to one.

Resolution: `Base` backs the three interactive states, `BorderFocus` falls back to `Border`, anything still unset falls through to the theme. An **assigned flat `Color*` field wins over the set**, so existing code keeps its appearance when a `ColorSet` arrives.

## Three spec corrections

- **Q5 reversed — plain `Color`, not `Opt[Color]`.** Q5's premise ("`Color` has no reserved zero") is false: `Color` carries its own `set` flag (`gui/color.go:11`) and `ColorTransparent` is explicitly set (`:40`). `Opt[Color]` would add a second notion of unset where `Some(Color{})` means "set to unset" — the §3.1 two-conventions defect.
- **`Base` does not back the borders.** Applied literally, "unset states fall back to `Base`" makes the border match the fill, i.e. no visible border. Not a plausible meaning for omitting the field.
- **§4.5's `PadAll`/`PadXY` already exist** (`gui/padding.go:56,61`) returning `Padding`. Redefining `PadAll` to return `Opt[Padding]` is breaking at nine internal sites plus siblings, and `PadXY(x,y)` inverts `PadTBLR`'s argument order. `Some(PadAll(12))` already works. Dropped.

## §4.5 `Opt[T]`

Rule documented in `CLAUDE.md`: `Opt[T]` when the zero value is a legitimate choice that must be distinguishable from unset; plain otherwise.

Audit recorded in the spec. The field count is **165**, not the 110 §4.5 cites, but the large majority already conform — `Padding`, `Radius`, `SizeBorder`, `Spacing`, opacities and enum fields all have meaningful zeros. Roughly **11 fields** (text `Size`, widths, heights) fail the rule and move in phase 4.

## Scope

`ColorSet` is on `ButtonCfg` only, matching §4.4's phase-4 deletion list. `InputCfg` is the obvious next adopter but widening before phase 4 removes the flat fields buys nothing.

## Verification

`go build`, `go vet`, `gofmt -l`, `golangci-lint run ./...` (0 issues), `go test ./...` all clean. Escape analysis confirms `ColorSet` resolution inlines with no heap allocation — it runs per styled widget per frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)