### PR TITLE
fix(ergoaudit): attribute call sites, dedup by type, bucket value returns

### DIFF
--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -471,6 +471,108 @@ auto-handled class. Cost is real — 23 `Bubble()`/`Consume()` sites in
 `examples/` alone plus all sibling call sites — which is precisely why
 it bundles with the signature work rather than shipping separately.
 
+#### 4.3.1 Pre-implementation verification (2026-08-08)
+
+Phase 4 is the first breaking phase, so every concrete claim in §4.3 and
+§4.7 was re-checked against the tree before any code was written. What
+follows is the result, not a plan.
+
+**Verified exactly, no change needed:** the 12 out-of-scope lifecycle
+signatures including all four `OnDone` variants; `OnCellFormat`
+returning `GridCellFormat` and `OnDetailRowView` returning `gg.View`,
+both confined to `gui/datagrid/`; zero sibling references to either;
+`RTF(cfg RtfCfg)` at `gui/view_rtf.go:212`; zero sibling references to
+`RtfCfg` or `gui.RTF`; `OnEvent` declared twice as
+`func(*Event, *Window)`; and the 8 `Color*` sibling sites, all in
+go-charts. The `27` distinct `func(T..., *Window)` signatures reproduce
+from `ergoaudit`.
+
+**Three event-driven callbacks appear in neither list.** §4.3 partitions
+27 signatures into 14 out-of-scope and 13 to convert. Scanning
+`gui/datagrid/` as well — it uses `*gg.Window`, which the §4.3 sweep
+did not match — surfaces three more:
+
+- `OnItemClick func(string, int, *Event, *Window)` — 2 call sites.
+- `OnColumnPinChange func(string, GridColumnPin, *gg.Event, *gg.Window)`
+- `OnCopyRows func([]GridRow, *gg.Event, *gg.Window) (string, bool)`
+
+The first two carry a raw `*Event` and convert cleanly. **`OnCopyRows`
+does not fit the target at all**: it returns `(string, bool)`, and both
+target shapes — `func(EventCtx)` and `func(T, EventCtx)` — return
+nothing. §4.3 found two value-returning callbacks and disposed of them
+by renaming out of the `On*` space, but that remedy does not apply
+here: `OnCopyRows` is genuinely event-driven, so it needs either a
+third target shape or an explicit exemption. This is the one gap that
+changes the design rather than the count.
+
+**`OnReorder` has one signature, not two.** "Both `OnReorder` variants"
+describes four declaration sites of an identical type. Conversely
+`OnChange` and `OnSelect` each have two genuinely distinct signatures
+that the list counts once apiece.
+
+**The `Bubble()`/`Consume()` figure is wrong, and understates the real
+cost by an order of magnitude.** `examples/` contains 19 `Consume()`
+calls and **zero** `Bubble()` calls, not 23 combined. All 26 non-test
+`Bubble()` sites are inside go-gui itself (`gui/` 15, `gui/datagrid/`
+6, `tools/eventctx` 5), plus 7 in siblings (go-edit 5, go-term 2).
+
+But counting `Bubble()`/`Consume()` measures the wrong thing. Under the
+collapse, `Consume()` keeps working unchanged; what changes is every
+**consume-class callback that relies on auto-handling** — those stop
+being handled by default and begin propagating to ancestors.
+`examples/` has **138** such sites (137 `OnClick`, 1 `OnGesture`). Most
+sit on widgets with no clickable ancestor and will be unaffected, but
+which ones those are is not determinable without checking nesting at
+each. That is the §7.2 silent class, at 138 sites rather than 23.
+
+**No sibling pays for the signature conversion.** Zero sibling call
+sites touch the 13-item convert set. After the tool fixes below, the
+five repos hold **25** `*Window`-tailed literals in go-gui-declared
+fields, and every one is `OnInit` (13), `OnDone` (9) or `OnValue`
+(3) — all in the out-of-scope 12.
+
+| Repo      | go-gui fields          | Declared by the sibling |
+| --------- | ---------------------- | ----------------------- |
+| go-charts | 9 (OnDone/OnInit/OnValue) | 0                    |
+| go-edit   | 8 (OnDone/OnInit)      | 3 (`OnFileDrop`)        |
+| go-kite   | 1 (OnInit)             | 0                       |
+| go-term   | 1 (OnInit)             | 0                       |
+| go-map    | 6 (OnInit)             | 29 (`InfoWindowAction`) |
+
+Reaching those numbers required fixing three bugs in `ergoaudit
+-mode callbacks`, each of which had produced a claim in this spec:
+
+1. **Call sites were not attributed to a declaring package.** Any
+   `OnX: func(..., *Window)` literal counted, so go-map's own
+   `mapview.InfoWindowAction.OnClick` and go-edit's own `OnFileDrop`
+   were reported as go-gui migration work. The tool now resolves the
+   literal's type through the file's imports and reports the two
+   groups separately. Nested literals that elide their type
+   (`[]T{{...}}`, exactly go-map's shape) inherit the element type.
+2. **Distinct signatures were deduplicated on printed source**, so
+   `func(movedID, beforeID string, w *Window)` and
+   `func(string, string, *Window)` counted as two. That is the origin
+   of "both `OnReorder` variants". Dedup is now by type, ignoring
+   parameter names.
+3. **Classification ignored results**, so the value-returning
+   callbacks were bucketed by their parameters — `OnCellFormat` and
+   `OnDetailRowView` as ordinary `*Window`-tailed, `OnCopyRows` as
+   ordinary `*Event`-leaking. The audit therefore could not surface
+   the one category that fits no target shape. There is now a
+   `returns a value` bucket, and it holds exactly those three.
+
+Corrected declaration figures for `./gui`: **69** distinct signatures
+(was 70), `func(T..., *Window)` **24** (was 27), `leaks raw *Event`
+**5** (was 6), `returns a value` **3** (new). The §4.3 partition
+should be restated against these.
+
+So the sibling cost of phase 4 is **not** "every change costs five
+repos a bump". It is: 8 `Color*` sites in go-charts, 7 `Bubble()`
+deletions in go-edit and go-term, and whatever silent exposure the
+model collapse creates in their consume-class handlers — which their
+71 combined `Consume()` sites suggest is the part worth measuring
+properly before starting.
+
 ### 4.4 Color-set collapse — highest per-app line savings
 
 `examples/todo/main.go:139-166` sets six `Color*` fields on one button
@@ -1125,6 +1227,13 @@ or `make ergo-audit` for the go-gui-only run. Mode `focus` **derives**
 the unguarded `Cfg` set from the source instead of hardcoding it, so the
 numbers track the code — and the per-file scan that once misreported
 `ListBoxCfg` cannot recur.
+
+**Sibling figures published before 2026-08-08 are not reliable.** Mode
+`callbacks` counted any `OnX: func(..., *Window)` literal regardless of
+which module declared the field, so sibling numbers included the
+siblings' own callbacks. It now splits the two; only the "go-gui
+fields" figure is a migration cost. See §4.3.1 for that fix and two
+others in the same mode.
 
 ## 8. Doc deliverables
 

--- a/tools/ergoaudit/callbacks.go
+++ b/tools/ergoaudit/callbacks.go
@@ -16,11 +16,12 @@ import (
 type callbackShape int
 
 const (
-	shapeBareCtx  callbackShape = iota // func(EventCtx)
-	shapePayload                       // func(T..., EventCtx)
-	shapeWindow                        // func(T..., *Window)
-	shapeRawEvent                      // mentions *Event in the parameter list
-	shapeOther                         // no trailing Window/EventCtx
+	shapeBareCtx     callbackShape = iota // func(EventCtx)
+	shapePayload                          // func(T..., EventCtx)
+	shapeWindow                           // func(T..., *Window)
+	shapeRawEvent                         // mentions *Event in the parameter list
+	shapeValueReturn                      // returns a value — fits neither target shape
+	shapeOther                            // no trailing Window/EventCtx
 )
 
 func (s callbackShape) String() string {
@@ -33,9 +34,18 @@ func (s callbackShape) String() string {
 		return "func(T..., *Window)"
 	case shapeRawEvent:
 		return "leaks raw *Event"
+	case shapeValueReturn:
+		return "returns a value"
 	default:
 		return "other"
 	}
+}
+
+// allShapes is the report order. Value-returning callbacks come first
+// because they are the ones no target signature accommodates.
+var allShapes = []callbackShape{
+	shapeValueReturn, shapeWindow, shapeRawEvent,
+	shapeBareCtx, shapePayload, shapeOther,
 }
 
 // runCallbacks reports the On* callback surface of the go-gui packages,
@@ -56,21 +66,26 @@ func runCallbacks(guiRoot string, repos []string) error {
 	fmt.Printf("On* callback declarations in %s/gui\n\n", guiRoot)
 	fmt.Printf("  raw declarations (with duplicates): %d\n", raw)
 	fmt.Printf("  distinct signatures:                %d\n\n", len(decls))
-	for _, sh := range []callbackShape{shapeBareCtx, shapePayload, shapeWindow, shapeRawEvent, shapeOther} {
+	for _, sh := range allShapes {
 		fmt.Printf("  %-24s %d\n", sh.String(), byShape[sh])
 	}
 	fmt.Println()
 
 	if *listShape != "" {
-		for _, sh := range []callbackShape{shapeWindow, shapeRawEvent, shapeOther, shapeBareCtx, shapePayload} {
+		for _, sh := range allShapes {
 			if strings.EqualFold(sh.String(), *listShape) || *listShape == "all" {
 				listSignatures(decls, sh)
 			}
 		}
 	}
 
+	// The go-gui repo is identified by path so unqualified literal
+	// types can be attributed; every other repo's bare identifiers
+	// name its own types.
+	guiAbs, _ := filepath.Abs(guiRoot)
 	for _, repo := range repos {
-		if err := reportWindowTailSites(repo); err != nil {
+		repoAbs, _ := filepath.Abs(repo)
+		if err := reportWindowTailSites(repo, repoAbs == guiAbs); err != nil {
 			return err
 		}
 	}
@@ -104,7 +119,7 @@ func scanCallbackDecls(root string) (map[string]callbackShape, int, error) {
 						continue
 					}
 					raw++
-					sig := name.Name + " " + renderExpr(fset, ft)
+					sig := name.Name + " " + renderFuncType(fset, ft)
 					out[sig] = classifyCallback(fset, ft)
 				}
 			}
@@ -115,7 +130,18 @@ func scanCallbackDecls(root string) (map[string]callbackShape, int, error) {
 }
 
 // classifyCallback buckets a callback signature by its parameters.
+//
+// Results are checked before parameters. A callback that returns a
+// value fits neither `func(EventCtx)` nor `func(T..., EventCtx)`, so
+// it is a distinct migration problem regardless of what it takes —
+// and bucketing it by its parameters hid exactly that. OnCellFormat
+// and OnDetailRowView were counted as ordinary Window-tailed
+// callbacks, and OnCopyRows as an ordinary Event-leaking one, so the
+// audit could not surface the category it most needed to.
 func classifyCallback(fset *token.FileSet, ft *ast.FuncType) callbackShape {
+	if ft.Results != nil && len(ft.Results.List) > 0 {
+		return shapeValueReturn
+	}
 	params := ft.Params.List
 	if len(params) == 0 {
 		return shapeOther
@@ -138,65 +164,222 @@ func classifyCallback(fset *token.FileSet, ft *ast.FuncType) callbackShape {
 	}
 }
 
+// guiModulePath is the module prefix that marks a composite literal's
+// type as belonging to go-gui rather than to the repo being scanned.
+const guiModulePath = "github.com/go-gui-org/go-gui"
+
 // reportWindowTailSites lists callback literals in one repo whose
-// signature ends in *Window, grouped by field name so lifecycle and
-// animation callbacks (which legitimately carry no event) are visible
-// as their own category.
-func reportWindowTailSites(repo string) error {
-	byName := map[string]int{}
-	total := 0
+// signature ends in *Window, split by which module declares the field.
+//
+// The split is the point. Without it the audit counts a sibling's own
+// callbacks as go-gui migration work: go-map's
+// mapview.InfoWindowAction.OnClick and go-edit's own OnFileDrop were
+// both reported as sibling exposure, inflating the estimate with code
+// that renaming go-gui's signatures cannot touch. Only the go-gui
+// column is a migration cost.
+func reportWindowTailSites(repo string, isGuiRepo bool) error {
+	guiSites := map[string]int{}
+	foreign := map[string]int{}
+	guiTotal, foreignTotal := 0, 0
+
 	err := walkGo(repo, func(path string, fset *token.FileSet, f *ast.File) {
-		ast.Inspect(f, func(n ast.Node) bool {
-			lit, ok := n.(*ast.CompositeLit)
-			if !ok {
-				return true
+		imports := importAliases(f)
+		// ownedByGui reports whether a literal of type t declares its
+		// fields in go-gui. An unqualified name is go-gui's only when
+		// the repo under scan is go-gui itself.
+		var ownedByGui func(t ast.Expr) bool
+		ownedByGui = func(t ast.Expr) bool {
+			switch v := t.(type) {
+			case *ast.StarExpr:
+				return ownedByGui(v.X)
+			case *ast.Ident:
+				return isGuiRepo
+			case *ast.SelectorExpr:
+				pkg, ok := v.X.(*ast.Ident)
+				if !ok {
+					return false
+				}
+				return strings.HasPrefix(imports[pkg.Name], guiModulePath)
 			}
+			return false
+		}
+
+		var visitLit func(lit *ast.CompositeLit, inherited ast.Expr)
+		visitLit = func(lit *ast.CompositeLit, inherited ast.Expr) {
+			// A nested literal may elide its type: []T{{...}} leaves
+			// the inner literal's Type nil, which is precisely the
+			// shape go-map's menu actions take.
+			typ := lit.Type
+			if typ == nil {
+				typ = inherited
+			}
+			gui := ownedByGui(typ)
+			child := elemType(typ)
 			for _, el := range lit.Elts {
+				if inner, ok := el.(*ast.CompositeLit); ok {
+					visitLit(inner, child)
+					continue
+				}
 				kv, isKV := el.(*ast.KeyValueExpr)
 				if !isKV {
+					ast.Inspect(el, inspectNested(visitLit))
 					continue
+				}
+				if inner, ok := kv.Value.(*ast.CompositeLit); ok {
+					visitLit(inner, nil)
 				}
 				key, isIdent := kv.Key.(*ast.Ident)
 				if !isIdent || !strings.HasPrefix(key.Name, "On") {
+					ast.Inspect(kv.Value, inspectNested(visitLit))
 					continue
 				}
 				fn, isFunc := kv.Value.(*ast.FuncLit)
 				if !isFunc {
 					continue
 				}
+				// A callback body can hold further literals.
+				ast.Inspect(fn.Body, inspectNested(visitLit))
 				params := fn.Type.Params.List
 				if len(params) == 0 {
 					continue
 				}
-				if baseType(renderExpr(fset, params[len(params)-1].Type)) == "Window" {
-					byName[key.Name]++
-					total++
+				last := renderExpr(fset, params[len(params)-1].Type)
+				if baseType(last) != "Window" {
+					continue
+				}
+				if gui {
+					guiSites[key.Name]++
+					guiTotal++
+				} else {
+					foreign[key.Name]++
+					foreignTotal++
 				}
 			}
-			return true
-		})
+		}
+		ast.Inspect(f, inspectNested(visitLit))
 	})
 	if err != nil {
 		return fmt.Errorf("walking %s: %w", repo, err)
 	}
 
-	fmt.Printf("=== %s: callback literals with a trailing *Window (%d) ===\n",
-		filepath.Base(repo), total)
-	names := make([]string, 0, len(byName))
-	for k := range byName {
+	base := filepath.Base(repo)
+	fmt.Printf("=== %s: callback literals with a trailing *Window ===\n", base)
+	fmt.Printf("  go-gui fields (migration cost): %d\n", guiTotal)
+	printCounts(guiSites)
+	fmt.Printf("  fields declared elsewhere (not a cost): %d\n", foreignTotal)
+	printCounts(foreign)
+	fmt.Println()
+	return nil
+}
+
+// inspectNested returns an ast.Inspect visitor that hands every
+// top-level composite literal to visitLit and does not descend into it
+// again — visitLit walks its own children so it can carry the elided
+// element type down.
+func inspectNested(visitLit func(*ast.CompositeLit, ast.Expr)) func(ast.Node) bool {
+	return func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		visitLit(lit, nil)
+		return false
+	}
+}
+
+// elemType returns the element type of a slice, array or map type, so
+// a nested literal that elided its own type can inherit it.
+func elemType(t ast.Expr) ast.Expr {
+	switch v := t.(type) {
+	case *ast.ArrayType:
+		return v.Elt
+	case *ast.MapType:
+		return v.Value
+	}
+	return nil
+}
+
+// importAliases maps each imported package's local name to its path.
+func importAliases(f *ast.File) map[string]string {
+	out := map[string]string{}
+	for _, im := range f.Imports {
+		p, err := strconv.Unquote(im.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := p
+		if i := strings.LastIndex(p, "/"); i >= 0 {
+			name = p[i+1:]
+		}
+		if im.Name != nil {
+			name = im.Name.Name
+		}
+		out[name] = p
+	}
+	return out
+}
+
+// printCounts writes a name/count block in descending count order.
+func printCounts(m map[string]int) {
+	names := make([]string, 0, len(m))
+	for k := range m {
 		names = append(names, k)
 	}
 	sort.Slice(names, func(i, j int) bool {
-		if byName[names[i]] != byName[names[j]] {
-			return byName[names[i]] > byName[names[j]]
+		if m[names[i]] != m[names[j]] {
+			return m[names[i]] > m[names[j]]
 		}
 		return names[i] < names[j]
 	})
 	for _, n := range names {
-		fmt.Println("  " + n + " " + strconv.Itoa(byName[n]))
+		fmt.Println("    " + n + " " + strconv.Itoa(m[n]))
 	}
-	fmt.Println()
-	return nil
+}
+
+// renderFuncType renders a func type using parameter and result types
+// only, discarding parameter names.
+//
+// Deduplicating on the printed source instead counts
+// `func(movedID, beforeID string, w *Window)` and
+// `func(string, string, *Window)` as two distinct signatures when they
+// are one type. That is where the "both OnReorder variants" claim came
+// from: four declarations of a single signature, three of them named,
+// reported as two. Naming is a documentation choice and must not move
+// the count.
+func renderFuncType(fset *token.FileSet, ft *ast.FuncType) string {
+	var b strings.Builder
+	b.WriteString("func(")
+	b.WriteString(renderFieldTypes(fset, ft.Params))
+	b.WriteString(")")
+	if ft.Results != nil && len(ft.Results.List) > 0 {
+		res := renderFieldTypes(fset, ft.Results)
+		if len(ft.Results.List) > 1 || len(ft.Results.List[0].Names) > 0 {
+			res = "(" + res + ")"
+		}
+		b.WriteString(" " + res)
+	}
+	return b.String()
+}
+
+// renderFieldTypes joins a field list's types, repeating a type once
+// per name so `a, b string` renders as `string, string` rather than
+// collapsing to one parameter.
+func renderFieldTypes(fset *token.FileSet, fl *ast.FieldList) string {
+	if fl == nil {
+		return ""
+	}
+	var parts []string
+	for _, f := range fl.List {
+		t := renderExpr(fset, f.Type)
+		n := len(f.Names)
+		if n == 0 {
+			n = 1
+		}
+		for range n {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // renderExpr prints an AST expression back to source text.

--- a/tools/ergoaudit/ergoaudit_test.go
+++ b/tools/ergoaudit/ergoaudit_test.go
@@ -126,10 +126,17 @@ func TestClassifyCallback(t *testing.T) {
 		{"func(string, EventCtx)", shapePayload},
 		{"func(*Window)", shapeWindow},
 		{"func(float32, *Window)", shapeWindow},
-		{"func(GridRow, *gg.Window) gg.View", shapeWindow},
 		{"func(*Event, *Window)", shapeRawEvent},
 		{"func(string, GridColumnPin, *gg.Event, *gg.Window)", shapeRawEvent},
 		{"func(*DrawContext)", shapeOther},
+		// Value-returning callbacks fit neither target shape, so they
+		// are their own bucket regardless of what they take. Bucketing
+		// these by their parameters is what hid OnCopyRows from the
+		// §4.3 partition.
+		{"func(GridRow, *gg.Window) gg.View", shapeValueReturn},
+		{"func(GridRow, int, GridColumnCfg, string, *gg.Window) GridCellFormat",
+			shapeValueReturn},
+		{"func([]GridRow, *gg.Event, *gg.Window) (string, bool)", shapeValueReturn},
 	}
 	fset := token.NewFileSet()
 	for _, c := range cases {
@@ -256,4 +263,75 @@ func findLit(t *testing.T, expr ast.Expr, want string) *ast.CompositeLit {
 		t.Fatalf("no %s literal found", want)
 	}
 	return out
+}
+
+// TestRenderFuncTypeIgnoresParamNames pins the dedupe fix. Naming a
+// parameter is a documentation choice; it must not split one signature
+// into two. This is the bug behind the spec's "both OnReorder
+// variants" — four declarations of one type, three of them named.
+func TestRenderFuncTypeIgnoresParamNames(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	var rendered []string
+	for _, src := range []string{
+		"func(movedID, beforeID string, w *Window)",
+		"func(string, string, *Window)",
+	} {
+		expr, err := parser.ParseExpr(src)
+		if err != nil {
+			t.Fatalf("parse %s: %v", src, err)
+		}
+		ft, ok := expr.(*ast.FuncType)
+		if !ok {
+			t.Fatalf("%s is not a func type", src)
+		}
+		rendered = append(rendered, renderFuncType(fset, ft))
+	}
+	if rendered[0] != rendered[1] {
+		t.Fatalf("named and unnamed forms render differently:\n  %s\n  %s",
+			rendered[0], rendered[1])
+	}
+}
+
+// A multi-value result must survive the render, so OnCopyRows stays
+// distinguishable from a callback returning one value.
+func TestRenderFuncTypeKeepsResults(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	expr, err := parser.ParseExpr("func([]GridRow, *gg.Event, *gg.Window) (string, bool)")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := renderFuncType(fset, expr.(*ast.FuncType))
+	want := "func([]GridRow, *gg.Event, *gg.Window) (string, bool)"
+	if got != want {
+		t.Fatalf("renderFuncType = %q, want %q", got, want)
+	}
+}
+
+// TestImportAliases covers both the derived name and an explicit alias,
+// since package attribution depends on resolving the qualifier.
+func TestImportAliases(t *testing.T) {
+	t.Parallel()
+	src := `package p
+import (
+	"github.com/go-gui-org/go-gui/gui"
+	gg "github.com/go-gui-org/go-gui/gui"
+	"example.com/other/mapview"
+)`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := importAliases(f)
+	for name, want := range map[string]string{
+		"gui":     "github.com/go-gui-org/go-gui/gui",
+		"gg":      "github.com/go-gui-org/go-gui/gui",
+		"mapview": "example.com/other/mapview",
+	} {
+		if got[name] != want {
+			t.Errorf("importAliases[%q] = %q, want %q", name, got[name], want)
+		}
+	}
 }


### PR DESCRIPTION
Step 1 of the revised phase-4 order. Fixes the measurement tool before trusting any further number from it.

Three bugs in `-mode callbacks`, each of which produced a wrong claim in `docs/specs/developer-ergonomics.md`:

1. **Call sites were not attributed to a declaring package.** Any `OnX: func(..., *Window)` literal counted, so go-map's own `mapview.InfoWindowAction.OnClick` and go-edit's own `OnFileDrop` were reported as go-gui migration work. The literal's type is now resolved through the file's imports, and the two groups are reported separately. Nested literals that elide their type (`[]T{{...}}` — exactly go-map's shape) inherit the element type.

2. **Distinct signatures were deduplicated on printed source.** `func(movedID, beforeID string, w *Window)` and `func(string, string, *Window)` counted as two signatures of one type. That is the origin of the spec's "both `OnReorder` variants". Dedup is now by type, ignoring parameter names.

3. **Classification ignored results.** Value-returning callbacks were bucketed by their parameters, so `OnCellFormat` and `OnDetailRowView` read as ordinary `*Window`-tailed and `OnCopyRows` as ordinary `*Event`-leaking — the audit could not surface the one category that fits neither target shape. There is now a `returns a value` bucket, holding exactly those three.

## Corrected figures

`./gui` declarations: **69** distinct (was 70), `func(T..., *Window)` **24** (was 27), `leaks raw *Event` **5** (was 6), `returns a value` **3** (new).

Across the five siblings, **25** literals use go-gui-declared fields, and every one is `OnInit` (13), `OnDone` (9) or `OnValue` (3) — all already out of scope. **No sibling pays for the §4.3 signature conversion.**

| Repo | go-gui fields | Declared by the sibling |
|---|---|---|
| go-charts | 9 | 0 |
| go-edit | 8 | 3 (`OnFileDrop`) |
| go-kite | 1 | 0 |
| go-term | 1 | 0 |
| go-map | 6 | 29 (`InfoWindowAction`) |

## Spec

§4.3.1 records the full pre-implementation verification. §7.3 now warns that sibling figures published before today are unreliable.

## Tests

The one failing existing case asserted the old behavior (`OnDetailRowView` as `*Window`-tailed) and was updated — that was the bug. Added coverage for all three fixes: name-insensitive dedup, result preservation, and import-alias resolution.

`go build`, `go vet`, `gofmt -l`, `golangci-lint` (0 issues), `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)