### PR TITLE
feat!: RTFCfg and datagrid builder renames (v0.54.0, phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to
 Developer-ergonomics phases 2 and 3 (`docs/specs/developer-ergonomics.md`
 §4.4–§4.6): an app-testing API and the `ColorSet` collapse. Additive.
 
+Phase 4 (§4.3, §4.7) has begun and **is breaking**; it will ship as v0.54.0.
+Breaking items are listed under "Changed" below as they land.
+
+### Changed
+
+- **BREAKING: `RtfCfg` is now `RTFCfg`**, and the exported `Rtf*` fields on
+  `Shape.TC` are now `RTF*` — `RTFRuns`, `RTFLayout`, `RTFFlatText`,
+  `RTFBaseStyle`, `RTFLineSpacing`. `RTF(cfg RtfCfg)` was the only factory whose
+  name disagreed with its `Cfg` in casing. The `Shape` fields are renamed
+  alongside it because leaving them as `Rtf*` next to a new `RTFCfg` would trade
+  one inconsistency for another inside the same widget. Unexported identifiers
+  (`renderRtf`, `hasRtfLayout`) are unchanged.
+
+- **BREAKING: `DataGridCfg.OnCellFormat` and `OnDetailRowView` are now
+  `CellFormat` and `DetailRowView`.** Neither is an event callback — both are
+  view builders that return a value (`GridCellFormat` and `gg.View`), so the
+  `On*` prefix misdescribed them. No reference to either name exists in any
+  sibling repo, so the rename costs nothing outside this module.
+
 ### Added
 
 - **`ColorSet` and `Flat`** (`gui/color_set.go`), on `ButtonCfg` as the `Colors`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ Breaking items are listed under "Changed" below as they land.
   one inconsistency for another inside the same widget. Unexported identifiers
   (`renderRtf`, `hasRtfLayout`) are unchanged.
 
+  The casing split was not only cosmetic. `requiredid` derives a factory name by
+  trimming `Cfg`, so `RtfCfg` implied a factory called `Rtf`, never matched the
+  real `RTF`, and every `gui.RTF(gui.RtfCfg{…})` literal was skipped as
+  possibly-wrapped. The rename re-enabled the check and surfaced four focusable
+  RTF blocks in the showcase with no `ID` — keyboard-unreachable since they were
+  written. All four now have one.
+
+### Fixed
+
+- **Four focusable RTF blocks in `examples/showcase` had no `ID`**, so they
+  rendered and clicked but never joined the tab order. Found by `requiredid`
+  once the `RTFCfg` rename let it see them.
+
 - **BREAKING: `DataGridCfg.OnCellFormat` and `OnDetailRowView` are now
   `CellFormat` and `DetailRowView`.** Neither is an event callback — both are
   view builders that return a value (`GridCellFormat` and `gg.View`), so the

--- a/examples/rtf/main.go
+++ b/examples/rtf/main.go
@@ -1,4 +1,4 @@
-// Rtf demonstrates rich text runs, links, abbreviations, and
+// RTF demonstrates rich text runs, links, abbreviations, and
 // wrapping inside the RTF widget.
 package main
 
@@ -79,7 +79,7 @@ func mainView(w *gui.Window) gui.View {
 		Scrollable: true,
 		Padding:    gui.SomeP(10, 10, 10, 10),
 		Content: []gui.View{
-			gui.RTF(gui.RtfCfg{
+			gui.RTF(gui.RTFCfg{
 				RichText:      rt,
 				Mode:          gui.TextModeWrap,
 				BaseTextStyle: &t.N3,

--- a/examples/showcase/demo_text.go
+++ b/examples/showcase/demo_text.go
@@ -320,6 +320,7 @@ func demoRtf(_ *gui.Window) gui.View {
 			// Mixed inline styles in a single paragraph
 			sectionLabel(t, "Mixed Inline Styles"),
 			gui.RTF(gui.RTFCfg{
+				ID:        "rtf-inline-styles",
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{
@@ -345,6 +346,7 @@ func demoRtf(_ *gui.Window) gui.View {
 			// Underline and strikethrough
 			sectionLabel(t, "Decorations"),
 			gui.RTF(gui.RTFCfg{
+				ID:        "rtf-decorations",
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{
@@ -368,6 +370,7 @@ func demoRtf(_ *gui.Window) gui.View {
 			// Clickable link
 			sectionLabel(t, "Links & Abbreviations"),
 			gui.RTF(gui.RTFCfg{
+				ID:        "rtf-links",
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{
@@ -390,6 +393,7 @@ func demoRtf(_ *gui.Window) gui.View {
 			// Multi-line with breaks
 			sectionLabel(t, "Line Breaks"),
 			gui.RTF(gui.RTFCfg{
+				ID:        "rtf-line-breaks",
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{

--- a/examples/showcase/demo_text.go
+++ b/examples/showcase/demo_text.go
@@ -319,7 +319,7 @@ func demoRtf(_ *gui.Window) gui.View {
 
 			// Mixed inline styles in a single paragraph
 			sectionLabel(t, "Mixed Inline Styles"),
-			gui.RTF(gui.RtfCfg{
+			gui.RTF(gui.RTFCfg{
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{
@@ -344,7 +344,7 @@ func demoRtf(_ *gui.Window) gui.View {
 
 			// Underline and strikethrough
 			sectionLabel(t, "Decorations"),
-			gui.RTF(gui.RtfCfg{
+			gui.RTF(gui.RTFCfg{
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{
@@ -367,7 +367,7 @@ func demoRtf(_ *gui.Window) gui.View {
 
 			// Clickable link
 			sectionLabel(t, "Links & Abbreviations"),
-			gui.RTF(gui.RtfCfg{
+			gui.RTF(gui.RTFCfg{
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{
@@ -389,7 +389,7 @@ func demoRtf(_ *gui.Window) gui.View {
 
 			// Multi-line with breaks
 			sectionLabel(t, "Line Breaks"),
-			gui.RTF(gui.RtfCfg{
+			gui.RTF(gui.RTFCfg{
 				Focusable: true,
 				Mode:      gui.TextModeWrap,
 				RichText: gui.RichText{

--- a/examples/showcase/docs/widget_data_grid.md
+++ b/examples/showcase/docs/widget_data_grid.md
@@ -164,8 +164,8 @@ datagrid.New(w, datagrid.DataGridCfg{
 | OnCellEdit             | func(GridCellEdit, *Event, *Window)                               | Inline cell edit committed |
 | OnRowsChange           | func([]GridRow, *Event, *Window)                                  | Row data changes           |
 | OnCellClick            | func(string, *Event, *Window)                                     | Cell clicked               |
-| OnCellFormat           | func(GridRow, int, GridColumnCfg, string, *Window) GridCellFormat | Custom cell formatting     |
-| OnDetailRowView        | func(GridRow, *Window) View                                       | Render detail row content  |
+| CellFormat             | func(GridRow, int, GridColumnCfg, string, *Window) GridCellFormat | Custom cell formatting     |
+| DetailRowView          | func(GridRow, *Window) View                                       | Render detail row content  |
 | OnCopyRows             | func([]GridRow, *Event, *Window) (string, bool)                   | Copy selected rows         |
 | OnRowActivate          | func(GridRow, *Event, *Window)                                    | Row double-click/enter     |
 

--- a/examples/showcase/docs/widget_rtf.md
+++ b/examples/showcase/docs/widget_rtf.md
@@ -5,7 +5,7 @@ text block. Build a paragraph from `RichTextRun` slices rendered by `gui.RTF`.
 
 ```go
 t := gui.CurrentTheme()
-gui.RTF(gui.RtfCfg{
+gui.RTF(gui.RTFCfg{
     RichText: gui.RichText{
         Runs: []gui.RichTextRun{
             gui.RichRun("Normal, ", t.N3),
@@ -19,7 +19,7 @@ gui.RTF(gui.RtfCfg{
 ## With Links and Abbreviations
 
 ```go
-gui.RTF(gui.RtfCfg{
+gui.RTF(gui.RTFCfg{
     RichText: gui.RichText{
         Runs: []gui.RichTextRun{
             gui.RichRun("Visit ", t.N3),

--- a/gui/datagrid/view_data_grid.go
+++ b/gui/datagrid/view_data_grid.go
@@ -203,8 +203,8 @@ type DataGridCfg struct {
 	OnCellEdit             func(GridCellEdit, gg.EventCtx)
 	OnRowsChange           func([]GridRow, gg.EventCtx)
 	OnCRUDError            func(string, gg.EventCtx)
-	OnCellFormat           func(GridRow, int, GridColumnCfg, string, *gg.Window) GridCellFormat
-	OnDetailRowView        func(GridRow, *gg.Window) gg.View
+	CellFormat             func(GridRow, int, GridColumnCfg, string, *gg.Window) GridCellFormat
+	DetailRowView          func(GridRow, *gg.Window) gg.View
 	OnCopyRows             func([]GridRow, *gg.Event, *gg.Window) (string, bool)
 	OnRowActivate          func(GridRow, gg.EventCtx)
 	Query                  GridQueryState

--- a/gui/datagrid/view_data_grid_cache.go
+++ b/gui/datagrid/view_data_grid_cache.go
@@ -59,7 +59,7 @@ func dataGridCachedPresentation(cfg *DataGridCfg, columns []GridColumnCfg, rowIn
 
 func dataGridPresentationSignature(cfg *DataGridCfg, _ []GridColumnCfg, visibleIndices []int, groupCols []string, valueCols []string, groupTitles map[string]string) uint64 {
 	h := gg.Fnv64Offset
-	if len(groupCols) == 0 && len(cfg.Aggregates) == 0 && cfg.OnDetailRowView == nil {
+	if len(groupCols) == 0 && len(cfg.Aggregates) == 0 && cfg.DetailRowView == nil {
 		h = gg.Fnv64Str(h, cfg.ID)
 		h = gg.Fnv64Byte(h, 0x1e)
 		for _, idx := range visibleIndices {
@@ -95,7 +95,7 @@ func dataGridPresentationSignature(cfg *DataGridCfg, _ []GridColumnCfg, visibleI
 		h = gg.Fnv64Str(h, agg.Label)
 		h = gg.Fnv64Byte(h, 0x1f)
 	}
-	detailEnabled := cfg.OnDetailRowView != nil
+	detailEnabled := cfg.DetailRowView != nil
 	if detailEnabled {
 		h = gg.Fnv64Byte(h, '1')
 	} else {
@@ -169,7 +169,7 @@ func dataGridPresentationRowsWithGroupRanges(cfg *DataGridCfg, _ []GridColumnCfg
 				Kind:       dataGridDisplayRowData,
 				DataRowIdx: rowIdx,
 			})
-			if cfg.OnDetailRowView != nil && dataGridDetailRowExpanded(cfg, dataGridRowID(row, rowIdx)) {
+			if cfg.DetailRowView != nil && dataGridDetailRowExpanded(cfg, dataGridRowID(row, rowIdx)) {
 				rows = append(rows, dataGridDisplayRow{
 					Kind:       dataGridDisplayRowDetail,
 					DataRowIdx: rowIdx,
@@ -224,7 +224,7 @@ func dataGridPresentationRowsWithGroupRanges(cfg *DataGridCfg, _ []GridColumnCfg
 			Kind:       dataGridDisplayRowData,
 			DataRowIdx: rowIdx,
 		})
-		if cfg.OnDetailRowView != nil && dataGridDetailRowExpanded(cfg, dataGridRowID(row, rowIdx)) {
+		if cfg.DetailRowView != nil && dataGridDetailRowExpanded(cfg, dataGridRowID(row, rowIdx)) {
 			rows = append(rows, dataGridDisplayRow{
 				Kind:       dataGridDisplayRowDetail,
 				DataRowIdx: rowIdx,

--- a/gui/datagrid/view_data_grid_rows.go
+++ b/gui/datagrid/view_data_grid_rows.go
@@ -38,7 +38,7 @@ func dataGridGroupHeaderRowView(cfg *DataGridCfg, entry dataGridDisplayRow, rowH
 
 func dataGridDetailRowView(dctx dataGridCtx, rowData GridRow, rowIdx int) gg.View {
 	cfg := dctx.cfg
-	if cfg.OnDetailRowView == nil {
+	if cfg.DetailRowView == nil {
 		return gg.Rectangle(gg.RectangleCfg{
 			Height: dctx.rowHeight,
 			Sizing: gg.FillFixed,
@@ -46,7 +46,7 @@ func dataGridDetailRowView(dctx dataGridCtx, rowData GridRow, rowIdx int) gg.Vie
 		})
 	}
 	rowID := dataGridRowID(rowData, rowIdx)
-	detailView := cfg.OnDetailRowView(rowData, dctx.w)
+	detailView := cfg.DetailRowView(rowData, dctx.w)
 	pc := cfg.PaddingCell.Get(gg.Padding{})
 	focusID := dctx.focusID
 	return gg.Row(gg.ContainerCfg{
@@ -95,7 +95,7 @@ func dataGridRowView(dctx dataGridCtx, rowData GridRow, rowIdx int, showDeleteAc
 	editEnabled := dataGridEditingEnabled(cfg)
 	editorFocusBase := dataGridCellEditorFocusBaseID(cfg, len(columns))
 	colCount := len(columns)
-	detailEnabled := cfg.OnDetailRowView != nil
+	detailEnabled := cfg.DetailRowView != nil
 	detailToggleEnabled := cfg.OnDetailExpandedChange != nil
 	detailExpanded := dataGridDetailRowExpanded(cfg, rowID)
 	isEditingRow := dctx.editingRowID == rowID && editEnabled
@@ -109,8 +109,8 @@ func dataGridRowView(dctx dataGridCtx, rowData GridRow, rowIdx int, showDeleteAc
 		}
 		textStyle := baseTextStyle
 		cellColor := gg.ColorTransparent
-		if cfg.OnCellFormat != nil {
-			cellFormat := cfg.OnCellFormat(rowData, rowIdx, col, value, w)
+		if cfg.CellFormat != nil {
+			cellFormat := cfg.CellFormat(rowData, rowIdx, col, value, w)
 			textStyle, cellColor = dataGridResolveCellFormat(baseTextStyle, cellFormat)
 		}
 		isEditingCell := isEditingRow && col.Editable
@@ -486,7 +486,7 @@ func dataGridFrozenTopViews(dctx dataGridCtx, frozenTopIndices []int, showDelete
 		rowID := dataGridRowID(rowData, rowIdx)
 		views = append(views, dataGridRowView(dctx, rowData, rowIdx, showDeleteAction))
 		displayRows++
-		if cfg.OnDetailRowView != nil && dataGridDetailRowExpanded(cfg, rowID) {
+		if cfg.DetailRowView != nil && dataGridDetailRowExpanded(cfg, rowID) {
 			views = append(views, dataGridDetailRowView(dctx, rowData, rowIdx))
 			displayRows++
 		}

--- a/gui/datagrid/view_data_grid_test.go
+++ b/gui/datagrid/view_data_grid_test.go
@@ -317,7 +317,7 @@ func TestDataGridBuildPresentationDetail(t *testing.T) {
 			{ID: "r1", Cells: map[string]string{"a": "2"}},
 		},
 		DetailExpandedRowIDs: map[string]bool{"r0": true},
-		OnDetailRowView: func(GridRow, *gg.Window) gg.View {
+		DetailRowView: func(GridRow, *gg.Window) gg.View {
 			return nil
 		},
 	}

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -45,7 +45,7 @@ func TestDebugAuditFocusableWithoutID(t *testing.T) {
 }
 
 // A focusable shape excluded from tab traversal is not a defect:
-// FocusSkip is how Text/Rtf keep click-focus without a tab stop.
+// FocusSkip is how Text/RTF keep click-focus without a tab stop.
 func TestDebugAuditFocusSkipAndDisabledAreQuiet(t *testing.T) {
 	buf := captureDebug(t)
 	w := &Window{}

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -193,12 +193,12 @@ type rtfLayoutEntry struct {
 }
 
 func layoutWrapRTF(shape *Shape, tc *ShapeTextConfig, w *Window) {
-	if tc.RtfRuns == nil {
+	if tc.RTFRuns == nil {
 		return
 	}
 	if tc.wrapCacheValid &&
 		f32AreClose(tc.wrapCacheWidth, shape.Width) &&
-		tc.RtfLayout != nil {
+		tc.RTFLayout != nil {
 		shape.Height = tc.wrapCacheHeight
 		return
 	}
@@ -208,12 +208,12 @@ func layoutWrapRTF(shape *Shape, tc *ShapeTextConfig, w *Window) {
 	// cache state mixed in so layout invalidates when an inline
 	// math fetch transitions Loading→Ready (different glyph
 	// runs: raw LaTeX text vs InlineObject placeholder).
-	contentKey := rtfRunsKey(tc.RtfRuns)
-	styleKey := rtfStyleKey(tc.RtfBaseStyle)
-	mathKey := rtfMathStateKey(tc.RtfRuns, w.viewState.diagramCache)
+	contentKey := rtfRunsKey(tc.RTFRuns)
+	styleKey := rtfStyleKey(tc.RTFBaseStyle)
+	mathKey := rtfMathStateKey(tc.RTFRuns, w.viewState.diagramCache)
 	cacheKey := contentKey ^ styleKey ^ mathKey ^
 		uint64(math.Float32bits(shape.Width)) ^
-		(uint64(math.Float32bits(tc.RtfLineSpacing)) << 1)
+		(uint64(math.Float32bits(tc.RTFLineSpacing)) << 1)
 	vs := &w.viewState
 
 	// Invalidate on theme change.
@@ -226,13 +226,13 @@ func layoutWrapRTF(shape *Shape, tc *ShapeTextConfig, w *Window) {
 	// Check cross-frame cache.
 	if vs.rtfLayoutCache != nil {
 		if entry, ok := vs.rtfLayoutCache.Get(cacheKey); ok {
-			tc.RtfLayout = &entry.Layout
+			tc.RTFLayout = &entry.Layout
 			shape.Height = entry.Layout.Height
 			tc.wrapCacheWidth = shape.Width
 			tc.wrapCacheHeight = entry.Layout.Height
 			tc.wrapCacheValid = true
-			if tc.RtfFlatText == "" {
-				tc.RtfFlatText = rtfFlatTextFromRuns(tc.RtfRuns)
+			if tc.RTFFlatText == "" {
+				tc.RTFFlatText = rtfFlatTextFromRuns(tc.RTFRuns)
 			}
 			return
 		}
@@ -249,17 +249,17 @@ func layoutWrapRTF(shape *Shape, tc *ShapeTextConfig, w *Window) {
 		vgRT = *tc.rtfGlyphRT
 	} else {
 		var mh []int64
-		vgRT, mh = tc.RtfRuns.toGlyphRichTextWithMath(
+		vgRT, mh = tc.RTFRuns.toGlyphRichTextWithMath(
 			w.viewState.diagramCache)
 		tc.rtfMathHashes = mh
 	}
 	cfg := glyph.TextConfig{
-		Style: tc.RtfBaseStyle,
+		Style: tc.RTFBaseStyle,
 		Block: glyph.BlockStyle{
 			Wrap:        glyph.WrapWord,
 			Width:       shape.Width,
 			Indent:      -tc.HangingIndent,
-			LineSpacing: tc.RtfLineSpacing,
+			LineSpacing: tc.RTFLineSpacing,
 		},
 	}
 	l, err := tm.LayoutRichText(vgRT, cfg)
@@ -267,13 +267,13 @@ func layoutWrapRTF(shape *Shape, tc *ShapeTextConfig, w *Window) {
 		return
 	}
 	rtfSuppressInlineObjectGlyphs(&l)
-	tc.RtfLayout = &l
+	tc.RTFLayout = &l
 	shape.Height = l.Height
 	tc.wrapCacheWidth = shape.Width
 	tc.wrapCacheHeight = l.Height
 	tc.wrapCacheValid = true
-	if tc.RtfFlatText == "" {
-		tc.RtfFlatText = rtfFlatTextFromRuns(tc.RtfRuns)
+	if tc.RTFFlatText == "" {
+		tc.RTFFlatText = rtfFlatTextFromRuns(tc.RTFRuns)
 	}
 
 	// Store in cross-frame cache.

--- a/gui/layout_pipeline_test.go
+++ b/gui/layout_pipeline_test.go
@@ -624,7 +624,7 @@ func abs32(x float32) float32 {
 	return x
 }
 
-// --- layoutWrapRTF: RtfFlatText population ---
+// --- layoutWrapRTF: RTFFlatText population ---
 
 func TestLayoutWrapRTF_RtfFlatText_SetOnCacheMiss(t *testing.T) {
 	w := &Window{windowBackend: windowBackend{
@@ -641,15 +641,15 @@ func TestLayoutWrapRTF_RtfFlatText_SetOnCacheMiss(t *testing.T) {
 		Width:     200,
 		TC: &ShapeTextConfig{
 			TextMode:     TextModeWrap,
-			RtfRuns:      &rt,
-			RtfBaseStyle: glyph.TextStyle{Size: 12},
+			RTFRuns:      &rt,
+			RTFBaseStyle: glyph.TextStyle{Size: 12},
 		},
 	}
 	layoutWrapRTF(shape, shape.TC, w)
 
 	want := "hello world"
-	if shape.TC.RtfFlatText != want {
-		t.Errorf("RtfFlatText = %q, want %q", shape.TC.RtfFlatText, want)
+	if shape.TC.RTFFlatText != want {
+		t.Errorf("RTFFlatText = %q, want %q", shape.TC.RTFFlatText, want)
 	}
 }
 
@@ -665,21 +665,21 @@ func TestLayoutWrapRTF_RtfFlatText_NotOverwrittenOnCacheHit(t *testing.T) {
 		Width:     200,
 		TC: &ShapeTextConfig{
 			TextMode:     TextModeWrap,
-			RtfRuns:      &rt,
-			RtfBaseStyle: glyph.TextStyle{Size: 12},
+			RTFRuns:      &rt,
+			RTFBaseStyle: glyph.TextStyle{Size: 12},
 		},
 	}
-	// First call: cache miss, RtfFlatText gets populated.
+	// First call: cache miss, RTFFlatText gets populated.
 	layoutWrapRTF(shape, shape.TC, w)
-	if shape.TC.RtfFlatText == "" {
-		t.Fatal("RtfFlatText should be set after first call")
+	if shape.TC.RTFFlatText == "" {
+		t.Fatal("RTFFlatText should be set after first call")
 	}
 	// Overwrite to verify the cache-hit path respects the if-empty guard.
-	shape.TC.RtfFlatText = "already-set"
+	shape.TC.RTFFlatText = "already-set"
 	// Second call: cache hit (same shape.Width), should not overwrite.
 	layoutWrapRTF(shape, shape.TC, w)
-	if shape.TC.RtfFlatText != "already-set" {
-		t.Errorf("RtfFlatText overwritten on cache hit, got %q",
-			shape.TC.RtfFlatText)
+	if shape.TC.RTFFlatText != "already-set" {
+		t.Errorf("RTFFlatText overwritten on cache hit, got %q",
+			shape.TC.RTFFlatText)
 	}
 }

--- a/gui/markdown_select.go
+++ b/gui/markdown_select.go
@@ -100,8 +100,8 @@ func mdWalkBlocks(l *Layout, mdID string, out *[]mdBlockInfo) {
 			H:         l.Shape.Height,
 			StartRune: tc.MarkdownBlockStart,
 			RuneLen:   tc.MarkdownRuneLen,
-			Layout:    *tc.RtfLayout, // shallow copy — safe for Items slice from cache
-			FlatText:  tc.RtfFlatText,
+			Layout:    *tc.RTFLayout, // shallow copy — safe for Items slice from cache
+			FlatText:  tc.RTFFlatText,
 			ShapeX:    l.Shape.X,
 			ShapeY:    l.Shape.Y,
 		})
@@ -130,8 +130,8 @@ func markdownBlockOnClick(ctx EventCtx) {
 	ctx.Window.SetFocus(mdID)
 
 	// Compute abs rune position within the markdown flat text.
-	gl := shape.TC.RtfLayout
-	flatText := shape.TC.RtfFlatText
+	gl := shape.TC.RTFLayout
+	flatText := shape.TC.RTFFlatText
 	byteIdx := gl.GetClosestOffset(ctx.Event.MouseX, ctx.Event.MouseY)
 	localRune := byteToRuneIndex(flatText, byteIdx)
 	absRune := uint32(localRune) + shape.TC.MarkdownBlockStart

--- a/gui/render_layout_test.go
+++ b/gui/render_layout_test.go
@@ -569,7 +569,7 @@ func TestRenderInputSelectionFallbackEmitsRect(t *testing.T) {
 	}
 }
 
-// --- renderRtf: RtfFlatText selection highlight ---
+// --- renderRtf: RTFFlatText selection highlight ---
 
 // makeCharLayout builds a glyph.Layout with CharRects for each byte of text
 // (ASCII assumed: one byte per char). Each char is 10px wide, 20px tall.
@@ -609,8 +609,8 @@ func TestRenderRtf_SelectionHighlight_Emitted(t *testing.T) {
 		Width:     float32(len(text)) * 10, Height: 20,
 		Opacity: 1.0,
 		TC: &ShapeTextConfig{
-			RtfLayout:   &gl,
-			RtfFlatText: text,
+			RTFLayout:   &gl,
+			RTFFlatText: text,
 			TextSelBeg:  2,
 			TextSelEnd:  7,
 			TextStyle:   &style,
@@ -626,7 +626,7 @@ func TestRenderRtf_SelectionHighlight_Emitted(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("expected selection highlight rect when RtfFlatText is set and selection is non-empty")
+		t.Error("expected selection highlight rect when RTFFlatText is set and selection is non-empty")
 	}
 }
 
@@ -640,8 +640,8 @@ func TestRenderRtf_EmptyRtfFlatText_NoSelectionHighlight(t *testing.T) {
 		Width:     float32(len(text)) * 10, Height: 20,
 		Opacity: 1.0,
 		TC: &ShapeTextConfig{
-			RtfLayout:   &gl,
-			RtfFlatText: "", // empty → renderInputSelection not called
+			RTFLayout:   &gl,
+			RTFFlatText: "", // empty → renderInputSelection not called
 			TextSelBeg:  2,
 			TextSelEnd:  7,
 			TextStyle:   &style,
@@ -652,7 +652,7 @@ func TestRenderRtf_EmptyRtfFlatText_NoSelectionHighlight(t *testing.T) {
 
 	for _, r := range w.renderers {
 		if r.Kind == RenderRect && r.Fill {
-			t.Error("should not emit selection highlight when RtfFlatText is empty")
+			t.Error("should not emit selection highlight when RTFFlatText is empty")
 			return
 		}
 	}

--- a/gui/render_rtf_math_test.go
+++ b/gui/render_rtf_math_test.go
@@ -36,7 +36,7 @@ func TestRenderRtfEmitsInlineMathImages(t *testing.T) {
 	shape := &Shape{
 		X: 10, Y: 20, Width: 300, Height: 100,
 		TC: &ShapeTextConfig{
-			RtfLayout:     layout,
+			RTFLayout:     layout,
 			rtfMathHashes: []int64{hash},
 		},
 	}
@@ -96,7 +96,7 @@ func TestRenderRtfNoImagesWithoutCache(t *testing.T) {
 	}
 	shape := &Shape{
 		X: 0, Y: 0, Width: 200, Height: 100,
-		TC: &ShapeTextConfig{RtfLayout: layout},
+		TC: &ShapeTextConfig{RTFLayout: layout},
 	}
 	w := &Window{}
 	clip := drawClip{X: 0, Y: 0, Width: 500, Height: 500}
@@ -130,7 +130,7 @@ func TestRenderRtfSkipsLoadingEntry(t *testing.T) {
 	}
 	shape := &Shape{
 		X: 0, Y: 0, Width: 200, Height: 100,
-		TC: &ShapeTextConfig{RtfLayout: layout},
+		TC: &ShapeTextConfig{RTFLayout: layout},
 	}
 	w := &Window{}
 	w.viewState.diagramCache = cache

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -440,12 +440,12 @@ func renderRtf(shape *Shape, clip drawClip, w *Window) {
 		Kind:      RenderRTF,
 		X:         baseX,
 		Y:         baseY,
-		LayoutPtr: shape.TC.RtfLayout,
+		LayoutPtr: shape.TC.RTFLayout,
 	}, w)
 
-	if shape.TC.RtfFlatText != "" {
-		renderInputSelection(shape, shape.TC.RtfFlatText,
-			baseX, baseY, *shape.TC.RtfLayout, true, w)
+	if shape.TC.RTFFlatText != "" {
+		renderInputSelection(shape, shape.TC.RTFFlatText,
+			baseX, baseY, *shape.TC.RTFLayout, true, w)
 	}
 
 	// Emit RenderImage for inline math objects.
@@ -459,8 +459,8 @@ func renderRtf(shape *Shape, clip drawClip, w *Window) {
 		return
 	}
 	objIdx := 0
-	for i := range shape.TC.RtfLayout.Items {
-		item := &shape.TC.RtfLayout.Items[i]
+	for i := range shape.TC.RTFLayout.Items {
+		item := &shape.TC.RTFLayout.Items[i]
 		if !item.IsObject {
 			continue
 		}

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -121,7 +121,7 @@ type Shape struct {
 
 	// FocusSkip excludes a Focusable widget from Tab traversal while
 	// keeping it click-focusable and able to hold selection state
-	// (used by Text/Rtf/Markdown selection).
+	// (used by Text/RTF/Markdown selection).
 	FocusSkip bool
 
 	// Scrollable makes the widget respond to scroll events (mouse
@@ -329,15 +329,15 @@ type ShapeTextConfig struct {
 	textLayoutStyle    TextStyle
 	TextStyle          *TextStyle
 	TextLayout         *glyph.Layout
-	RtfRuns            *RichText
-	RtfLayout          *glyph.Layout
+	RTFRuns            *RichText
+	RTFLayout          *glyph.Layout
 	rtfGlyphRT         *glyph.RichText // cached conversion
 	Text               string
-	RtfFlatText        string // concatenation of all run texts; rune↔byte conversion for selection
+	RTFFlatText        string // concatenation of all run texts; rune↔byte conversion for selection
 	textLayoutText     string
 	rtfMathHashes      []int64 // cache keys per inline math object
-	RtfBaseStyle       glyph.TextStyle
-	RtfLineSpacing     float32 // gui LineSpacing; glyph.TextStyle drops it, so carried separately for BlockStyle
+	RTFBaseStyle       glyph.TextStyle
+	RTFLineSpacing     float32 // gui LineSpacing; glyph.TextStyle drops it, so carried separately for BlockStyle
 	TextSelBeg         uint32
 	TextSelEnd         uint32
 	TextTabSize        uint32
@@ -362,7 +362,7 @@ type ShapeTextConfig struct {
 
 // hasRtfLayout returns true if the shape has an RTF layout.
 func (s *Shape) hasRtfLayout() bool {
-	return s.TC != nil && s.TC.RtfLayout != nil
+	return s.TC != nil && s.TC.RTFLayout != nil
 }
 
 // TextMode controls how a text view renders text.

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -222,7 +222,7 @@ func buildMarkdownTableData(
 			Value:    richTextPlain(h),
 			HeadCell: true,
 			RichText: &rt,
-			Content: RTF(RtfCfg{
+			Content: RTF(RTFCfg{
 				RichText: h,
 				Mode:     TextModeSingleLine,
 			}),
@@ -243,7 +243,7 @@ func buildMarkdownTableData(
 			cells = append(cells, TableCellCfg{
 				Value:    richTextPlain(cell),
 				RichText: &rt,
-				Content: RTF(RtfCfg{
+				Content: RTF(RTFCfg{
 					RichText: cell,
 					Mode:     TextModeSingleLine,
 				}),

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -81,7 +81,7 @@ func renderMdMermaid(
 		SizeBorder: NoBorder,
 		Sizing:     FillFit,
 		Content: []View{
-			RTF(RtfCfg{
+			RTF(RTFCfg{
 				RichText: block.Content,
 				Mode:     TextModeSingleLine,
 			}),
@@ -206,7 +206,7 @@ func renderMdCode(
 		Sizing:     FillFit,
 		Clip:       true,
 		Content: []View{
-			RTF(RtfCfg{
+			RTF(RTFCfg{
 				RichText: block.Content,
 				Mode:     TextModeSingleLine,
 			}),
@@ -291,7 +291,7 @@ func mdRenderHR(cfg MarkdownCfg) View {
 	})
 }
 
-func applyMdCtx(cfg *RtfCfg, ctx *mdBlockCtx) {
+func applyMdCtx(cfg *RTFCfg, ctx *mdBlockCtx) {
 	if ctx != nil {
 		cfg.markdownID = ctx.ID
 		cfg.markdownBlockStart = ctx.Start
@@ -304,7 +304,7 @@ func mdRenderBlockquote(
 ) View {
 	leftMargin := float32(
 		block.BlockquoteDepth-1) * cfg.Style.NestIndent
-	rtfCfg := RtfCfg{
+	rtfCfg := RTFCfg{
 		RichText:      block.Content,
 		Mode:          mode,
 		BaseTextStyle: &block.BaseStyle,
@@ -352,7 +352,7 @@ func mdRenderHeading(
 			Height: 3,
 		}))
 	}
-	rtfCfg := RtfCfg{
+	rtfCfg := RTFCfg{
 		ID:            block.AnchorSlug,
 		RichText:      block.Content,
 		Mode:          mode,
@@ -381,7 +381,7 @@ func mdRenderHeading(
 }
 
 func mdRenderDefTerm(block MarkdownBlock, mode TextMode, ctx *mdBlockCtx) View {
-	rtfCfg := RtfCfg{
+	rtfCfg := RTFCfg{
 		RichText:      block.Content,
 		Mode:          mode,
 		BaseTextStyle: &block.BaseStyle,
@@ -393,7 +393,7 @@ func mdRenderDefTerm(block MarkdownBlock, mode TextMode, ctx *mdBlockCtx) View {
 func mdRenderDefValue(
 	block MarkdownBlock, cfg MarkdownCfg, mode TextMode, ctx *mdBlockCtx,
 ) View {
-	rtfCfg := RtfCfg{
+	rtfCfg := RTFCfg{
 		RichText:      block.Content,
 		Mode:          mode,
 		BaseTextStyle: &block.BaseStyle,
@@ -436,7 +436,7 @@ func mdRenderListItem(
 		})
 	}
 
-	rtfCfg := RtfCfg{
+	rtfCfg := RTFCfg{
 		RichText:      block.Content,
 		Mode:          mode,
 		BaseTextStyle: &block.BaseStyle,
@@ -504,7 +504,7 @@ func mdRenderParagraph(
 	block MarkdownBlock, cfg MarkdownCfg, mode TextMode,
 	ctx *mdBlockCtx,
 ) View {
-	rtfCfg := RtfCfg{
+	rtfCfg := RTFCfg{
 		ID:            cfg.ID,
 		Clip:          cfg.Clip,
 		FocusSkip:     cfg.FocusSkip,

--- a/gui/view_rtf.go
+++ b/gui/view_rtf.go
@@ -14,8 +14,8 @@ import (
 	"github.com/go-gui-org/go-gui/gui/markdown"
 )
 
-// RtfCfg configures a Rich Text View.
-type RtfCfg struct {
+// RTFCfg configures a Rich Text View.
+type RTFCfg struct {
 	BaseTextStyle *TextStyle
 
 	ID              string
@@ -68,7 +68,7 @@ func rtfRuneCountFromRuns(rt *RichText) int {
 }
 
 type rtfView struct {
-	RtfCfg
+	RTFCfg
 	sizing Sizing
 }
 
@@ -176,11 +176,11 @@ func (v *rtfView) GenerateLayout(w *Window) Layout {
 		TC: &ShapeTextConfig{
 			TextMode:           v.Mode,
 			HangingIndent:      v.HangingIndent,
-			RtfBaseStyle:       baseStyle,
-			RtfLineSpacing:     lineSpacing,
-			RtfLayout:          &layout,
-			RtfRuns:            &v.RichText,
-			RtfFlatText:        flatText,
+			RTFBaseStyle:       baseStyle,
+			RTFLineSpacing:     lineSpacing,
+			RTFLayout:          &layout,
+			RTFRuns:            &v.RichText,
+			RTFFlatText:        flatText,
 			MarkdownID:         v.markdownID,
 			MarkdownBlockStart: v.markdownBlockStart,
 			MarkdownRuneLen:    uint32(utf8RuneCount(flatText)),
@@ -189,7 +189,7 @@ func (v *rtfView) GenerateLayout(w *Window) Layout {
 		},
 	})
 	l := Layout{Shape: shape}
-	blockKey := rtfRunsKey(shape.TC.RtfRuns)
+	blockKey := rtfRunsKey(shape.TC.RTFRuns)
 	if ts := &w.viewState.tooltip; ts.id != "" &&
 		ts.text != "" && ts.blockKey != 0 &&
 		blockKey == ts.blockKey {
@@ -209,7 +209,7 @@ func (v *rtfView) GenerateLayout(w *Window) Layout {
 }
 
 // RTF creates a rich text view.
-func RTF(cfg RtfCfg) View {
+func RTF(cfg RTFCfg) View {
 	if cfg.Invisible {
 		return invisibleContainerView()
 	}
@@ -218,7 +218,7 @@ func RTF(cfg RtfCfg) View {
 		cfg.Mode == TextModeWrapKeepSpaces {
 		sizing = FillFit
 	}
-	return &rtfView{RtfCfg: cfg, sizing: sizing}
+	return &rtfView{RTFCfg: cfg, sizing: sizing}
 }
 
 // --- Hit testing ---
@@ -242,11 +242,11 @@ func rtfFindRunAtIndex(
 	l *Layout, startIndex int,
 ) RichTextRun {
 	if l.Shape == nil || l.Shape.TC == nil ||
-		l.Shape.TC.RtfRuns == nil {
+		l.Shape.TC.RTFRuns == nil {
 		return RichTextRun{}
 	}
 	idx := 0
-	for _, r := range l.Shape.TC.RtfRuns.Runs {
+	for _, r := range l.Shape.TC.RTFRuns.Runs {
 		runLen := len(r.Text)
 		if startIndex >= idx &&
 			startIndex < idx+runLen {
@@ -264,7 +264,7 @@ func rtfMouseMove(ctx EventCtx) {
 		return
 	}
 	ts := &ctx.Window.viewState.tooltip
-	layout := ctx.Layout.Shape.TC.RtfLayout
+	layout := ctx.Layout.Shape.TC.RTFLayout
 	for _, run := range layout.Items {
 		if run.IsObject {
 			continue
@@ -289,7 +289,7 @@ func rtfMouseMove(ctx EventCtx) {
 				ts.floatOffsetX = r.X + r.Width/2
 				ts.floatOffsetY = r.Y - 3
 				ts.blockKey = rtfRunsKey(
-					ctx.Layout.Shape.TC.RtfRuns)
+					ctx.Layout.Shape.TC.RTFRuns)
 				ts.hoverStart = time.Now()
 				ctx.Window.AnimationAdd(rtfTooltipAnimation(tipID))
 				ctx.Consume()
@@ -480,7 +480,7 @@ func rtfOnClick(ctx EventCtx) {
 	if !ctx.Layout.Shape.hasRtfLayout() {
 		return
 	}
-	layout := ctx.Layout.Shape.TC.RtfLayout
+	layout := ctx.Layout.Shape.TC.RTFLayout
 	for _, run := range layout.Items {
 		if run.IsObject {
 			continue
@@ -492,7 +492,7 @@ func rtfOnClick(ctx EventCtx) {
 					showLinkContextMenu(ctx.Window, found.Link,
 						ctx.Event.MouseX,
 						ctx.Event.MouseY,
-						rtfRunsKey(ctx.Layout.Shape.TC.RtfRuns))
+						rtfRunsKey(ctx.Layout.Shape.TC.RTFRuns))
 					ctx.Consume()
 					return
 				}

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -38,8 +38,8 @@ func rtfSelectOnClick(ctx EventCtx) {
 	}
 	ctx.Window.SetFocus(shape.ID)
 
-	gl := shape.TC.RtfLayout
-	flatText := shape.TC.RtfFlatText
+	gl := shape.TC.RTFLayout
+	flatText := shape.TC.RTFFlatText
 
 	byteIdx := gl.GetClosestOffset(ctx.Event.MouseX, ctx.Event.MouseY)
 	runePos := byteToRuneIndex(flatText, byteIdx)
@@ -195,8 +195,8 @@ func rtfSelectOnKeyDown(ctx EventCtx) {
 		return
 	}
 	id := shape.ID
-	flatText := shape.TC.RtfFlatText
-	gl := *shape.TC.RtfLayout
+	flatText := shape.TC.RTFFlatText
+	gl := *shape.TC.RTFLayout
 
 	imap := StateMap[string, InputState](ctx.Window, nsInput, capMany)
 	// Default InputState{}: zero value seeds initial keyboard-nav state.

--- a/gui/view_rtf_test.go
+++ b/gui/view_rtf_test.go
@@ -57,7 +57,7 @@ func (m *rtfCaptureMeasurer) LayoutRichText(
 
 // TestLayoutWrapRTFLineSpacing verifies the gui base-style LineSpacing
 // reaches glyph's BlockStyle — it lives on BlockStyle, not TextStyle,
-// so ToGlyphStyle drops it and it must be carried via RtfLineSpacing.
+// so ToGlyphStyle drops it and it must be carried via RTFLineSpacing.
 func TestLayoutWrapRTFLineSpacing(t *testing.T) {
 	m := &rtfCaptureMeasurer{
 		rtfStubTextMeasurer: rtfStubTextMeasurer{
@@ -72,9 +72,9 @@ func TestLayoutWrapRTFLineSpacing(t *testing.T) {
 		Width:     100,
 		TC: &ShapeTextConfig{
 			TextMode:       TextModeWrap,
-			RtfBaseStyle:   glyph.TextStyle{Size: 12},
-			RtfLineSpacing: 3,
-			RtfRuns:        &rt,
+			RTFBaseStyle:   glyph.TextStyle{Size: 12},
+			RTFLineSpacing: 3,
+			RTFRuns:        &rt,
 		},
 	}
 
@@ -141,8 +141,8 @@ func makeRtfTooltipLayout() (*Layout, *Window) {
 			Width:     100,
 			Height:    20,
 			TC: &ShapeTextConfig{
-				RtfLayout: &glyphLayout,
-				RtfRuns:   &rt,
+				RTFLayout: &glyphLayout,
+				RTFRuns:   &rt,
 			},
 		},
 	}
@@ -205,8 +205,8 @@ func TestRtfMouseMoveClearsOnNonTooltipRun(t *testing.T) {
 			Width:     100,
 			Height:    20,
 			TC: &ShapeTextConfig{
-				RtfLayout: &glyphLayout,
-				RtfRuns:   &rt,
+				RTFLayout: &glyphLayout,
+				RTFRuns:   &rt,
 			},
 		},
 	}
@@ -247,8 +247,8 @@ func TestRtfMouseMoveUnderlineWithoutLinkDoesNotSetPointingHand(t *testing.T) {
 			Width:     100,
 			Height:    20,
 			TC: &ShapeTextConfig{
-				RtfLayout: &glyphLayout,
-				RtfRuns:   &rt,
+				RTFLayout: &glyphLayout,
+				RTFRuns:   &rt,
 			},
 		},
 	}
@@ -293,8 +293,8 @@ func TestRtfMouseMoveLinkSetsPointingHand(t *testing.T) {
 			Width:     100,
 			Height:    20,
 			TC: &ShapeTextConfig{
-				RtfLayout: &glyphLayout,
-				RtfRuns:   &rt,
+				RTFLayout: &glyphLayout,
+				RTFRuns:   &rt,
 			},
 		},
 	}
@@ -324,7 +324,7 @@ func TestRtfGenerateLayoutSuppressesInlineObjectGlyphs(t *testing.T) {
 		},
 	}}
 
-	layout := generateViewLayout(RTF(RtfCfg{
+	layout := generateViewLayout(RTF(RTFCfg{
 		RichText: RichText{
 			Runs: []RichTextRun{{
 				MathID:    "math_1",
@@ -334,7 +334,7 @@ func TestRtfGenerateLayoutSuppressesInlineObjectGlyphs(t *testing.T) {
 		},
 	}), w)
 
-	items := layout.Shape.TC.RtfLayout.Items
+	items := layout.Shape.TC.RTFLayout.Items
 	if got := items[0].GlyphCount; got != 0 {
 		t.Fatalf("object GlyphCount = %d, want 0", got)
 	}
@@ -369,17 +369,17 @@ func TestLayoutWrapRTFSuppressesInlineObjectGlyphs(t *testing.T) {
 		Width:     100,
 		TC: &ShapeTextConfig{
 			TextMode:     TextModeWrap,
-			RtfBaseStyle: baseStyle,
-			RtfRuns:      &rt,
+			RTFBaseStyle: baseStyle,
+			RTFRuns:      &rt,
 		},
 	}
 
 	layoutWrapRTF(shape, shape.TC, w)
 
-	if shape.TC.RtfLayout == nil {
+	if shape.TC.RTFLayout == nil {
 		t.Fatal("expected wrapped RTF layout")
 	}
-	if got := shape.TC.RtfLayout.Items[0].GlyphCount; got != 0 {
+	if got := shape.TC.RTFLayout.Items[0].GlyphCount; got != 0 {
 		t.Fatalf("wrapped object GlyphCount = %d, want 0", got)
 	}
 }
@@ -613,8 +613,8 @@ func TestLayoutWrapRTF_MathReadyInvalidatesLoadingLayout(t *testing.T) {
 			Width:     200,
 			TC: &ShapeTextConfig{
 				TextMode:     TextModeWrap,
-				RtfBaseStyle: baseStyle,
-				RtfRuns:      &rt,
+				RTFBaseStyle: baseStyle,
+				RTFRuns:      &rt,
 			},
 		}
 	}
@@ -713,8 +713,8 @@ func TestRtfOnClickRightClickShowsMenu(t *testing.T) {
 			X:         100, Y: 200,
 			Width: 100, Height: 20,
 			TC: &ShapeTextConfig{
-				RtfLayout: &glyphLayout,
-				RtfRuns:   &rt,
+				RTFLayout: &glyphLayout,
+				RTFRuns:   &rt,
 			},
 		},
 	}
@@ -769,7 +769,7 @@ func TestRtfGenerateLayoutAddsTooltipChild(t *testing.T) {
 		floatOffsetY: -3,
 	}
 	v := &rtfView{
-		RtfCfg: RtfCfg{RichText: rt},
+		RTFCfg: RTFCfg{RichText: rt},
 		sizing: FitFit,
 	}
 	layout := v.GenerateLayout(w)
@@ -789,7 +789,7 @@ func TestRtfGenerateLayoutEmptyRichText(t *testing.T) {
 			layout: glyph.Layout{},
 		},
 	}}
-	layout := generateViewLayout(RTF(RtfCfg{
+	layout := generateViewLayout(RTF(RTFCfg{
 		RichText: RichText{},
 	}), w)
 	if layout.Shape == nil {
@@ -811,7 +811,7 @@ func (m *rtfErrorMeasurer) LayoutRichText(
 
 func TestRtfGenerateLayoutHandlesError(t *testing.T) {
 	w := &Window{windowBackend: windowBackend{textMeasurer: &rtfErrorMeasurer{}}}
-	layout := generateViewLayout(RTF(RtfCfg{
+	layout := generateViewLayout(RTF(RTFCfg{
 		RichText: RichText{
 			Runs: []RichTextRun{{Text: "hello"}},
 		},
@@ -849,8 +849,8 @@ func TestRtfOnClickIgnoresUnsafeLink(t *testing.T) {
 			shapeType: shapeRTF,
 			Width:     100, Height: 20,
 			TC: &ShapeTextConfig{
-				RtfLayout: &glyphLayout,
-				RtfRuns:   &rt,
+				RTFLayout: &glyphLayout,
+				RTFRuns:   &rt,
 			},
 		},
 	}

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -345,7 +345,7 @@ func tableBuildRow(
 		var cellContent []View
 		if cell.RichText != nil {
 			cellContent = []View{
-				RTF(RtfCfg{RichText: *cell.RichText}),
+				RTF(RTFCfg{RichText: *cell.RichText}),
 			}
 		} else if cell.Content != nil {
 			cellContent = []View{cell.Content}


### PR DESCRIPTION
Step 2 of the revised phase-4 order — the "loud half" of v0.54.0, starting with the two pure renames. **Breaking**, but every breakage is a compile error.

Landing these first keeps the mechanical part of v0.54.0 separable from the parts that need judgement (the callback conversion and the flat `Color*` deletion, both still to come in this release).

## `RtfCfg` → `RTFCfg`

`RTF(cfg RtfCfg)` was the only factory whose name disagreed with its `Cfg` in casing (§4.7).

The exported `Rtf*` fields on `Shape.TC` are renamed with it — `RTFRuns`, `RTFLayout`, `RTFFlatText`, `RTFBaseStyle`, `RTFLineSpacing`. The spec only asked for `RtfCfg`, but renaming that alone would leave `Rtf*` fields sitting beside a new `RTFCfg` — trading one inconsistency for another inside the same widget, in the one release where consumers are already migrating.

Unexported identifiers (`renderRtf`, `hasRtfLayout`, `demoRtf`) are untouched. They are not API, and renaming them would widen the diff for no consumer benefit.

## `OnCellFormat` → `CellFormat`, `OnDetailRowView` → `DetailRowView`

Neither is an event callback — both are view builders returning a value (`GridCellFormat`, `gg.View`), so the `On*` prefix misdescribed them. This is the rename §4.3 argued for but assigned to no phase.

Verified zero references in all five sibling repos, so the rename costs nothing outside this module.

## Note on the diff

The regex pass initially rewrote prose in `docs/specs/developer-ergonomics.md` and a `tools/ergoaudit` comment that discuss the *old* names deliberately. Both were reverted — those files still say `OnCellFormat`, correctly.

## Verification

`go build`, `go vet`, `gofmt -l`, `golangci-lint` (0 issues), `go test ./...` all clean. Markdown formatted with Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)