### PR TITLE
feat!: EventCtx on 17 event callbacks (v0.54.0, phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,38 @@ Breaking items are listed under "Changed" below as they land.
 
 ### Changed
 
+- **BREAKING: 17 event callbacks now take an `EventCtx`** instead of a trailing
+  `*Window`, and the four that leaked a raw `*Event` no longer do. The affected
+  fields are `OnAction`, `OnChange`, `OnColumnPinChange`, `OnCopyRows`,
+  `OnItemClick`, `OnLayoutChange`, `OnPanelClose`, `OnPanelSelect`, `OnReorder`,
+  `OnReset`, `OnSelect`, `OnSubmit`, `OnTextCommit`, `OnToggle` and
+  `OnValueCommit`.
+
+  The rule is uniform: `EventCtx` replaces the `*Layout`, `*Event` and `*Window`
+  parameters and lands last, while payloads keep their order and results are
+  untouched. So `TableCfg.OnSelect func(map[int]bool, int, *Event, *Window)`
+  becomes `func(map[int]bool, int, EventCtx)`, and `GridCfg.OnCopyRows` becomes
+  `func([]GridRow, EventCtx) (string, bool)` — returning a value was never a
+  reason to keep the old shape.
+
+  This finishes what the v0.52.0 `EventCtx` refactor started. Of the 30 distinct
+  signatures still carrying a `*Window` or a raw `*Event`, 17 converted; the
+  remaining 13 are deliberate. Twelve fire from a timer tick, a dialog
+  completion or a lifecycle transition (`OnInit`, `OnCloseRequest`, `OnOkYes`,
+  `OnCancelNo`, `OnDismiss`, `OnReply`, `OnLazyLoad`, `OnValue`, four `OnDone`
+  variants) — **there is no event** at those points, and handing them an
+  `EventCtx` would promise a permanently-nil `ctx.Event`. The thirteenth,
+  `Window.OnEvent`, is a raw escape hatch by design.
+
+  Where a widget dispatches one of these from inside an already-converted
+  callback, the full context is now passed through rather than a synthesized
+  one, so `OnPanelClose` and friends receive the layout they fire from —
+  strictly more than the old `*Window` carried.
+
+  Migration: `docs/migration-eventctx.md`, including the new `-fields` mode that
+  drove this round. No sibling repo is affected — none of the five uses any of
+  the 17.
+
 - **BREAKING: `RtfCfg` is now `RTFCfg`**, and the exported `Rtf*` fields on
   `Shape.TC` are now `RTF*` — `RTFRuns`, `RTFLayout`, `RTFFlatText`,
   `RTFBaseStyle`, `RTFLineSpacing`. `RTF(cfg RtfCfg)` was the only factory whose

--- a/docs/migration-eventctx.md
+++ b/docs/migration-eventctx.md
@@ -34,18 +34,36 @@ type EventCtx struct {
 Payload-carrying callbacks keep the payload as a leading argument — a `GridRow`
 is data, not context:
 
-| Before                              | After                    |
-| ----------------------------------- | ------------------------ |
-| `func(*Layout, *Event, *Window)`    | `func(EventCtx)`         |
-| `func(*Layout, *Window)`            | `func(EventCtx)`         |
-| `func(*Layout, string, *Window)`    | `func(string, EventCtx)` |
-| `func(T, *Event, *Window)`          | `func(T, EventCtx)`      |
-| `func(*Window)` / `func(T,*Window)` | unchanged                |
+| Before                               | After                         |
+| ------------------------------------ | ----------------------------- |
+| `func(*Layout, *Event, *Window)`     | `func(EventCtx)`              |
+| `func(*Layout, *Window)`             | `func(EventCtx)`              |
+| `func(*Layout, string, *Window)`     | `func(string, EventCtx)`      |
+| `func(T, *Event, *Window)`           | `func(T, EventCtx)`           |
+| `func(*Window)`                      | `func(EventCtx)`              |
+| `func(T, U, *Window)`                | `func(T, U, EventCtx)`        |
+| `func(T, *Event, *Window) (R, bool)` | `func(T, EventCtx) (R, bool)` |
 
-Lifecycle callbacks with neither a layout nor an event (animation
-`OnDone`/`OnValue`, native dialog and notification `OnDone`,
-`NativeMenuCfg.OnAction`) are unchanged, as is `OnDraw func(*DrawContext)` and
-`Window.OnEvent func(*Event, *Window)`.
+The rule is uniform: `EventCtx` replaces the `*Layout`, `*Event` and `*Window`
+parameters and lands last. Everything else keeps its position — payloads in
+their original order, and results untouched, which is why `GridCfg.OnCopyRows`
+is now `func([]GridRow, EventCtx) (string, bool)`.
+
+The last three rows arrived in v0.54.0; the rest shipped in v0.52.0.
+
+### What did not convert
+
+Callbacks that fire from a timer tick, a dialog completion, or a lifecycle
+transition keep their `*Window`. **There is no event** at those points, so an
+`EventCtx` would only promise a permanently-nil `ctx.Event`:
+
+> `OnInit`, `OnCloseRequest`, `OnOkYes`, `OnCancelNo`, `OnDismiss`, `OnReply`,
+> `OnLazyLoad`, `OnValue`, and the four `OnDone` variants (animation, native
+> alert, native dialog, native notification)
+
+Also unchanged: `OnDraw func(*DrawContext)`,
+`NativeMenuCfg.OnAction func(string)`, and
+`Window.OnEvent func(*Event, *Window)` — a raw escape hatch by design.
 
 ## The consume / notify split
 
@@ -142,6 +160,30 @@ for pkg in (go list ./...)
     go test -c -gcflags=-e -o /dev/null $pkg
 end 2>&1 | go run ./tools/eventctx/cmd/eventctxfold
 ```
+
+### Converting a named set of callbacks
+
+The three passes above match by signature alone, which is safe only for the
+shapes that carry a `*Layout` or an `*Event` — nothing else in the codebase
+looks like those. The v0.54.0 round widened the target to any signature ending
+in `*Window`, and that shape is indistinguishable from ordinary internal
+plumbing, so the wide matcher is gated on an explicit list of field names:
+
+```fish
+set -l fields OnSelect,OnTextCommit,OnValueCommit,OnLayoutChange
+go run ./tools/eventctx/cmd/eventctx -w -fields=$fields ./path
+go run ./tools/eventctx/cmd/eventctx -w -decls -fields=$fields ./path
+```
+
+Under `-fields` a callback converts only where its owning struct field,
+assignment target, or parameter is one of the named ones — matched ignoring the
+leading case, so the internal spelling `onSelect` matches the field `OnSelect`.
+A closure nested _inside_ a converted callback does not inherit the name: a
+`w.QueueCommand(func(w *gui.Window) {…})` argument stays as it is.
+
+`-fields` also drops the "returns nothing" restriction, which is how
+`OnCopyRows func([]GridRow, *Event, *Window) (string, bool)` converts while
+keeping its results.
 
 ### The review list
 

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -573,6 +573,66 @@ model collapse creates in their consume-class handlers — which their
 71 combined `Consume()` sites suggest is the part worth measuring
 properly before starting.
 
+#### 4.3.2 Conversion as implemented (2026-08-08)
+
+17 distinct signatures converted, against the 13 §4.3 listed: the three
+`gui/datagrid/` callbacks §4.3.1 surfaced, plus `OnChange` and
+`OnSelect` each contributing a second distinct signature the original
+count folded into one. The 13 that stayed are exactly the 12 lifecycle
+signatures plus `OnEvent`.
+
+**`OnCopyRows` took the invariant, not an exemption.** The rule adopted
+is that `EventCtx` replaces the `*Layout`, `*Event` and `*Window`
+parameters and says nothing about results, so it is now
+`func([]GridRow, EventCtx) (string, bool)`. No third target shape and
+no carve-out — the two target shapes in §4.3 were simply stated too
+narrowly, since "returns nothing" was never load-bearing.
+
+Verified by re-running `ergoaudit -mode callbacks`:
+`func(T..., *Window)` 24 → **12**, `leaks raw *Event` 5 → **1**
+(`OnEvent` alone), `func(EventCtx)` 16 → **18**,
+`func(T..., EventCtx)` 19 → **32**.
+
+**The codemod needed a name filter to be safe at all.** The v0.52 tool
+matched by signature, which works only because nothing else in the
+codebase looks like `func(*Layout, *Event, *Window)`. A trailing
+`*Window` is not distinctive — it describes most internal plumbing — so
+the widened matcher is gated on an explicit list of field names
+(`-fields`), matched ignoring the leading case so the internal spelling
+`onSelect` matches the field `OnSelect`.
+
+Three defects surfaced only by running it against the tree, each a case
+where the name filter was consulted in the wrong place:
+
+1. **Nested closures inherited the owner name**, converting every
+   `w.QueueCommand(func(w *gui.Window) {…})` written inside a converted
+   callback. Harmless in the old signature-driven mode, where the owner
+   only tinted the consume-class report; fatal once the owner is the
+   gate.
+2. **Named declarations were filtered by their own name.** A function
+   reaches the declaration pass only because the plan established it is
+   wired to an included field, but the filter then tested
+   `onShowcaseSplitterMainChange` against the field list and rejected
+   it.
+3. **Assignment targets were read only from selectors**, so
+   `onChange := func(…)` — the spelling widget internals and tests
+   actually use — was invisible.
+
+All three are pinned by tests in `tools/eventctx/general_test.go`.
+
+**Dispatch now passes the real context through.** Where a widget
+invokes one of these callbacks from inside an already-converted
+callback, the fold emits `ctx` rather than
+`EventCtx{nil, ctx.Event, ctx.Window}` — 29 sites. The old signature
+carried no `*Layout`, so this hands callers strictly more than before;
+synthesizing a nil layout when one is in scope would manufacture an
+absence. Where no layout genuinely exists (six internal helpers that
+only ever had a `*Window`), `EventCtx{nil, nil, w}` is emitted and is
+faithful.
+
+Cost: 45 files, zero rule-4 review items, and **zero sibling sites** —
+confirming §4.3.1's finding that no sibling pays for this conversion.
+
 ### 4.4 Color-set collapse — highest per-app line savings
 
 `examples/todo/main.go:139-166` sets six `Color*` fields on one button
@@ -1127,7 +1187,7 @@ burying them in the same diff.
 | 3     | §4.5 `PadAll` / `PadXY` shorthands       | n/a — already exist |
 | 4     | §4.7 `RTFCfg` + datagrid builder renames | done   |
 | 4     | §4.4 `ColorSet` on six `Cfg`s, flat state fields deleted | done |
-| 4     | §4.3 callback signature conversion       | todo   |
+| 4     | §4.3 callback signature conversion       | done   |
 | 4     | §4.3b event-model collapse               | deferred — see §4.3.1 |
 | 5     | §4.8 example audit                       | todo   |
 

--- a/examples/date_picker_options/main.go
+++ b/examples/date_picker_options/main.go
@@ -277,8 +277,8 @@ func weekdaysLenGroup(app *App) gui.View {
 				gui.NewRadioOption("Three letter", "three"),
 				gui.NewRadioOption("Full", "full"),
 			},
-			OnSelect: func(value string, w *gui.Window) {
-				gui.State[App](w).WeekdaysLen = value
+			OnSelect: func(value string, ctx gui.EventCtx) {
+				gui.State[App](ctx.Window).WeekdaysLen = value
 			},
 		}),
 	})

--- a/examples/dock_layout/main.go
+++ b/examples/dock_layout/main.go
@@ -54,15 +54,15 @@ func mainView(w *gui.Window) gui.View {
 				ID:     "dock",
 				Root:   app.Root,
 				Panels: panels(),
-				OnLayoutChange: func(root *gui.DockNode, w *gui.Window) {
-					gui.State[App](w).Root = root
+				OnLayoutChange: func(root *gui.DockNode, ctx gui.EventCtx) {
+					gui.State[App](ctx.Window).Root = root
 				},
-				OnPanelSelect: func(groupID, panelID string, w *gui.Window) {
-					app := gui.State[App](w)
+				OnPanelSelect: func(groupID string, panelID string, ctx gui.EventCtx) {
+					app := gui.State[App](ctx.Window)
 					app.Root = gui.DockTreeSelectPanel(app.Root, groupID, panelID)
 				},
-				OnPanelClose: func(panelID string, w *gui.Window) {
-					app := gui.State[App](w)
+				OnPanelClose: func(panelID string, ctx gui.EventCtx) {
+					app := gui.State[App](ctx.Window)
 					app.Root = gui.DockTreeRemovePanel(app.Root, panelID)
 				},
 			}),

--- a/examples/gradient_demo/main.go
+++ b/examples/gradient_demo/main.go
@@ -161,8 +161,8 @@ func mainView(w *gui.Window) gui.View {
 						Options:     dirOptions,
 						SizeBorder:  gui.Some[float32](1),
 						ColorBorder: gui.DarkGray,
-						OnSelect: func(value string, w *gui.Window) {
-							gui.State[App](w).Direction =
+						OnSelect: func(value string, ctx gui.EventCtx) {
+							gui.State[App](ctx.Window).Direction =
 								parseDirection(value)
 						},
 					}),

--- a/examples/process_monitor/view.go
+++ b/examples/process_monitor/view.go
@@ -281,8 +281,8 @@ func viewModeRadio(app *App) gui.View {
 		ID:    "pm-view",
 		Items: []string{"Flat", "Tree"},
 		Value: value,
-		OnSelect: func(v string, w *gui.Window) {
-			gui.State[App](w).TreeMode = v == "Tree"
+		OnSelect: func(v string, ctx gui.EventCtx) {
+			gui.State[App](ctx.Window).TreeMode = v == "Tree"
 		},
 	})
 }
@@ -292,8 +292,8 @@ func intervalRadio(app *App) gui.View {
 		ID:    "pm-interval",
 		Items: intervalLabels,
 		Value: intervalLabel(app.Interval),
-		OnSelect: func(v string, w *gui.Window) {
-			gui.State[App](w).Interval = intervalFromLabel(v)
+		OnSelect: func(v string, ctx gui.EventCtx) {
+			gui.State[App](ctx.Window).Interval = intervalFromLabel(v)
 		},
 	})
 }

--- a/examples/showcase/demo_data.go
+++ b/examples/showcase/demo_data.go
@@ -41,8 +41,8 @@ func demoTable(w *gui.Window) gui.View {
 	cfg.MultiSelect = app.TableMultiSelect
 	cfg.FreezeHeader = app.TableFreezeHeader
 	cfg.Selected = app.TableSelected
-	cfg.OnSelect = func(sel map[int]bool, _ int, _ *gui.Event, w *gui.Window) {
-		gui.State[ShowcaseApp](w).TableSelected = sel
+	cfg.OnSelect = func(sel map[int]bool, _ int, ctx gui.EventCtx) {
+		gui.State[ShowcaseApp](ctx.Window).TableSelected = sel
 	}
 
 	if cfg.BorderStyle == gui.TableBorderNone {
@@ -110,8 +110,8 @@ func demoTable(w *gui.Window) gui.View {
 							gui.NewRadioOption("Header only", "header_only"),
 							gui.NewRadioOption("None", "none"),
 						},
-						OnSelect: func(value string, w *gui.Window) {
-							gui.State[ShowcaseApp](w).TableBorderStyle = value
+						OnSelect: func(value string, ctx gui.EventCtx) {
+							gui.State[ShowcaseApp](ctx.Window).TableBorderStyle = value
 						},
 					}),
 					gui.Column(gui.ContainerCfg{

--- a/examples/showcase/demo_dock_layout.go
+++ b/examples/showcase/demo_dock_layout.go
@@ -30,15 +30,15 @@ func demoDockLayout(w *gui.Window) gui.View {
 				ID:     "showcase-dock",
 				Root:   app.DockRoot,
 				Panels: dockPanels(),
-				OnLayoutChange: func(root *gui.DockNode, w *gui.Window) {
-					gui.State[ShowcaseApp](w).DockRoot = root
+				OnLayoutChange: func(root *gui.DockNode, ctx gui.EventCtx) {
+					gui.State[ShowcaseApp](ctx.Window).DockRoot = root
 				},
-				OnPanelSelect: func(groupID, panelID string, w *gui.Window) {
-					a := gui.State[ShowcaseApp](w)
+				OnPanelSelect: func(groupID string, panelID string, ctx gui.EventCtx) {
+					a := gui.State[ShowcaseApp](ctx.Window)
 					a.DockRoot = gui.DockTreeSelectPanel(a.DockRoot, groupID, panelID)
 				},
-				OnPanelClose: func(panelID string, w *gui.Window) {
-					a := gui.State[ShowcaseApp](w)
+				OnPanelClose: func(panelID string, ctx gui.EventCtx) {
+					a := gui.State[ShowcaseApp](ctx.Window)
 					a.DockRoot = gui.DockTreeRemovePanel(a.DockRoot, panelID)
 				},
 			}),

--- a/examples/showcase/demo_input.go
+++ b/examples/showcase/demo_input.go
@@ -109,8 +109,8 @@ func demoNumericInput(w *gui.Window) gui.View {
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
 					gui.State[ShowcaseApp](ctx.Window).NumericENText = text
 				},
-				OnValueCommit: func(_ *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-					app := gui.State[ShowcaseApp](w)
+				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+					app := gui.State[ShowcaseApp](ctx.Window)
 					app.NumericENValue = value
 					app.NumericENText = text
 				},
@@ -134,8 +134,8 @@ func demoNumericInput(w *gui.Window) gui.View {
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
 					gui.State[ShowcaseApp](ctx.Window).NumericDEText = text
 				},
-				OnValueCommit: func(_ *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-					app := gui.State[ShowcaseApp](w)
+				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+					app := gui.State[ShowcaseApp](ctx.Window)
 					app.NumericDEValue = value
 					app.NumericDEText = text
 				},
@@ -156,8 +156,8 @@ func demoNumericInput(w *gui.Window) gui.View {
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
 					gui.State[ShowcaseApp](ctx.Window).NumericCurrencyText = text
 				},
-				OnValueCommit: func(_ *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-					app := gui.State[ShowcaseApp](w)
+				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+					app := gui.State[ShowcaseApp](ctx.Window)
 					app.NumericCurrencyValue = value
 					app.NumericCurrencyText = text
 				},
@@ -178,8 +178,8 @@ func demoNumericInput(w *gui.Window) gui.View {
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
 					gui.State[ShowcaseApp](ctx.Window).NumericPercentText = text
 				},
-				OnValueCommit: func(_ *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-					app := gui.State[ShowcaseApp](w)
+				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+					app := gui.State[ShowcaseApp](ctx.Window)
 					app.NumericPercentValue = value
 					app.NumericPercentText = text
 				},
@@ -200,8 +200,8 @@ func demoNumericInput(w *gui.Window) gui.View {
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
 					gui.State[ShowcaseApp](ctx.Window).NumericPlainText = text
 				},
-				OnValueCommit: func(_ *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-					app := gui.State[ShowcaseApp](w)
+				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+					app := gui.State[ShowcaseApp](ctx.Window)
 					app.NumericPlainValue = value
 					app.NumericPlainText = text
 				},
@@ -293,8 +293,8 @@ func demoDatePickerRoller(w *gui.Window) gui.View {
 				ID:           "date-roller",
 				Focusable:    true,
 				SelectedDate: app.RollerDate,
-				OnChange: func(date time.Time, w *gui.Window) {
-					gui.State[ShowcaseApp](w).RollerDate = date
+				OnChange: func(date time.Time, ctx gui.EventCtx) {
+					gui.State[ShowcaseApp](ctx.Window).RollerDate = date
 				},
 			}),
 			gui.Text(gui.TextCfg{
@@ -353,15 +353,15 @@ func demoForms(w *gui.Window) gui.View {
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
 		Padding: gui.NoPadding,
-		OnSubmit: func(e gui.FormSubmitEvent, w *gui.Window) {
-			app := gui.State[ShowcaseApp](w)
+		OnSubmit: func(e gui.FormSubmitEvent, ctx gui.EventCtx) {
+			app := gui.State[ShowcaseApp](ctx.Window)
 			app.Form.SubmitMessage = fmt.Sprintf(
 				"Submitted username=%s, email=%s",
 				strings.TrimSpace(e.Values["username"]),
 				strings.TrimSpace(e.Values["email"]))
 		},
-		OnReset: func(e gui.FormResetEvent, w *gui.Window) {
-			app := gui.State[ShowcaseApp](w)
+		OnReset: func(e gui.FormResetEvent, ctx gui.EventCtx) {
+			app := gui.State[ShowcaseApp](ctx.Window)
 			app.Form.Username = e.Values["username"]
 			app.Form.Email = e.Values["email"]
 			app.Form.AgeText = e.Values["age"]
@@ -418,11 +418,11 @@ func demoForms(w *gui.Window) gui.View {
 					gui.State[ShowcaseApp](ctx.Window).Form.AgeText = text
 					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, ageAdapterCfg(text), gui.FormTriggerChange)
 				},
-				OnValueCommit: func(l *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-					app := gui.State[ShowcaseApp](w)
+				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+					app := gui.State[ShowcaseApp](ctx.Window)
 					app.Form.AgeValue = value
 					app.Form.AgeText = text
-					gui.FormOnFieldEvent(w, l, ageAdapterCfg(text), gui.FormTriggerBlur)
+					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, ageAdapterCfg(text), gui.FormTriggerBlur)
 				},
 			})),
 			showcaseFormFieldState(w, "age"),

--- a/examples/showcase/demo_layout.go
+++ b/examples/showcase/demo_layout.go
@@ -230,8 +230,8 @@ func demoExpandPanel(w *gui.Window) gui.View {
 						}),
 					},
 				}),
-				OnToggle: func(w *gui.Window) {
-					a := gui.State[ShowcaseApp](w)
+				OnToggle: func(ctx gui.EventCtx) {
+					a := gui.State[ShowcaseApp](ctx.Window)
 					a.ExpandOpen = !a.ExpandOpen
 				},
 			}),
@@ -427,16 +427,16 @@ func showcaseSplitterPane(title, note string, accent gui.Color) gui.View {
 	})
 }
 
-func onShowcaseSplitterMainChange(ratio float32, collapsed gui.SplitterCollapsed, _ *gui.Event, w *gui.Window) {
-	app := gui.State[ShowcaseApp](w)
+func onShowcaseSplitterMainChange(ratio float32, collapsed gui.SplitterCollapsed, ctx gui.EventCtx) {
+	app := gui.State[ShowcaseApp](ctx.Window)
 	app.SplitterMainState = gui.SplitterStateNormalize(gui.SplitterState{
 		Ratio:     ratio,
 		Collapsed: collapsed,
 	})
 }
 
-func onShowcaseSplitterDetailChange(ratio float32, collapsed gui.SplitterCollapsed, _ *gui.Event, w *gui.Window) {
-	app := gui.State[ShowcaseApp](w)
+func onShowcaseSplitterDetailChange(ratio float32, collapsed gui.SplitterCollapsed, ctx gui.EventCtx) {
+	app := gui.State[ShowcaseApp](ctx.Window)
 	app.SplitterDetailState = gui.SplitterStateNormalize(gui.SplitterState{
 		Ratio:     ratio,
 		Collapsed: collapsed,

--- a/examples/showcase/demo_selection.go
+++ b/examples/showcase/demo_selection.go
@@ -100,8 +100,8 @@ func demoRadioGroup(w *gui.Window) gui.View {
 					gui.NewRadioOption("Rust", "rust"),
 					gui.NewRadioOption("Zig", "zig"),
 				},
-				OnSelect: func(v string, w *gui.Window) {
-					gui.State[ShowcaseApp](w).RadioValue = v
+				OnSelect: func(v string, ctx gui.EventCtx) {
+					gui.State[ShowcaseApp](ctx.Window).RadioValue = v
 				},
 			}),
 			gui.Text(gui.TextCfg{Text: "Row layout", TextStyle: t.B3}),
@@ -113,8 +113,8 @@ func demoRadioGroup(w *gui.Window) gui.View {
 					gui.NewRadioOption("Rust", "rust"),
 					gui.NewRadioOption("Zig", "zig"),
 				},
-				OnSelect: func(v string, w *gui.Window) {
-					gui.State[ShowcaseApp](w).RadioValue = v
+				OnSelect: func(v string, ctx gui.EventCtx) {
+					gui.State[ShowcaseApp](ctx.Window).RadioValue = v
 				},
 			}),
 		},
@@ -268,8 +268,8 @@ func demoDragReorder(w *gui.Window) gui.View {
 				Scrollable:  true,
 				Data:        app.DragListItems,
 				Reorderable: true,
-				OnReorder: func(movedID, beforeID string, w *gui.Window) {
-					a := gui.State[ShowcaseApp](w)
+				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
+					a := gui.State[ShowcaseApp](ctx.Window)
 					from, to := gui.ReorderIndices(
 						dragListIDs(a.DragListItems), movedID, beforeID)
 					if from >= 0 {
@@ -286,8 +286,8 @@ func demoDragReorder(w *gui.Window) gui.View {
 				Selected:    app.DragTabSel,
 				Sizing:      gui.FillFit,
 				Reorderable: true,
-				OnReorder: func(movedID, beforeID string, w *gui.Window) {
-					a := gui.State[ShowcaseApp](w)
+				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
+					a := gui.State[ShowcaseApp](ctx.Window)
 					from, to := gui.ReorderIndices(
 						dragTabIDs(a.DragTabItems), movedID, beforeID)
 					if from >= 0 {
@@ -307,8 +307,8 @@ func demoDragReorder(w *gui.Window) gui.View {
 				MaxHeight:   250,
 				Scrollable:  true,
 				Reorderable: true,
-				OnReorder: func(movedID, beforeID string, w *gui.Window) {
-					a := gui.State[ShowcaseApp](w)
+				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
+					a := gui.State[ShowcaseApp](ctx.Window)
 					dragTreeReorder(a, movedID, beforeID)
 				},
 			}),

--- a/examples/showcase/demo_theme.go
+++ b/examples/showcase/demo_theme.go
@@ -102,12 +102,12 @@ func demoThemeGen(w *gui.Window) gui.View {
 												OnTextChanged: func(text string, ctx gui.EventCtx) {
 													gui.State[ShowcaseApp](ctx.Window).ThemeGenRadiusText = text
 												},
-												OnValueCommit: func(_ *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-													app := gui.State[ShowcaseApp](w)
+												OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+													app := gui.State[ShowcaseApp](ctx.Window)
 													app.ThemeGenRadiusText = text
 													if v, ok := value.Value(); ok {
 														app.ThemeGenRadius = float32(v)
-														applyGenTheme(w)
+														applyGenTheme(ctx.Window)
 													}
 												},
 											}),
@@ -132,12 +132,12 @@ func demoThemeGen(w *gui.Window) gui.View {
 												OnTextChanged: func(text string, ctx gui.EventCtx) {
 													gui.State[ShowcaseApp](ctx.Window).ThemeGenBorderText = text
 												},
-												OnValueCommit: func(_ *gui.Layout, value gui.Opt[float64], text string, w *gui.Window) {
-													app := gui.State[ShowcaseApp](w)
+												OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
+													app := gui.State[ShowcaseApp](ctx.Window)
 													app.ThemeGenBorderText = text
 													if v, ok := value.Value(); ok {
 														app.ThemeGenBorder = float32(v)
-														applyGenTheme(w)
+														applyGenTheme(ctx.Window)
 													}
 												},
 											}),

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -152,8 +152,8 @@ func composerView(w *gui.Window) gui.View {
 					// Keep the input fully controlled by app state.
 					gui.State[appState](ctx.Window).Draft = text
 				},
-				OnTextCommit: func(_ *gui.Layout, text string, _ gui.InputCommitReason, w *gui.Window) {
-					addTodo(w, text)
+				OnTextCommit: func(text string, _ gui.InputCommitReason, ctx gui.EventCtx) {
+					addTodo(ctx.Window, text)
 				},
 			}),
 			gui.Button(gui.ButtonCfg{

--- a/gui/datagrid/view_data_grid.go
+++ b/gui/datagrid/view_data_grid.go
@@ -196,7 +196,7 @@ type DataGridCfg struct {
 	OnQueryChange          func(GridQueryState, gg.EventCtx)
 	OnSelectionChange      func(GridSelection, gg.EventCtx)
 	OnColumnOrderChange    func([]string, gg.EventCtx)
-	OnColumnPinChange      func(string, GridColumnPin, *gg.Event, *gg.Window)
+	OnColumnPinChange      func(string, GridColumnPin, gg.EventCtx)
 	OnHiddenColumnsChange  func(map[string]bool, gg.EventCtx)
 	OnPageChange           func(int, gg.EventCtx)
 	OnDetailExpandedChange func(map[string]bool, gg.EventCtx)
@@ -205,7 +205,7 @@ type DataGridCfg struct {
 	OnCRUDError            func(string, gg.EventCtx)
 	CellFormat             func(GridRow, int, GridColumnCfg, string, *gg.Window) GridCellFormat
 	DetailRowView          func(GridRow, *gg.Window) gg.View
-	OnCopyRows             func([]GridRow, *gg.Event, *gg.Window) (string, bool)
+	OnCopyRows             func([]GridRow, gg.EventCtx) (string, bool)
 	OnRowActivate          func(GridRow, gg.EventCtx)
 	Query                  GridQueryState
 	ID                     string `gui:"required"`

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -274,7 +274,7 @@ func dataGridPinControl(cfg *DataGridCfg, col GridColumnCfg) gg.View {
 				return
 			}
 			nextPin := dataGridColumnNextPin(colPin)
-			onColumnPinChange(colID, nextPin, ctx.Event, ctx.Window)
+			onColumnPinChange(colID, nextPin, ctx)
 			ctx.Consume()
 		})
 }

--- a/gui/datagrid/view_data_grid_header_test.go
+++ b/gui/datagrid/view_data_grid_header_test.go
@@ -482,7 +482,7 @@ func TestHeaderCellWithControls(t *testing.T) {
 		TextStyleHeader:     gg.DefaultTextStyle,
 		ColorHeaderHover:    gg.RGBA(220, 220, 220, 255),
 		OnColumnOrderChange: func(_ []string, ctx gg.EventCtx) {},
-		OnColumnPinChange:   func(string, GridColumnPin, *gg.Event, *gg.Window) {},
+		OnColumnPinChange:   func(_ string, _ GridColumnPin, ctx gg.EventCtx) {},
 	}
 	col := GridColumnCfg{
 		ID: "c1", Title: "Column 1",

--- a/gui/datagrid/view_data_grid_keys.go
+++ b/gui/datagrid/view_data_grid_keys.go
@@ -24,7 +24,7 @@ func dataGridMakeOnChar(cfg *DataGridCfg, columns []GridColumnCfg) func(gg.Event
 		}
 		var payload string
 		if onCopyRows != nil {
-			text, ok := onCopyRows(selectedRows, ctx.Event, ctx.Window)
+			text, ok := onCopyRows(selectedRows, ctx)
 			if ok {
 				payload = text
 			} else {

--- a/gui/dock_layout_drag.go
+++ b/gui/dock_layout_drag.go
@@ -71,7 +71,7 @@ func dockDragClear(w *Window, dockID string) {
 func dockDragStart(
 	dockID, panelID, sourceGroup string,
 	root *DockNode,
-	onLayoutChange func(*DockNode, *Window),
+	onLayoutChange func(*DockNode, EventCtx),
 	layout *Layout, e *Event, w *Window,
 ) {
 	// Ghost base offset: tab position relative to dock container.
@@ -143,7 +143,7 @@ func dockDragOnMouseMove(
 // dockDragOnMouseUp handles the drop or cancel.
 func dockDragOnMouseUp(
 	dockID string, root *DockNode,
-	onLayoutChange func(*DockNode, *Window), w *Window,
+	onLayoutChange func(*DockNode, EventCtx), w *Window,
 ) {
 	state := dockDragGet(w, dockID)
 	w.MouseUnlock()
@@ -152,7 +152,7 @@ func dockDragOnMouseUp(
 		newRoot := DockTreeMovePanel(
 			root, state.panelID, state.hoverGroupID,
 			state.hoverZone)
-		onLayoutChange(newRoot, w)
+		onLayoutChange(newRoot, EventCtx{nil, nil, w})
 	}
 
 	dockDragClear(w, dockID)

--- a/gui/drag_reorder.go
+++ b/gui/drag_reorder.go
@@ -198,7 +198,7 @@ func dragReorderIDsChanged(state dragReorderState, meta dragReorderIDsMeta) bool
 
 // dragReorderStartCfg groups parameters for dragReorderStart.
 type dragReorderStartCfg struct {
-	OnReorder     func(string, string, *Window)
+	OnReorder     func(string, string, EventCtx)
 	Layout        *Layout
 	Event         *Event
 	DragKey       string
@@ -307,7 +307,7 @@ func dragReorderMakeLock(
 	dragKey string,
 	axis DragReorderAxis,
 	itemIDs []string,
-	onReorder func(string, string, *Window),
+	onReorder func(string, string, EventCtx),
 ) MouseLockCfg {
 	return MouseLockCfg{
 		MouseMove: func(ctx EventCtx) {
@@ -465,7 +465,7 @@ func dragReorderOnMouseMove(
 func dragReorderOnMouseUp(
 	dragKey string,
 	itemIDs []string,
-	onReorder func(string, string, *Window),
+	onReorder func(string, string, EventCtx),
 	w *Window,
 ) {
 	state := dragReorderGet(w, dragKey)
@@ -495,7 +495,7 @@ func dragReorderOnMouseUp(
 				beforeID = itemIDs[gap]
 			}
 			w.AnimateLayout(LayoutTransitionCfg{})
-			onReorder(movedID, beforeID, w)
+			onReorder(movedID, beforeID, EventCtx{nil, nil, w})
 		}
 	}
 	w.UpdateWindow()
@@ -575,7 +575,7 @@ func dragReorderKeyboardMove(
 	axis DragReorderAxis,
 	currentIndex int,
 	itemIDs []string,
-	onReorder func(string, string, *Window),
+	onReorder func(string, string, EventCtx),
 	w *Window,
 ) bool {
 	itemCount := len(itemIDs)
@@ -622,7 +622,7 @@ func dragReorderKeyboardMove(
 		beforeID = itemIDs[newIndex]
 	}
 	w.AnimateLayout(LayoutTransitionCfg{})
-	onReorder(movedID, beforeID, w)
+	onReorder(movedID, beforeID, EventCtx{nil, nil, w})
 	return true
 }
 

--- a/gui/drag_reorder_test.go
+++ b/gui/drag_reorder_test.go
@@ -173,7 +173,7 @@ func TestDragReorderStartSetsLayoutValidity(t *testing.T) {
 		Parent: parent,
 	}
 	e := &Event{MouseX: 1, MouseY: 1}
-	noop := func(string, string, *Window) {}
+	noop := func(string, string, EventCtx) {}
 
 	dragKeyOK := "drag_layout_ok"
 	dragReorderStart(dragReorderStartCfg{
@@ -208,7 +208,7 @@ func TestDragReorderKeyboardMoveRequiresAlt(t *testing.T) {
 	handled := dragReorderKeyboardMove(
 		KeyDown, ModNone, DragReorderVertical, 1,
 		[]string{"a", "b", "c"},
-		func(string, string, *Window) { called = true }, w)
+		func(string, string, EventCtx) { called = true }, w)
 	if handled || called {
 		t.Error("should not handle without Alt modifier")
 	}
@@ -222,7 +222,7 @@ func TestDragReorderKeyboardMovePayloadAndBoundary(t *testing.T) {
 	handled := dragReorderKeyboardMove(
 		KeyRight, ModAlt, DragReorderHorizontal, 1,
 		[]string{"a", "b", "c", "d"},
-		func(m, b string, _ *Window) {
+		func(m, b string, _ EventCtx) {
 			called = true
 			moved = m
 			before = b
@@ -239,7 +239,7 @@ func TestDragReorderKeyboardMovePayloadAndBoundary(t *testing.T) {
 	handled = dragReorderKeyboardMove(
 		KeyLeft, ModAlt, DragReorderHorizontal, 0,
 		[]string{"a", "b", "c"},
-		func(string, string, *Window) { boundaryCalled = true }, w)
+		func(string, string, EventCtx) { boundaryCalled = true }, w)
 	if handled || boundaryCalled {
 		t.Error("Alt+Left at 0 should be a no-op")
 	}
@@ -336,7 +336,7 @@ func TestDragReorderCancelsOnMidDragMutation(t *testing.T) {
 	dragReorderStart(dragReorderStartCfg{
 		DragKey: dragKey, Index: 0, ItemID: "a",
 		Axis: DragReorderVertical, ItemIDs: []string{"a", "b", "c"},
-		OnReorder:     func(string, string, *Window) { called = true },
+		OnReorder:     func(_ string, _ string, ctx EventCtx) { called = true },
 		ItemLayoutIDs: []string{"a", "b", "c"},
 		Layout:        item, Event: e,
 	}, w)
@@ -345,7 +345,7 @@ func TestDragReorderCancelsOnMidDragMutation(t *testing.T) {
 	// Simulate list mutation before mouse-up.
 	dragReorderIDsMetaSet(w, dragKey, []string{"a", "c"})
 	dragReorderOnMouseUp(dragKey, []string{"a", "c"},
-		func(string, string, *Window) { called = true }, w)
+		func(string, string, EventCtx) { called = true }, w)
 	if called {
 		t.Error("callback should not fire on mutation")
 	}

--- a/gui/focus_defects_test.go
+++ b/gui/focus_defects_test.go
@@ -58,10 +58,10 @@ func TestToastButtonsGetPerToastIDs(t *testing.T) {
 	w := &Window{}
 	w.toasts = []toastNotification{
 		{id: 1, animFrac: 1, cfg: ToastCfg{
-			Title: "A", ActionLabel: "Undo", OnAction: func(*Window) {},
+			Title: "A", ActionLabel: "Undo", OnAction: func(ctx EventCtx) {},
 		}},
 		{id: 2, animFrac: 1, cfg: ToastCfg{
-			Title: "B", ActionLabel: "Undo", OnAction: func(*Window) {},
+			Title: "B", ActionLabel: "Undo", OnAction: func(ctx EventCtx) {},
 		}},
 	}
 

--- a/gui/list_core.go
+++ b/gui/list_core.go
@@ -27,7 +27,7 @@ type listCoreCfg struct {
 	TextStyle       TextStyle
 	DetailStyle     TextStyle
 	SubheadingStyle TextStyle
-	OnItemClick     func(string, int, *Event, *Window)
+	OnItemClick     func(string, int, EventCtx)
 	OnItemHover     func(int, EventCtx)
 	PaddingItem     Padding
 	ColorHighlight  Color
@@ -399,7 +399,7 @@ func listCoreItemView(item listCoreItem, index int, isHighlighted, isSelected bo
 		Content:    content,
 		OnClick: func(ctx EventCtx) {
 			if hasClick && !isDisabled {
-				onItemClick(itemID, index, ctx.Event, ctx.Window)
+				onItemClick(itemID, index, ctx)
 			}
 		},
 		OnHover: func(ctx EventCtx) {

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -324,11 +324,8 @@ func cpPreviewRow(cfg *ColorPickerCfg) View {
 				OnTextChanged: func(text string, ctx EventCtx) {
 					cpApplyHex(text, cfgID, onChange, ctx.Window)
 				},
-				OnTextCommit: func(
-					_ *Layout, text string,
-					_ InputCommitReason, w *Window,
-				) {
-					cpApplyHex(text, cfgID, onChange, w)
+				OnTextCommit: func(text string, _ InputCommitReason, ctx EventCtx) {
+					cpApplyHex(text, cfgID, onChange, ctx.Window)
 				},
 			}),
 		},
@@ -425,11 +422,8 @@ func cpInputColumn(
 				OnTextChanged: func(text string, ctx EventCtx) {
 					applyFn(text, ctx.Window)
 				},
-				OnTextCommit: func(
-					_ *Layout, text string,
-					_ InputCommitReason, w *Window,
-				) {
-					applyFn(text, w)
+				OnTextCommit: func(text string, _ InputCommitReason, ctx EventCtx) {
+					applyFn(text, ctx.Window)
 				},
 			}),
 		},

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -139,11 +139,11 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		ColorHover:     cfg.ColorHover,
 		ColorSelected:  cfg.ColorHighlight,
 		PaddingItem:    cfg.Padding.Get(Padding{}),
-		OnItemClick: func(itemID string, _ int, e *Event, w *Window) {
+		OnItemClick: func(itemID string, _ int, ctx EventCtx) {
 			if onSelect != nil {
-				onSelect(itemID, EventCtx{nil, e, w})
+				onSelect(itemID, EventCtx{nil, ctx.Event, ctx.Window})
 			}
-			comboboxClose(cfgID, w)
+			comboboxClose(cfgID, ctx.Window)
 		},
 	}
 

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -140,13 +140,13 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 		PaddingItem:    PaddingTwoFive,
 		ShowDetails:    true,
 		ShowIcons:      true,
-		OnItemClick: func(itemID string, _ int, e *Event, w *Window) {
+		OnItemClick: func(itemID string, _ int, ctx EventCtx) {
 			if onAction != nil {
-				onAction(itemID, EventCtx{nil, e, w})
+				onAction(itemID, EventCtx{nil, ctx.Event, ctx.Window})
 			}
-			CommandPaletteDismiss(paletteID, w)
+			CommandPaletteDismiss(paletteID, ctx.Window)
 			if onDismiss != nil {
-				onDismiss(w)
+				onDismiss(ctx.Window)
 			}
 		},
 	}

--- a/gui/view_date_picker_calendar.go
+++ b/gui/view_date_picker_calendar.go
@@ -273,12 +273,12 @@ func datePickerYearMonthPicker(
 		Color:        ColorTransparent,
 		ColorBorder:  ColorTransparent,
 		SizeBorder:   NoBorder,
-		OnChange: func(t time.Time, w *Window) {
+		OnChange: func(t time.Time, ctx EventCtx) {
 			if !cfg.FocusDisabled {
-				w.SetFocus(cfg.ID)
+				ctx.Window.SetFocus(cfg.ID)
 			}
 			sm := StateMap[string, datePickerState](
-				w, nsDatePicker, capModerate)
+				ctx.Window, nsDatePicker, capModerate)
 			s, ok := sm.Get(cfgID)
 			if !ok {
 				return
@@ -286,7 +286,7 @@ func datePickerYearMonthPicker(
 			s.ViewMonth = int(t.Month())
 			s.ViewYear = t.Year()
 			sm.Set(cfgID, s)
-			w.UpdateWindow()
+			ctx.Window.UpdateWindow()
 		},
 	})
 }

--- a/gui/view_date_picker_roller.go
+++ b/gui/view_date_picker_roller.go
@@ -20,7 +20,7 @@ const (
 type DatePickerRollerCfg struct {
 	TextStyle        TextStyle
 	SelectedDate     time.Time
-	OnChange         func(time.Time, *Window)
+	OnChange         func(time.Time, EventCtx)
 	ID               string
 	A11YLabel        string
 	A11YDescription  string
@@ -248,7 +248,7 @@ func rollerDrum(
 func rollerDrumAdjust(
 	name string, delta int, sel time.Time,
 	minYear, maxYear int,
-	onChange func(time.Time, *Window), w *Window,
+	onChange func(time.Time, EventCtx), w *Window,
 	wrapYear bool,
 ) {
 	switch name {
@@ -263,7 +263,7 @@ func rollerDrumAdjust(
 
 // rollerOnKeyDown handles keyboard navigation for the roller.
 func rollerOnKeyDown(
-	onChange func(time.Time, *Window),
+	onChange func(time.Time, EventCtx),
 	sel time.Time, minYear, maxYear int,
 	e *Event, w *Window,
 	mode DatePickerRollerDisplayMode,
@@ -311,7 +311,7 @@ func rollerOnKeyDown(
 func rollerAdjustDay(
 	delta int, sel time.Time,
 	minYear, maxYear int,
-	onChange func(time.Time, *Window), w *Window,
+	onChange func(time.Time, EventCtx), w *Window,
 ) {
 	if onChange == nil {
 		return
@@ -320,13 +320,13 @@ func rollerAdjustDay(
 	if newDate.Year() < minYear || newDate.Year() > maxYear {
 		return
 	}
-	onChange(newDate, w)
+	onChange(newDate, EventCtx{nil, nil, w})
 }
 
 func rollerAdjustMonth(
 	delta int, sel time.Time,
 	minYear, maxYear int,
-	onChange func(time.Time, *Window), w *Window,
+	onChange func(time.Time, EventCtx), w *Window,
 ) {
 	if onChange == nil {
 		return
@@ -353,13 +353,13 @@ func rollerAdjustMonth(
 	newDate := time.Date(ny, time.Month(nm), nd,
 		sel.Hour(), sel.Minute(), sel.Second(), sel.Nanosecond(),
 		sel.Location())
-	onChange(newDate, w)
+	onChange(newDate, EventCtx{nil, nil, w})
 }
 
 func rollerAdjustYear(
 	delta int, sel time.Time,
 	minYear, maxYear int,
-	onChange func(time.Time, *Window), w *Window,
+	onChange func(time.Time, EventCtx), w *Window,
 	wrap bool,
 ) {
 	if onChange == nil {
@@ -376,7 +376,7 @@ func rollerAdjustYear(
 	newDate := time.Date(newYear, sel.Month(), day,
 		sel.Hour(), sel.Minute(), sel.Second(), sel.Nanosecond(),
 		sel.Location())
-	onChange(newDate, w)
+	onChange(newDate, EventCtx{nil, nil, w})
 }
 
 func rollerDayFormat(v int) string {

--- a/gui/view_date_picker_roller_test.go
+++ b/gui/view_date_picker_roller_test.go
@@ -114,7 +114,7 @@ func TestRollerMonthFormatOutOfRange(t *testing.T) {
 func TestRollerAdjustDay(t *testing.T) {
 	sel := time.Date(2025, 3, 15, 0, 0, 0, 0, time.Local)
 	var got time.Time
-	onChange := func(d time.Time, _ *Window) { got = d }
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
 	w := &Window{}
 
 	rollerAdjustDay(1, sel, 1900, 2100, onChange, w)
@@ -137,7 +137,7 @@ func TestRollerAdjustDayNilOnChange(_ *testing.T) {
 func TestRollerAdjustMonth(t *testing.T) {
 	sel := time.Date(2025, 1, 15, 0, 0, 0, 0, time.Local)
 	var got time.Time
-	onChange := func(d time.Time, _ *Window) { got = d }
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
 	w := &Window{}
 
 	rollerAdjustMonth(1, sel, 1900, 2100, onChange, w)
@@ -154,7 +154,7 @@ func TestRollerAdjustMonth(t *testing.T) {
 func TestRollerAdjustYear(t *testing.T) {
 	sel := time.Date(2024, 2, 29, 0, 0, 0, 0, time.Local) // leap day
 	var got time.Time
-	onChange := func(d time.Time, _ *Window) { got = d }
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
 	w := &Window{}
 
 	rollerAdjustYear(1, sel, 1900, 2100, onChange, w, false)
@@ -167,7 +167,7 @@ func TestRollerAdjustYear(t *testing.T) {
 func TestRollerAdjustYearBounds(t *testing.T) {
 	sel := time.Date(2100, 6, 1, 0, 0, 0, 0, time.Local)
 	called := false
-	onChange := func(_ time.Time, _ *Window) { called = true }
+	onChange := func(_ time.Time, ctx EventCtx) { called = true }
 	w := &Window{}
 
 	rollerAdjustYear(1, sel, 1900, 2100, onChange, w, false)
@@ -194,7 +194,7 @@ func TestRollerDefaultsMinMaxSwap(t *testing.T) {
 
 func TestRollerAdjustYearWrap(t *testing.T) {
 	var got time.Time
-	onChange := func(d time.Time, _ *Window) { got = d }
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
 	w := &Window{}
 
 	// Wrap forward past max.
@@ -216,7 +216,7 @@ func TestRollerAdjustMonthDayClamping(t *testing.T) {
 	// Jan 31 + 1 month → Feb 28 (non-leap).
 	sel := time.Date(2025, 1, 31, 0, 0, 0, 0, time.Local)
 	var got time.Time
-	onChange := func(d time.Time, _ *Window) { got = d }
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
 	w := &Window{}
 
 	rollerAdjustMonth(1, sel, 1900, 2100, onChange, w)
@@ -234,7 +234,7 @@ func TestRollerAdjustMonthDayClamping(t *testing.T) {
 
 func TestRollerOnKeyDown(t *testing.T) {
 	var got time.Time
-	onChange := func(d time.Time, _ *Window) { got = d }
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
 	w := &Window{}
 	sel := time.Date(2025, 6, 15, 0, 0, 0, 0, time.Local)
 

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -16,9 +16,9 @@ type DockPanelDef struct {
 // DockLayoutCfg configures a dock layout component.
 type DockLayoutCfg struct {
 	Root              *DockNode
-	OnLayoutChange    func(*DockNode, *Window)
-	OnPanelSelect     func(string, string, *Window) // (groupID, panelID)
-	OnPanelClose      func(string, *Window)
+	OnLayoutChange    func(*DockNode, EventCtx)
+	OnPanelSelect     func(string, string, EventCtx) // (groupID, panelID)
+	OnPanelClose      func(string, EventCtx)
 	ID                string
 	Panels            []DockPanelDef
 	ColorZonePreview  Color
@@ -37,9 +37,9 @@ type DockLayoutCfg struct {
 // full DockLayoutCfg (which holds []DockPanelDef with []View).
 type dockLayoutCore struct {
 	root             *DockNode
-	onLayoutChange   func(*DockNode, *Window)
-	onPanelSelect    func(string, string, *Window)
-	onPanelClose     func(string, *Window)
+	onLayoutChange   func(*DockNode, EventCtx)
+	onPanelSelect    func(string, string, EventCtx)
+	onPanelClose     func(string, EventCtx)
 	id               string
 	colorZonePreview Color
 }
@@ -188,10 +188,10 @@ func dockSplitView(
 		Orientation: orientation,
 		Ratio:       SomeF(node.Ratio),
 		Sizing:      FillFill,
-		OnChange: func(ratio float32, _ SplitterCollapsed, _ *Event, w *Window) {
+		OnChange: func(ratio float32, _ SplitterCollapsed, ctx EventCtx) {
 			newRoot := dockTreeUpdateRatio(root, splitID, ratio)
 			if onLayoutChange != nil {
-				onLayoutChange(newRoot, w)
+				onLayoutChange(newRoot, ctx)
 			}
 		},
 		First:  SplitterPaneCfg{Content: firstContent},
@@ -328,7 +328,7 @@ func dockTabButton(
 			Colors:     ColorSet{Hover: guiTheme.ColorHover},
 			Radius:     SomeF(2),
 			OnClick: func(ctx EventCtx) {
-				onPanelClose(panelID, ctx.Window)
+				onPanelClose(panelID, ctx)
 			},
 			Content: []View{
 				Text(TextCfg{
@@ -352,7 +352,7 @@ func dockTabButton(
 			dockDragStart(dockID, panelID, groupID, root,
 				onLayoutChange, ctx.Layout, ctx.Event, ctx.Window)
 			if onPanelSelect != nil {
-				onPanelSelect(groupID, panelID, ctx.Window)
+				onPanelSelect(groupID, panelID, ctx)
 			}
 		},
 		Content: btnContent,

--- a/gui/view_dock_layout_test.go
+++ b/gui/view_dock_layout_test.go
@@ -98,7 +98,7 @@ func TestDockLayoutGeneratesLayout(t *testing.T) {
 				Text(TextCfg{Text: "hello"}),
 			}},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape == nil {
@@ -122,7 +122,7 @@ func TestDockLayoutWithSplit(t *testing.T) {
 			{ID: "p1", Label: "Left"},
 			{ID: "p2", Label: "Right"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	})
 	layout := generateViewLayout(v, w)
 	if layout.Shape.ID != "dock1" {
@@ -147,7 +147,7 @@ func TestDockGroupViewTabButtons(t *testing.T) {
 			{ID: "b", Label: "Beta"},
 			{ID: "c", Label: "Gamma"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)
@@ -170,8 +170,8 @@ func TestDockGroupViewWithClosable(t *testing.T) {
 		Panels: []DockPanelDef{
 			{ID: "a", Label: "Alpha", Closable: true},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
-		OnPanelClose:   func(pid string, _ *Window) { closeCalled = pid },
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
+		OnPanelClose:   func(pid string, ctx EventCtx) { closeCalled = pid },
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)
@@ -197,7 +197,7 @@ func TestDockGroupViewDraggedTabHidden(t *testing.T) {
 			{ID: "a", Label: "Alpha"},
 			{ID: "b", Label: "Beta"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)
@@ -261,7 +261,7 @@ func TestDockGroupViewHideSingleTab(t *testing.T) {
 				Root:           group,
 				Panels:         panelDefsFor(tt.panelIDs...),
 				HideSingleTab:  tt.hideSingle,
-				OnLayoutChange: func(_ *DockNode, _ *Window) {},
+				OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 			}
 			applyDockLayoutDefaults(cfg)
 
@@ -304,7 +304,7 @@ func TestDockSplitViewOrientation(t *testing.T) {
 			{ID: "p1", Label: "P1"},
 			{ID: "p2", Label: "P2"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)
@@ -331,7 +331,7 @@ func TestDockNodeViewRoutesSplit(t *testing.T) {
 			{ID: "p1", Label: "P1"},
 			{ID: "p2", Label: "P2"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)
@@ -353,7 +353,7 @@ func TestDockNodeViewRoutesGroup(t *testing.T) {
 		Panels: []DockPanelDef{
 			{ID: "p1", Label: "P1"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)
@@ -372,7 +372,7 @@ func TestNewDockLayoutCore(t *testing.T) {
 	cfg := &DockLayoutCfg{
 		ID:               "d1",
 		Root:             DockPanelGroup("g", nil, ""),
-		OnLayoutChange:   func(_ *DockNode, _ *Window) { called = true },
+		OnLayoutChange:   func(_ *DockNode, ctx EventCtx) { called = true },
 		ColorZonePreview: Color{1, 2, 3, 4, true},
 	}
 	core := newDockLayoutCore(cfg)
@@ -385,7 +385,7 @@ func TestNewDockLayoutCore(t *testing.T) {
 	if core.colorZonePreview != (Color{1, 2, 3, 4, true}) {
 		t.Fatal("wrong color")
 	}
-	core.onLayoutChange(nil, nil)
+	core.onLayoutChange(nil, EventCtx{nil, nil, nil})
 	if !called {
 		t.Fatal("callback not wired")
 	}
@@ -418,12 +418,12 @@ func TestDockSplitOnChangeCallback(t *testing.T) {
 			{ID: "p1", Label: "P1"},
 			{ID: "p2", Label: "P2"},
 		},
-		OnLayoutChange: func(r *DockNode, _ *Window) { newRoot = r },
+		OnLayoutChange: func(r *DockNode, ctx EventCtx) { newRoot = r },
 	}
 
 	// Simulate ratio update via dockTreeUpdateRatio
 	updated := dockTreeUpdateRatio(cfg.Root, "s1", 0.7)
-	cfg.OnLayoutChange(updated, nil)
+	cfg.OnLayoutChange(updated, EventCtx{nil, nil, nil})
 
 	if newRoot == nil {
 		t.Fatal("callback not called")
@@ -457,7 +457,7 @@ func TestDockLayoutFullTreeIntegration(t *testing.T) {
 		ID:             "dock1",
 		Root:           root,
 		Panels:         panels,
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	})
 
 	layout := generateViewLayout(v, w)
@@ -492,8 +492,8 @@ func TestDockTabButtonWithSelect(t *testing.T) {
 			{ID: "a", Label: "Alpha"},
 			{ID: "b", Label: "Beta"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
-		OnPanelSelect: func(gid, pid string, _ *Window) {
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
+		OnPanelSelect: func(gid string, pid string, ctx EventCtx) {
 			selectCalled = true
 			if gid != "g1" || pid != "a" {
 				t.Fatalf("wrong select args: %s, %s", gid, pid)
@@ -530,8 +530,8 @@ func TestDockTabButtonCloseButtonHasTextColor(t *testing.T) {
 		Panels: []DockPanelDef{
 			{ID: "a", Label: "Alpha", Closable: true},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
-		OnPanelClose:   func(_ string, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
+		OnPanelClose:   func(_ string, ctx EventCtx) {},
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)
@@ -567,7 +567,7 @@ func TestDockGroupViewFallbackContent(t *testing.T) {
 			{ID: "a", Label: "Alpha"},
 			{ID: "b", Label: "Beta"},
 		},
-		OnLayoutChange: func(_ *DockNode, _ *Window) {},
+		OnLayoutChange: func(_ *DockNode, ctx EventCtx) {},
 	}
 	applyDockLayoutDefaults(cfg)
 	core := newDockLayoutCore(cfg)

--- a/gui/view_expand_panel.go
+++ b/gui/view_expand_panel.go
@@ -5,7 +5,7 @@ package gui
 type ExpandPanelCfg struct {
 	Head     View
 	Content  View
-	OnToggle func(*Window)
+	OnToggle func(EventCtx)
 	ID       string
 
 	// Accessibility
@@ -97,7 +97,7 @@ func ExpandPanel(cfg ExpandPanelCfg) View {
 				},
 				OnClick: func(ctx EventCtx) {
 					if onToggle != nil {
-						onToggle(ctx.Window)
+						onToggle(ctx)
 					}
 				},
 				OnChar: func(ctx EventCtx) {
@@ -107,7 +107,7 @@ func ExpandPanel(cfg ExpandPanelCfg) View {
 						ctx.Bubble()
 						return
 					}
-					onToggle(ctx.Window)
+					onToggle(ctx)
 				},
 				OnHover: func(ctx EventCtx) {
 					ctx.Window.SetMouseCursorPointingHand()

--- a/gui/view_expand_panel_test.go
+++ b/gui/view_expand_panel_test.go
@@ -73,7 +73,7 @@ func TestExpandPanelOnToggle(t *testing.T) {
 	cfg := ExpandPanelCfg{
 		Head:    Text(TextCfg{Text: "H"}),
 		Content: Text(TextCfg{Text: "C"}),
-		OnToggle: func(_ *Window) {
+		OnToggle: func(ctx EventCtx) {
 			called = true
 		},
 	}

--- a/gui/view_form.go
+++ b/gui/view_form.go
@@ -142,8 +142,8 @@ const formLayoutIDPrefix = "form:"
 type FormCfg struct {
 
 	// Callbacks.
-	OnSubmit    func(FormSubmitEvent, *Window)
-	OnReset     func(FormResetEvent, *Window)
+	OnSubmit    func(FormSubmitEvent, EventCtx)
+	OnReset     func(FormResetEvent, EventCtx)
 	ErrorSlot   func(string, []FormIssue) View
 	SummarySlot func(FormSummaryState) View
 	PendingSlot func(FormPendingState) View

--- a/gui/view_form_process.go
+++ b/gui/view_form_process.go
@@ -176,8 +176,8 @@ func formCleanupStale(w *Window, formID string) {
 func formProcessRequests(
 	w *Window,
 	formID string,
-	onSubmit func(FormSubmitEvent, *Window),
-	onReset func(FormResetEvent, *Window),
+	onSubmit func(FormSubmitEvent, EventCtx),
+	onReset func(FormResetEvent, EventCtx),
 ) {
 	state := formRuntime(w, formID)
 	stateChanged := false
@@ -208,7 +208,7 @@ func formProcessRequests(
 			onReset(FormResetEvent{
 				FormID: formID,
 				Values: values,
-			}, w)
+			}, EventCtx{nil, nil, w})
 		}
 	}
 
@@ -252,7 +252,7 @@ func formProcessRequests(
 			Valid:   summary.Valid,
 			Pending: summary.Pending,
 			State:   summary,
-		}, w)
+		}, EventCtx{nil, nil, w})
 	}
 	if stateChanged {
 		w.UpdateWindow()

--- a/gui/view_form_test.go
+++ b/gui/view_form_test.go
@@ -167,7 +167,7 @@ func TestFormSubmitBlock(t *testing.T) {
 	})
 
 	var submitted bool
-	onSubmit := func(_ FormSubmitEvent, _ *Window) {
+	onSubmit := func(_ FormSubmitEvent, ctx EventCtx) {
 		submitted = true
 	}
 
@@ -211,7 +211,7 @@ func TestFormReset(t *testing.T) {
 	formApplyCfg(w, formID, FormCfg{ID: formID})
 
 	var resetEvent FormResetEvent
-	onReset := func(e FormResetEvent, _ *Window) {
+	onReset := func(e FormResetEvent, ctx EventCtx) {
 		resetEvent = e
 	}
 

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -26,7 +26,7 @@ type InputCfg struct {
 	// OnTextCommit fires when the user finalizes input: pressing
 	// Enter, losing focus (blur), or completing IME composition.
 	// The InputCommitReason indicates the trigger.
-	OnTextCommit func(*Layout, string, InputCommitReason, *Window)
+	OnTextCommit func(string, InputCommitReason, EventCtx)
 
 	OnEnter   func(EventCtx)
 	OnKeyDown func(EventCtx)
@@ -313,7 +313,7 @@ func applyInputDefaults(cfg *InputCfg) {
 type inputHandlerCfg struct {
 	CompiledMask        *CompiledInputMask
 	OnTextChanged       func(string, EventCtx)
-	OnTextCommit        func(*Layout, string, InputCommitReason, *Window)
+	OnTextCommit        func(string, InputCommitReason, EventCtx)
 	OnEnter             func(EventCtx)
 	OnKeyDown           func(EventCtx)
 	OnKeyUp             func(EventCtx)
@@ -530,8 +530,7 @@ func inputAmendLayout(
 				hcfg.fireTextChanged(ctx.Layout, text, ctx.Window)
 			}
 			if hcfg.OnTextCommit != nil {
-				hcfg.OnTextCommit(
-					ctx.Layout, text, CommitBlur, ctx.Window)
+				hcfg.OnTextCommit(text, CommitBlur, ctx)
 			}
 			if spellChk {
 				spellCheckClear(

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -249,7 +249,7 @@ func inputDateTextField(
 			sm := StateMap[string, string](ctx.Window, nsInputDateText, capModerate)
 			sm.Set(cfgID, s)
 		},
-		OnTextCommit: func(_ *Layout, text string, _ InputCommitReason, w *Window) {
+		OnTextCommit: func(text string, _ InputCommitReason, ctx EventCtx) {
 			// A read-only inner Input still fires OnTextCommit on Enter
 			// (text unchanged); do not surface it as a date selection.
 			if cfg.ReadOnly {
@@ -257,9 +257,9 @@ func inputDateTextField(
 			}
 			if text == "" {
 				if cfg.OnSelect != nil {
-					cfg.OnSelect(nil, EventCtx{nil, &Event{}, w})
+					cfg.OnSelect(nil, EventCtx{nil, &Event{}, ctx.Window})
 				}
-				w.UpdateWindow()
+				ctx.Window.UpdateWindow()
 				return
 			}
 			t, err := localeParseDate(text,
@@ -268,9 +268,9 @@ func inputDateTextField(
 				return
 			}
 			if cfg.OnSelect != nil {
-				cfg.OnSelect([]time.Time{t}, EventCtx{nil, &Event{}, w})
+				cfg.OnSelect([]time.Time{t}, EventCtx{nil, &Event{}, ctx.Window})
 			}
-			w.UpdateWindow()
+			ctx.Window.UpdateWindow()
 		},
 		OnKeyDown: func(ctx EventCtx) {
 			if isOpen && ctx.Event.KeyCode == KeyEscape {

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -249,8 +249,7 @@ func inputCommitEnter(
 		hcfg.fireTextChanged(layout, commitText, w)
 	}
 	if hcfg.OnTextCommit != nil {
-		hcfg.OnTextCommit(
-			layout, commitText, CommitEnter, w)
+		hcfg.OnTextCommit(commitText, CommitEnter, EventCtx{layout, nil, w})
 	}
 	if hcfg.OnEnter != nil {
 		hcfg.OnEnter(EventCtx{layout, e, w})

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -8,7 +8,7 @@ type NumericInputCfg struct {
 
 	// Callbacks
 	OnTextChanged func(string, EventCtx)
-	OnValueCommit func(*Layout, Opt[float64], string, *Window)
+	OnValueCommit func(Opt[float64], string, EventCtx)
 
 	ID          string `gui:"required,focus"`
 	Text        string
@@ -213,7 +213,7 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 				cfg.Decimals, locale, modeCfg)
 			return committed
 		},
-		OnTextCommit: func(layout *Layout, text string, _ InputCommitReason, w *Window) {
+		OnTextCommit: func(text string, _ InputCommitReason, ctx EventCtx) {
 			// A read-only inner Input still fires OnTextCommit on Enter
 			// (with text unchanged); do not surface it as a value commit.
 			if cfg.ReadOnly {
@@ -223,7 +223,7 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 				text, cfg.Value, cfg.Min, cfg.Max,
 				cfg.Decimals, locale, modeCfg)
 			if cfg.OnValueCommit != nil {
-				cfg.OnValueCommit(layout, value, committed, w)
+				cfg.OnValueCommit(value, committed, ctx)
 			}
 		},
 	})
@@ -326,7 +326,7 @@ func numericInputApplyStep(
 		cfg.Decimals, stepCfg, locale, dir,
 		e.Modifiers, modeCfg)
 	if cfg.OnValueCommit != nil {
-		cfg.OnValueCommit(layout, value, committed, w)
+		cfg.OnValueCommit(value, committed, EventCtx{layout, nil, w})
 	}
 }
 

--- a/gui/view_input_numeric_test.go
+++ b/gui/view_input_numeric_test.go
@@ -84,7 +84,7 @@ func TestNumericInputReadOnlyStepButtonsGated(t *testing.T) {
 			ReadOnly: readOnly,
 			Text:     "5",
 			StepCfg:  NumericStepCfg{ShowButtons: true, Step: 1},
-			OnValueCommit: func(_ *Layout, _ Opt[float64], _ string, _ *Window) {
+			OnValueCommit: func(_ Opt[float64], _ string, ctx EventCtx) {
 				committed = true
 			},
 		})

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -385,7 +385,7 @@ func TestInputKeyDownEnterSingleLine(t *testing.T) {
 	layout := generateViewLayout(Input(InputCfg{
 		Text: "hi",
 		ID:   "f600",
-		OnTextCommit: func(_ *Layout, _ string, reason InputCommitReason, _ *Window) {
+		OnTextCommit: func(_ string, reason InputCommitReason, ctx EventCtx) {
 			committed = true
 			if reason != CommitEnter {
 				t.Fatalf("got reason %d, want CommitEnter", reason)
@@ -1283,9 +1283,7 @@ func TestInputReadOnlyEnterDoesNotNormalize(t *testing.T) {
 		OnTextChanged: func(nt string, ctx EventCtx) {
 			changed = nt
 		},
-		OnTextCommit: func(
-			_ *Layout, ct string, _ InputCommitReason, _ *Window,
-		) {
+		OnTextCommit: func(ct string, _ InputCommitReason, ctx EventCtx) {
 			committed = ct
 		},
 	}), w)
@@ -1315,9 +1313,7 @@ func TestInputReadOnlyBlurDoesNotNormalize(t *testing.T) {
 		OnTextChanged: func(nt string, ctx EventCtx) {
 			changed = nt
 		},
-		OnTextCommit: func(
-			_ *Layout, ct string, _ InputCommitReason, _ *Window,
-		) {
+		OnTextCommit: func(ct string, _ InputCommitReason, ctx EventCtx) {
 			committed = ct
 		},
 	}

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -25,7 +25,7 @@ type ListBoxCfg struct {
 	TextStyle       TextStyle
 	SubheadingStyle TextStyle
 	OnSelect        func([]string, EventCtx)
-	OnReorder       func(movedID, beforeID string, w *Window)
+	OnReorder       func(string, string, EventCtx)
 
 	ID string `gui:"required"`
 

--- a/gui/view_radio_button_group.go
+++ b/gui/view_radio_button_group.go
@@ -17,7 +17,7 @@ func NewRadioOption(label, value string) RadioOption {
 type RadioButtonGroupCfg struct {
 	TextStyle TextStyle
 
-	OnSelect func(string, *Window)
+	OnSelect func(string, EventCtx)
 	Value    string
 	Title    string
 
@@ -104,7 +104,7 @@ func buildRadioOptions(cfg RadioButtonGroupCfg) []View {
 			TextStyle:     cfg.TextStyle,
 			OnClick: func(ctx EventCtx) {
 				if onSelect != nil {
-					onSelect(optValue, ctx.Window)
+					onSelect(optValue, ctx)
 				}
 			},
 		}))

--- a/gui/view_radio_button_group_test.go
+++ b/gui/view_radio_button_group_test.go
@@ -14,7 +14,7 @@ func TestRadioButtonGroupColumnBasic(t *testing.T) {
 			{Label: "B", Value: "b"},
 			{Label: "C", Value: "c"},
 		},
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	kids := v.Content()
 	if len(kids) != 3 {
@@ -30,7 +30,7 @@ func TestRadioButtonGroupRowBasic(t *testing.T) {
 			{Label: "X", Value: "x"},
 			{Label: "Y", Value: "y"},
 		},
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	kids := v.Content()
 	if len(kids) != 2 {
@@ -47,7 +47,7 @@ func TestRadioButtonGroupFocusIDs(t *testing.T) {
 			{Label: "B", Value: "b"},
 			{Label: "C", Value: "c"},
 		},
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	w := newTestWindow()
 	kids := v.Content()
@@ -71,7 +71,7 @@ func TestRadioButtonGroupFocusIDs(t *testing.T) {
 func TestRadioButtonGroupEmpty(t *testing.T) {
 	v := RadioButtonGroupColumn(RadioButtonGroupCfg{
 		ID:       "radio_button_group_test_test_radio_button_group_empty",
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	if len(v.Content()) != 0 {
 		t.Error("empty options should produce no children")
@@ -87,7 +87,7 @@ func TestRadioButtonGroupOnSelect(t *testing.T) {
 			{Label: "A", Value: "a"},
 			{Label: "B", Value: "b"},
 		},
-		OnSelect: func(val string, _ *Window) {
+		OnSelect: func(val string, ctx EventCtx) {
 			selected = val
 		},
 	})
@@ -113,7 +113,7 @@ func TestRadioButtonGroupDisabledPropagation(t *testing.T) {
 			{Label: "A", Value: "a"},
 			{Label: "B", Value: "b"},
 		},
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	kids := v.Content()
 	for i, child := range kids {
@@ -133,7 +133,7 @@ func TestRadioButtonGroupItems(t *testing.T) {
 		ID:       "radio_button_group_test_test_radio_button_group_items",
 		Value:    "rust",
 		Items:    []string{"go", "rust", "zig"},
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	kids := v.Content()
 	if len(kids) != 3 {
@@ -150,7 +150,7 @@ func TestRadioButtonGroupItemsPrecedence(t *testing.T) {
 		Options: []RadioOption{
 			{Label: "Ignored", Value: "ignored"},
 		},
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	kids := v.Content()
 	if len(kids) != 2 {
@@ -164,7 +164,7 @@ func TestRadioButtonGroupItemsOnSelect(t *testing.T) {
 		ID:    "radio_button_group_test_test_radio_button_group_items_on_select",
 		Value: "a",
 		Items: []string{"a", "b"},
-		OnSelect: func(val string, _ *Window) {
+		OnSelect: func(val string, ctx EventCtx) {
 			selected = val
 		},
 	})
@@ -184,7 +184,7 @@ func TestRadioButtonGroupRowItems(t *testing.T) {
 		ID:       "radio_button_group_test_test_radio_button_group_row_items",
 		Value:    "go",
 		Items:    []string{"go", "rust", "zig"},
-		OnSelect: func(_ string, _ *Window) {},
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	kids := v.Content()
 	if len(kids) != 3 {

--- a/gui/view_splitter.go
+++ b/gui/view_splitter.go
@@ -122,7 +122,7 @@ type splitterPaneCore struct {
 
 // SplitterCfg configures a splitter component.
 type SplitterCfg struct {
-	OnChange func(float32, SplitterCollapsed, *Event, *Window)
+	OnChange func(float32, SplitterCollapsed, EventCtx)
 	ID       string
 
 	A11YLabel           string
@@ -156,7 +156,7 @@ type SplitterCfg struct {
 
 // splitterCore holds callback-relevant fields.
 type splitterCore struct {
-	onChange      func(float32, SplitterCollapsed, *Event, *Window)
+	onChange      func(float32, SplitterCollapsed, EventCtx)
 	id            string
 	first         splitterPaneCore
 	second        splitterPaneCore
@@ -609,7 +609,7 @@ func splitterEmitChange(
 		Collapsed: collapsed,
 	})
 	if core.onChange != nil {
-		core.onChange(state.Ratio, state.Collapsed, e, w)
+		core.onChange(state.Ratio, state.Collapsed, EventCtx{nil, e, w})
 	}
 	splitterFocus(core, w)
 	e.IsHandled = true

--- a/gui/view_splitter_test.go
+++ b/gui/view_splitter_test.go
@@ -16,7 +16,7 @@ func TestSplitterBasic(t *testing.T) {
 		Second: SplitterPaneCfg{
 			Content: []View{Text(TextCfg{Text: "right"})},
 		},
-		OnChange: func(_ float32, _ SplitterCollapsed, _ *Event, _ *Window) {},
+		OnChange: func(_ float32, _ SplitterCollapsed, ctx EventCtx) {},
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
@@ -29,7 +29,7 @@ func TestSplitterBasic(t *testing.T) {
 func TestSplitAlias(t *testing.T) {
 	v := Splitter(SplitterCfg{
 		ID:       "sp",
-		OnChange: func(_ float32, _ SplitterCollapsed, _ *Event, _ *Window) {},
+		OnChange: func(_ float32, _ SplitterCollapsed, ctx EventCtx) {},
 		First:    SplitterPaneCfg{},
 		Second:   SplitterPaneCfg{},
 	})

--- a/gui/view_tab_control.go
+++ b/gui/view_tab_control.go
@@ -22,7 +22,7 @@ type TabControlCfg struct {
 	TextStyleSelected TextStyle
 	TextStyleDisabled TextStyle
 	OnSelect          func(string, EventCtx)
-	OnReorder         func(movedID, beforeID string, w *Window)
+	OnReorder         func(string, string, EventCtx)
 
 	ID       string
 	Selected string
@@ -167,7 +167,7 @@ func makeTabDragClick(
 	dragIdx int,
 	itemID string,
 	tabIDs []string,
-	onReorder func(string, string, *Window),
+	onReorder func(string, string, EventCtx),
 	tabLayoutIDs []string,
 	onSelect func(string, EventCtx),
 	focusID string,

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -48,7 +48,7 @@ type TableCfg struct {
 	ColorRowAlt      *Color
 	AlignHead        *HorizontalAlign
 	Selected         map[int]bool
-	OnSelect         func(map[int]bool, int, *Event, *Window)
+	OnSelect         func(map[int]bool, int, EventCtx)
 	ID               string `gui:"required"`
 	A11YLabel        string
 	A11YDescription  string
@@ -315,7 +315,7 @@ func tableBuildRow(
 	cfg *TableCfg, rowIdx int, columnWidths []float32,
 	cellBorder float32, selected map[int]bool,
 	multiSelect bool, colorHover Color,
-	onSelect func(map[int]bool, int, *Event, *Window),
+	onSelect func(map[int]bool, int, EventCtx),
 ) View {
 	r := cfg.Data[rowIdx]
 	cells := make([]View, 0, len(r.Cells))
@@ -417,7 +417,7 @@ func tableBuildRow(
 				} else {
 					newSel[ri] = true
 				}
-				onSelect(newSel, ri, ctx.Event, ctx.Window)
+				onSelect(newSel, ri, ctx)
 			}
 		},
 		OnHover: func(ctx EventCtx) {
@@ -437,7 +437,7 @@ func tableFreezeLayout(
 	cfg *TableCfg, columnWidths []float32, cellBorder float32,
 	rowSpacing float32, selected map[int]bool,
 	multiSelect bool, colorHover Color,
-	onSelect func(map[int]bool, int, *Event, *Window),
+	onSelect func(map[int]bool, int, EventCtx),
 	bodyRows []View,
 	scrollID string,
 ) View {

--- a/gui/view_table_test.go
+++ b/gui/view_table_test.go
@@ -210,7 +210,7 @@ func TestTableSelection(t *testing.T) {
 			TR([]TableCellCfg{TD("a")}),
 			TR([]TableCellCfg{TD("b")}),
 		},
-		OnSelect: func(sel map[int]bool, row int, _ *Event, _ *Window) {
+		OnSelect: func(sel map[int]bool, row int, ctx EventCtx) {
 			selectedRows = sel
 			clickedRow = row
 		},

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -19,7 +19,7 @@ const (
 
 // ToastCfg configures a toast notification.
 type ToastCfg struct {
-	OnAction    func(*Window)
+	OnAction    func(EventCtx)
 	Title       string
 	Body        string
 	ActionLabel string
@@ -172,7 +172,7 @@ func toastItemView(toast *toastNotification, style ToastStyle) View {
 			Color:   ColorTransparent,
 			Content: []View{Text(TextCfg{Text: toast.cfg.ActionLabel, TextStyle: style.TextStyle})},
 			OnClick: func(ctx EventCtx) {
-				onAction(ctx.Window)
+				onAction(ctx)
 				toastStartExit(ctx.Window, id)
 			},
 		}))

--- a/gui/view_toast_test.go
+++ b/gui/view_toast_test.go
@@ -201,11 +201,11 @@ func TestToastOnActionCallback(t *testing.T) {
 		{id: 1, cfg: ToastCfg{
 			Title:       "T",
 			ActionLabel: "Undo",
-			OnAction:    func(_ *Window) { fired = true },
+			OnAction:    func(ctx EventCtx) { fired = true },
 		}, animFrac: 1, phase: toastVisible},
 	}
 	// Simulate action callback.
-	w.toasts[0].cfg.OnAction(w)
+	w.toasts[0].cfg.OnAction(EventCtx{nil, nil, w})
 	if !fired {
 		t.Error("expected OnAction callback to fire")
 	}

--- a/gui/view_tree.go
+++ b/gui/view_tree.go
@@ -12,7 +12,7 @@ type TreeCfg struct {
 	OnSelect   func(string, EventCtx)
 	OnLazyLoad func(string, string, *Window)
 
-	OnReorder func(movedID, beforeID string, w *Window)
+	OnReorder func(string, string, EventCtx)
 
 	ID string `gui:"required"`
 

--- a/tools/eventctx/cmd/eventctx/main.go
+++ b/tools/eventctx/cmd/eventctx/main.go
@@ -27,6 +27,10 @@ import (
 func main() {
 	write := flag.Bool("w", false, "write result to source file")
 	report := flag.String("report", "", "write rule-4 report to this file")
+	fields := flag.String("fields", "",
+		"comma-separated callback field names to convert. Setting it "+
+			"switches on the general matcher: any signature ending in "+
+			"*Window folds, but only under these field names.")
 	decls := flag.Bool("decls", false,
 		"declaration mode: convert named callback functions and their "+
 			"call sites instead of closures. Run after the closure pass.")
@@ -36,6 +40,8 @@ func main() {
 			"usage: eventctx [-w] [-decls] [-report file] path...")
 		os.Exit(2)
 	}
+
+	opts := parseFields(*fields)
 
 	files, err := collect(flag.Args())
 	if err != nil {
@@ -48,7 +54,7 @@ func main() {
 	// as a value rather than only calling it.
 	var plan eventctx.DeclPlan
 	if *decls {
-		plan, err = buildPlan(files)
+		plan, err = buildPlan(files, opts)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "eventctx:", err)
 			os.Exit(1)
@@ -60,7 +66,7 @@ func main() {
 	var findings []eventctx.Finding
 	changed := 0
 	for _, p := range files {
-		n, fs2, err := processFile(p, *write, plan)
+		n, fs2, err := processFile(p, *write, plan, opts)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "eventctx:", err)
 			os.Exit(1)
@@ -130,7 +136,9 @@ func collect(roots []string) ([]string, error) {
 // every file, then keeps only the candidates that are used as values.
 //
 // #nosec G304 — paths come from the developer-supplied CLI arguments
-func buildPlan(files []string) (eventctx.DeclPlan, error) {
+func buildPlan(
+	files []string, opts *eventctx.Options,
+) (eventctx.DeclPlan, error) {
 	cands := eventctx.DeclPlan{}
 	used := map[string]bool{}
 	for _, p := range files {
@@ -138,7 +146,7 @@ func buildPlan(files []string) (eventctx.DeclPlan, error) {
 		if err != nil {
 			return nil, err
 		}
-		c, u, err := eventctx.ScanDecls(p, src)
+		c, u, err := eventctx.ScanDeclsWith(p, src, opts)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", p, err)
 		}
@@ -159,6 +167,7 @@ func buildPlan(files []string) (eventctx.DeclPlan, error) {
 // #nosec G304 — path comes from the developer-supplied CLI arguments
 func processFile(
 	path string, write bool, plan eventctx.DeclPlan,
+	opts *eventctx.Options,
 ) (int, []eventctx.Finding, error) {
 	src, err := os.ReadFile(path)
 	if err != nil {
@@ -167,7 +176,7 @@ func processFile(
 	if !eventctx.NeedsRewrite(src) {
 		return 0, nil, nil
 	}
-	res, err := eventctx.Rewrite(path, src, plan)
+	res, err := eventctx.RewriteWith(path, src, plan, opts)
 	if err != nil {
 		return 0, nil, fmt.Errorf("%s: %w", path, err)
 	}
@@ -188,4 +197,19 @@ func processFile(
 		return 0, nil, err
 	}
 	return 1, res.Findings, nil
+}
+
+// parseFields turns the -fields flag into Options. An empty flag leaves
+// the original narrow matcher in place.
+func parseFields(list string) *eventctx.Options {
+	if strings.TrimSpace(list) == "" {
+		return nil
+	}
+	set := map[string]bool{}
+	for f := range strings.SplitSeq(list, ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			set[f] = true
+		}
+	}
+	return &eventctx.Options{Fields: set}
 }

--- a/tools/eventctx/eventctx.go
+++ b/tools/eventctx/eventctx.go
@@ -45,6 +45,40 @@ var consumeFields = []string{
 	"OnChar", "OnClick", "OnMouseUp", "OnGesture", "OnFileDrop",
 }
 
+// Options tunes what the rewrite is willing to touch. A nil *Options
+// selects the original, deliberately narrow behaviour used for the
+// v0.52 conversion: only the four fixed three-argument shapes convert,
+// and a callback of that shape converts wherever it is found.
+type Options struct {
+	// Fields is an include list of callback field names ("OnSelect").
+	// Setting it switches the rewrite to general mode: ANY parameter
+	// list ending in *Window folds — payload parameters keep their
+	// position and results are left alone, so a callback that returns
+	// a value converts too — but only where the owning struct field or
+	// assignment target is named here.
+	//
+	// The name filter is what makes the wider matcher safe. Without
+	// it, every internal helper that happens to take a trailing
+	// *Window would be rewritten as though it were a callback.
+	//
+	// Matching ignores the leading case, so the parameter spelling
+	// onSelect matches the field OnSelect. Widget internals routinely
+	// pass a callback onward under the lowercased name.
+	Fields map[string]bool
+}
+
+// general reports whether the name-filtered wide matcher is in effect.
+func (o *Options) general() bool { return o != nil && o.Fields != nil }
+
+// owns reports whether name is one of the included callback fields.
+func (o *Options) owns(name string) bool {
+	if !o.general() || name == "" {
+		return false
+	}
+	return o.Fields[name] ||
+		o.Fields[strings.ToUpper(name[:1])+name[1:]]
+}
+
 // Finding is one entry in the rule-4 report: a return path in a
 // consume-class callback that is not dominated by a handled assignment,
 // and so is a human decision between ctx.Bubble() and accepting the new
@@ -78,7 +112,7 @@ type edit struct {
 // its call sites, so the two are planned together across the whole
 // package before any file is rewritten. A nil plan leaves declarations
 // and calls alone.
-type DeclPlan map[string]sigKind
+type DeclPlan map[string]sigShape
 
 // ScanDecls finds the named functions in one file that must convert:
 // those whose signature matches a callback shape and whose name is used
@@ -87,6 +121,20 @@ type DeclPlan map[string]sigKind
 // directly is internal dispatch plumbing and keeps its three-argument
 // form.
 func ScanDecls(filename string, src []byte) (DeclPlan, map[string]bool, error) {
+	return ScanDeclsWith(filename, src, nil)
+}
+
+// ScanDeclsWith is ScanDecls under explicit options.
+//
+// In general mode the second return value is not "used as a value"
+// but the narrower "used as the value of an included callback field".
+// That is deliberate: the wide matcher accepts almost every helper
+// taking a trailing *Window, so intersecting against a bare value-use
+// set (which buildPlan does) would convert half the package. Only a
+// function actually wired to one of the named fields may convert.
+func ScanDeclsWith(
+	filename string, src []byte, opts *Options,
+) (DeclPlan, map[string]bool, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, src, parser.SkipObjectResolution)
 	if err != nil {
@@ -103,11 +151,12 @@ func ScanDecls(filename string, src []byte) (DeclPlan, map[string]bool, error) {
 		// the bare name, so two same-named methods on different
 		// receivers convert together — which is what you want, since
 		// both had to match the callback signature to get here.
-		if sig := classify(fd.Type); sig != sigNone {
-			cands[fd.Name.Name] = sig
-		} else if classifyTwo(fd.Type) {
-			cands[fd.Name.Name] = sigLW
+		if sh, matched := classify(fd.Type, opts); matched {
+			cands[fd.Name.Name] = sh
 		}
+	}
+	if opts.general() {
+		return cands, assignedToFields(f, opts), nil
 	}
 	// Names used as values: every ident occurrence that is not the
 	// callee of a call and not the declaration's own name.
@@ -134,9 +183,49 @@ func ScanDecls(filename string, src []byte) (DeclPlan, map[string]bool, error) {
 	return cands, used, nil
 }
 
+// assignedToFields collects the bare function names wired to one of the
+// included callback fields, either as a struct-literal value
+// (OnSelect: handleSelect) or by assignment (cfg.OnSelect = handleSelect).
+func assignedToFields(f *ast.File, opts *Options) map[string]bool {
+	used := map[string]bool{}
+	note := func(e ast.Expr) {
+		switch v := e.(type) {
+		case *ast.Ident:
+			used[v.Name] = true
+		case *ast.SelectorExpr: // a method value, x.handleSelect
+			used[v.Sel.Name] = true
+		}
+	}
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch t := n.(type) {
+		case *ast.KeyValueExpr:
+			if id, ok := t.Key.(*ast.Ident); ok && opts.owns(id.Name) {
+				note(t.Value)
+			}
+		case *ast.AssignStmt:
+			for i, lhs := range t.Lhs {
+				sel, ok := lhs.(*ast.SelectorExpr)
+				if !ok || !opts.owns(sel.Sel.Name) || i >= len(t.Rhs) {
+					continue
+				}
+				note(t.Rhs[i])
+			}
+		}
+		return true
+	})
+	return used
+}
+
 // Rewrite parses and rewrites a single file. filename is used only for
 // positions in diagnostics. plan may be nil.
 func Rewrite(filename string, src []byte, plan DeclPlan) (Result, error) {
+	return RewriteWith(filename, src, plan, nil)
+}
+
+// RewriteWith is Rewrite under explicit options.
+func RewriteWith(
+	filename string, src []byte, plan DeclPlan, opts *Options,
+) (Result, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
 	if err != nil {
@@ -144,7 +233,7 @@ func Rewrite(filename string, src []byte, plan DeclPlan) (Result, error) {
 	}
 	r := &rewriter{
 		fset: fset, src: src, base: fset.File(f.Pos()).Base(), plan: plan,
-		guiAlias: guiAlias(f),
+		guiAlias: guiAlias(f), opts: opts,
 	}
 	r.run(f)
 	if len(r.edits) == 0 {
@@ -166,6 +255,7 @@ type rewriter struct {
 	plan       DeclPlan
 	declRanges []declRange
 	guiAlias   string // how this file spells the gui package, if at all
+	opts       *Options
 }
 
 // declRange is the body of a converted named declaration, with the
@@ -224,18 +314,45 @@ func (r *rewriter) run(f *ast.File) {
 	})
 	// Pass 1: bare type expressions (struct fields, parameters, results,
 	// var declarations). These carry no body.
-	ast.Inspect(f, func(n ast.Node) bool {
-		ft, ok := n.(*ast.FuncType)
-		if !ok || owned[ft] {
+	if r.opts.general() {
+		// General mode is name-driven, so pass 1 walks *ast.Field
+		// rather than every FuncType: a field node carries the name
+		// the filter needs, and it covers both a struct member
+		// (OnSelect func(...)) and a parameter that passes the
+		// callback onward (onSelect func(...)). A FuncType with no
+		// name attached cannot be attributed and is left alone.
+		ast.Inspect(f, func(n ast.Node) bool {
+			fld, ok := n.(*ast.Field)
+			if !ok {
+				return true
+			}
+			ft, isFn := fld.Type.(*ast.FuncType)
+			if !isFn || owned[ft] {
+				return true
+			}
+			for _, nm := range fld.Names {
+				if !r.opts.owns(nm.Name) {
+					continue
+				}
+				if sh, matched := classify(ft, r.opts); matched {
+					r.rewriteParams(ft, sh, false, "")
+				}
+				break
+			}
 			return true
-		}
-		if sig := classify(ft); sig != sigNone {
-			r.rewriteParams(ft, sig, false, "")
-		} else if classifyTwo(ft) {
-			r.replace(ft.Params.Pos(), ft.Params.End(), "("+ctxType(ft)+")")
-		}
-		return true
-	})
+		})
+	} else {
+		ast.Inspect(f, func(n ast.Node) bool {
+			ft, ok := n.(*ast.FuncType)
+			if !ok || owned[ft] {
+				return true
+			}
+			if sh, matched := classify(ft, r.opts); matched {
+				r.rewriteParams(ft, sh, false, "")
+			}
+			return true
+		})
+	}
 	// Pass 3 (declaration mode) rewrites call sites from the original
 	// source text, which pass 2 also edits, so the two modes run as
 	// separate invocations: closures first, then declarations.
@@ -246,7 +363,7 @@ func (r *rewriter) run(f *ast.File) {
 	}
 	// Pass 2: bodies. Collect innermost-first, then rewrite.
 	var lits []*litInfo
-	collectLits(f, nil, "", &lits)
+	collectLits(f, nil, "", &lits, r.opts)
 	for _, li := range lits {
 		r.rewriteBody(li)
 	}
@@ -263,7 +380,7 @@ func (r *rewriter) rewriteDecls(f *ast.File) {
 		if _, want := r.plan[fd.Name.Name]; !want {
 			continue
 		}
-		li := makeLit(fd.Type, fd.Body, fd.Name.Name)
+		li := makeLit(fd.Type, fd.Body, fd.Name.Name, r.opts, true)
 		if li == nil {
 			continue
 		}
@@ -319,44 +436,23 @@ func (r *rewriter) rewriteCalls(f *ast.File) {
 		default:
 			return true
 		}
-		sig, want := r.plan[id.Name]
-		if !want || call.Ellipsis.IsValid() {
+		sh, want := r.plan[id.Name]
+		if !want || call.Ellipsis.IsValid() || len(call.Args) != sh.n {
 			return true
 		}
-		var layout, event, window, payload string
 		src := func(i int) string {
+			if i < 0 {
+				return "nil"
+			}
 			return r.renameArg(call.Args[i].Pos(), r.srcOf(call.Args[i]))
 		}
-		switch sig {
-		case sigLEW:
-			if len(call.Args) != 3 {
-				return true
-			}
-			layout, event, window = src(0),
-				src(1), src(2)
-		case sigLW:
-			if len(call.Args) != 2 {
-				return true
-			}
-			layout, event, window = src(0), "nil",
-				src(1)
-		case sigLPW:
-			if len(call.Args) != 3 {
-				return true
-			}
-			layout, event, window = src(0), "nil",
-				src(2)
-			payload = src(1)
-		case sigPEW:
-			if len(call.Args) != 3 {
-				return true
-			}
-			layout, event, window = "nil", src(1),
-				src(2)
-			payload = src(0)
-		default:
-			return true
+		layout, event, window := src(sh.layout), src(sh.event),
+			src(sh.window)
+		var payloads []string
+		for _, i := range sh.payload {
+			payloads = append(payloads, src(i))
 		}
+		payload := strings.Join(payloads, ", ")
 		ctxArg := "EventCtx{" + layout + ", " + event + ", " + window + "}"
 		if r.guiAlias != "" {
 			// Keyed form: go vet rejects unkeyed literals of a type
@@ -376,15 +472,19 @@ func (r *rewriter) rewriteCalls(f *ast.File) {
 	})
 }
 
-type sigKind int
-
-const (
-	sigNone sigKind = iota
-	sigLEW          // (*Layout, *Event, *Window)
-	sigLW           // (*Layout, *Window)
-	sigLPW          // (*Layout, payload, *Window)
-	sigPEW          // (payload, *Event, *Window) — payload is not *Layout
-)
+// sigShape records where the EventCtx components sit in a parameter
+// list, as indices into flatParams. -1 means the role is absent, and
+// the corresponding EventCtx field folds to a nil.
+//
+// This subsumes the four fixed shapes the tool originally handled:
+// (*Layout, *Event, *Window) is {0, 1, 2, nil}, (*Layout, *Window) is
+// {0, -1, 1, nil}, (*Layout, T, *Window) is {0, -1, 2, [1]}, and
+// (T, *Event, *Window) is {-1, 1, 2, [0]}.
+type sigShape struct {
+	layout, event, window int
+	payload               []int // kept parameters, in source order
+	n                     int   // total parameter count
+}
 
 // isPtrTo reports whether expr is *Name or *pkg.Name.
 func isPtrTo(expr ast.Expr, name string) bool {
@@ -430,32 +530,75 @@ func flatParams(ft *ast.FuncType) []param {
 	return ps
 }
 
-// classify matches a function type against the four convertible shapes.
-func classify(ft *ast.FuncType) sigKind {
-	ps := flatParams(ft)
-	if len(ps) != 3 || ft.Results != nil {
-		return sigNone
+// classify matches a function type against the convertible shapes,
+// under whichever matcher the options select.
+func classify(ft *ast.FuncType, opts *Options) (sigShape, bool) {
+	if opts.general() {
+		return classifyGeneral(ft)
 	}
-	l, m, w := ps[0].typ, ps[1].typ, ps[2].typ
-	if !isPtrTo(w, "Window") {
-		return sigNone
-	}
-	switch {
-	case isPtrTo(l, "Layout") && isPtrTo(m, "Event"):
-		return sigLEW
-	case isPtrTo(l, "Layout"):
-		return sigLPW
-	case isPtrTo(m, "Event"):
-		return sigPEW
-	}
-	return sigNone
+	return classifyStrict(ft)
 }
 
-// classifyTwo matches func(*Layout, *Window).
-func classifyTwo(ft *ast.FuncType) bool {
+// classifyGeneral matches any parameter list ending in *Window. A
+// leading *Layout and the first *Event fold into the EventCtx; every
+// other parameter is payload and keeps its position.
+//
+// Results are deliberately not examined. OnCopyRows returns
+// (string, bool) and still converts — the agreed invariant is that
+// EventCtx replaces the *Window and *Event parameters and says nothing
+// about what a callback returns.
+func classifyGeneral(ft *ast.FuncType) (sigShape, bool) {
 	ps := flatParams(ft)
-	return len(ps) == 2 && ft.Results == nil &&
-		isPtrTo(ps[0].typ, "Layout") && isPtrTo(ps[1].typ, "Window")
+	sh := sigShape{layout: -1, event: -1, window: -1, n: len(ps)}
+	if len(ps) == 0 || !isPtrTo(ps[len(ps)-1].typ, "Window") {
+		return sh, false
+	}
+	sh.window = len(ps) - 1
+	for i := range ps[:len(ps)-1] {
+		switch {
+		case i == 0 && isPtrTo(ps[i].typ, "Layout"):
+			sh.layout = i
+		case sh.event < 0 && isPtrTo(ps[i].typ, "Event"):
+			sh.event = i
+		default:
+			sh.payload = append(sh.payload, i)
+		}
+	}
+	return sh, true
+}
+
+// classifyStrict is the original matcher: exactly the four
+// three-argument shapes plus func(*Layout, *Window), and never a
+// function that returns a value.
+func classifyStrict(ft *ast.FuncType) (sigShape, bool) {
+	ps := flatParams(ft)
+	sh := sigShape{layout: -1, event: -1, window: -1, n: len(ps)}
+	if len(ps) == 0 || ft.Results != nil ||
+		!isPtrTo(ps[len(ps)-1].typ, "Window") {
+		return sh, false
+	}
+	switch len(ps) {
+	case 2:
+		if !isPtrTo(ps[0].typ, "Layout") {
+			return sh, false
+		}
+		sh.layout, sh.window = 0, 1
+		return sh, true
+	case 3:
+		sh.window = 2
+		switch {
+		case isPtrTo(ps[0].typ, "Layout") && isPtrTo(ps[1].typ, "Event"):
+			sh.layout, sh.event = 0, 1
+		case isPtrTo(ps[0].typ, "Layout"):
+			sh.layout, sh.payload = 0, []int{1}
+		case isPtrTo(ps[1].typ, "Event"):
+			sh.event, sh.payload = 1, []int{0}
+		default:
+			return sh, false
+		}
+		return sh, true
+	}
+	return sh, false
 }
 
 // ctxType returns the EventCtx type expression spelled the same way the
@@ -483,7 +626,7 @@ func (r *rewriter) srcOf(n ast.Node) string {
 // EventCtx parameter gets the name "ctx"; bare type expressions leave it
 // unnamed.
 func (r *rewriter) rewriteParams(
-	ft *ast.FuncType, sig sigKind, named bool, cn string,
+	ft *ast.FuncType, sh sigShape, named bool, cn string,
 ) {
 	ps := flatParams(ft)
 	ct := ctxType(ft)
@@ -491,20 +634,15 @@ func (r *rewriter) rewriteParams(
 	if named {
 		ctxParam = cn + " " + ct
 	}
-	var text string
-	switch sig {
-	case sigLEW, sigLW:
-		text = "(" + ctxParam + ")"
-	case sigLPW:
-		// Payload is the middle parameter; the *Layout is folded away.
-		text = "(" + r.payload(ps[1], named) + ", " + ctxParam + ")"
-	case sigPEW:
-		// Payload is the leading parameter; the *Event is folded away.
-		text = "(" + r.payload(ps[0], named) + ", " + ctxParam + ")"
-	default:
-		return
+	// Payloads keep their order and their names; the EventCtx always
+	// lands last, which is the target shape func(T…, EventCtx).
+	var parts []string
+	for _, i := range sh.payload {
+		parts = append(parts, r.payload(ps[i], named))
 	}
-	r.replace(ft.Params.Pos(), ft.Params.End(), text)
+	parts = append(parts, ctxParam)
+	r.replace(ft.Params.Pos(), ft.Params.End(),
+		"("+strings.Join(parts, ", ")+")")
 }
 
 func (r *rewriter) payload(p param, named bool) string {
@@ -524,8 +662,7 @@ func (r *rewriter) payload(p param, named bool) string {
 type litInfo struct {
 	ft    *ast.FuncType
 	body  *ast.BlockStmt
-	sig   sigKind
-	two   bool // matched func(*Layout, *Window)
+	sh    sigShape
 	names [3]string
 	owner string // enclosing field or func name, for the report
 	cls   bool   // true when consume-class
@@ -535,47 +672,65 @@ type litInfo struct {
 // collectLits gathers convertible function literals and declarations
 // innermost-first. owner is the nearest enclosing struct field key or
 // assignment target, which is how the class is determined.
-func collectLits(n ast.Node, _ ast.Node, owner string, out *[]*litInfo) {
+func collectLits(
+	n ast.Node, _ ast.Node, owner string, out *[]*litInfo, opts *Options,
+) {
 	switch t := n.(type) {
 	case *ast.KeyValueExpr:
 		key := ""
 		if id, ok := t.Key.(*ast.Ident); ok {
 			key = id.Name
 		}
-		collectLits(t.Value, t, key, out)
+		collectLits(t.Value, t, key, out, opts)
 		return
 	case *ast.AssignStmt:
 		for i, rhs := range t.Rhs {
 			key := owner
 			if i < len(t.Lhs) {
-				if sel, ok := t.Lhs[i].(*ast.SelectorExpr); ok {
-					key = sel.Sel.Name
+				switch lhs := t.Lhs[i].(type) {
+				case *ast.SelectorExpr:
+					key = lhs.Sel.Name
+				case *ast.Ident:
+					// A local holding a callback — onChange := func(…) —
+					// names the field just as well as cfg.OnChange does,
+					// and widget internals and tests are full of them.
+					key = lhs.Name
 				}
 			}
-			collectLits(rhs, t, key, out)
+			collectLits(rhs, t, key, out, opts)
 		}
 		for _, lhs := range t.Lhs {
-			collectLits(lhs, t, owner, out)
+			collectLits(lhs, t, owner, out, opts)
 		}
 		return
 	case *ast.FuncDecl:
 		// Body only — the declaration's own signature is left for a
 		// human, since its call sites move with it.
 		for _, c := range childNodes(t) {
-			collectLits(c, t, t.Name.Name, out)
+			collectLits(c, t, t.Name.Name, out, opts)
 		}
 		return
 	case *ast.FuncLit:
-		for _, c := range childNodes(t) {
-			collectLits(c, t, owner, out)
+		// Nested closures are not the callback. In strict mode the
+		// inherited owner only tinted the consume-class report, so
+		// passing it down was harmless; in general mode the owner is
+		// the gate, and inheriting it converts every *Window-tailed
+		// closure written inside a callback body — a QueueCommand
+		// argument, say. Clear it there.
+		inner := owner
+		if opts.general() {
+			inner = ""
 		}
-		if li := makeLit(t.Type, t.Body, owner); li != nil {
+		for _, c := range childNodes(t) {
+			collectLits(c, t, inner, out, opts)
+		}
+		if li := makeLit(t.Type, t.Body, owner, opts, false); li != nil {
 			*out = append(*out, li)
 		}
 		return
 	}
 	for _, c := range childNodes(n) {
-		collectLits(c, n, owner, out)
+		collectLits(c, n, owner, out, opts)
 	}
 }
 
@@ -599,34 +754,40 @@ func childNodes(n ast.Node) []ast.Node {
 	return kids
 }
 
-func makeLit(ft *ast.FuncType, body *ast.BlockStmt, owner string) *litInfo {
+// force skips the name filter. A named declaration reaches makeLit
+// only because the plan already established that it is wired to an
+// included callback field; re-testing its own name (handleSelect, not
+// OnSelect) would reject every one of them.
+func makeLit(
+	ft *ast.FuncType, body *ast.BlockStmt, owner string, opts *Options,
+	force bool,
+) *litInfo {
 	if body == nil {
 		return nil
 	}
-	sig := classify(ft)
-	two := false
-	if sig == sigNone {
-		if !classifyTwo(ft) {
-			return nil
-		}
-		two = true
+	// In general mode the name filter is the whole safety margin: the
+	// matcher accepts anything ending in *Window, so an unattributed
+	// closure must not convert.
+	if opts.general() && !force && !opts.owns(owner) {
+		return nil
+	}
+	sh, ok := classify(ft, opts)
+	if !ok {
+		return nil
 	}
 	ps := flatParams(ft)
 	li := &litInfo{
-		ft: ft, body: body, sig: sig, two: two, owner: owner,
+		ft: ft, body: body, sh: sh, owner: owner,
 		cls: isConsumeOwner(owner),
 		cn:  contextName(body, ps),
 	}
-	switch {
-	case two:
-		li.names = [3]string{ps[0].name, "", ps[1].name}
-	case sig == sigLEW:
-		li.names = [3]string{ps[0].name, ps[1].name, ps[2].name}
-	case sig == sigLPW:
-		li.names = [3]string{ps[0].name, "", ps[2].name}
-	case sig == sigPEW:
-		li.names = [3]string{"", ps[1].name, ps[2].name}
+	at := func(i int) string {
+		if i < 0 {
+			return ""
+		}
+		return ps[i].name
 	}
+	li.names = [3]string{at(sh.layout), at(sh.event), at(sh.window)}
 	return li
 }
 
@@ -670,12 +831,7 @@ func contextName(body *ast.BlockStmt, ps []param) string {
 }
 
 func (r *rewriter) rewriteBody(li *litInfo) {
-	if li.two {
-		ct := ctxType(li.ft)
-		r.replace(li.ft.Params.Pos(), li.ft.Params.End(), "("+li.cn+" "+ct+")")
-	} else {
-		r.rewriteParams(li.ft, li.sig, true, li.cn)
-	}
+	r.rewriteParams(li.ft, li.sh, true, li.cn)
 	r.rewriteHandled(li)
 	r.renameIdents(li)
 	if li.cls {

--- a/tools/eventctx/fold.go
+++ b/tools/eventctx/fold.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"slices"
 	"strings"
 )
 
@@ -35,6 +36,14 @@ func guiAlias(f *ast.File) string {
 type FoldSpec struct {
 	Line, Col int
 	Have      string
+
+	// WrapWindow selects the other diagnostic shape. When a callback
+	// gains no parameters overall — func(T, *Window) becoming
+	// func(T, EventCtx) — the argument count still matches, so the
+	// compiler reports a type mismatch on the trailing *Window rather
+	// than a surplus argument, and Have is unavailable. Only that one
+	// argument needs wrapping; every other argument stays put.
+	WrapWindow bool
 }
 
 // FoldCalls applies the given fold specs to one file.
@@ -71,6 +80,10 @@ func FoldCalls(filename string, src []byte, specs []FoldSpec) ([]byte, error) {
 		if !ok {
 			return nil, fmt.Errorf("%s:%d:%d: no call found", filename, sp.Line, sp.Col)
 		}
+		if sp.WrapWindow {
+			r.wrapWindowArg(call, off)
+			continue
+		}
 		text, err := foldArgs(r, call, sp.Have)
 		if err != nil {
 			return nil, fmt.Errorf("%s:%d:%d: %w", filename, sp.Line, sp.Col, err)
@@ -81,6 +94,32 @@ func FoldCalls(filename string, src []byte, specs []FoldSpec) ([]byte, error) {
 		return src, nil
 	}
 	return r.apply(), nil
+}
+
+// wrapWindowArg replaces the single *Window argument at off with an
+// EventCtx. Inside an already-converted callback the window is spelled
+// ctx.Window, and the whole context is both available and strictly more
+// informative, so pass ctx through rather than discarding the layout
+// and event it carries.
+func (r *rewriter) wrapWindowArg(call *ast.CallExpr, off int) {
+	for _, a := range call.Args {
+		if r.offset(a.Pos()) != off {
+			continue
+		}
+		text := r.srcOf(a)
+		if text == "ctx.Window" {
+			r.replace(a.Pos(), a.End(), "ctx")
+			return
+		}
+		ctxName := "EventCtx"
+		if r.guiAlias != "" {
+			r.replace(a.Pos(), a.End(),
+				r.guiAlias+".EventCtx{Window: "+text+"}")
+			return
+		}
+		r.replace(a.Pos(), a.End(), ctxName+"{nil, nil, "+text+"}")
+		return
+	}
 }
 
 // foldArgs builds the replacement argument list. The shape of Have says
@@ -105,7 +144,12 @@ func foldArgs(r *rewriter, call *ast.CallExpr, have string) (string, error) {
 	// matched by type name, then any remaining untyped nil is filled
 	// right to left: event first, then layout. An untyped nil carries
 	// no type in the diagnostic, so position is the only signal.
-	layout, event, payload := "nil", "nil", ""
+	// layout stays empty while no argument maps to it, which
+	// distinguishes "the old signature had no *Layout at all" from "the
+	// caller deliberately passed nil for one". Only the former may be
+	// widened to the enclosing ctx below.
+	layout, event := "", "nil"
+	var payloads []string // built back to front, reversed below
 	window := src(len(parts) - 1)
 	for i := len(parts) - 2; i >= 0; i-- {
 		p := parts[i]
@@ -121,11 +165,27 @@ func foldArgs(r *rewriter, call *ast.CallExpr, have string) (string, error) {
 				layout = src(i)
 			}
 		default:
-			if payload != "" {
-				return "", fmt.Errorf("two payload arguments in %q", have)
-			}
-			payload = src(i)
+			// Any number of payload arguments is legitimate:
+			// OnTextCommit carries a string and an
+			// InputCommitReason. They keep their relative order.
+			payloads = append(payloads, src(i))
 		}
+	}
+	slices.Reverse(payloads)
+	payload := strings.Join(payloads, ", ")
+
+	// Inside an already-converted callback the whole context is in
+	// scope. Where the old signature carried no *Layout, synthesising
+	// EventCtx{nil, ctx.Event, ctx.Window} would manufacture an absence
+	// — there is a layout, the callback is dispatched from it — so pass
+	// ctx through and let the callback see it. A layout the caller
+	// explicitly passed as nil is left alone; that was a decision.
+	layoutAbsent := layout == ""
+	if layoutAbsent {
+		layout = "nil"
+	}
+	if layoutAbsent && event == "ctx.Event" && window == "ctx.Window" {
+		return join(payload, "ctx"), nil
 	}
 
 	out := ctxName + "{" + layout + ", " + event + ", " + window + "}"
@@ -143,6 +203,14 @@ func foldArgs(r *rewriter, call *ast.CallExpr, have string) (string, error) {
 		out = payload + ", " + out
 	}
 	return out, nil
+}
+
+// join prefixes the payload arguments, if any, to the context argument.
+func join(payload, ctx string) string {
+	if payload == "" {
+		return ctx
+	}
+	return payload + ", " + ctx
 }
 
 // splitParams splits a compiler-reported parameter list on commas at
@@ -176,7 +244,11 @@ func ParseBuildErrors(out string) map[string][]FoldSpec {
 	specs := map[string][]FoldSpec{}
 	lines := strings.Split(out, "\n")
 	for i, ln := range lines {
-		if !strings.Contains(ln, "too many arguments in call to") {
+		surplus := strings.Contains(ln, "too many arguments in call to")
+		// The second shape: same argument count, wrong type on the
+		// trailing *Window. The column points at that argument.
+		mismatch := strings.Contains(ln, "EventCtx value in argument to")
+		if !surplus && !mismatch {
 			continue
 		}
 		head := strings.SplitN(ln, ":", 4)
@@ -186,6 +258,11 @@ func ParseBuildErrors(out string) map[string][]FoldSpec {
 		file := head[0]
 		var line, col int
 		if _, err := fmt.Sscanf(head[1]+" "+head[2], "%d %d", &line, &col); err != nil {
+			continue
+		}
+		if mismatch {
+			specs[file] = append(specs[file],
+				FoldSpec{Line: line, Col: col, WrapWindow: true})
 			continue
 		}
 		have := ""

--- a/tools/eventctx/general_test.go
+++ b/tools/eventctx/general_test.go
@@ -1,0 +1,182 @@
+package eventctx
+
+import (
+	"go/format"
+	"strings"
+	"testing"
+)
+
+// convertSet is the §4.3 include list in miniature: enough names to
+// exercise the filter in both directions.
+func convertSet() *Options {
+	return &Options{Fields: map[string]bool{
+		"OnSelect": true, "OnTextCommit": true, "OnCopyRows": true,
+		"OnLayoutChange": true,
+	}}
+}
+
+func rewriteGeneral(t *testing.T, src string) string {
+	t.Helper()
+	res, err := RewriteWith("p.go", []byte(src), nil, convertSet())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := format.Source(res.Src)
+	if err != nil {
+		t.Fatalf("result does not parse: %v\n%s", err, res.Src)
+	}
+	return string(out)
+}
+
+// The plain *Window-tailed case: the shape the strict matcher rejected
+// because it has neither a *Layout nor an *Event to fold.
+func TestGeneralConvertsWindowTail(t *testing.T) {
+	got := rewriteGeneral(t, `package p
+
+type Cfg struct {
+	OnSelect func(string, *Window)
+	OnInit   func(*Window)
+}
+`)
+	if !strings.Contains(got, "OnSelect func(string, EventCtx)") {
+		t.Errorf("OnSelect not converted:\n%s", got)
+	}
+	// The filter is the safety margin — an excluded lifecycle callback
+	// of the identical shape must be left exactly as it was.
+	if !strings.Contains(got, "OnInit   func(*Window)") {
+		t.Errorf("OnInit was touched:\n%s", got)
+	}
+}
+
+// Multiple payloads keep their order, and the *Layout in front folds
+// away with the *Window at the back.
+func TestGeneralPreservesPayloadOrder(t *testing.T) {
+	got := rewriteGeneral(t, `package p
+
+type Cfg struct {
+	OnTextCommit func(*Layout, string, InputCommitReason, *Window)
+}
+`)
+	want := "OnTextCommit func(string, InputCommitReason, EventCtx)"
+	if !strings.Contains(got, want) {
+		t.Errorf("want %q, got:\n%s", want, got)
+	}
+}
+
+// The agreed OnCopyRows invariant: EventCtx replaces the *Window and
+// *Event parameters and says nothing about the results.
+func TestGeneralKeepsResults(t *testing.T) {
+	got := rewriteGeneral(t, `package p
+
+type Cfg struct {
+	OnCopyRows func([]GridRow, *Event, *Window) (string, bool)
+}
+`)
+	want := "OnCopyRows func([]GridRow, EventCtx) (string, bool)"
+	if !strings.Contains(got, want) {
+		t.Errorf("want %q, got:\n%s", want, got)
+	}
+}
+
+// Widget internals pass a callback onward under the lowercased name.
+func TestGeneralMatchesLowercasedParam(t *testing.T) {
+	got := rewriteGeneral(t, `package p
+
+func rows(onSelect func(string, *Window)) {}
+`)
+	if !strings.Contains(got, "onSelect func(string, EventCtx)") {
+		t.Errorf("lowercased parameter not converted:\n%s", got)
+	}
+}
+
+// A closure body renames through the context, and only under an
+// included key.
+func TestGeneralRewritesClosureBodies(t *testing.T) {
+	got := rewriteGeneral(t, `package p
+
+func f() {
+	_ = Cfg{
+		OnSelect: func(id string, w *Window) {
+			use(w, id)
+		},
+		OnInit: func(w *Window) {
+			use(w, "")
+		},
+	}
+}
+`)
+	if !strings.Contains(got, "func(id string, ctx EventCtx)") ||
+		!strings.Contains(got, "use(ctx.Window, id)") {
+		t.Errorf("OnSelect closure not converted:\n%s", got)
+	}
+	if !strings.Contains(got, "OnInit: func(w *Window)") {
+		t.Errorf("OnInit closure was touched:\n%s", got)
+	}
+}
+
+// A closure written inside a converted callback belongs to whatever
+// takes it, not to the callback. Inheriting the owner name down the
+// tree converted every QueueCommand argument in the examples.
+func TestGeneralDoesNotInheritOwnerIntoNestedClosures(t *testing.T) {
+	got := rewriteGeneral(t, `package p
+
+func f() {
+	_ = Cfg{
+		OnSelect: func(id string, w *Window) {
+			w.QueueCommand(func(w2 *Window) {
+				use(w2, id)
+			})
+		},
+	}
+}
+`)
+	if !strings.Contains(got, "func(id string, ctx EventCtx)") {
+		t.Errorf("outer callback not converted:\n%s", got)
+	}
+	if !strings.Contains(got, "func(w2 *Window)") {
+		t.Errorf("nested closure was converted:\n%s", got)
+	}
+}
+
+// A *Window-tailed helper that is not wired to an included field must
+// survive the wide matcher untouched. This is the regression the name
+// filter exists to prevent.
+func TestGeneralLeavesUnattributedHelpersAlone(t *testing.T) {
+	src := `package p
+
+func helper(l *Layout, e *Event, w *Window) {
+	use(l, e, w)
+}
+`
+	if got := rewriteGeneral(t, src); got != src {
+		t.Errorf("helper rewritten:\n%s", got)
+	}
+}
+
+// The declaration plan in general mode keys off the field wiring, not
+// off the signature: only a function actually assigned to an included
+// field may convert.
+func TestGeneralScanDeclsUsesFieldWiring(t *testing.T) {
+	src := []byte(`package p
+
+func handleSelect(id string, w *Window) {}
+func handleOther(id string, w *Window)  {}
+
+var c = Cfg{OnSelect: handleSelect, OnInit: handleOther}
+`)
+	cands, used, err := ScanDeclsWith("p.go", src, convertSet())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The wide matcher accepts both declarations as candidates...
+	if _, ok := cands["handleOther"]; !ok {
+		t.Fatal("handleOther missing from candidates")
+	}
+	// ...and the field wiring is what narrows the plan to one.
+	if !used["handleSelect"] {
+		t.Error("handleSelect not recorded as wired to an included field")
+	}
+	if used["handleOther"] {
+		t.Error("handleOther wired to OnInit, which is excluded")
+	}
+}


### PR DESCRIPTION
Implements §4.3 of `docs/specs/developer-ergonomics.md`. Finishes what the
v0.52.0 `EventCtx` refactor started.

## What converts

17 distinct signatures, across 56 files: `OnAction`, `OnChange`,
`OnColumnPinChange`, `OnCopyRows`, `OnItemClick`, `OnLayoutChange`,
`OnPanelClose`, `OnPanelSelect`, `OnReorder`, `OnReset`, `OnSelect`,
`OnSubmit`, `OnTextCommit`, `OnToggle`, `OnValueCommit`.

The rule is uniform: `EventCtx` replaces the `*Layout`, `*Event` and `*Window`
parameters and lands last. Payloads keep their order, results are untouched.

```go
// Before
OnSelect func(map[int]bool, int, *Event, *Window)
// After
OnSelect func(map[int]bool, int, EventCtx)
```

**`OnCopyRows` took the invariant, not an exemption** — it is now
`func([]GridRow, EventCtx) (string, bool)`. The spec's two target shapes were
stated too narrowly; "returns nothing" was never load-bearing.

## What deliberately does not

The 13 remaining signatures. Twelve fire from a timer tick, a dialog completion
or a lifecycle transition — `OnInit`, `OnCloseRequest`, `OnOkYes`, `OnCancelNo`,
`OnDismiss`, `OnReply`, `OnLazyLoad`, `OnValue`, four `OnDone` variants. There
is no event at those points, so an `EventCtx` would promise a permanently-nil
`ctx.Event`. The thirteenth, `Window.OnEvent`, is a raw escape hatch by design.

Verified by re-running `ergoaudit -mode callbacks`:

| Bucket               | Before | After |
| -------------------- | ------ | ----- |
| `func(T…, *Window)`  | 24     | 12    |
| leaks raw `*Event`   | 5      | 1     |
| `func(EventCtx)`     | 16     | 18    |
| `func(T…, EventCtx)` | 19     | 32    |

## Codemod changes

`tools/eventctx` gains a `-fields` mode. The v0.52 tool matched by signature,
which is safe only because nothing else looks like
`func(*Layout, *Event, *Window)`. A trailing `*Window` is not distinctive — it
describes most internal plumbing — so the widened matcher is gated on an
explicit list of field names, matched ignoring the leading case so `onSelect`
matches `OnSelect`.

Three defects surfaced only by running it against the tree, each a case where
the name filter was consulted in the wrong place. All are pinned by tests in
`tools/eventctx/general_test.go`:

1. Nested closures inherited the owner name, converting every
   `w.QueueCommand(func(w *gui.Window) {…})` inside a converted body.
2. Named declarations were filtered by their own name rather than the field they
   are wired to, so `onShowcaseSplitterMainChange` was rejected.
3. Assignment targets were read only from selectors, making
   `onChange := func(…)` invisible.

## One judgment call

Where a widget dispatches these from inside an already-converted callback, the
fold emits `ctx` rather than `EventCtx{nil, ctx.Event, ctx.Window}` — 29 sites.
The old signature carried no `*Layout`, so callers now receive strictly more
than before; synthesizing a nil layout when one is in scope would manufacture an
absence. The six internal helpers that genuinely only ever had a `*Window` still
get `EventCtx{nil, nil, w}`, which is faithful.

This is additive, but it is a behavior change beyond the mechanical rewrite.

## Impact and verification

**Zero sibling sites.** None of `go-charts`, `go-edit`, `go-kite`, `go-term` or
`go-map` uses any of the 17 — confirming the §4.3.1 finding that no sibling pays
for this conversion.

Local: `gofmt`, `go build`, `go vet`, `requiredid`, `golangci-lint` (0 issues),
78/78 test packages, Prettier — all clean. Zero rule-4 review items.

Docs: CHANGELOG breaking entry, `docs/migration-eventctx.md` (new table rows,
exclusion list, `-fields` mode), spec §4.3.2 and progress table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
