### PR TITLE
feat(debug): event-collapse check, and the number it produced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,27 @@ Breaking items are listed under "Changed" below as they land.
 
 ### Added
 
+- **An event-collapse check under `gui.Debug(true)`**, plus
+  `(*Window).TestEventCollapse` to sweep a window with it armed. It reports
+  consume-class callbacks that rely on automatic handling while an ancestor
+  would also have received the event — the sites that would silently start
+  firing twice if the consume/notify split were ever collapsed into one rule
+  (spec §4.3b).
+
+  This class of risk cannot be counted from source, because "would an ancestor
+  have received it" is a property of the layout tree at dispatch time. The check
+  therefore runs after each consume-class callback and replays that event's real
+  dispatch condition — hit test plus `ClickButton` filter for `OnClick`, the
+  centroid for `OnGesture`, focus for `OnChar` — against each ancestor.
+
+  Sweeping 37 examples finds **18** such sites, against the 138 consume-class
+  sites a source count had suggested, and nearly every one is a go-gui widget
+  nested in another go-gui widget rather than application code. go-charts and
+  go-map sweep clean. Findings and method: spec §4.3.3.
+
+  Diagnostics only; nothing about dispatch changes. Off by default, and the
+  event benchmarks stay at zero allocations.
+
 - **`ColorSet` and `Flat`** (`gui/color_set.go`), as the `Colors` field. Landed
   on `ButtonCfg` in phase 3 and widened to six widgets in phase 4 (see
   "Changed"). Groups `Base`, `Hover`, `Click`, `Focus`, `Border` and

--- a/docs/migration-eventctx.md
+++ b/docs/migration-eventctx.md
@@ -106,6 +106,33 @@ get no auto-consume: mouse lock already bypasses hit-testing and propagation.
 Their coordinates stay window-absolute, unlike the shape-relative coordinates
 everywhere else.
 
+## Checking your app against a future one-rule model
+
+The consume/notify split is settled for v0.54.0, but collapsing it into a single
+rule — nothing pre-marked, every callback consumes explicitly — is still on the
+table. If that happens, a consume-class callback that relies on the pre-mark
+today would start letting the event through to an ancestor, with no compile
+error to warn you.
+
+`gui.Debug(true)` reports those sites as they are dispatched, and
+`TestEventCollapse` sweeps a whole window for them:
+
+```go
+w := gui.NewTestWindow(gui.WindowCfg{State: &App{}})
+w.TestRender(mainView)
+for _, f := range w.TestEventCollapse() {
+    t.Log(f)
+}
+```
+
+Each finding names an inner callback and the ancestor that would also have
+received the event. The fix is to add `ctx.Consume()` to the inner handler,
+which pins today's behaviour and is correct under either model.
+
+The sweep fires every consume-class callback in the window, so give it a window
+built for the purpose. It also sees only the frame in front of it — a hazard
+behind a tab or a dialog needs the app driven into that state first.
+
 ## What `Bubble()` does and does not do
 
 `ctx.Bubble()` opts out of **this callback's** auto-consume. It does not

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -633,6 +633,73 @@ faithful.
 Cost: 45 files, zero rule-4 review items, and **zero sibling sites** —
 confirming §4.3.1's finding that no sibling pays for this conversion.
 
+#### 4.3.3 Measuring the §4.3b collapse (2026-08-08)
+
+§7.2 says the collapse's risk is silent, and §4.3.1 put the exposure at
+138 consume-class sites in `examples/` — while noting that "most sit on
+widgets with no clickable ancestor, but which ones those are is not
+determinable" from the source. That is the whole difficulty: the
+question is about the layout tree at dispatch time, so no amount of
+grepping answers it.
+
+**So it is now answered at dispatch time.** `gui.Debug(true)` gained a
+check (`gui/debug_event.go`) that runs after every consume-class
+callback and reports the site when both halves of the hazard hold: the
+callback relied on the pre-mark (it neither called `ctx.Consume()` nor
+`ctx.Bubble()`), **and** an ancestor would also have received the event.
+Ancestor is decided by replaying that event's real dispatch condition —
+`PointInShape` plus the `ClickButton` filter for `OnClick`, the centroid
+for `OnGesture`, focus for `OnChar` — so the answer is the one dispatch
+would actually give.
+
+`(*Window).TestEventCollapse` sweeps a rendered window with the check
+armed: it fires one synthetic event per consume-class callback in the
+tree and returns the findings. It presses every button in the window,
+so it belongs on a throwaway window.
+
+**Measured exposure: 18 sites, not 138.** Sweeping 37 of the 59
+examples (the rest build their state inside `main()`, so a generated
+sweep cannot construct them):
+
+| Example               | Findings |
+| --------------------- | -------- |
+| `color_picker`        | 8        |
+| `dock_layout`         | 4        |
+| `date_picker_options` | 1        |
+| `key_up_demo`         | 1        |
+| `menu_demo`           | 1        |
+| `multiline_input`     | 1        |
+| `showcase`            | 1        |
+| `todo`                | 1        |
+
+**The important part is not the count but the owner.** Read the pairs:
+`"dock_close:editor"` inside `"dock_tab:top:editor"`, `"picker.rgb.0"`
+inside the color picker's row, a text input inside its clickable
+container. Both sides of nearly every pair are go-gui's own widget
+internals — `view_color_picker.go`, `dock_layout.go`, `view_input.go` —
+not application code. The collapse's silent cost is therefore mostly
+go-gui's to pay, in a handful of files, and mechanically: add
+`ctx.Consume()` to the inner handler and its behaviour is pinned before
+the model changes at all.
+
+**Siblings: zero findings.** go-charts (`basic_bar`, `basic_line`) and
+go-map (`basic`, `full-map`, `partial-map`, `reference-map`) sweep
+clean against this branch. Not sweepable without building their real
+state: go-charts `showcase` (still uses the `Color*` fields deleted in
+§4.4, so it does not compile against the branch — that is the pending
+go-charts bump, not a check failure), go-edit `npad`, go-term
+`falcon`/`minimal`, go-map `gallery-map`/`stacked-map`.
+
+**A sweep is a lower bound.** It sees one rendered frame, so a hazard
+behind a tab, a dialog, or a collapsed panel is invisible until the app
+is driven into that state. The 18 are what the default view of each
+example exposes.
+
+**This does not decide §4.3b.** It replaces the argument's missing
+number: the silent class is 18 known sites concentrated in ~6 go-gui
+widget files, each fixable ahead of the collapse and verifiable by
+re-running the sweep. Whether to collapse is still a separate call.
+
 ### 4.4 Color-set collapse — highest per-app line savings
 
 `examples/todo/main.go:139-166` sets six `Color*` fields on one button
@@ -1188,7 +1255,7 @@ burying them in the same diff.
 | 4     | §4.7 `RTFCfg` + datagrid builder renames | done   |
 | 4     | §4.4 `ColorSet` on six `Cfg`s, flat state fields deleted | done |
 | 4     | §4.3 callback signature conversion       | done   |
-| 4     | §4.3b event-model collapse               | deferred — see §4.3.1 |
+| 4     | §4.3b event-model collapse               | measured — see §4.3.3 |
 | 5     | §4.8 example audit                       | todo   |
 
 Two corrections to §4.2 arising from the implementation.

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -72,6 +72,12 @@ func envTruthy(name string) bool {
 //     other ID-less scrollable in the window)
 //   - a shape with an OnMouseLeave and no ID (the callback never fires)
 //
+// It also reports, from dispatch rather than from the frame audit, any
+// consume-class callback that relies on automatic handling while an
+// ancestor would also have received the event — the sites that would
+// silently start firing twice under the one-rule event model. See
+// debug_event.go.
+//
 // Findings go to stderr, once per finding per window. Turning the
 // gate off and on again clears that memory, so a re-enabled gate
 // reports the state of the frame in front of it.
@@ -101,6 +107,9 @@ const (
 	debugCheckFocusNoID
 	debugCheckScrollNoID
 	debugCheckMouseLeaveNoID
+	// debugCheckEventCollapse is the only check that runs from dispatch
+	// rather than from the per-frame layout audit; see debug_event.go.
+	debugCheckEventCollapse
 )
 
 // debugWarnKey is the warn-once key. For the ID-less checks the
@@ -115,7 +124,11 @@ type debugWarnKey struct {
 // debugState is a window's warn-once memory. Zero value is ready.
 type debugState struct {
 	warned map[debugWarnKey]struct{}
-	gen    uint64
+	// collect, when non-nil, receives findings instead of debugOut. Set
+	// only by TestEventCollapse, which needs the findings as data
+	// rather than as text on stderr.
+	collect *[]string
+	gen     uint64
 }
 
 // debugAudit runs the dev-mode checks over one frame's composed
@@ -213,6 +226,11 @@ func (w *Window) debugWarn(check debugCheck, subject, format string, args ...any
 		w.debug.warned = make(map[debugWarnKey]struct{})
 	}
 	w.debug.warned[key] = struct{}{}
+	if w.debug.collect != nil {
+		*w.debug.collect = append(*w.debug.collect,
+			fmt.Sprintf(format, args...))
+		return
+	}
 	// Diagnostics are best-effort; a failed write to stderr is not
 	// something a GUI frame can act on.
 	_, _ = fmt.Fprintf(debugOut, "gui: "+format+"\n", args...)

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -1,0 +1,255 @@
+package gui
+
+import "strconv"
+
+// Event-model collapse check.
+//
+// §4.3b of docs/specs/developer-ergonomics.md proposes deleting the
+// consume/notify split: one rule, nothing is pre-marked, every callback
+// consumes explicitly. The compile-time half of that change is loud —
+// ctx.Bubble() disappears and its call sites stop building. The other
+// half is silent, and it is the reason the collapse is still deferred:
+// a consume-class callback that relied on the pre-mark and never called
+// ctx.Consume() would, under the collapse, leave the event unhandled
+// and let it reach an ancestor's handler. No compile error, no panic,
+// just a click that now fires twice.
+//
+// Counting call sites cannot measure this. §4.3.1 counted 138
+// consume-class sites in examples/ alone and concluded that most sit on
+// widgets with no clickable ancestor — but which ones those are is a
+// property of the layout tree at dispatch time, not of the source.
+//
+// So the check is a counterfactual, evaluated where the answer is
+// actually knowable: right after a consume-class callback returns, ask
+// (a) did it rely on the pre-mark, and (b) is there an ancestor that
+// would have received this same event. Both true is a site that changes
+// behaviour under the collapse. Everything else is safe to convert.
+//
+// Turn it on with gui.Debug(true) or GOGUI_DEBUG=1, exercise the app,
+// and read the findings off stderr. Each is reported once per window.
+
+// debugCollapse reports one dispatch as a collapse hazard when the
+// callback relied on the consume-class pre-mark and an ancestor would
+// also have received the event.
+//
+// Called from callRelative, executeFocusCallback and the gesture
+// dispatch after every named consume-class callback. explicit is the
+// callback's own ctx.Consume() decision, passed in because callRelative
+// restores the event before calling and would otherwise have handed
+// back the enclosing frame's value.
+//
+// No-op unless [Debug] is on, which is one atomic load.
+func debugCollapse(
+	class evClass, layout *Layout, e *Event, w *Window, explicit bool,
+) {
+	// Dispatch already guards on named(); repeated here so the function
+	// is safe to call directly and cannot be the reason an unnamed
+	// class gets a made-up ancestor rule.
+	if !class.named() {
+		return
+	}
+	if !debugEnabled.Load() || w == nil || e == nil {
+		return
+	}
+	// Bubbling already means the callback opted out, and an explicit
+	// Consume() already means it would keep working verbatim. Only the
+	// silent middle — still handled, never asked for — is at risk.
+	if !e.IsHandled || explicit {
+		return
+	}
+	anc := class.ancestorHandler(layout, e, w)
+	if anc == nil {
+		return
+	}
+	self := debugShapeName(layout)
+	other := debugShapeName(anc)
+	w.debugWarn(debugCheckEventCollapse, class.name()+":"+self+">"+other,
+		"%s on %s relies on automatic handling and %s above it also "+
+			"handles %s; under the one-rule event model (spec §4.3b) the "+
+			"event would reach both. Add ctx.Consume() to the %s handler "+
+			"to make the current behaviour explicit",
+		class.name(), self, other, class.name(), self)
+}
+
+// ancestorHandler returns the nearest ancestor of layout that would
+// have received this event had the callback left it unhandled, or nil.
+//
+// This mirrors what dispatch does, in reverse. The mouse handlers
+// recurse depth-first into children and only run a shape's own callback
+// once every child has declined, so "the next handler" is exactly the
+// nearest enclosing shape with a live callback. The event's coordinates
+// are back in the enclosing space by the time this runs — callRelative
+// restores them before calling.
+func (c evClass) ancestorHandler(layout *Layout, e *Event, w *Window) *Layout {
+	for anc := layout.Parent; anc != nil; anc = anc.Parent {
+		s := anc.Shape
+		// Dispatch skips disabled subtrees (isChildEnabled), so a
+		// disabled ancestor is not a second handler.
+		if s == nil || s.Disabled || !s.hasEvents() {
+			continue
+		}
+		if c.wouldReach(anc, e, w) {
+			return anc
+		}
+	}
+	return nil
+}
+
+// wouldReach reports whether this ancestor's own dispatch condition
+// holds for the event. Each consume-class event has a different one.
+func (c evClass) wouldReach(anc *Layout, e *Event, w *Window) bool {
+	s := anc.Shape
+	ev := s.events
+	switch c {
+	case evClick:
+		// The button filter is part of the dispatch condition
+		// (mouseDownHandler), so an ancestor listening for right-click
+		// only is not reached by a left-click.
+		if ev.OnClick == nil ||
+			(ev.ClickButton != 0 && e.MouseButton != ev.ClickButton) {
+			return false
+		}
+		return s.PointInShape(e.MouseX, e.MouseY)
+	case evMouseUp:
+		return ev.OnMouseUp != nil && s.PointInShape(e.MouseX, e.MouseY)
+	case evFileDrop:
+		return ev.OnFileDrop != nil && s.PointInShape(e.MouseX, e.MouseY)
+	case evGesture:
+		// gestureHandler hit-tests the centroid, not the mouse.
+		return ev.OnGesture != nil && s.PointInShape(e.CentroidX, e.CentroidY)
+	case evChar:
+		// charHandler delivers only to the focused target, and a window
+		// has one focus ID — so this is nearly always false, and the
+		// dialog shape (reservedDialogID, which isFocusedTarget treats
+		// as focused unconditionally) is the one case that fires.
+		return ev.OnChar != nil && isFocusedTarget(anc, w)
+	}
+	return false
+}
+
+// name is the callback spelling, for the finding text and the
+// warn-once key.
+func (c evClass) name() string {
+	switch c {
+	case evClick:
+		return "OnClick"
+	case evChar:
+		return "OnChar"
+	case evMouseUp:
+		return "OnMouseUp"
+	case evFileDrop:
+		return "OnFileDrop"
+	case evGesture:
+		return "OnGesture"
+	}
+	return "event"
+}
+
+// TestEventCollapse sweeps the window for sites that would change
+// behaviour under the one-rule event model of spec §4.3b, and returns
+// one finding per site.
+//
+// It renders a frame, then for every shape carrying a consume-class
+// callback it synthesizes that event at the shape's centre and runs it
+// through real dispatch with the collapse check armed. A finding means
+// the callback relied on automatic handling while an ancestor would
+// also have received the event.
+//
+// **This fires the app's callbacks.** Sweeping a window presses every
+// button in it, in tree order, and whatever state that mutates stays
+// mutated. Call it on a window built for the purpose, not on one an
+// assertion still depends on.
+//
+// Empty result means the window is collapse-safe as rendered. It does
+// not mean the app is: a hazard behind a tab, a dialog, or a scrolled
+// region is only visible once that state is on screen, so drive the app
+// into each interesting state and sweep again.
+//
+// The debug gate is turned on for the duration and restored after.
+func (w *Window) TestEventCollapse() []string {
+	root := w.TestRender(nil)
+	if root == nil {
+		return nil
+	}
+	var found []string
+	prevOn := debugEnabled.Load()
+	// A fresh warn-once map: a sweep should report the window in front
+	// of it, not skip what an earlier sweep or a stray frame reported.
+	prevWarned := w.debug.warned
+	w.debug.warned = nil
+	w.debug.collect = &found
+	Debug(true)
+	defer func() {
+		Debug(prevOn)
+		w.debug.collect = nil
+		w.debug.warned = prevWarned
+	}()
+	w.sweepCollapse(root)
+	return found
+}
+
+// sweepCollapse walks the tree depth-first, dispatching one synthetic
+// event per consume-class callback it finds.
+//
+// Dispatch starts from the root every time rather than from the shape,
+// because hit-testing, focus and the topmost-first traversal are the
+// parts that decide who actually receives the event — starting halfway
+// down would skip exactly the logic the check reasons about.
+func (w *Window) sweepCollapse(root *Layout) {
+	var walk func(l *Layout)
+	walk = func(l *Layout) {
+		if s := l.Shape; s != nil && s.hasEvents() && !s.Disabled {
+			w.sweepShape(root, l)
+		}
+		for i := range l.Children {
+			walk(&l.Children[i])
+		}
+	}
+	walk(root)
+}
+
+// sweepShape fires one synthetic event per consume-class callback on
+// this shape. OnFileDrop is skipped: synthesizing a drop means inventing
+// a file path, and an app that acts on it would touch the filesystem.
+func (w *Window) sweepShape(root, l *Layout) {
+	s := l.Shape
+	ev := s.events
+	cx := s.shapeClip.X + s.shapeClip.Width/2
+	cy := s.shapeClip.Y + s.shapeClip.Height/2
+	if ev.OnClick != nil {
+		mouseDownHandler(root, false,
+			&Event{MouseX: cx, MouseY: cy, MouseButton: ev.ClickButton}, w)
+	}
+	if ev.OnMouseUp != nil {
+		mouseUpHandler(root, &Event{MouseX: cx, MouseY: cy}, w)
+	}
+	if ev.OnGesture != nil {
+		gestureHandler(root, &Event{CentroidX: cx, CentroidY: cy}, w)
+	}
+	// OnChar reaches only the focused target, so focus has to move
+	// there first. Restored afterwards: a sweep should not leave the
+	// window focused on whatever it happened to visit last.
+	if ev.OnChar != nil && s.ID != "" {
+		prev := w.FocusID()
+		w.SetFocus(s.ID)
+		charHandler(root, &Event{CharCode: 'x'}, w)
+		w.SetFocus(prev)
+	}
+}
+
+// debugShapeName identifies a shape in a finding. Prefers the ID; falls
+// back to the position, which is not stable across a resize but is
+// enough to find the widget on screen and to keep two unnamed siblings
+// from sharing a warn-once key.
+func debugShapeName(layout *Layout) string {
+	s := layout.Shape
+	if s == nil {
+		return "<no shape>"
+	}
+	if s.ID != "" {
+		return strconv.Quote(s.ID)
+	}
+	return "the ID-less shape at " +
+		strconv.FormatFloat(float64(s.X), 'g', -1, 32) + "," +
+		strconv.FormatFloat(float64(s.Y), 'g', -1, 32)
+}

--- a/gui/debug_event_test.go
+++ b/gui/debug_event_test.go
@@ -1,0 +1,205 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+)
+
+// collapseTree builds root -> outer -> inner, all covering the same
+// 100x100 box so a click at (5,5) hits every level. Parent pointers are
+// wired, which the collapse check walks. Returns the root.
+func collapseTree(outer, inner *eventHandlers) *Layout {
+	box := drawClip{X: 0, Y: 0, Width: 100, Height: 100}
+	root := &Layout{
+		Shape: &Shape{shapeClip: box},
+		Children: []Layout{{
+			Shape: &Shape{ID: "outer", events: outer, shapeClip: box},
+			Children: []Layout{{
+				Shape: &Shape{ID: "inner", events: inner, shapeClip: box},
+			}},
+		}},
+	}
+	layoutParents(root, nil)
+	return root
+}
+
+// clickCollapse dispatches a left-click at (5,5) and returns whatever
+// the debug gate wrote.
+func clickCollapse(t *testing.T, root *Layout) string {
+	t.Helper()
+	buf := captureDebug(t)
+	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, &Window{})
+	return buf.String()
+}
+
+// The hazard itself: the inner handler never says Consume, so today the
+// pre-mark stops the event, and under §4.3b it would not.
+func TestCollapseWarnsWhenAncestorAlsoHandles(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	got := clickCollapse(t, root)
+	if !strings.Contains(got, `OnClick on "inner"`) ||
+		!strings.Contains(got, `"outer"`) {
+		t.Errorf("expected a collapse finding naming both shapes, got %q", got)
+	}
+}
+
+// An explicit Consume() is what the collapse asks for, so such a site
+// is already correct and must stay quiet.
+func TestCollapseSilentOnExplicitConsume(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(ctx EventCtx) { ctx.Consume() }},
+	)
+	if got := clickCollapse(t, root); got != "" {
+		t.Errorf("explicit Consume() is collapse-safe, got %q", got)
+	}
+}
+
+// Bubble() means the event already reaches the ancestor today, so the
+// collapse changes nothing for this site.
+func TestCollapseSilentOnBubble(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(ctx EventCtx) { ctx.Bubble() }},
+	)
+	if got := clickCollapse(t, root); got != "" {
+		t.Errorf("Bubble() already propagates, got %q", got)
+	}
+}
+
+// The common case §4.3.1 could not count: a handler with no handling
+// ancestor. Most of the 138 example sites are expected to land here.
+func TestCollapseSilentWithoutAncestorHandler(t *testing.T) {
+	root := collapseTree(nil, &eventHandlers{OnClick: func(EventCtx) {}})
+	if got := clickCollapse(t, root); got != "" {
+		t.Errorf("no ancestor handler means no hazard, got %q", got)
+	}
+}
+
+// Dispatch skips disabled subtrees, so a disabled ancestor is not a
+// second handler.
+func TestCollapseSilentWhenAncestorDisabled(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	root.Children[0].Shape.Disabled = true
+	if got := clickCollapse(t, root); got != "" {
+		t.Errorf("disabled ancestor never receives the click, got %q", got)
+	}
+}
+
+// ClickButton is part of the ancestor's dispatch condition, so an
+// ancestor listening for right-click only is not reached by a left one.
+func TestCollapseRespectsAncestorClickButton(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{
+			OnClick: func(EventCtx) {}, ClickButton: MouseRight,
+		},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	if got := clickCollapse(t, root); got != "" {
+		t.Errorf("button filter excludes the ancestor, got %q", got)
+	}
+}
+
+// The check is diagnostics only; with the gate off it must not fire.
+func TestCollapseSilentWhenDebugOff(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	buf := captureDebug(t)
+	Debug(false)
+	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, &Window{})
+	if got := buf.String(); got != "" {
+		t.Errorf("gate off must be silent, got %q", got)
+	}
+}
+
+// Findings are warn-once per window, so holding a mouse button down for
+// a second does not produce sixty identical lines.
+func TestCollapseWarnsOncePerWindow(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	buf := captureDebug(t)
+	w := &Window{}
+	for range 3 {
+		mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, w)
+	}
+	if n := strings.Count(buf.String(), "OnClick on"); n != 1 {
+		t.Errorf("want 1 finding across 3 dispatches, got %d", n)
+	}
+}
+
+// OnMouseUp is consume-class too, and shares the ancestor rule with
+// OnClick.
+func TestCollapseCoversMouseUp(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnMouseUp: func(EventCtx) {}},
+		&eventHandlers{OnMouseUp: func(EventCtx) {}},
+	)
+	buf := captureDebug(t)
+	mouseUpHandler(root, &Event{MouseX: 5, MouseY: 5}, &Window{})
+	if !strings.Contains(buf.String(), `OnMouseUp on "inner"`) {
+		t.Errorf("expected an OnMouseUp finding, got %q", buf.String())
+	}
+}
+
+// OnChar reaches only the focused target and a window has one focus ID,
+// so nesting two OnChar handlers is not a hazard. Pins the reasoning in
+// wouldReach rather than an accident of the tree.
+func TestCollapseSilentForNestedOnChar(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnChar: func(EventCtx) {}},
+		&eventHandlers{OnChar: func(EventCtx) {}},
+	)
+	for _, l := range []*Layout{
+		&root.Children[0], &root.Children[0].Children[0],
+	} {
+		l.Shape.Focusable = true
+	}
+	buf := captureDebug(t)
+	w := &Window{}
+	w.SetFocus("inner")
+	charHandler(root, &Event{CharCode: 'x'}, w)
+	if got := buf.String(); got != "" {
+		t.Errorf("only one shape can hold focus, got %q", got)
+	}
+}
+
+// Notify-class dispatch never pre-marks, so the check must not run for
+// it at all — an unconsumed OnMouseMove under another is by design.
+func TestCollapseIgnoresNotifyClass(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnMouseMove: func(EventCtx) {}},
+		&eventHandlers{OnMouseMove: func(EventCtx) {}},
+	)
+	buf := captureDebug(t)
+	mouseMoveHandler(root, &Event{MouseX: 5, MouseY: 5}, &Window{})
+	if got := buf.String(); got != "" {
+		t.Errorf("notify-class is out of scope, got %q", got)
+	}
+}
+
+// The unnamed generic evConsume carries no ancestor rule, so callers
+// that have not been given a specific kind stay silent rather than
+// guessing.
+func TestCollapseSkipsUnnamedConsumeClass(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	inner := &root.Children[0].Children[0]
+	buf := captureDebug(t)
+	callRelative(inner, &Event{MouseX: 5, MouseY: 5}, &Window{},
+		inner.Shape.events.OnClick, evConsume)
+	if got := buf.String(); got != "" {
+		t.Errorf("evConsume names no event, got %q", got)
+	}
+}

--- a/gui/event.go
+++ b/gui/event.go
@@ -362,6 +362,15 @@ type Event struct {
 	// (already carrying OS momentum). False for discrete mouse-wheel
 	// notches, which the gui side eases via scrollSmoothAnimation.
 	ScrollPrecise bool
+	// explicitConsume records that a callback called ctx.Consume()
+	// rather than leaving IsHandled at whatever dispatch set. Only the
+	// event-collapse debug check reads it (debug_event.go): under the
+	// current model a consume-class callback is pre-marked handled, so
+	// IsHandled alone cannot tell "the callback meant to consume" from
+	// "the callback relied on the pre-mark". Dispatch clears it before
+	// each consume-class callback and the callRelative save/restore
+	// unwinds it, so nested dispatch cannot leak a stale value.
+	explicitConsume bool
 }
 
 // eventRelativeTo returns a copy of the event with mouse

--- a/gui/event_ctx.go
+++ b/gui/event_ctx.go
@@ -27,6 +27,10 @@ type EventCtx struct {
 func (c EventCtx) Consume() {
 	if c.Event != nil {
 		c.Event.IsHandled = true
+		// Record that consumption was asked for, not merely inherited
+		// from the consume-class pre-mark. One unconditional store,
+		// cheaper than gating it on the debug atomic.
+		c.Event.explicitConsume = true
 	}
 }
 
@@ -56,18 +60,49 @@ func (c EventCtx) Handled() bool {
 // events are not, and the callback must call ctx.Consume() to stop
 // propagation.
 //
+// Consume-class values additionally name *which* event is being
+// dispatched. The class alone is enough to dispatch, but the
+// event-collapse debug check (debug_event.go) has to ask "would an
+// ancestor also have received this?", and that question is
+// per-callback: it means OnClick on a containing shape for evClick and
+// the focused target's OnChar for evChar. Carrying the name in the
+// existing parameter keeps the two facts from drifting apart.
+//
 // The classification is internal: it is encoded at the dispatch sites
 // and is neither exposed nor configurable.
-type evClass bool
+type evClass uint8
 
 const (
 	// evNotify leaves IsHandled alone; the callback opts in with
 	// ctx.Consume(). Used for OnKeyDown, OnKeyUp, OnHover, OnMouseMove,
 	// OnMouseLeave, OnMouseScroll, OnScroll, AmendLayout, OnIMECommit.
-	evNotify evClass = false
+	evNotify evClass = iota
 
 	// evConsume pre-marks IsHandled before the callback runs; the
-	// callback opts out with ctx.Bubble(). Used for OnClick, OnChar,
-	// OnMouseUp, OnGesture, OnFileDrop.
-	evConsume evClass = true
+	// callback opts out with ctx.Bubble(). Consume-class without naming
+	// an event: dispatches identically to the named values below but
+	// carries no ancestor rule, so the collapse check skips it.
+	evConsume
+
+	// The named consume-class events. Each pre-marks IsHandled exactly
+	// as evConsume does.
+	evClick
+	evChar
+	evMouseUp
+	evFileDrop
+	evGesture
 )
+
+// consumes reports whether this class pre-marks IsHandled before the
+// callback runs.
+func (c evClass) consumes() bool { return c != evNotify }
+
+// named reports whether this class identifies a specific event, which
+// is the precondition for the collapse check. Ordered so the test is
+// one comparison: the named values are the ones above evConsume.
+//
+// Dispatch guards the debugCollapse call with this rather than letting
+// the check reject the class itself, so notify-class dispatch — the
+// overwhelming majority of events — does not pay for a function call
+// it will always return from immediately.
+func (c evClass) named() bool { return c > evConsume }

--- a/gui/event_handlers.go
+++ b/gui/event_handlers.go
@@ -36,7 +36,7 @@ func charHandler(layout *Layout, e *Event, w *Window) {
 		events = layout.Shape.events
 	}
 	// OnChar is consume-class: pre-marked handled before the callback.
-	if executeFocusCallback(layout, e, w, onChar, evConsume) {
+	if executeFocusCallback(layout, e, w, onChar, evChar) {
 		return
 	}
 	// Spacebar-to-click: when ClickOnSpace is set, fire OnClick
@@ -227,7 +227,7 @@ func mouseDownHandler(
 			}
 		}
 		// OnClick is consume-class.
-		executeMouseCallback(layout, e, w, onClick, evConsume)
+		executeMouseCallback(layout, e, w, onClick, evClick)
 	}
 }
 
@@ -292,7 +292,7 @@ func mouseUpHandler(layout *Layout, e *Event, w *Window) {
 		onMouseUp = layout.Shape.events.OnMouseUp
 	}
 	// OnMouseUp is consume-class.
-	executeMouseCallback(layout, e, w, onMouseUp, evConsume)
+	executeMouseCallback(layout, e, w, onMouseUp, evMouseUp)
 }
 
 func focusedScrollTarget(layout *Layout, w *Window) *Layout {
@@ -400,5 +400,5 @@ func fileDropHandler(layout *Layout, e *Event, w *Window) {
 		onFileDrop = layout.Shape.events.OnFileDrop
 	}
 	// OnFileDrop is consume-class.
-	executeMouseCallback(layout, e, w, onFileDrop, evConsume)
+	executeMouseCallback(layout, e, w, onFileDrop, evFileDrop)
 }

--- a/gui/event_traversal.go
+++ b/gui/event_traversal.go
@@ -34,10 +34,14 @@ func executeFocusCallback(
 	if callback == nil {
 		return false
 	}
-	if class == evConsume {
+	if class.consumes() {
+		e.explicitConsume = false
 		e.IsHandled = true
 	}
 	callback(EventCtx{layout, e, w})
+	if class.named() {
+		debugCollapse(class, layout, e, w, e.explicitConsume)
+	}
 	return e.IsHandled
 }
 
@@ -56,14 +60,29 @@ func callRelative(
 	saved := *e
 	e.MouseX = saved.MouseX - layout.Shape.X
 	e.MouseY = saved.MouseY - layout.Shape.Y
-	if class == evConsume {
+	if class.consumes() {
+		e.explicitConsume = false
 		e.IsHandled = true // pre-mark AFTER the save
 	}
 	callback(EventCtx{layout, e, w})
 	handled := e.IsHandled // a ctx.Bubble() in the callback shows up here
+	// The callback's own Consume() decision, read before the restore
+	// puts the outer frame's value back. Guarded so the notify-class
+	// path — nearly every event — pays a predictable branch and no
+	// load; this is the mouse-scroll hot path.
+	var explicit bool
+	if class.named() {
+		explicit = e.explicitConsume
+	}
 	*e = saved
 	if handled {
 		e.IsHandled = true
+	}
+	// The collapse check runs on the restored event: its ancestor test
+	// needs the coordinates in the enclosing shape's space, not the
+	// shape-relative ones the callback saw.
+	if class.named() {
+		debugCollapse(class, layout, e, w, explicit)
 	}
 	return handled
 }

--- a/gui/gesture.go
+++ b/gui/gesture.go
@@ -518,8 +518,10 @@ func gestureHandler(layout *Layout, e *Event, w *Window) {
 	if layout.Shape.hasEvents() &&
 		layout.Shape.events.OnGesture != nil {
 		// OnGesture is consume-class: pre-mark before the call.
+		e.explicitConsume = false
 		e.IsHandled = true
 		layout.Shape.events.OnGesture(EventCtx{layout, e, w})
+		debugCollapse(evGesture, layout, e, w, e.explicitConsume)
 		if e.IsHandled {
 			return
 		}


### PR DESCRIPTION
Step 3 of the phase-4 order: make the §4.3b event-model collapse loud, then
run it. Diagnostics only — dispatch is unchanged.

## Why a runtime check

§7.2 says the collapse's risk is silent. §4.3.1 put the exposure at 138
consume-class sites in `examples/`, while conceding that "most sit on widgets
with no clickable ancestor, but which ones those are is not determinable"
from the source. That is the whole difficulty: *would an ancestor have
received this event* is a property of the layout tree at dispatch time, so
no amount of grepping answers it.

So it is answered at dispatch time. Under `gui.Debug(true)`, after every
consume-class callback, the check reports the site when both halves hold:

1. the callback relied on the pre-mark — neither `ctx.Consume()` nor
   `ctx.Bubble()`, and
2. an ancestor would also have received the event.

The second half replays that event's real dispatch condition rather than
approximating it: `PointInShape` plus the `ClickButton` filter for `OnClick`,
the centroid for `OnGesture`, focus for `OnChar`, and disabled subtrees
skipped as `isChildEnabled` skips them.

## The measurement

**18 sites, not 138** — across 37 of the 59 examples (the rest build their
state inside `main()`, so a generated sweep cannot construct them).

| Example               | Findings |
| --------------------- | -------- |
| `color_picker`        | 8        |
| `dock_layout`         | 4        |
| `date_picker_options` | 1        |
| `key_up_demo`         | 1        |
| `menu_demo`           | 1        |
| `multiline_input`     | 1        |
| `showcase`            | 1        |
| `todo`                | 1        |

**The count matters less than the ownership.** Read the pairs:
`"dock_close:editor"` inside `"dock_tab:top:editor"`, `"picker.rgb.0"` inside
the picker's row, a text input inside its clickable container. Both sides of
nearly every pair are go-gui's own widget internals — `view_color_picker.go`,
`dock_layout.go`, `view_input.go` — not application code. The collapse's
silent cost is mostly go-gui's to pay, in ~6 files, and mechanically: adding
`ctx.Consume()` to the inner handler pins today's behaviour and is correct
under either model.

**Siblings sweep clean.** go-charts (`basic_bar`, `basic_line`) and go-map
(`basic`, `full-map`, `partial-map`, `reference-map`): zero findings. Not
sweepable without building their real state: go-edit `npad`, go-term
`falcon`/`minimal`, go-map `gallery-map`/`stacked-map`. go-charts `showcase`
does not compile against this branch because it still uses the `Color*`
fields deleted in #199 — that is the pending go-charts bump, not a failure
here.

Two caveats stated in the spec: a sweep sees one frame, so a hazard behind a
tab or dialog is invisible and 18 is a lower bound; and **this does not
decide §4.3b**, it only supplies the number the argument was missing.

## Implementation

- `Event.explicitConsume` (unexported), set by `ctx.Consume()`. Under the
  current model a consume-class callback is pre-marked, so `IsHandled` alone
  cannot tell "meant to consume" from "inherited the pre-mark".
- `evClass` widens from `bool` to `uint8` so consume-class values also name
  their event. `evNotify` and `evConsume` keep their meaning, so no dispatch
  or test site changes behaviour; the named values order above `evConsume`,
  making the hot-path gate one comparison.
- `(*Window).TestEventCollapse` sweeps a rendered window with the check
  armed, returning findings as data. It fires every consume-class callback in
  the tree, so it is documented as belonging on a throwaway window.

12 tests in `gui/debug_event_test.go` pin the behaviour, including the
negatives that make the finding trustworthy: explicit `Consume()`, `Bubble()`,
no ancestor handler, disabled ancestor, `ClickButton` mismatch, notify-class,
gate off, and warn-once.

## Verification

`gofmt`, `go build`, `go vet`, `requiredid`, `golangci-lint` (0 issues),
78/78 test packages, Prettier — all clean.

Event benchmarks stay at **zero allocations**. Timing is noise, not cost:
`MouseScrollFocused` reads 35.4 ns/op against a 33.7 baseline while
`DeepNesting` reads 43.9 against 46.4 on the same run — opposite directions
on adjacent benchmarks. Moving the gate to an inlinable comparison did not
shift either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
