### PR TITLE
refactor(examples): FillFill instead of manual viewport math (v0.54.0, phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,23 @@ Breaking items are listed under "Changed" below as they land.
 
 ### Added
 
+- **Examples now teach `FillFill` instead of manual viewport math** (spec §4.8).
+  `WindowSize()` in `examples/` drops from 45 files / 50 call sites to 8 files /
+  9 call sites. The dominant pattern — fetch the window size, set it as the
+  root's `Width`/`Height`, mark the root `FixedFixed` — is now just
+  `Sizing: gui.FillFill`. `todo`'s hand-computed `cardView(ww-24, wh-24)` and
+  `listbox`'s `Height: wh - 70` are gone; `minesweeper` no longer threads the
+  viewport through both screens.
+
+  The 8 remaining calls are allowlisted and each carries a one-line reason at
+  the call site: canvas, particle, game and virtualized-list demos that compute
+  positions in pixel space. `calculator` is one of them for a reason worth
+  knowing — its root is a `Canvas`, which does not arrange its content, so a
+  `FillFill` child of it measures 0×0.
+
+  Three example tests moved from "did not panic" to real state assertions using
+  the phase-2 testing API: `key_up_demo`, `todo` and `dialogs`.
+
 - **An event-collapse check under `gui.Debug(true)`**, plus
   `(*Window).TestEventCollapse` to sweep a window with it armed. It reports
   consume-class callbacks that rely on automatic handling while an ancestor

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -1059,6 +1059,71 @@ Also convert two or three example tests from no-panic assertions to
 real state-transition assertions once §4.6 lands, so the testing
 pattern is demonstrated rather than described.
 
+#### 4.8.1 Audit result (2026-08-08)
+
+**45 files / 50 call sites → 8 files / 9 call sites.** 37 files
+converted; 8 allowlisted, each with a one-line reason at the call site
+so the remaining calls read as deliberate.
+
+Most of the conversion was one shape repeated 34 times: fetch the
+window size, set it as the root's `Width`/`Height`, and mark the root
+`FixedFixed`. That is `Sizing: gui.FillFill` and nothing else. Six
+cases carried real arithmetic:
+
+| Example         | Was                              | Now                        |
+| --------------- | -------------------------------- | -------------------------- |
+| `todo`          | `cardView(ww-24, wh-24, w)`      | card is `FillFill` inside the page's 12px padding |
+| `listbox`       | `Height: float32(wh) - 70`       | list `FillFill` takes the column remainder |
+| `minesweeper`   | `ww, wh` threaded into both screens | both screens `FillFill`, params dropped |
+| `2048`          | window size in both screens      | `gameView` `FillFill`; landing still needs it |
+| `snake`         | window size in both screens      | play screen `FillFill`; landing still needs it |
+| `animation_stress` | window size in three places   | root `FillFill`; two spawn helpers still need it |
+
+**The allowlist, with the reason each one is real:**
+
+| Example            | Why the viewport is genuinely needed                  |
+| ------------------ | ----------------------------------------------------- |
+| `calculator`       | root is a `Canvas`, which does not arrange, so its centring child cannot Fill |
+| `digital_rain`     | grid columns/rows are the viewport divided by the character cell |
+| `fontviewer`       | virtualization: `ListVisibleRange` needs the viewport height before arrange |
+| `particles`        | particle field is simulated in pixel space            |
+| `solitaire`        | cards, status bar and win overlay at absolute positions |
+| `2048` (landing)   | backdrop tiles at computed pixel coordinates          |
+| `snake` (landing)  | same, plus a backdrop sized `ww-64` × `wh-88`         |
+| `animation_stress` | random spawn and retarget coordinates                 |
+
+**`calculator` is the one that failed.** It was converted, measured, and
+reverted: with the inner column set to `FillFill`, a probe read the
+child as **0×0** against an 800×600 root. `Canvas` "does not arrange or
+layout its content" (`gui/view_container.go:454`), so a Fill child of a
+Canvas has nothing to fill against. The revert is the finding, and the
+comment at the call site now records it.
+
+Verification is by probe, not by absence of panic. Renders at 800×600
+confirmed the converted view roots fill exactly 800×600 (`markdown`,
+`context_menu`, `dock_layout`, `scroll_demo` — covering a scrollable
+root and a non-`ContainerCfg` root), that `todo`'s card resolves to
+773×573 inside the page's 12px padding and 1.5px border, and that
+`listbox`'s list still gets a real height (534.6) from Fill rather than
+from `wh - 70`.
+
+**Test conversion.** Three examples moved from `TestMainViewNoPanic` to
+state assertions: `key_up_demo` (one `TestKey` moves both the down and
+up counters, which a no-panic render cannot distinguish), `todo`
+(`TestType` + `TestClick` grows the list, clears the draft; a second
+test deletes by generated per-item ID), and `dialogs` (clicking
+`dlg_message` puts the dialog overlay in the tree).
+
+`scroll_demo` was attempted and abandoned: `TestScroll` returns
+`ErrTestUnhandled` because with a nil `TextMeasurer` the content does
+not overflow, so there is nothing to scroll. Scroll assertions need a
+container whose overflow does not depend on measured text.
+
+**Found, not fixed:** `examples/scroll_demo/main.go:111` gives all five
+percentage buttons the same ID, `"scroll_demo_pct_button"`. IDs must be
+unique per window; this is a §4.2-class defect, out of scope for a
+sizing audit, and it makes those buttons untargetable by ID from a test.
+
 ### 4.9 Close the `Scrollable`/ID hole alongside focus
 
 Same defect class as §4.2, found by the same audit. Scroll offsets are
@@ -1256,7 +1321,7 @@ burying them in the same diff.
 | 4     | §4.4 `ColorSet` on six `Cfg`s, flat state fields deleted | done |
 | 4     | §4.3 callback signature conversion       | done   |
 | 4     | §4.3b event-model collapse               | measured — see §4.3.3 |
-| 5     | §4.8 example audit                       | todo   |
+| 5     | §4.8 example audit                       | done — see §4.8.1 |
 
 Two corrections to §4.2 arising from the implementation.
 

--- a/examples/2048/main.go
+++ b/examples/2048/main.go
@@ -123,6 +123,8 @@ func startGame(w *gui.Window) {
 
 func landingView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
+	// Allowlisted viewport use: the landing backdrop tiles are placed at
+	// computed pixel coordinates. gameView below needs no such numbers.
 	ww, wh := w.WindowSize()
 	theme := gui.CurrentTheme()
 
@@ -216,13 +218,10 @@ func landingBackdrop(ww, wh float32, frame int) gui.View {
 
 func gameView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
-	ww, wh := w.WindowSize()
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		Padding: gui.SomeP(40, 0, 0, 0),
 		Spacing: gui.Some[float32](20),

--- a/examples/android_demo/demo.go
+++ b/examples/android_demo/demo.go
@@ -175,13 +175,10 @@ func A11yPerformAction(index, action int32) { android.A11yPerformAction(index, a
 func PendingA11yAnnouncement() string { return android.PendingA11yAnnouncement() }
 
 func view(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Content: []gui.View{

--- a/examples/animation_stress/main.go
+++ b/examples/animation_stress/main.go
@@ -58,7 +58,6 @@ func main() {
 
 func mainView(w *gui.Window) gui.View {
 	state := gui.State[State](w)
-	ww, wh := w.WindowSize()
 
 	content := make([]gui.View, len(state.Items))
 	for i, item := range state.Items {
@@ -66,9 +65,7 @@ func mainView(w *gui.Window) gui.View {
 	}
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		Content: []gui.View{
 			gui.Row(gui.ContainerCfg{
 				Spacing:    gui.SomeF(20),
@@ -148,6 +145,8 @@ func renderItem(item animatedItem) gui.View {
 
 func addItems(w *gui.Window, count int) {
 	state := gui.State[State](w)
+	// Allowlisted viewport use: spawn coordinates are chosen in pixel
+	// space, so there is no layout box to Fill against.
 	ww, wh := w.WindowSize()
 
 	safeW := float32(ww)
@@ -208,6 +207,8 @@ func startWander(w *gui.Window, id string) {
 	currentY := state.Items[idx].y
 	size := state.Items[idx].size
 
+	// Allowlisted viewport use: the retarget destination is a random
+	// pixel coordinate, same reason as addItems above.
 	ww, wh := w.WindowSize()
 	safeW := float32(ww)
 	if safeW <= 0 {

--- a/examples/animations/main.go
+++ b/examples/animations/main.go
@@ -51,12 +51,9 @@ func main() {
 
 func mainView(w *gui.Window) gui.View {
 	s := gui.State[State](w)
-	ww, wh := w.WindowSize()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Spacing: gui.Some[float32](20),
 		Padding: gui.SomeP(20, 20, 20, 20),
 		Content: []gui.View{
@@ -148,13 +145,10 @@ func mainView(w *gui.Window) gui.View {
 }
 
 func detailView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Spacing: gui.Some[float32](20),
 		Padding: gui.SomeP(20, 20, 20, 20),
 		Content: []gui.View{

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -134,7 +134,6 @@ func startAnimation(w *gui.Window) {
 }
 
 func benchView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 	countOptions := []string{"10", "100", "1000", "5000"}
@@ -155,9 +154,7 @@ func benchView(w *gui.Window) gui.View {
 	}
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.SomeP(8, 8, 8, 8),
 		Content: []gui.View{
 			// Controls row.

--- a/examples/calculator/main.go
+++ b/examples/calculator/main.go
@@ -186,6 +186,9 @@ func keyDigit(key gui.KeyCode) string {
 }
 
 func mainView(w *gui.Window) gui.View {
+	// Allowlisted viewport use: the root is a Canvas, which does not
+	// arrange its content, so the centring Column inside it cannot Fill
+	// and has to be told the window size.
 	ww, wh := w.WindowSize()
 
 	return gui.Canvas(gui.ContainerCfg{

--- a/examples/color_picker/main.go
+++ b/examples/color_picker/main.go
@@ -30,14 +30,11 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	t := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.Some(t.PaddingMedium),
 		Spacing: gui.Some(t.SpacingMedium),
 		Content: []gui.View{

--- a/examples/command_demo/main.go
+++ b/examples/command_demo/main.go
@@ -120,15 +120,12 @@ func registerCommands(w *gui.Window) {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
 		Padding: gui.NoPadding,
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Spacing: gui.SomeF(0),
 		Content: []gui.View{
 			menuBar(w),

--- a/examples/context_menu/main.go
+++ b/examples/context_menu/main.go
@@ -28,14 +28,11 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.ContextMenu(w, gui.ContextMenuCfg{
 		ID:     "ctx",
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Items: []gui.MenuItemCfg{

--- a/examples/cursor_demo/main.go
+++ b/examples/cursor_demo/main.go
@@ -50,7 +50,6 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 
@@ -100,9 +99,7 @@ func mainView(w *gui.Window) gui.View {
 	// mouse (hover dispatch stops at the first handled shape), giving
 	// clean leave semantics for the cursor reset.
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.SomeP(16, 16, 16, 16),
 		Spacing: gui.SomeF(12),
 		OnHover: func(ctx gui.EventCtx) {

--- a/examples/custom_shader/main.go
+++ b/examples/custom_shader/main.go
@@ -39,13 +39,10 @@ func main() {
 
 func mainView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
-	ww, wh := w.WindowSize()
 	elapsed := float32(time.Since(app.StartTime).Milliseconds()) / 1000.0
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		VAlign:  gui.VAlignMiddle,
 		Spacing: gui.Some[float32](20),

--- a/examples/data_grid_data_source/main.go
+++ b/examples/data_grid_data_source/main.go
@@ -42,7 +42,6 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	stats := datagrid.GetSourceStats(w, "source-grid")
 	theme := gui.CurrentTheme()
@@ -66,9 +65,7 @@ func mainView(w *gui.Window) gui.View {
 	}
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.Some(theme.PaddingSmall),
 		Spacing: gui.Some(theme.SpacingSmall),
 		Content: []gui.View{

--- a/examples/date_picker_options/main.go
+++ b/examples/date_picker_options/main.go
@@ -67,13 +67,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		VAlign:  gui.VAlignMiddle,
 		Spacing: gui.Some(gui.SpacingLarge),

--- a/examples/dialogs/main.go
+++ b/examples/dialogs/main.go
@@ -29,14 +29,11 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		Content: []gui.View{
 			toggleTheme(app, theme),

--- a/examples/dialogs/main_test.go
+++ b/examples/dialogs/main_test.go
@@ -6,14 +6,31 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
-func TestMainViewNoPanic(t *testing.T) {
+// The library keys its dialog overlay by this reserved ID
+// (gui.reservedDialogID, unexported). Mirrored here so the test can find
+// the overlay in the tree.
+const dialogShapeID = "___dialog_reserved_do_not_use___"
+
+// Clicking the button should put a dialog on screen. Asserting on the
+// rendered tree rather than on a bool is the point: the dialog is an
+// overlay built by the library, so this also proves the click reached
+// the button through whatever is drawn over it.
+func TestMessageButtonOpensDialog(t *testing.T) {
 	t.Parallel()
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
-	w := gui.NewWindow(gui.WindowCfg{
-		State:  &App{},
-		Width:  640,
-		Height: 550,
-	})
-	_ = mainView(w).GenerateLayout(w)
 
+	w := gui.NewTestWindow(gui.WindowCfg{State: &App{}, Width: 640, Height: 550})
+	root := w.TestRender(mainView)
+	if _, ok := root.FindByID(dialogShapeID); ok {
+		t.Fatal("dialog present before any click")
+	}
+
+	if err := w.TestClick("dlg_message"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+
+	root = w.TestRender(nil)
+	if _, ok := root.FindByID(dialogShapeID); !ok {
+		t.Fatal("no dialog in the tree after clicking DialogMessage")
+	}
 }

--- a/examples/digital_rain/main.go
+++ b/examples/digital_rain/main.go
@@ -127,6 +127,8 @@ func restartTick(w *gui.Window) {
 }
 
 func mainView(w *gui.Window) gui.View {
+	// Allowlisted viewport use: the rain grid's column and row counts are
+	// the viewport divided by the character cell, not a layout result.
 	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 

--- a/examples/dock_layout/main.go
+++ b/examples/dock_layout/main.go
@@ -39,13 +39,10 @@ func initialLayout() *gui.DockNode {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.NoPadding,
 		Spacing: gui.NoSpacing,
 		Content: []gui.View{

--- a/examples/draw_canvas/main.go
+++ b/examples/draw_canvas/main.go
@@ -24,12 +24,9 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.Some(gui.CurrentTheme().PaddingLarge),
 		Spacing: gui.SomeF(16),
 		Content: []gui.View{

--- a/examples/floating_layout/main.go
+++ b/examples/floating_layout/main.go
@@ -44,13 +44,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		Content: []gui.View{
 			// Faux menu bar
 			gui.Row(gui.ContainerCfg{

--- a/examples/fontviewer/main.go
+++ b/examples/fontviewer/main.go
@@ -371,6 +371,9 @@ func fontGrid(w *gui.Window, matches []string) gui.View {
 		return emptyState(len(s.Families) == 0)
 	}
 
+	// Allowlisted viewport use: virtualization needs real numbers —
+	// ListVisibleRange takes the viewport height and the column count
+	// comes from the width, both before any arrange pass has run.
 	winW, winH := w.WindowSize()
 	cardH := cardHeight(s.FontSize)
 	rowH := cardH + gap

--- a/examples/gradient_demo/main.go
+++ b/examples/gradient_demo/main.go
@@ -118,7 +118,6 @@ var (
 )
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	dir := app.Direction
 
@@ -135,9 +134,7 @@ func mainView(w *gui.Window) gui.View {
 
 	return gui.Row(gui.ContainerCfg{
 		ID:         "gradient-scroll",
-		Width:      float32(ww),
-		Height:     float32(wh),
-		Sizing:     gui.FixedFixed,
+		Sizing:     gui.FillFill,
 		Scrollable: true,
 		ScrollbarCfgY: &gui.ScrollbarCfg{
 			Overflow: gui.ScrollbarAuto,

--- a/examples/ios_demo/main.go
+++ b/examples/ios_demo/main.go
@@ -26,13 +26,10 @@ func init() {
 }
 
 func view(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Content: []gui.View{

--- a/examples/key_up_demo/main.go
+++ b/examples/key_up_demo/main.go
@@ -32,12 +32,9 @@ func main() {
 
 func mainView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
-	ww, wh := w.WindowSize()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		VAlign:  gui.VAlignMiddle,
 		Spacing: gui.SomeF(10),

--- a/examples/key_up_demo/main_test.go
+++ b/examples/key_up_demo/main_test.go
@@ -6,13 +6,28 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
-func TestMainViewNoPanic(t *testing.T) {
+// Demonstrates the app-testing API on the thing this example exists to
+// show: that OnKeyDown and OnKeyUp both fire, and are counted
+// separately. A no-panic render could not tell the two apart.
+func TestKeyPressCountsBothEdges(t *testing.T) {
 	t.Parallel()
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
-	w := gui.NewWindow(gui.WindowCfg{
-		State:  &App{},
-		Width:  400,
-		Height: 300,
-	})
-	_ = mainView(w).GenerateLayout(w)
+
+	app := &App{}
+	w := gui.NewTestWindow(gui.WindowCfg{State: app, Width: 400, Height: 300})
+	w.TestRender(mainView)
+
+	// TestKey delivers a press and a release, so one call should move
+	// both counters by one.
+	if err := w.TestKey("kud_input", gui.KeyA, 0); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	if app.keyDownCount != 1 || app.keyUpCount != 1 {
+		t.Fatalf("after one key: down=%d up=%d, want 1 and 1",
+			app.keyDownCount, app.keyUpCount)
+	}
+	if app.lastKeyDown != gui.KeyA || app.lastKeyUp != gui.KeyA {
+		t.Fatalf("last keys: down=%v up=%v, want KeyA on both",
+			app.lastKeyDown, app.lastKeyUp)
+	}
 }

--- a/examples/listbox/main.go
+++ b/examples/listbox/main.go
@@ -42,7 +42,6 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 
@@ -52,10 +51,8 @@ func mainView(w *gui.Window) gui.View {
 	}
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
 		HAlign:  gui.HAlignCenter,
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Spacing: gui.Some(theme.SpacingSmall),
 		Padding: gui.SomeP(8, 8, 8, 8),
 		Content: []gui.View{
@@ -68,10 +65,11 @@ func mainView(w *gui.Window) gui.View {
 				TextStyle: theme.N5,
 			}),
 			gui.ListBox(gui.ListBoxCfg{
-				ID:          "virtual-listbox-10k",
-				Scrollable:  true,
-				Height:      float32(wh) - 70,
-				Sizing:      gui.FillFixed,
+				ID:         "virtual-listbox-10k",
+				Scrollable: true,
+				// Fill takes whatever the two labels above leave, so no
+				// "window height minus 70" guess to keep in sync.
+				Sizing:      gui.FillFill,
 				SelectedIDs: app.SelectedIDs,
 				Data:        app.Items,
 				OnSelect: func(ids []string, ctx gui.EventCtx) {

--- a/examples/markdown/main.go
+++ b/examples/markdown/main.go
@@ -38,16 +38,13 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	theme := gui.CurrentTheme()
 
 	style := gui.DefaultMarkdownStyle()
 	style.CodeBlockBG = gui.RGB(40, 44, 52)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:      float32(ww),
-		Height:     float32(wh),
-		Sizing:     gui.FixedFixed,
+		Sizing:     gui.FillFill,
 		Padding:    gui.Some(theme.PaddingLarge),
 		Focusable:  true,
 		ID:         "markdown-scroll",

--- a/examples/menu_demo/main.go
+++ b/examples/menu_demo/main.go
@@ -32,13 +32,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
 		Padding: gui.NoPadding,
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Spacing: gui.Some[float32](0),
 		Content: []gui.View{
 			menu(w),

--- a/examples/minesweeper/main.go
+++ b/examples/minesweeper/main.go
@@ -146,11 +146,10 @@ func startNewGame(app *App, diff Difficulty) {
 
 func mainView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
-	ww, wh := w.WindowSize()
 	if app.Screen == ScreenPlaying {
-		return gameView(w, float32(ww), float32(wh))
+		return gameView(w)
 	}
-	return landingView(w, float32(ww), float32(wh))
+	return landingView(w)
 }
 
 // --- Color palette ---
@@ -181,13 +180,11 @@ var numberColors = [9]gui.Color{
 
 // --- Landing page ---
 
-func landingView(w *gui.Window, ww, wh float32) gui.View {
+func landingView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
-		Width:   ww,
-		Height:  wh,
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Color:   colorBG,
 		HAlign:  gui.HAlignCenter,
 		VAlign:  gui.VAlignMiddle,
@@ -488,7 +485,7 @@ func cellPxSize(d Difficulty) float32 {
 	}
 }
 
-func gameView(w *gui.Window, ww, wh float32) gui.View {
+func gameView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
 	g := app.Game
 	theme := gui.CurrentTheme()
@@ -507,7 +504,7 @@ func gameView(w *gui.Window, ww, wh float32) gui.View {
 	}
 
 	return gui.Column(gui.ContainerCfg{
-		Width: ww, Height: wh, Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter, VAlign: gui.VAlignMiddle,
 		Spacing: gui.SomeF(8), SizeBorder: gui.NoBorder,
 		Padding: gui.SomeP(12, 16, 12, 16),

--- a/examples/multi_window/main.go
+++ b/examples/multi_window/main.go
@@ -47,13 +47,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[MainState](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		VAlign:  gui.VAlignMiddle,
 		Spacing: gui.SomeF(8),
@@ -118,13 +115,10 @@ func mainView(w *gui.Window) gui.View {
 }
 
 func inspectorView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	state := gui.State[InspectorState](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.Some(gui.PadAll(8)),
 		Content: []gui.View{
 			gui.Text(gui.TextCfg{

--- a/examples/multiline_input/main.go
+++ b/examples/multiline_input/main.go
@@ -95,13 +95,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		Content: []gui.View{
 			gui.Input(gui.InputCfg{
 				ID:         inputFocusID,

--- a/examples/native_menu/main.go
+++ b/examples/native_menu/main.go
@@ -102,14 +102,11 @@ func registerCommands(w *gui.Window) {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		Content: []gui.View{
 			gui.Rectangle(gui.RectangleCfg{

--- a/examples/particles/main.go
+++ b/examples/particles/main.go
@@ -171,6 +171,8 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 
 func mainView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
+	// Allowlisted viewport use: the particle field is simulated in pixel
+	// space and the play screen splits it against a fixed sidebar.
 	ww, wh := w.WindowSize()
 	if app.Screen == ScreenPlaying {
 		return playView(w, float32(ww), float32(wh))

--- a/examples/process_monitor/view.go
+++ b/examples/process_monitor/view.go
@@ -135,13 +135,10 @@ func lessRSS(a, b *Process) bool {
 // refresh via Window.UpdateWindow.
 func rootView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
-	ww, wh := w.WindowSize()
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Color:   theme.ColorBackground,
 		Padding: gui.NoPadding,
 		Content: []gui.View{

--- a/examples/rtf/main.go
+++ b/examples/rtf/main.go
@@ -36,7 +36,6 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	t := gui.CurrentTheme()
 
 	// Compose the document from styled runs so each feature is easy to spot.
@@ -73,9 +72,7 @@ func mainView(w *gui.Window) gui.View {
 
 	return gui.Column(gui.ContainerCfg{
 		ID:         "rtf-scroll",
-		Width:      float32(ww),
-		Height:     float32(wh),
-		Sizing:     gui.FixedFixed,
+		Sizing:     gui.FillFill,
 		Scrollable: true,
 		Padding:    gui.SomeP(10, 10, 10, 10),
 		Content: []gui.View{

--- a/examples/scroll_demo/main.go
+++ b/examples/scroll_demo/main.go
@@ -33,13 +33,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		Content: []gui.View{
 			topRow(app),
 			gui.Rectangle(gui.RectangleCfg{Height: 0.5, Sizing: gui.FillFixed}),

--- a/examples/showcase/demo_layout.go
+++ b/examples/showcase/demo_layout.go
@@ -572,13 +572,10 @@ func demoMultiWindow(w *gui.Window) gui.View {
 func multiWindowChildView(parent *gui.Window) func(*gui.Window) gui.View {
 	return func(w *gui.Window) gui.View {
 		t := gui.CurrentTheme()
-		ww, wh := w.WindowSize()
 		cs := gui.State[multiWindowChildState](w)
 
 		return gui.Column(gui.ContainerCfg{
-			Width:   float32(ww),
-			Height:  float32(wh),
-			Sizing:  gui.FixedFixed,
+			Sizing:  gui.FillFill,
 			Padding: gui.Some(gui.PadAll(12)),
 			Spacing: gui.SomeF(8),
 			Content: []gui.View{

--- a/examples/showcase/main.go
+++ b/examples/showcase/main.go
@@ -57,11 +57,8 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	return gui.Row(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Padding: gui.NoPadding,
 		Spacing: gui.NoSpacing,
 		Content: []gui.View{catalogPanel(w), detailPanel(w)},

--- a/examples/snake/main.go
+++ b/examples/snake/main.go
@@ -107,9 +107,11 @@ func startGame(w *gui.Window) {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	if !app.Started {
+		// The landing screen paints a pixel-space backdrop, so it still
+		// takes the viewport explicitly. The play screen below does not.
+		ww, wh := w.WindowSize()
 		return landingView(w, float32(ww), float32(wh))
 	}
 	g := app.Game
@@ -126,9 +128,7 @@ func mainView(w *gui.Window) gui.View {
 	}
 
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		VAlign:  gui.VAlignMiddle,
 		Spacing: gui.Some[float32](10),

--- a/examples/solitaire/main.go
+++ b/examples/solitaire/main.go
@@ -105,6 +105,8 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 
 func mainView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
+	// Allowlisted viewport use: both screens place cards, the status bar
+	// and the win overlay at absolute pixel positions.
 	ww, wh := w.WindowSize()
 	if app.Screen == ScreenPlaying {
 		return gameView(w, float32(ww), float32(wh))

--- a/examples/svg/main.go
+++ b/examples/svg/main.go
@@ -90,13 +90,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[SvgViewerApp](w)
 
 	return gui.Row(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		Content: []gui.View{
 			navPanel(app.Selected),
 			contentPanel(app.Selected),

--- a/examples/svg_spinners/isolate_test_main.go
+++ b/examples/svg_spinners/isolate_test_main.go
@@ -8,11 +8,8 @@ import "github.com/go-gui-org/go-gui/gui"
 const useIsolation = false
 
 func isolatedView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		VAlign:  gui.VAlignMiddle,
 		Padding: gui.Some(gui.PaddingSmall),

--- a/examples/svg_spinners/main.go
+++ b/examples/svg_spinners/main.go
@@ -64,7 +64,6 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	rows := make([]gui.View, 0, len(showcase)/cellsPerRow+1)
 	for i := 0; i < len(showcase); i += cellsPerRow {
 		cells := make([]gui.View, 0, cellsPerRow)
@@ -78,9 +77,7 @@ func mainView(w *gui.Window) gui.View {
 		}))
 	}
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		HAlign:  gui.HAlignCenter,
 		Padding: gui.Some(gui.PaddingSmall),
 		Content: rows,

--- a/examples/system_tray/main.go
+++ b/examples/system_tray/main.go
@@ -57,14 +57,11 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		Content: []gui.View{
 			gui.Rectangle(gui.RectangleCfg{

--- a/examples/termgrid/main.go
+++ b/examples/termgrid/main.go
@@ -37,13 +37,10 @@ func main() {
 }
 
 func view(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Color:  gui.RGB(16, 16, 20),

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -72,25 +72,21 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
-
 	return gui.Column(gui.ContainerCfg{
-		Width:   float32(ww),
-		Height:  float32(wh),
-		Sizing:  gui.FixedFixed,
+		Sizing:  gui.FillFill,
 		Color:   colorPageBG,
 		Padding: gui.SomeP(12, 12, 12, 12),
 		Content: []gui.View{
-			cardView(float32(ww)-24, float32(wh)-24, w),
+			cardView(w),
 		},
 	})
 }
 
-func cardView(width, height float32, w *gui.Window) gui.View {
+// The card fills what the page's 12px padding leaves, so it no longer
+// needs the window size threaded in as "minus 24".
+func cardView(w *gui.Window) gui.View {
 	return gui.Column(gui.ContainerCfg{
-		Width:       width,
-		Height:      height,
-		Sizing:      gui.FixedFixed,
+		Sizing:      gui.FillFill,
 		Color:       colorCardBG,
 		Radius:      gui.SomeF(18),
 		Padding:     gui.SomeP(34, 34, 34, 34),

--- a/examples/todo/main_test.go
+++ b/examples/todo/main_test.go
@@ -6,14 +6,58 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
-func TestMainViewNoPanic(t *testing.T) {
+// Types into the composer and presses ADD, asserting the list actually
+// grew. This is the whole point of the app-testing API: the previous
+// version of this test only proved mainView did not panic, which would
+// still have held if the button were wired to nothing.
+func TestAddTodoAppendsItem(t *testing.T) {
 	t.Parallel()
 	gui.SetTheme(gui.ThemeLight.WithPadding(false))
-	w := gui.NewWindow(gui.WindowCfg{
-		State:  newAppState(),
-		Width:  540,
-		Height: 640,
-	})
-	_ = mainView(w).GenerateLayout(w)
 
+	app := newAppState()
+	before := len(app.Items)
+	w := gui.NewTestWindow(gui.WindowCfg{State: app, Width: 540, Height: 640})
+	w.TestRender(mainView)
+
+	if err := w.TestType("todo-input", "write the test"); err != nil {
+		t.Fatalf("TestType: %v", err)
+	}
+	if app.Draft != "write the test" {
+		t.Fatalf("draft %q, want the typed text", app.Draft)
+	}
+	if err := w.TestClick("add-todo"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+
+	if len(app.Items) != before+1 {
+		t.Fatalf("items %d, want %d", len(app.Items), before+1)
+	}
+	if got := app.Items[len(app.Items)-1].Title; got != "write the test" {
+		t.Fatalf("new item %q, want the typed text", got)
+	}
+	// addTodo clears the draft so the input is ready for the next task.
+	if app.Draft != "" {
+		t.Fatalf("draft %q after add, want empty", app.Draft)
+	}
+}
+
+// The delete button is generated per item, so its ID is only correct if
+// the list rendered the item at all — a click that lands proves both the
+// ID scheme and the callback.
+func TestDeleteTodoRemovesItem(t *testing.T) {
+	t.Parallel()
+	gui.SetTheme(gui.ThemeLight.WithPadding(false))
+
+	app := newAppState()
+	w := gui.NewTestWindow(gui.WindowCfg{State: app, Width: 540, Height: 640})
+	w.TestRender(mainView)
+
+	if err := w.TestClick("todo-delete-1"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	for _, it := range app.Items {
+		if it.ID == 1 {
+			t.Fatal("item 1 still present after delete")
+		}
+	}
 }

--- a/examples/vibrancy/main.go
+++ b/examples/vibrancy/main.go
@@ -34,12 +34,9 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Content: []gui.View{

--- a/examples/web_demo/main.go
+++ b/examples/web_demo/main.go
@@ -31,13 +31,10 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	ww, wh := w.WindowSize()
 	app := gui.State[App](w)
 
 	return gui.Column(gui.ContainerCfg{
-		Width:  float32(ww),
-		Height: float32(wh),
-		Sizing: gui.FixedFixed,
+		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Content: []gui.View{


### PR DESCRIPTION
Phase 5, the last `todo` row in the spec's progress table.

`examples/get_started/main.go:36` documents that `FillFill` removes the need
for `WindowSize()` and manual arithmetic. **45 example files called it
anyway.** That is not one contradictory pair — it is the dominant idiom in
the examples, teaching the opposite of what the library recommends.

## Result

**45 files / 50 call sites → 8 files / 9 call sites.**

34 of the conversions were one shape repeated: fetch the window size, assign
it to the root's `Width`/`Height`, mark the root `FixedFixed`. That is
`Sizing: gui.FillFill` and nothing else. Six carried real arithmetic:

| Example            | Was                                 | Now                                               |
| ------------------ | ----------------------------------- | ------------------------------------------------- |
| `todo`             | `cardView(ww-24, wh-24, w)`         | card `FillFill` inside the page's 12px padding     |
| `listbox`          | `Height: float32(wh) - 70`          | list `FillFill` takes the column remainder         |
| `minesweeper`      | `ww, wh` threaded into both screens | both screens `FillFill`, params dropped            |
| `2048`             | window size in both screens         | `gameView` `FillFill`; landing still needs it      |
| `snake`            | window size in both screens         | play screen `FillFill`; landing still needs it     |
| `animation_stress` | window size in three places         | root `FillFill`; two spawn helpers still need it   |

The 8 survivors are allowlisted with a one-line reason at each call site, so
what remains reads as deliberate rather than as more of the same noise:
`calculator`, `digital_rain`, `fontviewer`, `particles`, `solitaire`, the
`2048` and `snake` landing screens, and `animation_stress`'s spawn helpers —
canvas, particle, game and virtualized-list demos that work in pixel space.

## The one that failed

`calculator` was converted, **measured, and reverted**. With its inner column
set to `FillFill`, a probe read the child as **0×0** against an 800×600 root.
`Canvas` "does not arrange or layout its content"
(`gui/view_container.go:454`), so a Fill child of a Canvas has nothing to fill
against. The revert plus its call-site comment is the finding.

## Verification

By probe, not by absence of panic. Rendering at 800×600 confirmed:

- converted view roots measure exactly 800×600 — `markdown`, `context_menu`,
  `dock_layout`, `scroll_demo`, covering both a scrollable root and a
  non-`ContainerCfg` root;
- `todo`'s card resolves to 773×573, the page's 12px padding and 1.5px border
  subtracted, versus the 776×576 it used to compute by hand;
- `listbox`'s list still gets a real height (534.6) from Fill rather than from
  `wh - 70`.

`gofmt`, `go build`, `go vet`, `requiredid`, `golangci-lint` (0 issues), full
test suite, Prettier — all clean.

## Test conversion

Three examples move from `TestMainViewNoPanic` to state assertions on the
phase-2 testing API:

- `key_up_demo` — one `TestKey` moves both the down and the up counter, which
  a no-panic render cannot distinguish;
- `todo` — `TestType` + `TestClick` grows the list and clears the draft; a
  second test deletes by generated per-item ID, which only resolves if the
  item rendered;
- `dialogs` — clicking `dlg_message` puts the dialog overlay in the tree.

`scroll_demo` was attempted and abandoned: `TestScroll` returns
`ErrTestUnhandled` because with a nil `TextMeasurer` the content does not
overflow, so there is nothing to scroll. Scroll assertions need a container
whose overflow does not depend on measured text. Recorded in the spec.

## Found, not fixed

`examples/scroll_demo/main.go:111` gives all five percentage buttons the same
ID, `"scroll_demo_pct_button"`. IDs must be unique per window; this is a
§4.2-class defect, out of scope for a sizing audit, and it makes those buttons
untargetable by ID from a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
