### PR TITLE
fix(event): make every consume-class handler consume explicitly

### DIFF
--- a/examples/scroll_demo/main.go
+++ b/examples/scroll_demo/main.go
@@ -108,7 +108,10 @@ func pctRow(app *App) gui.View {
 func pctButton(idScroll string, pct int) gui.View {
 	pctF := float32(pct) / 100
 	return gui.Button(gui.ButtonCfg{
-		ID: "scroll_demo_pct_button",
+		// IDs are unique per window: all five buttons shared one ID, so
+		// focus and per-widget state collided and no single button could
+		// be targeted by ID from a test. Suffix with the percentage.
+		ID: fmt.Sprintf("scroll_demo_pct_button_%d", pct),
 		Content: []gui.View{
 			gui.Text(gui.TextCfg{Text: fmt.Sprintf("%d%%", pct)}),
 		},

--- a/gui/datagrid/view_data_grid_edit.go
+++ b/gui/datagrid/view_data_grid_edit.go
@@ -122,7 +122,7 @@ func dataGridCellEditorView(cfg *DataGridCfg, rowID string, rowIdx int, col Grid
 				if gridFocusID != "" {
 					ctx.Window.SetFocus(gridFocusID)
 				}
-				ctx.Event.IsHandled = true
+				ctx.Consume()
 			},
 		})
 	}

--- a/gui/datagrid/view_data_grid_keys.go
+++ b/gui/datagrid/view_data_grid_keys.go
@@ -38,7 +38,7 @@ func dataGridMakeOnChar(cfg *DataGridCfg, columns []GridColumnCfg) func(gg.Event
 			return
 		}
 		ctx.Window.SetClipboard(payload)
-		ctx.Event.IsHandled = true
+		ctx.Consume()
 	}
 }
 

--- a/gui/markdown_select.go
+++ b/gui/markdown_select.go
@@ -156,7 +156,7 @@ func markdownBlockOnClick(ctx EventCtx) {
 		st.SelEnd = absRune
 	}
 	imap.Set(mdID, st)
-	ctx.Event.IsHandled = true
+	ctx.Consume()
 
 	// Capture drag state. Copy layout value so it's safe across frames.
 	anchorBeg := st.SelBeg
@@ -283,7 +283,7 @@ func markdownContainerOnKeyDown(ctx EventCtx) {
 	}
 
 	if handled {
-		ctx.Event.IsHandled = true
+		ctx.Consume()
 	}
 }
 

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -239,7 +239,7 @@ func datePickerControls(
 			ctx.Window.SetFocus(focusID)
 		}
 		ctx.Window.UpdateWindow()
-		ctx.Event.IsHandled = true
+		ctx.Consume()
 	}
 
 	onPrev := func(ctx EventCtx) {

--- a/gui/view_date_picker_roller.go
+++ b/gui/view_date_picker_roller.go
@@ -107,7 +107,7 @@ func (rv *datePickerRollerView) GenerateLayout(w *Window) Layout {
 				ctx.Layout.Shape.ColorBorder = cfg.ColorBorderFocus
 			}
 			ctx.Layout.Shape.events.OnMouseScroll = func(ctx EventCtx) {
-				ctx.Event.IsHandled = true
+				ctx.Consume()
 				if onChange == nil {
 					return
 				}

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -93,7 +93,7 @@ func DockLayout(cfg DockLayoutCfg) View {
 					state := dockDragGet(ctx.Window, dockID)
 					if state.active {
 						dockDragCancel(dockID, ctx.Window)
-						ctx.Event.IsHandled = true
+						ctx.Consume()
 					}
 				}
 			},
@@ -329,6 +329,11 @@ func dockTabButton(
 			Radius:     SomeF(2),
 			OnClick: func(ctx EventCtx) {
 				onPanelClose(panelID, ctx)
+				// The close button sits inside its own tab button, which
+				// selects the panel on click. Closing must not also
+				// select. The pre-mark stops that today; consume so it
+				// still holds if spec §4.3b removes the pre-mark.
+				ctx.Consume()
 			},
 			Content: []View{
 				Text(TextCfg{

--- a/gui/view_rtf.go
+++ b/gui/view_rtf.go
@@ -274,7 +274,7 @@ func rtfMouseMove(ctx EventCtx) {
 			if found.Tooltip != "" {
 				tipID := found.Tooltip
 				if ts.hoverID == tipID {
-					ctx.Event.IsHandled = true
+					ctx.Consume()
 					return
 				}
 				r := rtfRunRect(run)

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -68,7 +68,7 @@ func rtfSelectOnClick(ctx EventCtx) {
 	}
 	is.CursorOffset = -1
 	imap.Set(focusID, is)
-	ctx.Event.IsHandled = true
+	ctx.Consume()
 
 	anchorPos := is.SelectBeg
 	anchorEnd := is.SelectEnd
@@ -248,6 +248,6 @@ func rtfSelectOnKeyDown(ctx EventCtx) {
 	}
 
 	if handled {
-		ctx.Event.IsHandled = true
+		ctx.Consume()
 	}
 }

--- a/gui/view_tab_control.go
+++ b/gui/view_tab_control.go
@@ -158,7 +158,7 @@ func makeTabOnClick(
 		if focusID != "" {
 			ctx.Window.SetFocus(focusID)
 		}
-		ctx.Event.IsHandled = true
+		ctx.Consume()
 	}
 }
 
@@ -378,7 +378,7 @@ func (tv *tabControlView) GenerateLayout(w *Window) Layout {
 			if reorderable {
 				if dragReorderEscape(
 					controlID, ctx.Event.KeyCode, ctx.Window) {
-					ctx.Event.IsHandled = true
+					ctx.Consume()
 					return
 				}
 				for idx, id := range tabIDs {

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -80,7 +80,7 @@ func textOnClick(ctx EventCtx) {
 	is.CursorOffset = -1
 	imap.Set(focusID, is)
 	resetBlinkCursorVisible(ctx.Window)
-	ctx.Event.IsHandled = true
+	ctx.Consume()
 
 	// Drag-to-select via MouseLock.
 	anchorPos := is.SelectBeg

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -79,7 +79,7 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 						if onSel != nil {
 							onSel(name, EventCtx{nil, ctx.Event, ctx.Window})
 						}
-						ctx.Event.IsHandled = true
+						ctx.Consume()
 					},
 				}),
 			},
@@ -104,6 +104,12 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 			if opening {
 				themePickerSyncHighlight(lbID, ctx.Window)
 			}
+			// Toggling the popup is the whole click. Consume it so an
+			// enclosing clickable (a menu item hosting the picker as a
+			// CustomView, in menu_demo) does not also act on it — today
+			// the consume-class pre-mark stops that implicitly, and
+			// spec §4.3b would remove the pre-mark.
+			ctx.Consume()
 		},
 		AmendLayout: func(ctx EventCtx) {
 			if ctx.Window.IsFocus(focusID) {


### PR DESCRIPTION
Precursor to the spec §4.3b event-model collapse. **Behavior-neutral today**;
removes the measured silent hazard class.

## The finding

`TestEventCollapse` (added in #201) reported **18 sites** where a consume-class
callback relied on dispatch's automatic handled-marking while an ancestor would
also have received the event. Under the one-rule model those events reach both
handlers, with no compile error.

## The cause was one anti-idiom

Not 18 unrelated bugs. **14 sites across 12 files wrote
`ctx.Event.IsHandled = true` directly** instead of calling `ctx.Consume()`.

Runtime-identical — but `Consume()` also sets `explicitConsume`
(`gui/event_ctx.go:33`), the flag separating "the callback asked for this" from
"dispatch pre-marked it". Every one of those sites looked like a decision and
was in fact a reliance. Swapping all 14 cleared **13 of the 18** findings on
its own.

## The five that needed a real decision

| Site | Why it must consume |
| ---- | ------------------- |
| `view_dock_layout.go` close button (×4) | sits inside its own tab button, which selects the panel — closing must not also select |
| `view_theme_picker.go` root | hosted as a menu-item `CustomView` in `menu_demo`, so the enclosing item would also act on the click |

## Verification

Sweep regenerated against this branch, then re-run after the fix:

| Example | Before | After |
| ------- | ------ | ----- |
| `color_picker` | 8 | 0 |
| `dock_layout` | 4 | 0 |
| `date_picker_options` | 1 | 0 |
| `key_up_demo` | 1 | 0 |
| `menu_demo` | 1 | 0 |
| `multiline_input` | 1 | 0 |
| `showcase` | 1 | 0 |
| `todo` | 1 | 0 |

`gofmt`, `go build`, `go vet`, full `go test`, `golangci-lint` (0 issues) — all
clean under `GOWORK=off`.

## What this does not do

It does not make the collapse compile-error-only. An AST audit of the full
static population — every consume-class callback that calls neither `Consume()`
nor `Bubble()` — finds **81 in `gui/` and 133 in `examples/`**. `TestEventCollapse`
only fires on the intersection of *relies on the pre-mark* **and** *an ancestor
would also receive that same event* **in the default rendered frame**, which is
why it reported 18. Those 214 are unmeasured, not proven safe. They are the
subject of the follow-up.

## Also

`examples/scroll_demo/main.go:111` gave all five percentage buttons the ID
`scroll_demo_pct_button`. IDs must be unique per window; the duplicate collided
focus and per-widget state and made the buttons untargetable by ID from a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)