### PR TITLE
fix(event): count focus-stealing ancestors in the collapse check

### DIFF
--- a/gui/datagrid/view_data_grid_events.go
+++ b/gui/datagrid/view_data_grid_events.go
@@ -50,6 +50,10 @@ func dataGridQuickFilterRow(cfg *DataGridCfg, w *gg.Window) gg.View {
 			if inputFocusID != "" {
 				ctx.Window.SetFocus(inputFocusID)
 			}
+			// The row exists to hand focus to its input. Consume, or
+			// the enclosing focusable grid would take that focus
+			// straight back once spec §4.3b removes the pre-mark.
+			ctx.Consume()
 		},
 		Content: []gg.View{
 			gg.Input(gg.InputCfg{

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -243,7 +243,15 @@ func dataGridIndicatorButton(id, label string, baseStyle gg.TextStyle, hoverColo
 		Color:      gg.ColorTransparent,
 		Colors:     gg.ColorSet{Hover: hoverColor, Click: hoverColor, Focus: gg.ColorTransparent, Border: gg.ColorTransparent},
 		Disabled:   disabled,
-		OnClick:    onClick,
+		// Wrapped rather than passed through: every toolbar control
+		// sits inside the focusable grid, which takes focus on any
+		// click that reaches it. The consume-class pre-mark stops that
+		// today; consuming here keeps it stopped if spec §4.3b removes
+		// the pre-mark, and does it once for all eight controls.
+		OnClick: func(ctx gg.EventCtx) {
+			onClick(ctx)
+			ctx.Consume()
+		},
 		Content: []gg.View{
 			gg.Text(gg.TextCfg{
 				Text:      label,

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -64,11 +64,11 @@ func debugCollapse(
 	self := debugShapeName(layout)
 	other := debugShapeName(anc)
 	w.debugWarn(debugCheckEventCollapse, class.name()+":"+self+">"+other,
-		"%s on %s relies on automatic handling and %s above it also "+
-			"handles %s; under the one-rule event model (spec §4.3b) the "+
-			"event would reach both. Add ctx.Consume() to the %s handler "+
-			"to make the current behaviour explicit",
-		class.name(), self, other, class.name(), self)
+		"%s on %s relies on automatic handling and %s above it %s; "+
+			"under the one-rule event model (spec §4.3b) the event would "+
+			"reach both. Add ctx.Consume() to the %s handler to make the "+
+			"current behaviour explicit",
+		class.name(), self, other, class.ancestorReason(anc, e, w), self)
 }
 
 // ancestorHandler returns the nearest ancestor of layout that would
@@ -85,7 +85,19 @@ func (c evClass) ancestorHandler(layout *Layout, e *Event, w *Window) *Layout {
 		s := anc.Shape
 		// Dispatch skips disabled subtrees (isChildEnabled), so a
 		// disabled ancestor is not a second handler.
-		if s == nil || s.Disabled || !s.hasEvents() {
+		if s == nil || s.Disabled {
+			continue
+		}
+		// A focusable ancestor is a second handler even with no
+		// callback at all: mouseDownHandler takes focus on the way past
+		// (and marks the event handled doing so), so an unconsumed click
+		// on a non-focusable child would move focus to the ancestor —
+		// a behaviour change with no OnClick anywhere in sight. Checked
+		// before hasEvents(), which such an ancestor need not have.
+		if c == evClick && s.stealsFocusOn(e) {
+			return anc
+		}
+		if !s.hasEvents() {
 			continue
 		}
 		if c.wouldReach(anc, e, w) {
@@ -93,6 +105,26 @@ func (c evClass) ancestorHandler(layout *Layout, e *Event, w *Window) *Layout {
 		}
 	}
 	return nil
+}
+
+// ancestorReason describes, for the finding text, what the ancestor
+// would do with the event. Distinguishing the two matters: "also
+// handles OnClick" sends the reader looking for a callback that, in the
+// focus case, does not exist.
+func (c evClass) ancestorReason(anc *Layout, e *Event, w *Window) string {
+	s := anc.Shape
+	if s.hasEvents() && c.wouldReach(anc, e, w) {
+		return "also handles " + c.name()
+	}
+	return "would take focus on " + c.name()
+}
+
+// stealsFocusOn reports whether mouseDownHandler would take focus for
+// this shape, which is the branch at gui/event_handlers.go:216. Right
+// clicks are excluded there and so are excluded here.
+func (s *Shape) stealsFocusOn(e *Event) bool {
+	return s.Focusable && s.ID != "" && e.MouseButton != MouseRight &&
+		s.PointInShape(e.MouseX, e.MouseY)
 }
 
 // wouldReach reports whether this ancestor's own dispatch condition

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -198,6 +198,10 @@ func cpSVArea(
 							ctx.Window.SetMouseCursorArrow()
 						},
 					})
+					// Same as the hue strip: nested in the focusable
+					// picker root, so consume to keep the focus where
+					// it is once spec §4.3b removes the pre-mark.
+					ctx.Consume()
 				},
 			}),
 		},
@@ -266,6 +270,10 @@ func cpHueSlider(
 					ctx.Window.MouseUnlock()
 				},
 			})
+			// The hue strip is inside the focusable picker root, which
+			// would take focus off this click once spec §4.3b removes
+			// the consume-class pre-mark.
+			ctx.Consume()
 		},
 	})
 }

--- a/gui/view_scrollbar.go
+++ b/gui/view_scrollbar.go
@@ -237,6 +237,11 @@ func makeScrollbarGutterClick(cfg ScrollbarCfg) func(EventCtx) {
 	scrollID := cfg.ScrollID
 	return func(ctx EventCtx) {
 		if ctx.Window.MouseIsLocked() {
+			// A drag already owns the pointer, so this click is not the
+			// gutter's to act on — but it is still not the enclosing
+			// scroll container's either. Consume so the early return
+			// keeps swallowing it once the pre-mark is gone.
+			ctx.Consume()
 			return
 		}
 		if orientation == ScrollbarHorizontal {

--- a/gui/view_slider.go
+++ b/gui/view_slider.go
@@ -178,6 +178,12 @@ func Slider(cfg SliderCfg) View {
 					ctx.Window.MouseUnlock()
 				},
 			})
+			// A press on the track sets the value and starts a drag.
+			// Consume it: a slider nested in a focusable container (the
+			// color picker's alpha slider inside "picker") would
+			// otherwise hand that container the focus once spec §4.3b
+			// removes the pre-mark.
+			ctx.Consume()
 		},
 		AmendLayout: func(ctx EventCtx) {
 			sliderAmendLayoutSlide(ctx.Layout, ctx.Window,


### PR DESCRIPTION
Second precursor to the spec §4.3b collapse, after #204. Behavior-neutral;
widens the *measurement* and fixes what it finds.

## The check was measuring the smaller half

`ancestorHandler` asked only whether an ancestor had a live callback for the
same event. But `mouseDownHandler` takes focus on the way past any focusable
shape under the cursor — and marks the event handled doing so — **before any
callback runs**:

```go
if layout.Shape.PointInShape(e.MouseX, e.MouseY) {
    if layout.Shape.Focusable && layout.Shape.ID != "" &&
        e.MouseButton != MouseRight {
        w.SetFocus(layout.Shape.ID)
        e.IsHandled = true          // gui/event_handlers.go:219
    }
```

So an unconsumed click on a non-focusable child inside a focusable ancestor
does not merely fail to stop at the child: **it moves focus to the ancestor**.
No `OnClick` is involved anywhere, which is precisely why the original check
could not see it.

## Change

`ancestorHandler` now treats a focusable ancestor as a second handler, tested
before `hasEvents()` since such an ancestor need not have any. The finding text
distinguishes the two cases — "also handles OnClick" sends the reader looking
for a callback that, in the focus case, does not exist.

## What it found

Sweeping **all 37 constructible examples** (not just the 8 from §4.3.3) turned
up 7 further sites, every one of this new class:

| Owner | Sites | Why it must consume |
| ----- | ----- | ------------------- |
| `view_color_picker.go` | 2 | hue strip and SV area, both inside the focusable picker root |
| `view_slider.go` | 1 | track press — how the picker's alpha slider was reached |
| `view_scrollbar.go` | 2 | the gutter's mouse-locked early return, hit in `listbox` and `markdown` |
| `gui/datagrid` | 2 | toolbar controls (consumed once in `dataGridIndicatorButton`, covering all eight) and the quick-filter row, whose whole job is handing focus to its input |

**Sweep is now 0 across all 37.**

## Verification

`gofmt`, `go build`, `go vet`, full `go test`, `golangci-lint` (0 issues), all
under `GOWORK=off`.

The sweep remains a lower bound in one respect: it sees one rendered frame, so
a hazard behind a tab or dialog stays invisible until the app is driven there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)