### PR TITLE
feat(event)!: collapse the event model to one rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING: one event rule. Nothing is marked handled for you.** A callback
+  that acts on an event calls `ctx.Consume()`; a callback that does not, lets
+  the event travel on. This is now true of every callback, closing §4.3b of
+  `docs/specs/developer-ergonomics.md` — the last open item in that spec.
+
+  Until now `OnClick`, `OnChar`, `OnMouseUp`, `OnGesture` and `OnFileDrop` were
+  "consume-class": dispatch marked their events handled _before_ the callback
+  ran, and the callback opted out with `ctx.Bubble()`. Everything else consumed
+  explicitly. Which of the two you had written was invisible in the signature.
+
+  ```go
+  // Before — the pre-mark absorbed the click
+  OnClick: func(ctx gui.EventCtx) {
+      dismiss(ctx.Window)
+  },
+
+  // After
+  OnClick: func(ctx gui.EventCtx) {
+      dismiss(ctx.Window)
+      ctx.Consume()
+  },
+  ```
+
+- **BREAKING: `EventCtx.Bubble()` is deleted.** Declining is what saying nothing
+  already means. Every call site is a compile error; deleting the call is the
+  fix.
+
+- **BREAKING: `(*Window).TestEventCollapse` is now `TestUnconsumedEvents`.** It
+  measured the cost of a collapse that has since happened. It now reports
+  handlers that act without consuming while an ancestor would also receive the
+  event, and `gui.Debug(true)` reports the same as they dispatch.
+
+**Upgrading.** The compile-time half is loud — `Bubble()` disappears. The other
+half is silent, so search for **empty** consume-class handlers: an `OnClick`
+with an empty body used to be a working click-blocker, and now blocks nothing.
+Overlays, backdrops, popups and cards that stop clicks reaching what they cover
+all need a real `ctx.Consume()`. Four of the five handlers this change broke
+inside go-gui were exactly that. `docs/migration-eventctx.md` has the full
+guide; `TestUnconsumedEvents` sweeps a window for the rest.
+
+Also in this release, as precursors: 14 sites across 12 files that wrote
+`ctx.Event.IsHandled = true` now call `ctx.Consume()`, the unconsumed-event
+check counts focus-stealing ancestors (a focusable ancestor takes focus on an
+unconsumed click, with no `OnClick` involved anywhere), and
+`examples/scroll_demo` no longer gives five buttons the same ID.
+
 ## [v0.54.0] - 2026-08-08
 
 Developer-ergonomics phases 2–5 (`docs/specs/developer-ergonomics.md`), shipped

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,12 +112,17 @@ Backend injects at startup. Nil in tests:
   coords. Moving parent in `AmendLayout` does NOT move children. Use float
   system (`FloatAnchor`/`FloatTieOff`/`FloatOffset`) to position elements with
   children.
-- Events split into two classes. **Consume-class** (`OnClick`, `OnChar`,
-  `OnMouseUp`, `OnGesture`, `OnFileDrop`) are marked handled by dispatch before
-  the callback runs; call `ctx.Bubble()` to opt a path out. **Notify-class**
-  (everything else, incl. `OnKeyDown`, `OnHover`, `OnMouseScroll`) must call
-  `ctx.Consume()` to stop propagation. `ctx.Event` is nil in `AmendLayout` and
-  `OnScroll`; all three `EventCtx` methods are nil-safe
+- **One event rule (since v0.55.0): nothing is marked handled for you. A
+  callback that acts on an event calls `ctx.Consume()`; one that does not, lets
+  the event travel on.** This holds for every callback — `OnClick` and `OnChar`
+  no differently from `OnKeyDown` and `OnHover`. There is no `ctx.Bubble()`:
+  declining is what silence already means. Before v0.55.0 the five hit-tested
+  callbacks were "consume-class" and dispatch pre-marked their events, so an
+  empty `OnClick` was a working click-blocker; such a handler now blocks nothing
+  unless it consumes. `ctx.Event` is nil in `AmendLayout` and `OnScroll`; both
+  `EventCtx` methods are nil-safe. `gui.Debug(true)` reports handlers that act
+  without consuming while an ancestor also handles;
+  `(*Window).TestUnconsumedEvents` sweeps a whole window for them
 
 ## Coding Conventions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,8 +128,8 @@ UI from the view function.
 │ OS event → Event struct              │  │ Animation interface:      │
 │  ├─ hit-test Layout tree          │  │  ├─ Tween (value lerp)       │
 │  ├─ bubble up to ancestors        │  │  ├─ Spring (physics-based)   │
-│  ├─ ctx.Consume() stops it,       │  │  ├─ Keyframe (waypoints)     │
-│  │   ctx.Bubble() resumes it      │  │  ├─ Layout (FLIP-style)      │
+│  ├─ ctx.Consume() stops it;       │  │  ├─ Keyframe (waypoints)     │
+│  │   silence lets it travel       │  │  ├─ Layout (FLIP-style)      │
 │  └─ callbacks: func(EventCtx)     │  │  ├─ Hero (cross-view)        │
 │                                   │  │  └─ BlinkCursor              │
 │ Key dispatch also feeds Commands  │  │                              │

--- a/docs/cookbook-add-widget.md
+++ b/docs/cookbook-add-widget.md
@@ -20,10 +20,10 @@ Every widget has a `*Cfg` struct. Conventions:
   Container-like widgets add `Sizing Sizing`, `Float bool`,
   `FloatAnchor FloatAttach`, `FloatTieOff FloatAttach`, `Padding Opt[Padding]`,
   `Radius Opt[float32]`, `SizeBorder Opt[float32]`.
-- **Callbacks** — one func field per event. Sig: `func(EventCtx)`. Consume-class
-  events (`OnClick`, `OnChar`, `OnMouseUp`, `OnGesture`, `OnFileDrop`) arrive
-  already marked handled; call `ctx.Bubble()` on any path that means "not mine".
-  Notify-class events call `ctx.Consume()` to stop propagation.
+- **Callbacks** — one func field per event. Sig: `func(EventCtx)`. One rule for
+  all of them: call `ctx.Consume()` on any path that acts on the event, and
+  nothing on any path that means "not mine". Nothing is marked handled for you,
+  so a widget that means to absorb a click has to say so.
 - **`gui:"required"` tag** — fields that must be non-empty get the tag. The
   `requiredid` vet analyzer enforces this at `go vet` time. Only use when the
   widget cannot function without the value (e.g. `FormCfg.ID`).

--- a/docs/migration-eventctx.md
+++ b/docs/migration-eventctx.md
@@ -65,85 +65,88 @@ Also unchanged: `OnDraw func(*DrawContext)`,
 `NativeMenuCfg.OnAction func(string)`, and
 `Window.OnEvent func(*Event, *Window)` — a raw escape hatch by design.
 
-## The consume / notify split
+## One rule (v0.55.0)
 
-**Consume-class** events are marked handled _before_ the callback runs:
+**Nothing is marked handled for you.** A callback that acts on an event calls
+`ctx.Consume()`. A callback that does not, lets the event travel on. That is the
+whole model, and it applies to every callback.
 
-> `OnClick`, `OnChar`, `OnMouseUp`, `OnGesture`, `OnFileDrop`
+v0.52.0 through v0.54.0 split callbacks into two classes: `OnClick`, `OnChar`,
+`OnMouseUp`, `OnGesture` and `OnFileDrop` were "consume-class" and dispatch
+marked their events handled before the callback ran, while everything else was
+"notify-class" and had to consume explicitly. Which class you had written was
+invisible in the signature. v0.55.0 deletes the split.
 
-Delete the trailing `e.IsHandled = true` from these — it is now the default.
-Where the old body returned early meaning "not mine, pass it on", call
-`ctx.Bubble()`:
+**What to change.** Add `ctx.Consume()` to any of those five that means to
+absorb the event:
 
 ```go
 OnChar: func(ctx gui.EventCtx) {
     if ctx.Event.CharCode != gui.CharSpace {
-        ctx.Bubble() // every other character keeps travelling
-        return
+        return // every other character keeps travelling
     }
     toggle(ctx.Window)
+    ctx.Consume()
 },
 ```
 
-**Notify-class** events are unchanged in behaviour: nothing is pre-marked, and
-the callback calls `ctx.Consume()` to stop propagation.
+**The case to search for is the empty handler.** An `OnClick` with an empty body
+used to be a working click-blocker — the pre-mark did the absorbing. It now
+absorbs nothing. Overlays, backdrops, popups and cards that stopped clicks
+reaching what they cover all need a real `ctx.Consume()`.
 
-> `OnKeyDown`, `OnKeyUp`, `OnHover`, `OnMouseMove`, `OnMouseLeave`,
-> `OnMouseScroll`, `OnScroll`, `AmendLayout`, `OnIMECommit`
+Nothing changes for `OnKeyDown`, `OnKeyUp`, `OnHover`, `OnMouseMove`,
+`OnMouseLeave`, `OnMouseScroll`, `OnScroll`, `AmendLayout` and `OnIMECommit` —
+they always worked this way. The behaviours that made them the model are why:
 
-The carve-outs are deliberate:
-
-- `OnKeyDown` receives every key. Auto-consuming would kill tab traversal and
+- `OnKeyDown` receives every key. Consuming unasked would kill tab traversal and
   accelerators in any widget with a key handler.
 - Hover, move and leave are notifications. Nested shapes legitimately all want
-  them, so auto-consuming would break every hover-highlight-on-container.
+  them, so consuming unasked would break every hover-highlight-on-container.
 - `OnMouseScroll` cascades to the enclosing scroll container **only if the
   handler leaves the event unhandled**. Scroll chaining is to scrolling what
   bubbling is to keys.
 
-`MouseLockCfg`'s `MouseDown`/`MouseMove`/`MouseUp` take the new signature but
-get no auto-consume: mouse lock already bypasses hit-testing and propagation.
-Their coordinates stay window-absolute, unlike the shape-relative coordinates
-everywhere else.
+`MouseLockCfg`'s `MouseDown`/`MouseMove`/`MouseUp` are unaffected: mouse lock
+already bypasses hit-testing and propagation. Their coordinates stay
+window-absolute, unlike the shape-relative coordinates everywhere else.
 
-## Checking your app against a future one-rule model
+## Finding the handlers you missed
 
-The consume/notify split is settled for v0.54.0, but collapsing it into a single
-rule — nothing pre-marked, every callback consumes explicitly — is still on the
-table. If that happens, a consume-class callback that relies on the pre-mark
-today would start letting the event through to an ancestor, with no compile
-error to warn you.
+The compile-time half of the v0.55.0 change is loud: `ctx.Bubble()` is gone, so
+every call site stops building, and deleting the call is the fix. The other half
+is silent — a handler that should consume and does not simply lets the event
+carry on, and the symptom is a click that fires twice or a popup that dismisses
+itself.
 
 `gui.Debug(true)` reports those sites as they are dispatched, and
-`TestEventCollapse` sweeps a whole window for them:
+`TestUnconsumedEvents` sweeps a whole window for them:
 
 ```go
 w := gui.NewTestWindow(gui.WindowCfg{State: &App{}})
 w.TestRender(mainView)
-for _, f := range w.TestEventCollapse() {
+for _, f := range w.TestUnconsumedEvents() {
     t.Log(f)
 }
 ```
 
-Each finding names an inner callback and the ancestor that would also have
-received the event. The fix is to add `ctx.Consume()` to the inner handler,
-which pins today's behaviour and is correct under either model.
+Each finding names a handler that did not consume and the ancestor that will
+therefore also run — either because it has its own handler for the event, or
+because it is focusable and will take focus on the way past.
 
-The sweep fires every consume-class callback in the window, so give it a window
-built for the purpose. It also sees only the frame in front of it — a hazard
+**Read the findings; do not just drive them to zero.** A handler that inspects
+an event, decides it is not its own and passes it on is now the ordinary way to
+decline, and it looks exactly like one that forgot.
+
+The sweep fires every hit-tested callback in the window, so give it a window
+built for the purpose. It also sees only the frame in front of it — a site
 behind a tab or a dialog needs the app driven into that state first.
-
-## What `Bubble()` does and does not do
-
-`ctx.Bubble()` opts out of **this callback's** auto-consume. It does not
-un-handle an event that an earlier handler already consumed, because the
-coordinate save/restore in dispatch re-applies the incoming flag.
 
 ## Nil `ctx.Event`
 
 `AmendLayout` and `OnScroll` have no originating event, so `ctx.Event` is nil
-there. All three methods are nil-safe — `Consume()` and `Bubble()` do nothing,
-`Handled()` reports false — so no guard is needed.
+there. Both methods are nil-safe — `Consume()` does nothing, `Handled()` reports
+false — so no guard is needed.
 
 ## `Window.OnEvent` sees less
 
@@ -216,7 +219,7 @@ keeping its results.
 
 Pass 1 writes a report of every return path in a consume-class callback that is
 not dominated by a handled assignment. Each entry is a human decision — insert
-`ctx.Bubble()`, or confirm consume-by-default is right. The tool cannot infer
+`ctx.Consume()`, or confirm passing the event on is right. The tool cannot infer
 which, because the old encoding wrote nothing in both cases.
 
 Do not batch-approve it. The recurring shapes worth care are `OnChar` filtering

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -695,10 +695,73 @@ behind a tab, a dialog, or a collapsed panel is invisible until the app
 is driven into that state. The 18 are what the default view of each
 example exposes.
 
-**This does not decide §4.3b.** It replaces the argument's missing
+**This did not decide §4.3b** — §4.3.4 does. It replaced the missing
 number: the silent class is 18 known sites concentrated in ~6 go-gui
 widget files, each fixable ahead of the collapse and verifiable by
-re-running the sweep. Whether to collapse is still a separate call.
+re-running the sweep.
+
+#### 4.3.4 The collapse, as shipped (v0.55.0)
+
+Done. Nothing is pre-marked; every callback consumes explicitly;
+`ctx.Bubble()` is gone. Landed as three PRs, because the measurement was
+wrong twice before it was right.
+
+**The 18 were one anti-idiom.** 14 sites across 12 files wrote
+`ctx.Event.IsHandled = true` instead of calling `ctx.Consume()`.
+Runtime-identical, but `Consume()` also set `explicitConsume`, the flag
+separating "the callback asked" from "dispatch pre-marked" — so every
+one of those sites looked like a decision and was a reliance. Swapping
+all 14 cleared 13 of the 18. The remaining five needed real judgement:
+the dock close button (4, inside its own tab button) and the theme
+picker root (1, hosted as a menu-item `CustomView`).
+
+**The check was measuring the smaller half.** §4.3.3 asked only whether
+an ancestor had a live callback for the same event. But
+`mouseDownHandler` takes focus on the way past any focusable shape under
+the cursor and marks the event handled doing so, **before any callback
+runs** (`gui/event_handlers.go:216`). So an unconsumed click on a
+non-focusable child inside a focusable ancestor does not merely fail to
+stop — it moves focus. No `OnClick` is involved anywhere, which is why
+the original check could not see it. Widening `ancestorHandler` to count
+focus-stealing ancestors, and sweeping all 37 constructible examples
+rather than the 8, found 7 more: the colour picker's hue strip and SV
+area, a slider track press, the scrollbar gutter's mouse-locked early
+return, and two in `gui/datagrid`.
+
+**The static population was 214** — every consume-class callback calling
+neither `Consume()` nor `Bubble()`, 81 in `gui/` and 133 in `examples/`.
+That number is not a defect count and was never the work: under the new
+model an app callback with nothing above it is *correct* not consuming.
+The examples needed no changes at all.
+
+**What the collapse actually broke** was five handlers, and the test
+suite caught two of them:
+
+| Site | Why it broke |
+| ---- | ------------ |
+| `view_command_palette.go` backdrop | dismissal must not reach what the palette floats over |
+| `view_command_palette.go` card | **empty body**, whose only job was to stop the backdrop dismissing under a click into the card |
+| `view_toast.go` | **empty body** — a toast absorbs the clicks it covers |
+| `inspector.go` | **empty body** — clicks must not reach through and mutate what is under study |
+| `view_input_date.go` popup | **empty body** — a click in the popup is not the field's |
+
+Four of five were empty handlers. That is the migration hazard worth
+publishing: an empty consume-class callback used to be a working
+click-blocker, and now blocks nothing.
+
+**The debug check survives, inverted.** `debugCollapse` measured
+reliance on a pre-mark that no longer exists; `debugUnconsumed` reports
+a handler that acted without consuming while an ancestor also receives
+the event, and `TestEventCollapse` is now `TestUnconsumedEvents`. It has
+one honest false positive: deliberate pass-through — a handler that
+inspects an event, decides it is not its own and declines — is now the
+ordinary way to say no, and is indistinguishable from forgetting. The
+sweep is a list to read, not a list to drive to zero.
+
+Sweep across all 37 examples after the collapse: **one finding**, and it
+is that false positive — `inputOnClick`'s "no glyph layout, cannot place
+a cursor" path, reachable only with a nil `TextMeasurer`, i.e. only in
+tests.
 
 ### 4.4 Color-set collapse — highest per-app line savings
 
@@ -1320,7 +1383,7 @@ burying them in the same diff.
 | 4     | §4.7 `RTFCfg` + datagrid builder renames | done   |
 | 4     | §4.4 `ColorSet` on six `Cfg`s, flat state fields deleted | done |
 | 4     | §4.3 callback signature conversion       | done   |
-| 4     | §4.3b event-model collapse               | measured — see §4.3.3 |
+| 4     | §4.3b event-model collapse               | done — see §4.3.4 |
 | 5     | §4.8 example audit                       | done — see §4.8.1 |
 
 Two corrections to §4.2 arising from the implementation.
@@ -1437,6 +1500,13 @@ meaning silently.
 This is the strongest argument for landing §4.6's test API first
 (phase 2): event-propagation regressions are precisely what an app-level
 test can catch and a compiler cannot.
+
+**Resolved (v0.55.0, §4.3.4).** The argument held, and the test API paid
+for itself: of the five go-gui handlers the collapse actually broke, the
+suite caught two on the first run. The silent class turned out to be
+smaller and more specific than "any handler that omitted `Consume()`" —
+it is the **empty** handler, whose only function was to trigger the
+pre-mark. Four of the five were empty bodies.
 
 ### 7.3 Reproducing these counts
 

--- a/gui/datagrid/view_data_grid_events.go
+++ b/gui/datagrid/view_data_grid_events.go
@@ -238,7 +238,7 @@ func dataGridColumnChooserRow(cfg *DataGridCfg, isOpen bool, focusID string) gg.
 func dataGridMakeColumnChooserOnClick(onHiddenColumnsChange func(map[string]bool, gg.EventCtx), hiddenColumnIDs map[string]bool, columns []GridColumnCfg, colID string, focusID string) func(gg.EventCtx) {
 	return func(ctx gg.EventCtx) {
 		if onHiddenColumnsChange == nil {
-			ctx.Bubble() // no handler configured: pass the click on
+			// No handler configured: pass the click on
 			return
 		}
 		nextHidden := dataGridNextHiddenColumns(hiddenColumnIDs, colID, columns)

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -149,11 +149,14 @@ func dataGridResizeHandle(cfg *DataGridCfg, col GridColumnCfg, focusID string) g
 		Color:   colorResizeHandle,
 		OnClick: func(ctx gg.EventCtx) {
 			if disabled {
-				ctx.Bubble() // a disabled handle must not eat the click
+				// A disabled handle must not eat the click
 				return
 			}
 			startX := ctx.Layout.Shape.X + ctx.Event.MouseX
 			dataGridStartResize(gridID, columns, rows, textStyleHeader, textStyle, paddingCell, col, focusID, startX, ctx.Event, ctx.Window)
+			// Starting a resize is the click; the header cell it sits
+			// on must not also sort.
+			ctx.Consume()
 		},
 		OnHover: func(ctx gg.EventCtx) {
 			if disabled {

--- a/gui/datagrid/view_data_grid_keys.go
+++ b/gui/datagrid/view_data_grid_keys.go
@@ -14,12 +14,12 @@ func dataGridMakeOnChar(cfg *DataGridCfg, columns []GridColumnCfg) func(gg.Event
 	onCopyRows := cfg.OnCopyRows
 	return func(ctx gg.EventCtx) {
 		if !dataGridCharIsCopy(ctx.Event) {
-			ctx.Bubble() // only the copy chord is ours
+			// Only the copy chord is ours
 			return
 		}
 		selectedRows := dataGridSelectedRows(rows, selection)
 		if len(selectedRows) == 0 {
-			ctx.Bubble() // nothing selected: nothing to copy
+			// Nothing selected: nothing to copy
 			return
 		}
 		var payload string
@@ -34,7 +34,7 @@ func dataGridMakeOnChar(cfg *DataGridCfg, columns []GridColumnCfg) func(gg.Event
 			payload = gridRowsToTSV(columns, selectedRows)
 		}
 		if payload == "" {
-			ctx.Bubble() // produced nothing: leave the chord to others
+			// Produced nothing: leave the chord to others
 			return
 		}
 		ctx.Window.SetClipboard(payload)

--- a/gui/datagrid/view_data_grid_rows.go
+++ b/gui/datagrid/view_data_grid_rows.go
@@ -386,7 +386,7 @@ func dataGridDetailToggleControl(cfg *DataGridCfg, rowID string, expanded, enabl
 		Colors:     gg.ColorSet{Hover: cfg.ColorRowHover, Click: cfg.ColorRowHover, Focus: gg.ColorTransparent, Border: gg.ColorTransparent},
 		OnClick: func(ctx gg.EventCtx) {
 			if rowID == "" || onDetailExpandedChange == nil {
-				ctx.Bubble() // nothing to toggle: pass the click on
+				// Nothing to toggle: pass the click on
 				return
 			}
 			next := dataGridNextDetailExpandedMap(detailExpandedRowIDs, rowID)
@@ -394,6 +394,9 @@ func dataGridDetailToggleControl(cfg *DataGridCfg, rowID string, expanded, enabl
 			if focusID != "" {
 				ctx.Window.SetFocus(focusID)
 			}
+			// Expanding the detail is the click; the row beneath must
+			// not also select.
+			ctx.Consume()
 		},
 		Content: []gg.View{
 			gg.Text(gg.TextCfg{

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -107,9 +107,9 @@ const (
 	debugCheckFocusNoID
 	debugCheckScrollNoID
 	debugCheckMouseLeaveNoID
-	// debugCheckEventCollapse is the only check that runs from dispatch
+	// debugCheckUnconsumed is the only check that runs from dispatch
 	// rather than from the per-frame layout audit; see debug_event.go.
-	debugCheckEventCollapse
+	debugCheckUnconsumed
 )
 
 // debugWarnKey is the warn-once key. For the ID-less checks the
@@ -125,7 +125,7 @@ type debugWarnKey struct {
 type debugState struct {
 	warned map[debugWarnKey]struct{}
 	// collect, when non-nil, receives findings instead of debugOut. Set
-	// only by TestEventCollapse, which needs the findings as data
+	// only by TestUnconsumedEvents, which needs the findings as data
 	// rather than as text on stderr.
 	collect *[]string
 	gen     uint64

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -2,45 +2,43 @@ package gui
 
 import "strconv"
 
-// Event-model collapse check.
+// Unconsumed-event check.
 //
-// §4.3b of docs/specs/developer-ergonomics.md proposes deleting the
-// consume/notify split: one rule, nothing is pre-marked, every callback
-// consumes explicitly. The compile-time half of that change is loud —
-// ctx.Bubble() disappears and its call sites stop building. The other
-// half is silent, and it is the reason the collapse is still deferred:
-// a consume-class callback that relied on the pre-mark and never called
-// ctx.Consume() would, under the collapse, leave the event unhandled
-// and let it reach an ancestor's handler. No compile error, no panic,
-// just a click that now fires twice.
+// §4.3b of docs/specs/developer-ergonomics.md deleted the
+// consume/notify split in v0.55.0: one rule, nothing is pre-marked,
+// every callback consumes explicitly. The compile-time half of that
+// change was loud — ctx.Bubble() disappeared and its call sites stopped
+// building. This check covers the other half, which is silent: a
+// callback that acts on an event and forgets to consume it lets that
+// event carry on to an ancestor. No compile error, no panic, just a
+// click that fires twice.
 //
-// Counting call sites cannot measure this. §4.3.1 counted 138
-// consume-class sites in examples/ alone and concluded that most sit on
-// widgets with no clickable ancestor — but which ones those are is a
-// property of the layout tree at dispatch time, not of the source.
+// Reading the source cannot answer it. Whether an unconsumed event
+// reaches a second handler is a property of the layout tree at dispatch
+// time, so the check is evaluated where the answer is knowable: right
+// after a callback returns, ask whether the event is still unhandled
+// and whether an ancestor would receive it. Both true is a double
+// dispatch.
 //
-// So the check is a counterfactual, evaluated where the answer is
-// actually knowable: right after a consume-class callback returns, ask
-// (a) did it rely on the pre-mark, and (b) is there an ancestor that
-// would have received this same event. Both true is a site that changes
-// behaviour under the collapse. Everything else is safe to convert.
+// The one false positive to know about is deliberate pass-through — a
+// handler that inspects an event, decides it is not its own, and leaves
+// it alone. That is now the ordinary way to decline, and it is
+// indistinguishable from forgetting. Findings are a list to read, not
+// a list of bugs.
 //
 // Turn it on with gui.Debug(true) or GOGUI_DEBUG=1, exercise the app,
 // and read the findings off stderr. Each is reported once per window.
 
-// debugCollapse reports one dispatch as a collapse hazard when the
-// callback relied on the consume-class pre-mark and an ancestor would
-// also have received the event.
+// debugUnconsumed reports one dispatch where a callback acted on an
+// event, did not consume it, and an ancestor will therefore also
+// receive it.
 //
 // Called from callRelative, executeFocusCallback and the gesture
-// dispatch after every named consume-class callback. explicit is the
-// callback's own ctx.Consume() decision, passed in because callRelative
-// restores the event before calling and would otherwise have handed
-// back the enclosing frame's value.
+// dispatch after every named callback.
 //
 // No-op unless [Debug] is on, which is one atomic load.
-func debugCollapse(
-	class evClass, layout *Layout, e *Event, w *Window, explicit bool,
+func debugUnconsumed(
+	class evClass, layout *Layout, e *Event, w *Window,
 ) {
 	// Dispatch already guards on named(); repeated here so the function
 	// is safe to call directly and cannot be the reason an unnamed
@@ -51,10 +49,8 @@ func debugCollapse(
 	if !debugEnabled.Load() || w == nil || e == nil {
 		return
 	}
-	// Bubbling already means the callback opted out, and an explicit
-	// Consume() already means it would keep working verbatim. Only the
-	// silent middle — still handled, never asked for — is at risk.
-	if !e.IsHandled || explicit {
+	// A consumed event is going nowhere, so there is nothing to report.
+	if e.IsHandled {
 		return
 	}
 	anc := class.ancestorHandler(layout, e, w)
@@ -63,11 +59,10 @@ func debugCollapse(
 	}
 	self := debugShapeName(layout)
 	other := debugShapeName(anc)
-	w.debugWarn(debugCheckEventCollapse, class.name()+":"+self+">"+other,
-		"%s on %s relies on automatic handling and %s above it %s; "+
-			"under the one-rule event model (spec §4.3b) the event would "+
-			"reach both. Add ctx.Consume() to the %s handler to make the "+
-			"current behaviour explicit",
+	w.debugWarn(debugCheckUnconsumed, class.name()+":"+self+">"+other,
+		"%s on %s did not consume the event and %s above it %s, so both "+
+			"will run. Call ctx.Consume() in the %s handler if it means "+
+			"to act on the event; ignore this if it means to pass it on",
 		class.name(), self, other, class.ancestorReason(anc, e, w), self)
 }
 
@@ -128,7 +123,7 @@ func (s *Shape) stealsFocusOn(e *Event) bool {
 }
 
 // wouldReach reports whether this ancestor's own dispatch condition
-// holds for the event. Each consume-class event has a different one.
+// holds for the event. Each named event has a different one.
 func (c evClass) wouldReach(anc *Layout, e *Event, w *Window) bool {
 	s := anc.Shape
 	ev := s.events
@@ -177,28 +172,33 @@ func (c evClass) name() string {
 	return "event"
 }
 
-// TestEventCollapse sweeps the window for sites that would change
-// behaviour under the one-rule event model of spec §4.3b, and returns
-// one finding per site.
+// TestUnconsumedEvents sweeps the window for handlers that act on an
+// event without consuming it while an ancestor would also receive it,
+// and returns one finding per site.
 //
-// It renders a frame, then for every shape carrying a consume-class
-// callback it synthesizes that event at the shape's centre and runs it
-// through real dispatch with the collapse check armed. A finding means
-// the callback relied on automatic handling while an ancestor would
-// also have received the event.
+// It renders a frame, then for every shape carrying one of the five
+// hit-tested callbacks it synthesizes that event at the shape's centre
+// and runs it through real dispatch with the check armed.
 //
 // **This fires the app's callbacks.** Sweeping a window presses every
 // button in it, in tree order, and whatever state that mutates stays
 // mutated. Call it on a window built for the purpose, not on one an
 // assertion still depends on.
 //
-// Empty result means the window is collapse-safe as rendered. It does
-// not mean the app is: a hazard behind a tab, a dialog, or a scrolled
-// region is only visible once that state is on screen, so drive the app
-// into each interesting state and sweep again.
+// Read the findings, do not simply drive them to zero: a handler that
+// inspects an event, decides it is not its own and passes it on is
+// indistinguishable from one that forgot, and both are reported.
+//
+// An empty result covers the window as rendered, not the app: a site
+// behind a tab, a dialog or a scrolled region is only visible once that
+// state is on screen, so drive the app into each interesting state and
+// sweep again.
 //
 // The debug gate is turned on for the duration and restored after.
-func (w *Window) TestEventCollapse() []string {
+//
+// Named TestUnconsumedEvents before v0.55.0, when it measured the cost of
+// a collapse that has since happened.
+func (w *Window) TestUnconsumedEvents() []string {
 	root := w.TestRender(nil)
 	if root == nil {
 		return nil
@@ -216,18 +216,18 @@ func (w *Window) TestEventCollapse() []string {
 		w.debug.collect = nil
 		w.debug.warned = prevWarned
 	}()
-	w.sweepCollapse(root)
+	w.sweepUnconsumed(root)
 	return found
 }
 
-// sweepCollapse walks the tree depth-first, dispatching one synthetic
+// sweepUnconsumed walks the tree depth-first, dispatching one synthetic
 // event per consume-class callback it finds.
 //
 // Dispatch starts from the root every time rather than from the shape,
 // because hit-testing, focus and the topmost-first traversal are the
 // parts that decide who actually receives the event — starting halfway
 // down would skip exactly the logic the check reasons about.
-func (w *Window) sweepCollapse(root *Layout) {
+func (w *Window) sweepUnconsumed(root *Layout) {
 	var walk func(l *Layout)
 	walk = func(l *Layout) {
 		if s := l.Shape; s != nil && s.hasEvents() && !s.Disabled {

--- a/gui/debug_event_test.go
+++ b/gui/debug_event_test.go
@@ -32,8 +32,8 @@ func clickCollapse(t *testing.T, root *Layout) string {
 	return buf.String()
 }
 
-// The hazard itself: the inner handler never says Consume, so today the
-// pre-mark stops the event, and under §4.3b it would not.
+// The finding itself: the inner handler never says Consume, so the
+// click carries on to the ancestor and both run.
 func TestCollapseWarnsWhenAncestorAlsoHandles(t *testing.T) {
 	root := collapseTree(
 		&eventHandlers{OnClick: func(EventCtx) {}},
@@ -46,32 +46,19 @@ func TestCollapseWarnsWhenAncestorAlsoHandles(t *testing.T) {
 	}
 }
 
-// An explicit Consume() is what the collapse asks for, so such a site
-// is already correct and must stay quiet.
+// A consumed event is going nowhere, so there is nothing to report.
 func TestCollapseSilentOnExplicitConsume(t *testing.T) {
 	root := collapseTree(
 		&eventHandlers{OnClick: func(EventCtx) {}},
 		&eventHandlers{OnClick: func(ctx EventCtx) { ctx.Consume() }},
 	)
 	if got := clickCollapse(t, root); got != "" {
-		t.Errorf("explicit Consume() is collapse-safe, got %q", got)
+		t.Errorf("a consumed event reaches no ancestor, got %q", got)
 	}
 }
 
-// Bubble() means the event already reaches the ancestor today, so the
-// collapse changes nothing for this site.
-func TestCollapseSilentOnBubble(t *testing.T) {
-	root := collapseTree(
-		&eventHandlers{OnClick: func(EventCtx) {}},
-		&eventHandlers{OnClick: func(ctx EventCtx) { ctx.Bubble() }},
-	)
-	if got := clickCollapse(t, root); got != "" {
-		t.Errorf("Bubble() already propagates, got %q", got)
-	}
-}
-
-// The common case §4.3.1 could not count: a handler with no handling
-// ancestor. Most of the 138 example sites are expected to land here.
+// The common case: a handler with no handling ancestor. Not consuming
+// is unremarkable when nothing is above you.
 func TestCollapseSilentWithoutAncestorHandler(t *testing.T) {
 	root := collapseTree(nil, &eventHandlers{OnClick: func(EventCtx) {}})
 	if got := clickCollapse(t, root); got != "" {
@@ -187,10 +174,9 @@ func TestCollapseIgnoresNotifyClass(t *testing.T) {
 	}
 }
 
-// The unnamed generic evConsume carries no ancestor rule, so callers
-// that have not been given a specific kind stay silent rather than
-// guessing.
-func TestCollapseSkipsUnnamedConsumeClass(t *testing.T) {
+// The unnamed evNotify carries no ancestor rule, so callers that have
+// not been given a specific kind stay silent rather than guessing.
+func TestCollapseSkipsUnnamedClass(t *testing.T) {
 	root := collapseTree(
 		&eventHandlers{OnClick: func(EventCtx) {}},
 		&eventHandlers{OnClick: func(EventCtx) {}},
@@ -198,8 +184,8 @@ func TestCollapseSkipsUnnamedConsumeClass(t *testing.T) {
 	inner := &root.Children[0].Children[0]
 	buf := captureDebug(t)
 	callRelative(inner, &Event{MouseX: 5, MouseY: 5}, &Window{},
-		inner.Shape.events.OnClick, evConsume)
+		inner.Shape.events.OnClick, evNotify)
 	if got := buf.String(); got != "" {
-		t.Errorf("evConsume names no event, got %q", got)
+		t.Errorf("evNotify names no event, got %q", got)
 	}
 }

--- a/gui/event.go
+++ b/gui/event.go
@@ -362,15 +362,6 @@ type Event struct {
 	// (already carrying OS momentum). False for discrete mouse-wheel
 	// notches, which the gui side eases via scrollSmoothAnimation.
 	ScrollPrecise bool
-	// explicitConsume records that a callback called ctx.Consume()
-	// rather than leaving IsHandled at whatever dispatch set. Only the
-	// event-collapse debug check reads it (debug_event.go): under the
-	// current model a consume-class callback is pre-marked handled, so
-	// IsHandled alone cannot tell "the callback meant to consume" from
-	// "the callback relied on the pre-mark". Dispatch clears it before
-	// each consume-class callback and the callRelative save/restore
-	// unwinds it, so nested dispatch cannot leak a stale value.
-	explicitConsume bool
 }
 
 // eventRelativeTo returns a copy of the event with mouse

--- a/gui/event_ctx.go
+++ b/gui/event_ctx.go
@@ -18,34 +18,17 @@ type EventCtx struct {
 }
 
 // Consume marks the event handled so ancestors do not receive it.
-// Needed only in notify-class callbacks (OnKeyDown, OnKeyUp, OnHover,
-// OnMouseMove, OnMouseLeave, OnMouseScroll); consume-class callbacks
-// (OnClick, OnChar, OnMouseUp, OnGesture, OnFileDrop) are already
-// marked handled before they run.
+//
+// One rule, every event: a callback that acts on an event says so. No
+// event is marked handled on a callback's behalf, so a callback that
+// does not call Consume lets the event travel on. This holds for every
+// callback — OnClick and OnChar no differently from OnKeyDown and
+// OnHover.
 //
 // Safe to call when Event is nil.
 func (c EventCtx) Consume() {
 	if c.Event != nil {
 		c.Event.IsHandled = true
-		// Record that consumption was asked for, not merely inherited
-		// from the consume-class pre-mark. One unconditional store,
-		// cheaper than gating it on the debug atomic.
-		c.Event.explicitConsume = true
-	}
-}
-
-// Bubble marks the event unhandled so ancestors receive it. This is
-// the explicit opt-out for consume-class callbacks.
-//
-// Bubble opts out of *this* callback's auto-consume only. It does not
-// un-handle an event that an earlier handler already consumed, because
-// the coordinate save/restore in callRelative re-applies the incoming
-// handled flag.
-//
-// Safe to call when Event is nil.
-func (c EventCtx) Bubble() {
-	if c.Event != nil {
-		c.Event.IsHandled = false
 	}
 }
 
@@ -55,37 +38,32 @@ func (c EventCtx) Handled() bool {
 	return c.Event != nil && c.Event.IsHandled
 }
 
-// evClass distinguishes the two event-dispatch classes. Consume-class
-// events are pre-marked handled before the callback runs; notify-class
-// events are not, and the callback must call ctx.Consume() to stop
-// propagation.
+// evClass names which event is being dispatched.
 //
-// Consume-class values additionally name *which* event is being
-// dispatched. The class alone is enough to dispatch, but the
-// event-collapse debug check (debug_event.go) has to ask "would an
-// ancestor also have received this?", and that question is
-// per-callback: it means OnClick on a containing shape for evClick and
-// the focused target's OnChar for evChar. Carrying the name in the
-// existing parameter keeps the two facts from drifting apart.
+// It no longer carries a dispatch rule. Until v0.55.0 there were two
+// classes — consume-class events were marked handled before the
+// callback ran, notify-class events were not — and the difference was
+// invisible in a callback's signature, so which one you had written was
+// something you had to know rather than something you could see. That
+// split is gone: nothing is pre-marked and every callback consumes
+// explicitly.
+//
+// What remains is the name, which the unconsumed-event debug check
+// (debug_event.go) needs: "would an ancestor also have received this?"
+// is a per-event question, meaning OnClick on a containing shape for
+// evClick and the focused target's OnChar for evChar.
 //
 // The classification is internal: it is encoded at the dispatch sites
 // and is neither exposed nor configurable.
 type evClass uint8
 
 const (
-	// evNotify leaves IsHandled alone; the callback opts in with
-	// ctx.Consume(). Used for OnKeyDown, OnKeyUp, OnHover, OnMouseMove,
-	// OnMouseLeave, OnMouseScroll, OnScroll, AmendLayout, OnIMECommit.
+	// evNotify is the unnamed default: dispatched like every other
+	// event, but carrying no ancestor rule, so the debug check skips
+	// it.
 	evNotify evClass = iota
 
-	// evConsume pre-marks IsHandled before the callback runs; the
-	// callback opts out with ctx.Bubble(). Consume-class without naming
-	// an event: dispatches identically to the named values below but
-	// carries no ancestor rule, so the collapse check skips it.
-	evConsume
-
-	// The named consume-class events. Each pre-marks IsHandled exactly
-	// as evConsume does.
+	// The named events, all of which had been consume-class.
 	evClick
 	evChar
 	evMouseUp
@@ -93,16 +71,11 @@ const (
 	evGesture
 )
 
-// consumes reports whether this class pre-marks IsHandled before the
-// callback runs.
-func (c evClass) consumes() bool { return c != evNotify }
-
 // named reports whether this class identifies a specific event, which
-// is the precondition for the collapse check. Ordered so the test is
-// one comparison: the named values are the ones above evConsume.
+// is the precondition for the debug check.
 //
-// Dispatch guards the debugCollapse call with this rather than letting
-// the check reject the class itself, so notify-class dispatch — the
+// Dispatch guards the debugUnconsumed call with this rather than
+// letting the check reject the class itself, so unnamed dispatch — the
 // overwhelming majority of events — does not pay for a function call
 // it will always return from immediately.
-func (c evClass) named() bool { return c > evConsume }
+func (c evClass) named() bool { return c != evNotify }

--- a/gui/event_ctx_test.go
+++ b/gui/event_ctx_test.go
@@ -33,18 +33,20 @@ func clickableShape(eh *eventHandlers) *Layout {
 func TestEventCtxNilEventMethods(t *testing.T) {
 	t.Parallel()
 	ctx := EventCtx{Layout: &Layout{}, Window: &Window{}}
-	// All three must be callable from AmendLayout/OnScroll, which carry
-	// no originating event.
+	// Both must be callable from AmendLayout/OnScroll, which carry no
+	// originating event.
 	ctx.Consume()
-	ctx.Bubble()
 	if ctx.Handled() {
 		t.Error("Handled() must be false with a nil Event")
 	}
 }
 
-// --- Consume class ---
+// --- The one rule ---
 
-func TestConsumeClassHandledByDefault(t *testing.T) {
+// OnClick was consume-class until v0.55.0, marked handled before the
+// callback ran. It is now exactly like every other callback: silence
+// means the event travels on.
+func TestClickNotHandledUnlessConsumed(t *testing.T) {
 	t.Parallel()
 	called := false
 	root := clickableShape(&eventHandlers{
@@ -55,40 +57,37 @@ func TestConsumeClassHandledByDefault(t *testing.T) {
 	if !called {
 		t.Fatal("OnClick not called")
 	}
-	if !e.IsHandled {
-		t.Error("consume-class callback should not have to mark handled")
+	if e.IsHandled {
+		t.Error("no callback is marked handled on its behalf any more")
 	}
 }
 
-func TestConsumeClassBubbleOptsOut(t *testing.T) {
+func TestClickConsumeStops(t *testing.T) {
 	t.Parallel()
 	root := clickableShape(&eventHandlers{
-		OnClick: func(ctx EventCtx) { ctx.Bubble() },
+		OnClick: func(ctx EventCtx) { ctx.Consume() },
 	})
 	e := &Event{MouseX: 5, MouseY: 5}
 	mouseDownHandler(root, false, e, &Window{})
-	if e.IsHandled {
-		t.Error("ctx.Bubble() should restore propagation")
+	if !e.IsHandled {
+		t.Error("ctx.Consume() should stop propagation")
 	}
 }
 
-// TestBubbleDoesNotUnhandleEarlierConsumer pins the documented limit of
-// Bubble: it opts out of this callback's auto-consume only, because
-// callRelative re-applies the incoming handled flag.
-func TestBubbleDoesNotUnhandleEarlierConsumer(t *testing.T) {
+// TestCallRelativeKeepsEarlierConsume pins the save/restore contract:
+// a callback that declines to consume must not un-handle an event some
+// earlier handler already consumed.
+func TestCallRelativeKeepsEarlierConsume(t *testing.T) {
 	t.Parallel()
 	layout := &Layout{Shape: &Shape{
 		shapeClip: drawClip{X: 0, Y: 0, Width: 100, Height: 100},
 	}}
 	e := &Event{MouseX: 5, MouseY: 5, IsHandled: true}
-	callRelative(layout, e, &Window{},
-		func(ctx EventCtx) { ctx.Bubble() }, evConsume)
+	callRelative(layout, e, &Window{}, func(EventCtx) {}, evClick)
 	if !e.IsHandled {
-		t.Error("Bubble must not un-handle an event a prior handler consumed")
+		t.Error("declining to consume must not un-handle a prior consume")
 	}
 }
-
-// --- Notify class ---
 
 func TestNotifyClassStillBubbles(t *testing.T) {
 	t.Parallel()
@@ -172,9 +171,11 @@ func TestFocusedMouseScrollDoesNotAutoConsume(t *testing.T) {
 	}
 }
 
-func TestOnCharAutoConsumesButKeyUpDoesNot(t *testing.T) {
+func TestOnCharAndKeyUpBothNeedConsume(t *testing.T) {
 	t.Parallel()
-	// Both go through executeFocusCallback; only OnChar is consume.
+	// Both go through executeFocusCallback, and since v0.55.0 neither
+	// is treated differently: OnChar was the last keyboard callback
+	// that consumed without being asked.
 	charRoot := focusedChild("f1", &eventHandlers{
 		OnChar: func(EventCtx) {},
 	})
@@ -182,8 +183,8 @@ func TestOnCharAutoConsumesButKeyUpDoesNot(t *testing.T) {
 	w.SetFocus("f1")
 	ce := &Event{CharCode: 'a'}
 	charHandler(charRoot, ce, w)
-	if !ce.IsHandled {
-		t.Error("OnChar should auto-consume")
+	if ce.IsHandled {
+		t.Error("OnChar must not auto-consume")
 	}
 
 	upRoot := focusedChild("f1", &eventHandlers{
@@ -286,7 +287,7 @@ func TestOnEventSkippedForConsumedClick(t *testing.T) {
 		return n
 	}
 	if got := sniff(clickableShape(&eventHandlers{
-		OnClick: func(EventCtx) {},
+		OnClick: func(ctx EventCtx) { ctx.Consume() },
 	})); got != 0 {
 		t.Errorf("consumed click reached OnEvent %d times, want 0", got)
 	}
@@ -321,9 +322,8 @@ func TestReentrantDispatchKeepsOuterCtxUsable(t *testing.T) {
 		callRelative(inner, ctx.Event, w, func(EventCtx) {}, evNotify)
 		samePtr = ctx.Event == e
 		sameCoords = ctx.Event.MouseX == x && ctx.Event.MouseY == y
-		ctx.Bubble()
 		ctx.Consume()
-	}, evConsume)
+	}, evClick)
 
 	if !samePtr {
 		t.Error("outer ctx.Event pointer changed across nested dispatch")

--- a/gui/event_handlers_test.go
+++ b/gui/event_handlers_test.go
@@ -27,6 +27,7 @@ func TestCharHandler(t *testing.T) {
 		root := focusedChild("f1", &eventHandlers{
 			OnChar: func(ctx EventCtx) {
 				called = true
+				ctx.Consume()
 			},
 		})
 		w := &Window{}
@@ -281,6 +282,7 @@ func TestMouseDownHandler(t *testing.T) {
 				events: &eventHandlers{
 					OnClick: func(ctx EventCtx) {
 						hitID = ctx.Layout.Shape.ID
+						ctx.Consume()
 					},
 				},
 			}}
@@ -579,6 +581,7 @@ func TestFileDropHandler(t *testing.T) {
 				events: &eventHandlers{
 					OnFileDrop: func(ctx EventCtx) {
 						hitID = ctx.Layout.Shape.ID
+						ctx.Consume()
 					},
 				},
 			}}
@@ -620,6 +623,7 @@ func TestFileDropHandler(t *testing.T) {
 						Width: 100, Height: 100},
 					events: &eventHandlers{
 						OnFileDrop: func(ctx EventCtx) {
+							ctx.Consume()
 						},
 					},
 				}},

--- a/gui/event_traversal.go
+++ b/gui/event_traversal.go
@@ -21,9 +21,8 @@ func isFocusedTarget(layout *Layout, w *Window) bool {
 }
 
 // executeFocusCallback delivers a keyboard event to the focused
-// target. class states whether the event is consume- or notify-class;
-// the helper serves both (OnChar is consume, OnKeyDown/OnKeyUp are
-// notify), so the caller must say which.
+// target. class names the event for the debug check; it no longer
+// selects a dispatch rule, because there is only one.
 func executeFocusCallback(
 	layout *Layout, e *Event, w *Window,
 	callback ShapeCallback, class evClass,
@@ -34,13 +33,9 @@ func executeFocusCallback(
 	if callback == nil {
 		return false
 	}
-	if class.consumes() {
-		e.explicitConsume = false
-		e.IsHandled = true
-	}
 	callback(EventCtx{layout, e, w})
 	if class.named() {
-		debugCollapse(class, layout, e, w, e.explicitConsume)
+		debugUnconsumed(class, layout, e, w)
 	}
 	return e.IsHandled
 }
@@ -49,10 +44,9 @@ func executeFocusCallback(
 // calls the callback, restores coordinates, and propagates
 // IsHandled. Assumes layout.Shape and callback are non-nil.
 //
-// class states whether the event is consume- or notify-class. The
-// consume pre-mark must land AFTER saved := *e: marking before the
-// save would copy IsHandled = true into saved, and the restore below
-// would then silently undo any ctx.Bubble() the callback performed.
+// class names the event for the debug check and no longer selects a
+// dispatch rule. The pre-mark that used to land here — and the
+// save/restore ordering it forced — is gone with spec §4.3b.
 func callRelative(
 	layout *Layout, e *Event, w *Window,
 	callback ShapeCallback, class evClass,
@@ -60,29 +54,17 @@ func callRelative(
 	saved := *e
 	e.MouseX = saved.MouseX - layout.Shape.X
 	e.MouseY = saved.MouseY - layout.Shape.Y
-	if class.consumes() {
-		e.explicitConsume = false
-		e.IsHandled = true // pre-mark AFTER the save
-	}
 	callback(EventCtx{layout, e, w})
-	handled := e.IsHandled // a ctx.Bubble() in the callback shows up here
-	// The callback's own Consume() decision, read before the restore
-	// puts the outer frame's value back. Guarded so the notify-class
-	// path — nearly every event — pays a predictable branch and no
-	// load; this is the mouse-scroll hot path.
-	var explicit bool
-	if class.named() {
-		explicit = e.explicitConsume
-	}
+	handled := e.IsHandled
 	*e = saved
 	if handled {
 		e.IsHandled = true
 	}
-	// The collapse check runs on the restored event: its ancestor test
+	// The debug check runs on the restored event: its ancestor test
 	// needs the coordinates in the enclosing shape's space, not the
 	// shape-relative ones the callback saw.
 	if class.named() {
-		debugCollapse(class, layout, e, w, explicit)
+		debugUnconsumed(class, layout, e, w)
 	}
 	return handled
 }

--- a/gui/gesture.go
+++ b/gui/gesture.go
@@ -517,11 +517,8 @@ func gestureHandler(layout *Layout, e *Event, w *Window) {
 	}
 	if layout.Shape.hasEvents() &&
 		layout.Shape.events.OnGesture != nil {
-		// OnGesture is consume-class: pre-mark before the call.
-		e.explicitConsume = false
-		e.IsHandled = true
 		layout.Shape.events.OnGesture(EventCtx{layout, e, w})
-		debugCollapse(evGesture, layout, e, w, e.explicitConsume)
+		debugUnconsumed(evGesture, layout, e, w)
 		if e.IsHandled {
 			return
 		}

--- a/gui/inspector.go
+++ b/gui/inspector.go
@@ -160,7 +160,10 @@ func inspectorFloatingPanel(w *Window) View {
 		ScrollbarCfgY: scrollbarCfg,
 		Padding:       SomeP(0, scrollbarPad, 0, 0),
 		Spacing:       SomeF(0),
+		// The inspector panel overlays the app being inspected; clicks
+		// on it must not reach through and mutate what is under study.
 		OnClick: func(ctx EventCtx) {
+			ctx.Consume()
 		},
 		Content: []View{
 			inspectorHelpBar(),

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -378,16 +378,16 @@ const (
 
 // eventHandlers holds optional event callback fields.
 type eventHandlers struct {
-	// Consume-class: dispatch marks the event handled before the
-	// callback runs. Opt out with ctx.Bubble().
+	// One rule for all of these: the callback must call ctx.Consume()
+	// to stop propagation. Until v0.55.0 the five below were
+	// "consume-class" and dispatch marked their events handled before
+	// the callback ran; that split is gone.
 	OnChar     func(EventCtx)
 	OnClick    func(EventCtx)
 	OnMouseUp  func(EventCtx)
 	OnGesture  func(EventCtx)
 	OnFileDrop func(EventCtx)
 
-	// Notify-class: the callback must call ctx.Consume() to stop
-	// propagation.
 	OnKeyDown     func(EventCtx)
 	OnKeyUp       func(EventCtx)
 	OnMouseMove   func(EventCtx)

--- a/gui/testing.go
+++ b/gui/testing.go
@@ -57,7 +57,7 @@ var (
 	// ErrTestUnhandled means the event was dispatched and reached the
 	// end of traversal with nothing claiming it. The widget is present
 	// and hittable, but something above it in z-order absorbed the
-	// event, or the handler called ctx.Bubble() all the way out.
+	// event, or no handler along the way called ctx.Consume().
 	ErrTestUnhandled = errors.New("gui: event was not handled by any widget")
 )
 

--- a/gui/testing_test.go
+++ b/gui/testing_test.go
@@ -158,8 +158,14 @@ func TestTestClickBlockedByOverlay(t *testing.T) {
 					Sizing:   FixedFixed,
 					Width:    400,
 					Height:   400,
-					OnClick:  func(_ EventCtx) { overFired = true },
-					Color:    Hex(0x000000),
+					OnClick: func(ctx EventCtx) {
+						overFired = true
+						// An overlay absorbs what lands on it. Under
+						// the one-rule model that is a Consume, not a
+						// side effect of being consume-class.
+						ctx.Consume()
+					},
+					Color: Hex(0x000000),
 				}),
 			},
 		})

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -320,12 +320,12 @@ func makeComboboxOnChar(cfgID string) func(EventCtx) {
 		// Default false: absent entry means "not open".
 		isOpen := ss.GetOr(cfgID, false)
 		if !isOpen {
-			ctx.Bubble() // closed: typing is not ours to swallow
+			// Closed: typing is not ours to swallow
 			return
 		}
 		ch := rune(ctx.Event.CharCode)
 		if ch < CharSpace {
-			ctx.Bubble() // control characters belong to OnKeyDown
+			// Control characters belong to OnKeyDown
 			return
 		}
 		sq := StateMap[string, string](ctx.Window, nsComboboxQuery, capModerate)

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -182,6 +182,9 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 			if onDismiss != nil {
 				onDismiss(ctx.Window)
 			}
+			// A click on the backdrop is the dismissal, not something
+			// for whatever the palette is floating over.
+			ctx.Consume()
 		},
 		Content: []View{
 			Column(ContainerCfg{
@@ -196,7 +199,13 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 				Spacing:     SomeF(0),
 				Sizing:      FixedFit,
 				OnClick: func(ctx EventCtx) {
-					// Prevent backdrop click when clicking card.
+					// Absorb the click so it never reaches the
+					// backdrop, which would dismiss the palette the
+					// user is clicking into. An empty body used to be
+					// enough, back when dispatch marked consume-class
+					// events handled on the callback's behalf; now the
+					// consume has to be said.
+					ctx.Consume()
 				},
 				Content: []View{
 					Row(ContainerCfg{

--- a/gui/view_command_palette_test.go
+++ b/gui/view_command_palette_test.go
@@ -291,7 +291,7 @@ func TestPaletteBackdropDismiss(t *testing.T) {
 	// OnClick is consume-class, so the handled flag is set by dispatch,
 	// not by the callback body.
 	e := &Event{}
-	callRelative(&layout, e, w, layout.Shape.events.OnClick, evConsume)
+	callRelative(&layout, e, w, layout.Shape.events.OnClick, evClick)
 	if !dismissed {
 		t.Error("backdrop click should trigger OnDismiss")
 	}

--- a/gui/view_date_picker_calendar.go
+++ b/gui/view_date_picker_calendar.go
@@ -161,7 +161,7 @@ func datePickerMonth(
 					sm := StateMap[string, datePickerState](ctx.Window, nsDatePicker, capModerate)
 					s, ok := sm.Get(cfgID)
 					if !ok {
-						ctx.Bubble() // no picker state: not ours
+						// No picker state: not ours
 						return
 					}
 					s.FocusDay = dayVal
@@ -177,6 +177,10 @@ func datePickerMonth(
 					if onSelect != nil {
 						onSelect(dates, EventCtx{nil, ctx.Event, ctx.Window})
 					}
+					// Picking a day is the click. The calendar sits
+					// inside the picker and, when popped over a field,
+					// inside that field too.
+					ctx.Consume()
 				},
 			}))
 		}
@@ -247,7 +251,7 @@ func datePickerAdjacentCell(
 			sm := StateMap[string, datePickerState](ctx.Window, nsDatePicker, capModerate)
 			s, ok := sm.Get(cfgID)
 			if !ok {
-				ctx.Bubble() // no picker state: not ours
+				// No picker state: not ours
 				return
 			}
 			dates := datePickerUpdateSelections(
@@ -256,6 +260,9 @@ func datePickerAdjacentCell(
 			if onSelect != nil {
 				onSelect(dates, EventCtx{nil, ctx.Event, ctx.Window})
 			}
+			// As for an in-month day: navigating and selecting is the
+			// whole click.
+			ctx.Consume()
 		},
 	})
 }

--- a/gui/view_expand_panel.go
+++ b/gui/view_expand_panel.go
@@ -98,16 +98,17 @@ func ExpandPanel(cfg ExpandPanelCfg) View {
 				OnClick: func(ctx EventCtx) {
 					if onToggle != nil {
 						onToggle(ctx)
+						ctx.Consume()
 					}
 				},
 				OnChar: func(ctx EventCtx) {
 					// Only the spacebar activates the header; every
 					// other character has to keep travelling.
 					if ctx.Event.CharCode != CharSpace || onToggle == nil {
-						ctx.Bubble()
 						return
 					}
 					onToggle(ctx)
+					ctx.Consume()
 				},
 				OnHover: func(ctx EventCtx) {
 					ctx.Window.SetMouseCursorPointingHand()

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -393,7 +393,7 @@ func inputScrollIDFor(cfg *InputCfg) string {
 func inputOnClick(scrollID string) func(EventCtx) {
 	return func(ctx EventCtx) {
 		if len(ctx.Layout.Children) < 1 {
-			ctx.Bubble() // no inner text shape: not ours
+			// No inner text shape: not ours
 			return
 		}
 		ly := ctx.Layout.Children[0]
@@ -401,7 +401,7 @@ func inputOnClick(scrollID string) func(EventCtx) {
 			ctx.Window.SetFocus(ly.Shape.ID)
 		}
 		if ly.Shape.TC == nil {
-			ctx.Bubble() // no text config: not ours
+			// No text config: not ours
 			return
 		}
 		if ly.Shape.TC.TextIsPlaceholder {
@@ -425,7 +425,7 @@ func inputOnClick(scrollID string) func(EventCtx) {
 			text, ly.Shape, style, ctx.Window,
 		)
 		if !ok {
-			ctx.Bubble() // no glyph layout: cannot place a cursor
+			// No glyph layout: cannot place a cursor
 			return
 		}
 		relX := ctx.Event.MouseX - (ly.Shape.X - ctx.Layout.Shape.X)

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -154,7 +154,10 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 			Padding:      NoPadding,
 			SizeBorder:   NoBorder,
 			FloatOffsetY: -cfg.SizeBorder.Get(0),
+			// The popup floats over the form; a click inside it is the
+			// popup's, not that of the field it is covering.
 			OnClick: func(ctx EventCtx) {
+				ctx.Consume()
 			},
 			Content: []View{
 				DatePicker(DatePickerCfg{

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -40,7 +40,7 @@ func inputTextChange(hcfg inputHandlerCfg, layout *Layout, text, ins string, id 
 func makeInputOnChar(hcfg inputHandlerCfg) func(EventCtx) {
 	return func(ctx EventCtx) {
 		if hcfg.FocusID == "" || !ctx.Window.IsFocus(hcfg.FocusID) {
-			ctx.Bubble() // not our field: let the character travel on
+			// Not our field: let the character travel on
 			return
 		}
 		// Swallow typed and IME-composed text; the field keeps focus so

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -207,7 +207,12 @@ func toastItemView(toast *toastNotification, style ToastStyle) View {
 				ctx.Layout.Shape.Height *= frac
 			}
 		},
+		// A toast floats over the app, so it has to absorb the clicks
+		// that land on it rather than let them through to whatever it
+		// happens to be covering. The empty body did that back when
+		// dispatch marked consume-class events handled for you.
 		OnClick: func(ctx EventCtx) {
+			ctx.Consume()
 		},
 		OnHover: func(ctx EventCtx) {
 			toastSetHovered(ctx.Window, id, true)

--- a/tools/eventctx/cmd/eventctx/main.go
+++ b/tools/eventctx/cmd/eventctx/main.go
@@ -7,7 +7,7 @@
 //
 // Without -w the rewritten source is printed to stdout and nothing is
 // modified. The rule-4 report (return paths in consume-class callbacks
-// that may now need an explicit ctx.Bubble()) goes to stderr, or to the
+// that may now need an explicit ctx.Consume()) goes to stderr, or to the
 // file named by -report.
 package main
 

--- a/tools/eventctx/eventctx.go
+++ b/tools/eventctx/eventctx.go
@@ -15,10 +15,9 @@
 //     the last statement of the function or of a terminal branch. That
 //     is the safe subset.
 //  4. Everything else in a consume-class callback is reported, not
-//     guessed at. A consume-class callback that returns early without
-//     setting handled was relying on bubble-by-default and may now need
-//     an explicit ctx.Bubble(); the old encoding cannot distinguish
-//     "not mine, pass it on" from "done, nothing to do".
+//     guessed at: the old encoding cannot distinguish "not mine, pass
+//     it on" from "done, nothing to do", and since v0.55.0 the two
+//     spellings differ — the second needs a ctx.Consume().
 //
 // The rewrite is textual: edits are computed from AST positions and
 // spliced into the original source, so everything the rewrite does not
@@ -81,8 +80,8 @@ func (o *Options) owns(name string) bool {
 
 // Finding is one entry in the rule-4 report: a return path in a
 // consume-class callback that is not dominated by a handled assignment,
-// and so is a human decision between ctx.Bubble() and accepting the new
-// consume-by-default.
+// and so is a human decision between adding ctx.Consume() and accepting
+// that the event travels on.
 type Finding struct {
 	Pos  token.Position
 	Kind string // "early-return" or "falls-off-end"
@@ -889,7 +888,11 @@ func (r *rewriter) rewriteHandled(li *litInfo) {
 			return
 		}
 		if !val {
-			r.replace(s.Pos(), s.End(), li.cn+".Bubble()")
+			// e.IsHandled = false said "let this travel on". Since
+			// v0.55.0 that is what a callback does by saying nothing,
+			// and there is no Bubble() to translate it into, so the
+			// statement goes.
+			r.deleteStmt(list, i)
 			return
 		}
 		// Rule 3: in a consume-class callback the pre-mark already
@@ -1081,7 +1084,7 @@ func (r *rewriter) walkRename(n ast.Node, repl map[string]string) {
 
 // reportRule4 lists the return paths of a consume-class callback that
 // are not dominated by a handled assignment. Each entry is a human
-// decision: insert ctx.Bubble(), or confirm consume-by-default.
+// decision: add ctx.Consume(), or confirm passing the event on is right.
 func (r *rewriter) reportRule4(li *litInfo) {
 	ev := li.names[1]
 	sawHandled := false

--- a/tools/eventctx/eventctx_test.go
+++ b/tools/eventctx/eventctx_test.go
@@ -86,9 +86,10 @@ func f(c *Cfg) {
 	}
 }
 
-// TestBubble checks that an explicit unhandled assignment becomes
-// ctx.Bubble() regardless of class.
-func TestBubble(t *testing.T) {
+// TestUnhandledAssignDropped checks that an explicit unhandled
+// assignment is deleted: under the one-rule model of v0.55.0 letting
+// the event travel on is what a callback does by saying nothing.
+func TestUnhandledAssignDropped(t *testing.T) {
 	src := []byte(`package p
 
 var f = func(l *Layout, e *Event, w *Window) {
@@ -99,8 +100,9 @@ var f = func(l *Layout, e *Event, w *Window) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(res.Src), "ctx.Bubble()") {
-		t.Errorf("want ctx.Bubble(), got:\n%s", res.Src)
+	if strings.Contains(string(res.Src), "IsHandled") ||
+		strings.Contains(string(res.Src), "Bubble") {
+		t.Errorf("want the assignment gone, got:\n%s", res.Src)
 	}
 }
 


### PR DESCRIPTION
Closes **§4.3b** of `docs/specs/developer-ergonomics.md` — the last open item in
that spec. Third and final PR of the sequence, after #204 and #205.

## The rule

**Nothing is marked handled for you.** A callback that acts on an event calls
`ctx.Consume()`; one that does not, lets the event travel on. That is now true
of every callback.

Until now `OnClick`, `OnChar`, `OnMouseUp`, `OnGesture` and `OnFileDrop` were
"consume-class" — dispatch marked their events handled *before* the callback
ran, and the callback opted out with `ctx.Bubble()`. Everything else consumed
explicitly. **Which of the two you had written was invisible in the signature.**

## Breaking

- **`ctx.Bubble()` is deleted.** Declining is what saying nothing already means.
  Every call site is a compile error; deleting the call is the fix. 14 sites in
  `gui/`, 7 in siblings (go-edit 5, go-term 2).
- **`(*Window).TestEventCollapse` → `TestUnconsumedEvents`.** It measured the
  cost of a collapse that has since happened.

## What actually broke

Five handlers inside go-gui. The test suite caught two on the first run:

| Site | Why |
| ---- | --- |
| `view_command_palette.go` backdrop | dismissal must not reach what the palette floats over |
| `view_command_palette.go` card | **empty body** — its only job was to stop the backdrop dismissing under a click *into* the card |
| `view_toast.go` | **empty body** — a toast absorbs the clicks it covers |
| `inspector.go` | **empty body** — clicks must not reach through and mutate what is under study |
| `view_input_date.go` popup | **empty body** — a click in the popup is not the field's |

**Four of five were empty handlers.** That is the migration hazard worth
publishing: an empty consume-class callback used to be a working click-blocker,
and now blocks nothing. It is the first thing `docs/migration-eventctx.md` tells
you to search for.

The static population — 214 consume-class callbacks calling neither `Consume()`
nor `Bubble()`, 81 in `gui/` and 133 in `examples/` — was never the work. Under
the new model an app callback with nothing above it is *correct* not consuming.
**The examples needed no changes at all.**

## The check survives, inverted

`debugCollapse` measured reliance on a pre-mark that no longer exists.
`debugUnconsumed` reports a handler that acted without consuming while an
ancestor also receives the event.

It has one honest false positive: deliberate pass-through — inspect an event,
decide it is not yours, decline — is now the ordinary way to say no, and is
indistinguishable from forgetting. The doc comment says so, and says to read the
findings rather than drive them to zero.

## Verification

Sweep across **all 37 constructible examples**: **one finding**, and it is that
false positive — `inputOnClick`'s "no glyph layout, cannot place a cursor" path,
reachable only with a nil `TextMeasurer`, i.e. only in tests.

`gofmt`, `go build`, `go vet`, full `go test`, `golangci-lint` (0 issues), and
`make tidy-check vet deps-doc-check large-files generate-check` — all clean
under `GOWORK=off`.

## Docs

`CLAUDE.md` event section, `docs/migration-eventctx.md` (rewritten for the one
rule, plus a "finding the handlers you missed" section), `docs/cookbook-add-widget.md`,
`docs/architecture.md`, `CHANGELOG.md`, and the spec's new §4.3.4 and the
resolution of §7.2.

`tools/eventctx` no longer emits a call to a method that does not exist: an
`e.IsHandled = false` assignment is now deleted rather than rewritten to
`Bubble()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)