### PR TITLE
changelog: add v0.55.0 (one event rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.55.0] - 2026-08-08
 
 ### Changed
 


### PR DESCRIPTION
Release notes for v0.55.0.

The event model collapsed to one rule: a callback that acts on an event calls `ctx.Consume()`, and one that does not lets the event travel on. No event is marked handled on a callback's behalf any more. `EventCtx.Bubble()` is deleted; `(*Window).TestEventCollapse` is now `TestUnconsumedEvents`.

Shipped across #204, #205 and #206. Closes §4.3b of `docs/specs/developer-ergonomics.md` — the last open item in that spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)