### PR TITLE
fix(testing): give wrapped text a real height headlessly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`ErrTestNoScrollRoom`.** `TestScroll` on a scroll container whose content
+  already fits now says so, instead of returning the generic `ErrTestUnhandled`.
+  The two conditions call for opposite fixes — one means the fixture never had
+  anything to scroll, the other means the container is real but already pinned
+  at its limit — and the message carries the content and viewport sizes that
+  decided it.
+
+### Fixed
+
+- **Wrapped text has a plausible height in headless tests.** Text is not
+  zero-sized without a `TextMeasurer` — the width falls back to `0.6em` per rune
+  — but the post-sizing pass that turns a paragraph into N lines bailed out, so
+  wrapped text kept its one-line seed however much text it held. A scroll
+  container around a wall of text therefore never overflowed, and `TestScroll`
+  failed for a reason that had nothing to do with the widget under test. Heights
+  are now estimated from the same per-rune approximation. Still an estimate:
+  assert on structure and overflow, not on pixels.
+
+- `examples/scroll_demo` now asserts that its panel scrolls and that the
+  percentage buttons move it, the conversion §4.8 of
+  `docs/specs/developer-ergonomics.md` attempted and abandoned.
+
 ## [v0.55.0] - 2026-08-08
 
 ### Changed

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -1182,10 +1182,58 @@ test deletes by generated per-item ID), and `dialogs` (clicking
 not overflow, so there is nothing to scroll. Scroll assertions need a
 container whose overflow does not depend on measured text.
 
+**Resolved (v0.55.1, §4.8.2).** Both blockers are fixed and
+`scroll_demo` now carries the two state assertions it was meant to
+have.
+
 **Found, not fixed:** `examples/scroll_demo/main.go:111` gives all five
 percentage buttons the same ID, `"scroll_demo_pct_button"`. IDs must be
 unique per window; this is a §4.2-class defect, out of scope for a
 sizing audit, and it makes those buttons untargetable by ID from a test.
+
+#### 4.8.2 The headless-overflow gap, as closed
+
+The diagnosis in the paragraph above was right about the symptom and
+wrong about the mechanism. Text is _not_ zero-sized without a
+`TextMeasurer`: `Window.TextWidth` falls back to `0.6em` per rune and
+`view_text.go` seeds a `1.4em` height, so a single-line label has a
+plausible size headlessly. What is missing is the second pass.
+`layoutPlainText` recomputes height after sizing — that is where a
+wrapped paragraph learns it is 40 lines tall — and it returned
+immediately when `w.textMeasurer == nil`. Wrapped text therefore kept
+its **one-line seed** no matter how much text it held. Measured on a
+1000-rune paragraph in a 200×100 container: content height 22.4 against
+a 77px viewport, so no overflow, so no scroll.
+
+Two changes:
+
+**`plainTextHeightNoMeasurer` (`gui/text_layout.go`)** estimates the
+wrapped height from the same per-rune approximation the width fallback
+already uses: hard lines split on `\n`, each divided by the resolved
+width, times a shared `fallbackLineHeight`. The same paragraph now
+measures 1232px and the container overflows. It is an estimate of an
+estimate — right for "does this overflow", wrong for any pixel
+assertion, which is already `NewTestWindow`'s documented contract. It
+walks the string with `strings.IndexByte` rather than `strings.Split`,
+because this runs once per text shape inside the layout walk and a
+`Split` would heap-allocate on every one.
+
+**`ErrTestNoScrollRoom` (`gui/testing.go`)** is the diagnostic half.
+Even with the estimate, a fixture whose content genuinely fits still
+failed with a bare `ErrTestUnhandled`, which reads as "some widget
+swallowed your event". The two conditions call for opposite fixes — one
+says the fixture has nothing to scroll, the other says the container is
+real but already pinned at its limit — so they are now separate errors,
+and the message carries the content and viewport sizes that decided it.
+Room is measured exactly as `layoutAdjustScrollOffsets` clamps, so the
+error cannot disagree with the clamp that swallowed the scroll.
+
+Verified in both directions: the wrapped-text scroll test fails with
+`ErrTestUnhandled` before the estimate and passes after, and the
+existing `TestTestScrollClampsAtEnd` still gets `ErrTestUnhandled` at
+the limit rather than the new error. Full suite green, no benchmark
+movement — `plainTextNeedsGlyphLayout` gates the new path behind
+non-single-line text, which the hot-path benchmarks do not use.
 
 ### 4.9 Close the `Scrollable`/ID hole alongside focus
 
@@ -1385,6 +1433,7 @@ burying them in the same diff.
 | 4     | §4.3 callback signature conversion       | done   |
 | 4     | §4.3b event-model collapse               | done — see §4.3.4 |
 | 5     | §4.8 example audit                       | done — see §4.8.1 |
+| 5     | §4.8 headless-overflow gap               | done — see §4.8.2 |
 
 Two corrections to §4.2 arising from the implementation.
 

--- a/examples/scroll_demo/main_test.go
+++ b/examples/scroll_demo/main_test.go
@@ -6,14 +6,84 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
-func TestMainViewNoPanic(t *testing.T) {
-	t.Parallel()
+// newTestWindow builds the demo the way main() does, minus the backend.
+func newTestWindow(t *testing.T) *gui.Window {
+	t.Helper()
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
-	w := gui.NewWindow(gui.WindowCfg{
+	w := gui.NewTestWindow(gui.WindowCfg{
 		State:  &App{},
 		Width:  400,
 		Height: 600,
+		OnInit: func(w *gui.Window) {
+			w.UpdateView(mainView)
+			w.SetFocus("scroll-panel")
+		},
 	})
-	_ = mainView(w).GenerateLayout(w)
+	w.TestRender(nil)
+	return w
+}
 
+// The panel scrolls. Written as a state assertion rather than a
+// no-panic render: §4.8 of the developer-ergonomics spec tried this
+// conversion and abandoned it because headless wrapped text kept its
+// single-line height, so the panel never overflowed and TestScroll came
+// back ErrTestUnhandled. plainTextHeightNoMeasurer now estimates the
+// wrapped height, so the overflow is real in a test too.
+func TestScrollPanelScrolls(t *testing.T) {
+	w := newTestWindow(t)
+
+	_, y0, err := w.TestScrollOffset("scroll-panel")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if y0 != 0 {
+		t.Fatalf("initial offset y = %v, want 0", y0)
+	}
+	if err = w.TestScroll("scroll-panel", 0, -5); err != nil {
+		t.Fatalf("TestScroll = %v, want nil", err)
+	}
+	_, y1, err := w.TestScrollOffset("scroll-panel")
+	if err != nil {
+		t.Fatalf("TestScrollOffset after scroll = %v, want nil", err)
+	}
+	if y1 >= 0 {
+		t.Fatalf("offset y = %v after scrolling down, want < 0", y1)
+	}
+}
+
+// The percentage buttons drive the panel programmatically. This is what
+// the duplicate-ID fix bought: before it, all five shared one ID and
+// none could be targeted.
+func TestPctButtonsJumpToPosition(t *testing.T) {
+	w := newTestWindow(t)
+
+	if err := w.TestClick("scroll_demo_pct_button_100"); err != nil {
+		t.Fatalf("TestClick(100%%) = %v, want nil", err)
+	}
+	if got := gui.State[App](w).Pct; got != 1 {
+		t.Fatalf("Pct = %v after clicking 100%%, want 1", got)
+	}
+	_, bottom, err := w.TestScrollOffset("scroll-panel")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if bottom >= 0 {
+		t.Fatalf("offset y = %v at 100%%, want < 0", bottom)
+	}
+
+	// Back to the top: a distinct button, so a shared ID would show up
+	// here as the offset not moving.
+	if err = w.TestClick("scroll_demo_pct_button_0"); err != nil {
+		t.Fatalf("TestClick(0%%) = %v, want nil", err)
+	}
+	if got := gui.State[App](w).Pct; got != 0 {
+		t.Fatalf("Pct = %v after clicking 0%%, want 0", got)
+	}
+	_, top, err := w.TestScrollOffset("scroll-panel")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if top != 0 {
+		t.Fatalf("offset y = %v at 0%%, want 0", top)
+	}
 }

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -294,10 +294,21 @@ func layoutPlainText(
 	style TextStyle,
 	w *Window,
 ) {
-	if w.textMeasurer == nil || tc.TextStyle == nil {
+	if len(tc.Text) == 0 {
 		return
 	}
-	if len(tc.Text) == 0 {
+	if w.textMeasurer == nil {
+		// Headless: approximate rather than leave the single-line
+		// estimate standing. Only the height, and only when it grows —
+		// the estimate already covers the one-line case, and shrinking
+		// it here would fight sizing over a number this path cannot
+		// know accurately.
+		if h := plainTextHeightNoMeasurer(shape, tc, style, w); h > shape.Height {
+			shape.Height = h
+		}
+		return
+	}
+	if tc.TextStyle == nil {
 		return
 	}
 	l, ok := plainTextLayoutResolved(tc.Text, shape, style, w)

--- a/gui/testing.go
+++ b/gui/testing.go
@@ -59,6 +59,15 @@ var (
 	// and hittable, but something above it in z-order absorbed the
 	// event, or no handler along the way called ctx.Consume().
 	ErrTestUnhandled = errors.New("gui: event was not handled by any widget")
+
+	// ErrTestNoScrollRoom means the widget is Scrollable but its
+	// content fits inside it on the requested axis, so there is
+	// nowhere to scroll. Separated from ErrTestUnhandled because the
+	// two call for opposite fixes: this one says the fixture is wrong
+	// (give the container more content, or less height), whereas
+	// ErrTestUnhandled from a scroll says the container is real but
+	// already pinned at its limit.
+	ErrTestNoScrollRoom = errors.New("gui: scroll container has no room to scroll")
 )
 
 // TabDirection selects forward or backward traversal for TestTab.
@@ -346,10 +355,11 @@ func (w *Window) TestTab(dir TabDirection) (focusedID string, err error) {
 // behavior, faithfully reproduced; clear focus first if the test means
 // to isolate the container.
 //
-// Returns ErrTestNoHandler when the widget is neither Scrollable nor has
-// an OnMouseScroll, and ErrTestUnhandled when the event reached no one —
-// including the case where it fell through to a scrollable already
-// pinned at its limit.
+// Returns ErrTestNoHandler when the widget is neither Scrollable nor
+// has an OnMouseScroll, ErrTestNoScrollRoom when it is a scroll
+// container whose content already fits, and ErrTestUnhandled when the
+// event reached no one — including the case where it fell through to a
+// scrollable already pinned at its limit.
 func (w *Window) TestScroll(id string, dx, dy float32) error {
 	ly, err := w.testTarget(id)
 	if err != nil {
@@ -372,9 +382,45 @@ func (w *Window) TestScroll(id string, dx, dy float32) error {
 	w.EventFn(&e)
 	w.settle()
 	if !e.IsHandled {
+		// Re-resolve: settle() rebuilt the tree, so the ly captured
+		// above is stale (see TestRender's doc comment).
+		if cur, rerr := w.testTarget(id); rerr == nil {
+			if err = testScrollRoomErr(cur, id, dx, dy); err != nil {
+				return err
+			}
+		}
 		return fmt.Errorf("%w: scroll on %q", ErrTestUnhandled, id)
 	}
 	return nil
+}
+
+// testScrollRoomErr reports ErrTestNoScrollRoom when ly is a scroll
+// container whose content fits on every axis the caller asked to
+// scroll. Returns nil when there is room, leaving the caller to report
+// the generic ErrTestUnhandled.
+//
+// Room is measured the same way layoutAdjustScrollOffsets clamps —
+// viewport minus content — so this cannot disagree with the clamp that
+// actually swallowed the scroll.
+func testScrollRoomErr(ly *Layout, id string, dx, dy float32) error {
+	if !ly.Shape.Scrollable {
+		return nil
+	}
+	roomX := contentWidth(ly) - (ly.Shape.Width - ly.Shape.paddingWidth())
+	roomY := contentHeight(ly) - (ly.Shape.Height - ly.Shape.paddingHeight())
+	if dx != 0 && roomX > 0 {
+		return nil
+	}
+	if dy != 0 && roomY > 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %q content is %.0fx%.0f inside a %.0fx%.0f viewport",
+		ErrTestNoScrollRoom, id,
+		contentWidth(ly), contentHeight(ly),
+		ly.Shape.Width-ly.Shape.paddingWidth(),
+		ly.Shape.Height-ly.Shape.paddingHeight(),
+	)
 }
 
 // TestScrollOffset reads a scroll container's current offset.

--- a/gui/testing_test.go
+++ b/gui/testing_test.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -425,6 +426,63 @@ func TestTestScrollClampsAtEnd(t *testing.T) {
 	if up <= end {
 		t.Fatalf("offset y = %v after scrolling up from %v, want greater",
 			up, end)
+	}
+}
+
+// A scroll container whose content fits reports that specifically,
+// rather than the generic ErrTestUnhandled a clamped-at-the-limit
+// container gets. The two mean opposite things to whoever is reading
+// the failure: this one says the fixture never had anything to scroll.
+func TestTestScrollNoRoom(t *testing.T) {
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			ID:         "roomy",
+			Scrollable: true,
+			Sizing:     FixedFixed,
+			Width:      200,
+			Height:     400,
+			Content: []View{
+				Column(ContainerCfg{Sizing: FillFixed, Height: 20}),
+			},
+		})
+	})
+	err := w.TestScroll("roomy", 0, -3)
+	if !errors.Is(err, ErrTestNoScrollRoom) {
+		t.Fatalf("TestScroll on a fitting container = %v, want ErrTestNoScrollRoom",
+			err)
+	}
+}
+
+// The gap this closes: wrapped text used to keep its single-line
+// estimate headlessly, so a scroll container around a wall of text
+// never overflowed and TestScroll failed for a reason that had nothing
+// to do with the widget. This is the shape scroll_demo has, which §4.8
+// tried and abandoned.
+func TestTestScrollOverWrappedText(t *testing.T) {
+	long := strings.Repeat("word ", 300)
+	w := NewTestWindow(WindowCfg{State: &counterState{}})
+	w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			ID:         "panel",
+			Scrollable: true,
+			Sizing:     FixedFixed,
+			Width:      200,
+			Height:     100,
+			Content: []View{
+				Text(TextCfg{Text: long, Mode: TextModeWrap}),
+			},
+		})
+	})
+	if err := w.TestScroll("panel", 0, -3); err != nil {
+		t.Fatalf("TestScroll over wrapped text = %v, want nil", err)
+	}
+	_, y, err := w.TestScrollOffset("panel")
+	if err != nil {
+		t.Fatalf("TestScrollOffset = %v, want nil", err)
+	}
+	if y >= 0 {
+		t.Fatalf("offset y = %v after scrolling down, want < 0", y)
 	}
 }
 

--- a/gui/text_layout.go
+++ b/gui/text_layout.go
@@ -1,6 +1,76 @@
 package gui
 
-import "github.com/go-gui-org/go-glyph"
+import (
+	"strings"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+// fallbackLineHeight is the height of one line of text when no
+// TextMeasurer is injected — the same 1.4em approximation the initial
+// estimate in view_text.go uses. Shared so the estimate and the
+// post-sizing fallback below cannot drift apart.
+func fallbackLineHeight(style TextStyle) float32 {
+	return style.Size * 1.4
+}
+
+// plainTextHeightNoMeasurer approximates the height of a text shape
+// when w.textMeasurer is nil, i.e. in headless tests.
+//
+// Without this the shape keeps the single-line estimate assigned in
+// view_text.go no matter how much text it holds, because the real
+// wrap path (plainTextLayoutResolved) needs a measurer and bails.
+// Wrapped text then reports one line, a scroll container around it
+// never overflows, and TestScroll comes back ErrTestUnhandled for a
+// reason that has nothing to do with the widget under test.
+//
+// Line count is derived from Window.TextWidth, which has its own
+// no-measurer approximation (0.6em per rune). The result is an
+// estimate of an estimate — right for "does this overflow", wrong for
+// any pixel assertion, which is already the documented contract of a
+// window built by NewTestWindow.
+func plainTextHeightNoMeasurer(
+	shape *Shape,
+	tc *ShapeTextConfig,
+	style TextStyle,
+	w *Window,
+) float32 {
+	lineH := fallbackLineHeight(style)
+	if style.LineSpacing != 0 {
+		lineH += style.LineSpacing
+	}
+	wraps := tc.TextMode == TextModeWrap ||
+		tc.TextMode == TextModeWrapKeepSpaces
+	// Only wrap against a width that sizing has actually resolved; a
+	// zero or negative width would divide every line into infinity.
+	avail := shape.Width
+
+	// Walk the hard lines with Cut rather than strings.Split: this runs
+	// inside the layout walk, once per text shape, and Split would put
+	// a slice on the heap for every one of them.
+	lines := 0
+	rest := tc.Text
+	for {
+		line, tail, more := strings.Cut(rest, "\n")
+		rest = tail
+		n := 1
+		if wraps && avail > 0 {
+			ln := w.TextWidth(line, style)
+			// Ceiling division without math.Ceil: one line per full
+			// avail, plus one for any remainder.
+			n = int(ln / avail)
+			if ln > float32(n)*avail {
+				n++
+			}
+			n = max(n, 1)
+		}
+		lines += n
+		if !more {
+			break
+		}
+	}
+	return float32(lines) * lineH
+}
 
 func plainTextNeedsGlyphLayout(
 	shape *Shape,

--- a/gui/text_layout_test.go
+++ b/gui/text_layout_test.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-gui-org/go-glyph"
@@ -106,5 +107,53 @@ func TestPlainTextLayoutResolvedNilWindow(t *testing.T) {
 	_, ok := plainTextLayoutResolved("test", s, TextStyle{}, nil)
 	if ok {
 		t.Error("nil window should return false")
+	}
+}
+
+// plainTextHeightNoMeasurer is what keeps headless wrapped text from
+// reporting one line tall. Asserted as a line count rather than a pixel
+// height: the per-rune width is an approximation and may be retuned,
+// but "more text in the same width is more lines" must hold.
+func TestPlainTextHeightNoMeasurer(t *testing.T) {
+	style := TextStyle{Size: 10}
+	lineH := fallbackLineHeight(style)
+
+	measure := func(text string, mode TextMode, width float32) float32 {
+		tc := &ShapeTextConfig{Text: text, TextMode: mode}
+		s := &Shape{Width: width, TC: tc}
+		return plainTextHeightNoMeasurer(s, tc, style, nil)
+	}
+
+	// Single line, no wrapping: exactly one line however wide it is.
+	if got := measure("hello", TextModeSingleLine, 10); got != lineH {
+		t.Errorf("single line height = %v, want %v", got, lineH)
+	}
+	// Hard newlines count even without wrapping.
+	if got := measure("a\nb\nc", TextModeMultiline, 500); got != 3*lineH {
+		t.Errorf("three hard lines = %v, want %v", got, 3*lineH)
+	}
+	// Wrapping: 100 runes at ~6px each in a 60px box is ~10 lines.
+	wrapped := measure(strings.Repeat("x", 100), TextModeWrap, 60)
+	if wrapped <= lineH {
+		t.Errorf("wrapped height = %v, want more than one line (%v)",
+			wrapped, lineH)
+	}
+	// Twice the text in the same width is about twice as tall.
+	twice := measure(strings.Repeat("x", 200), TextModeWrap, 60)
+	if twice <= wrapped {
+		t.Errorf("200 runes = %v, want more than 100 runes = %v",
+			twice, wrapped)
+	}
+	// An unresolved width cannot wrap; fall back to the hard lines.
+	if got := measure(strings.Repeat("x", 100), TextModeWrap, 0); got != lineH {
+		t.Errorf("zero width = %v, want one line %v", got, lineH)
+	}
+	// LineSpacing widens every line.
+	spaced := TextStyle{Size: 10, LineSpacing: 6}
+	tc := &ShapeTextConfig{Text: "a\nb", TextMode: TextModeMultiline}
+	s := &Shape{Width: 500, TC: tc}
+	want := 2 * (fallbackLineHeight(spaced) + 6)
+	if got := plainTextHeightNoMeasurer(s, tc, spaced, nil); got != want {
+		t.Errorf("line spacing height = %v, want %v", got, want)
 	}
 }

--- a/gui/view_text.go
+++ b/gui/view_text.go
@@ -97,7 +97,7 @@ func (tv *textView) GenerateLayout(w *Window) Layout {
 	if w.textMeasurer != nil {
 		layout.Shape.Height = w.textMeasurer.FontHeight(*ts)
 	} else {
-		layout.Shape.Height = ts.Size * 1.4
+		layout.Shape.Height = fallbackLineHeight(*ts)
 	}
 	if c.Mode == TextModeSingleLine ||
 		layout.Shape.Sizing.Width == SizingFixed {


### PR DESCRIPTION
Closes the `TestScroll` gap — the last of the four loose ends from the developer-ergonomics work.

## The mechanism was not what §4.8 recorded

The spec blamed a nil `TextMeasurer` making content zero-sized. It doesn't. `Window.TextWidth` falls back to `0.6em` per rune and `view_text.go` seeds a `1.4em` height, so a single-line label has a plausible size headlessly.

What bailed out was the **second** pass. `layoutPlainText` recomputes height after sizing — that is where a wrapped paragraph learns it is 40 lines tall — and it returned immediately when `w.textMeasurer == nil`. Wrapped text kept its **one-line seed** however much text it held.

Measured on a 1000-rune paragraph in a 200×100 container:

| | content height | viewport | scrollable |
| - | - | - | - |
| before | 22.4 | 77 | no |
| after | 1232 | 77 | yes |

## Two changes

**`plainTextHeightNoMeasurer`** estimates the wrapped height from the same per-rune approximation the width fallback already uses: hard lines split on `\n`, each divided by the resolved width, times a shared `fallbackLineHeight`. An estimate of an estimate — right for "does this overflow", wrong for pixels, which is already `NewTestWindow`'s documented contract. It walks with `strings.Cut` rather than `strings.Split`, since this runs once per text shape inside the layout walk.

**`ErrTestNoScrollRoom`** is the diagnostic half. Even with the estimate, a fixture whose content genuinely fits still failed with a bare `ErrTestUnhandled`, which reads as "something above you swallowed the event". The two conditions call for opposite fixes, so they are separate errors now, and the message carries the content and viewport sizes. Room is measured exactly as `layoutAdjustScrollOffsets` clamps.

## Verification

Verified in both directions: the wrapped-text scroll test fails with `ErrTestUnhandled` before the estimate and passes after, and `TestTestScrollClampsAtEnd` still gets `ErrTestUnhandled` at the limit rather than the new error.

`examples/scroll_demo` picks up the two state assertions §4.8 attempted and abandoned — one that the panel scrolls, one that the percentage buttons move it (which the earlier duplicate-ID fix made targetable).

Full suite green. No benchmark movement: `plainTextNeedsGlyphLayout` gates the new path behind non-single-line text, which the hot-path benchmarks don't use — `GenerateViewLayout` and `ViewFrame` are alloc-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)