### PR TITLE
docs: document standalone requiredid analyzer invocation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,20 @@
 
 ```bash
 go test ./... && go vet ./... && golangci-lint run ./...
+go run ./tools/requiredid/cmd/requiredid ./...
 ```
+
+`go vet` does not run the `requiredid` analyzer — it is a standalone
+framework-owned analyzer. CI runs it on every push, and `make vet` includes it.
+Adopter projects can invoke it the same way, standalone, without the Makefile:
+
+```bash
+go run github.com/go-gui-org/go-gui/tools/requiredid/cmd/requiredid ./...
+```
+
+It flags focusable/scrollable widgets created without an `ID` (a silent no-op
+that never joins the tab order). Escalate with a `//requiredid:ignore` comment
+on the offending line if an ID is genuinely not needed.
 
 Tests exercise layout and widget logic without a display. On macOS, suppress
 harmless duplicate-library warnings with


### PR DESCRIPTION
Closes #211

## Summary
The `requiredid` analyzer was only reachable via `make lint`/CI; adopter projects and contributors had no documented standalone invocation.

## Changes
- CONTRIBUTING.md: added `go run ./tools/requiredid/cmd/requiredid ./...` to Build and Test, with a note that `go vet` does not run it, an adopter-style `go run github.com/go-gui-org/go-gui/tools/requiredid/cmd/requiredid ./...` example, and the `//requiredid:ignore` escape hatch.

## Acceptance criteria
- [x] CI already runs `requiredid` on `./...` (ci.yml Required-ID check step) and would fail on a new violation
- [x] CONTRIBUTING.md documents standalone invocation

Not done: `.golangci.yml` custom-linter wiring — golangci-lint v2 custom linters require a prebuilt `-buildmode=plugin` .so, unsupported on Windows, so the CI-direct invocation is the right call.