### PR TITLE
docs: surface GOGUI_DEBUG in README (#212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ https://go-gui.com
 Guides: [Debugging](docs/debugging.md) · [Styling](docs/styling.md) ·
 [Testing](docs/testing.md)
 
+> **Debugging?** Set `GOGUI_DEBUG=1` (or `gui.Debug(true)`) to audit every
+> frame for duplicate widget IDs and focusable widgets without IDs. See
+> [docs/debugging.md](docs/debugging.md).
+>
 > **Upgrading?** Event callbacks now take a single `gui.EventCtx`, and nothing
 > is marked handled for you. A callback that acts on an event calls
 > `ctx.Consume()`. A callback that does not lets the event travel on. See

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,7 +1,6 @@
 # Debugging
 
-A few widget mistakes are silent by construction, because they produce no error
-and no visual difference:
+A few widget mistakes are silent by construction because they produce no error.
 
 - Two widgets sharing an `ID`. `ID` is the identity key for focus, scroll
   offsets, and per-widget state, so the two collapse onto one identity.


### PR DESCRIPTION
Closes #212.

- README now mentions `GOGUI_DEBUG=1` / `gui.Debug(true)` with a link to docs/debugging.md (discoverable without reading gui/debug.go)
- Drop redundant phrase in docs/debugging.md intro