### PR TITLE
fix(id): stop composite widgets duplicating their own ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,5 @@ deep-dive/
 
 
 .direnv/
-docs/specs/
 .tokensave/
 .codegraph/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ### Added
 
+- **`(*Window).TestDuplicateIDs`.** The assertable form of what `GOGUI_DEBUG=1`
+  prints: renders the window and returns every identity defect in the frame —
+  duplicate IDs, and ID-less shapes whose focus, scroll, or `OnMouseLeave`
+  silently does nothing. Unlike `TestUnconsumedEvents` it dispatches nothing and
+  fires no callbacks, so it is safe on a window an assertion still depends on.
+  It sees the window as rendered, so drive the app into each state and check
+  again.
+
 - **`ErrTestNoScrollRoom`.** `TestScroll` on a scroll container whose content
   already fits now says so, instead of returning the generic `ErrTestUnhandled`.
   The two conditions call for opposite fixes — one means the fixture never had
@@ -18,6 +26,25 @@ and this project adheres to
   decided it.
 
 ### Fixed
+
+- **Composite widgets no longer duplicate their own ID.** `Input` put `cfg.ID`
+  on both its outer container and its inner text shape, and every `Markdown`
+  paragraph claimed the markdown widget's ID — so a `GOGUI_DEBUG=1` run of a
+  normal application drowned in duplicate-ID reports it could do nothing about,
+  and the check could not be trusted to mean anything. An inner shape that needs
+  the owning widget's focus and spell-check state now references it instead of
+  claiming its identity, and a markdown document's container owns the ID while
+  its blocks are tied to it through the existing markdown selection key.
+  `FindByID` on a markdown ID now resolves to the container rather than to the
+  first paragraph. `ID` is once again an identity that is unique per window.
+  Rationale and the remaining ergonomics question:
+  `docs/specs/widget-id-scoping.md`.
+
+- **`Markdown` document selection works.** Giving the markdown container the
+  widget's ID also fixed a latent defect: the container carried no ID at all,
+  and both its selection hook and its key handler bail out on an empty one — so
+  drag-selection across blocks, `Ctrl+A` and `Ctrl+C` were dead on every
+  `Focusable` markdown document.
 
 - **Wrapped text has a plausible height in headless tests.** Text is not
   zero-sized without a `TextMeasurer` — the width falls back to `0.6em` per rune

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,13 @@ The `requiredid` analyzer flags this. IDs must be unique per window: menu items
 are keyed by raw command ID, so `CommandButton` namespaces its auto-filled ID
 with `cmdbtn:`.
 
+Uniqueness is strict, including within one widget: a composite widget's inner
+shape that needs the owning widget's focus or spell-check state sets
+`Shape.focusOwner` (a reference) instead of repeating its `ID` (an identity) —
+see `Input`'s text shape and `Shape.focusKey()`. `(*Window).TestDuplicateIDs`
+asserts a rendered window is clean; `docs/specs/widget-id-scoping.md` covers the
+open scoping question.
+
 #### `Opt[T]` vs plain fields
 
 **Rule: `Opt[T]` when the zero value is a legitimate user choice that must be

--- a/docs/specs/cgo-free-backend-feasibility.md
+++ b/docs/specs/cgo-free-backend-feasibility.md
@@ -1,0 +1,207 @@
+# CGo-free desktop backend — feasibility assessment
+
+Assessment of [issue #137](https://github.com/go-gui-org/go-gui/issues/137).
+Date: 2026-07-31. Status: **Phase 1 implemented**; Phase 2 (macOS) not started.
+
+## Phase 1 outcome (2026-07-31)
+
+`github.com/go-gl/gl` is gone. It was replaced by
+`gui/backend/internal/glbind`, a purego binding for the 55 GL entry points and
+45 constants the backend uses, resolved through the proc-address functions that
+already existed (`eglProc` on Linux; a new `glProc` on Windows reproducing
+go-gl's wglGetProcAddress-then-opengl32 fallback). Call sites changed by import
+swap only.
+
+Measured result:
+
+| Target | `CGO_ENABLED=0 go build` |
+|---|---|
+| windows/amd64, windows/arm64 | `./...` — **entire module** |
+| linux/amd64, linux/arm64, linux/386 | `./gui/backend/...` |
+
+Two corrections to the assessment below:
+
+- The constant count is **45**, not 47. The original `grep` used
+  `\b(gogl|gl)\.` where `go?gl` was intended, so bare `gl.`-qualified
+  references in `backend.go` were miscounted.
+- **`github.com/go-gl/gl` was not the only CGo dependency on Linux.**
+  `gui/audio` pulls in `github.com/ebitengine/oto/v3`, whose Linux driver is
+  cgo (`#cgo pkg-config: alsa` in `driver_unix.go`). The original verification
+  missed it because `go build` stopped at the go-gl load error. Windows is
+  unaffected — oto's Windows driver is pure syscall. Full `CGO_ENABLED=0
+  GOOS=linux go build ./...` therefore still fails, on `gui/audio` alone.
+  That is a separate dependency needing its own decision (gate `gui/audio`
+  behind a build tag, or replace oto on Linux) and was left out of Phase 1.
+
+32-bit was **not** dropped: purego supports 386/arm via `syscall_32bit.go`,
+and `linux/386` builds.
+
+## Summary
+
+Issue #137 proposes a CGo-free desktop backend built on goffi + wgpu-native +
+GLFW, scoped as "roughly a full backend rewrite — 4–8k lines Go + ~12 WGSL
+shaders."
+
+Both of the issue's premises verify. Its scoping does not.
+
+Linux and Windows are already CGo-free apart from **one** dependency
+(`github.com/go-gl/gl`), whose surface area in this repo is 55 functions and 47
+constants — and whose proc-address loader is already written in pure Go. The
+wgpu path is a superset of that work, does not address macOS (the only real CGo
+backend), and trades a build-time C toolchain for a runtime shared-library
+distribution burden.
+
+**Recommendation: close the wgpu/goffi path. Do the 55-function swap instead.**
+
+## 1. The stated blockers are genuinely resolved
+
+The issue is correct on both counts.
+
+**Pure-Go text.** The go-glyph root package has zero `import "C"`.
+`bitmap_puregoft.go`, `context_puregoft.go`, `layout_ft.go`, and
+`grapheme_ft.go` all build under `//go:build linux || darwin || windows` with no
+cgo tag gate — the pure-Go path is the *default*, not an opt-in.
+`go-glyph/go.mod` requires only go-text/typesetting, x/image, uniseg, and x/text.
+CGo in go-glyph is confined to `backend/gpu/`, `backend/android/`,
+`backend/ios/`, and examples.
+
+**Zero-CGo FFI.** goffi is real: 8 desktop targets, crosscall2 C-thread
+callbacks, full struct ABI, 88–114 ns/call.
+
+## 2. Linux and Windows are already almost CGo-free
+
+`gui/backend/gl/` contains no `import "C"` in any file. It already uses:
+
+| Concern | Mechanism | File |
+|---|---|---|
+| X11 windowing / events | `github.com/jezek/xgb` (pure Go) | `platform_x11.go` |
+| EGL context creation    | `github.com/ebitengine/purego` | `egl_linux.go:65` |
+| Win32 / WGL             | `golang.org/x/sys` syscall     | `platform_win32.go`, `wgl_windows.go` |
+| GL dispatch             | **`github.com/go-gl/gl` (cgo)** | 8 files |
+
+The last row is the only CGo dependency. Confirmed by build — both targets fail
+with exactly one error, and it is that import:
+
+```
+package .../gui/backend
+    imports .../gui/backend/gl
+    imports github.com/go-gl/gl/v3.3-core/gl: build constraints exclude all Go files
+```
+
+Surface area to port: **55 distinct GL functions, 47 constants**. Crucially, the
+proc-address plumbing needed to bind them is already written and already pure
+Go — `platform_x11.go:287` calls `gl.InitWithProcAddrFunc(eglProc)`, where
+`eglProc` comes from a purego-loaded `eglGetProcAddress`; `wgl_windows.go` has
+the Windows equivalent.
+
+Phase 1 is therefore a swap of one dispatch layer: roughly 600 lines of purego
+bindings. No shader rewrite, no wgpu, no GLFW, no windowing changes.
+
+## 3. macOS is the entire remaining problem
+
+- `gui/backend/metal/` — 7,202 lines total; 9 Go files with `import "C"`; 3,311
+  lines of `.m`/`.h`. Across the whole tree (metal, ios, android, filedialog):
+  5,924 lines of ObjC/C.
+- macOS-only CGo outside the backend: `nativemenu/menu_darwin.go`,
+  `filedialog/dialog_darwin.go`, `printdialog/print_darwin.go`,
+  `spellcheck/spellcheck_darwin.go`, `sysbeep/sysbeep_darwin.go`,
+  `gui/locale_detect_darwin.go`.
+- The Linux/Windows counterparts of those services are *already* pure Go:
+  `dialog_linux.go` (396 lines, portal/zenity), `dialog_windows.go` (369 lines,
+  syscall), `spellcheck_linux.go` (244 lines), godbus for SNI and AT-SPI.
+
+Nothing about the wgpu proposal touches any of this.
+
+## 4. Why wgpu + goffi is the wrong instrument
+
+**It does not supply native services.** `gui/native_platform.go` defines
+`NativePlatform` as 10 sub-interfaces and ~30 methods: dialogs, notifier,
+printer, bookmarks, a11y, IME, spellcheck, menubar, system tray, sound, plus
+`OpenURI`, `TitlebarDark`, `SetWindowVibrancy`. wgpu-native and GLFW supply none
+of it. The issue's claim that "existing pure-Go fallbacks (Android/iOS prove the
+pattern)" does not hold: `android/native_platform.go` no-ops only menubar, tray,
+and beep, and the android/ios backends are themselves cgo (`import "C"` in
+`backend.go`, `draw.go`, `text.go`, `textures.go`).
+
+**CGo-free is not dependency-free.** Today's Linux/Windows build bundles no
+native library — it dlopens the system's `libEGL`/`libGL`/`opengl32`. A
+wgpu-native + GLFW backend replaces a *build-time* C toolchain requirement with a
+*runtime* obligation to ship and load ~10–40 MB of platform-specific shared
+objects. That is a net regression for distribution, not an improvement.
+
+**goffi is pre-1.0.** v0.6.0 is in progress; API stability is planned for v1.0.0.
+It also has a documented duplicate-`_cgo_init` symbol conflict with purego, which
+go-gui already depends on (`go.mod`: `github.com/ebitengine/purego v0.10.1`).
+Adopting goffi would force `-tags nofakecgo` on every downstream consumer.
+
+**The cost is strictly larger.** 12 WGSL shaders, device/surface init, and
+windowing glue, on top of the same GL-dispatch problem — and macOS still
+unsolved at the end of it.
+
+## 5. Recommended path
+
+### Phase 1 — Linux + Windows CGo-free (high value, low risk)
+
+Replace `github.com/go-gl/gl/v3.3-core/gl` with an internal purego-backed GL
+binding.
+
+- New package `gui/backend/internal/glbind/`: 55 function pointers plus the 47
+  referenced constants, bound through the existing proc-address callbacks.
+- Reuse the `purego.Dlopen` / `purego.RegisterLibFunc` pattern already in
+  `gui/backend/gl/egl_linux.go`, and the existing `eglProc` / WGL proc lookups.
+  Do not introduce a second loader.
+- Touch points: the 8 files importing `go-gl/gl` (`backend.go`, `draw.go`,
+  `pipeline.go`, `buffers.go`, `textures.go`, `text.go`, `platform_x11.go`,
+  `platform_win32.go`). Import swap only — call sites keep their signatures.
+- Watch items:
+  - `gogl.Strs` returns a free func; reimplement as a null-terminated
+    byte-slice helper.
+  - `VertexAttribPointerWithOffset` — offset marshaling.
+  - `GetShaderiv` / `GetShaderInfoLog` / `GetProgramiv` / `GetProgramInfoLog`
+    out-params need explicit pointer marshaling under purego.
+- Outcome: `CGO_ENABLED=0` cross-compilation to Linux and Windows from any host.
+
+### Phase 2 — macOS: time-boxed spike, no commitment
+
+Evaluate `github.com/ebitengine/purego/objc` for hosting an `NSView` /
+`CAMetalLayer` subclass with delegate callbacks via `objc_msgSend` and runtime
+class registration. Gate the decision on two questions:
+
+1. Does purego work under `CGO_ENABLED=0` on darwin/arm64 for the
+   *class-registration* path, not just plain function calls?
+2. Can the ObjC be ported service-by-service, or does the NSApplication/NSView
+   delegate graph force an all-or-nothing rewrite?
+
+If either answer is bad, macOS stays cgo. That is an acceptable outcome: macOS is
+the one platform where a C toolchain (Xcode CLT) is universally present anyway.
+
+### Out of scope
+
+wgpu-native, GLFW/SDL2, WGSL shaders, goffi.
+
+## Verification
+
+Every number above is reproducible:
+
+```fish
+# 1. go-glyph root package has no cgo
+cd ~/Documents/github/go-glyph; grep -rl 'import "C"' --include='*.go' .
+
+# 2. gl backend has no cgo; one dependency blocks CGO_ENABLED=0
+cd ~/Documents/github/go-gui
+grep -rl 'import "C"' --include='*.go' gui/backend/gl/   # empty
+env CGO_ENABLED=0 GOOS=linux go build -tags gl ./gui/...
+env CGO_ENABLED=0 GOOS=windows go build ./gui/...
+
+# 3. GL surface area to port (55 functions, 47 constants)
+grep -rhoE '\b(gogl|gl)\.[A-Z][A-Za-z0-9_]*\(' gui/backend/gl/ --include='*.go' | sort -u | wc -l
+grep -rhoE '\b(gogl|gl)\.[A-Z][A-Z0-9_]+\b'    gui/backend/gl/ --include='*.go' | sort -u | wc -l
+
+# 4. macOS native surface
+grep -rl 'import "C"' --include='*.go' gui/backend/metal/ | wc -l   # 9
+find gui -name '*.m' -o -name '*.h' | xargs wc -l | tail -1         # 5924
+```
+
+Acceptance test if Phase 1 is approved: both `CGO_ENABLED=0` builds above
+succeed, `go test ./gui/...` passes, and `go run ./examples/get_started/` on
+Linux renders unchanged.

--- a/docs/specs/eventctx-callback-refactor.md
+++ b/docs/specs/eventctx-callback-refactor.md
@@ -1,0 +1,484 @@
+# EventCtx: reduce event-handling ceremony
+
+Status: proposed — for review. Breaking change.
+
+## Context
+
+Event handling in `go-gui` carries three kinds of friction:
+
+1. **Manual handled-marking.** Every consuming callback must write
+   `e.IsHandled = true` or the event keeps bubbling. There are 371 such
+   assignments across the repo. Forgetting one is a silent bug.
+2. **Three-argument callbacks.** ~57 callback fields declare
+   `func(*Layout, *Event, *Window)`, plus ~25 payload-carrying variants.
+   Every closure repeats the same three parameters.
+3. **State access.** `gui.State[T](w)` is verbose at the call site.
+
+Only the five sibling repos (`go-charts`, `go-edit`, `go-kite`, `go-term`,
+`go-map`) consume this library, so a large breaking change is affordable
+now and will not be later.
+
+Intended outcome: one breaking release that collapses the callback
+signature to `func(EventCtx)`, flips the handled default for consuming
+events, and leaves keyboard/hover propagation semantics intact.
+
+**Item 3 is dropped.** Go cannot give a typed `ctx.State` — methods
+cannot take type parameters, and a generic `EventCtx[T]` would force
+every `Cfg` struct and widget factory to become generic, which the
+heterogeneous `Layout` callback storage forbids. The achievable version
+saves ~10 characters. Instead, document the one-line app-side helper:
+
+```go
+func st(ctx gui.EventCtx) *AppState { return gui.State[AppState](ctx.Window) }
+```
+
+## Design
+
+### The type
+
+New file `gui/event_ctx.go`. `EventCtx` is passed **by value**. It is
+three pointers (24 bytes), so Go's register ABI passes it in registers
+with no heap allocation even through an indirect call. Value semantics
+also makes nested dispatch inherently safe — see
+[Reentrancy](#reentrancy) below. Mutation still works because `Event` is
+a pointer.
+
+```go
+// EventCtx bundles the three values every input-event callback needs.
+// Passed by value. Methods use value receivers and mutate through the
+// Event pointer, so they match the alloc story and avoid addressability
+// footguns on non-addressable EventCtx values.
+type EventCtx struct {
+	Layout *Layout
+	Event  *Event // nil for OnAmend and OnScroll (no originating event)
+	Window *Window
+}
+
+// Consume marks the event handled so ancestors do not receive it.
+// Needed only in notify-class callbacks; consume-class callbacks are
+// already marked handled before they run.
+func (c EventCtx) Consume() {
+	if c.Event != nil {
+		c.Event.IsHandled = true
+	}
+}
+
+// Bubble marks the event unhandled so ancestors receive it. This is the
+// explicit opt-out for consume-class callbacks.
+func (c EventCtx) Bubble() {
+	if c.Event != nil {
+		c.Event.IsHandled = false
+	}
+}
+
+// Handled reports whether the event has been consumed.
+func (c EventCtx) Handled() bool {
+	return c.Event != nil && c.Event.IsHandled
+}
+```
+
+All three methods are nil-`Event` safe, so they are callable from
+`OnAmend` / `OnScroll` without a guard. No `HasEvent()` helper: plain
+`ctx.Event != nil` needs no wrapper, and the nil case is documented per
+callback.
+
+`ShapeCallback` (`gui/event_traversal.go:4`) becomes
+`type ShapeCallback = func(EventCtx)`. Keeping it a type **alias** means
+untyped closure literals in `Cfg` structs continue to compile without a
+conversion.
+
+### Handled-by-default, per event class
+
+The flip happens in dispatch, not globally. Two classes:
+
+The class list below is exhaustive over the real fields in
+`eventHandlers` (`gui/shape.go:380-395`). There is **no `OnMouseDown`
+callback** — mouse-down dispatches to `OnClick` via
+`handleMouseDownEvent` (`gui/window_event.go:151`).
+
+**Consume — marked handled before the callback runs.** `OnClick`,
+`OnChar`, `OnMouseUp`, `OnGesture`, `OnFileDrop`.
+
+**Notify — unchanged; callback must consume explicitly.** `OnKeyDown`,
+`OnKeyUp`, `OnHover`, `OnMouseMove`, `OnMouseLeave`, `OnMouseScroll`,
+`OnScroll`, `AmendLayout`, `OnDraw`, `OnIMECommit`. Also
+`shapeButtonColors.OnHover` / `OnAmend` (`gui/shape.go:409-410`).
+
+Rationale for the carve-outs, since this is the one non-mechanical
+decision in the change:
+
+- `OnKeyDown` receives _every_ key. A widget handling only Enter must
+  leave Tab, Escape, and accelerators to bubble — which is why the
+  `ClickOnEnter` dispatch (`gui/event_handlers.go:93-101`) consumes only
+  on match. Auto-consuming would silently kill tab traversal in any
+  widget with a key handler.
+- Hover/move/leave are notifications, not consumption. Nested shapes
+  legitimately all want hover; auto-consuming breaks every
+  hover-highlight-on-container pattern and reintroduces the same
+  boilerplate inverted.
+- **`OnMouseScroll` is notify, not consume.**
+  `mouseScrollFallbackHandler` (`gui/event_handlers.go:329-337`) calls
+  the user handler and then falls through to the scroll container
+  _only if the handler left the event unhandled_. Cascade-on-unhandled
+  is the designed contract, asserted by
+  `TestMouseScrollUnhandledCascadesToScrollContainer`
+  (`gui/event_handlers_test.go:444`). Auto-consuming would invert it and
+  silently break nested scroll containers. Scroll chaining is to scroll
+  what bubbling is to keys — same carve-out, same reason.
+
+**`MouseLockCfg`** (`gui/window.go:282-284`) — its `MouseDown`,
+`MouseMove`, `MouseUp` convert to the new signature but get **no
+auto-consume**. Mouse lock already bypasses hit-testing and normal
+propagation, so handled-marking is moot there. Note its coordinates stay
+window-absolute, unlike the shape-relative coords everywhere else.
+
+This classification is **internal** — encoded at the dispatch sites and
+described in prose in the docs. It is not exposed or configurable.
+
+### Reentrancy
+
+Nested synchronous dispatch is routine in this codebase: an `OnClick`
+that scrolls a container reaches `fireOnScroll` → `OnScroll` while the
+click callback is still on the stack, and `AmendLayout` recurses through
+children from `gui/layout_pipeline.go:49`.
+
+A single reusable `EventCtx` owned by `*Window` would therefore be
+corrupted by any nested callback overwriting `Layout` or `Event` under
+the outer frame. Value semantics removes the failure mode: each frame
+gets its own copy, and there is no shared buffer for a user to retain
+past the callback.
+
+### Allocation
+
+`AmendLayout` (`gui/layout_pipeline.go:49`) and `fireOnScroll` (12
+internal call sites) run inside phases that are currently zero-allocation
+(`layout_pipeline_bench_test.go`, `render_layout_bench_test.go`). Passing
+`EventCtx` by value keeps them there — nothing escapes, because no
+pointer to the struct is formed. This is the reason for value semantics
+over `*EventCtx`; confirm with the alloc gates rather than assuming.
+
+### Pre-mark ordering inside `callRelative`
+
+`callRelative` (`gui/event_traversal.go:37-50`) does `saved := *e`,
+translates coordinates, calls back, then `*e = saved` and re-applies the
+post-callback handled flag. The auto-consume mark **must be set after
+`saved := *e`**, not before:
+
+```go
+saved := *e
+e.MouseX = saved.MouseX - layout.Shape.X
+e.MouseY = saved.MouseY - layout.Shape.Y
+if consume { // class parameter; see the next section
+	e.IsHandled = true // pre-mark AFTER the save
+}
+callback(EventCtx{layout, e, w})
+handled := e.IsHandled // Bubble() inside the callback shows up here
+*e = saved
+if handled {
+	e.IsHandled = true
+}
+```
+
+Marking before the save would copy `IsHandled = true` into `saved`, and
+the restore would then undo any `ctx.Bubble()` the callback performed —
+a silent, hard-to-trace failure. `EventCtx.Event` stays a pointer to the
+same `Event`, so the save/restore is otherwise unaffected.
+
+Semantics to document: **`Bubble()` opts out of *this* callback's
+auto-consume only.** It does not un-handle an event some earlier handler
+already consumed, because the restore re-applies the incoming flag.
+
+### Where the pre-mark goes — class is a parameter, not a helper
+
+**The three shared traversal helpers each serve both classes.** A blanket
+pre-mark inside them would silently destroy the carve-outs this spec
+spends its length defending:
+
+| Helper                  | Consume-class callers            | Notify-class callers                    |
+| ----------------------- | -------------------------------- | --------------------------------------- |
+| `executeFocusCallback`  | `OnChar` (`:38`)                 | `OnKeyDown` (`:89`), `OnKeyUp` (`:137`)  |
+| `executeMouseCallback`  | `OnClick` (`:219`), `OnMouseUp` (`:281`), `OnFileDrop` (`:384`) | `OnMouseMove` (`:252`) |
+| `callRelative`          | via `executeMouseCallback`       | `OnMouseScroll` (`:306`)                 |
+
+(Line numbers in `gui/event_handlers.go`.) Marking inside `callRelative`
+would make `if callRelative(...) { return }` at `:306` always true and
+kill focused-target scroll cascading; marking inside
+`executeMouseCallback` would auto-consume `OnMouseMove` and kill
+hover-on-container.
+
+**Therefore: add an explicit class argument** to
+`executeFocusCallback`, `executeMouseCallback`, and `callRelative` —
+`consume bool`, or a two-valued `evClass` type if it reads better. The
+pre-mark then happens inside `callRelative` (after `saved := *e`, per the
+ordering above) but only when the flag is set. Every call site is forced
+to state its class, and the compiler catches a new dispatch path that
+forgets to.
+
+This **replaces** any single `invokeConsuming(...)` helper: such a helper
+would have to duplicate the coordinate translation, and the classes are
+not separable by call path.
+
+**Direct call sites bypassing all three helpers** — each needs the class
+decision applied by hand:
+
+- `mouseScrollFallbackHandler` (`gui/event_handlers.go:329-337`) calls
+  `OnMouseScroll` directly. Notify: no pre-mark, and the
+  cascade-on-unhandled behaviour must be preserved verbatim.
+- `ClickOnSpace` (`:41-50`) and `ClickOnEnter` (`:93-101`) call `OnClick`
+  directly, bypassing the mouse path. Consume: both need the pre-mark.
+- `OnGesture` dispatches directly at `gui/gesture.go:520`, through none
+  of the three helpers. Consume: needs the pre-mark.
+
+### Interaction with `Window.OnEvent`
+
+`Window.OnEvent func(*Event, *Window)` (`gui/window.go:168`) is the
+app-level last-resort hook, fired at `gui/window_event.go:69` **only when
+`!e.IsHandled`**. It has no `Layout`, so it stays `func(*Event, *Window)`
+— unchanged, and outside the signature table by design.
+
+But auto-consume changes when it fires: clicks, chars, mouse-ups, file
+drops and gestures that any widget handled will no longer reach
+`OnEvent`, where previously a widget that forgot `IsHandled = true` let
+them through. That is the intended semantics, not a regression — but it
+is a visible behaviour change for apps using `OnEvent` as a global
+sniffer. Call it out in the migration guide.
+
+### Signature groups
+
+| Current                             | Count | New                          |
+| ----------------------------------- | ----: | ---------------------------- |
+| `func(*Layout, *Event, *Window)`    |    54 | `func(EventCtx)`             |
+| `func(*Layout, *Window)`            |   ≥6† | `func(EventCtx)` (nil Event) |
+| `func(*Layout, string, *Window)`    |     5 | `func(string, EventCtx)`     |
+| `func(T, *Event, *Window)`          |   ~25 | `func(T, EventCtx)`          |
+| `func(*Window)` / `func(T,*Window)` |   ~24 | **unchanged**                |
+
+† Counts are Shape/Cfg **field declarations**, not textual occurrences;
+the latter are higher because of factory helpers returning these types.
+The `func(*Layout, *Window)` set is at least: `eventHandlers.OnScroll`
+and `.AmendLayout` (`gui/shape.go:388-389`),
+`shapeButtonColors.OnAmend` (`:410`), `InputCfg.OnBlur`
+(`gui/view_input.go:34`), `ButtonCfg.AmendLayout`
+(`gui/view_button.go:23`), `ContainerCfg.OnScroll` / `.AmendLayout`
+(`gui/view_container.go:48,53`), and the tooltip callback
+(`gui/view_tooltip.go:180`). Enumerate exhaustively before writing the
+tool's match list.
+
+`OnBlur` fires from `gui/view_input.go:537` with no event in hand, so it
+converts with a nil `ctx.Event` like the other lifecycle callbacks. It is
+arguable that blur should carry the click that moved focus; that is a
+separate change and explicitly out of scope here.
+
+Payload carriers keep their payload as a leading argument rather than
+being stuffed into `EventCtx` — a `GridRow` is not context, and hiding it
+in a struct field loses type safety at the call site.
+
+Lifecycle callbacks (animation `OnDone`/`OnValue`, native dialog and
+notification `OnDone`, `NativeMenuCfg.OnAction`) are **not** converted:
+they have no `Layout` and no `Event`, so an `EventCtx` would carry two
+nil fields and dilute what the type means.
+
+`OnDraw func(*DrawContext)` is unchanged — `DrawContext` is already its
+own context type.
+
+Parameter naming convention: `ctx EventCtx`. Note the adjacency to
+`Window.Ctx() context.Context` (`gui/window.go:327`), which is untouched
+and unrelated.
+
+## Work
+
+### Phase 0 — Issues
+
+- File tracking issue for the refactor; add to org Project board
+  (`projects/1`) with Kind/Area/Status set.
+- File a **separate issue to update the GitHub wiki**
+  (`github.com/go-gui-org/go-gui/wiki`). The wiki is linked from
+  `README.md` as the primary documentation surface and is outside the
+  repo, so it cannot be updated in-tree. Blocked-by the tracking issue.
+
+### Phase 1 — Core
+
+`gui/event_ctx.go` (new), `gui/event_traversal.go`, `gui/event.go`,
+`gui/event_handlers.go`, `gui/shape.go` (callback field types in `ShapeEvents`).
+
+Thread the class argument through `executeFocusCallback`,
+`executeMouseCallback`, and `callRelative`, and apply the pre-mark at the
+direct dispatch sites — see "Where the pre-mark goes" above. The blanket
+"pre-mark inside the shared helpers" shortcut is wrong; those helpers
+serve both classes.
+
+**Keyboard-activation dispatch.** The live click-on-key semantics are the
+`eventHandlers` struct fields, not wrappers: `ClickOnSpace` fires through
+**OnChar** dispatch (`gui/event_handlers.go:41-50`), `ClickOnEnter`
+through **OnKeyDown** dispatch (`:93-101`), and `ClickButton` filters
+`OnClick` (`:214`). The two key paths fall on opposite sides of the
+consume/notify split — `OnChar` is auto-handled, `OnKeyDown` is not — so
+the Enter path must `Consume()` explicitly and the space path must not
+double-handle. Test both.
+
+**Internal handlers keep their three-arg form.** `charHandler`,
+`keydownHandler`, `keyupHandler`, `mouseDownHandler`, `mouseMoveHandler`,
+`mouseUpHandler`, `mouseScrollHandler`, `mouseScrollFallbackHandler`, and
+`fileDropHandler` (`gui/event_handlers.go`) are package-internal dispatch
+plumbing, not user-facing callbacks. Only the `ShapeCallback` boundary
+converts. Leaving them as `(layout, e, w)` keeps the diff to the public
+surface.
+
+**Delete the deprecated wrappers.** `spacebarToClick`, `enterToClick`,
+and `leftClickOnly` (the three `Deprecated:` wrappers at the end of
+`gui/event.go`) have no production call sites — only
+`gui/event_test.go:141-210` exercises them. They were superseded by the
+`eventHandlers` fields above to avoid per-frame closure allocation.
+Remove them and their tests rather than porting them; a breaking release
+is the right moment. Update
+the referring comments in `gui/view_container.go:33-43` and
+`gui/shape.go:397-399` — the latter cites
+`docs/specs/perf-optimizations.md` §6, which does not exist. Do not
+propagate that citation; drop it.
+
+### Phase 2 — Migration tool
+
+Built **before** the mechanical rewrite, since phases 3 and 5 are driven
+by it. `tools/eventctx/` (beside `tools/requiredid/`), using `go/ast` +
+`golang.org/x/tools/go/ast/astutil`, with `testdata/` golden tests
+matching the `tools/requiredid` layout. Regex is not viable — the rewrite
+restructures parameter lists and conditionally deletes statements inside
+nested closures.
+
+**Rewrite rules, in order:**
+
+1. **Signature.** `func(l *Layout, e *Event, w *Window)` →
+   `func(ctx EventCtx)`. Rewrite body references: `l`→`ctx.Layout`,
+   `e`→`ctx.Event`, `w`→`ctx.Window`, honouring the actual parameter
+   names and any `_` blanks. Payload carriers keep the leading argument.
+2. **Notify-class callbacks:** rewrite `e.IsHandled = true` →
+   `ctx.Consume()`. Never delete it.
+3. **Consume-class callbacks:** delete `e.IsHandled = true` when it is
+   the last statement of the function or of a terminal branch. This is
+   the safe subset.
+4. **Everything else in a consume-class callback: report, do not
+   rewrite.**
+
+**Rule 4 is the migration's real risk and it is not automatable.** A
+consume-class callback that today returns early *without* setting
+handled is relying on the old bubble-by-default, and after the flip it
+must call `ctx.Bubble()` on that path. The tool cannot infer whether a
+given early return meant "not mine, pass it on" or "done, nothing to
+do" — those are indistinguishable in the old encoding, because both
+wrote nothing.
+
+So the tool **emits a report** rather than guessing: for every
+consume-class callback, list each `return` (explicit or implicit
+fall-off-the-end) that is not dominated by an `IsHandled = true`
+assignment. Each entry is a human decision: insert `ctx.Bubble()` or
+confirm consume-by-default is correct. Expect this list to be short now
+that `OnMouseScroll` is notify-class — the remaining consume set is
+`OnClick`, `OnChar`, `OnMouseUp`, `OnGesture`, `OnFileDrop`, where
+conditional consumption is uncommon but real. The sharpest case is
+**`OnChar` filtering**: a focused input whose `OnChar` ignores non-text
+characters previously let them fall through to container-level ancestors,
+and now blocks them by default. Hit-test subregions and disabled-state
+guards are the other recurring shapes. Budget review time for this list;
+do not batch-approve.
+
+The report is also the tool's contract for the sibling repos, which get
+the same treatment in Phase 7 without a maintainer who knows this spec.
+
+### Phase 3 — Mechanical rewrite of `gui/`
+
+~205 callback literals plus ~371 `IsHandled = true` sites across
+`gui/view_*.go`, `gui/datagrid/`, `gui/markdown/`, driven by the Phase 2
+tool. Representative files: `gui/view_button.go`, `gui/view_input.go`,
+`gui/view_scrollbar.go`, `gui/view_tab_control.go`, `gui/view_select.go`,
+`gui/list_core.go`, `gui/datagrid/view_data_grid.go`.
+
+Work the rule-4 report to zero before moving on.
+
+### Phase 4 — Non-standard signatures
+
+`OnScroll` and `AmendLayout` (`gui/shape.go:388-389`) and
+`shapeButtonColors.OnAmend` (`:410`) take an `EventCtx` with a nil
+`Event`; update `fireOnScroll` and `gui/layout_pipeline.go:49`.
+`OnIMECommit` becomes `func(string, EventCtx)`. `MouseLockCfg`'s three
+fields (`gui/window.go:282-284`) convert with no auto-consume.
+
+### Phase 5 — Examples
+
+59 example programs, 29 of which contain `IsHandled` or three-arg
+callbacks. Same tool. `examples/showcase` is the largest consumer.
+
+### Phase 6 — Docs
+
+- `CLAUDE.md` — the "callbacks share sig `func(*Layout, *Event, *Window)`"
+  and "must set `e.IsHandled = true`" rules both become wrong.
+- `README.md`, `docs/architecture.md`, `docs/commands.md`,
+  `docs/cookbook-add-widget.md`, `CHANGELOG.md`.
+- 21 markdown files reference the old signature or `IsHandled`, incl. ~15
+  of the 71 files in `examples/showcase/docs/`.
+- 12 per-example READMEs.
+- Migration guide in `docs/` covering: the new signature, the
+  consume/notify split, `ctx.Bubble()` vs `ctx.Consume()`, the fact that
+  `Bubble()` opts out only of this callback's auto-consume, the nil
+  `ctx.Event` in `AmendLayout`/`OnScroll`, and the `st(ctx)` state helper
+  pattern.
+
+### Phase 7 — Siblings
+
+Run the tool across `go-charts`, `go-edit`, `go-kite`, `go-term`,
+`go-map` after go-gui tags. Follow the existing `sync-siblings` skill
+order. Verify each with `GOWORK=off` per the CI-drift note.
+
+## Verification
+
+1. `go build ./...` and `CGO_ENABLED=0 go build ./...` (Linux/Windows
+   parity must not regress).
+2. `golangci-lint run ./...`, `gofmt -l .`, `go vet ./...` (exercises the
+   `requiredid` analyzer — confirm it does not pattern-match callback
+   types).
+3. `go test ./...` — full suite.
+4. **Alloc gates, the real risk:**
+   `go test -run '^$' -bench . -benchmem ./gui/` focusing on
+   `layout_pipeline_bench_test.go`, `render_layout_bench_test.go`,
+   `event_bench_test.go`, `view_frame_bench_test.go`. Zero-alloc phases
+   must stay at 0 allocs. Compare against `main` with `benchstat`.
+5. New tests: consume-class callback bubbles nothing by default;
+   notify-class callback still bubbles; `ctx.Bubble()` restores
+   propagation; `ctx.Consume()` stops it from a notify-class callback;
+   `OnKeyDown` on a focused widget still lets Tab reach the traversal
+   handler; nested hover fires on both child and ancestor;
+   `ClickOnSpace` and `ClickOnEnter` both activate exactly once and both
+   consume; all three `EventCtx` methods are no-ops on a nil `Event`.
+6. Reentrancy: an `OnClick` that triggers a synchronous `OnScroll` must
+   leave the outer callback's `EventCtx` usable. `ctx.Layout` stability
+   is trivial under value semantics, so assert the stronger property —
+   after the nested dispatch returns, the outer `ctx.Event` is the same
+   pointer, its coordinates are still shape-relative to the outer
+   layout, and `ctx.Consume()` from the outer frame still takes effect.
+7. Class-parameter correctness — the shared helpers serve both classes,
+   so assert each side explicitly: `OnMouseMove` through
+   `executeMouseCallback` does **not** auto-consume (hover-on-container
+   survives); `OnMouseScroll` through `callRelative` at
+   `event_handlers.go:306` does **not** auto-consume (focused-target
+   scroll still cascades); `OnChar` through `executeFocusCallback` does,
+   while `OnKeyDown`/`OnKeyUp` through the same helper do not.
+8. `Window.OnEvent` reachability: a click consumed by a widget no longer
+   reaches `OnEvent`, and an unhandled event still does.
+9. Scroll chaining regression: `TestMouseScrollUnhandledCascadesToScroll\
+   Container` (`gui/event_handlers_test.go:444`) must pass unmodified —
+   it encodes the cascade contract that keeps `OnMouseScroll` in the
+   notify class. Treat any need to edit it as a design error, not a test
+   to update.
+10. Run `go run ./examples/showcase/` and exercise click, keyboard
+   traversal, hover, scroll chaining, and a data grid by hand — the
+   scroll-chaining and tab-traversal changes are the ones unit tests are
+   most likely to miss.
+
+## Decisions
+
+1. **Single PR.** Phases 1–6 land together. Split PRs would leave `main`
+   uncompilable between them, which is worse than one unbisectable
+   commit — and the repo has no external consumers to strand. Phase 0
+   (issues) precedes it; Phase 7 (siblings) follows the go-gui tag.
+2. **Wiki rewrite is out of scope** for this PR. Phase 0 still files the
+   issue; the rewrite happens immediately after the PR merges, against
+   the shipped API rather than a moving target.

--- a/docs/specs/focusable-default-input.md
+++ b/docs/specs/focusable-default-input.md
@@ -1,0 +1,338 @@
+# Spec: `Focusable` defaults true for input controls (`FocusDisabled` opt-out)
+
+Status: draft (pre-implementation)
+Base: `main` @ `8522098`
+Target release: go-gui `v0.36.0` (breaking)
+
+## Motivation
+
+Nearly every interactive `InputCfg` site in-repo sets `Focusable: true`;
+the exceptions are not designed non-focusable inputs but the two wrapper
+factories (which pass `cfg.Focusable` through) and a couple of tests.
+Requiring the field on every input is boilerplate that adds nothing — an
+input the user can't tab to is a bug, not a design choice. Flip the
+default: input controls are focusable unless the caller opts out with
+`FocusDisabled`.
+
+**Phase 2 is an accessibility change, not just deboilerplating.** `Select`,
+`Slider`, `Toggle`, `Switch` are mostly *not* focusable in-repo today
+(Slider: 0% set `Focusable: true`), so flipping them enrolls those controls
+in the Tab order — the intended, correct behavior (a slider should be
+keyboard-adjustable), a visible behavior change, not silent cleanup. Zero
+`Focusable: false` anywhere (repo + all five siblings) confirms nobody
+relies on the opt-out, so the flip is safe.
+
+Scope caveat: focus still requires `s.ID != ""` (`layout_query.go:94`), so
+this benefit only reaches **ID-bearing** call sites. `Slider`'s ID is
+`gui:"required"` (always present); `Select`/`Toggle`/`Switch` IDs are
+optional, so an ID-less one becomes a focusable-but-inert shape (renders,
+never a tab stop) — consistent with the whole "no ID → inert" design, not
+a regression. The a11y win lands where callers supply an ID; encourage
+that in the field docs (Phase 3), do not force it.
+
+This is **only a default flip**, not auto-generated identity. Focus still
+requires a non-empty `ID` (`isFocusedTarget`: `Focusable && ID != ""`). A
+defaulted-focusable input with no `ID` is simply **inert** — it renders,
+but holds no focus, cursor, or state. That graceful degradation is
+accepted: no ID → no state → the control doesn't respond. No ID is ever
+fabricated, so the identity==state-key invariant (see
+[idfocus-to-focusable.md](idfocus-to-focusable.md)) is untouched and no
+state can be silently corrupted.
+
+## Why `FocusDisabled bool`, not `Opt[bool]`
+
+`Focusable bool` cannot default true (zero value is false) and can't
+distinguish "unset" from "explicitly false." Inverting to `FocusDisabled
+bool` gives a zero-value default of _focusable_, a single obvious opt-out,
+and — because the `Focusable` field is removed from in-scope Cfgs — turns
+every existing `Focusable: true` on those Cfgs into a **compile error**,
+which is the migration guide. Preferred over `Opt[bool]`: no wrapper type,
+no `.Get()` at every read, loud break at the call site.
+
+## Decisions (locked)
+
+1. In-scope Cfgs drop `Focusable bool`, add `FocusDisabled bool`. Factory
+   sets `Shape.Focusable = !cfg.FocusDisabled`.
+2. `Shape.Focusable bool` (runtime field) is **unchanged**. Only the
+   Cfg-level field flips. Tab traversal, `isFocusedTarget`, and the
+   `requiredid` analyzer are all keyed on `Shape`/literals and need no
+   model change.
+3. No auto-ID. No ID → inert. ID stays **optional** where it is optional
+   today (Input) and stays **required** where `gui:"required"` already
+   demands it (Slider, Combobox, DatePicker, Listbox — unchanged).
+4. `Disabled` still excludes from tab order (`collectFocusCandidates`
+   already gates `!Disabled`); `ReadOnly` still keeps the control
+   focusable. `FocusDisabled` is orthogonal to both.
+5. Out-of-scope widgets keep `Focusable bool` opt-in (Button, Container,
+   Text, RTF, Markdown, DrawCanvas, TabControl, Splitter, Breadcrumb,
+   OverflowPanel, TermGrid, Inspector, and standalone `Radio` — the
+   `RadioButtonGroup` composite is deferred separately).
+6. Clean break — no back-compat shim. All consumers are sibling repos
+   owned by the same author (matches idfocus-to-focusable decision #5).
+7. **Phase 1 and Phase 2 ship together** as a single `v0.36.0` migration
+   (one break for consumers, not two).
+8. **Composites and Input wrappers deferred** (Combobox, DatePicker,
+   Listbox, RadioButtonGroup, **NumericInput, InputDate**) — each either
+   governs focus over internal children or has a focus-model defect the
+   flip would expose (see [Deferred — why](#deferred--why)). Revisit in a
+   follow-up.
+9. **Borderline widgets stay opt-in** (ColorPicker, ThemePicker, Tree) —
+   Tree is navigation, the pickers are composite.
+10. **Analyzer stays silent** on an in-scope input with no `ID`. Inert is
+    a valid choice; no positive lint.
+11. **In-scope invariant** — a widget qualifies for the flip only if it
+    (a) never fabricates a non-empty `ID` from an empty `cfg.ID`, and
+    (b) exposes exactly **one** focus candidate (tab stop). Both are
+    required so that "no ID → inert" holds and the flip adds no duplicate
+    tab stops. Audited per widget below.
+
+## In-scope widget set
+
+Only widgets that satisfy the Decision-11 invariant are in scope. Audit
+against the two failure modes (fabricated ID from empty `cfg.ID`; more
+than one focus candidate):
+
+| Cfg               | Focus candidates                                   | Fabricates ID? | Verdict |
+| ----------------- | -------------------------------------------------- | -------------- | ------- |
+| `InputCfg`        | 1 (outer `Column`; inner `Text` is `FocusSkip`, same `ID`) | no             | ✅ in — Phase 1 |
+| `SelectCfg`       | 1 (`cfg.ID`; dropdown never focusable)             | no¹            | ✅ in — Phase 2 |
+| `SliderCfg`       | 1 (`cfg.ID`)                                        | no             | ✅ in — Phase 2 |
+| `ToggleCfg`       | 1 (`cfg.ID`)                                        | no             | ✅ in — Phase 2 |
+| `SwitchCfg`       | 1 (`cfg.ID`)                                        | no             | ✅ in — Phase 2 |
+| `NumericInputCfg` | **2** (outer Row `cfg.ID` + inner Input `cfg.ID+"_field"`) | no (gated)     | ❌ deferred |
+| `InputDateCfg`    | 1, but inner Input `ID = cfgID+".input"` **ungated** | **yes**        | ❌ deferred |
+| `ComboboxCfg`, `DatePickerCfg`, `ListBoxCfg`, `RadioButtonGroupCfg` | focus over internal children | — | ❌ deferred (composite) |
+
+¹ `SelectCfg.ID` is optional; empty `ID` yields one *inert* focus target
+but its open-state (`nsSelect`) is keyed on `""` and thus shared across
+ID-less Selects — a pre-existing quirk, not focus corruption. Passing an
+`ID` is recommended in practice; not required for the flip.
+
+**Phase 1:** `InputCfg` (single-line + multiline; the 96% case).
+**Phase 2:** `SelectCfg`, `SliderCfg` (`gui:"required"` ID), `ToggleCfg`,
+`SwitchCfg`.
+
+### Deferred — why
+
+The two Input **wrappers** each break the Decision-11 invariant and need a
+dedicated focus-model fix before they can flip:
+
+- **`InputDate`** — `inputDateTextField` sets the inner Input's `ID` to
+  `cfgID + ".input"` unconditionally (`view_input_date.go:233`); with an
+  empty `cfg.ID` that is `".input"`, a fabricated non-empty ID. After the
+  flip the inner Input becomes a live tab stop under `".input"`, two
+  ID-less InputDates collide, and `nsInputDateText`/`nsInputDate` state
+  keyed on `""` is shared — the exact corruption the invariant forbids.
+  Same for `cfgID + ".picker"` (line 158). It also embeds the deferred
+  `DatePicker` composite. Fix later: make `InputDateCfg.ID` required
+  (it is stateful), or gate every derived ID on `cfg.ID != ""` the way
+  `NumericInput` gates `_field` (`view_input_numeric.go:156`).
+- **`NumericInput`** — with step buttons, the outer Row (`cfg.ID`,
+  focusable) and the inner Input (`cfg.ID+"_field"`, focusable) are two
+  distinct tab stops for one control. Not caused by the flip, but the flip
+  makes it the default. A correct fix is non-trivial: the Row also takes
+  clicks and calls `SetFocus(cfg.ID)`, while the editable state lives on
+  `cfg.ID+"_field"`, so "just `FocusSkip` the Row" focuses the wrong
+  shape. Rework so the inner Input is the sole tab stop and clicks focus
+  it, then re-scope.
+
+## Core changes
+
+### Per in-scope Cfg
+
+- Remove `Focusable bool`; add `FocusDisabled bool`.
+- Factory: every `Focusable: cfg.Focusable` → `!cfg.FocusDisabled`.
+  `InputCfg` sets this on both the outer `Column` (tab stop) and the inner
+  `Text` (which stays `FocusSkip` under the same `ID` → still one tab
+  stop).
+- Phase 2 controls each set it on their single focusable shape.
+
+### Call-site migration (mandatory, same commit as the field removal)
+
+Enumerate `InputCfg` construction sites with a command rather than a fixed
+count (the count drifts — do not hardcode it):
+
+```
+rg -n '\bInputCfg\{' -g '*.go'      # Go literals (compile-relevant)
+rg -n 'InputCfg\{' -g '*.md' docs README.md .claude   # docs/snippets
+```
+
+**The compiler is not a complete checklist.** Removing the field only
+breaks literals that *write* `Focusable:`; a literal that omits it compiles
+fine but silently flips to focusable-by-default — a behavior change the
+build won't flag. And Markdown snippets never compile at all. So review
+**every** `InputCfg` literal the commands list, not just the ones that
+error. Each must be rewritten in the same phase so the repo compiles and
+the gate passes:
+
+- Literal `Focusable: true` → **delete the line** (now the default; these
+  widgets keep an `ID`, so behavior is unchanged).
+- `Focusable: <expr>` → `FocusDisabled: !<expr>`.
+
+**Critically, the deferred wrappers and other internal factories that
+build an `InputCfg` must translate, not drop, their focus intent** — else
+the deferred bug (Decision 11 / [Deferred — why](#deferred--why)) ships
+early:
+
+```go
+// view_input_date.go, view_input_numeric.go — stays opt-in:
+Input(InputCfg{ ..., FocusDisabled: !cfg.Focusable })
+```
+
+Internal `gui/` factories to migrate in Phase 1 (all currently pass
+`Focusable: true` or `cfg.Focusable`): `view_input_numeric.go`,
+`view_input_date.go`, `view_color_picker.go` (×2),
+`view_command_palette.go`, `view_dialog.go`, and `datagrid/`
+(`data_source_grid.go`, `view_data_grid_edit.go`, `_events.go`,
+`_header.go`, `_pager.go`). Internal Inputs that set `Focusable: true`
+just drop the line; the two wrappers use `FocusDisabled: !cfg.Focusable`.
+
+### `view_input.go` a11y read-only clause
+
+Currently:
+
+```go
+if cfg.ReadOnly || !cfg.Focusable {
+    a11yState = AccessStateReadOnly
+}
+```
+
+Drop the second clause → `if cfg.ReadOnly`. With focusable-by-default,
+non-focusable is now an explicit `FocusDisabled` opt-out, not the
+historical proxy for read-only; a missing ID must not announce read-only
+on a field nobody marked read-only.
+
+### `requiredid` analyzer (`tools/requiredid/`)
+
+No code change expected: its "Focusable: true without ID" rule keys on the
+literal field, which no longer exists on in-scope Cfgs (writing it is a
+compile error). Verify the rule is generic (not Cfg-type-named) and that
+`gui:"required"` tags on Slider/Combobox/DatePicker/Listbox IDs are
+retained. An analyzer test can assert no diagnostic on a fake Cfg with
+neither field, but note it is low value — `tools/requiredid/testdata`
+defines its own fake widgets, so it cannot catch regressions against the
+real `gui` types.
+
+## Migration
+
+Each phase is a single compile break for the field it removes and **must
+migrate every construction site of that Cfg in the same commit** (internal
+factories, examples, and tests) so `make check && go test ./...` stays
+green. A phase is not "widget + its own tests" — it is the widget plus its
+whole in-repo call graph.
+
+- `Focusable: true` on an in-scope Cfg → delete the line (now default).
+- `Focusable: <expr>` (wrappers/internal factories) → `FocusDisabled:
+  !<expr>`.
+- `Focusable: false` on an in-scope Cfg → `FocusDisabled: true`
+  (**zero** occurrences in-repo and across all five consumers).
+- Out-of-scope widgets: untouched.
+
+### Consumers (breaking; dependency order)
+
+Re-verify per repo before shipping (grep `Focusable: true` on in-scope
+Cfg literals):
+
+1. **go-charts** — 1 `InputCfg` site.
+2. **go-kite** — `Input` literals.
+3. **go-map** — verify no in-scope literals.
+4. **go-edit** — builds `EditorCfg`, not `Input`; expected clean.
+5. **go-term** — no `gui.Input(` usage; expected clean.
+
+## Tests / examples / docs
+
+- Update in-scope example literals: drop `Focusable: true`.
+- Unit assertions, split by ID-requiredness (an ID-less required-ID widget
+  cannot be constructed — `Slider` calls `RequireID`/panics at
+  `view_slider.go:45`):
+  - **All in-scope widgets** (with an `ID`, no `FocusDisabled`): **exactly
+    one** focus candidate (assert the count via
+    `collectFocusCandidates`/`NextFocusable`, to pin against duplicate tab
+    stops). With `FocusDisabled: true`: zero.
+  - **Optional-ID widgets only** (`Input`, `Select`, `Toggle`, `Switch`):
+    with no `ID`, zero candidates (inert, still renders). Not applicable to
+    `Slider` (would panic).
+- `view_input_test.go`: existing `Focusable: true` literals → remove.
+- **Rewrite `TestInputReadOnlyWithoutFocus`** — it currently asserts
+  non-focusable ⇒ `AccessStateReadOnly`, which relied on the dropped
+  `!cfg.Focusable` clause. New assertions: `ReadOnly` announces
+  `AccessStateReadOnly`; `FocusDisabled` alone does **not**.
+- Docs: `shape.go` doc comment already documents `Shape.Focusable`
+  (unchanged). Update per-Cfg field docs, the widget skill scaffold,
+  README/CHANGELOG, and the per-example READMEs of any example app whose
+  literals changed in Phases 1–2. Add a note that input controls are
+  focusable by default and inert without an `ID`. Include a
+  **disambiguation table** for the four now-coexisting flags:
+
+  | Flag | Meaning |
+  |------|---------|
+  | `Shape.Focusable` | widget participates in the focus system |
+  | `FocusSkip` | focusable + click/selection, but excluded from Tab order |
+  | `FocusDisabled` (Cfg) | opt out of the default-on focus (in-scope Cfgs) |
+  | `Disabled` | non-interactive; also excluded from Tab order |
+
+## Release
+
+Breaking (field removed) → minor bump `v0.36.0`, CHANGELOG entry. Merge to
+`main`, tag, then bump siblings per dependency order.
+
+## Execution protocol
+
+Branch `feat/focusable-default-input` off `main`. One commit per phase,
+**pause for review after each**. Verification gate before every commit:
+
+```
+make check && go test ./... && golangci-lint run ./...
+```
+
+Each code phase migrates the **whole in-repo call graph** of the Cfg it
+changes (internal factories, examples, tests), or the gate fails to
+compile — see [Call-site migration](#call-site-migration-mandatory-same-commit-as-the-field-removal).
+
+- **Phase 0** — create the branch, commit this spec, pause.
+- **Phase 1** — `InputCfg` (single-line + multiline): drop `Focusable`,
+  add `FocusDisabled`, drop the `!cfg.Focusable` a11y clause. Migrate
+  **all `InputCfg` sites** (enumerate via the commands in [Call-site
+  migration](#call-site-migration-mandatory-same-commit-as-the-field-removal)):
+  internal factories (wrappers via
+  `FocusDisabled: !cfg.Focusable`; color-picker / command-palette / dialog
+  / datagrid drop `Focusable: true`), the 8 example files, and tests
+  (incl. the one-candidate assertion and the `TestInputReadOnlyWithoutFocus`
+  rewrite). Gate, commit, pause.
+- **Phase 2** — `Select`, `Slider`, `Toggle`, `Switch`: same swap, each
+  with its full call graph (factories, examples, tests). Gate, commit,
+  pause.
+- **Phase 3** — docs only (per-Cfg field docs, disambiguation table,
+  widget skill scaffold, README, per-example READMEs for the example apps
+  touched in Phases 1–2), `requiredid` analyzer test, CHANGELOG. Gate,
+  commit, pause.
+- **Release** — merge to `main`, tag `v0.36.0`. Then siblings in
+  dependency order (go-charts → go-kite → go-map → go-edit → go-term):
+  one commit per repo, gated and shipped, pause after each.
+
+No commits without explicit permission at each pause.
+
+## Resolved
+
+- Phase 1 reduced to `Input`; the two Input wrappers (`NumericInput`,
+  `InputDate`) join the deferred bucket per the Decision-11 invariant and
+  the audit (Findings 1–2 from review).
+- Composites deferred; borderline widgets stay opt-in; Phase 1+2 ship
+  together as `v0.36.0`; analyzer stays silent (Decisions 7–11).
+- Review round 3 folded in: wrappers/internal factories map to
+  `FocusDisabled: !cfg.Focusable` (keeps deferred bug out); each phase
+  migrates its full call graph (not "widget + own tests"); Motivation
+  stats corrected and Phase 2 reframed as an a11y change;
+  `TestInputReadOnlyWithoutFocus` rewrite named; standalone `Radio`
+  explicitly opt-in.
+- Review round 4 folded in: Phase 2 a11y win scoped to ID-bearing sites
+  (focus still needs `ID != ""`); the "no ID → zero candidates" test split
+  by ID-requiredness (`Slider` panics without an ID, so it's excluded);
+  hardcoded `InputCfg` counts replaced with `rg` commands, with the caveat
+  that the compiler catches only `Focusable`-bearing literals (docs and
+  omitted-field sites need manual review).
+
+## Open questions
+
+None blocking. Confirm the exact consumer call-sites at ship time by
+grepping `Focusable: true` on in-scope Cfg literals in each repo.

--- a/docs/specs/font-viewer.md
+++ b/docs/specs/font-viewer.md
@@ -1,0 +1,742 @@
+# Font Viewer
+
+Browsable system-font catalog. Type sample text; every installed font family
+renders it in a scrollable card grid. Filter by name, adjust preview size,
+click to copy the family name.
+
+**What it stresses (be precise):** because the grid is virtualized (P0), it
+does **not** shape all N families at once — it exercises per-family
+*resolution*, wrapping, and glyph-atlas growth *as you scroll* (the windowing +
+cache-warming path), not simultaneous N-family layout. An optional
+`--shape-all` debug mode (P2) drops virtualization to shape **all N families in
+one frame** (still main-thread — "concurrent" would be wrong; go-glyph shaping
+is single-threaded). The default path deliberately never does. (shirei's
+reference prewarms off-thread; this port cannot — main-thread only — so
+scroll-windowing is the substitute, not a background prewarm.)
+
+Reference: `go-shirei/examples/fontviewer` — same feature set, ported to
+go-gui's widget model (immediate-mode `Layout` tree, not shirei's
+closure-based DSL).
+
+## Feature Summary
+
+| #   | Feature                                                            | Priority |
+| --- | ------------------------------------------------------------------ | -------- |
+| 1   | Enumerate installed fonts (same catalog go-glyph resolves), sorted | P0       |
+| 2   | Filterable card grid — type to narrow by family name               | P0       |
+| 3   | Editable sample text — type or shuffle                             | P0       |
+| 4   | Adjustable preview size (12–72 px slider)                          | P0       |
+| 5   | Click card to copy family name to clipboard                        | P0       |
+| 6   | Grid virtualization — window fixed-size cards to the visible range  | P0       |
+| 7   | Visible-range / spacer-math test (grid correctness, not optional)  | P0       |
+| 8   | "Copied" transient confirmation on the clicked card                | P1       |
+| 9   | State tests (empty, filtered, copied, sizing)                      | P1       |
+| 10  | `--shape-all` debug mode — drop virtualization, shape all N (stress) | P2       |
+| 11  | Skeleton on cold scroll-in (optional cosmetic)                     | P2       |
+| 12  | Headless PNG export (`--png out.png`) — speculative                | P2       |
+
+**Phasing note (why #6 is P0):** go-gui's layout shapes text for _every_ card
+in the tree, with no scroll-visibility gate (`layoutWrapTextWalk`,
+`layout_pipeline.go`); scroll offset is applied later, in the positioning
+phase (`layout_position.go`). Emitting all 500–800 cards would cold-shape
+every family on the first frame — a hard stall. Virtualization emits only the
+visible window, so per-frame cost is **O(visible), not O(N)**, and it reuses
+go-gui's tested `listCoreVisibleRange` primitive (the same one behind
+`ListBox`, `Tree`, and `Table`). Fixed card size is the precondition it needs.
+
+## Non-goals (v1)
+
+Explicit so the feature table is not read as a finished font browser:
+
+- **Desktop only.** `ListSystemFonts` returns nil where no `FontLister` backend
+  exists (WASM stub), so the web build shows the empty state permanently.
+  Browser enumeration (`FontFace` / `queryLocalFonts`) is a separate future
+  phase, not a v1 gap to paper over.
+- **Regular weight only.** Previews resolve the bare family key, i.e. the
+  Regular face; per-weight/italic preview is out of scope.
+- **Mouse-first.** Cards are click-to-copy; no roving tab-stop across the grid
+  and a11y is whatever the containers default to (family names are not exposed
+  to assistive tech). **v1 is intentionally inaccessible**; a keyboard-navigable
+  catalog with proper `AccessRole`s is a later increment.
+- **"No fonts" copy is coarse.** A nil `FontLister` (WASM / not-yet-ready
+  backend) and a genuinely empty catalog both show "no system fonts"; the view
+  does not distinguish "not ready yet" from "backend has no lister." Acceptable
+  given desktop-only scope — revisit if the web build ships.
+
+| Topic                    | Decision                                                                                                                                                                                                                                                                               |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Enumeration source       | go-glyph's discovered font catalog (system discovery + app-registered fonts), surfaced through a **clean family set captured at registration time** — **not** a parallel CTFontManager / fontconfig / DirectWrite / AWT list, and **not** a reverse-parse of the resolution map's keys |
+| App fonts                | Families from `RegisterAppFont` / `AddFontFile` flow through the same `registerFontPath` and land in the same set. **P0 contract:** fonts registered *before the window runs* (the normal demo flow) are listed. Fonts registered *after* the first successful enumeration are invisible until a refresh (`s.Loaded = false`) — that refresh is P3, and this limit must be stated, not left implied |
+| Hidden / generic keys    | Excluded **at the source**: leading-`"."` families and generic aliases (`sans-serif`, `serif`, `monospace`, …) never enter the family set                                                                                                                                              |
+| Style variants           | A face's `-Regular/-Bold/-Italic/-BoldItalic` resolution keys are **not** families; the set stores only the clean display name, so `Arial` appears once, not four times                                                                                                                |
+| go-gui ↔ go-glyph seam   | Optional `FontLister` capability interface + type assertion — **not** a widened mandatory `TextMeasurer` interface                                                                                                                                                                     |
+| `LayoutText` concurrency | **Not safe.** go-glyph `doc.go` documents `Context` / `Renderer` / `TextSystem` / `GlyphAtlas` as _"Not safe for concurrent use. Call all glyph methods from the main/render thread."_ All shaping stays on the main thread                                                            |
+| Scaling strategy         | **Grid virtualization.** Read the previous frame's scroll offset (`w.ScrollY().Get(id)`), compute the visible row range, emit only those rows padded by top/bottom spacer rects. O(visible) per frame. Same pattern as `ListBox` / `Tree` / `Table`                                     |
+| Visible-range primitive  | **Export `func ListVisibleRange(itemCount int, rowHeight, listHeight, scrollY float32, overscan int) (first, last int)`** from `gui`. Wraps the tested core but takes the overscan **as an argument** (the internal `listCoreVirtualBufferRows` is not stacked on top), so the caller sets one buffer number, not 2+4. The example is `package main` and cannot call the unexported original; exporting beats duplicating the arithmetic. Scope is **only** the arithmetic helper — the grid's column/spacer math stays in the example; do not let Phase 1 grow a general virtualized-grid widget |
+| **Grid drives BOTH its dimensions** | The grid `Column` is **`Sizing: FixedFixed`** with explicit `Width: outerW` and `Height: listH` — the *same* numbers feed the `cols`/`ListVisibleRange` math **and** the arranged box, so neither axis can disagree with layout. Height alone was not enough: width computed from `WindowSize` but arranged by `Fill` is the identical X-axis footgun (wrong `cols` → overflow / dead space). No `FindByID` width-readback API exists, so making width explicit is the fix. `listH` is clamped `>= rowH` (`listCoreVisibleRange` yields no rows at `<= 0`) |
+| Row geometry             | The two axes carry gap **differently**: the grid `Column` sets `Spacing: SomeF(0)` (vertical spacing must be 0 or it corrupts the spacer arithmetic — `rowH` alone accounts for the vertical `gap`); each `Row` sets `Spacing: SomeF(gap)` to draw the **horizontal** gutter between cards (this is where the `(cols-1)*gap` that `cardW` subtracts actually goes — zero it and cards abut with dead space on the right). Each `Row` is **exactly `rowH` tall** (`cardH` + vertical `gap` folded in) so `top + rows + bottom == totalRows*rowH`; trailing `gap` on the last row is an intentional bottom margin |
+| Container chrome         | Root and grid `Column`s set `Padding: NoPadding`, `Spacing: SomeF(0)`, **and `SizeBorder: Some(0)`** — `DefaultContainerStyle` is `PaddingMedium` + `SpacingMedium` + `SizeBorderDef` (1.5), and `paddingHeight()` counts `2·SizeBorder`, so an un-zeroed box eats `2·pad + spacing + 2·border` (~6 px of border alone across root+grid) and `listH`/`outerW` go optimistic → over-height root / wrong `cols`. `sidePad` is the grid's **real** horizontal `Padding` (right side widened to clear the overlay scrollbar), folded into `contentW` |
+| Hover under virtualization | **Sticky-`Copy` footgun.** `layoutMouseLeave` walks only the *current* tree and needs a non-empty `shape.ID`; a hovered card scrolled out of the window is never visited, so its `OnMouseLeave` never fires. Rule: (a) every card gets a **stable ID** `"card:"+family` (also required for click/leave identity), and (b) the retained `hoveredFam` is cleared each frame if it is **not in the emitted `[first,last]` window**. Without (b) the "Copy" affordance reappears when the family scrolls back |
+| Card grid layout         | **Manual column math over fixed-size cards.** `gui.Wrap` lays out _all_ children and can't window, so it is not usable for a virtualized grid; compute `cols` from viewport width each frame instead                                                                                    |
+| Family de-duplication    | Fold case when building the family set (canonical first-seen display case, keyed by `strings.ToLower`) so two faces reporting `Arial` / `arial` list once — matches shirei                                                                                                             |
+
+## Architecture
+
+### State
+
+```go
+type FontViewerState struct {
+    Sample   string   // current sample text (init: a random pangram)
+    Filter   string   // case-insensitive family-name substring
+    FontSize float32  // preview size in px (12–72; init: 28)
+    Families []string // all discovered family names, sorted (from ListSystemFonts); may be nil
+    Loaded   bool     // families have been enumerated (backend was ready)
+
+    CopiedFam   string  // family whose "Copied" badge is showing ("" = none)
+    CopyOpacity float32 // 1→0, written by the fade tween's OnValue, read by the card view
+    HoveredFam  string  // family under the pointer ("" = none); cleared on eviction
+}
+```
+
+Initialize `FontSize: 28` and `Sample:` a random pangram (matching shirei) in
+the `WindowCfg{State: ...}` seed. `CopiedAt` is intentionally **absent** — the
+tween owns the fade's timing and `OnDone` clears `CopiedFam`, so no timestamp
+is read anywhere.
+
+Virtualization needs no per-family state: the scroll offset lives in go-gui's
+scroll store (keyed by the grid's `ID`), and the visible range is derived from
+it each frame. There is no `Ready` map and no batch-reveal pass — windowing
+bounds measurement structurally, so nothing has to be staged in.
+
+`CopyOpacity` is the **state channel** the badge fade needs: an animation's
+`OnValue` runs outside the view, so the animated value must land in a field the
+view reads (the pattern `view_toast.go` uses with `animFrac`).
+
+Per-window via `gui.State[FontViewerState](w)`. No package-level globals.
+Any deferred work uses `w.QueueCommand` to mutate state and `w.Ctx()` for
+cancellation on window close. No background goroutine ever touches the text
+system.
+
+### FontFamily
+
+Family names are just `string`s returned by `ListSystemFonts(w)`. No struct
+needed — the viewer only needs the name to pass to `TextStyle.Family`.
+`ListSystemFonts` returns **nil** before backend init (and on WASM stubs), so
+`state.Families` may be nil; `filterFontFamilies` and every `range` over it must
+be nil-safe (ranging nil is fine; the filter returns nil for a nil input).
+
+### View function skeleton
+
+Ties enumeration timing, the filter, and the virtualized grid together. The
+view runs under `w.mu`, so it only calls lock-free reads (`ListSystemFonts`,
+`w.ScrollY().Get`, `w.WindowSize`).
+
+```go
+const (
+    gridID       = "font-grid"
+    cardMaxW     = 380 // fixed nominal card width (px, layout units)
+    gap          = 16  // gutter between cards; also folded into rowH
+    sidePad      = 24  // grid horizontal padding
+    scrollbarW   = 14  // deliberate slack to clear the overlay thumb, not an
+                       // engine constant: DefaultScrollbarStyle Size(7)+GapEdge(3)
+                       // ≈10px footprint, rounded up. Derive from the style if it changes
+    nameRowH     = 28  // name row + its padding (the fixed part of cardH)
+    previewPad   = 24  // preview box vertical padding (top+bottom)
+    previewLines = 3   // preview clamps to this many lines
+    lineFactor   = 1.4 // engine line-height factor (matches listCoreRowHeightEstimate)
+    headerH      = 72  // fixed header bar height — must equal header()'s
+    toolbarH     = 104 // fixed two-row toolbar height — must equal toolbar()'s
+    overscanRows = 4   // grid's own overscan (shared const is only 2 — see Rendering)
+    minSample    = 12
+    maxSample    = 72
+)
+
+// cardHeight is uniform per FontSize. Uses the engine's 1.4× line height, not
+// a flat previewLines*FontSize (which under-counts by ~40% and would clip).
+func cardHeight(fontSize float32) float32 {
+    return nameRowH + previewPad + previewLines*fontSize*lineFactor
+}
+
+func fontViewer(w *Window) View {
+    s := State[FontViewerState](w)
+
+    // Lazy one-time enumeration. ListSystemFonts reads a pre-built set
+    // (cheap, no shaping) and sorts once. nil until the backend is ready →
+    // retry next frame. Fonts registered via RegisterAppFont *after* this
+    // succeeds stay invisible until a refresh sets s.Loaded = false again
+    // (see open question on late registration).
+    if !s.Loaded {
+        s.Families = ListSystemFonts(w)
+        s.Loaded = s.Families != nil
+    }
+
+    matches := filterFontFamilies(s.Families, s.Filter) // nil-safe
+
+    // Zero ALL inherited chrome (default is PaddingMedium + SpacingMedium +
+    // SizeBorderDef 1.5) so listH = winH - headerH - toolbarH is exact — not
+    // off by 2*pad + spacing + 2*border.
+    return Column(ContainerCfg{
+        Sizing:     FillFill,
+        Padding:    NoPadding,
+        Spacing:    SomeF(0),
+        SizeBorder: Some(float32(0)),
+        Content: []View{
+            header(),
+            toolbar(w, s, len(matches)),
+            fontGrid(w, s, matches),
+        },
+    })
+}
+```
+
+### View Tree
+
+```
+RootView (FillFill column)
+├── Header (title + subtitle bar)
+├── Toolbar (sample text, shuffle, filter, size slider, match count)
+└── FontGrid (Column + Scrollable + ID)   ← virtualized
+    ├── top spacer rect        (height = firstRow * rowH)
+    ├── Row × (visible rows)                ← only [firstRow, lastRow] emitted
+    │   └── FontCard × cols (fixed W × H)
+    │       ├── Name row (UI font + copy badge)
+    │       └── Preview box (sample text in family's font)
+    └── bottom spacer rect     (height = (rows-1-lastRow) * rowH)
+```
+
+### Widget Mapping (shirei → go-gui)
+
+| shirei                               | go-gui equivalent                                                                                                          |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `Container(Attrs(...), func(){...})` | `Row`/`Column`/`Wrap(ContainerCfg{...})` (grid rows use `Row`, not `Wrap` — see FontGrid)                                  |
+| `Label(text, Fonts(name), ...)`      | `Text(TextCfg{Text: text, TextStyle: ts})` with `ts.Family = name`                                                         |
+| `TextInputExt(&var, attrs)`          | `Input(InputCfg{ID: "...", Text: state.Sample, OnTextChanged: fn})` — no `&var`                                            |
+| `Slider(&var, SliderAttrs{...})`     | `Slider(SliderCfg{ID: "...", Value: state.FontSize, Min: 12, Max: 72, Step: 1, OnChange: fn})`                             |
+| `Button(label, "tooltip")`           | `Button(ButtonCfg{ID: "...", Content: ..., OnClick: fn})`                                                                  |
+| `VirtualListView(nil, rows, ...)`    | Manual grid virtualization: `Column{Scrollable, ID}` + `listCoreVisibleRange` → emit visible rows only, padded by top/bottom spacer rects (same pattern as `ListBox` / `Table`) |
+| `RequestTextCopy(text)`              | `w.SetClipboard(text)`                                                                                                     |
+| `Icon(SymCopy, ...)`                 | Feather has no `IconCopy` — use a text "Copy"/"Copied" badge (add a glyph to `gui/fonts.go` only if a real icon is wanted) |
+| `Icon(SymShuffle, ...)`              | `Text(TextCfg{Text: gui.IconSync, TextStyle: iconStyle})`                                                                  |
+| `PressAction()`                      | `OnClick` (containers default to `ClickButton: MouseLeft`)                                                                 |
+| `IsHovered()` + `ModAttrs(...)`      | `OnHover` / leave handling on `ContainerCfg`; call `w.RequestRedraw()` if needed                                           |
+| `RequestNextFrame()`                 | `w.QueueCommand(...)` (wakes main) or `w.UpdateWindow()` / `w.RequestRedraw()`                                             |
+
+**Callback signatures diverge — do not assume the generic `func(*Layout,
+*Event, *Window)`:**
+
+- `InputCfg.OnTextChanged` is `func(*Layout, string, *Window)` — the new text
+  arrives as the second argument.
+- `SliderCfg.OnChange` is `func(float32, *Event, *Window)` — the new value is
+  the first argument.
+
+### Font Enumeration — capture a clean family set, don't reverse-parse
+
+go-gui has no public font list today. go-glyph **already** discovers system
+fonts into `Context.fontPaths` via directory walks (`discover_darwin.go`,
+`discover_linux.go`, `discover_windows.go`, `discover_android.go`) and resolves
+`TextStyle.Family` against that map. It does **not** use CTFontManager,
+fontconfig, DirectWrite, or AWT.
+
+**`fontPaths` is a resolution map, not an enumeration source.**
+`registerFontPath` inserts _multiple keys per face_: a style key
+`family + styleSuffix` (`Arial-Regular`, `Arial-Bold`, `Arial-Italic`,
+`Arial-BoldItalic`), the bare `family` key, and lowercase generic aliases.
+Iterating those keys and string-deduping yields duplicate, style-mangled
+"families" (`Arial` next to `Arial-Bold`) — a naive list is wrong by
+construction.
+
+**Correct approach — capture the clean name where it is already known.**
+`registerFontPath` receives the clean `family` _before_ the style suffix is
+appended. But it is a **free function** (`registerFontPath(fontPaths,
+keyWeights, family, aspect, path)`), not a `Context` method — so thread a
+`families` set through it and add the entry at both call sites (the
+`AddFontFile` path and `fontScan.consider`). Aliases are inserted into
+`fontPaths` **outside** `registerFontPath`, so they never reach the set — the
+exclusion is structural, not a filter.
+
+   ```go
+   // Context gains a case-folded set: lower(family) -> first-seen display case.
+   families map[string]string
+
+   // registerFontPath signature gains the set; both existing call sites pass
+   // ctx.families / s.ctx.families:
+   func registerFontPath(fontPaths map[string]string, keyWeights map[string]font.Weight,
+       families map[string]string, family string, aspect font.Aspect, path string) {
+
+       if family != "" && !strings.HasPrefix(family, ".") {
+           if lc := strings.ToLower(family); families[lc] == "" {
+               families[lc] = family // fold case → "Arial" and "arial" list once
+           }
+       }
+       // ... existing styleSuffix / considerFontKey logic unchanged ...
+   }
+
+   // ListFontFamilies returns the display-case values, sorted case-
+   // insensitively. Excludes leading-"." names and generic aliases by
+   // construction. Not safe for concurrent use — call from the main/UI thread.
+   // TextSystem embeds *Context, so this delegates to ctx.families.
+   func (ts *TextSystem) ListFontFamilies() []string
+   ```
+
+   Correct by construction: no suffix-stripping heuristics, aliases and style
+   variants never enter the set, case is folded (matching shirei), and
+   `RegisterAppFont` / `AddFontFile` families appear because they flow through
+   the same `registerFontPath`.
+
+2. **go-gui** — optional capability interface + type assertion. Do **not**
+   widen the mandatory `TextMeasurer` interface (that would force a
+   simultaneous implementation across metal/gl/web/android/ios):
+
+   ```go
+   // FontLister is an optional capability. Backends that wrap a
+   // *glyph.TextSystem opt in; others need no change.
+   type FontLister interface{ ListFontFamilies() []string }
+
+   // ListSystemFonts returns family names from the active text system's
+   // catalog, sorted case-insensitively. Returns nil before backend init,
+   // on WASM stub backends with no fonts, or on backends that do not
+   // implement FontLister. Includes RegisterAppFont families once those
+   // paths have been added to the text system.
+   func ListSystemFonts(w *Window) []string {
+       if fl, ok := w.textMeasurer.(FontLister); ok {
+           return fl.ListFontFamilies()
+       }
+       return nil
+   }
+   ```
+
+   Incremental rollout (one backend at a time), nil-safe in tests, zero
+   forced churn.
+
+3. **Filtering is a pure function** — factored out so it is testable without a
+   backend:
+
+   ```go
+   // filterFontFamilies returns the entries of all whose family name
+   // contains filter (case-insensitive), preserving all's sort order.
+   // Runs every frame, so an empty filter returns all as-is (no clone);
+   // nil-safe (nil in → nil out).
+   func filterFontFamilies(all []string, filter string) []string
+   ```
+
+**Rejected:** Android `java.awt.GraphicsEnvironment` (desktop AWT, not
+Android). go-glyph already walks `/system/fonts`, `/product/fonts`, etc.
+
+**Rejected:** Linux fontconfig in go-gui — conflicts with go-glyph's
+no-fontconfig directory walk and invites dual catalogs.
+
+**Rejected:** a parallel platform enumerator in `gui/backend/` — names from
+CTFontManager / fontconfig / DirectWrite can diverge from go-glyph's family
+strings, so cards would show fonts that silently fall back to Helvetica /
+Roboto / etc.
+
+### Rendering — virtualize the grid
+
+**The constraint:** go-gui is immediate-mode. `layoutWrapTextWalk`
+(`layout_pipeline.go`) recurses **every** child unconditionally — there is no
+scroll-visibility gate — and scroll offset is applied later, in the
+positioning phase (`layout_position.go`). So emitting all N cards shapes text
+for all N on every frame they are in the tree. Windowing removes them from the
+tree, so they are never measured until visible.
+
+**The mechanism — reuse `listCoreVisibleRange`.** go-gui already virtualizes
+`ListBox`, `Tree`, and `Table` through one pure, tested helper:
+
+```go
+// list_core.go — pure arithmetic, plus listCoreVirtualBufferRows overscan.
+func listCoreVisibleRange(itemCount int, rowHeight, listHeight, scrollY float32) (first, last int)
+```
+
+The immediate-mode trick that makes this work: the view reads the **previous
+frame's** scroll offset at generate time via `w.ScrollY().Get(id)` (exported
+`BoundedMap`), so the range is one frame stale — the overscan buffer absorbs
+the lag.
+
+**Grid adaptation (2-D).** `ListBox`/`Table` are one item per row;
+the font grid is a wrapped grid. Fixed card size closes the gap. Each frame:
+
+1. `cols = max(1, floor((contentW + gap) / (cardMaxW + gap)))`, recomputed from
+   the current content width so columns still reflow responsively.
+2. `rows = ceil(len(matches) / cols)`, `rowH = cardH + gap`.
+3. `first, last := ListVisibleRange(rows, rowH, listH, scrollY, overscanRows)` —
+   the exported wrapper applies the overscan internally (no separate widening
+   step, no stacked buffers).
+4. Emit `Column{Scrollable: true, ID: gridID, Sizing: FixedFixed, Width: outerW, Height: listH}` containing:
+   - a top spacer rect of height `first * rowH`,
+   - one `Row` per visible row in `[first, last]`, each holding the `cols`
+     cards from `matches[r*cols : min((r+1)*cols, len(matches))]`,
+   - a bottom spacer rect of height `(rows-1-last) * rowH`.
+
+The spacers keep the total scroll range equal to the full catalog, so the
+scrollbar stays correct.
+
+**Overscan buffer.** The internal `listCoreVirtualBufferRows = 2` is tuned for
+~20–32 px list rows; at `rowH ≈ 150–200 px` that is only 300–400 px, which a
+fast flick outruns, flashing blank rows. The exported `ListVisibleRange` takes
+the buffer as an argument, so the grid passes one `overscanRows` (start ~4,
+tune against a fast scroll on a 500+ font machine) rather than stacking its own
+widening on top of a hidden 2. Overscan cards are O(1) per row.
+
+**Viewport dimensions (`outerW`, `listH`).** `ListBox`/`Table` virtualize only
+with an explicit `Height`/`MaxHeight` (`virtualize := cfg.Scrollable &&
+listHeight > 0`) — so the grid does **not** try to be `FillFill`/`FillFixed`
+and estimate its own size. It is **`Sizing: FixedFixed` with explicit `Width:
+outerW` and `Height: listH`**, and the *same* numbers feed `cols`/spacer math
+and `ListVisibleRange`: on **both** axes one number drives arrange and math, so
+they cannot disagree. (Height alone was insufficient — a `Fill` width arranged
+differently from the `WindowSize`-derived `cols` estimate is the identical
+X-axis footgun: wrong `cols` → overflow or dead space. There is no
+previous-frame width-readback API, so explicit width is the fix.) Source from
+`w.WindowSize()` (callable at view time; its values seed the `FillFill` root,
+so they are already in layout units — see open Q1):
+
+- `listH = max(rowH, winH - headerH - toolbarH)`. The **clamp is mandatory**:
+  `listCoreVisibleRange` returns no rows for `listHeight <= 0`, so a short
+  window or overshooting chrome constants would otherwise blank the grid.
+- `outerW = winW` (the grid box fills the window; root chrome is zeroed).
+  `contentW = outerW - 2*sidePad - scrollbarW` after the grid's real horizontal
+  `Padding`, where the right inset is widened by `scrollbarW` — an **overlay
+  inset**, since the vertical scrollbar is `OverDraw: true` (reserves no layout
+  space), a deliberate choice to keep cards clear of the thumb, not an
+  engine-reserved gutter (`ListBox` does not do it). `cols`/`cardW` derive from
+  `contentW`.
+
+Chrome constants (`headerH`, `toolbarH`) must equal the real rendered heights,
+which requires the root/grid columns to zero their default `PaddingMedium`,
+`SpacingMedium`, **and `SizeBorderDef` (1.5, counted twice per box via
+`paddingHeight`)**; otherwise `listH`/`outerW` are wrong on frame one.
+Recomputing per frame keeps resize correct.
+
+**Scroll offset must be reset on content-shape changes.** The scroll store
+holds a raw pixel offset and is re-clamped only during user-scroll events —
+never when content geometry changes. So:
+
+- **FontSize change** alters `rowH`; the old pixel offset then points at the
+  wrong row (offset −1600 at `rowH` 160 shows row 10; at `rowH` 200 it shows
+  row 8). The size slider's `OnChange` must call
+  `w.ScrollVerticalTo(gridID, 0)` after updating `state.FontSize`.
+- **Filter change** alters the match set (and can empty it); the filter
+  input's `OnTextChanged` must likewise `w.ScrollVerticalTo(gridID, 0)`.
+  `listCoreVisibleRange(0, …)` already returns `(0, -1)` (no rows), so an empty
+  result is safe; the reset just keeps the stored offset honest.
+- **Window resize** changes `cols`/`rows` but **not** `rowH`, so vertical
+  depth stays valid; no reset. A now-out-of-range offset self-corrects on the
+  next scroll event. (A future refinement could anchor by first-visible family
+  index instead of resetting, if resetting-to-top on size change feels abrupt.)
+
+**Cost.** Arrange and shaping are both O(visible), independent of catalog
+size. No skeleton, batch reveal, prewarm API, background thread, or
+`TextMeasurer` access is required for scale.
+
+### Skeleton on cold scroll-in (optional, P2)
+
+Windowing means a newly-scrolled-in row shapes its ~`cols` cards (3–5) that
+frame — trivial, and normally invisible. If fast scrolling ever janks on
+cold-cache families, a card may render fixed-size skeleton rects for the single
+frame before its font is in the glyph cache. This is cosmetic polish, not a
+scaling mechanism, and carries no persistent state.
+
+### Clipboard Copy
+
+`w.SetClipboard(text string)` already exists on `Window`, wired to all
+backends (NSPasteboard on macOS, X11 CLIPBOARD on Linux, Win32 clipboard on
+Windows, Clipboard API on web). No new API needed.
+
+### "Copied" transient — driven by a real animation
+
+`SetClipboard` and `QueueCommand` do not self-schedule a wake at T+1.2 s, so
+the confirmation needs a frame source. Two API facts drive the shape: the
+`NewTweenAnimation(id, from, to, onValue)` constructor takes **no** `Duration`
+or `OnDone` (its default duration is 300 ms), and `OnValue` runs outside the
+view — so the animated value must be written into a field the view reads.
+Construct with a struct literal and store the value in `state.CopyOpacity`:
+
+```go
+w.SetClipboard(fam)
+s.CopiedFam = fam    // reset explicitly each click — do not rely on the old
+s.CopyOpacity = 1    // tween's OnDone (AnimationAdd drops the prior same-ID
+                     // anim without firing OnDone)
+w.AnimationAdd(&TweenAnimation{
+    AnimID:   "copied-fade", // stable ID: a fresh click restarts the same fade
+    Duration: 1200 * time.Millisecond, // default is 300ms — must override
+    Easing:   EaseOutCubic,
+    From:     1,
+    To:       0,
+    OnValue:  func(v float32, _ *Window) { s.CopyOpacity = v }, // state channel
+    OnDone:   func(_ *Window) { s.CopiedFam = "" },
+})
+```
+
+The card view renders the "Copied" badge at `s.CopyOpacity` when
+`s.CopiedFam == name`. Resetting `CopiedFam`/`CopyOpacity` on every click (the
+toast pattern) means a rapid click on another card is correct even though
+`AnimationAdd` replaces the same-ID tween and skips the previous `OnDone`. The
+animation loop guarantees the redraws; no manual timer.
+
+**Refresh cost:** `TweenAnimation.RefreshKind()` is `AnimationRefreshLayout`, so
+each of the ~1.2 s of ticks rebuilds and re-shapes the layout. Virtualization
+bounds that to the *visible* window (not N), so it is acceptable — but opacity
+does not change geometry, so if it janks while scrolling, replace the tween with
+a small custom `Animation` whose `RefreshKind()` returns
+`AnimationRefreshRenderOnly` (the pattern `BlinkCursorAnimation` uses).
+
+## UI Layout Details
+
+### Header
+
+Dark accent bar with title "go-gui font viewer" and subtitle. Fixed height
+(feeds the `listH` derivation).
+
+### Toolbar — Row 1
+
+- "Sample Text" label → `Input` with `ID`, `Text: state.Sample`,
+  `OnTextChanged` writing the new string back to state (wide, ~440–640 px)
+- "Shuffle" button → `OnClick` sets `state.Sample` to a random entry from a
+  fixed pangram pool (package var), **excluding the current sample** so a
+  re-pick never silently no-ops. E.g.:
+
+  ```go
+  var pangrams = []string{
+      "The quick brown fox jumps over the lazy dog",
+      "Sphinx of black quartz, judge my vow",
+      "Pack my box with five dozen liquor jugs",
+      "How vexingly quick daft zebras jump",
+      "Waltz, bad nymph, for quick jigs vex",
+      "Jackdaws love my big sphinx of quartz",
+  }
+  ```
+
+### Toolbar — Row 2
+
+- "Filter Fonts" label → `Input` bound to `state.Filter`. `OnTextChanged`
+  updates `state.Filter` **and** resets scroll: `w.ScrollVerticalTo(gridID, 0)`
+  (the match set changed — see Rendering).
+- Clear control when filter is non-empty (text "×" button is fine; also resets
+  scroll).
+- Spacer
+- "Size" label → `Slider` `ID` + `Value: state.FontSize`, Min 12, Max 72,
+  Step 1. `OnChange` updates `state.FontSize` **and** resets scroll:
+  `w.ScrollVerticalTo(gridID, 0)` (`rowH` changed). Width ~170 px → "NN px"
+  readout.
+- Spacer
+- "N / M fonts" match count label
+
+The toolbar's height is fixed (two rows) so it can be subtracted from
+`w.WindowSize()` to yield the grid viewport height.
+
+### FontCard
+
+**Fixed width AND uniform height** — the precondition for virtualization.
+`cardH = cardHeight(FontSize)` = `nameRowH + previewPad + previewLines *
+FontSize * 1.4`. This is a **uniform clip box**, deliberately *not* a per-face
+fit: `1.4` approximates go-gui's list line-height (`listCoreRowHeightEstimate`),
+but go-glyph's real per-face `LineHeight` varies, so a tall face clips at the
+box and a short face leaves a small band. That is the accepted trade — uniform
+declared height is what keeps `rowH` constant and the spacer math honest; the
+Latin-only note does not cover this metric variance. If the clip/band looks bad,
+measure the box **once per `FontSize`** with a reference face (never per family
+— that reintroduces N measurements), not a flat multiplier.
+
+- **Name row**: family name in UI font (13 px, medium weight). Truncate via
+  single-line `Text` + parent `Clip` / `MaxWidth` (no `MaxLines`/ellipsis API
+  today — clip is enough for v1). On hover: "Copy" badge at right. When
+  `state.CopiedFam == name`: "Copied" badge at alpha `state.CopyOpacity`.
+- **Preview box**: white rounded rect with light border. Sample text in the
+  family's own face, `TextModeWrap` at width `cardW - 2*previewPad`, clipped
+  with parent `MaxHeight` / `Clip` to `previewLines` lines of the current
+  `FontSize`. **Latin-only contract:** sample text is Latin pangrams; non-Latin
+  runes fall back per-rune to a covering face and do **not** exercise the
+  card's family — do not "fix" this with Unicode samples that silently lie.
+
+Card states:
+
+- **Default**: subtle background, name visible
+- **Hovered**: slightly brighter background, "Copy" affordance appears. Each
+  card has a **stable ID** `"card:"+family`, so `OnHover` sets `hoveredFam` and
+  `OnMouseLeave` clears it while the card is on-screen. Because a card evicted by
+  windowing is never visited by `layoutMouseLeave`, the grid **also** clears
+  `hoveredFam` each frame when it falls outside `[first,last]` (see hover
+  decision) — otherwise the affordance sticks when the family scrolls back
+- **Copied**: green "Copied" badge at `state.CopyOpacity` (fades 1→0 over
+  ~1.2 s; the tween's `OnDone` clears `state.CopiedFam`)
+
+Changing `FontSize` changes `cardH` (preview grows) → recompute `rowH`; the
+virtualization math handles it, but every card must use the same height for a
+given size.
+
+### FontGrid
+
+Virtualized `Column` — **not** `gui.Wrap` (Wrap lays out all children and
+can't window):
+
+```go
+func fontGrid(w *Window, s *FontViewerState, matches []string) View {
+    // len(Families)==0 covers both nil (backend not ready) and a non-nil empty
+    // enumerate; emptyState distinguishes copy via the nil check itself.
+    if len(matches) == 0 {
+        return emptyState(len(s.Families) == 0)
+    }
+    winW, winH := w.WindowSize() // view-time; values seed FillFill root (open Q1)
+
+    cardH := cardHeight(s.FontSize)                    // clip-height, uniform per size
+    rowH := cardH + gap                                // gap folded into the row
+    outerW := float32(winW)                            // grid box == window (root chrome zeroed)
+    listH := max(rowH, float32(winH)-headerH-toolbarH) // clamp: never <= 0
+    // contentW after the grid's own horizontal padding; right side widened to
+    // clear the overlay scrollbar. Same numbers arrange the box (FixedFixed).
+    contentW := outerW - 2*sidePad - scrollbarW
+
+    cols := max(1, int((contentW+gap)/(cardMaxW+gap)))
+    cardW := min(cardMaxW, (contentW-float32(cols-1)*gap)/float32(cols))
+    rows := (len(matches) + cols - 1) / cols
+
+    scrollY, _ := w.ScrollY().Get(gridID)
+    // Buffer passed explicitly (overscanRows) — the exported wrapper does NOT
+    // add its own, so overscan is one number, not stacked magic (2+4).
+    first, last := ListVisibleRange(rows, rowH, listH, scrollY, overscanRows)
+
+    // Clear hover if its card was evicted (layoutMouseLeave never visits
+    // off-window cards → OnMouseLeave won't fire → sticky "Copy" otherwise).
+    if s.HoveredFam != "" && !inWindow(matches, s.HoveredFam, first, last, cols) {
+        s.HoveredFam = ""
+    }
+
+    children := []View{spacerV(float32(first) * rowH)}
+    for r := first; r <= last; r++ {
+        children = append(children, gridRow(w, s, matches, r, cols, cardW, cardH, rowH))
+    }
+    children = append(children, spacerV(float32(rows-1-last)*rowH))
+
+    // FixedFixed with explicit Width AND Height — the SAME numbers as the
+    // cols/range math, so neither axis can disagree with arrange. Padding is
+    // real (sidePad + scrollbar clearance); Spacing/SizeBorder zeroed.
+    return Column(ContainerCfg{
+        ID: gridID, Scrollable: true,
+        Sizing:     FixedFixed,
+        Width:      outerW,
+        Height:     listH,
+        Padding:    Some(Padding{Left: sidePad, Right: sidePad + scrollbarW}),
+        Spacing:    SomeF(0),
+        SizeBorder: Some(float32(0)),
+        Content:    children,
+    })
+}
+```
+
+- `gridRow` builds one `Row{Height: rowH, Spacing: SomeF(gap)}` (horizontal
+  card gutter — vertical gap lives in `rowH`, not row spacing) holding up to
+  `cols` cards of `cardW × cardH`, top-aligned (the `gap` slack sits below the
+  card so the row measures exactly `rowH`). Each card has a **stable ID**
+  `"card:"+family` so click, hover, and `OnMouseLeave` identity survive.
+- `inWindow(matches, fam, first, last, cols)` reports whether `fam`'s index in
+  `matches` lies in `[first*cols, (last+1)*cols)` — the emitted card range —
+  used to clear `HoveredFam` on eviction.
+- `RequireScrollID` enforces the non-empty `ID` at construction.
+- **Narrow viewport:** when `contentW < cardMaxW`, `cols` stays 1 and `cardW`
+  shrinks to fit — cards never overflow horizontally, no horizontal scrollbar.
+  The preview `TextModeWrap` width is `cardW - 2*previewPad` (recomputed with
+  `cardW`, so wrapping tracks the shrunk card).
+- **Empty states:** `emptyState(len(s.Families) == 0)` renders "no system fonts
+  found" (nil *or* empty enumerate) vs "no fonts match the filter" (families
+  present, filter excludes all) — no grid, no virtualization.
+
+## Implementation Plan
+
+### Phase 1: Font Enumeration API (go-glyph + go-gui)
+
+- go-glyph: case-folded `Context.families` set threaded through
+  `registerFontPath` — **a signature change to a free function with direct test
+  call sites**; Phase 1 owns updating both call sites (`AddFontFile` path and
+  `fontScan.consider`) and their tests. `.LastResort` still enters `fontPaths`
+  as before — the new set only *excludes* it, no discovery behavior changes.
+  Then `(*TextSystem).ListFontFamilies() []string` returns display-case names
+  sorted case-insensitively
+- go-glyph test — **bidirectional** (`ResolveFontName` is the wrong API: it
+  returns `resolveFontFamily(...)`, always succeeds, never consults
+  `fontPaths`). White-box in `package glyph`:
+  - *forward* — every `ListFontFamilies()` name has a real `ctx.fontPaths` key
+    (bare family **or** a `-Regular/-Bold/…` style key) mapping to a non-empty
+    path that is **not** only the generic-fallback path (the map `newFTFont` /
+    `fontPaths[family]` actually resolve against, `freetype_types_puregoft.go`)
+  - *reverse* — a fixture directory with a known family enumerates it **exactly
+    once** (catches a scan path that never hits `registerFontPath`, and the
+    case-fold dedup)
+- go-gui: **export `ListVisibleRange(itemCount, rowHeight, listHeight, scrollY,
+  overscan)`** so the `package main` example can call it (buffer as an arg — no
+  stacked `listCoreVirtualBufferRows`)
+- go-gui: `FontLister` interface + `ListSystemFonts(w *Window) []string` type
+  assertion; opt in the native text backend
+- No CTFontManager / fontconfig / DirectWrite / AWT enumerator
+
+`filterFontFamilies` is **not** a `gui` export — it is example-local
+(`examples/fontviewer`, tested there); it has no shared caller and does not
+belong in the widget API.
+
+**Release coupling:** go-glyph is upstream. Landing `ListFontFamilies`
+requires a go-glyph tag + a go-gui `go.mod` bump before Phase 2 can build
+against it.
+
+### Phase 2: Core Font Viewer
+
+- `examples/fontviewer/main.go` with full state (init `FontSize: 28`, random
+  pangram), header, toolbar, grid
+- Sample text, shuffle, filter, size slider; filter/size handlers reset scroll
+  via `w.ScrollVerticalTo(gridID, 0)`
+- **Virtualized grid**: `FixedFixed` grid with explicit `Width: outerW` +
+  `Height: listH` (both from `w.WindowSize()`, both feeding the math);
+  `Padding`/`Spacing`/`SizeBorder` zeroed on root+grid; uniform-height cards
+  (`cardHeight`), `ListVisibleRange(..., overscanRows)` over rows, `rowH`-tall
+  rows, top/bottom spacers, `listH` clamped `>= rowH`
+- Click-to-copy + tween-driven "Copied" transient (`CopyOpacity`)
+- Empty states keyed on `len(s.Families) == 0` (not `== nil`)
+- Layout/state tests: empty, filtered, copied, sizing, **and the visible-range
+  math** — assert emitted card count and that `topSpacer + rows*rowH +
+  bottomSpacer == totalRows*rowH` for a given `(N, cols, rowH, listH, scrollY)`
+  (pure, headless; mirrors `TestListCoreVisibleRange` / `TestTableVirtualization`)
+
+### Phase 3: Polish (optional)
+
+- `--shape-all` debug mode: drop virtualization (emit all N cards) to stress
+  **all-N main-thread shaping** in one frame (not "concurrent" — go-glyph is
+  single-threaded) — the honest "stress test at scale" path
+- Skeleton on cold scroll-in (P2) if profiling shows fast-scroll jank
+- Late-registration refresh: re-enumerate when `RegisterAppFont` fires after
+  the first successful list (set `s.Loaded = false`)
+- P2 PNG export only if an offscreen/render + encode path is defined (none
+  exists today — skip rather than invent ad hoc)
+
+## Remaining Open Questions
+
+1. **Viewport-size units / DPI — Phase 2 entry criterion (a geometry spike,
+   NOT a Phase 1 gate).** Phase 1 is the enumeration API (`ListFontFamilies` /
+   `FontLister` / `ListVisibleRange`) and does not touch window geometry, so
+   this must not block or rubber-stamp it. `w.WindowSize()` returns cached
+   `windowWidth/windowHeight` that seed the `FillFill` root, so `listH`/`outerW`
+   are consistent *with each other* in layout units. The landmine is
+   `w.BackingScale` (real field, default 1, 2 on Retina): if `TextStyle.Size`
+   (hence `cardHeight`) and window dims ever live in different scales, `rowH`
+   and the arranged rows diverge and the overscan cannot hide it. **Spike this
+   on a Retina display with a 500+ font catalog as the first task of Phase 2**,
+   before the grid geometry is built on the assumption.
+
+2. **Tuning constants** (empirical on a 500+ font machine, not fundamental):
+   `overscanRows` (start 4 — enough to hide a fast flick at grid `rowH`);
+   `nameRowH` / `previewPad` / `lineFactor` so `cardHeight(FontSize)` matches
+   the actually-rendered card and rows stay uniform.
+
+3. **Chrome geometry, not just drift**: `listH`/`contentW` subtract `headerH`,
+   `toolbarH`, `sidePad`, `scrollbarW`. These hold only if the root/grid columns
+   zero `Padding` **and** `SizeBorder` (default `SizeBorderDef` 1.5, counted
+   twice per box) — otherwise `listH` is optimistic → blank bands the overscan
+   can't cover. Bias the estimate large, and assert `headerH`/`toolbarH` against
+   the rendered heights of `header()`/`toolbar()` in a layout test so they can't
+   silently diverge.
+
+4. **Headless PNG export**: no `RenderToPNG` equivalent exists. Keep P2
+   speculative until an offscreen buffer + encode path lands; otherwise cut
+   from v1.
+
+5. **List API surface**: `ListSystemFonts(w *Window)` matches how other
+   window-scoped text helpers are exposed. A window-free variant taking a
+   `TextMeasurer` / backend handle is possible later if a caller needs it —
+   same rule: list only what resolution can see.

--- a/docs/specs/idfocus-to-focusable.md
+++ b/docs/specs/idfocus-to-focusable.md
@@ -1,0 +1,205 @@
+# Spec: Replace `IDFocus uint32` with `Focusable bool` + string focus identity
+
+Status: in progress (branch `focusable-migration`)
+Base: `main` @ `7f80679`
+Target release: go-gui `v0.34.0` (breaking)
+
+## Motivation
+
+`IDFocus uint32` pulls double duty: it is both the **tab-order value**
+(ascending) and the **StateMap key** for per-widget input state (cursor,
+selection, undo/redo, IME, spell-check, markdown selection). Changing a
+widget's tab order therefore silently changes its state identity — an
+acknowledged accidental coupling.
+
+Every stateful widget already requires a non-empty string `ID` (via
+`RequireID`) and every widget `Cfg` already carries an `ID string` field.
+Using that string as the sole focus identity removes the coupling:
+
+- **Focus identity / StateMap key** = existing `Cfg.ID` (string).
+- **Tab participation** = new `Focusable bool` opt-in.
+- **Tab order** = layout-tree depth-first (DFS) traversal order.
+
+`IDScroll` (scroll-state key, `uint32`) has no double-duty problem and is
+explicitly **out of scope**; it stays `uint32` and keeps its `FnvSum32`
+string derivation.
+
+## Decisions (locked)
+
+1. Tab order: layout-tree DFS order. Numeric ordering retired.
+2. Window API: `SetFocus(id string)`, `FocusID() string`,
+   `IsFocus(id string) bool`, `ClearFocus()`. No public `SetFocus("")`;
+   `ClearFocus()` is the documented way to defocus.
+3. Opt-in: explicit `Focusable bool`. `Focusable: true` requires a
+   non-empty `ID`.
+
+   **Amended 2026-08-07 (developer-ergonomics §4.2).** The runtime
+   guard named here was never wired up: `RequireFocusID` shipped with
+   zero call sites in go-gui or any sibling repo, so `Focusable: true`
+   without an `ID` rendered and clicked but never joined the tab
+   order, silently. The guard is now deleted. Enforcement is the
+   `requiredid` analyzer at build time (static case, with the `Cfg`
+   type named) plus the `gui.Debug` gate at render time (dynamic
+   `Focusable`, or an `ID` expression that evaluates empty).
+4. `IDScroll` untouched.
+5. Clean break — no back-compat shim (single owner: all consumers are
+   sibling repos owned by the same author).
+6. Duplicate focusable IDs in one frame: `collectFocusCandidates` dedups
+   to a single tab stop and emits a **dev-mode warning** (once per
+   colliding ID per frame), guarded by the debug/inspector gate — silent
+   in release.
+
+   **Amended 2026-08-07 (developer-ergonomics §4.1).** The warning
+   moved to the `gui.Debug` gate, which walks the composed tree once
+   per frame and so sees **every** duplicate ID, not only focusable
+   ones — `ID` also keys scroll offsets and per-widget state. It warns
+   once per ID per window rather than once per frame.
+7. go-term: add optional `term.Cfg.ID string`; when set it is the focus
+   identity, when empty fall back to the existing generated
+   `"term-"+seq` scheme.
+
+## Core model changes
+
+### `Shape` (`gui/shape.go`)
+
+- Remove `IDFocus uint32`.
+- Add `Focusable bool`.
+- Reuse existing `Shape.ID string` as focus identity.
+- `FocusSkip bool` unchanged: click-focusable and holds selection state,
+  but excluded from Tab traversal. Text / RTF / Markdown selection
+  widgets set `Focusable: true, FocusSkip: true, ID: ...`.
+
+### `Window` / `ViewState`
+
+- `ViewState.idFocus uint32` → `focusID string`.
+- `gui/window_focus.go`: `IDFocus()→FocusID() string`,
+  `SetIDFocus(uint32)→SetFocus(string)`, add `ClearFocus()`,
+  `IsFocus(uint32)→IsFocus(string)`. Blink-cursor / IME gates change
+  `id > 0` → `id != ""` (`setFocusLocked`).
+
+### Tab traversal (`gui/layout_query.go`, `gui/window_event.go`)
+
+- `focusCandidate{shape *Shape; id string}`.
+- `collectFocusCandidates`: gate `Focusable && !FocusSkip && !Disabled`;
+  dedup by `ID` (dev-mode warn on collision); DFS order preserved.
+- Replace numeric `focusFindNext`/`focusFindPrevious` with **positional**
+  next/previous: find current `FocusID()` index in the ordered slice,
+  return `(i±1)` with wrap; current not found → first / last.
+- `FindLayoutByIDFocus` → `FindLayoutByFocusID(layout, id string)`
+  matching `Shape.ID`.
+- `handleKeyDownEvent` dialog-layer scoping is unchanged, so Tab stays
+  trapped in the dialog subtree (preserves `RetainDialogFocus`).
+
+### Click / scroll focus (`gui/event_handlers.go`)
+
+- Click-to-focus: `Focusable && ID != "" && button != right →
+SetFocus(ID)`.
+- `focusedScrollTarget`: guard `FocusID() == ""`; use
+  `FindLayoutByFocusID`.
+
+## StateMap key retype (`gui/state_registry.go` + consumers)
+
+Six namespaces flip `uint32` (IDFocus) → `string` key. `nsScrollX` /
+`nsScrollY` (IDScroll) stay `uint32`.
+
+| Namespace            | Change                                                                |
+| -------------------- | --------------------------------------------------------------------- |
+| `nsInput`            | key `uint32`→`string` (widget `ID`)                                   |
+| `nsInputFocus`       | key `uint32`→`string`                                                 |
+| `nsSpellCheck`       | key `uint32`→`string`                                                 |
+| `nsMdSel`            | key `uint32`→`string`                                                 |
+| `nsMdBlocks`         | key `uint32`→`string`                                                 |
+| `nsMenu`             | key `uint32`→`string`; drop `FnvSum32("menu_"+ID)`, use `ID` directly |
+| `nsContextMenuFocus` | **value** `uint32`→`string` (saved prior focus)                       |
+
+Consumers threading `idFocus uint32` → `focusID string`:
+`input_state.go`, `view_input*.go`, `view_rtf_select.go`,
+`render_text.go`, `spell_check.go`, `markdown_select.go`,
+`view_menu*.go`, `a11y_tree.go`, `inspector.go`.
+
+## Widget factories (34 Cfgs)
+
+All 34 focusable `Cfg` structs already have an `ID string` field —
+**no new ID fields required**. Per Cfg:
+
+- Drop `IDFocus uint32`; add `Focusable bool`. Focus identity = `ID`.
+
+Special cases:
+
+- Menus (`view_menu.go`, `view_menubar.go`, `view_context_menu.go`):
+  drop `FnvSum32` focus derivation; use `cfg.ID`.
+- `RadioButtonGroup`: `idFocus++` → per-child `ID = cfg.ID + "/" +
+strconv.Itoa(i)`.
+- `DataGrid`: focus id → `cfg.ID + ":focus"` (string). The `:scroll`
+  IDScroll derivation keeps `FnvSum32` (IDScroll untouched).
+- Splitter / Slider / TabControl internal `idFocus` plumbing → string.
+
+Cfg structs affected (files): `view_slider`, `view_radio`, `view_button`,
+`view_rtf`, `view_radio_button_group`, `view_splitter`, `view_text`,
+`view_command_palette`, `view_tab_control`, `view_input`
+(Input + MultiLineInput), `view_select`, `view_switch`, `view_combobox`,
+`view_breadcrumb`, `inspector`, `view_color_picker`, `termgrid`,
+`view_date_picker_roller`, `view_listbox`, `view_overflow_panel`,
+`view_container`, `view_markdown`, `view_theme_picker`,
+`view_input_date`, `view_input_numeric`, `view_tree`, `view_toggle`,
+`view_context_menu`, `view_dialog`, `view_draw_canvas`, `view_menubar`,
+`view_date_picker`, `datagrid/view_data_grid`.
+
+## Tests / examples / docs (go-gui)
+
+- Tests: swap numeric IDs → `Focusable: true, ID: "x"` and
+  `viewState.focusID = "x"` (`layout_query_test`, `view_widget_test`,
+  `view_input_test`, `input_state_test`, `render_layout_test`,
+  `a11y_tree_test`, `event_handlers_test`, `spell_check_test`,
+  `termgrid_test`, `event_fuzz_test`).
+- 37 example files: `IDFocus: N` → `Focusable: true, ID: "..."`.
+- 41 `.md` files + `.claude/skills/{widget,new-example}` scaffolds +
+  `shape.go` doc comment: update field name and guidance.
+
+## Release
+
+Breaking → minor bump `v0.34.0`, CHANGELOG entry. Merge branch to `main`
+and tag before bumping siblings.
+
+## Sibling repos (dependency order)
+
+Each: migrate → bump `go.mod` require → `go build && go vet &&
+golangci-lint run && go test ./...` → ship.
+
+1. **go-charts** — 1 site (`InputCfg`, iota `focusSearch`). Trivial.
+2. **go-kite** — 4 literals (`Input`/`Button`/`Container`). Trivial.
+3. **go-map** — `mapview` Cfg `IDFocus`/`IDFocusBase uint32` → string
+   base; legend/gallery derive `ID+index` (build order == old numeric
+   order → tab order preserved). Its own string-based overlay-marker
+   focus system is independent → unaffected.
+4. **go-edit** — `EditorCfg.IDFocus uint32` → `EditorCfg.ID string`;
+   root container `Focusable: true`. `SetIDFocus(focusEditor)` →
+   `SetFocus("editor")`. 3 prod + 114 test occurrences (mechanical).
+5. **go-term** — `Term.focusID uint32` → `string` (optional `Cfg.ID`,
+   else `"term-"+seq`); `FocusID() uint32→string`; 11 runtime
+   `SetIDFocus`→`SetFocus`; Workspace pane compares strings.
+
+## Verification gate (every repo)
+
+```
+go build ./... && go vet ./... && golangci-lint run ./... && go test ./...
+```
+
+## Execution protocol
+
+- Branch `focusable-migration` off `main`.
+- Phase 0: this spec (commit, pause).
+- Phase 1+2 folded into one green commit (core + widgets), gate, pause.
+- Phase 3: tests/examples/docs, full gate, pause.
+- Release: merge to main, changelog, tag `v0.34.0`, pause.
+- Phase 4: one commit per sibling, gated + shipped, pause after each.
+
+## Open risks
+
+- Tab order changes for any app that relied on numeric order differing
+  from tree order. Inventory shows all siblings assign IDs in ascending
+  tree order, so tree order matches; low risk.
+- Focus identity must be unique per frame among focusable widgets;
+  duplicates collapse to one tab stop (dev-mode warned).
+- Auto-focus-on-launch (`SetIDFocus` in `OnInit`, go-edit/go-term)
+  becomes `SetFocus(string)`.

--- a/docs/specs/idscroll-to-scrollable.md
+++ b/docs/specs/idscroll-to-scrollable.md
@@ -1,0 +1,940 @@
+# Spec: Replace `IDScroll uint32` with `Scrollable bool` + string scroll identity
+
+Status: implemented (go-gui #78, released v0.35.0; all five siblings bumped)
+Base: `main` @ `3c5dac7`
+Target release: go-gui `v0.35.0` (breaking)
+Precedent: [idfocus-to-focusable.md](idfocus-to-focusable.md) (`v0.34.0`)
+
+## Motivation
+
+`IDScroll uint32` carries the same overload `IDFocus` did: the value is
+both the **opt-in flag** (`IDScroll > 0` gates scroll dispatch, scrollbar
+injection, sizing, and hit-testing) and the **key** into the window's
+scroll-offset maps (`w.scrollXMap` / `w.scrollYMap`, reached via
+`Window.ScrollX()` / `ScrollY()`). It is a weaker case than `IDFocus`,
+which was overloaded three ways — the numeric value also encoded tab
+order. `IDScroll` has no ordering semantics, so this is consistency work,
+not a coupling bug.
+
+`v0.34.0` explicitly deferred it ("`IDScroll` untouched"). Post-#76 the
+API is split-brained: focus opts in with a bool and identifies by `ID`,
+scroll opts in with a magic number and identifies by that number.
+Consumers hash strings into it by hand — `FnvSum32(cfg.ID + ":scroll")`
+(datagrid), `FnvSum32(cfg.ID + ".dropdown")` (`view_select`),
+`idScrollHash(id)` (go-charts) — the same derivation #76 deleted from the
+focus path. Examples pick numbers out of the air: `9110`, `101`, `9182`.
+
+## Key insight: the derived-ID convention already exists
+
+**Every composite widget that hashes a scroll id is hashing a string it
+already stores in `Shape.ID`.** This is the single most important fact
+for the implementer, and it de-risks most of PR C:
+
+| site | today |
+|------|-------|
+| `datagrid/view_data_grid.go:584-585` | `ID: resolvedCfg.ID + ":scroll"` **and** `IDScroll: FnvSum32(resolvedCfg.ID + ":scroll")` |
+| `view_select.go:68,128` | `ID: cfg.ID + ".dropdown"` **and** `IDScroll: FnvSum32(cfg.ID + ".dropdown")` |
+| `view_combobox.go:207,219` | `ID: cfg.ID + ".dropdown"` **and** `IDScroll: cfg.IDScroll` |
+
+For these, the migration is: **delete the hash, set `Scrollable: true`,
+and the identity is already correct in `ID`.** No new naming scheme is
+needed — `cfg.ID + ":scroll"` is the established convention (mirroring
+`cfg.ID + ":focus"` from #76).
+
+## Measured evidence
+
+Benchmarked on `main` @ `3c5dac7` (M5, go1.26.5, `benchstat`, n=8–10).
+All spikes reverted; nothing committed.
+
+**Shape size — the migration makes `Shape` smaller:**
+
+| field change | bytes |
+|--------------|-------|
+| remove `IDScroll uint32` | −4 |
+| remove `IDScrollContainer uint32` (dead) | −4 |
+| add `Scrollable bool` (absorbed into existing `Focusable`/`FocusSkip` padding) | +0 |
+| identity reuses existing `Shape.ID string` | +0 |
+| **net** | **272 → 264** |
+
+Measured with a mirror struct, not predicted. An earlier estimate of
+*+24 bytes* assumed both fields must become strings; wrong on both counts.
+
+**Key type:**
+
+| operation | uint32 | string |
+|-----------|--------|--------|
+| `BoundedMap.Get` (per frame) | 10.70 ns | 5.23 ns |
+| raw `map[K]float32` Get | 2.37 ns | 5.33 ns |
+| `BoundedMap.Set` (per scroll event) | 10.25 ns | 14.15 ns |
+| tree walk, worst case | 241 ns | 310 ns |
+
+Net cost is the tree walk: +69 ns per scrollbar per frame via
+`AmendLayout`, against a 4–5 ms frame budget. Noise. Read the `Get`
+improvement with the caveat in "Out of scope" — it is borrowed, not
+earned.
+
+## Decisions (locked)
+
+1. **Opt-in**: `Scrollable bool`. Identity = existing `Cfg.ID` (string).
+2. **`ScrollMode` stays** as the axis restriction. It cannot serve as the
+   opt-in: its zero value is `ScrollBoth`, so making it the gate would
+   silently turn every container into a scroll container.
+3. **`IDScrollContainer` deleted outright**, not migrated (PR A).
+4. **`FindLayoutByIDScroll` → `FindLayoutByScrollID`**, parallel to
+   #76's `FindLayoutByIDFocus` → `FindLayoutByFocusID`. Keep it as a
+   separate function from `FindLayoutByFocusID` — near-identical,
+   differing only in which bool they gate on (`Scrollable` vs
+   `Focusable`). Predicate: `id != "" && layout.Shape.Scrollable &&
+   layout.Shape.ID == id` (empty id → miss, same as focus). Do not leave
+   the old name: `IDScroll` is being deleted.
+
+   **This is a behavior change, not only a rename.** Today's predicate
+   (`layout_query.go:61-63`) is a bare `layout.Shape.IDScroll == idScroll`
+   — no opt-in gate and no zero guard, so `findScrollLayout(w, 0)`
+   currently matches the root (the first shape with `IDScroll == 0`). The
+   new predicate is strictly better; it is called out here so the tightened
+   diff does not read as an unexplained mismatch during review.
+5. **Meaningful string IDs** in examples (`"catalog"`, `"detail"`), not
+   mechanical translations of the old numbers.
+6. Clean break — no back-compat shim.
+7. `Scrollable: true` requires non-empty `ID`. Add `RequireScrollID`
+   next to `RequireFocusID` (`gui/state_registry.go:134`) as the
+   sibling helper:
+
+   ```go
+   // RequireScrollID panics if a Scrollable widget has an empty ID.
+   func RequireScrollID(widget string, scrollable bool, id string) {
+       if scrollable && id == "" {
+           panic("gui: " + widget + " with Scrollable:true requires a non-empty Cfg.ID")
+       }
+   }
+   ```
+
+   **Do not frame this as "mirroring wired focus enforcement."**
+   `RequireFocusID` exists but has **zero call sites** — #76 enforced
+   non-empty IDs via `RequireID` on stateful widget factories, not via
+   a central Focusable check. Containers are different: `ContainerCfg.ID`
+   is optional for non-scroll containers, so there is no per-factory
+   `RequireID` to lean on. **Wire `RequireScrollID("container",
+   cfg.Scrollable, cfg.ID)` inside `buildContainerShape`**
+   (`gui/view_container.go:316`) — every layout container compiles down to
+   it, including widgets that build a `containerView` directly. That is
+   intentional strengthening relative to focus, not a copy of an existing
+   pattern.
+
+   **Coverage caveat — it catches one class of site, not "every missed
+   site".** Do not treat this as a general safety net:
+
+   - **Suffix-derived ids defeat it.** `cfg.ID + ":scroll"` and
+     `cfg.ID + ".dropdown"` are never empty, so DataGrid, CommandPalette,
+     Combobox, Select and Table's freeze path can never trip it — even
+     with an empty `cfg.ID`, which silently keys scroll on the bare
+     suffix. (Pre-existing: `FnvSum32(".dropdown")` has the same hole
+     today. Not a regression, not fixed here.)
+   - **Direct-`cfg.ID` containers already have a guard.** ListBox, Tree,
+     Table, Combobox, CommandPalette and DataGrid each call `RequireID`
+     at their factory (`view_listbox.go:75`, `view_tree.go:149`,
+     `view_table.go:130`, `view_combobox.go:64`,
+     `view_command_palette.go:63`, `datagrid/view_data_grid.go:455`), so
+     `RequireScrollID` is redundant there.
+   - **Its only live catch** is a bare `Column(ContainerCfg{Scrollable:
+     true})` with no `ID` — which is exactly what the 14 examples using
+     `IDScroll: 9110` become if migrated carelessly. That is why it is
+     still worth wiring.
+   - A hand-rolled `&Shape{Scrollable: true}` bypasses it entirely. None
+     exist today; grep `rg -n 'Shape\{' --type go gui/` at land time to
+     confirm none arrived in the meantime.
+
+8. **No duplicate-ID detection. Do not build it.** #76 warns on duplicate
+   focusable IDs, and the obvious move is to mirror that here. Don't —
+   the two failure modes are not comparable:
+
+   | | duplicate focus ID | duplicate scroll ID |
+   |---|---|---|
+   | symptom | widget silently skipped in tab order | two containers scroll in lockstep |
+   | noticed | easy to miss | usually obvious when scrolling; weaker signal under virtualization |
+   | diagnosis | needs a warning to find | usually self-evident; not worth a per-frame seen-set |
+
+    A warning would cost a `scrollDebug` env gate, a `scrollDupWarn`
+    helper, and a per-frame seen-set in the view-phase runtime — to detect
+    a bug that usually announces itself the first time anyone scrolls.
+    Not worth it.
+
+    Note decision 12 forces a deliberate near-miss here: Table's freeze
+    path puts a scrollable `bodyCfg` under an outer that already holds
+    `ID: cfg.ID`. Suffixing the body `:scroll` keeps ids unique; the
+    rejected alternative would have made two shapes share one.
+
+   `RequireScrollID` (decision 7) still catches the empty-`ID` case,
+   which is the one that matters during this migration: it is a
+   compile-clean mistake with a panic as the backstop.
+
+9. **`DataGridCfg.IDScroll` override is deleted**, not migrated.
+   `dataGridScrollID` collapses to `return cfg.ID + ":scroll"` with no
+   branch, matching its sibling `dataGridFocusID` (`:119-121`), which has
+   no override. Breaking for any consumer setting it explicitly; grep
+   shows none across the five siblings, so blast radius is zero.
+
+10. **`ScrollbarCfg.IDScroll` is renamed `ScrollID string`** — it points
+    at another container's state and never becomes a bool. Name locked
+    now, before the sibling migration, since go-charts touches it.
+    `dragReorderStartCfg` takes the same `ScrollID string` treatment
+    (unexported, no consumer impact). Also retype the runtime
+    `dragReorder` state field and `dragReorderAutoScroll` parameter
+    (`drag_reorder.go:135`, `:527`) — not just the start cfg.
+
+    **Static assist (not a guarantee):** tag `ScrollbarCfg.ScrollID` with
+    `` `gui:"required"` `` so `tools/requiredid` flags bare
+    `Scrollbar(ScrollbarCfg{…})` literals missing a target. The analyzer
+    only inspects factory-arg composite literals — it does **not** see
+    `ScrollbarCfgX/Y: &ScrollbarCfg{…}` overrides. Those are fine:
+    `appendScrollbar` always overwrites `ScrollID` from the container.
+    Real safety nets: that overwrite + `RequireScrollID` (decision 7).
+
+11. **Every public `IDScroll uint32` is an identity handle, not just an
+    opt-in — decision 9 generalizes to all of them.** The caller picks the
+    number *and* can pass it to `Window.ScrollVerticalTo` / `ScrollX()` /
+    `ScrollY()`. go-kite does exactly this (`IDScroll: timelineScrollID`
+    **and** `ScrollVerticalTo(timelineScrollID, 0)`), which is why the
+    "3 refs, trivial" note in the sibling section understates it.
+
+    Deleting the field takes that handle away from `ContainerCfg`,
+    `ListBoxCfg`, `TreeCfg`, `TableCfg`, `ComboboxCfg`,
+    `CommandPaletteCfg`, `InputCfg` and `DataGridCfg` alike. Do **not**
+    reintroduce an optional `ScrollID string` override to preserve it —
+    that is the branch decision 9 just deleted.
+
+    Instead, **the derivation becomes the public contract and must be
+    documented on each `Scrollable` field's doc comment.** An undocumented
+    derivation is not a handle, it is a private convention consumers have
+    to read go-gui's source to discover. Today only datagrid's
+    (`cfg.ID + ":scroll"`) is written down anywhere.
+
+    | Cfg | scroll key after migration |
+    |-----|----------------------------|
+    | `ContainerCfg` | `cfg.ID` |
+    | `ListBoxCfg` | `cfg.ID` |
+    | `TreeCfg` | `cfg.ID` |
+    | `InputCfg` (multiline) | `cfg.ID` |
+    | `TableCfg` | `cfg.ID`, or `cfg.ID + ":scroll"` when `FreezeHeader` (decision 12) |
+    | `ComboboxCfg` | `cfg.ID + ".dropdown"` |
+    | `CommandPaletteCfg` | `cfg.ID + ":scroll"` |
+    | `DataGridCfg` | `cfg.ID + ":scroll"` |
+
+    ```go
+    // ListBoxCfg
+    //
+    // Scrollable opts the list into the scroll system. Scroll state is
+    // keyed by Cfg.ID — pass that same id to Window.ScrollVerticalTo.
+    Scrollable bool
+
+    // ComboboxCfg
+    //
+    // Scrollable opts the dropdown into the scroll system. Scroll state
+    // is keyed by Cfg.ID + ".dropdown".
+    Scrollable bool
+    ```
+
+    CHANGELOG must list the lost handle as breaking for all eight, not
+    just `DataGridCfg` — **and must list `Window.ScrollX()` / `ScrollY()`
+    as a third breaking change**: they return
+    `*BoundedMap[uint32, float32]` today and
+    `*BoundedMap[string, float32]` after. Both are exported and their doc
+    comments state they exist for external packages doing virtualization,
+    so the retype breaks any consumer reading offsets directly, not just
+    those setting a Cfg field.
+
+12. **`TableCfg` has two layout paths with different scroll structure;
+    identity branches on `freeze`.** See "Table's two paths" under PR C.
+    Non-freeze keeps identity `cfg.ID` (the outer `Column` already carries
+    it); the freeze path's `bodyCfg` gets `ID: cfg.ID + ":scroll"`. Add
+    `tableScrollID(cfg *TableCfg, freeze bool) string` so the container
+    and the virtualization read cannot drift apart:
+
+    ```go
+    func tableScrollID(cfg *TableCfg, freeze bool) string {
+        if freeze {
+            return cfg.ID + ":scroll" // inner bodyCfg carries it
+        }
+        return cfg.ID // outerCfg carries it
+    }
+    ```
+
+    **Call it once per view, into a local — do not call it per use.** On
+    the freeze path each call allocates a concatenation, and there are two
+    uses (the `:202` virtualization read and the `bodyCfg` literal at
+    `:471`). `freeze` is computed at `:175`; derive `scrollID` immediately
+    below it and thread the local to both. Same rule for every other
+    suffix-derived site (see "Per-frame allocation" below).
+
+    Rejected: giving the freeze `bodyCfg` `ID: cfg.ID` to avoid the
+    branch. Scroll would still resolve (`FindLayoutByScrollID` gates on
+    `Scrollable`, and the freeze outer is not scrollable), but two shapes
+    in the same tree would share an id and `FindByID(cfg.ID)` becomes
+    ambiguous. Also rejected: restructuring the non-freeze path to add a
+    dedicated inner scroll container so both derive `cfg.ID + ":scroll"` —
+    correct, but it adds a layout node and is outside this spec's blast
+    radius.
+
+## Phase 0 — branch + execution protocol (do before any edit)
+
+Work happens on one feature branch, not on `main`. Confirm the base is
+current first (`git fetch && git status` — rebase if stale), then:
+
+```fish
+git switch -c idscroll-to-scrollable main
+```
+
+The work spans six repos. Phases 1–4 are go-gui on the branch above;
+phases 5–9 are the release and the sibling migration, each sibling on its
+own branch in its own repo.
+
+| phase | repo | scope | commit subject |
+|-------|------|-------|----------------|
+| 0 | go-gui | branch created, no code | *(no commit)* |
+| 1 | go-gui | PR A — delete `IDScrollContainer` | `gui: delete dead IDScrollContainer field and its tree walk` |
+| 2 | go-gui | PR B — `ViewFrame` benchmark | `gui: add BenchmarkViewFrame to catch Shape-size regressions` |
+| 3 | go-gui | PR C — `Scrollable` + string identity | `gui: replace IDScroll uint32 with Scrollable + string scroll identity` |
+| 4 | go-gui | tests / examples / docs / CHANGELOG | `docs: migrate IDScroll references to Scrollable` |
+| 5 | go-kite, go-charts | **dry run** — migrate against unreleased go-gui, prove clean, do not merge | *(no commit; branches held)* |
+| 6 | go-gui | release `v0.35.0` (PR A + PR C batched), await proxy | *(release skill)* |
+| 7 | go-kite | migration + `go.mod` bump, one PR | `deps: migrate to go-gui v0.35.0 Scrollable API` |
+| 8 | go-charts | migration + `go.mod` bump + CI `ref:` pins, one PR | `deps: migrate to go-gui v0.35.0 Scrollable API` |
+| 9 | go-edit, go-map, go-term | bump only, via `/sync-siblings` | *(sync-siblings drives)* |
+
+Rules for every phase:
+
+1. **Run the verification gate before committing** (`go build ./... &&
+   go vet ./... && golangci-lint run ./... && go test ./...`). A phase
+   with a red gate is not done; do not commit past it.
+2. **Commit at the end of the phase**, that phase only — no squashing
+   phases together, no work from the next phase riding along.
+3. **Pause after the commit and wait for review.** Do not start the next
+   phase until the reviewer says so. Report what was committed, the gate
+   result, and anything the phase surfaced that the spec did not predict.
+4. Do not push or open PRs without explicit permission.
+
+Phase 3 is the breaking one and is large; if it cannot reach a green gate
+as a single commit, stop and ask rather than committing a broken tree or
+inventing a sub-split the spec does not describe.
+
+### Why phase 5 (dry run) precedes phase 6 (release)
+
+**Module tags are immutable.** Once `v0.35.0` is pushed it cannot be
+corrected, only superseded — and a defect found while migrating go-kite or
+go-charts would burn a `v0.35.1` across all five siblings. go-kite is the
+canonical decision-11 case and go-charts owns its own `idScrollHash`
+helper, so those two repos are precisely where a spec defect surfaces.
+
+Phase 5 migrates both **against the unreleased go-gui**, using a local
+resolution rather than a published version:
+
+```fish
+go mod edit -replace github.com/go-gui-org/go-gui=../go-gui
+go build ./... && go test ./...   # NOT GOWORK=off — local resolution is the point
+```
+
+Do **not** commit the `replace`, do not merge, do not tag. The branches are
+held and reused by phases 7–8. If phase 5 fails, the fix goes into go-gui
+**before** the tag exists — that is the entire point.
+
+### Why migration and bump are one commit (phases 7–8)
+
+For go-kite and go-charts the two cannot be split, in either order:
+
+| order | result |
+|-------|--------|
+| bump first, migrate after | `go.mod` points at `v0.35.0`; `IDScroll` is gone; repo does not compile |
+| migrate first, bump after | migrated code needs `Scrollable`; `v0.34.x` does not have it; repo does not compile |
+
+So the bump rides in the migration PR. **`/sync-siblings` cannot drive
+these two** — its phase 3 is `go get` → `go mod tidy` → `go build`, with no
+step that edits call sites, and its red-CI triage has no category for "the
+upstream API changed." It would `go get` the breaking version and stall on
+compile errors. It drives phase 9 only, where the three zero-ref repos are
+pure bumps and that flow fits exactly.
+
+Phases 7–8 drop the phase-5 `replace`, add the real require, and gate with
+`GOWORK=off` (go-kite has a gitignored `go.work` that would otherwise mask
+the published-module resolution CI uses).
+
+### go-charts also pins go-gui in CI (easy to miss)
+
+`go-charts/.github/workflows/ci.yml:27` and `gallery.yml` check out go-gui
+at a **hardcoded `ref: v0.34.0`** and `go mod edit -replace` onto it. That
+pin overrides `go.mod`, so bumping the require alone leaves CI building the
+migrated source against a go-gui that still has `IDScroll` — red, with a
+confusing error. **Phase 8 must bump both `ref:` pins to `v0.35.0` in the
+same PR.**
+
+Consequence: go-charts CI cannot verify phase 5 (the workflow needs a real
+tag). Its dry run is local-only, which is why phase 5 exists rather than
+trusting CI to catch it. Note also that this pin means go-gui's `main`
+advancing does **not** red go-charts — do not expect that signal.
+
+## PR A (phase 1) — delete `IDScrollContainer` (independent, do first)
+
+Pure dead-code removal, no design dependency on the rest of this spec.
+
+- `gui/shape.go:70-72` — remove field + doc comment.
+- `gui/layout_position.go:193-205` — remove `layoutScrollContainers`
+  entirely. It walks the **whole tree every frame** and its only output
+  is the unread field.
+- `gui/layout_pipeline.go:31` — remove the call.
+- `gui/layout_test.go:334-359`
+  (`TestLayoutScrollContainersNearestScrollParent`) and
+  `gui/layout_position_test.go:190-201`
+  (`TestLayoutScrollContainersNoScroll`) — delete. Both only assert the
+  value the writer just wrote.
+
+Verified: zero readers in go-gui outside its own writer, zero across all
+five sibling repos. History — field dates from Phase 1 (`3edcac9`), last
+functional touch `985a7b4` (Slider). Orphaned legacy, not scaffolding.
+
+Effect: `Shape` 272 → 268, one full-tree pass removed from every frame.
+
+## PR B (phase 2) — `ViewFrame` benchmark (independent, non-breaking, do first)
+
+**Why this exists:** every current view-phase benchmark pre-builds its
+`Shape`s in the fixture outside the loop (`benchViewFlat` /
+`benchViewNested`, `gui/view_bench_test.go:28-70`) and only allocates
+`Layout{Shape: &v.shape}` pointers in the hot loop. The suite therefore
+**cannot see a `Shape`-size regression at all** — a flat `B/op` from those
+benches is an artifact, not evidence. Without this bench, PR C's "−8
+bytes" claim is unverifiable in CI.
+
+**Do not "fix" the existing benches instead.** They measure something
+real (layout generation over a stable tree); this is an additional bench,
+not a replacement.
+
+Add as `gui/view_frame_bench_test.go` and add `ViewFrame` to the
+`bench-gate` regex in the `Makefile` (target `bench-gate`, ~line 86):
+
+```go
+package gui
+
+import (
+	"strconv"
+	"testing"
+)
+
+// benchFrameIDs is hoisted so the bench measures view construction, not
+// strconv.
+var benchFrameIDs = func() []string {
+	ids := make([]string, 256)
+	for i := range ids {
+		ids[i] = "row-" + strconv.Itoa(i)
+	}
+	return ids
+}()
+
+// buildFrameView constructs a widget tree through the public factories,
+// exactly as a per-frame view function would. Unlike benchViewFlat, the
+// Shapes are allocated inside the loop, which is what makes this bench
+// sensitive to sizeof(Shape).
+func buildFrameView(rows int) View {
+	content := make([]View, rows)
+	for i := range rows {
+		content[i] = Row(ContainerCfg{
+			ID:      benchFrameIDs[i],
+			Sizing:  FillFit,
+			Padding: NoPadding,
+			Content: []View{
+				Column(ContainerCfg{Sizing: FillFit, Color: ColorTransparent}),
+				Column(ContainerCfg{Sizing: FillFit, Color: ColorTransparent}),
+			},
+		})
+	}
+	return Column(ContainerCfg{
+		ID:      "frame-root",
+		Sizing:  FillFill,
+		Content: content,
+	})
+}
+
+// BenchmarkViewFrame builds the view tree AND generates the layout each
+// iteration, which is what happens on every real frame.
+func BenchmarkViewFrame(b *testing.B) {
+	for _, rows := range []int{50, 200} {
+		b.Run("rows_"+strconv.Itoa(rows), func(b *testing.B) {
+			w := &Window{scratch: newScratchPools()}
+			w.windowWidth = 1200
+			w.windowHeight = 900
+			b.ReportAllocs()
+			for b.Loop() {
+				// Mirrors window_update.go: the frame-scoped arena is
+				// recycled once per frame.
+				w.scratch.resetViewPools()
+				view := buildFrameView(rows)
+				_ = generateViewLayout(view, w)
+			}
+		})
+	}
+}
+```
+
+Reference numbers on `main` @ `3c5dac7` (M5): `rows_50` ≈ 16.3 µs,
+54.34 KiB, **353 allocs**; `rows_200` ≈ 66.5 µs, 216.2 KiB, 1403 allocs.
+The nonzero alloc count is the point — if a future edit drives `B/op` to
+a constant, the bench has regressed into the same blind spot.
+
+Sanity check: with a `[24]byte` pad spiked into `Shape`, this bench
+reports `B/op` +8.7% and `allocs/op` unchanged. That is the signal it
+exists to catch.
+
+**Known blind spot — do not mistake this bench for full alloc coverage.**
+`buildFrameView` constructs no scrollable containers, so it cannot see the
+per-frame concatenation allocs PR C introduces on the suffix-derived
+scroll paths (see "Per-frame allocation" under PR C). It gates
+`sizeof(Shape)`, which is what it was built for. The scroll-path allocs
+are prevented by hoisting, by review — not by this gate. The fixture is
+left alone deliberately: the reference numbers above are measured, and
+editing the fixture to chase a second signal invalidates them.
+
+## PR C (phase 3) — `Scrollable` + string identity
+
+### `Shape` (`gui/shape.go`)
+- Remove `IDScroll uint32`; add `Scrollable bool` next to
+  `Focusable`/`FocusSkip` (**adjacent placement matters** — that is what
+  lets it land in existing padding for free).
+- Reuse existing `Shape.ID string` as scroll identity.
+- Update doc comments referencing `IDScroll`: `shape.go:65-66`,
+  `shape.go:153`.
+
+### Cfg classification — DO NOT swap mechanically
+
+The `IDScroll` fields are **not all the same thing**. A blind
+`IDScroll` → `Scrollable: true` pass will corrupt the reference and
+override cases into self-scrolling widgets. Each is classified below;
+the "action" column is the whole job.
+
+| Cfg | file:line | kind | action |
+|-----|-----------|------|--------|
+| `ContainerCfg` | `view_container.go:98` | **container** | `Scrollable bool`; identity = `cfg.ID` |
+| `ListBoxCfg` | `view_listbox.go:48` | **container** | `Scrollable bool`; container already sets `ID: cfg.ID` (`:118`, `:217`) alongside `Focusable` — same shape, both identities, different namespaces, no collision |
+| `TreeCfg` | `view_tree.go:36` | **container** | same as ListBox (`:238`) |
+| `TableCfg` | `view_table.go:70` | **container ×2** | ⚠️ two paths. Non-freeze: `outerCfg` already sets `ID: cfg.ID` (`:271`), gate at `:289` becomes `if cfg.Scrollable`. Freeze: see "Table's two paths" below — the spec's earlier draft missed it entirely |
+| `ComboboxCfg` | `view_combobox.go:46` | **container + identity handle** | dropdown already sets `ID: cfg.ID + ".dropdown"` (`:207`); `:219` becomes `Scrollable: cfg.Scrollable` — **not `true`**, see below. ⚠️ `cfg.IDScroll` is also the caller's scroll handle (decision 11) — key becomes `cfg.ID + ".dropdown"`, document it. Read at `:121` needs that string, not a bool |
+| `CommandPaletteCfg` | `view_command_palette.go:48` | **container, NO ID** | ⚠️ `IDScroll uint32` → `Scrollable bool`. The scroll `Column` at `:218` has **no `ID` field at all** — must add `ID: cfg.ID + ":scroll"`. `CommandPaletteShow` (`:234`) and `CommandPaletteToggle` (`:261`) also take `idScroll uint32`; remove the parameter, derive `id + ":scroll"` internally for the scroll-reset on show (`:243`). **Behavior change:** today Show resets scroll only when `idScroll > 0`; after the param is gone it **always** resets `id+":scroll"` to 0 on show — intentional. |
+| `InputCfg` | `view_input.go:78` | **container** (multiline only) | gate at `:152` is `cfg.Mode == InputMultiline && cfg.IDScroll > 0`; becomes `&& cfg.Scrollable`. Threads to `inputHandlerCfg` (`:134`, `:222`) |
+| `inputHandlerCfg` | `view_input.go:284` | **internal plumb** | unexported; thread `string` through `:546`, `:644` (`inputScrollCursorIntoView`) |
+| `DataGridCfg` | `datagrid/view_data_grid.go:238` | **identity override** | ⚠️ **not** a bool — **delete the field** (decision 9). See below. |
+| `ScrollbarCfg` | `view_scrollbar.go:23` | **reference** | ⚠️ rename to `ScrollID string` and tag with `` `gui:"required"` `` (decision 10) — points at *another* container's state. Never becomes a bool. |
+| `dragReorderStartCfg` | `drag_reorder.go:210` | **reference** | ⚠️ unexported; `ScrollID string` (decision 10). Never a bool. |
+| `inspectorNodeProps` | `inspector.go:64` | **display copy** | ⚠️ unexported; holds the *inspected* shape's id for rendering (`:494`), not an opt-in |
+
+**`appendScrollbar`** (`view_container.go:436`) is the bridge that wires the
+container's ID into the scrollbar's `IDScroll` field. Post-migration, its
+`idScroll uint32` parameter becomes `id string`, and struct-literal lines
+`:443` and `:448` change `IDScroll:` → `ScrollID:` (decision 10). Called
+from `container()` at `:387-390`, which changes `cfg.IDScroll` → `cfg.ID`.
+
+**`DataGridCfg.IDScroll` is a third category.** Today
+(`view_data_grid_helpers.go:124-127`):
+
+```go
+func dataGridScrollID(cfg *DataGridCfg) uint32 {
+    if cfg.IDScroll > 0 { return cfg.IDScroll }   // user override
+    return gg.FnvSum32(cfg.ID + ":scroll")        // derived default
+}
+```
+
+It is an optional *identity override*, not an opt-in flag. Per decision
+9 the field is **deleted** and the id always derived:
+
+```go
+func dataGridScrollID(cfg *DataGridCfg) string {
+    return cfg.ID + ":scroll"
+}
+```
+
+That is already the exact string the container's `ID` carries at
+`view_data_grid.go:584`, so the function may be inlinable at its call
+sites — check whether it still earns its keep. `Scrollable: true` goes on
+that same container (`:585`, replacing `IDScroll: scrollID`).
+
+### Per-frame allocation — the migration is not alloc-neutral
+
+An earlier draft claimed this migration "only removes per-frame work."
+**Wrong.** Every `cfg.ID + ":scroll"` / `cfg.ID + ".dropdown"` is a
+string concatenation, i.e. a heap allocation, evaluated in the view phase
+— the one phase that is not already zero-alloc. The ledger per scrollable
+widget per frame:
+
+| site | today | after | delta |
+|------|-------|-------|-------|
+| DataGrid | concat (`ID:`) + concat-and-hash (`IDScroll:`) | one concat, reused | **−1** |
+| Select / Combobox dropdown | concat (`ID:`) + concat-and-hash / passthrough | one concat, reused | **−1 / 0** |
+| CommandPalette | none (the scroll `Column` has **no `ID` today**) | one concat | **+1** |
+| Table, freeze | none | one concat, if hoisted; **two if not** | **+1** |
+| Table, non-freeze | none | none (`cfg.ID` used directly) | 0 |
+| Container / ListBox / Tree / Input | none | none (`cfg.ID` used directly) | 0 |
+
+Net is close to zero and none of it is on a hot path, but the `+1` rows
+are real and the `+2` row is avoidable. **Rule: derive each scroll id once
+per view call into a local, then thread the local.** Never call a
+derivation helper (`tableScrollID`, `dataGridScrollID`) at two sites in
+the same view — that doubles the alloc for nothing. The two-call trap is
+specifically Table's freeze path (decision 12) and CommandPalette, where
+`Show`/`Toggle` derive `id + ":scroll"` independently of the container.
+
+`BenchmarkViewFrame` (PR B) does **not** cover this — it builds no
+scrollable containers. This is a review obligation, not a gated one.
+
+### Table's two paths (`gui/view_table.go`) — easy to miss
+
+`Table` builds two different trees, and **the scroll container is a
+different node in each**:
+
+| | non-freeze (`:271-300`) | freeze (`tableFreezeLayout`, `:440-500`) |
+|---|---|---|
+| outer `Column` | `ID: cfg.ID`, **carries `IDScroll`** (`:289-290`) | `ID: cfg.ID` (`:481`), **not scrollable** |
+| inner `bodyCfg` | — | **carries `IDScroll`** (`:471`), **no `ID` field at all** |
+
+The freeze path is therefore the same ⚠️ case the spec flags for
+`CommandPaletteCfg`: the scrollable container has no identity to reuse and
+one must be invented. Per decision 12 it becomes `ID: cfg.ID + ":scroll"`.
+
+**The trap is `:202`, not the containers.** Virtualization reads the key
+once, for both paths:
+
+```go
+scrollY, _ := w.scrollY().Get(cfg.IDScroll)  // :202, path-independent today
+```
+
+That works today because both paths pass the same `uint32`. Once identity
+is derived from where the container sits, it is no longer path-independent
+— `:202` must read `tableScrollID(&cfg, freeze)` (decision 12) or the
+freeze path virtualizes against an empty key and renders the wrong rows.
+`freeze` is computed at `:175`, above the read, so it is in scope.
+
+Also update `:175`, `:196`, `:290` (gates) and `:471` (`bodyCfg` literal).
+
+### Compile break vs silent break — read this before the lists
+
+Deleting `IDScroll` makes **every** reference to it a compile error. The
+gate and plumbing lists below are therefore a *convenience for estimating
+the diff*, not a safety net, and they are known to be incomplete (e.g.
+`view_container.go:354`, `:387`; `view_table.go:175,196,202,471`;
+`view_listbox.go:187,300`; `view_tree.go:181,189`; `view_input.go:185`).
+A missed site does not ship — it fails to build. Regenerate at land time
+rather than trusting the lists.
+
+**The sites that matter are the ones that still compile after a
+mechanical swap.** Two shapes:
+
+1. **Bool flip next to a key read.** `if cfg.IDScroll > 0 { x, _ =
+   w.scrollY().Get(cfg.IDScroll) }` → the gate becomes `cfg.Scrollable`
+   *and* the `Get` needs the derived string. Swapping only the gate leaves
+   a compile error, but swapping both without checking **which** string
+   that container carries compiles and reads the wrong key.
+   Sites: `view_combobox.go:120-121` (`cfg.ID + ".dropdown"`),
+   `view_command_palette.go:120-121` (`cfg.ID + ":scroll"`),
+   `view_table.go:202` (branches, decision 12),
+   `view_listbox.go:300` (`cfg.ID`).
+2. **Reference/override Cfgs** (`ScrollbarCfg`, `dragReorderStartCfg`,
+   `inspectorNodeProps`) — already covered in the classification table.
+3. **Passthrough opt-in mistaken for an unconditional one.** Two dropdown
+   sites look identical and are not:
+
+   | site | today | after |
+   |------|-------|-------|
+   | `view_select.go:143` | `IDScroll: idScroll`, hashed unconditionally at `:68` — Select's dropdown is *always* scrollable | `Scrollable: true` ✅ |
+   | `view_combobox.go:219` | `IDScroll: cfg.IDScroll` — **passthrough**, scroll is the caller's opt-in | `Scrollable: cfg.Scrollable` ✅ |
+
+   Writing `Scrollable: true` at `view_combobox.go:219` compiles, and
+   makes every dropdown scrollable regardless of what the caller asked
+   for — while the read at `:121` is gated on `cfg.Scrollable`. Gate and
+   container then disagree: a combobox that did not opt in gets a
+   scrollbar injected and scroll dispatch, but virtualizes against a key
+   nothing reads. Copy the gate expression; do not assume a literal.
+
+### Gates: `IDScroll > 0` → `Scrollable` (bool gate sites)
+
+`event_handlers.go:103,343`; `gesture.go:528`; `layout_overflow.go:10`;
+`layout_sizing.go:123,433`; `layout_position.go:11,68,236`;
+`scroll.go:112,190,214,243`; `scroll_smooth.go:140-141`;
+`view_container.go:308,384`; `inspector.go:432`;
+`view_combobox.go:121`; `view_command_palette.go:120`;
+`view_listbox.go:144,293`; `view_tree.go:175`; `view_input.go:152`;
+`view_table.go:175,196,289`.
+
+Also in `view_container.go`, not gates but same file:
+- `:354` — `IDScroll: cfg.IDScroll` inside `buildContainerShape`, the
+  literal that puts the value on the `Shape`. Becomes
+  `Scrollable: cfg.Scrollable`.
+- `:387` — `deriveContainerA11YRole` maps `IDScroll > 0` →
+  `AccessRoleScrollArea`. Becomes `c.Scrollable`.
+
+**Easy to miss** (parent-walk lookups that read `Shape.IDScroll` off an
+ancestor, not a Cfg):
+- `view_rtf_select.go:84-85`
+- `view_text_select.go:101-102`
+- `scroll.go:112,120` (`scrollParent.Shape.IDScroll`)
+- `scroll.go:243-244`
+
+### Typed plumbing: `uint32` key → `string` (easy to miss)
+
+Bool gates alone are not enough. These hold or thread the scroll key
+type and will not compile until retargeted — regenerate with
+`rg -n 'IDScroll|idScroll' --type go gui/` at land time:
+
+| location | what changes |
+|----------|----------------|
+| `window.go:183-184` | `scrollXMap` / `scrollYMap` → `*BoundedMap[string, float32]` |
+| `state_registry.go:77-110` | `ScrollX`/`ScrollY`/`scrollXRead`/`scrollYRead` signatures |
+| `scroll_smooth.go:32,42` | `scrollSmoothEntry.idScroll`, `scrollApply.idScroll` → `string` |
+| `scroll_smooth.go:115-207` | `entryFor` / `findEntry` / `scrollSmoothCancel` params |
+| `view_scrollbar.go:288,299` | `offsetMouseChangeX/Y` map + `idScroll` params |
+| `drag_reorder.go:135,210,527` | cfg + runtime state + `dragReorderAutoScroll` |
+| `view_listbox.go:118,217,537` | `IDScroll:` literals / locals → `Scrollable` + `ID` |
+| `view_tree.go:238`; `view_tree_rows.go:254` | same |
+| `view_combobox.go:219`; `view_command_palette.go:218` | same |
+| `datagrid/view_data_grid.go:585` + helpers | override deleted; string identity |
+
+### Window API (`gui/scroll.go`, `gui/state_registry.go`, `gui/layout_query.go`)
+
+All `idScroll uint32` → `id string`: `ScrollHorizontalBy/To/ToPct/Pct`
+(`:260,277,292,309`), `ScrollVerticalBy/To/ToPct/Pct`
+(`:324,341,356,373`), `ScrollX()`/`ScrollY()` →
+`*BoundedMap[string, float32]` (`state_registry.go:77,84`),
+`FindLayoutByIDScroll` → `FindLayoutByScrollID(layout, id string)`
+(decision 4; predicate gates on `Scrollable`),
+`findScrollLayout` (`scroll.go:7`), `inputScrollCursorIntoView`
+(`scroll.go:45`, guard `idScroll == 0` → `id == ""`).
+
+`ScrollToView(id string)` (`scroll.go:235`) already takes a string —
+unaffected.
+
+**`nsScrollX` / `nsScrollY` need no change — do not touch them.** They are
+namespace *name* strings (`state_registry.go:163-164`), not keys, and the
+scroll maps are not StateMap namespaces at all: `ScrollX()`/`ScrollY()`
+return dedicated `w.scrollXMap`/`scrollYMap` fields via `lazyBoundedMap`
+(`state_registry.go:63-90`), which never registers into
+`registry.maps`. There is nothing to rekey.
+
+Consequence worth knowing but **out of scope**: `nsScrollX`/`nsScrollY`
+are in time-travel's snapshotable whitelist (`time_travel.go:58-59`), but
+`snapshotWhitelistedNamespaces` walks `registry.maps` — which the scroll
+maps are absent from. **Scroll offsets are therefore not captured by
+time-travel today.** Pre-existing bug, unrelated to this migration and
+unchanged by it (the whitelist stays just as inert after the retype).
+File it separately; do not fix it here.
+
+### Hash derivations to delete
+- `datagrid/view_data_grid_helpers.go:127` — `FnvSum32(cfg.ID + ":scroll")`
+- `view_select.go:68` — `FnvSum32(cfg.ID + ".dropdown")` (feeds `:143`)
+- `view_theme_picker.go:64` — `FnvSum32(lbID)`
+
+Then check `FnvSum32` (`gui/fnv.go`) for remaining callers — #76 removed
+the focus ones. If none remain it is deletable, **but it is exported
+API**: grep all five siblings first.
+
+### Inspector specifics (`gui/inspector.go`)
+- `:12` — `inspectorIDScrollPanel = uint32(0xFFF00001)` magic sentinel →
+  string const, e.g. `inspectorScrollPanel = "gui:inspector:panel"`.
+  Consumed at `:156`, `:676`.
+- `:435` — `strconv.Itoa(int(p.IDScroll))` displays the id; with a string
+  it is printed directly. Compile break, trivial fix.
+- `:494` — `IDScroll: shape.IDScroll` copies the inspected shape's id for
+  display. Becomes the string.
+
+## Tests / examples / docs (phase 4, go-gui)
+
+- 21 test files reference `IDScroll` → `Scrollable: true, ID: "x"`.
+  Regenerate the list with:
+  `grep -rl IDScroll --include='*_test.go' gui/`
+- 14 example files: `benchmark`, `rtf`, `markdown`, `gradient_demo`,
+  `listbox`, `particles`, `command_demo`, `scroll_demo`,
+  `multiline_input`, `showcase/{catalog,detail,demo_layout,
+  demo_selection,demo_data}`. Meaningful IDs per decision 5.
+- **Doc comments on every `Scrollable` field must state that Cfg's derived
+  scroll key** (decision 11 table). This is a deliverable, not a nicety —
+  it is the only place the post-migration scripting contract is written
+  down.
+- Docs: `CHANGELOG.md`, `docs/commands.md`, 10
+  `examples/showcase/docs/widget_*.md` (`listbox`, `table`,
+  `command_palette`, `scrollbar`, `row`, `combobox`, `gesture`, `column`,
+  `tree`, `data_grid`), plus `examples/showcase/docs/commands.md` — which
+  is **not** `widget_`-prefixed and is a different file from
+  `docs/commands.md`. Both need updating. 13 files total; regenerate with
+  `rg -l IDScroll --glob '*.md'`.
+- `.claude/skills/{widget,new-example}` scaffolds if they mention
+  `IDScroll`.
+
+## Release (phase 6)
+
+Breaking → minor bump `v0.35.0`, CHANGELOG entry. **Batch PR A and PR C
+into the same release** so siblings migrate once. PR B is non-breaking and
+lands independently.
+
+**Gated on phase 5.** Do not tag until the go-kite and go-charts dry runs
+build clean against the unreleased go-gui — the tag is immutable, and those
+two repos are where a spec defect surfaces. See Phase 0.
+
+CHANGELOG must call out **two** breaking changes, not one: the opt-in
+retype (`IDScroll uint32` → `Scrollable bool`) *and* the loss of the
+caller-supplied scroll handle across all eight Cfgs (decision 11), with
+the derived-key table so consumers can fix their `ScrollVerticalTo` calls
+without reading go-gui's source.
+
+## Sibling repos (dependency order)
+
+Zero-ref repos: bump → gate → ship, via `/sync-siblings` (phase 9).
+go-kite and go-charts: migrate **+** bump in one PR (phases 7–8) — see
+"Why migration and bump are one commit" under Phase 0. `/sync-siblings`
+does not migrate API call sites and cannot drive those two.
+
+1. **go-edit** — 0 refs. Bump only.
+2. **go-map** — 0 refs. Bump only.
+3. **go-term** — 0 refs. Bump only.
+4. **go-kite** — 2 refs, `views.go:116` (`IDScroll: timelineScrollID`) and
+   `:124` (`ScrollVerticalTo(timelineScrollID, 0)`).
+   Mechanically small, but it is the **canonical decision-11 case**, not a
+   rename: the same const is both the opt-in and the scroll handle. The
+   container must acquire `ID: timelineScrollID` (a string) with
+   `Scrollable: true`, and the `ScrollVerticalTo` call must pass that same
+   string. `RequireScrollID` catches the container if its `ID` is left
+   empty; it does **not** catch an `ID` that simply disagrees with what
+   `ScrollVerticalTo` passes. That case compiles and scrolls nothing.
+5. **go-charts** — regenerate counts at land (`rg -n 'IDScroll|idScrollHash|ScrollVertical|ScrollHorizontal|scrollCatalog|scrollDetail'`).
+   `chart/data_table.go:14,67` has its own `idScrollHash(id)` helper
+   feeding `gui.TableCfg.IDScroll`; **delete the helper**, pass the
+   string. `examples/showcase` uses `scrollCatalog`/`scrollDetail`
+   consts across `catalog.go:29,94-96,237-238`, `detail.go:11,32`,
+   `main.go:9-10,51-56`.
+
+   ⚠️ **Also a CI change, not just source.**
+   `.github/workflows/ci.yml:27` and `gallery.yml` hardcode
+   `ref: v0.34.0` for the go-gui checkout they `replace` onto. Both pins
+   → `v0.35.0` in the same PR, or CI builds migrated source against the
+   old API. The pin overrides `go.mod`, so the require bump alone does
+   not fix it.
+## Verification gate (every repo)
+
+```
+go build ./... && go vet ./... && golangci-lint run ./... && go test ./...
+```
+
+Plus `make bench-gate` on go-gui, which after PR B can see the `Shape`
+delta. Expect `B/op` on `BenchmarkViewFrame` to *drop* ~3% from PR A+C
+(272 → 264). If it does not move at all, the bench is not wired in.
+
+## Out of scope
+
+- **`BoundedMap[uint32, V]` generic penalty** —
+  [#77](https://github.com/go-gui-org/go-gui/issues/77). `Get` is ~4.5×
+  slower than a raw `map[uint32]V` (10.70 ns vs 2.37 ns) while the string
+  instantiation pays nothing. Suspected GC-shape stenciling dropping the
+  lookup off the runtime's `fast32` path — **effect measured, mechanism
+  unverified**. Affects every uint32-keyed namespace.
+
+  **Not a prerequisite. #77 does not block this spec, and this spec does
+  not block #77.** Do not chase it inside this work.
+
+  Read the `Get` improvement correctly: PR C does not *fix* this bug, it
+  *sidesteps* it by keying with a string. If #77 is fixed first, uint32
+  reads drop to ~2.4 ns and string keys become the slower choice by
+  ~2.8 ns per read — a handful of containers × 2.8 ns per frame against a
+  4–5 ms budget, i.e. irrelevant. The size (272 → 264) and consistency
+  arguments carry this spec on their own; **PR C must not be justified on
+  the `Get` number.**
+- Enum reorder of `ScrollMode` to add a `ScrollNone` zero value.
+
+## Unresolved
+
+None. Decisions 4, 7, 8, 9, and 10 incorporate the first 2026-07-15
+review pass (rename, RequireScrollID wiring clarifications,
+typed-plumbing checklist, requiredid caveat). Decisions 11 and 12, the
+"Table's two paths" and "Compile break vs silent break" subsections, and
+the go-kite note incorporate the second 2026-07-15 pass, which verified
+the spec's claims against `main` @ `3c5dac7`:
+
+- `IDScrollContainer` has zero readers (sole writer `layout_position.go:200`,
+  plus the two named tests). PR A confirmed.
+- `RequireFocusID` has zero call sites. Decision 7's framing confirmed.
+- `Shape` is **272** bytes today, and adding `Scrollable bool` next to
+  `FocusSkip` is **free** (measured 272 → 272 on a spike). The
+  padding-absorption claim holds; the net 264 follows from removing 8
+  bytes of `uint32`.
+- `FnvSum32` retains only test callers once the three production sites go
+  — deletable pending the sibling grep, as written.
+
+A third 2026-07-15 pass re-verified against the same base and corrected
+four things the second pass got wrong or oversold:
+
+- **`IDScroll` is not a StateMap key.** The motivation said it was and the
+  typed-plumbing list carried a "rekey `nsScrollX`/`nsScrollY`" item.
+  Offsets live in dedicated `w.scrollXMap`/`scrollYMap`; the consts are
+  inert. Item deleted. Surfaced a real pre-existing bug — time-travel does
+  not snapshot scroll offsets — explicitly left out of scope.
+- **Combobox.** The classification table said "just `Scrollable: true`";
+  `view_combobox.go:219` is a passthrough (`IDScroll: cfg.IDScroll`), so
+  that literal would have silently forced scroll on every dropdown. Now
+  `Scrollable: cfg.Scrollable`, with the Select contrast written out as a
+  third silent-break shape.
+- **Alloc neutrality.** "This migration only removes per-frame work" was
+  false: CommandPalette and Table-freeze each gain a concat. New
+  "Per-frame allocation" subsection; decision 12 now mandates hoisting;
+  PR B's blind spot documented rather than papered over.
+- **`RequireScrollID`** was framed as catching "every missed site". It
+  catches one: a bare `ContainerCfg` with `Scrollable: true` and no `ID`.
+  Every other scroll container either derives a never-empty suffix id or
+  already calls `RequireID`. Still worth wiring; no longer oversold.
+- Also: `Window.ScrollX()`/`ScrollY()` added to the CHANGELOG's breaking
+  list as a third item; decision 4 flagged as a behavior change (today's
+  predicate has no opt-in gate and no zero guard); go-kite ref count
+  corrected 3 → 2; doc file count corrected 11 → 13 with `commands.md`
+  miscategorization fixed.
+
+Measured this pass: `sizeof(Shape) == 272` on `main` @ `3c5dac7`,
+confirming the 272 → 264 claim's starting point.
+
+Nothing in this spec requires a judgement call the implementer has to
+make alone — if something here looks underspecified, that is a defect in
+the spec, not an invitation to improvise. Decision 12 exists because the
+first draft *was* underspecified on Table.
+
+## Open risks
+
+- Scroll identity must be unique per frame among scroll containers;
+  duplicates share offsets. **Accepted, undetected** (decision 8) —
+  usually obvious when scrolling; weaker under virtualization, still
+  not worth a per-frame seen-set.
+- Containers opting in with `IDScroll: 1` and no `ID` must acquire one.
+  Wire `RequireScrollID` in **early** — it is the safety net that turns
+  every missed site in this migration into a panic at first render rather
+  than a silent no-scroll.
+- `ScrollbarCfg` / `dragReorderStartCfg` / `inspectorNodeProps` are
+  references, not opt-ins. A mechanical pass corrupts them.
+- Typed key holders (`scroll_smooth` entries, `window` maps,
+  `view_scrollbar` helpers, drag-reorder runtime state) are easy to miss
+  if the implementer only greps `IDScroll > 0` — use the typed-plumbing
+  table in PR C. Missing one is a **build failure**, not a silent bug;
+  see "Compile break vs silent break".
+- **The silent failures are gate-flips next to a key read** — the four
+  sites listed in "Compile break vs silent break". A swap that satisfies
+  the compiler while reading a key nothing writes produces a container
+  that renders but never scrolls, or virtualizes against offset 0.
+- **Table's freeze path** (`tableFreezeLayout`) puts the scroll container
+  somewhere different than the non-freeze path does, and `:202` reads the
+  key for both. Decision 12 branches; forgetting the branch mis-virtualizes
+  frozen-header tables specifically, which is the configuration least
+  likely to be in a smoke test.
+- **Consumers lose the caller-supplied scroll handle** (decision 11). The
+  derived key is recoverable from the docs, but a sibling that migrates
+  the Cfg field and forgets its `ScrollVerticalTo` call site compiles and
+  silently stops scrolling. go-kite is the known instance; regrep the
+  others for `ScrollVertical|ScrollHorizontal` at land time, not just for
+  `IDScroll`.
+- `CommandPaletteCfg`'s scroll container has no `ID` today and needs one
+  invented (`cfg.ID + ":scroll"`); Show always resets that key after the
+  API shrink.
+- `allocs/op` on `BenchmarkViewFrame` (PR B) must not rise after PR C.
+  Nothing in this migration touches the paths that bench covers, so any
+  movement there is a mistake regardless of where it came from. Note this
+  is a **weaker** gate than it looks: the bench builds no scrollable
+  containers, and the migration is **not** alloc-neutral on the scroll
+  paths it cannot see (+1/frame for CommandPalette and Table-freeze, +2 if
+  the derivation is called twice). See "Per-frame allocation" under PR C —
+  those are caught by hoisting and review, not by `bench-gate`.

--- a/docs/specs/macos-native-backend.md
+++ b/docs/specs/macos-native-backend.md
@@ -1,0 +1,526 @@
+# Native macOS backend (SDL2 elimination)
+
+## Summary
+
+Replace SDL2's window creation, event loop, clipboard, cursors, and IME in the
+macOS Metal backend with direct Cocoa/AppKit calls. The existing Metal rendering
+pipeline (`metal_darwin.m`, ~800 lines) is unchanged — it already takes a raw
+`CAMetalLayer*` and has zero SDL dependency. All existing native feature
+bridges (file drops, scroll phases, accessibility, dock icon, menus, print
+dialog, spellcheck) are already SDL-free — they use system frameworks directly.
+
+Net result: zero SDL on macOS. `go build` works with no Homebrew/pkg-config/MSYS2.
+
+## Motivation
+
+SDL2 is the #1 friction point for new users (issue #10). It requires:
+
+| Platform | SDL2 install |
+|---|---|
+| macOS | `brew install sdl2` |
+| Windows | MSYS2/MinGW (recently pinned to stable release, v0.27.1) |
+| Linux | `apt install libsdl2-dev` or equivalent |
+
+The shim approach (sdl3-shim.md) eliminates MSYS2 by swapping to zig-built
+SDL3, but keeps a C build-toolchain dependency (zig). A native macOS backend
+eliminates ALL build-toolchain C dependencies on macOS. System framework CGo
+(Metal, AppKit, CoreFoundation) requires zero installs — they ship with macOS.
+
+SDL3 is the current SDL stable, so the shim is the right answer for Linux and
+eventually Windows. But for macOS specifically, the Metal backend already does
+native rendering — SDL is only providing window + events + clipboard + cursors
++ IME. All of these have direct AppKit equivalents with smaller API surfaces.
+
+## Architecture
+
+```
+Before:                              After:
+┌──────────────┐                    ┌──────────────┐
+│  backend.go  │                    │  backend.go  │
+│  events.go   │                    │  events.go   │  (rewritten)
+│  (SDL2)      │                    │  (NSEvent)   │
+├──────────────┤                    ├──────────────┤
+│  SDL window  │                    │  NSWindow +  │
+│  + Metal     │                    │  CAMetalLayer│
+│  view        │                    │              │
+├──────────────┤                    ├──────────────┤
+│metal_darwin.m│ ← (unchanged)      │metal_darwin.m│ ← (unchanged)
+│  GPU render  │                    │  GPU render  │
+├──────────────┤                    ├──────────────┤
+│  filedrop.m  │ ← (simplified)     │  filedrop.m  │ ← (no SDL reach-through)
+│  scroll.m    │ ← (simplified)     │  scroll.m    │ ← (no SDL reach-through)
+│  a11y.m      │ ← (simplified)     │  a11y.m      │ ← (no SDL reach-through)
+│  icon.m      │ ← (unchanged)      │  icon.m      │ ← (unchanged)
+└──────────────┘                    └──────────────┘
+```
+
+## What SDL provides today (and its native replacement)
+
+| Capability | SDL2 API | Cocoa replacement | Lines |
+|---|---|---|---|
+| Window creation | `sdl.CreateWindow(WINDOW_METAL)` | `NSWindow` + `MetalContentView` with `CAMetalLayer` | ~150 |
+| Window title | `win.SetTitle()` | `[nsWindow setTitle:]` | 1 line |
+| Window size | `win.GetSize()` | `[nsWindow frame].size` | 1 line |
+| Event pump | `sdl.WaitEventTimeout` / `sdl.PollEvent` | `[NSApp nextEventMatchingMask:…]` | ~80 |
+| Mouse events | `sdl.MouseButtonEvent`, etc. | `NSEventTypeLeftMouseDown`, etc. | ~100 |
+| Keyboard events | `sdl.KeyboardEvent` | `NSEventTypeKeyDown` + key code mapping | ~80 |
+| Scroll events | `sdl.MouseWheelEvent` | `NSEventTypeScrollWheel` | ~30 |
+| Window events | `sdl.WindowEvent` (resize, focus, close) | `NSWindowDelegate` callbacks | ~50 |
+| Touch events | `sdl.FingerEvent` | `NSTouch` via touch tracking | ~60 |
+| Text input | `sdl.TextInputEvent` / `sdl.TextEditingEvent` | `NSTextInputClient` protocol | ~120 |
+| Clipboard get | `sdl.GetClipboardText()` | `[NSPasteboard generalPasteboard] stringForType:` | ~5 |
+| Clipboard set | `sdl.SetClipboardText()` | `[NSPasteboard generalPasteboard] clearContents` + `setString:` | ~8 |
+| Cursors | `[11]*sdl.Cursor` with `CreateSystemCursor` | `[NSCursor arrowCursor]` etc. | ~15 |
+| Live resize | `sdl.AddEventWatchFunc` + `WINDOWEVENT_SIZE_CHANGED` | `NSWindowDelegate windowDidResize:` | ~20 |
+| App quit | `sdl.QuitEvent` | `NSApplicationDelegate applicationShouldTerminate:` | ~8 |
+| Wake from timer | `sdl.RegisterEvents` + `sdl.PushEvent(UserEvent)` | `dispatch_async(dispatch_get_main_queue(), …)` or CFRunLoop source | ~15 |
+
+## Files changed
+
+### New files
+
+```
+gui/backend/metal/metal_window.h       (~40 lines)
+gui/backend/metal/metal_window.m       (~200 lines)
+```
+
+`metal_window.h` exposes:
+
+```c
+// Opaque handle to a GoGuiWindow + its CAMetalLayer.
+typedef void* GoGuiNSWindow;
+
+// Create a window. Returns nil on failure.
+GoGuiNSWindow metalWindowCreate(const char *title, int width, int height,
+                                int fixedSize);
+
+// Window properties.
+void metalWindowSetTitle(GoGuiNSWindow w, const char *title);
+void metalWindowGetSize(GoGuiNSWindow w, int *width, int *height);
+void metalWindowGetFramebufferSize(GoGuiNSWindow w, int *w, int *h);
+
+// Metal layer accessor for the rendering pipeline.
+void *metalWindowGetLayer(GoGuiNSWindow w);
+
+// Window ID for multi-window tracking (matches gui.App registration).
+unsigned int metalWindowGetID(GoGuiNSWindow w);
+
+// Close and destroy.
+void metalWindowDestroy(GoGuiNSWindow w);
+```
+
+`metal_window.m` implements:
+- `GoGuiNSWindow` → wraps `NSWindow*` + `MetalContentView*`
+- `MetalContentView` → `NSView` subclass with `CAMetalLayer` backing, implements
+  `NSTextInputClient` for IME
+- Window delegate for resize, focus, close callbacks
+
+### Modified files
+
+```
+gui/backend/metal/backend.go           (~300 changed, ~200 deleted)
+gui/backend/metal/events.go            (~200 new, ~250 deleted)
+gui/backend/metal/native_platform.go   (~50 new, ~20 deleted)
+gui/backend/metal/text.go              (~15 new IME methods)
+gui/backend/metal/a11y_darwin.h        (~4 lines: SDL_Window → GoGuiNSWindow)
+gui/backend/metal/a11y_darwin.m        (~10 lines: drop SDL_GetWindowWMInfo)
+gui/backend/metal/filedrop_darwin.h    (~4 lines: SDL_Window → GoGuiNSWindow)
+gui/backend/metal/filedrop_darwin.m    (~10 lines: drop SDL_GetWindowWMInfo)
+gui/backend/metal/scroll_phase_darwin.h (~4 lines: SDL_Window → GoGuiNSWindow)
+gui/backend/metal/scroll_phase_darwin.m (~10 lines: drop SDL_GetWindowWMInfo)
+```
+
+### Unchanged files
+
+```
+gui/backend/metal/metal_darwin.{h,m}   — GPU rendering (no SDL used)
+gui/backend/metal/icon.go              — dock icon (no SDL used)
+gui/backend/metal/icon_darwin.m        — dock icon (pure Cocoa)
+gui/backend/metal/draw.go             — render command dispatch
+gui/backend/metal/textures.go         — texture cache
+gui/backend/metal/rotation.go         — screen rotation
+```
+
+### Deleted files
+
+None. The Metal backend is gated by `//go:build darwin && !ios`. All SDL2 and
+GL backend files continue to serve Linux and Windows. `gui/compat_mingw.go`
+stays — it's gated `//go:build windows && cgo` and remains needed for SDL2 on
+Windows.
+
+### Shared files (no impact)
+
+No shared Go files are modified. The changes are entirely within
+`gui/backend/metal/` (Darwin-only build tag) plus the two new `.h/.m` files.
+Linux and Windows compilation paths are untouched — `go build` on Linux
+continues to select the SDL2 or GL backend as before.
+
+## Design details
+
+### 1. Event loop
+
+The SDL `WaitEventTimeout` / `PollEvent` pattern is replaced with manual NSEvent
+polling. This mirrors what SDL does internally on macOS and gives Go full control
+over the loop timing.
+
+```go
+// backend.go
+func (b *Backend) Run(w *gui.Window) {
+    // ... setup ...
+
+    for running {
+        for ev := pollNSEvent(waitMs); ev != nil; ev = pollNSEvent(0) {
+            mapped, cont := mapNSEvent(ev, b)
+            if !cont {
+                running = false
+                break
+            }
+            if mapped.Type != gui.EventInvalid {
+                w.EventFn(mapped)
+            }
+        }
+        // frame + render (unchanged from current)
+    }
+}
+```
+
+`pollNSEvent` in the `.m` file delegates to `[NSApp nextEventMatchingMask:…]`.
+Events are sent to `[NSApp sendEvent:]` first so AppKit handles window
+management (close button, miniaturize, key window, main window). Go callbacks
+fire from the window delegate during `sendEvent:`.
+
+The wake mechanism replaces `sdl.PushEvent(&sdl.UserEvent{…})` with
+`dispatch_async(dispatch_get_main_queue(), ^{ [NSApp postEvent:… atStart:NO] })`
+— or more simply, a CFRunLoop source that Go signals.
+
+### 2. Event mapping
+
+`events.go` is rewritten. The mapping NSEvent → `gui.Event` is simpler than the
+SDL path because NSEvent already carries more structured data (e.g., button
+number, click count, pressure, precise scrolling deltas):
+
+```go
+func mapNSEvent(event C.NSEventRef, b *Backend) (gui.Event, bool) {
+    switch C.nsEventType(event) {
+    case C.NSEventTypeLeftMouseDown:
+        return gui.Event{
+            Type:        gui.EventMouseDown,
+            MouseButton: gui.MouseButtonLeft,
+            MouseX:      float32(C.nsEventX(event)),
+            MouseY:      float32(C.nsEventY(event)),
+            Modifiers:   mapNSModifiers(C.nsEventModifiers(event)),
+        }, true
+    // ... etc
+    }
+}
+```
+
+A thin C layer in `metal_window.m` extracts fields from NSEvent (location in
+window, button number, modifier flags, etc.) as simple C functions callable
+from cgo. This avoids exposing NSEvent's ObjC interface to Go.
+
+Key mappings:
+
+| NSEvent | gui.Event |
+|---|---|
+| `NSEventTypeLeftMouseDown/Up` | `EventMouseDown/Up` with `MouseButtonLeft` |
+| `NSEventTypeRightMouseDown/Up` | `EventMouseDown/Up` with `MouseButtonRight` |
+| `NSEventTypeOtherMouseDown/Up` | `EventMouseDown/Up` with `MouseButtonMiddle` |
+| `NSEventTypeMouseMoved` / `NSEventTypeLeftMouseDragged` | `EventMouseMove` |
+| `NSEventTypeScrollWheel` | `EventMouseScroll` |
+| `NSEventTypeKeyDown/Up` | `EventKeyDown/Up` (with key code mapping) |
+| `NSEventTypeFlagsChanged` | Modifier-only key events |
+| Window delegate `windowDidResize:` | `EventResized` |
+| Window delegate `windowDidBecomeKey:` | `EventFocused` |
+| Window delegate `windowDidResignKey:` | `EventUnfocused` |
+| `NSTextInputClient insertText:` | `EventChar` |
+| `NSTextInputClient setMarkedText:` | `EventIMEComposition` |
+
+Key code mapping replaces `sdlkey.MapKeyCode(e.Keysym.Sym)`. macOS key codes
+(`e.keyCode`) are hardware-scancode-based, similar to SDL scancodes. A new
+`gui/backend/internal/nskey` mapping table (or inlined in events.go for the
+first iteration) translates `UInt16` key codes to `gui.KeyCode`.
+
+Where SDL uses string-based key symbols (`SDLK_a`), NSEvent uses virtual key
+codes. The `gui.KeyCode` constants already map to logical keys (letters,
+function keys, arrows) — the NSEvent translation is a direct table lookup:
+
+```go
+var nsKeyToGui = [128]gui.KeyCode{
+    kVK_ANSI_A: gui.KeyA,
+    kVK_ANSI_B: gui.KeyB,
+    // ...
+    kVK_Return:   gui.KeyEnter,
+    kVK_Escape:   gui.KeyEscape,
+    kVK_Space:    gui.KeySpace,
+    kVK_LeftArrow:  gui.KeyLeft,
+    kVK_RightArrow: gui.KeyRight,
+    kVK_UpArrow:    gui.KeyUp,
+    kVK_DownArrow:  gui.KeyDown,
+}
+```
+
+### 3. Cursors
+
+SDL creates 11 `*sdl.Cursor` objects, one for each `gui.MouseCursor` value.
+NSCursor has class methods for all standard shapes — no pre-creation needed:
+
+```go
+var nsCursorSelectors = [11]string{
+    gui.CursorDefault:      "arrowCursor",
+    gui.CursorArrow:        "arrowCursor",
+    gui.CursorIBeam:        "IBeamCursor",
+    gui.CursorCrosshair:    "crosshairCursor",
+    gui.CursorPointingHand: "pointingHandCursor",
+    gui.CursorResizeEW:     "resizeLeftRightCursor",
+    gui.CursorResizeNS:     "resizeUpDownCursor",
+    gui.CursorResizeNWSE:   "_windowResizeNorthWestSouthEastCursor",
+    gui.CursorResizeNESW:   "_windowResizeNorthEastSouthWestCursor",
+    gui.CursorResizeAll:    "closedHandCursor",
+    gui.CursorNotAllowed:   "operationNotAllowedCursor",
+}
+```
+
+Usage: `[[NSCursor className] performSelector:NSSelectorFromString(name)]`. This
+avoids pre-defining all 11 cursors. The cursor is set once per frame in the
+event loop (existing pattern unchanged). The `Backend.cursors` array field is
+removed.
+
+Note: `_windowResizeNorthWestSouthEastCursor` is a private selector. If App
+Store submission is ever a goal, replace with `[[NSCursor alloc] initWithImage:
+hotSpot:]` from bundled PNG. Not needed now.
+
+### 4. Clipboard
+
+Three lines of ObjC each direction:
+
+```c
+// metal_window.m
+const char *metalClipboardGet(void) {
+    NSPasteboard *pb = [NSPasteboard generalPasteboard];
+    NSString *s = [pb stringForType:NSPasteboardTypeString];
+    return s ? strdup([s UTF8String]) : NULL;
+}
+
+void metalClipboardSet(const char *text) {
+    NSPasteboard *pb = [NSPasteboard generalPasteboard];
+    [pb clearContents];
+    [pb setString:[NSString stringWithUTF8String:text]
+          forType:NSPasteboardTypeString];
+}
+```
+
+Go side calls these via cgo. The returned string from `metalClipboardGet` is
+freed by Go via `C.free()`.
+
+### 5. IME (text input)
+
+The most substantial new piece. `MetalContentView` implements
+`NSTextInputClient`. The Go side sets cursor position / composition state via
+simple C setters:
+
+```c
+// IME state (in metal_window.h)
+void metalWindowIMESetCursorRect(GoGuiNSWindow w, float x, float y, float w, float h);
+void metalWindowIMESetActive(GoGuiNSWindow w, int active);
+```
+
+When IME is active and the user types, `NSTextInputClient insertText:` fires,
+which calls a Go callback. `setMarkedText:` fires for in-progress compositions
+(Chinese, Japanese, Korean). Both are bridged to `gui.EventChar` and
+`gui.EventIMEComposition` respectively, matching the current SDL behavior.
+
+The `NSTextInputClient` implementation in `MetalContentView`:
+
+```objc
+@interface MetalContentView : NSView <NSTextInputClient>
+@property (nonatomic) NSRange markedRange;
+@property (nonatomic) NSMutableAttributedString *markedText;
+@property (nonatomic) NSRect imeCursorRect;  // set from Go
+@end
+```
+
+`firstRectForCharacterRange:` returns `imeCursorRect` converted to screen
+coordinates. `insertText:` and `setMarkedText:` call the Go callbacks.
+
+### 6. Filedrop, scroll phases, accessibility
+
+These three bridges currently use `SDL_GetWindowWMInfo` to extract the NSWindow
+from SDL's window handle. With a native NSWindow, the indirection disappears:
+
+**Before:**
+```c
+SDL_SysWMinfo info;
+SDL_GetWindowWMInfo(win, &info);
+NSWindow *nsWin = info.info.cocoa.window;
+```
+
+**After:**
+```c
+NSWindow *nsWin = ((GoGuiWindow *)win)->nsWindow;
+```
+
+The `GoGuiWindow` struct is defined in the `.m` file:
+
+```objc
+typedef struct {
+    NSWindow           *nsWindow;
+    MetalContentView   *contentView;
+    uint32_t            windowID;
+    // Go callback function pointers
+    void (*onResize)(uint32_t windowID, int width, int height);
+    void (*onClose)(uint32_t windowID);
+    void (*onFocus)(uint32_t windowID, int gained);
+} GoGuiWindow;
+```
+
+The callback function pointers are set by Go via cgo and called from the
+NSWindowDelegate. This eliminates the `goFileDrop(SDL_Window*, char*)` pattern
+— all bridges use the same `GoGuiWindow` struct and its callbacks.
+
+### 7. Multi-window support
+
+The existing `RunApp` / `windowState` pattern maps cleanly. Each `GoGuiWindow`
+has a `windowID` that `gui.App` uses for registration. `NSApp` natively manages
+multiple windows — no SDL hacks needed.
+
+The `onClose` callback fires for each window. `NSApp terminate:` only fires when
+the last window closes (configurable via `NSWindowDelegate applicationShouldTerminateAfterLastWindowClosed:`).
+
+## Concerns
+
+### Key code mapping correctness
+
+SDL's `SDLK_*` values differ from macOS virtual key codes. The mapping table
+(`nsKeyToGui`) must be exhaustively verified against all keys go-gui supports:
+letters, digits, function keys (F1–F12), navigation (Home, End, PgUp, PgDn),
+modifiers, media keys, numpad.
+
+Testing strategy: write a key-event echo example that displays key codes, then
+run it side-by-side with the SDL backend's keyboard output. Diff until zero.
+
+### IME edge cases
+
+`NSTextInputClient` has subtle behavior around marked ranges, insertion points,
+and dead keys. The current SDL `TextEditingEvent` path handles these but
+through SDL's abstraction. Native IME needs:
+
+- Correct `firstRectForCharacterRange:` for CJK candidate windows
+- `attributedSubstringForProposedRange:` for inline composition
+- Dead key sequences (Option+E then E → é)
+
+The existing `gui.EventIMEComposition` with `IMEStart`/`IMELength` mirrors
+`-[NSTextInputClient markedRange]`, so the data model is compatible.
+
+### Touch/trackpad events
+
+SDL provides `FINGERDOWN`/`FINGERMOTION`/`FINGERUP` touch events. macOS exposes
+touch via `NSTouch` on `NSTouchBar`-capable devices and via
+`NSEventTypeGesture` for trackpad gestures. Direct `NSTouch` access requires
+`allowedTouchTypes` on the NSView. Multi-touch (e.g., for a drawing canvas) is
+usable but maps differently than SDL's finger abstraction.
+
+For the initial implementation, trackpad scroll (already handled via
+`NSEventTypeScrollWheel`) and mouse events cover the primary use cases. Full
+touch support can follow.
+
+### Dark mode / appearance
+
+`TitlebarDark(bool)` in `native_platform.go` is currently a no-op under Metal.
+The native backend can implement it via `NSAppearance`:
+
+```objc
+if (dark) {
+    nsWindow.appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+} else {
+    nsWindow.appearance = nil; // system default
+}
+```
+
+### Fullscreen
+
+SDL has `WINDOW_FULLSCREEN` / `WINDOW_FULLSCREEN_DESKTOP` flags. NSWindow has
+`toggleFullScreen:` and `NSWindowStyleMaskFullScreen`. The `WindowCfg` fullscreen
+options map to these. Not needed for v0.28 but should be noted.
+
+### CGo framework dependencies
+
+All system frameworks in this design are CGo (`import "C"`) but require zero
+build-toolchain installs:
+
+```
+-framework Metal
+-framework QuartzCore
+-framework AppKit
+-framework Cocoa
+-framework Foundation
+```
+
+These ship with macOS. `go build` works on a fresh macOS install with Xcode
+CLT only.
+
+### go-glyph CGo
+
+go-glyph continues to use CoreText via CGo for font shaping and rasterization.
+This is a system framework, not a build dependency. The goal is "no build
+toolchain," not "zero CGo." Pure-Go text is a separate effort tracked in
+go-glyph (see CLAUDE.md rejected WebGPU approach note).
+
+### Test divergence: TestBackendRenderSmoke
+
+The existing `TestBackendRenderSmoke` reads backbuffer after `Present()`. SDL3's
+hardware-accelerated flip-model renderers can return empty pixels on this read.
+Under the native Metal backend, the test either:
+- Skipped on Metal (software-readback of Metal drawables is possible but slow), or
+- Moved to a Metal-specific pixel-readback path (GPU→CPU texture copy).
+
+Production blur/color-matrix filter paths render to offscreen textures and are
+unaffected.
+
+## Build comparison
+
+| | Current (SDL2) | Proposed (Native Metal) |
+|---|---|---|
+| C toolchain | Homebrew sdl2 | None (Xcode CLT only) |
+| Window/events | SDL2 via pkg-config | Cocoa/AppKit via system frameworks |
+| Rendering | SDL Metal or direct Metal | Metal (unchanged) |
+| Audio | SDL_mixer | SDL_mixer (unchanged for now) |
+| Clipboard | SDL2 | NSPasteboard |
+| Cursors | SDL2 | NSCursor |
+| IME | SDL2 | NSTextInputClient |
+| Text shaping | go-glyph CoreText CGo | go-glyph CoreText CGo (unchanged) |
+| `go build` deps | Homebrew | None |
+| Static linking | Partial (SDL dylib) | Full (no external dylibs) |
+
+## Non-goals for v0.28
+
+- Linux/Windows SDL elimination (they continue using SDL2 or the SDL3 shim)
+- Audio backend replacement (SDL_mixer still used)
+- go-glyph pure-Go text (separate project)
+- GPU pixel readback for TestBackendRenderSmoke
+- iOS backend (already has its own native UIKit/Metal backend)
+- Android backend (already has its own native GLES backend)
+
+## Implementation order
+
+1. **`metal_window.h/.m`** — NSWindow + MetalContentView + CAMetalLayer creation,
+   window delegate with callbacks, NSTextInputClient stub
+2. **`backend.go` rewrite** — replace `New()` to use `metalWindowCreate`,
+   replace `Run()` event loop with NSEvent polling, replace cursor/clipboard/IME
+   glue
+3. **`events.go` rewrite** — NSEvent → `gui.Event` mapping, key code translation
+4. **`native_platform.go`** — IME delegates to `metalWindowIME*`, remove SDL
+   syscalls
+5. **Bridge updates** — `a11y_darwin`, `filedrop_darwin`, `scroll_phase_darwin`:
+   replace `SDL_Window*` with `GoGuiNSWindow`
+6. **Key code table validation** — side-by-side diff against SDL backend output
+7. **CI update** — macOS CI drops `brew install sdl2`, runs `go build ./...` and
+   `go test ./...` directly
+8. **Documentation** — README docs/sdl-support.md updated with macOS "zero
+   dependencies" note
+
+## Related
+
+- [sdl3-shim.md](sdl3-shim.md) — SDL3 shim evaluation (Linux/Windows path)
+- [Issue #10](https://github.com/go-gui-org/go-gui/issues/10) — static
+  compilation using Zig & SDL 3.4 (user feedback driving this)

--- a/docs/specs/perf-widget-factory-pools.md
+++ b/docs/specs/perf-widget-factory-pools.md
@@ -1,0 +1,217 @@
+# Spec: Cut per-frame widget-factory heap allocations
+
+Status: reviewed 2026-07-18 (claims verified against code; Circle migration,
+benchmark correction, cached-view tradeoff added)
+Area: performance / GC-allocation reduction
+Scope: `gui/` (examples excluded)
+
+## Context
+
+go-gui's per-frame pipeline (`view → generateViewLayout → layoutArrange →
+renderLayout`) is already arena/pool-backed and ~0-alloc once warm (see
+`gui/scratch_pools.go`). A survey of six candidate areas found the **only
+genuinely un-pooled per-frame heap traffic** lives in the widget-**factory**
+layer: `w.viewGenerator(w)` re-runs the user's whole builder every full-refresh
+frame (any input event triggers this via `UpdateWindow`), and the factories
+allocate objects the downstream pools never see.
+
+Root cause: factories (`container`, `Row`, `Column`, `Button`, …) run **without a
+`*Window`**, so they cannot reach the pools (`allocShape`, `allocEventHandlers`,
+`buttonColors`) — those are only usable in `GenerateLayout`, which has `w`.
+
+### Current per-`container()` allocations, per frame
+
+Traced in `gui/view_container.go`:
+
+1. `&containerView{}` — the `View` interface box (`container` :398). **Unavoidable**
+   without a factory API change (interface boxing of a large struct).
+2. `buildContainerShape(&cfg)` → heap `&Shape{}` (:323). **Pure waste** —
+   `containerView.GenerateLayout` immediately copies it *by value* into a pooled
+   shape: `w.allocShape(*cv.shape)` (:182), then discards the template.
+3. `makeContainerEffects` → `&shapeEffects{}` when effects set (:263).
+4. `makeContainerEvents` → `&eventHandlers{}` when any handler set (:282). Buttons
+   always hit this (`ClickOnSpace/Enter` + `OnClick`).
+5. `makeContainerA11Y` → `*AccessInfo` when label/desc set (:301).
+
+`Button` adds a second box: `&buttonView{cv: *containerView}` (`view_button.go`
+:206) wrapping the container — so a button is ~2 boxes + template shape +
+eventHandlers per frame, plus its `Text` child. Downstream pools (`viewShapes`,
+`viewEvents`, `buttonColors`) recycle only the *layout-phase copies*, not these
+factory-phase originals.
+
+## Goal
+
+Route allocations #2–#5 through the existing per-frame pools by **deferring shape
+construction from the factory into `GenerateLayout`** (where `w` exists). Expected:
+a container drops from ~2–4 allocs/frame to **1** (the unavoidable box); a button
+from ~4 to ~2. On a widget-dense frame (hundreds of nodes) this is a large drop in
+GC object count per frame.
+
+Non-goals: changing the public factory signatures (`Row`/`Column`/`Button` stay
+`func(cfg) View`); reworking the layout/render passes (already 0-alloc); the
+per-frame `make([]View, …)` in `container()`'s Scrollable branch (:390) — an
+un-pooled factory alloc, but scrollable containers are rare per frame; follow-up
+if it shows in profiles.
+
+## Approach
+
+Precedent: this is already the codebase's dominant widget pattern. `view_svg.go`
+:142-148, `view_image.go` :93-100, `view_rtf.go` :142-162, `view_draw_canvas.go`
+:59-82, and `termgrid.go` :138-168 all build their `Shape` inside `GenerateLayout`
+via `w.allocShape` + `w.allocEventHandlers`. This spec converts containers (and
+buttons) to the same deferred-build shape-in-`GenerateLayout` pattern.
+
+### 0. Create a feature branch
+Branch off the current base (`main`) before any edits:
+`git switch main && git switch -c perf-widget-factory-pools` (confirm `main` is up
+to date first; the working tree is clean). All work lands on this branch.
+
+### 1. Add an effects pool (mirror the existing events pool)
+- `gui/scratch_pools.go`: add `viewEffects scratchObjPool[shapeEffects]` to
+  `scratchPools` (next to `viewEvents` at :136), init in `newScratchPools` (mirror
+  `viewEvents` caps ~ `{retainMax: 4096, shrinkTo: 256}`), and reset in
+  `resetViewPools` (:204).
+- `gui/window.go`: add `allocEffects(src shapeEffects) *shapeEffects` mirroring
+  `allocEventHandlers` (:459) — pooled, nil-`w` heap fallback for tests.
+
+### 2. Defer container shape construction into `GenerateLayout`
+`gui/view_container.go`:
+- Change `containerView` (:170) to hold the **resolved `ContainerCfg` by value**
+  (plus already-resolved `content []View`) instead of the pre-built `shape *Shape`.
+  cfg carries title/titleBG/colorBorder/disabled, so drop those duplicate fields.
+- `container()` (:377) keeps its cheap cfg resolution (OnAnyClick→OnClick,
+  ClickButton default, Scrollable content expansion) but stops calling
+  `buildContainerShape`; it stores the resolved cfg: `&containerView{cfg: cfg,
+  content: content}`. Still exactly **one** heap alloc (the box).
+- Convert `buildContainerShape(cfg *ContainerCfg) *Shape` into a **value-returning,
+  `w`-aware** builder, e.g. `buildContainerShape(cfg *ContainerCfg, w *Window)
+  Shape`, that:
+  - returns a `Shape` value (no `&Shape{}`),
+  - sets `events` from `w.allocEventHandlers(...)` — nil when no handlers,
+  - sets `fx` from `w.allocEffects(...)` — nil when no effects,
+  - `A11Y` unchanged (user pointer or `makeA11YInfo`; pooling it is a stretch goal).
+- `containerView.GenerateLayout` (:181) becomes:
+  `layout := Layout{Shape: w.allocShape(buildContainerShape(&cv.cfg, w))}` then the
+  existing `addGroupBoxTitle` call reading fields off `cv.cfg`.
+- **`Circle()` (:434-439) mutates the pre-built shape**
+  (`cv.shape.shapeType = shapeCircle`) — impossible once the shape is deferred.
+  Add an internal `shapeType shapeType` field to `ContainerCfg` (next to `axis`,
+  :147; zero value = `shapeRectangle` path preserved in `buildContainerShape`),
+  set by `Circle` before calling `container()`. Without this, step 2 does not
+  compile.
+- **Rewrite the `containerView` doc comment (:159-169)** — it documents the
+  pre-built-shape design ("Shape is pre-built at factory time…", shallow-copy
+  rationale) and becomes false after this change. New comment: cfg held by value,
+  shape built per `GenerateLayout` call from pooled allocs; cached views re-run
+  the build each frame (see Risks).
+
+`makeContainerEvents`/`makeContainerEffects` stay as pure field-mappers but their
+results feed the pool allocators rather than heap-escaping; keep their nil
+fast-paths (no handlers/effects → nil pointer, zero alloc).
+
+### 3. Migrate the three direct callers
+`gui/view_select.go:202`, `gui/view_color_picker.go:107`,
+`gui/view_combobox.go:289` all use the identical pattern
+`&containerView{shape: buildContainerShape(&ccfg), content: content}` with **no
+post-build shape mutation** (verified). Replace each with the deferred form
+`&containerView{cfg: ccfg, content: content}`. These sites already run inside a
+`GenerateLayout` with `w` in scope, so they stay correct.
+
+`invisibleContainerView()` (:457) becomes fully stateless under cfg-by-value
+(no mutable template shape; `GenerateLayout` copies into pooled shapes), so
+replace the per-call construction with a package-level singleton
+`var invisibleView = &containerView{cfg: …}` — deletes that box alloc too. Safe
+because nothing mutates a `containerView` after construction once `Circle` moves
+its `shapeType` into cfg (step 2); an invisible "circle" losing its circle
+shapeType is moot (placeholder, never drawn as either).
+
+### 4. (Same-PR, high value) collapse `buttonView` into the container path
+`buttonView` (`view_button.go:79`) is a *second* box per button. Fold its six
+button-color/hover fields into `containerView` (as optional fields set only by
+`Button`), moving the `shapeButtonColors` pooling (:103) into
+`containerView.GenerateLayout`. Removes one alloc per button per frame — buttons
+are the highest-frequency interactive widget. If this entangles button focus/hover
+logic, split it into a follow-up PR and land steps 1–3 first.
+
+Details:
+- `buttonView.GenerateLayout` gates the color attach on
+  `layout.Shape.events != nil` (:93); once folded, every container with handlers
+  would match. Add an `isButton bool` discriminator on `containerView`, set by
+  `Button`.
+- Cost: every `containerView` grows ~80 B (4 `Color` + 2 func ptrs) whether or
+  not it is a button. Still a net win (removes a whole heap object per button);
+  acknowledged under Struct growth below.
+- Bonus correctness: today `buttonView.GenerateLayout` mutates
+  `layout.Shape.events.AmendLayout/OnHover` (:107-108) through a pointer *shared
+  with the factory template* (`allocShape` shallow-copies the Shape; `events` is
+  the same heap object every frame). Idempotent today, but fragile. Per-frame
+  pooled `eventHandlers` gives each frame its own copy and removes the
+  cross-frame sharing.
+
+## Files
+- `gui/scratch_pools.go` — add `viewEffects` pool + reset.
+- `gui/window.go` — add `allocEffects`.
+- `gui/view_container.go` — core refactor (`containerView`, `container`,
+  `buildContainerShape`, `GenerateLayout`, `Circle`, `invisibleContainerView`,
+  rewrite :159-169 comment).
+- `gui/view_select.go`, `gui/view_color_picker.go`, `gui/view_combobox.go` —
+  migrate direct callers.
+- `gui/view_button.go` — step 4 (buttonView fold-in).
+
+## Verification
+- **`BenchmarkViewFrame` (`gui/view_frame_bench_test.go`) already exercises the
+  factory phase** — it builds the tree through public `Row`/`Column` factories
+  inside `b.Loop()` (deliberately: "Shapes are allocated inside the loop") and
+  resets view pools per iter. It measures the container win directly; capture it
+  before/after. (`BenchmarkGenerateViewLayout` does *not* — it pre-builds a
+  custom `benchView` outside the loop.)
+- Add a `-benchmem` benchmark for the **uncovered widgets**: `Button` (2-box +
+  buttonColors path) and containers with effects/events set (exercises the new
+  `viewEffects` pool). Model on `BenchmarkViewFrame` / `list_core_alloc_bench_test.go`
+  (resetViewPools per iter).
+- Capture before/after `allocs/op` + `B/op` via
+  `go test ./gui/ -bench='ViewFrame|Factory' -benchmem -count=5` + benchstat.
+  Target: measured drop in allocs/op for container- and button-heavy trees. allocs
+  are the hard gate (per CLAUDE.md); ns/op advisory — expect a small ns/op *rise*
+  for cached views (see Risks) against a large alloc drop for rebuilt trees.
+- `go test ./...` (headless, ~12s) and `golangci-lint run ./...` must stay green.
+  Watch the `no covering tests` widgets (containerView, buttonView, select,
+  color_picker) — add targeted assertions that `GenerateLayout` still produces the
+  correct Shape (events/fx present when configured, nil otherwise) and that pooled
+  pointers are non-nil.
+- Run a widget-dense example (e.g. `go run ./examples/showcase/`) to confirm no
+  visual/behavioral regression in containers, buttons, select, combobox, color
+  picker, group-box titles.
+
+## Risks / open questions
+- **Struct growth**: storing `ContainerCfg` by value enlarges `containerView`. Net
+  GC win still holds (1 larger object beats 3–5 small ones), but confirm the single
+  box does not itself regress `B/op` beyond the alloc-count savings.
+- **Cached views re-pay the cfg→Shape build**: the current design pre-builds the
+  shape precisely so cached views (combobox/command-palette dropdown caches, which
+  retain the View and re-call `GenerateLayout` each frame) pay only a Shape copy
+  per frame (`view_container.go` :159-169 comment). Deferred build trades that for
+  a full ~70-field `buildContainerShape` per frame — pure CPU, zero allocs.
+  Accepted: alloc count is the stated bottleneck (CLAUDE.md perf baseline), and
+  the field-copy cost is in the same ballpark as the Shape copy it replaces.
+  Verify with `BenchmarkViewFrame` ns/op (advisory).
+- **Per-frame defaults/validation**: `applyContainerDefaults` and
+  `RequireScrollID` move from factory time into `GenerateLayout`. Behavior change:
+  `DefaultContainerStyle` edits now take effect on cached views next frame
+  (arguably a fix); the missing-scroll-ID panic fires at layout instead of build —
+  same frame, same message.
+- **Pool lifetime**: `fx`/`events` pooled in the view phase are read during render;
+  pools reset at frame *start* (`resetViewPools`) and are valid through
+  `buildRenderers` — the same guarantee `viewShapes`/`viewEvents` already rely on.
+  Safe, but assert it in a test.
+- **Step 4 scope**: fold buttonView in the same PR only if it stays clean;
+  otherwise defer to a follow-up.
+- Pool `AccessInfo` (`makeA11YInfo`) too? Left as a stretch goal — usually nil.
+
+## Rejected alternatives
+- **Pool the `containerView`/`buttonView` boxes themselves** via a package-level
+  `sync.Pool`: factories lack `w`, and reclaiming the boxes safely requires knowing
+  when `generateViewLayout` has consumed them. Higher complexity and `sync.Pool`
+  overhead for a single-alloc saving. Not pursued.
+- **Pass `*Window` into factories**: eliminates the boxing but breaks the entire
+  public widget API (`Row`/`Column`/`Button` signatures). Out of scope.

--- a/docs/specs/process-monitor-example.md
+++ b/docs/specs/process-monitor-example.md
@@ -1,0 +1,346 @@
+# Spec: `process_monitor` example
+
+Status: draft
+Author: spec generated for go-gui
+Target: `examples/process_monitor/`
+
+## Goal
+
+Port the [go-shirei `process_monitor`](../../../go-shirei/examples/process_monitor)
+example to go-gui as a **functional** equivalent — a live task manager: process
+list, filter, flat/tree view, sortable columns, per-process CPU/RAM history
+charts. NOT a visual reproduction. Layout and styling take cues from existing
+go-gui examples (`todo`, `data_grid_data_source`, `scroll_demo`, `animations`)
+and use the **standard go-gui theme tokens** (no hand-picked HSL colors like the
+shirei original).
+
+## Non-goals
+
+- Pixel/visual parity with shirei's HSL-tinted look.
+- Headless one-frame PNG render (`-png`): go-gui exposes no public
+  render-to-PNG API. Dropped. See Open Questions.
+- New core go-gui dependencies. The example must stay dependency-free
+  (stdlib only) because examples live in the **main go-gui module** — there is
+  no per-example `go.mod`, so any import lands in the root `go.mod`.
+- Windows-grade CPU% fidelity in v1 (see Data Collection).
+
+## Reference behavior (feature checklist)
+
+From shirei's README + `main.go`. Port each:
+
+1. Live process list: PID, CPU%, RSS, MEM%, USER, STATE, THREADS, NAME.
+2. Click a column header to sort; click again to reverse.
+3. Row selection → detail panel + ~60s rolling CPU and RAM bar charts.
+4. Filter box: match name, command line, user, or PID (substring, case-insensitive).
+5. Flat list OR parent/child tree (collapse with ▸/▾; filter keeps ancestors visible).
+6. Sample interval selector: 0.5s / 1s / 2s / 5s.
+7. Unreadable metrics render `--`, never a fake `0`.
+8. Header stats: active/kept process counts, last-updated time, system memory bar.
+9. Terminal mode (`-once`): print a sorted report and exit, no window.
+10. Charts built from ordinary containers (rects) — no canvas, no chart lib.
+
+## Architecture
+
+### File layout
+
+```
+examples/process_monitor/
+  main.go            # window setup, flags, RootView, sampler goroutine launch
+  view.go            # header / toolbar / table / detail views (theme-driven)
+  chart.go           # UsageChart + resampleHistory (container-bar chart)
+  store.go           # ProcessStore, Process, history ring buffer
+  collect.go         # ProcInfo/Snapshot types + Collect() dispatch + platform iface
+  collect_unix.go    # //go:build darwin || linux  — ps-based collector
+  collect_windows.go # //go:build windows          — tasklist-based collector
+  collect_other.go   # //go:build !darwin && !linux && !windows — stub
+  sysmem_darwin.go   # //go:build darwin — total/used memory via sysctl + vm_stat
+  sysmem_linux.go    # //go:build linux  — /proc/meminfo
+  sysmem_other.go    # fallback: report 0 (UI hides the memory bar)
+  once.go            # runOnce terminal report
+  store_test.go      # ProcessStore.Update, PID-reuse identity, ring buffer
+  tree_test.go       # treeRows: hierarchy, collapse, ancestor-keep on filter
+  chart_test.go      # resampleHistory bucketing + interpolation
+  view_test.go       # headless smoke: build the view tree, assert no panic
+  README.md
+```
+
+Mirrors shirei's separation (sampler / store / model / main) but split along
+go-gui/Go build-tag lines for the platform collectors.
+
+### Data collection (dependency-free, cross-platform)
+
+shirei uses `go.hasen.dev/procinfo`. go-gui cannot: adding it (or gopsutil)
+pollutes the root module. Instead, a tiny self-contained collector behind a
+platform build tag, mirroring shirei's `procinfo` abstraction.
+
+Types (in `collect.go`, unchanged from shirei semantics):
+
+```go
+type ProcInfo struct {
+    PID, PPID      int
+    Name, Cmdline  string
+    User, State    string
+    RSSBytes       uint64
+    MemPercent     float64
+    CPUPercent     float64   // CPUPercentUnknown (-1) when unreadable
+    StartTime      time.Time
+    Threads        int
+    MetricsUnknown bool
+}
+type Snapshot struct {
+    Time             time.Time
+    Processes        []ProcInfo
+    TotalMemoryBytes uint64
+    UsedMemoryBytes  uint64
+}
+const CPUPercentUnknown float64 = -1
+```
+
+Per-platform `collect()`:
+
+- **darwin + linux** (`collect_unix.go`): shell out via `os/exec` to
+  `ps -axo pid=,ppid=,pcpu=,rss=,user=,state=,nlwp=,comm=,args=` (drop `nlwp`
+  on darwin, which lacks it → threads = `MetricsUnknown`/`--`). Parse fixed
+  leading numeric columns, then `comm`/`args` as the trailing free text.
+  RSS is in KiB → ×1024. `StartTime` from `ps -o lstart=` (second field set) or
+  left zero if not collected.
+- **windows** (`collect_windows.go`): `tasklist /fo csv /nh /v` → image name,
+  PID, session, mem usage, status, user, CPU time. No live per-interval CPU%
+  from a single call; report `CPUPercentUnknown` in v1 (renders `--`), or
+  compute a delta from two `tasklist` CPU-time reads if cheap. RSS from the
+  "Mem Usage" column.
+- **other** (`collect_other.go`): return an error; the UI shows the sample
+  error (matches shirei's error path).
+
+CPU% decision (v1): use `ps pcpu` directly. Caveat: on Unix `pcpu` is a
+**lifetime average**, not an interval rate. This is functionally present and
+keeps the collector to one `exec` per sample. A delta-based interval CPU%
+(re-read cumulative CPU time each sample and divide by wall-clock, like
+shirei's `computeSnapshot`) is a documented enhancement, not v1. History charts
+work regardless — they plot whatever CPU% is reported, over time.
+
+System memory (`sysmem_*.go`): `/proc/meminfo` (`MemTotal`, `MemTotal-MemAvailable`)
+on linux; `sysctl hw.memsize` + `vm_stat` on darwin. On failure/other, return
+`(0, 0)`; the header omits the memory bar rather than inventing a value
+(shirei's "-- not fake zero" philosophy).
+
+### Sampler goroutine + refresh model
+
+go-gui has **no `WithFrameLock`/`RequestNextFrame`**. The equivalent:
+
+- The backend event loop calls `w.FrameFn()` each iteration and, when idle,
+  waits at most ~100ms (`platform_*.go` Run loops: `waitMessage(100)` /
+  `time.After(100ms)`). So a background mutation is picked up within ~100ms
+  without any explicit wake. `w.wakeMainFn` is private (not callable from an
+  example), and none is needed at 0.5–5s sample intervals.
+- Sampling spawns a subprocess (`ps`), so it MUST run off the frame thread.
+
+Pattern (in `main.go`, launched from `WindowCfg.OnInit`):
+
+```go
+func startSampler(w *gui.Window) {
+    go func() {
+        var prev *Snapshot // for optional CPU-delta enhancement
+        for {
+            app := gui.State[App](w)          // read interval (see note)
+            snap, err := collectSnapshot(prev) // blocking exec, OFF frame thread
+            prev = snap
+
+            w.Lock()
+            app.Snapshot = snap
+            app.Err = err
+            app.LastRefresh = time.Now()
+            app.Store.Update(snap, app.Selected)
+            if snap != nil && app.Selected == nil { /* auto-select top row */ }
+            w.UpdateWindow()  // full layout refresh; re-runs the view fn next
+                              // frame WITHOUT clearing the state registry, so
+                              // the filter input keeps focus/caret.
+            w.Unlock()
+
+            time.Sleep(app.Interval) // read under lock in practice
+        }
+    }()
+}
+```
+
+Critical detail: use `w.UpdateWindow()` (alias `markLayoutRefresh`), **NOT**
+`w.UpdateView(fn)`. `UpdateView` clears the view-state registry every call,
+which would drop input focus and scroll position on every sample.
+`RequestRedraw()` is render-only (no view re-run) so new rows would not appear —
+also wrong. `UpdateWindow` re-runs the registered view generator against fresh
+state while preserving the registry. Register the generator once in `OnInit`
+via `w.UpdateView(rootView)`.
+
+Reads of shared state during sampling and all mutations happen under `w.Lock()`
+/ `w.Unlock()`. The view function itself runs under `w.mu` already (per
+CLAUDE.md), so it reads state consistently.
+
+### Process store
+
+Port `ProcessStore` / `Process` / `ProcessPoint` from shirei nearly verbatim —
+it is pure Go, no shirei API:
+
+- Key by identity surviving PID reuse: `{PID, StartTime}`. When `StartTime` is
+  unavailable (darwin `ps` without `lstart`), fall back to `{PID}` only and
+  document the reduced PID-reuse safety.
+- Ring buffer history (`maxHistoryPoints = 240`), `appendHistory`.
+- Keep stopped processes 60s so their charts linger, then evict (unless
+  selected).
+- `Processes()`, `ActiveCount()`, `ByKey` for the header counts.
+
+## UI (standard theme, immediate-mode)
+
+Root: a `gui.Column` filling the window (`FixedFixed`, `w.WindowSize()`),
+`Color: theme.ColorBackground`. Sections stacked: Header, Toolbar, Table
+(fills), DetailPanel.
+
+Theme tokens (from `gui.CurrentTheme()`) replace all shirei HSL literals:
+
+| shirei intent            | go-gui token                                  |
+|--------------------------|-----------------------------------------------|
+| page background          | `theme.ColorBackground`                       |
+| panel / card background  | `theme.ColorPanel`, `theme.ColorInterior`     |
+| row hover / selection    | `theme.ColorHover`, `theme.ColorSelect`       |
+| borders                  | `theme.ColorBorder`                           |
+| title / heading text     | `theme.B2`, `theme.B3`                         |
+| body / cell text         | `theme.N4`, `theme.N5`                         |
+| muted secondary text     | `theme.N5`/`N6`                               |
+| stopped / error accent   | `theme.ColorError`, `theme.ColorWarning`      |
+| running / ok accent      | `theme.ColorSuccess`                          |
+| padding / spacing / radius | `theme.PaddingSmall`, `theme.SpacingSmall`, `theme.RadiusSmall` |
+
+Default theme: `gui.SetTheme(gui.ThemeDark.WithBorders(true))` (matches
+`data_grid_data_source`). A `ThemePicker` widget MAY be added to the toolbar to
+demo light/dark switching (optional, see Open Questions).
+
+### Header (`view.go`)
+
+`gui.Row` of: title `gui.Text{TextStyle: theme.B2}`, spacer, and stat chips
+(`gui.Row`+`gui.Text` in a rounded `ColorInterior` container) for "active/kept"
+counts and last-updated time. System memory shown as a labelled `UsageBar`
+(see below) + "used / total" text. If `Snapshot == nil`: "Collecting…". If
+`Err != nil`: error text in `theme.ColorError`.
+
+### Toolbar
+
+- Filter: `gui.Input` (like `todo`'s composer), fixed width ~300, bound to
+  `app.Filter` via `OnTextChanged`. Placeholder "Filter by name, cmd, user, PID".
+- View mode: `gui.RadioButtonGroupRow` or `gui.Toggle` → Flat / Tree,
+  bound to `app.TreeMode`.
+- Sample interval: `gui.RadioButtonGroupRow` or `gui.Select` → 0.5s/1s/2s/5s,
+  bound to `app.Interval`.
+
+### Process table
+
+The go-gui `Table` widget (`view_table.go`) takes text `TableCellCfg`s and does
+not support custom cell content (CPU usage bars, tree chevrons). So build the
+table **immediate-mode**, like shirei does, for full cell control:
+
+- A header `gui.Row` of clickable column-title cells. Each is a `gui.Button`
+  (or a container with `OnClick`) that sets `app.Sort.Column` / toggles
+  `app.Sort.Desc`; show a ▲/▼ marker on the active column.
+- Body: a **scrollable** `gui.Column` (`Scrollable: true` + `ScrollbarCfgY`,
+  per `scroll_demo`) containing one `gui.Row` per visible process.
+- Each row: fixed-width cells matching the header. Cells:
+  - PID/USER/STATE/MEM%/RSS/THR: `gui.Text` (`--` when `MetricsUnknown`).
+  - CPU: `gui.Text` + a `UsageBar` (see below).
+  - NAME: in tree mode, leading indent (`Width = depth*14`) + a ▸/▾ chevron
+    button toggling `p.Collapsed`, then the name.
+  - Row background: alternate `ColorPanel`/`ColorInterior`; `ColorSelect` when
+    `app.Selected == p`; `ColorHover` on hover. Row `OnClick` sets
+    `app.Selected = p`. `OnClick` is consume-class, so the click is
+    marked handled by dispatch.
+- Row ordering, filtering, and tree flattening are computed by the app (port
+  shirei's `visibleRows` / `treeRows` / `orderProcesses` — pure Go), NOT by the
+  table widget. The active sort column supplies the comparator.
+
+`UsageBar(value, max)`: a fixed-size rounded container (`ColorInterior`) holding
+an inner `gui.Rectangle` whose width = `ratio * fullWidth`, filled with an
+accent color (`ColorSuccess` scaling toward `ColorWarning`/`ColorError` at high
+load, or a single accent for simplicity).
+
+### Detail panel + history charts (`chart.go`)
+
+Selected-process panel: name, pid, ppid, cpu, rss, start time; "stopped …" in
+`ColorError` when not running; full command line in muted text. Then two
+`UsageChart`s (CPU, RAM) side by side.
+
+`UsageChart` — port shirei's container-bar chart, restyled with theme tokens:
+
+- `resampleHistory(hist, 60s, 1s, valueFn)` → `[]HistBucket{Value, HasData,
+  Interpolated}`. Port verbatim (pure Go; unit-tested).
+- Render: a fixed-size rounded panel; a `gui.Row` of per-bucket columns. Each
+  bucket is a `gui.Column` with a bottom-anchored `gui.Rectangle` whose height
+  = `ratio * chartHeight`. Empty buckets → 1px baseline. Interpolated buckets →
+  dimmer fill. A floating title label over the bars.
+- CPU chart pins the y-scale floor at 100%; RAM chart auto-scales to the max
+  seen (port `ramHistoryScale`).
+
+go-gui note: verify bottom-anchoring bars. shirei uses `Filler(1)` to push the
+bar down. In go-gui, achieve the same with a spacer child (empty `FillFill`
+container) above a fixed-height bar in a `Column`, or `VAlign: VAlignBottom` on
+the bucket column. Confirm during implementation.
+
+## CLI flags (`main.go`)
+
+Keep the subset that maps cleanly:
+
+- `-once` : print one sorted terminal report and exit (no window). Port
+  `runOnce` + `formatBytes`/`truncate` helpers. Pure Go, testable.
+- `-limit N` : rows in `-once` (default 10).
+- `-sort cpu|mem|pid|name|user|state|threads` : starting/`-once` sort column.
+- `-refresh D` : GUI sample interval default (default 1s).
+
+Drop `-png` (no headless render API). Drop `-samples`/`-period` (those drive
+shirei's multi-sample burst window for interval CPU%, unused with `ps pcpu`;
+reintroduce only if the CPU-delta enhancement lands).
+
+## Testing (headless, no backend)
+
+Follows CLAUDE.md: rebuild + `go test ./examples/process_monitor/...`.
+
+- `store_test.go`: `Update` adds/updates/evicts; PID-reuse produces a distinct
+  key; ring buffer caps at `maxHistoryPoints`; stopped processes linger then
+  evict; selected process is not evicted.
+- `tree_test.go`: `treeRows` builds correct depth/child-count; collapse hides
+  subtree; filter keeps matched nodes' ancestors and ignores collapse.
+- `chart_test.go`: `resampleHistory` — same-slot averaging, gap interpolation
+  flagged `Interpolated`, pre-first-sample slots stay `HasData=false`, fixed
+  wall-clock bucket boundaries (port shirei's intent).
+- `view_test.go`: seed `App` with a synthetic `Snapshot`, build the root view
+  via `rootView(w).GenerateLayout(w)` (nil backend, per CLAUDE.md test pattern),
+  assert it returns without panic and produces child shapes. Do NOT call the
+  real `ps` collector in tests (inject a synthetic snapshot).
+
+Collectors that `exec` `ps`/`tasklist` are not unit-tested (environment
+dependent); keep them thin and behind the `collect()` seam so tests use
+synthetic snapshots.
+
+## Docs deliverables
+
+Per `feedback_doc_sync`:
+
+- `examples/process_monitor/README.md`: what it does, how to run
+  (`go run ./examples/process_monitor`), `-once` usage, the container-chart and
+  background-sampler techniques, and the known CPU%-is-lifetime-average caveat.
+- Root `README.md` example list: add `process_monitor` with a one-line blurb.
+- `CHANGELOG.md`: new-example entry.
+
+## Open questions
+
+1. **CPU%**: accept `ps pcpu` (lifetime average, one exec/sample) for v1, or
+   implement shirei-style interval CPU% from two cumulative-CPU-time reads
+   (needs per-platform CPU-time + a `prev` snapshot)? Recommendation: `ps pcpu`
+   for v1, note the caveat, enhance later.
+2. **Windows fidelity**: ship a reduced `tasklist` collector (CPU% = `--`), or
+   mark Windows out of scope for v1 with the `collect_other.go` stub?
+   Recommendation: ship the reduced collector; it still lists processes.
+3. **StartTime on darwin**: pull `ps -o lstart=` (extra parse cost) for robust
+   PID-reuse keys, or fall back to `{PID}` only? Recommendation: `{PID}`-only
+   fallback in v1; document it.
+4. **ThemePicker in toolbar** to demo light/dark, or fixed `ThemeDark`?
+   Recommendation: fixed `ThemeDark.WithBorders(true)`; add picker only if it
+   doesn't crowd the toolbar.
+5. **Refresh latency**: rely on the ~100ms idle poll (simple, no wake), accept
+   up to ~100ms lag between sample-ready and repaint? Recommendation: yes;
+   imperceptible at these intervals.

--- a/docs/specs/sdl3-shim.md
+++ b/docs/specs/sdl3-shim.md
@@ -1,0 +1,199 @@
+# SDL3 shim evaluation
+
+Source: [cataggar/SDL#1](https://github.com/cataggar/SDL/pull/1) +
+[cataggar/go-gui#1](https://github.com/cataggar/go-gui/pull/1)
+
+## Summary
+
+Two coordinated PRs that let go-gui (and go-glyph) target SDL3 with zero
+source changes, via a cgo drop-in replacement for the `go-sdl2` API surface
+go-gui uses. The shim lives in a fork of SDL's zig-build port and is consumed
+with a single `go.mod` replace directive.
+
+## Architecture
+
+```
+go-gui backend code (unchanged)
+  → github.com/veandco/go-sdl2/sdl  (import path)
+    → replace → ../SDL/go-sdl2-sdl3  (go.mod)
+      → cgo → SDL3 C API (zig-built, dynamic or static)
+```
+
+Three layers in the shim:
+
+1. **`go-sdl2-sdl3/sdl`** — Hand-written cgo shim. Reshapes SDL3's split
+   window-event model and float coordinates back into the SDL2-style API.
+   Event conversion folds SDL3's distinct window event types into
+   SDL2-style `WindowEvent` subtypes. A `cbits.c`/`cbits.h` C layer avoids
+   cgo struct-field mangling by exposing field accessor functions.
+   ~382 SDL2 API calls across `gui/backend/sdl2/`, `gui/backend/gl/`, and
+   `sdlkey` compile unchanged.
+
+2. **`go-sdl2-sdl3/mix`** — SDL_mixer-compatible audio engine on SDL3's
+   native audio API (SDL3 doesn't bundle SDL_mixer). Per-channel
+   `SDL_AudioStream`s auto-mixed by SDL + dedicated music stream.
+   Looping/fades via get-callback, volume via per-stream gain. WAV decoded
+   natively; MP3/OGG via vendored dr_mp3 / stb_vorbis (public domain).
+
+3. **`gosdl3/`** — Experimental. Zig comptime bindgen emits full cgo SDL3
+   Go bindings. Separate from the hand-written shim; useful as a generated
+   reference surface.
+
+## Benefits
+
+- **Zero go-gui code changes.** The API shim absorbs all SDL2→SDL3
+  differences.
+- **Eliminates MSYS2/MinGW on Windows.** `zig build` + `zig cc` replaces the
+  entire SDL2 toolchain. Relevant given recent CI churn pinning MSYS2 to a
+  stable release (v0.27.1).
+- **Static linking.** `-tags sdl3static` produces a fully static binary with
+  no SDL3.dll/dylib. The static link file enumerates Win32 system libs
+  (kernel32, user32, gdi32, etc.) that can't be carried by a static archive.
+- **Audio without SDL_mixer.** Eliminates a separate build dependency.
+- **Covers go-glyph too.** go-glyph's SDL backend (3 files) works with the
+  same replace directive.
+- **SDL3 is the current stable.** SDL2 is maintenance-mode. Moving now is
+  right timing.
+
+## Concerns
+
+### zig as a new toolchain dependency
+
+Every contributor and CI pipeline needs zig installed. zig is increasingly
+popular for C/C++ cross-compilation and the `build.zig` already exists in
+the forked repo, but it's a non-trivial addition. On the upside, it
+*replaces* MSYS2, not adds to it — net toolchain count stays flat or drops.
+
+### Shim location
+
+The shim currently lives in `cataggar/SDL` (a fork of a fork of SDL's zig
+port). Long-term, the shim should be its own standalone repo (e.g.,
+`go-gui-org/go-sdl3-shim`) with its own lifecycle, tests, and versioning.
+Tying it to a personal SDL fork creates an unclear maintenance dependency.
+
+### Partial API coverage
+
+The shim covers only the go-sdl2 API surface go-gui actually uses. If
+go-gui later needs an API not in the shim, someone has to add it. Acceptable
+tradeoff — the full go-sdl2 surface is large and mostly unused — but must be
+acknowledged.
+
+### Metal backend CGo dependency
+
+**Decision: Required, scope is small (~20 lines in `backend.go`).**
+
+The Metal backend (`gui/backend/metal/backend.go`) directly includes
+`<SDL.h>` and `<SDL_metal.h>` via CGo and calls SDL2 C functions
+(`SDL_Metal_CreateView`, `SDL_Metal_GetLayer`, `SDL_Metal_GetDrawableSize`,
+`SDL_Metal_DestroyView`). These are raw CGo calls, not Go-level `sdl.*`
+calls — the shim only covers the Go→cgo path through `go-sdl2/sdl`.
+
+Without updating these, macOS compilation fails under the shim. The .m file
+(`metal_darwin.m`) is unaffected — it receives a `void*` CAMetalLayer
+pointer regardless of how it's obtained.
+
+Changes needed in the shim's `cbits.h`/`cbits.c`:
+- Expose SDL3's `SDL_GetPointerProperty(SDL_PROP_WINDOW_METAL_CAMetalLayer)`
+  to replace `SDL_Metal_CreateView` + `SDL_Metal_GetLayer`.
+- Expose `SDL_GetWindowSizeInPixels` to replace
+  `SDL_Metal_GetDrawableSize`.
+
+These are SDL3-native APIs with no SDL2 equivalent — they belong in the
+shim's C layer, not in go-gui. The callers in `backend.go` then switch from
+`C.SDL_Metal_*` to the shim's C accessors.
+
+### Downstream replace directive leakage
+
+**Decision: Acceptable for transition. File follow-up issue for module-based
+solution before v1.0.**
+
+The `replace` is fundamental to the "zero source changes" design. go-gui
+has `import "github.com/veandco/go-sdl2/sdl"` in ~100+ files. The replace
+redirects that import path to the shim without editing any source.
+There is no way to eliminate the replace without changing every import
+statement in go-gui (which defeats the purpose).
+
+Go modules documents `replace` directives as explicitly non-transitive.
+Any downstream project importing go-gui must manually copy the replace
+directive into their own `go.mod` to build against SDL3.
+
+Short-term this is tolerable — go-gui's primary consumers are Mike's own
+repos (go-glyph, go-charts, go-edit, go-kite), which can be updated in
+lockstep. Third-party consumers omitting the replace continue to build
+against standard go-sdl2 (SDL2) as before — the shim is opt-in.
+
+A standalone shim repo (`go-gui-org/go-sdl3-shim`) improves the replace
+target from a local filesystem path to a versioned module URL, but does
+not remove the replace itself. The only path to truly eliminating it is
+changing go-gui's import paths (e.g., to native SDL3 bindings via the
+`gosdl3/` experiment), which is a separate, larger effort.
+
+Ship v0.28 with replace. Accept that it's the design, not a temporary
+wart.
+
+### Audio format coverage
+
+**Decision: Non-issue. Comment fix only.**
+
+The `sound.go` doc comment lists FLAC, AIFF, and VOC as supported formats.
+The actual `Init()` default format mask is `mix.INIT_OGG | mix.INIT_MP3`
+(audio.go:65). FLAC requires `mix.INIT_FLAC`; AIFF/VOC require
+`mix.INIT_MOD`. These are never enabled by default — the comment documents
+SDL_mixer's theoretical capabilities, not go-gui's actual behavior.
+
+The shim's WAV/MP3/OGG coverage matches the default config exactly.
+No code change needed. Update the `LoadSound` doc comment to read
+"Supports WAV, MP3, OGG" to reflect reality.
+
+### Test divergence
+
+`TestBackendRenderSmoke` reads backbuffer after `Present()`. Defined in SDL2,
+undefined in SDL3 with hardware-accelerated flip-model renderers (Direct3D11).
+Passes on software renderers (CI), may read empty pixels on accelerated
+Windows. Production paths (blur/color-matrix filter readback to texture
+targets) are unaffected.
+
+Additional Metal-specific gap: the Metal backend sets
+`CAMetalLayer.presentsWithTransaction = YES` (metal_darwin.m:763) to
+eliminate content shift during live resize. SDL3's Metal integration may
+handle presentsWithTransaction differently or expose its own controls via
+the Properties API. A macOS Metal smoke test variant should verify live
+resize behavior under SDL3 before shipping.
+
+### go-glyph coordination
+
+Both repos need the same replace directive. Works with sibling-directory
+layout (`../SDL/go-sdl2-sdl3`) but doesn't compose well across independent
+projects. A standalone shim repo with its own `go.mod` module path solves
+this.
+
+## Build chain comparison
+
+| | Current | Proposed |
+|---|---|---|
+| C toolchain | MSYS2/MinGW (Windows), system cc (macOS/Linux) | zig cc (all platforms) |
+| SDL | SDL2 via pkg-config | SDL3 via zig build |
+| Audio | SDL_mixer | vendored decoders + SDL3 audio API |
+| Platform libs | implicit via pkg-config | explicit for static builds |
+
+## Recommendation
+
+**Adopt the approach, repackage first.**
+
+The architectural idea (API shim → zero go-gui changes) is excellent and
+the engineering is solid. Before merging into go-gui:
+
+1. Extract `go-sdl2-sdl3/` into a standalone repo with its own module path,
+   build instructions, and test suite.
+2. Add SDL3 Metal property accessors (`SDL_GetPointerProperty`,
+   `SDL_GetWindowSizeInPixels`) to the shim's `cbits.h`/`cbits.c`.
+   Update `backend.go` to use them instead of `SDL_Metal_*` CGo calls.
+3. Document `zig` as a build dependency in README and CI.
+4. Apply the same replace directive to go-glyph.
+5. Acknowledge `TestBackendRenderSmoke` caveat in backend test docs.
+   Add macOS Metal-specific smoke test for live-resize behavior under SDL3
+   (verifies `presentsWithTransaction` equivalent).
+6. Fix `LoadSound` doc comment: "Supports WAV, MP3, OGG" to match the
+   default format mask.
+7. Accept `replace` as a permanent part of the design. Document in README
+   that downstream consumers must copy the directive to opt into SDL3.

--- a/docs/specs/slot-text.md
+++ b/docs/specs/slot-text.md
@@ -1,0 +1,347 @@
+# SlotText — Rolling Character Animation Widget
+
+Slot-machine text animation. Each character position acts as a reel that
+rolls vertically through a sequence when the displayed string changes.
+Embeds in buttons, labels, containers — any `Content []View` slot.
+
+Reference: https://www.cssscript.com/demo/slot-text-roll-animation/
+
+## Visual behavior
+
+When `SlotText.Set(newText)` is called:
+
+1. Each character position transitions from old value to new value by
+   scrolling through intermediate characters vertically. Imagine a
+   physical slot-machine reel with characters printed around the
+   circumference — the reel spins until the target lands in view.
+
+2. Characters start with staggered timing. Position 0 begins immediately;
+   position N begins after `stagger * N` milliseconds.
+
+3. Character that is already correct can optionally stay in place
+   (`KeepMatching` flag).
+
+4. When the new string is shorter, excess positions animate out (roll
+   away to nothing). When it's longer, new positions animate in from
+   outside the visible area.
+
+5. Roll direction: up (characters rise from below) or down (characters
+   drop from above).
+
+6. Bounce: overshoot at the end of each character's roll for a physical
+   spring-settling effect.
+
+7. Optional chromatic sweep: hue gradient sweeps across the text during
+   animation.
+
+## Public API
+
+```go
+package gui
+
+// SlotTextCfg configures a slot-text widget.
+type SlotTextCfg struct {
+    // ID for animation tracking. Must be unique per window.
+    // Tagged gui:"required" — enforced by requiredid analyzer.
+    ID string `gui:"required"`
+
+    // Style for the text. Font, size, color, etc.
+    Style TextStyle
+
+    // Initial text to display (no animation on first render).
+    Text string
+
+    // Direction of the roll animation.
+    // Default: SlotDirDown
+    Direction SlotDirection
+
+    // Duration of each character's roll from start to settle.
+    // Default: 300ms
+    Duration Opt[time.Duration]
+
+    // Stagger delay between consecutive character positions.
+    // Default: 45ms
+    Stagger Opt[time.Duration]
+
+    // Easing function applied to each character's roll progress.
+    // Default: EaseOutCubic
+    Easing Opt[EasingFn]
+
+    // Bounce intensity [0, 1]. 0 = no bounce, >0 adds overshoot at end.
+    // Default: 0.6
+    Bounce Opt[float32]
+
+    // Character set used for intermediate rolling values.
+    // Default: alphanumeric (A-Z, a-z, 0-9) plus common symbols.
+    // nil means use the default set.
+    CharSet []rune
+
+    // If true, characters that already match the target don't animate.
+    // Default: true
+    KeepMatching Opt[bool]
+
+    // If true, calling Set() while an animation is running interrupts the
+    // current animation (remaining characters jump to their targets, then
+    // the new animation starts from resulting state).
+    // Default: true
+    Interrupt Opt[bool]
+
+    // ChromaticSweep enables a hue gradient that sweeps across the text
+    // during animation. nil or zero-value disables the effect.
+    // Default: nil (disabled)
+    ChromaticSweep *ChromaticSweepCfg
+
+    // Fixed width for the widget. If unset, measured from the current
+    // text (may change during animation as string length changes,
+    // potentially causing parent re-layout).
+    // Set this to stabilize layout when text length varies.
+    Width Opt[float32]
+
+    // Sizing mode for the widget.
+    // Default: FitFit (natural text size)
+    Sizing Sizing
+
+    // Opacity of the rendered text.
+    // Default: 1.0
+    Opacity Opt[float32]
+
+    // If set, clips rendering to bounds — characters mid-roll outside the
+    // widget bounds are hidden. Always true for slot text; exposed for
+    // unusual cases.
+    // Default: true
+    Clip Opt[bool]
+}
+
+// SlotDirection selects which way characters roll.
+type SlotDirection uint8
+
+const (
+    SlotDirDown SlotDirection = iota // characters roll downward (enter from top)
+    SlotDirUp                        // characters roll upward (enter from bottom)
+)
+
+// ChromaticSweepCfg configures the hue sweep color effect.
+type ChromaticSweepCfg struct {
+    // Starting hue, in degrees [0, 360].
+    // Default: 0
+    From float32
+
+    // Total hue spread across the text width, in degrees.
+    // Default: 120
+    Spread float32
+}
+
+// SlotText is the widget handle. Created by SlotText(cfg).
+// Its Set method triggers the roll animation to new text.
+type SlotText struct {
+    // unexported fields
+}
+
+// SlotText creates a new slot-text widget. Returns a View that can be
+// embedded in Content slices.
+func SlotText(cfg SlotTextCfg) View
+
+// Set animates from the current text to newText. If an animation is
+// already running, behavior depends on cfg.Interrupt.
+//
+// Safe to call from any goroutine (enqueues the animation on the
+// window's command queue).
+func (st *SlotText) Set(newText string)
+
+// Flash briefly flashes newText then returns to the original text.
+// A short two-phase animation: roll to newText, pause, roll back.
+// Duration is halved compared to a normal Set().
+func (st *SlotText) Flash(newText string)
+
+// Text returns the current visual text (the animation target, not
+// intermediate rolling characters).
+func (st *SlotText) Text() string
+
+// SetStyle updates the text style. Takes effect on next animation
+// or next frame.
+func (st *SlotText) SetStyle(style TextStyle)
+```
+
+## Usage examples
+
+### Basic
+
+```go
+st := gui.SlotText(gui.SlotTextCfg{
+    ID:    "score",
+    Text:  "0000",
+    Style: gui.TextStyle{FontFamily: "mono", Size: 24, Color: gui.White},
+})
+// Later, on some event:
+gui.SlotTextFromView(w, "score").Set("1234")
+```
+
+### In a button
+
+```go
+gui.Button(gui.ButtonCfg{
+    Content: []gui.View{
+        gui.SlotText(gui.SlotTextCfg{
+            ID:    "btn-label",
+            Text:  "Submit",
+            Style: gui.TextStyle{Size: 16, Color: gui.White},
+        }),
+    },
+    OnClick: func(l *gui.Layout, e *gui.Event, w *gui.Window) {
+        gui.SlotTextFromView(w, "btn-label").Set("Sending…")
+        ctx.Consume()
+    },
+})
+```
+
+### With chromatic sweep
+
+```go
+gui.SlotText(gui.SlotTextCfg{
+    ID:   "hero",
+    Text: "Welcome",
+    ChromaticSweep: &gui.ChromaticSweepCfg{From: 24, Spread: 120},
+})
+```
+
+## Deliverables checklist
+
+- [ ] `gui/view_slot_text.go` — widget implementation
+- [ ] `gui/view_slot_text_test.go` — tests
+- [ ] `examples/slot_text/` — standalone example app
+- [ ] `examples/showcase/state.go` — demo entry in `demoEntries`
+- [ ] `examples/showcase/demo_text.go` (or new `demo_slot_text.go`) — demo view
+- [ ] `README.md` — widget count bump (50+ → 51+)
+- [ ] `CHANGELOG.md` — entry under next version
+
+## Implementation plan
+
+### Phase 1 — Core widget + animation engine
+
+**Files:** `gui/view_slot_text.go` (~300 lines), `gui/view_slot_text_test.go`
+
+- `slotTextView` struct implementing `View`
+- `GenerateLayout` returns a `DrawCanvas` that renders the slot text
+- Per-character animation state stored in `StateMap` keyed by `ID`
+- `slotTextAnimation` struct implementing `Animation` interface:
+  - Tracks per-character progress, direction, start times
+  - Each `Update` call recomputes character states and enqueues
+    an `OnValue` callback to bump the DrawCanvas version
+- Character roll logic:
+  - For each position, compute `t = elapsed / duration` clamped to [0, 1]
+  - Apply staggered start: `t = (elapsed - stagger*i) / duration`
+  - Apply easing: `et = easing(t)`
+  - Apply bounce: overshoot at end using a secondary spring term
+  - Map to vertical offset: `y_offset = (1 - et) * slot_height * direction_sign`
+  - Select visible character: interpolate in char set between old and new
+
+**Edge cases:**
+- Zero-length text → empty widget (zero width, handled gracefully)
+- New string longer than old → new slots animate in from outside
+- New string shorter than old → excess slots animate out
+- Unicode (multi-byte, CJK wide, emoji) → measure via `TextMeasurer.TextWidth`,
+  not byte/runecount. Each slot corresponds to one *character position*
+  (grapheme cluster or code point, TBD).
+- Very fast consecutive `Set()` calls → interrupt behavior per `Interrupt` flag
+- Window closed mid-animation → auto-cancelled (view-bound animation)
+
+### Phase 2 — Refinements
+
+**File:** `gui/view_slot_text.go` (additions)
+
+- Chromatic sweep: compute per-character hue offset in OnDraw, pass to
+  per-character `dc.Text()` calls with per-character color
+- Character set configuration: pluggable `CharSet` slice
+- Flash mode: two-phase animation (forward + brief hold + reverse)
+- `SetStyle` support: write new style to StateMap, bump version
+
+### Phase 3 — Performance + integration
+
+- Pool-allocate animation state arrays to avoid per-frame allocs
+- Benchmark: target 0 allocs per frame during idle (no animation running)
+- Benchmark: target < 10 allocs per frame during animation
+- Reuse `[]GlyphPlacement` or intermediate buffers across frames
+- **Example app:** `examples/slot_text/main.go` — demonstrates Set, Flash,
+  chromatic sweep, embedding in a button, and config variants
+- **Showcase integration:**
+  - `examples/showcase/state.go`: add `DemoEntry` under `groupText`
+    (or `groupAnimations` if a new group is warranted)
+  - `examples/showcase/demo_text.go` (or new `demo_slot_text.go`):
+    demo view function showing the widget with interactive controls
+- **README.md:** bump widget count reference
+- **CHANGELOG.md:** add entry under next version
+
+## Design decisions
+
+1. **DrawCanvas, not multiple Text shapes.** Per-character `Text` shapes
+   would mean N shapes for N characters (alloc-heavy for long strings).
+   A single `DrawCanvas` with `OnDraw` renders all characters in one pass
+   with full position control.
+
+2. **AnimationRefreshLayout during roll, idle when settled.**
+   `slotTextAnimation.RefreshKind()` returns `AnimationRefreshLayout`
+   while any character is still rolling, then `AnimationRefreshNone` once
+   settled. This avoids rebuilding the layout tree when the widget is
+   static.
+
+3. **Cache bust via shape.Version.** The `OnDraw` callback bumps
+   `shape.Version` each frame during animation to defeat the DrawCanvas
+   tessellation cache. When idle, version is stable and the cache hits.
+
+4. **View-bound animation.** Uses `animationAddViewBound` so the animation
+   auto-cancels if the widget leaves the view tree. The animation ID is
+   `"slot-text-" + cfg.ID`.
+
+5. **StateMap for animation state.** Per-character progress stored in a
+   `slotTextState` struct keyed by `ID` in `StateMap`. The animation
+   writes to it; `OnDraw` reads from it.
+
+6. **Character set.** Default covers A-Z, a-z, 0-9, and common symbols
+   (`.` `,` `!` `?` `-` `_` `/` `:` `;` ` `). When a target character
+   isn't in the set, use its Unicode codepoint to index into a
+   reasonable range (e.g., wrap within the same Unicode block).
+
+7. **Variable-width character handling.** Each slot's width is the max
+   of the old character width and new character width for that position,
+   measured via `TextMeasurer.TextWidth()`. This prevents horizontal
+   jitter during animation. The overall widget width is the sum of
+   per-slot widths (or fixed via `cfg.Width`).
+
+8. **`gui:"required"` on ID.** The `requiredid` analyzer enforces that
+   `ID` is non-empty, preventing silent animation bugs from empty IDs.
+
+## Out of scope (v1)
+
+- RTL text direction
+- Multi-line text (single line only)
+- Continuous looping mode (like a loading spinner)
+- Per-character custom easing
+- Sound effects
+- Vertical text layout (CJK tategaki)
+- Grapheme-cluster-aware slot boundaries (v1 uses code points)
+
+## Unresolved questions
+
+1. **Slot boundaries — code points or grapheme clusters?** Treating each
+   Unicode code point as a slot is simplest but breaks for emoji with
+   ZWJ sequences (e.g., 👨‍👩‍👧‍👦 is 7 code points, 1 grapheme cluster).
+   Grapheme-cluster-aware splitting requires `uniseg` (already used by
+   go-term). Recommendation: start with code points, document the
+   limitation, add grapheme support in v2.
+
+2. **Should the intermediate rolling characters be deterministic or
+   random?** The reference uses deterministic scrolling through a
+   character set. Random would look different (more chaotic, less
+   predictable). Recommendation: deterministic, matching the reference.
+
+3. **Should `charSet` include uppercase, lowercase, or both?** When
+   rolling from 'A' to 'z', the distance is 57 codepoints. If the
+   char set is A-Z then a-z then 0-9, it's a shorter distance.
+   Recommendation: uppercase block, lowercase block, digit block,
+   then symbols — in that order. Each block is contiguous.
+
+4. **Should the widget expose `*Layout` directly for advanced use?**
+   The reference allows direct DOM manipulation. In go-gui, the widget
+   returns a `View`; advanced layout manipulation goes through
+   `AmendLayout` on the parent container. Recommendation: no direct
+   layout exposure; use `SlotTextCfg` for all configuration.

--- a/docs/specs/widget-id-scoping.md
+++ b/docs/specs/widget-id-scoping.md
@@ -1,0 +1,107 @@
+# Widget ID scoping
+
+Status: proposal, not implemented. Written 2026-08-09 after a
+`GOGUI_DEBUG=1` run of the showcase reported 39 duplicate IDs.
+
+## Problem
+
+`Shape.ID` is the identity key for focus, scroll offsets, per-widget
+state, `FindByID`, and hero animations. It must be unique per window.
+Nothing enforces that at compile time, and the failure is silent: two
+widgets sharing an ID collapse onto one tab stop and one state slot,
+with no error and no visual difference.
+
+The showcase run produced 39 reports. Only two were application
+mistakes. The rest came from the framework:
+
+| Count | Cause                                                       |
+| ----- | ----------------------------------------------------------- |
+| 32    | `Input` put `cfg.ID` on both its container and its inner text |
+| 5     | every markdown paragraph claimed the markdown widget's ID     |
+| 2     | showcase: a constant ID in a loop; a nested widget copy-paste |
+
+Both framework causes are now fixed (`Shape.focusOwner` for the first,
+container-owned ID for the second), and the check is available as
+`(*Window).TestDuplicateIDs`. This document is about the ergonomics
+question those bugs exposed.
+
+## Evidence that scoping is the missing primitive
+
+Composite widgets already build scoped IDs by hand, 36 times in `gui/`,
+with three different separators:
+
+| Separator | Example                                                    |
+| --------- | ---------------------------------------------------------- |
+| `/`       | `cfg.ID + "/" + strconv.Itoa(i)` (`view_radio_button_group.go:99`) |
+| `.`       | `cfg.ID + ".day." + strconv.Itoa(d)` (`view_date_picker_calendar.go:147`) |
+| `:`       | `cfg.ID + ":handle"` (`view_splitter_handle.go:41`)        |
+| prefix    | `cmdbtn:` namespacing in `CommandButton`                   |
+
+Every composite widget reimplements an ID stack through string
+concatenation. `mdRenderParagraph` is the one that forgot, and that is
+the whole of the second cause above. A primitive the framework itself
+needs 36 times is a primitive, not a convenience.
+
+Two further consequences of having no scope:
+
+- Uniqueness is window-global. The showcase reuses `"input-text"` in two
+  different panels and gets away with it only because the panels never
+  appear at once. Every ID in a large application is a global name.
+- Heading blocks key off `block.AnchorSlug`
+  (`view_markdown_blocks.go:356`), so two headings with identical text
+  in one document collide. A scope keyed to the document would remove
+  the collision without inventing a disambiguator.
+
+## Failure modes explicit IDs actually produce
+
+1. **A constant ID inside a loop.** Eight overflow-panel buttons built
+   from one literal (`examples/showcase/demo_layout.go`). The ID must be
+   derived from the item, and nothing in the type system says so.
+2. **Copy-paste into a nested widget.** A `Button` and the
+   `ProgressBar` inside it sharing one ID
+   (`examples/showcase/demo_feedback.go`).
+
+Both are cheap to catch once the duplicate check is trustworthy, which
+is what the framework fixes bought. Neither is an argument for dropping
+explicit IDs.
+
+## Why implicit IDs are the wrong fix
+
+The obvious reaction — derive IDs from tree position and let the author
+skip them — trades a loud failure for a silent one. In an immediate-mode
+tree, identity must survive reordering, insertion, and conditional
+rendering. A position-derived key migrates state when a list changes:
+insert a row at the top and every row below it inherits the row above's
+cursor, selection, scroll offset and focus. There is no warning for
+that, because from the framework's view nothing is wrong.
+
+Prior art agrees. Dear ImGui uses an explicit ID stack (`PushID`/`PopID`)
+precisely so loop iterations disambiguate; egui derives an `Id` from the
+parent scope plus a caller-supplied `id_salt`. Both are explicit
+identity plus a scope, not implicit identity.
+
+## Proposal to evaluate
+
+1. **An ID-scope primitive.** A way to push a namespace for a subtree so
+   that inner IDs are resolved relative to it — replacing the 36
+   hand-rolled concatenations with one mechanism, and giving loops a
+   structural answer (`scope(i)`) instead of a naming convention.
+2. **One separator.** Whatever the scope uses, applied consistently, so
+   composed IDs are parseable and predictable.
+3. **Per-container uniqueness.** Decide whether the invariant should be
+   "unique within the enclosing scope" rather than "unique per window".
+   This is the change that would make large applications composable, and
+   the one with the largest blast radius: `FindByID`, focus traversal,
+   scroll keys, `StateMap` keys and the debug audit all assume a flat
+   namespace today.
+
+Open questions:
+
+- Does a scope apply to every ID-keyed subsystem, or only to focus and
+  state? Hero animations match IDs across frames and across subtrees,
+  which a scope could break.
+- Do public IDs stay stable? Applications call `ScrollVerticalTo(id)`
+  and the test helpers take IDs; scoping changes what string an
+  application must pass.
+- Is the scope explicit at the call site or implicit in the container?
+  Implicit is less typing and harder to reason about when a widget moves.

--- a/examples/showcase/demo_feedback.go
+++ b/examples/showcase/demo_feedback.go
@@ -76,7 +76,9 @@ func buttonFeatureRows(w *gui.Window) []gui.View {
 			Content: []gui.View{
 				gui.Text(gui.TextCfg{Text: strconv.Itoa(app.ButtonClicks), MinWidth: 25}),
 				gui.ProgressBar(gui.ProgressBarCfg{
-					ID:      "showcase-button-progress",
+					// Distinct from the enclosing button's ID: the two
+					// are separate widgets and must not share identity.
+					ID:      "showcase-button-progress-bar",
 					Percent: progress,
 					Width:   75,
 					Height:  gui.CurrentTheme().TextStyleDef.Size,

--- a/examples/showcase/demo_layout.go
+++ b/examples/showcase/demo_layout.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/go-gui-org/go-gui/gui"
 )
@@ -193,7 +194,9 @@ func demoOverflowPanel(w *gui.Window) gui.View {
 		items[i] = gui.OverflowItem{
 			ID: label,
 			View: gui.Button(gui.ButtonCfg{
-				ID:      "demo_layout_demo_overflow_panel",
+				// Per item: a constant ID here would give all eight
+				// buttons one tab stop and one state slot.
+				ID:      "demo_layout_demo_overflow_panel_" + strconv.Itoa(i),
 				Color:   colors[i],
 				Content: []gui.View{gui.Text(gui.TextCfg{Text: label})},
 			}),

--- a/examples/showcase/showcase_test.go
+++ b/examples/showcase/showcase_test.go
@@ -408,3 +408,33 @@ func TestDetailPanel_BumpsAbortCounterWhenNavigatingAwayFromTree(t *testing.T) {
 			len(app.TreeLazyNodes))
 	}
 }
+
+// Every demo page must be free of identity defects: no two shapes
+// sharing an ID, and no ID-less shape claiming focus, scroll, or
+// OnMouseLeave. These collapse two widgets onto one tab stop and one
+// state slot without producing any error at runtime, so the check has
+// to be an assertion rather than something noticed on stderr.
+//
+// The sweep sees the window as rendered, which is why it walks every
+// entry: a widget behind an unselected catalog item is not in the tree.
+func TestDemoPagesHaveNoIDDefects(t *testing.T) {
+	w := gui.NewTestWindow(gui.WindowCfg{State: newShowcaseApp()})
+	w.UpdateView(mainView)
+	app := gui.State[ShowcaseApp](w)
+
+	for _, entry := range demoEntries {
+		app.SelectedGroup = entry.Group
+		app.SelectedComponent = entry.ID
+		app.ShowDocs = false
+		if found := w.TestDuplicateIDs(); len(found) > 0 {
+			t.Errorf("demo %q: %v", entry.ID, found)
+		}
+
+		// The docs view of a page is a separate tree.
+		app.ShowDocs = true
+		if found := w.TestDuplicateIDs(); len(found) > 0 {
+			t.Errorf("demo %q docs: %v", entry.ID, found)
+		}
+		app.ShowDocs = false
+	}
+}

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -21,6 +21,12 @@ import (
 //
 // The debug gate turns them into messages on stderr. It is off by
 // default and costs one atomic load per frame when off.
+//
+// The duplicate check is strict: no shape may claim an ID another
+// shape already claimed, ancestor or not. A composite widget whose
+// inner shape needs the owning widget's focus or state references it
+// through Shape.focusOwner rather than repeating its ID, which keeps
+// "one ID, one widget" true and keeps this check meaningful.
 
 // debugEnabled gates every check in this file. It is an atomic.Bool
 // rather than a plain bool because [Debug] makes it mutable at
@@ -213,6 +219,43 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids map[string]string) {
 			"shape at %s has an OnMouseLeave but no ID; leave tracking is "+
 				"keyed by ID, so the callback never fires", p)
 	}
+}
+
+// TestDuplicateIDs renders the window and returns every identity
+// finding in the frame as data: duplicate IDs, and the ID-less shapes
+// whose focus, scroll, or OnMouseLeave behaviour silently does not
+// work. An empty result means the frame's identities are sound.
+//
+// This is the assertable form of what GOGUI_DEBUG=1 prints to stderr.
+// Unlike [Window.TestUnconsumedEvents] it dispatches nothing and fires
+// no callbacks, so it is safe to call on a window an assertion still
+// depends on.
+//
+// An empty result covers the window as rendered, not the app: a widget
+// behind a tab or a dialog is only in the tree once that state is on
+// screen, so drive the app into each interesting state and check again.
+//
+// The debug gate is turned on for the duration and restored after.
+func (w *Window) TestDuplicateIDs() []string {
+	root := w.TestRender(nil)
+	if root == nil {
+		return nil
+	}
+	var found []string
+	prevOn := debugEnabled.Load()
+	// A fresh warn-once map: a sweep should report the window in front
+	// of it, not skip what an earlier sweep or a stray frame reported.
+	prevWarned := w.debug.warned
+	w.debug.warned = nil
+	w.debug.collect = &found
+	Debug(true)
+	defer func() {
+		Debug(prevOn)
+		w.debug.collect = nil
+		w.debug.warned = prevWarned
+	}()
+	w.debugAudit(root)
+	return found
 }
 
 // debugWarn prints a finding to stderr the first time this window

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -305,3 +305,89 @@ func TestDebugAuditMouseLeaveDisabledIsQuiet(t *testing.T) {
 		t.Errorf("want silence for a disabled shape, got %q", got)
 	}
 }
+
+// Two Inputs and a multi-paragraph Markdown are the two widgets that
+// used to report duplicates against themselves: Input repeated its ID
+// on its inner text shape, and every markdown paragraph claimed the
+// widget's ID. Both now reference their owner instead of claiming its
+// identity, so a window built only from them is silent.
+func TestTestDuplicateIDsCompositeWidgetsAreQuiet(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(w *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Input(InputCfg{ID: "one", Text: "hello"}),
+				Input(InputCfg{ID: "two", Mode: InputMultiline}),
+				w.Markdown(MarkdownCfg{
+					ID:     "doc",
+					Source: "First paragraph.\n\nSecond paragraph.\n\nThird.",
+				}),
+			},
+		})
+	})
+
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+// A genuine collision — a widget nested inside another with the same
+// ID — must still be reported. This is the case the "descendants may
+// reuse an ancestor's ID" shortcut would have hidden.
+func TestTestDuplicateIDsReportsNestedCollision(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Button(ButtonCfg{
+					ID: "dup",
+					Content: []View{
+						ProgressBar(ProgressBarCfg{ID: "dup", Percent: 50}),
+					},
+				}),
+			},
+		})
+	})
+
+	got := w.TestDuplicateIDs()
+	if len(got) != 1 || !strings.Contains(got[0], `duplicate ID "dup"`) {
+		t.Fatalf("want one duplicate-ID finding for the nested bar, got %q", got)
+	}
+}
+
+// The sweep borrows process-global state — the debug gate — and a
+// window's warn-once memory. Both must come back exactly as they were,
+// or a test that calls it silently changes what every later frame in
+// the process reports.
+func TestTestDuplicateIDsRestoresDebugState(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing:  FillFill,
+			Content: []View{Button(ButtonCfg{ID: "ok"})},
+		})
+	})
+
+	// A finding already remembered by this window: the sweep must not
+	// inherit it, and must not drop it either.
+	sentinel := debugWarnKey{check: debugCheckDupID, subject: "sentinel"}
+	w.debug.warned = map[debugWarnKey]struct{}{sentinel: {}}
+	prevOn := debugEnabled.Load()
+
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("want no findings, got %q", got)
+	}
+
+	if debugEnabled.Load() != prevOn {
+		t.Errorf("debug gate left at %v, want %v",
+			debugEnabled.Load(), prevOn)
+	}
+	if _, ok := w.debug.warned[sentinel]; !ok {
+		t.Error("warn-once memory not restored")
+	}
+	if w.debug.collect != nil {
+		t.Error("collect sink not cleared")
+	}
+}

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -9,6 +9,18 @@ import (
 // Text rendering functions. Extracted from render_layout.go to keep
 // both files under 800 lines.
 
+// textShapeFocused reports whether the widget this text shape renders
+// for currently holds focus. A standalone Text answers for itself via
+// Focusable+ID; an input's inner text shape answers for the container
+// named by focusOwner, which owns both the focus and the state.
+func textShapeFocused(shape *Shape, w *Window) bool {
+	if !shape.rendersFocusState() {
+		return false
+	}
+	key := shape.focusKey()
+	return key != "" && w.IsFocus(key)
+}
+
 // renderText emits a RenderText command for a text shape.
 //
 //nolint:gocyclo // text rendering options
@@ -18,9 +30,9 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 		return
 	}
 	if len(tc.Text) == 0 &&
-		(!shape.Focusable || !w.IsFocus(shape.ID) || !w.IMEComposing()) {
+		(!textShapeFocused(shape, w) || !w.IMEComposing()) {
 		// Empty text — still render cursor if focused.
-		if shape.Focusable && w.IsFocus(shape.ID) {
+		if textShapeFocused(shape, w) {
 			baseX := shape.X + shape.PaddingLeft()
 			baseY := shape.Y + shape.PaddingTop()
 			renderInputCursor(shape, "", baseX, baseY,
@@ -51,8 +63,8 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 	// A read-only field stays Focusable (to keep selection and
 	// cursor) but can never commit a composition, so its preedit
 	// must not render — makeInputOnChar would swallow the commit.
-	imeComposing := shape.Focusable && !tc.TextReadOnly &&
-		w.IsFocus(shape.ID) && w.IMEComposing()
+	imeComposing := !tc.TextReadOnly &&
+		textShapeFocused(shape, w) && w.IMEComposing()
 	compText := ""
 	compRuneLen := 0
 	compInsertPos := 0
@@ -60,7 +72,7 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 		compText = w.IMECompText()
 		compRunes := []rune(compText)
 		compRuneLen = len(compRunes)
-		is := StateReadOr(w, nsInput, shape.ID,
+		is := StateReadOr(w, nsInput, shape.focusKey(),
 			InputState{})
 		runes := []rune(text)
 		if tc.TextIsPlaceholder {
@@ -105,9 +117,9 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 	var preLayout glyph.Layout
 	hasPreLayout := false
 	needLayout := tc.TextSelBeg != tc.TextSelEnd ||
-		(shape.Focusable && w.IsFocus(shape.ID) && w.inputCursorOn()) ||
+		(textShapeFocused(shape, w) && w.inputCursorOn()) ||
 		imeComposing ||
-		spellCheckHasRanges(shape.ID, w)
+		spellCheckHasRanges(shape.focusKey(), w)
 	renderWithLayout := plainTextNeedsGlyphLayout(shape, tc, renderStyle)
 	if needLayout || renderWithLayout {
 		preLayout, hasPreLayout = inputGlyphLayoutResolved(text, shape, renderStyle, w, true)
@@ -189,7 +201,7 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 // layout engine for precise character-boundary positioning.
 func renderInputCursor(shape *Shape, text string, baseX, baseY float32,
 	preLayout glyph.Layout, hasPreLayout bool, w *Window) {
-	if !shape.Focusable || !w.IsFocus(shape.ID) {
+	if !textShapeFocused(shape, w) {
 		return
 	}
 	if !w.inputCursorOn() {
@@ -198,7 +210,7 @@ func renderInputCursor(shape *Shape, text string, baseX, baseY float32,
 	if shape.TC != nil && shape.TC.TextIsPlaceholder {
 		text = ""
 	}
-	is := StateReadOr(w, nsInput, shape.ID, InputState{})
+	is := StateReadOr(w, nsInput, shape.focusKey(), InputState{})
 	runeLen := utf8RuneCount(text)
 	pos := min(is.CursorPos, runeLen)
 

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -29,6 +29,15 @@ type Shape struct {
 	// interactive widgets.
 	ID string
 
+	// focusOwner is the ID of the widget this shape renders for. A
+	// composite widget sets it on an inner shape that must consult the
+	// owner's focus and spell-check state — Input's text shape draws
+	// the caret, selection, IME preedit and squiggles for the outer
+	// container — without claiming the owner's identity. ID is an
+	// identity and must be unique per window; focusOwner is a
+	// reference and deliberately is not.
+	focusOwner string
+
 	// Resource is an image file path, SVG source string, or data URI.
 	// Interpreted by the rendering backend.
 	Resource string
@@ -491,6 +500,25 @@ type AccessInfo struct {
 // hasEvents returns true if eventHandlers is allocated.
 func (s *Shape) hasEvents() bool {
 	return s.events != nil
+}
+
+// focusKey returns the ID whose focus and per-widget state this shape
+// renders from: focusOwner when the shape belongs to a composite
+// widget, otherwise its own ID. Empty for a shape that participates in
+// neither, which is the signal to render no caret or selection.
+func (s *Shape) focusKey() string {
+	if s.focusOwner != "" {
+		return s.focusOwner
+	}
+	return s.ID
+}
+
+// rendersFocusState reports whether this shape draws caret, selection
+// or spell-check state for some widget: for itself when Focusable, or
+// for the owner named by focusOwner. False for ordinary text, which
+// must render none of it even when it carries an ID.
+func (s *Shape) rendersFocusState() bool {
+	return s.Focusable || s.focusOwner != ""
 }
 
 // PointInShape determines if the given point is within shapeClip.

--- a/gui/spell_check.go
+++ b/gui/spell_check.go
@@ -100,14 +100,17 @@ func renderSpellCheckUnderlines(
 	gl glyph.Layout,
 	w *Window,
 ) {
-	if shape.ID == "" || !shape.Focusable {
+	// Keyed by the owning widget: an input's inner text shape carries
+	// focusOwner rather than the container's ID (see Shape.focusKey).
+	focusID := shape.focusKey()
+	if focusID == "" || !shape.rendersFocusState() {
 		return
 	}
 	sm := StateMapRead[string, spellCheckState](w, nsSpellCheck)
 	if sm == nil {
 		return
 	}
-	state, ok := sm.Get(shape.ID)
+	state, ok := sm.Get(focusID)
 	if !ok || len(state.Ranges) == 0 {
 		return
 	}

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -192,9 +192,12 @@ func Input(cfg InputCfg) View {
 
 	txtContent := []View{
 		Text(TextCfg{
-			ID:                cfg.ID,
-			Focusable:         !cfg.FocusDisabled,
-			FocusSkip:         true,
+			// No ID: the outer container below is the sole claimant of
+			// cfg.ID and the sole focus target. This shape only needs
+			// to read that widget's focus and spell-check state, which
+			// is what focusOwner expresses — claiming the ID too would
+			// put the same identity on two shapes.
+			focusOwner:        cfg.ID,
 			Sizing:            txtSizing,
 			Text:              txt,
 			TextStyle:         txtStyle,
@@ -228,7 +231,7 @@ func Input(cfg InputCfg) View {
 		Padding: NoPadding,
 		Sizing:  innerSizing,
 		VAlign:  vAlign,
-		OnClick: inputOnClick(scrollID),
+		OnClick: inputOnClick(cfg.ID, scrollID, !cfg.FocusDisabled),
 		Content: txtContent,
 	}
 	var inner View
@@ -390,15 +393,21 @@ func inputScrollIDFor(cfg *InputCfg) string {
 	return ""
 }
 
-func inputOnClick(scrollID string) func(EventCtx) {
+// inputOnClick handles a click on the inner row that wraps the text
+// shape. focusID is the owning container's ID — the key for focus and
+// for the nsInput state — and canFocus is false for a FocusDisabled
+// input, which still tracks a cursor but never takes focus. Both are
+// passed in rather than read off the text shape, which carries no ID
+// of its own (see Shape.focusOwner).
+func inputOnClick(focusID, scrollID string, canFocus bool) func(EventCtx) {
 	return func(ctx EventCtx) {
 		if len(ctx.Layout.Children) < 1 {
 			// No inner text shape: not ours
 			return
 		}
 		ly := ctx.Layout.Children[0]
-		if ly.Shape.Focusable && ly.Shape.ID != "" {
-			ctx.Window.SetFocus(ly.Shape.ID)
+		if canFocus && focusID != "" {
+			ctx.Window.SetFocus(focusID)
 		}
 		if ly.Shape.TC == nil {
 			// No text config: not ours
@@ -409,12 +418,12 @@ func inputOnClick(scrollID string) func(EventCtx) {
 				ctx.Window, nsInput, capMany,
 			)
 			// Default InputState{}: zero value seeds initial state.
-			is := imap.GetOr(ly.Shape.ID, InputState{})
+			is := imap.GetOr(focusID, InputState{})
 			is.CursorPos = 0
 			is.SelectBeg = 0
 			is.SelectEnd = 0
 			is.CursorOffset = -1
-			imap.Set(ly.Shape.ID, is)
+			imap.Set(focusID, is)
 			resetBlinkCursorVisible(ctx.Window)
 			ctx.Consume()
 			return
@@ -441,7 +450,7 @@ func inputOnClick(scrollID string) func(EventCtx) {
 		)
 		// Default InputState{}: zero LastClickTime safely gates
 		// double-click (the > 0 check below prevents false match).
-		is := imap.GetOr(ly.Shape.ID, InputState{})
+		is := imap.GetOr(focusID, InputState{})
 
 		// Double-click selects word.
 		now := time.Now().UnixMilli()
@@ -462,7 +471,7 @@ func inputOnClick(scrollID string) func(EventCtx) {
 			is.SelectEnd = uint32(runePos)
 		}
 		is.CursorOffset = -1
-		imap.Set(ly.Shape.ID, is)
+		imap.Set(focusID, is)
 		resetBlinkCursorVisible(ctx.Window)
 		if scrollID != "" && ctx.Layout.Parent != nil {
 			inputScrollCursorIntoView(
@@ -479,7 +488,7 @@ func inputOnClick(scrollID string) func(EventCtx) {
 			displayText: displayText,
 			txtOffX:     ly.Shape.X - ctx.Layout.Shape.X,
 			txtOffY:     ly.Shape.Y - ctx.Layout.Shape.Y,
-			focusID:     ly.Shape.ID,
+			focusID:     focusID,
 			scrollID:    scrollID,
 		}
 		if doubleClick {

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -743,6 +743,85 @@ func TestInputCursorNotRenderedWhenBlinkOff(t *testing.T) {
 	}
 }
 
+// Input's inner text shape carries neither ID nor Focusable — it names
+// the owning container through focusOwner (see Shape.focusKey). The
+// caret, and the cursor position it is drawn at, must resolve through
+// that reference.
+func TestInputCursorRenderedViaFocusOwner(t *testing.T) {
+	w := newTestWindow()
+	w.viewState.inputCursorOn.Store(true)
+	w.SetFocus("f703")
+	setInputState(w, "f703", InputState{CursorPos: 2})
+	style := DefaultTextStyle
+	shape := &Shape{
+		focusOwner: "f703",
+		shapeType:  shapeText,
+		Width:      200,
+		Height:     20,
+		TC: &ShapeTextConfig{
+			Text:      "hello",
+			TextStyle: &style,
+		},
+	}
+	w.renderers = w.renderers[:0]
+	renderInputCursor(shape, "hello", 0, 0, glyph.Layout{}, false, w)
+	found := false
+	for _, r := range w.renderers {
+		if r.Kind == RenderRect && r.Fill && r.W < 2 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("cursor RenderRect not emitted for focusOwner shape")
+	}
+}
+
+// The owner reference is what decides, not the mere presence of a
+// text shape: a shape whose owner is not the focused widget renders
+// nothing.
+func TestInputCursorNotRenderedWhenFocusOwnerUnfocused(t *testing.T) {
+	w := newTestWindow()
+	w.viewState.inputCursorOn.Store(true)
+	w.SetFocus("other")
+	style := DefaultTextStyle
+	shape := &Shape{
+		focusOwner: "f704",
+		shapeType:  shapeText,
+		TC: &ShapeTextConfig{
+			Text:      "hello",
+			TextStyle: &style,
+		},
+	}
+	w.renderers = w.renderers[:0]
+	renderInputCursor(shape, "hello", 0, 0, glyph.Layout{}, false, w)
+	if len(w.renderers) != 0 {
+		t.Fatal("cursor should not render for an unfocused owner")
+	}
+}
+
+// Ordinary text renders no caret however the window is focused: it is
+// neither Focusable nor owned, so it has no focus state to draw.
+func TestInputCursorNotRenderedForPlainText(t *testing.T) {
+	w := newTestWindow()
+	w.viewState.inputCursorOn.Store(true)
+	w.SetFocus("f705")
+	setInputState(w, "f705", InputState{CursorPos: 2})
+	style := DefaultTextStyle
+	shape := &Shape{
+		ID:        "f705",
+		shapeType: shapeText,
+		TC: &ShapeTextConfig{
+			Text:      "hello",
+			TextStyle: &style,
+		},
+	}
+	w.renderers = w.renderers[:0]
+	renderInputCursor(shape, "hello", 0, 0, glyph.Layout{}, false, w)
+	if len(w.renderers) != 0 {
+		t.Fatal("cursor should not render for non-focusable text")
+	}
+}
+
 func TestInputCursorUsesColumnZeroForPlaceholder(t *testing.T) {
 	w := newTestWindow()
 	w.viewState.inputCursorOn.Store(true)

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -306,6 +306,10 @@ func (w *Window) Markdown(cfg MarkdownCfg) View {
 		}))
 
 	colCfg := ContainerCfg{
+		// The container is the widget: sole claimant of cfg.ID, focus
+		// target for document selection, and what FindByID resolves to.
+		// Blocks reference it through TC.MarkdownID instead.
+		ID:          cfg.ID,
 		A11YRole:    AccessRoleGroup,
 		Color:       cfg.Color,
 		ColorBorder: cfg.ColorBorder,

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -505,7 +505,6 @@ func mdRenderParagraph(
 	ctx *mdBlockCtx,
 ) View {
 	rtfCfg := RTFCfg{
-		ID:            cfg.ID,
 		Clip:          cfg.Clip,
 		FocusSkip:     cfg.FocusSkip,
 		Disabled:      cfg.Disabled,
@@ -514,9 +513,12 @@ func mdRenderParagraph(
 		RichText:      block.Content,
 		BaseTextStyle: &block.BaseStyle,
 	}
+	// No ID and no Focusable: a paragraph is one block of a document,
+	// not the widget. The document's container claims cfg.ID and is
+	// the focus target; the blocks are tied to it through
+	// TC.MarkdownID (applyMdCtx), which is what selection keys on.
+	// Giving every block cfg.ID collapsed N paragraphs onto one
+	// identity.
 	applyMdCtx(&rtfCfg, ctx)
-	if ctx == nil {
-		rtfCfg.Focusable = cfg.Focusable
-	}
 	return RTF(rtfCfg)
 }

--- a/gui/view_text.go
+++ b/gui/view_text.go
@@ -41,6 +41,12 @@ type TextCfg struct {
 	// IME preedit on a read-only field that stays Focusable.
 	// Unexported: not a meaningful knob for standalone Text callers.
 	readOnly bool
+
+	// focusOwner is set by input widgets (view_input.go) to the ID of
+	// the container that owns the focus and per-widget state this text
+	// renders from. See Shape.focusOwner. Unexported: a standalone
+	// Text owns its identity through ID.
+	focusOwner string
 }
 
 // textView implements View for text rendering.
@@ -75,10 +81,11 @@ func (tv *textView) GenerateLayout(w *Window) Layout {
 
 	layout := Layout{
 		Shape: w.allocShape(Shape{
-			shapeType: shapeText,
-			ID:        c.ID,
-			Focusable: c.Focusable,
-			A11YRole:  AccessRoleStaticText,
+			shapeType:  shapeText,
+			ID:         c.ID,
+			focusOwner: c.focusOwner,
+			Focusable:  c.Focusable,
+			A11YRole:   AccessRoleStaticText,
 			A11Y: makeA11YInfo(
 				a11yLabel(c.A11YLabel, c.Text), c.A11YDescription,
 			),


### PR DESCRIPTION
A `GOGUI_DEBUG=1` run of the showcase reported 39 duplicate-ID warnings. Only two were application mistakes — the rest were the framework accusing itself.

## Root cause

`Shape.ID` carried two meanings:

- an **identity** for most widgets — the key for focus, scroll offsets, per-widget state and `FindByID`
- a **reference** on `Input`'s inner text shape, where `render_text.go` read `IsFocus(shape.ID)` to decide whether to draw the caret, selection and IME preedit belonging to the container

One field with two meanings means "IDs are unique per window" cannot be enforced, and the audit that would catch real collisions is untrustworthy.

## Changes

**Split reference from identity.** `Shape.focusOwner` is the reference; `Shape.focusKey()` resolves it. `Input`'s inner text now carries `focusOwner` and no `ID`, so the duplicate is gone from the tree rather than excused by the audit. 32 of the 39 warnings.

**Markdown blocks stop claiming the widget ID.** Every paragraph copied `cfg.ID`, so any document with two paragraphs collided with itself. Blocks are tied to their document through `TC.MarkdownID`, which is what selection already keys on, so the container owns `cfg.ID` and the blocks claim nothing. 5 warnings.

**The audit stays strict** — no shape may claim an ID another shape claimed, ancestor or not. Exempting descendants would have hidden the genuine `Button`/`ProgressBar` collision in the showcase, now fixed along with a constant ID used inside a loop. The remaining 2 warnings.

## Latent bug fixed on the way

The markdown container previously had **no ID at all**, and both `markdownContainerAmendLayout` and `markdownContainerOnKeyDown` early-return on an empty one — so drag-selection across blocks, `Ctrl+A` and `Ctrl+C` were dead on every `Focusable` markdown document.

## New API

`(*Window).TestDuplicateIDs()` returns every identity defect in a rendered frame as data — the assertable form of what `GOGUI_DEBUG=1` prints. Unlike `TestUnconsumedEvents` it dispatches nothing and fires no callbacks. The showcase now asserts every demo page is clean.

## Spec

`docs/specs/widget-id-scoping.md` records the ergonomics question this exposed: `gui/` hand-rolls ID namespacing 36 times with three different separators (`/`, `.`, `:`), which says a scoping primitive is missing. It also argues against the obvious reaction — implicit position-derived IDs — which trades a loud failure for a silent one in an immediate-mode tree. Not implemented here.

The first commit is unrelated bookkeeping: `docs/specs/` was gitignored, so eleven design documents lived only in working copies.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean
- `GOGUI_DEBUG=1 go run ./examples/showcase/` reports zero duplicate IDs
- New tests cover the `focusOwner` caret path, composite widgets being quiet, a nested collision still reporting, and `TestDuplicateIDs` restoring the global debug gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)