### PR TITLE
fix(listbox): virtualize under Fill sizing via deferred resolved height

### DIFF
--- a/gui/debug.go
+++ b/gui/debug.go
@@ -116,6 +116,9 @@ const (
 	// debugCheckUnconsumed is the only check that runs from dispatch
 	// rather than from the per-frame layout audit; see debug_event.go.
 	debugCheckUnconsumed
+	// debugCheckListBoxNoHeight fires from the listbox view phase
+	// rather than from the layout audit; see listBoxVisibleRange.
+	debugCheckListBoxNoHeight
 )
 
 // debugWarnKey is the warn-once key. For the ID-less checks the

--- a/gui/list_core_alloc_bench_test.go
+++ b/gui/list_core_alloc_bench_test.go
@@ -158,4 +158,30 @@ func BenchmarkListBoxGenerateLayout(b *testing.B) {
 			_ = generateViewLayout(v, w)
 		}
 	})
+
+	b.Run("fill_10k_virtualized", func(b *testing.B) {
+		// Fill sizing with no configured height: virtualization runs
+		// against the height the amend hook captured from the last
+		// arranged frame, so the 10k-row build stays bounded.
+		big := listBoxTestData(10_000)
+		w := newTestWindow()
+		cfg := ListBoxCfg{
+			ID:         "bench-lb-fill",
+			Scrollable: true,
+			Sizing:     FillFill,
+			Data:       big,
+			OnSelect:   func(_ []string, ctx EventCtx) {},
+		}
+		cache := listBoxEnsureCache(&cfg, w)
+		cache.resolvedH = 300
+		cache.hSeen = true
+		v := ListBox(cfg)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			w.scratch.resetViewPools()
+			_ = generateViewLayout(v, w)
+		}
+	})
 }

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -10,6 +10,15 @@ type listBoxCache struct {
 	itemIDs         []string
 	itemDataIndices []int
 	dataHash        uint64
+	// resolvedH is the list's height as resolved by the layout
+	// engine, captured after arrange (AmendLayout) each frame. The
+	// view phase runs before sizing, so virtualization under Fill
+	// sizing reads this from the previous frame. 0 until the first
+	// frame has been arranged.
+	resolvedH float32
+	// hSeen records that AmendLayout has run at least once, so a
+	// persistent 0 can be distinguished from "not arranged yet".
+	hSeen bool
 }
 
 // ListBoxOption represents one row in a ListBox.
@@ -40,13 +49,23 @@ type ListBoxCfg struct {
 	Padding    Opt[Padding]
 	Radius     Opt[float32]
 	SizeBorder Opt[float32]
-	Height     float32
-	MinWidth   float32
-	MaxWidth   float32
-	MinHeight  float32
-	MaxHeight  float32
+	// Height sets the list's height directly. Row virtualization
+	// needs a resolved height: with Height or MaxHeight the list
+	// virtualizes from the first frame; under Fill sizing the
+	// resolved height is read back from the previous frame's
+	// arrange, so the first frame builds every row once.
+	Height    float32
+	MinWidth  float32
+	MaxWidth  float32
+	MinHeight float32
+	// MaxHeight caps the list's height. Like Height, it resolves the
+	// height virtualization needs.
+	MaxHeight float32
 	// Scrollable opts the list into the scroll system. Scroll state
 	// is keyed by Cfg.ID — pass that same id to Window.ScrollVerticalTo.
+	// Virtualization is automatic; it requires a resolved height, so
+	// pair Scrollable with Height or MaxHeight, or rely on Fill
+	// sizing (which virtualizes from the second frame).
 	Scrollable bool
 	// FocusDisabled opts out of the default-on focus. Focus also
 	// requires a non-empty ID; without one the control is inert.
@@ -144,11 +163,12 @@ func ListBox(cfg ListBoxCfg) View {
 	})
 }
 
+// listBoxCanVirtualize reports whether the list takes the
+// virtualizing path. Scrollable alone qualifies: with no configured
+// height, virtualization starts on the second frame once Arrange has
+// resolved one.
 func listBoxCanVirtualize(cfg *ListBoxCfg) bool {
-	if cfg == nil || !cfg.Scrollable {
-		return false
-	}
-	return cfg.Height > 0 || cfg.MaxHeight > 0
+	return cfg != nil && cfg.Scrollable
 }
 
 func (lv *listBoxView) Content() []View { return nil }
@@ -164,7 +184,7 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 	selectedSet := listCoreSelectedSet(cfg.SelectedIDs)
 
 	first, last, virtualize, listH, rowH :=
-		listBoxVisibleRange(cfg, w)
+		listBoxVisibleRange(cfg, cache, w)
 
 	listBoxID := cfg.ID
 	isMultiple := cfg.Multiple
@@ -215,11 +235,12 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 	}
 
 	return generateViewLayout(Column(ContainerCfg{
-		ID:         cfg.ID,
-		A11YRole:   AccessRoleList,
-		A11YLabel:  a11yLabel(cfg.A11YLabel, cfg.ID),
-		Focusable:  !cfg.FocusDisabled,
-		Scrollable: cfg.Scrollable,
+		ID:          cfg.ID,
+		A11YRole:    AccessRoleList,
+		A11YLabel:   a11yLabel(cfg.A11YLabel, cfg.ID),
+		Focusable:   !cfg.FocusDisabled,
+		Scrollable:  cfg.Scrollable,
+		AmendLayout: listBoxAmendLayout(cache),
 		OnKeyDown: func(ctx EventCtx) {
 			if canReorder {
 				if dragReorderEscape(
@@ -290,9 +311,12 @@ func listBoxEnsureCache(cfg *ListBoxCfg, w *Window) *listBoxCache {
 }
 
 // listBoxVisibleRange computes the visible row range and
-// virtualization parameters for the list box.
+// virtualization parameters for the list box. The height comes from
+// Cfg.Height, then MaxHeight, then the cache's resolvedH — the
+// height the layout engine allocated last frame, which is how Fill
+// sizing virtualizes.
 func listBoxVisibleRange(
-	cfg *ListBoxCfg, w *Window,
+	cfg *ListBoxCfg, cache *listBoxCache, w *Window,
 ) (first, last int, virtualize bool, listH, rowH float32) {
 	first = 0
 	last = len(cfg.Data) - 1
@@ -300,6 +324,9 @@ func listBoxVisibleRange(
 	listH = cfg.Height
 	if listH <= 0 {
 		listH = cfg.MaxHeight
+	}
+	if listH <= 0 {
+		listH = cache.resolvedH
 	}
 	rowH = listCoreRowHeightEstimate(cfg.TextStyle, listBoxItemPad)
 	if virtualize && listH > 0 && len(cfg.Data) > 0 {
@@ -309,8 +336,38 @@ func listBoxVisibleRange(
 			len(cfg.Data), rowH, listH, scrollY)
 	} else {
 		virtualize = false
+		if cfg.Scrollable && cache.hSeen &&
+			len(cfg.Data) > 0 && DebugEnabled() {
+			// The layout has run at least once and still gave the
+			// list no height, so every row builds each frame.
+			w.debugWarn(debugCheckListBoxNoHeight, cfg.ID,
+				"scrollable listbox %q resolved to height 0, so "+
+					"virtualization is off and all %d rows build "+
+					"every frame; set Height/MaxHeight or give it "+
+					"sizing that allocates height",
+				cfg.ID, len(cfg.Data))
+		}
 	}
 	return first, last, virtualize, listH, rowH
+}
+
+// listBoxAmendLayout captures the arranged height into the cache so
+// the next frame's view phase can virtualize against it. Runs after
+// sizing, when Shape.Height holds the resolved height — including
+// the Fill-allocated height the view phase cannot know.
+func listBoxAmendLayout(cache *listBoxCache) func(EventCtx) {
+	return func(ctx EventCtx) {
+		if ctx.Layout == nil || ctx.Layout.Shape == nil {
+			return
+		}
+		// Guard against a non-finite or degenerate height: a
+		// non-finite value would flow into listCoreVisibleRange's
+		// float→int division.
+		if h := ctx.Layout.Shape.Height; h > 0 && f32IsFinite(h) {
+			cache.resolvedH = h
+		}
+		cache.hSeen = true
+	}
 }
 
 // listBoxDragIndexByRow builds a mapping from data row index to
@@ -686,6 +743,9 @@ func applyListBoxDefaults(cfg *ListBoxCfg) {
 	}
 }
 
+// listBoxDataHash hashes the fields the list box cache derives
+// from: ID and IsSubheading. Name and Value never reach the cache, so
+// hashing them would burn O(data) time every frame for nothing.
 func listBoxDataHash(items []ListBoxOption) uint64 {
 	const offset uint64 = 14695981039346656037
 	const prime uint64 = 1099511628211
@@ -694,20 +754,6 @@ func listBoxDataHash(items []ListBoxOption) uint64 {
 		it := items[i]
 		for j := range len(it.ID) {
 			h ^= uint64(it.ID[j])
-			h *= prime
-		}
-		h ^= 0xff
-		h *= prime
-
-		for j := range len(it.Name) {
-			h ^= uint64(it.Name[j])
-			h *= prime
-		}
-		h ^= 0xff
-		h *= prime
-
-		for j := range len(it.Value) {
-			h ^= uint64(it.Value[j])
 			h *= prime
 		}
 		h ^= 0xff

--- a/gui/view_listbox_test.go
+++ b/gui/view_listbox_test.go
@@ -1,6 +1,10 @@
 package gui
 
-import "testing"
+import (
+	"math"
+	"strconv"
+	"testing"
+)
 
 func TestListBoxIDPassthrough(t *testing.T) {
 	w := &Window{}
@@ -137,5 +141,239 @@ func TestListBoxSubheadingCount(t *testing.T) {
 	}), w)
 	if len(layout.Children) != 2 {
 		t.Errorf("children: got %d, want 2", len(layout.Children))
+	}
+}
+
+// listBoxTestData builds n rows of stable data.
+func listBoxTestData(n int) []ListBoxOption {
+	data := make([]ListBoxOption, n)
+	for i := range n {
+		s := strconv.Itoa(i)
+		data[i] = NewListBoxOption("id-"+s, "Name "+s, "")
+	}
+	return data
+}
+
+func TestListBoxFillVirtualizesNextFrame(t *testing.T) {
+	// Scrollable + Fill sizing must take the virtualizing path, and
+	// once Arrange has resolved a height (captured by the amend
+	// hook), the view phase builds only the visible rows.
+	w := newTestWindow()
+	cfg := ListBoxCfg{
+		ID:         "lb-fill",
+		Scrollable: true,
+		Sizing:     FillFill,
+		Data:       listBoxTestData(10_000),
+	}
+	v := ListBox(cfg)
+	if _, ok := v.(*listBoxView); !ok {
+		t.Fatal("Scrollable list with no Height must use the virtualizing path")
+	}
+
+	// Frame 1: no arranged height yet, so every row builds.
+	first := generateViewLayout(v, w)
+	if len(first.Children) < 9_000 {
+		t.Fatalf("frame 1 children = %d, want all rows (unresolved height)",
+			len(first.Children))
+	}
+
+	// Arrange resolves the height; the amend hook captures it.
+	first.Shape.Height = 350
+	first.Shape.events.AmendLayout(EventCtx{&first, nil, w})
+	w.scrollY().Set(cfg.ID, 1000)
+
+	// Frame 2: virtualized to the visible range plus spacers.
+	second := generateViewLayout(v, w)
+	if len(second.Children) > 500 {
+		t.Fatalf("frame 2 children = %d, want visible range only",
+			len(second.Children))
+	}
+	// Scrolled past row 0: leading spacer first, trailing spacer last.
+	if len(second.Children) < 3 {
+		t.Fatalf("frame 2 children = %d, want spacer+rows+spacer",
+			len(second.Children))
+	}
+	if !second.Children[0].Shape.Color.Eq(ColorTransparent) {
+		t.Error("leading virtualization spacer missing")
+	}
+	if !second.Children[len(second.Children)-1].Shape.Color.
+		Eq(ColorTransparent) {
+		t.Error("trailing virtualization spacer missing")
+	}
+}
+
+func TestListBoxAmendStoresResolvedHeight(t *testing.T) {
+	w := newTestWindow()
+	cfg := ListBoxCfg{
+		ID:         "lb-amend",
+		Scrollable: true,
+		Data:       listBoxTestData(10),
+	}
+	v := ListBox(cfg)
+	layout := generateViewLayout(v, w)
+	cache := listBoxEnsureCache(&cfg, w)
+
+	// No arrange yet: height unknown, hSeen false.
+	if cache.hSeen {
+		t.Fatal("hSeen set before any amend")
+	}
+
+	layout.Shape.Height = 220
+	layout.Shape.events.AmendLayout(EventCtx{&layout, nil, w})
+	if !cache.hSeen {
+		t.Fatal("hSeen not set after amend")
+	}
+	if cache.resolvedH != 220 {
+		t.Fatalf("resolvedH = %v, want 220", cache.resolvedH)
+	}
+
+	// A zero height must not clobber a previously resolved height.
+	layout.Shape.Height = 0
+	layout.Shape.events.AmendLayout(EventCtx{&layout, nil, w})
+	if cache.resolvedH != 220 {
+		t.Fatalf("resolvedH = %v after zero amend, want 220", cache.resolvedH)
+	}
+
+	// A non-finite height must be rejected outright.
+	layout.Shape.Height = float32(math.Inf(1))
+	layout.Shape.events.AmendLayout(EventCtx{&layout, nil, w})
+	if cache.resolvedH != 220 {
+		t.Fatalf("resolvedH = %v after Inf amend, want 220", cache.resolvedH)
+	}
+}
+
+func TestListBoxVisibleRangeHeightPriority(t *testing.T) {
+	// The height for virtualization resolves Height, then MaxHeight,
+	// then the resolved height from the last arranged frame.
+	w := newTestWindow()
+	data := listBoxTestData(100)
+
+	cases := []struct {
+		name              string
+		height, maxHeight float32
+		resolvedH         float32
+		wantListH         float32
+		wantVirtualize    bool
+	}{
+		{"height_wins", 300, 200, 100, 300, true},
+		{"max_height_wins", 0, 200, 100, 200, true},
+		{"resolved_wins", 0, 0, 100, 100, true},
+		{"none_zero", 0, 0, 0, 0, false},
+		// A negative resolved height is used verbatim as the final
+		// fallback; downstream treats any <=0 as "no height".
+		{"negative_resolved", 0, 0, -5, -5, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ListBoxCfg{
+				ID:         "lb-prio-" + tc.name,
+				Scrollable: true,
+				Height:     tc.height,
+				MaxHeight:  tc.maxHeight,
+				Data:       data,
+			}
+			cache := &listBoxCache{resolvedH: tc.resolvedH, hSeen: true}
+			first, last, virtualize, listH, _ :=
+				listBoxVisibleRange(&cfg, cache, w)
+			if listH != tc.wantListH {
+				t.Errorf("listH = %v, want %v", listH, tc.wantListH)
+			}
+			if virtualize != tc.wantVirtualize {
+				t.Errorf("virtualize = %v, want %v", virtualize,
+					tc.wantVirtualize)
+			}
+			// Non-virtualizing lists keep the full range: the caller
+			// builds every row.
+			if !tc.wantVirtualize && (first != 0 || last != len(data)-1) {
+				t.Errorf("range [%d,%d], want full [0,%d]", first, last,
+					len(data)-1)
+			}
+		})
+	}
+}
+
+func TestListBoxCacheRefreshIgnoresNameValue(t *testing.T) {
+	// The cache derives from ID and IsSubheading only, so mutating
+	// Name or Value must not refresh it, while mutating ID must.
+	w := newTestWindow()
+	data := listBoxTestData(5)
+	cfg := ListBoxCfg{ID: "lb-cache-hash", Data: data}
+	cache := listBoxEnsureCache(&cfg, w)
+	wantIDs := []string{"id-0", "id-1", "id-2", "id-3", "id-4"}
+	if len(cache.itemIDs) != 5 || cache.itemIDs[0] != wantIDs[0] {
+		t.Fatalf("cache not seeded: %v", cache.itemIDs)
+	}
+
+	mutate := func(fn func(*ListBoxOption)) {
+		for i := range cfg.Data {
+			fn(&cfg.Data[i])
+		}
+	}
+
+	// Name mutation: no refresh (the reduced hash ignores it).
+	mutate(func(o *ListBoxOption) { o.Name = "renamed" })
+	listBoxEnsureCache(&cfg, w)
+	if len(cache.itemIDs) != 5 {
+		t.Fatalf("Name mutation refreshed cache: %v", cache.itemIDs)
+	}
+
+	// Value mutation: no refresh.
+	mutate(func(o *ListBoxOption) { o.Value = "new value" })
+	listBoxEnsureCache(&cfg, w)
+	if len(cache.itemIDs) != 5 {
+		t.Fatalf("Value mutation refreshed cache: %v", cache.itemIDs)
+	}
+
+	// IsSubheading mutation: refresh.
+	cfg.Data[0].IsSubheading = true
+	listBoxEnsureCache(&cfg, w)
+	if len(cache.itemIDs) != 4 {
+		t.Fatalf("IsSubheading mutation not refreshed: %v", cache.itemIDs)
+	}
+
+	// ID mutation: refresh with the new IDs.
+	cfg.Data[0].IsSubheading = false
+	cfg.Data[0].ID = "renamed-id"
+	listBoxEnsureCache(&cfg, w)
+	if len(cache.itemIDs) != 5 || cache.itemIDs[0] != "renamed-id" {
+		t.Fatalf("ID mutation not refreshed: %v", cache.itemIDs)
+	}
+}
+
+func TestListBoxNoHeightWarning(t *testing.T) {
+	prevOn := DebugEnabled()
+	Debug(true)
+	defer Debug(prevOn)
+
+	// Persistent zero height: the layout arranged but gave the list
+	// nothing, so virtualization is off. Warn once, only after hSeen.
+	w := newTestWindow()
+	var found []string
+	w.debug.collect = &found
+	cfg := ListBoxCfg{
+		ID:         "lb-warn",
+		Scrollable: true,
+		Data:       listBoxTestData(500),
+	}
+	v := ListBox(cfg)
+
+	// First frame, never arranged: no warning yet.
+	layout := generateViewLayout(v, w)
+	if len(found) != 0 {
+		t.Fatalf("warned before first arrange: %v", found)
+	}
+
+	// Arrange gives zero height; amend marks hSeen.
+	layout.Shape.Height = 0
+	layout.Shape.events.AmendLayout(EventCtx{&layout, nil, w})
+	generateViewLayout(v, w)
+	if len(found) != 1 {
+		t.Fatalf("found %d findings, want 1: %v", len(found), found)
+	}
+
+	// Warn-once: later frames do not repeat it.
+	generateViewLayout(v, w)
+	if len(found) != 1 {
+		t.Fatalf("warning repeated: %v", found)
 	}
 }


### PR DESCRIPTION
Closes #222

## Problem

`examples/listbox` (10,000 rows) built every row each frame: 3.8ms / 70,120 allocs / 14.5MB garbage per frame in the view phase instead of ~30 visible rows.

`Scrollable` + `FillFill` sizing never virtualized. The view phase runs before `layoutArrange`, so at the virtualization gate both `cfg.Height` and `cfg.MaxHeight` were 0 and the widget silently fell back to building every row — a 12x slowdown introduced by 990d7c7 (#202), which moved the example from an explicit height to Fill sizing.

## Fix

- **Deferred height resolution**: the listbox column gets an internal `AmendLayout` hook (runs after arrange, when `Shape.Height` holds the resolved height — including the Fill-allocated one). The height is stored in the per-ID `listBoxCache` and read back by the next frame's view phase: `Height > MaxHeight > resolvedH`.
- **Gate on Scrollable alone**: `listBoxCanVirtualize` no longer requires a configured height. First frame builds all rows once (one bounded hitch), then virtualization takes over.
- **O(data) hash removed**: `listBoxDataHash` now hashes only the cache-relevant fields (ID, IsSubheading) instead of ID+Name+Value every frame — the remaining 305us@10k secondary cost from #222.
- **Debug warning** (once per ID, `gui.Debug(true)`): a Scrollable list that persistently resolves to height 0 with rows reports that virtualization is off.
- **Docs**: `ListBoxCfg.Height`/`MaxHeight`/`Scrollable` now state the virtualization height rule.

## Results (Apple M5, `generateViewLayout` only, 10k rows)

| config | ns/op | allocs/op | B/op |
| --- | --- | --- | --- |
| before (issue) | 3,819,191 | 70,120 | 14,563,224 |
| after | 89,521 | 127 | 23,906 |

44x faster, ~550x fewer allocations. The example stays FillFill — 990d7c7's intent (no manual viewport math) is preserved.

## Tests

- `TestListBoxFillVirtualizesNextFrame` — frame 1 all rows, amend captures height, frame 2 bounded to visible range with spacers
- `TestListBoxAmendStoresResolvedHeight` — hSeen/resolvedH capture, zero and non-finite heights rejected
- `TestListBoxVisibleRangeHeightPriority` — Height > MaxHeight > resolvedH fallback order
- `TestListBoxCacheRefreshIgnoresNameValue` — reduced-hash contract pinned
- `TestListBoxNoHeightWarning` — warn-once, first-frame silence
- `BenchmarkListBoxGenerateLayout/fill_10k_virtualized` — new bounded case