### PR TITLE
docs(examples): add per-example description headers (#216)

### DIFF
--- a/examples/2048/main.go
+++ b/examples/2048/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a 2048 tile-merging game with keyboard input and animations.
 package main
 
 import (

--- a/examples/android_demo/demo.go
+++ b/examples/android_demo/demo.go
@@ -1,5 +1,6 @@
 //go:build android
 
+// This example demonstrates go-gui on Android via OpenGL ES 3.0 (advanced: Android).
 // Package androidapp is an Android demo app for go-gui.
 // Built with gomobile bind to generate an AAR for Kotlin host.
 package androidapp

--- a/examples/animation_stress/main.go
+++ b/examples/animation_stress/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates many concurrent tween animations with random positions, sizes, colors, shapes, and easing functions.
 // Animation stress test: many concurrent tween animations with random
 // positions, sizes, colors, shapes, and easing functions.
 package main

--- a/examples/animations/main.go
+++ b/examples/animations/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates tween, spring, keyframe, layout, and hero transitions in one window.
 // The animations example showcases tween, spring, keyframe, layout,
 // and hero transitions in one window.
 package main

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates frame costs while rendering large widget batches.
 // Benchmark measures frame costs while rendering large batches of
 // widgets.
 package main

--- a/examples/blur_demo/main.go
+++ b/examples/blur_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates blur radius on shapes to create glows and soft-edged shapes.
 // The blur demo shows how blur radius can create glows and
 // soft-edged shapes.
 package main

--- a/examples/calculator/main.go
+++ b/examples/calculator/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a calculator app.
 // Package main implements a calculator example app.
 package main
 

--- a/examples/color_picker/main.go
+++ b/examples/color_picker/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates color editing with runtime theme switching.
 // The color picker example combines color editing with runtime
 // theme switching.
 package main

--- a/examples/command_demo/main.go
+++ b/examples/command_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a menu bar, registered commands, global and non-global hotkeys, CanExecute auto-disable, and CommandPalette integration.
 // Command demo shows a menu bar with shortcut hints and
 // buttons wired to registered commands. Demonstrates global
 // vs non-global hotkeys, CanExecute auto-disable, and

--- a/examples/context_menu/main.go
+++ b/examples/context_menu/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates right-click context menus and their action handling.
 // The context menu example demonstrates right-click menus and
 // action handling.
 package main

--- a/examples/cursor_demo/main.go
+++ b/examples/cursor_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates every mouse cursor shape the backends support.
 // Cursor demo shows every mouse cursor shape the backends support.
 // Hover a cell to change the cursor; hover empty space to reset it.
 // On Linux the two diagonal resize shapes come from the desktop's

--- a/examples/custom_shader/main.go
+++ b/examples/custom_shader/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates animated fragment shaders inside ordinary containers (advanced: custom shaders).
 // Custom_shader renders animated fragment shaders inside ordinary
 // go-gui containers.
 package main

--- a/examples/data_grid_data_source/main.go
+++ b/examples/data_grid_data_source/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a large data grid backed by a paged in-memory data source.
 // The data grid data source example shows a large grid backed by
 // a paged in-memory data source.
 package main

--- a/examples/date_picker_options/main.go
+++ b/examples/date_picker_options/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates DatePicker configuration with toggleable options, weekday, month, and year filters, and theme switching.
 // Date Picker Options example demonstrates DatePicker configuration
 // with toggleable options, weekday/month/year filters, and theme switching.
 package main

--- a/examples/dialogs/main.go
+++ b/examples/dialogs/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates custom dialogs and native file dialogs.
 // Dialogs demonstrates custom dialogs and native file dialogs.
 package main
 

--- a/examples/digital_rain/main.go
+++ b/examples/digital_rain/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the falling-character effect from "The Matrix".
 // Digital_rain recreates the falling-character effect from "The Matrix".
 package main
 

--- a/examples/dock_layout/main.go
+++ b/examples/dock_layout/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the DockLayout widget: IDE-style panels with splits, tabs, drag-and-drop rearrangement, and closable panels.
 // Dock_layout demonstrates the DockLayout widget: IDE-style
 // docking panels with splits, tabs, drag-and-drop rearrangement,
 // and closable panels.

--- a/examples/draw_canvas/main.go
+++ b/examples/draw_canvas/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the DrawCanvas widget with a line chart.
 // Draw_canvas demonstrates the DrawCanvas widget with a line chart.
 package main
 

--- a/examples/floating_layout/main.go
+++ b/examples/floating_layout/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates anchored overlays positioned over their parent content (advanced: floating layout).
 // The floating layout example shows how anchored overlays can be
 // positioned relative to their parent content.
 package main

--- a/examples/fontviewer/main.go
+++ b/examples/fontviewer/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a browsable catalog of system fonts in a virtualized grid.
 // Font Viewer — browsable system-font catalog.
 //
 // Virtualized card grid with filter, sample text, size slider,

--- a/examples/get_started/main.go
+++ b/examples/get_started/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the smallest stateful go-gui app: one button and one counter.
 // Get_started is the smallest stateful go-gui app: one button
 // and one counter.
 package main

--- a/examples/gradient_demo/main.go
+++ b/examples/gradient_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the built-in gradient directions and how to swap them at runtime.
 // Gradient_demo shows the built-in gradient directions and how
 // to swap them at runtime.
 package main

--- a/examples/ios_demo/main.go
+++ b/examples/ios_demo/main.go
@@ -1,5 +1,6 @@
 //go:build ios
 
+// This example demonstrates go-gui on iOS (advanced: iOS).
 // Command ios_demo is an iOS demo app for go-gui.
 // Compiled as a c-archive and linked into a native Xcode project.
 package main

--- a/examples/key_up_demo/main.go
+++ b/examples/key_up_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates key-down and key-up event handling.
 package main
 
 import (

--- a/examples/listbox/main.go
+++ b/examples/listbox/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a virtualized list with a large option set and simple selection state.
 // The listbox example demonstrates a virtualized list with a large
 // option set and simple selection state.
 package main

--- a/examples/markdown/main.go
+++ b/examples/markdown/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates an embedded markdown document in the markdown view.
 // Markdown renders an embedded markdown document with the built-in
 // markdown view.
 package main

--- a/examples/menu_demo/main.go
+++ b/examples/menu_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a menu bar, nested items, and simple stateful actions.
 // The menu demo shows a menu bar, nested items, and simple stateful
 // actions.
 package main

--- a/examples/minesweeper/main.go
+++ b/examples/minesweeper/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a complete Minesweeper game with no-guess mode, hints, and training mode.
 // Minesweeper example — a complete game with no-guess mode, CSP
 // solver, hints, board check, training mode, and garden theme.
 package main

--- a/examples/multi_window/main.go
+++ b/examples/multi_window/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates multi-window support: two windows with independent state and cross-window messaging (advanced: multi-window).
 // Multi_window demonstrates multi-window support: two windows
 // with independent state, cross-window communication, and
 // runtime window creation.

--- a/examples/multiline_input/main.go
+++ b/examples/multiline_input/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates multiline input: cursor movement, selection, clipboard, and scrolling.
 // The multiline input example is a playground for cursor movement,
 // selection, clipboard, and scrolling behavior.
 package main

--- a/examples/native_menu/main.go
+++ b/examples/native_menu/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a native macOS menubar with an auto-wired Edit menu (advanced: native menus).
 // Native menu demonstrates a native macOS menubar with
 // auto-wired Edit menu, command integration, and status
 // feedback.

--- a/examples/particles/main.go
+++ b/examples/particles/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates an interactive particle simulation with configurable physics and visual presets.
 // Particle system toy — interactive particle simulation with
 // configurable physics, emitter types, and visual presets.
 // Click/drag on the canvas to move the emitter.

--- a/examples/process_monitor/main.go
+++ b/examples/process_monitor/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a live process monitor with sortable columns and CPU and RAM history charts.
 package main
 
 import (

--- a/examples/rotated_box/main.go
+++ b/examples/rotated_box/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the RotatedBox widget with quarter-turn rotations, interactive content, and nesting.
 // The rotated_box example demonstrates the RotatedBox widget
 // with quarter-turn rotations, interactive content, and nesting.
 package main

--- a/examples/rtf/main.go
+++ b/examples/rtf/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates rich text runs, links, abbreviations, and wrapping in the RTF widget.
 // RTF demonstrates rich text runs, links, abbreviations, and
 // wrapping inside the RTF widget.
 package main

--- a/examples/scroll_demo/main.go
+++ b/examples/scroll_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates scroll containers, programmatic scroll control, and theme toggling.
 // The scroll demo shows scroll containers, programmatic scroll
 // control, and theme toggling.
 package main

--- a/examples/shadow_demo/main.go
+++ b/examples/shadow_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates shadow and glow configurations with theme toggling.
 // Shadow_demo compares shadow and glow configurations while
 // letting the user toggle themes.
 package main

--- a/examples/showcase/main.go
+++ b/examples/showcase/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the full go-gui widget gallery with a dev-mode inspector (advanced: inspector).
 // Package main implements a faithful showcase port for the Go-Gui framework.
 package main
 

--- a/examples/snake/main.go
+++ b/examples/snake/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a snake game built on go-gui state, input events, and animations.
 // The snake example is a small game built on go-gui state,
 // input events, and animations.
 package main

--- a/examples/solitaire/main.go
+++ b/examples/solitaire/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates Klondike solitaire with drag-and-drop card movement, scoring, and right-click auto-complete.
 // Solitaire example — Klondike solitaire with a 1980s arcade
 // landing page, drag-and-drop card movement, scoring, and
 // right-click auto-complete.

--- a/examples/svg/main.go
+++ b/examples/svg/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a split-view browser for several embedded SVG assets.
 // Svg lets you browse several embedded SVG assets in a simple
 // split-view viewer.
 package main

--- a/examples/svg_a11y/main.go
+++ b/examples/svg_a11y/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates SVG accessibility metadata parsing (title, description, aria attributes).
 // Svg_a11y demonstrates SVG accessibility metadata parsing — the
 // <title>, <desc>, aria-label, aria-roledescription, and
 // aria-hidden values surface on SvgParsed.A11y after LoadSvg.

--- a/examples/svg_aspect/main.go
+++ b/examples/svg_aspect/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates preserveAspectRatio meet and slice alignment on SVG renders.
 // Svg_aspect renders the same SVG with each preserveAspectRatio
 // alignment in a wide rectangular tile so the slack distribution
 // is visible. Toggles between "meet" (default, fits) and "slice"

--- a/examples/svg_css_selectors/main.go
+++ b/examples/svg_css_selectors/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates CSS selector additions: adjacent, general-sibling, and attribute selectors, plus :not().
 // Svg_css_selectors demonstrates v0.14.0 CSS selector additions:
 // adjacent (`+`), general-sibling (`~`), and attribute selectors,
 // plus :not(). Each tile renders the same path collection styled by

--- a/examples/svg_css_states/main.go
+++ b/examples/svg_css_states/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates :hover and :focus pseudo-class matching on SVG elements.
 // Svg_css_states demonstrates :hover and :focus pseudo-class
 // matching driven by HoveredElementID / FocusedElementID on SvgCfg.
 //

--- a/examples/svg_css_vars/main.go
+++ b/examples/svg_css_vars/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates CSS custom properties: var() with fallback and calc() arithmetic.
 // Svg_css_vars demonstrates v0.14.0 CSS custom-property additions:
 // `var(--name, fallback)` resolution and `calc()` arithmetic. The
 // theme switcher rebuilds the SVG source with a different `--primary`

--- a/examples/svg_flatness/main.go
+++ b/examples/svg_flatness/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the FlatnessTolerance knob on SVG tessellation.
 // Svg_flatness visualizes the FlatnessTolerance knob on SvgCfg. A
 // curve-heavy logo is rendered at five increasing tolerance values:
 // higher tolerance = coarser polyline approximation = fewer

--- a/examples/svg_gradient_spread/main.go
+++ b/examples/svg_gradient_spread/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates spreadMethod pad, reflect, and repeat on linear and radial gradients.
 // Svg_gradient_spread demonstrates spreadMethod="pad|reflect|repeat"
 // on linear and radial gradients. The same gradient is rendered with
 // each spread mode in a 2x3 grid so the falloff differences are

--- a/examples/svg_hittest/main.go
+++ b/examples/svg_hittest/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates hit testing: reporting which authored path the cursor sits inside on click.
 // Svg_hittest demonstrates TessellatedPath.ContainsPoint by
 // reporting which authored path the cursor sits inside on click.
 // SvgCfg.OnClick gives shape-relative MouseX/MouseY in display

--- a/examples/svg_radial/main.go
+++ b/examples/svg_radial/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates radial gradient parsing and rendering.
 // Svg_radial demonstrates radialGradient parsing and rendering. A
 // 2x3 grid renders the same shape filled with: linear gradient,
 // centered radial, off-center radial, large-R radial,

--- a/examples/svg_spinners/main.go
+++ b/examples/svg_spinners/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a selection of the built-in SvgSpinner kinds.
 // Svg_spinners showcases a curated subset of built-in
 // SvgSpinner kinds. The full catalog of 100+ assets is
 // available via the SvgSpinnerKind enum; the gallery renders

--- a/examples/svg_use_symbol/main.go
+++ b/examples/svg_use_symbol/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates <use> and <symbol> resolution with per-instance fill overrides.
 // Svg_use_symbol demonstrates <use href="#id"> and <symbol>
 // resolution. A single <symbol> is referenced multiple times via
 // <use> with translate offsets and per-instance fill overrides; the

--- a/examples/system_tray/main.go
+++ b/examples/system_tray/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a tray icon with a menu and re-show and quit actions (advanced: system tray).
 // System tray demonstrates a tray icon with menu. Closing the
 // window keeps the app alive via ExitOnTrayRemoved. The tray
 // menu can re-show the window or quit.

--- a/examples/termgrid/main.go
+++ b/examples/termgrid/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates the TermGrid primitive: a fixed-pitch character grid drawn from a cell buffer.
 // Termgrid demonstrates the TermGrid primitive: a fixed-pitch
 // character grid drawn straight from a cell buffer in one render
 // command (no per-cell Layout nodes). It shows per-cell foreground /

--- a/examples/time_travel/main.go
+++ b/examples/time_travel/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates time-travel debugging: a counter app with a state scrubber window (advanced: time travel).
 // The time_travel example demonstrates time-travel debugging.
 // A small counter app opts into DebugTimeTravel; the framework
 // auto-spawns a scrubber window with a slider, step buttons,

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a small stateful app with a text input, action buttons, and a list.
 // The todo example shows a small stateful GUI app with a text input,
 // action buttons, and a list rendered from window state.
 package main

--- a/examples/vibrancy/main.go
+++ b/examples/vibrancy/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a translucent, blurred native window backdrop on macOS.
 // Vibrancy demonstrates a translucent, blurred native window backdrop on
 // macOS via w.SetWindowVibrancy. The window BgColor is translucent (alpha <
 // 255) so the NSVisualEffectView behind the content shows through. On other

--- a/examples/web_demo/main.go
+++ b/examples/web_demo/main.go
@@ -1,3 +1,4 @@
+// This example demonstrates a go-gui app that runs in the browser via wasm (advanced: webassembly).
 // Web_demo is a go-gui app that runs in the browser via wasm.
 // Same source code pattern as get_started — proves cross-platform
 // compilation with no wasm-specific code.


### PR DESCRIPTION
Adds a one-line 'This example demonstrates ...' header comment to every example's main.go (and android_demo's demo.go), making examples grep-able:

```
grep -rn "This example demonstrates" examples/
```

- 58 files, one inserted line each; existing comments preserved below the header.
- 10 examples flagged `(advanced: ...)` — floating layout, time travel, multi-window, native menus, system tray, webassembly, Android, iOS, custom shaders, inspector (showcase).
- Closes #216.