### PR TITLE
feat(debug): per-category opt-in for dev-mode diagnostics (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ work.
 ## Debugging
 
 Set `GOGUI_DEBUG=1` (or `gui.Debug(true)`) to audit every frame for duplicate
-widget IDs and focusable widgets without IDs. See the
+widget IDs and focusable widgets without IDs. `gui.DebugCategories` enables each
+class of finding — duplicates, missing IDs, unconsumed events, listbox
+virtualization — independently. See the
 [Debugging](https://github.com/go-gui-org/go-gui/wiki/Debugging) wiki page.
 
 ## License

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -1,0 +1,302 @@
+# Spec: per-scope uniqueness (framework-computed effective IDs)
+
+Status: draft — pending approval. Written 2026-08-09; revised after review (round 2:
+generation-time scope for widget state, datagrid exception, migration-list gaps). Source:
+"Remaining work" in [`widget-id-scoping.md`](widget-id-scoping.md). Target: major version
+(semantic break; signatures unchanged).
+
+This document is the normative spec for the change. Implementation phases follow the
+decisions below. Parent doc [`widget-id-scoping.md`](widget-id-scoping.md) keeps the `:`
+grammar, `ScopeID` / `ScopeIDN`, and no-escaping rules.
+
+## Problem
+
+Nothing crashes. The remaining limit is **composability**.
+
+Today every `Shape.ID` is a **window-global** key for focus, scroll, hover, hero, and
+per-widget state. Two shapes with the same ID in one frame share one slot.
+`TestDuplicateIDs` and the debug audit report that. They do not make reuse safe.
+
+This is illegal (or fragile) even when the widgets sit in different panels:
+
+```go
+Panel{ID: "settings", Content: Input{ID: "name", ...}}
+Panel{ID: "profile",  Content: Input{ID: "name", ...}}
+```
+
+Both claim `"name"`. Authors must hand-namespace every nested control
+(`ScopeID("settings", "name")`, …). In a large app, every leaf ID is a global name.
+
+The showcase reuses `"input-text"` across demos only because those demos do not appear in
+the same frame. That is mutual exclusion, not scoping. Reuse under two ID-bearing panels
+becomes safe only after this change, and only if those panels actually carry IDs.
+
+[`widget-id-scoping.md`](widget-id-scoping.md) already fixed the other half: one
+separator, `ScopeID`, and framework self-collisions (`focusOwner`, markdown ownership).
+**Per-scope uniqueness** is the leftover: can two panels each use `"name"` if the
+framework joins ancestor IDs into an effective key?
+
+## Why raw IDs and tree position both fail
+
+Per-container uniqueness is only meaningful if the **framework** computes identity:
+
+| Approach                             | Result                                                                                                     |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Key stores on raw `Shape.ID`         | No-op. Both panels still store under `"name"`.                                                             |
+| Scope by tree position / child index | Silent identity migration on reorder — the failure Decision 1 in the parent spec rejects for implicit IDs. |
+
+## Invariant
+
+**Effective identity** (`effID`) is window-unique. **Leaf** `Shape.ID` may repeat across
+scopes.
+
+```
+effID(shape) =
+  shape.ID                           if shape.ID contains ":"   // absolute
+  ScopeID(effID(nearest ID-bearing ancestor), shape.ID)
+                                     if shape.ID != "" and an ID-bearing ancestor exists
+  shape.ID                           if shape.ID != "" and no ID-bearing ancestor
+  ""                                 if shape.ID == ""
+```
+
+Rules:
+
+- **ID-bearing** means non-empty `Shape.ID`. Join only on those ancestors. Never position,
+  never count.
+- ID-less ancestors add no scope. Children under them stay flat; collisions stay loud, as
+  today.
+- An absolute ancestor still contributes its full `effID` as the join prefix: leaf
+  `"name"` under `"app:settings"` → `"app:settings:name"`.
+- A leaf that already contains `:` is an **absolute** identity. The resolution pass does
+  not join further. That is the compatibility path for today's `ScopeID` results.
+- Absolute (`:`) is not an opt-out that keeps a bare global leaf under an ID'd ancestor.
+  Under an ID'd ancestor, a plain leaf always becomes `ancestor:leaf`. There is no "stay
+  bare `ok` under panel `p`" mode.
+- **Joined vs absolute can collide:** leaf `"b"` under ID-bearing ancestor `"a"` yields
+  `"a:b"`, which an absolute root leaf `"a:b"` also yields. Same stance as the parent
+  spec's escaping note: it is a duplicate ID, reported loudly by `TestDuplicateIDs` and
+  the debug audit, never silent.
+
+`TestDuplicateIDs` and the debug audit key on `effID`, not on the leaf.
+
+## Decisions
+
+These supersede parent Decisions 1–2 for identity resolution. The `:` grammar and
+no-escaping rules stay.
+
+This is **not** a widget-side ID stack inside `GenerateLayout`. Widget factories still set
+leaf `Shape.ID` (plain or absolute); scope is the framework's job. A post-build resolve
+pass stamps `effID` before any ID-keyed store or match that runs after layout generation.
+Widget-internal state read **during** `GenerateLayout` cannot wait for that pass —
+Decision 7 gives widgets their scope at generation time instead.
+
+1. **Framework join on ID-bearing ancestors.** Containers with an ID push a namespace for
+   descendants that use plain leaf IDs. Moving a widget under a differently-named ID'd
+   container **changes** its `effID` (and its state slot). That is intentional: the app
+   changed an explicit ancestor ID. Reorder under the same ancestor keeps identity stable.
+2. **Public APIs take effective IDs.** `SetFocus`, `ScrollVerticalTo`, `FindByID`, and
+   test helpers keep the same signatures (flat `string`). The string they match is
+   `effID`, not the leaf. Call sites that pass a bare leaf after an ancestor gains an ID
+   must pass the full path (or keep composing with `ScopeID` and rely on the absolute
+   escape). This is a **semantic** API break on a major version.
+3. **`Shape.ID` is the leaf; `Shape.effID` is the resolved path.** New unexported field.
+   Do not rewrite `ID` in the pass — that breaks debug paths and mid-frame reads that
+   still mean the leaf.
+4. **No bare global leaf under an ID'd ancestor.** Answer to the opt-out question: the `:`
+   absolute form is sufficient; a separate opt-out is not.
+5. **Hero stays identity-keyed.** Same leaf under different ancestor IDs does **not**
+   hero-match across a transition. Apps that need a shared hero key must use the same
+   absolute (`:`-bearing) ID on both sides, or share an ID-bearing ancestor path.
+6. **`focusOwner` / `focusKey` resolve to `effID`.** Today `focusOwner` is a string copy
+   of the owner's leaf ID; `focusKey()` returns that string or `s.ID`. After stores key on
+   `effID`, that leaf string is wrong under a scoped ancestor (`"name"` vs
+   `"settings:name"`). The resolve pass (or `focusKey`) must return the **owner's
+   `effID`**. Preferred: stamp an unexported owner effective key during resolve (or turn
+   `focusOwner` into a `*Shape` and read `owner.effID`). Do not leave `focusKey` returning
+   a bare leaf while focus / input-state / spell-check maps hold `effID`.
+7. **Generation-time scope for widget-state keys.** Widgets that read `StateMap` inside
+   `GenerateLayout` (combobox open/query/highlight/items, theme-picker select, tree /
+   sidebar / listbox state, …) cannot wait for the resolve pass — their tree shape depends
+   on the read. `generateViewLayout` maintains a framework-side scope: before recursing
+   into a child it pushes the child's `effID`; `w.EffID(leaf)` joins the current scope
+   with the leaf (absolute `:` leaves pass through unchanged). Stateful widgets key every
+   `ns*` map on `w.EffID(cfg.ID)`, reads and writes alike (event handlers close the key
+   over at generation; it stays valid while ancestor IDs do). The float boundary resets
+   scope to `""` at each float root during generation, matching the resolve pass. One
+   `resolveLeaf(scope, leaf)` helper implements both paths so they cannot drift. Cost: one
+   `:`-join per stateful widget per frame — Phase C's memo is shared with this path.
+
+## Worked examples
+
+| Tree                                                      | Leaf IDs           | `effID`s                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------ |
+| `Panel{ID:"settings"}` → `Input{ID:"name"}`               | `settings`, `name` | `settings`, `settings:name`                      |
+| Two such panels (`settings` / `profile`)                  | same leaves        | `settings:name` vs `profile:name` — no collision |
+| ID-less `Column` → two `Input{ID:"name"}`                 | `name`, `name`     | both `name` — loud collision, as today           |
+| `Input{ID: ScopeID("grid","row","1")}` under any ancestor | `grid:row:1`       | `grid:row:1` (absolute; no further join)         |
+
+### Producer simplification is load-bearing
+
+Absolute children skip the join. Nested `ScopeID(cfg.ID, part)` therefore stays
+window-global even when the owner shape sits under an ID'd panel:
+
+```go
+// Two pickers, same cfg.ID, under different panels — owners are fine,
+// absolute scroll children collide:
+Panel{ID: "settings", Content: ColorPicker{ID: "palette"}} // owner → settings:palette
+Panel{ID: "profile",  Content: ColorPicker{ID: "palette"}} // owner → profile:palette
+// each still emits ScopeID("palette", "scroll") → "palette:scroll" (absolute)
+```
+
+A composite whose own container nesting already mirrors `ScopeID(owner, part)` **must**
+drop that `ScopeID` and set a plain leaf (no `:`) once `resolveShapeIDs` exists. Until
+those producers simplify, reuse under ID'd ancestors is **not** safe for that widget —
+`TestDuplicateIDs` will still report the absolute children. Leave absolute only when the
+leaf needs `:` (`ScopeIDN`) or the owner is not an ancestor ID (synthetic prefixes, toast,
+command-button scopes).
+
+```go
+// App content under ID'd panels — the composability win
+Panel{ID: "settings", Content: Input{ID: "name"}}  // effID → settings:name
+Panel{ID: "profile",  Content: Input{ID: "name"}}  // effID → profile:name
+
+// Framework composite — scroll child under a shape that already has cfg.ID
+scrollID := ScopeID(cfg.ID, "scroll") // today: absolute "palette:scroll"
+ID: "scroll"                          // after: leaf; effID → palette:scroll
+                                      // under panel "settings" → settings:palette:scroll
+
+// Keep absolute when the leaf needs ":" (ScopeIDN) or the owner is not an
+// ancestor ID (synthetic prefixes, toast, command-button scopes):
+ID: ScopeIDN(cfg.ID, "opt", i)        // "group:opt:2" — do not strip
+```
+
+`ScopeIDN("", "opt", i)` is **not** a valid simplification: it yields `"opt:2"`, which
+contains `:` and therefore skips the join.
+
+**Datagrid is the canonical cannot-simplify composite.** Its children are absolute
+multi-part IDs by design: `dataGridHeaderColIDFromLayoutID` reverse- parses a header cell
+ID by trimming `dataGridHeaderPrefix(gridID)` off a `ScopeID(gridID, "header", col)` leaf
+(`gui/datagrid/view_data_grid_header.go`), and row keys (`ScopeID(cfg.ID, "row", rowID)`)
+and the scroll child (`dataGridScrollID`) are likewise multi-part. Absolute leaves skip
+the join, so two grids with the same `cfg.ID` under different ID'd panels **still collide
+on every child ID** — the composability win does not extend to datagrid, and the children
+must stay absolute because the reverse parse requires it. The grid root's own leaf becomes
+`panel:grid`; audit its leaf-ID consumers (`FindByID(cfg.ID)`, `IsFocus(cfg.ID)`,
+reverse-parse callers) as migration work. A future per-grid prefix fix would parse against
+the grid's `effID`.
+
+## Resolution pass
+
+`resolveShapeIDs(layout, scope string)` runs **first** in every `layoutPipeline` call
+(`gui/layout_pipeline.go`) — before width/height passes and before `applyLayoutTransition`
+/ `applyHeroTransition`. It stamps `effID` on every shape before any ID-keyed store or
+match that runs after layout generation.
+
+Wire it for **every root** `layoutArrange` feeds the pipeline (`gui/layout_arrange.go`):
+main layout and each floating layout. A miss on any root is a silent break.
+
+**Float scope boundary:** each float/dialog is its own pipeline root with an empty initial
+scope. It does **not** inherit ID-bearing ancestors from the main tree. Injected
+tooltips/menus only pick up scope from ID'd ancestors **inside their own tree**. Authors
+who need the triggering panel's prefix must set an absolute ID (or put an ID'd ancestor in
+the float tree).
+
+The Decision 7 generation-time scope resets identically: a `Float` layout's subtree
+generates with empty scope, so a widget inside a float reads the same keys the resolve
+pass produces. Both rules go through the shared `resolveLeaf(scope, leaf)` helper.
+
+## Migrate keying and match sites
+
+Switch `shape.ID` → `effID` at stores and matches that run after layout, and `cfg.ID` →
+`w.EffID(cfg.ID)` for widget-state keys read during `GenerateLayout`, one commit each with
+a test:
+
+- **Stores:** hover map (`gui/layout_pipeline.go`), focus `seen` map
+  (`gui/layout_query.go`), focus store `w.viewState.focusID` (`gui/window_focus.go`),
+  overflow map (`nsOverflow`, `gui/state_registry.go`), debug audit `ids` map
+  (`gui/debug.go`), layout-transition snapshots (`gui/animation_layout.go`), hero
+  snapshots/apply (`gui/animation_hero.go`), scroll matching / `findScrollLayout`,
+  **StateMap** entries keyed by widget identity:
+  - read **after** layout (input-state, spell-check, focus paint) → `effID`
+  - read **during** `GenerateLayout` (combobox, theme picker, tree, sidebar, listbox, date
+    picker, …) → `w.EffID(cfg.ID)` (Decision 7)
+- **Matches:** `FindByID`, `FindLayoutByFocusID`, `FindLayoutByScrollID`,
+  `gui/event_handlers.go`, `gui/view_slider.go`, `gui/view_tooltip.go`.
+- **`reservedDialogID`:** keep comparing the **leaf** sentinel
+  (`"___dialog_reserved_do_not_use___"`). Dialogs are separate float roots, so leaf and
+  `effID` stay equal under empty scope. Do not fold this into the FindByID migration;
+  optionally make the constant absolute later if dialogs ever nest under ID'd ancestors in
+  the same tree.
+- **Also migrate** any widget code that compares `cfg.ID` or `Shape.ID` to the focus /
+  scroll / hover / StateMap store (`IsFocus`, focus paint, input-state, spell-check).
+  After the change those stores hold `effID`. "Already a full path string" is not enough
+  once producers emit plain leaves. Fix `focusKey()` per Decision 6 so Input's inner text
+  keeps working. Note the `AmendLayout` `IsFocus` call sites that pass the leaf today —
+  e.g. the combobox's `AmendLayout` uses `ctx.Layout.Shape.ID` (`gui/view_combobox.go`) —
+  they become `effID` (or `w.EffID`).
+
+## Implementation phases
+
+### Phase A — per-scope uniqueness
+
+1. Land this spec (done as draft).
+2. Add `effID` + `resolveShapeIDs`; call it first in every `layoutPipeline` (main +
+   floats). Implement Decision 6 (`focusKey` → owner `effID`) and Decision 7
+   (generation-time scope, `w.EffID`, shared `resolveLeaf`).
+3. Migrate stores/matches as above (including StateMap — post-layout keys to `effID`,
+   `GenerateLayout`-time keys to `w.EffID`; exclude `reservedDialogID` leaf sentinel).
+4. **Required before the composability claim:** simplify every nesting-mirroring
+   `ScopeID(cfg.ID, part)` producer to a plain leaf. Leave absolute leaves that cannot
+   simplify. Until this lands, two instances of the same composite under different ID'd
+   panels still collide on absolute children.
+5. Ergoaudit `ids` mode: warn on state-keyed shapes (focusable / scrollable / stateful)
+   with a plain leaf and no ID-bearing ancestor (still globally competing).
+6. Docs: CLAUDE.md Focus section; parent Remaining work pointer; showcase regression.
+   Showcase win requires ID-bearing demo/panel ancestors.
+
+### Phase B — hero
+
+Constraint, not a feature: join depends only on explicit IDs, so paths stay stable across
+view transitions when ancestors stay the same. Key hero and layout snapshots on `effID`.
+Add a test with an ID-bearing ancestor. Document that different ancestor IDs do not match
+(Decision 5).
+
+### Phase C — ID caching
+
+The positional-cache objection dissolves: a cross-frame memo keyed by **(ownerEffectiveID,
+leafID) → string** is identity-keyed. Eviction recomputes; it never hands the wrong ID to
+the wrong row. The memo lives on `Window` and is shared with Decision 7's generation-time
+joins — same key, same pure function, so a miss recomputes identically.
+
+1. Benchmark two frames (allocs/op + ns/op): (a) today's absolute datagrid path — Phase A
+   adds nothing for `:` leaves; (b) a scoped-panel tree after Phase A.4, where joins run
+   inside `resolveShapeIDs`; (c) a stateful-widget tree (combobox-style), where Decision 7
+   joins run during `GenerateLayout`. Closing "no cache" on (a) alone is wrong once (b)
+   and (c) exist.
+2. If (b) or (c) shows: bounded (LRU) memo in the resolve pass **and** the generation-time
+   join path, alloc-gate test, invalidation note here.
+3. If not: record "no cache" here and close the item.
+
+## Relation to `widget-id-scoping.md`
+
+| Parent                                                      | This spec                                                                                                                                                         |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Decision 1: helper only; containers do not push a namespace | Superseded for plain leaves under ID-bearing ancestors — via post-build resolve plus a framework-side generation-time scope (Decision 7), not a widget-side stack |
+| Decision 2: flat window-global strings; per-scope deferred  | Effective IDs stay flat strings; uniqueness is on `effID`; leaf reuse across scopes is allowed                                                                    |
+| Grammar / no escaping / `ScopeID`                           | Unchanged; absolute leaves are today's composed strings                                                                                                           |
+
+## Closed questions
+
+1. **Version:** major. Semantic break for callers that pass leaf IDs into public APIs once
+   ancestors are ID'd.
+2. **`effID` field:** new unexported field. Do not rewrite `ID`.
+3. **Opt-out:** no separate opt-out. `:` means absolute; plain leaf under an ID'd ancestor
+   always joins.
+4. **`focusOwner`:** resolve to owner's `effID` (Decision 6). Preferred stamp during
+   resolve or `*Shape` reference; bare leaf `focusKey` is invalid after stores migrate.
+5. **Widget-state keys read during `GenerateLayout`:** migrate to `w.EffID(cfg.ID)`
+   (Decision 7) — the resolve pass alone cannot serve reads that happen before it.
+6. **Datagrid:** stays a permanent absolute-leaf exception; the composability claim
+   explicitly excludes it until a per-grid `effID`-based parse exists.
+7. **Joined vs absolute collision** (`"a:b"` from two spellings): allowed, reported loudly
+   by the duplicate-ID check; no escaping, per parent spec.

--- a/docs/specs/widget-id-scoping.md
+++ b/docs/specs/widget-id-scoping.md
@@ -179,18 +179,14 @@ the duplicate audit rather than passing silently.
 
 ## Remaining work
 
-- **Per-container uniqueness.** Whether the invariant should become "unique
-  within the enclosing scope" rather than "unique per window" is still open. It
-  is the change that would make large applications composable, and the one with
-  the largest blast radius.
-- **Caching composed IDs across frames.** A 30×10 datagrid composes ~390 IDs per
-  frame. Each is already exactly one allocation — `runtime.concatstrings`
-  allocates once regardless of operand count — so hoisting a prefix out of a
-  loop saves nothing. Removing the allocation means reusing the previous frame's
-  string, which is tractable only as a positional (row index, column index)
-  cache. A positional cache that goes stale on reorder hands the wrong ID to the
-  wrong row: the exact identity-migration failure this design rejects implicit
-  IDs for. It needs its own invalidation proof and benchmark.
-- **Hero animations** match IDs across frames and across subtrees. They are
-  unaffected today because IDs stayed flat; per-scope uniqueness would have to
-  account for them.
+Drafted in [`widget-id-per-scope-uniqueness.md`](widget-id-per-scope-uniqueness.md)
+(pending approval). That spec supersedes Decisions 1–2 here for identity
+resolution once implemented:
+
+- **Per-scope uniqueness** — framework-computed `effID` from ID-bearing
+  ancestors; leaf `Shape.ID` may repeat across scopes; uniqueness stays on the
+  effective key.
+- **Hero animations** — key on `effID`; same leaf under different ancestors does
+  not match (constraint of ID-only join).
+- **Caching composed IDs across frames** — benchmark first; identity-keyed memo
+  only if allocs show (positional cache still rejected).

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -28,13 +28,14 @@ import (
 // through Shape.focusOwner rather than repeating its ID, which keeps
 // "one ID, one widget" true and keeps this check meaningful.
 
-// debugEnabled gates every check in this file. It is an atomic.Bool
-// rather than a plain bool because [Debug] makes it mutable at
-// runtime, and the checks read it from the frame goroutine while an
-// application may flip it from another. atomic.Bool.Load compiles to
-// a plain load on amd64 and arm64, so the mutability is the reason,
-// not the lookup cost.
-var debugEnabled atomic.Bool
+// debugMask gates every check in this file, one bit per
+// [DebugCategory]. It is an atomic.Uint32 rather than a plain value
+// because [Debug] and [DebugCategories] make it mutable at runtime,
+// and the checks read it from the frame goroutine while an
+// application may flip it from another. Load compiles to a plain
+// load on amd64 and arm64, so the mutability is the reason, not the
+// lookup cost.
+var debugMask atomic.Uint32
 
 // debugGen increments on every false -> true transition of the gate.
 // Per-window warn-once state carries the generation it was built
@@ -47,12 +48,36 @@ var debugGen atomic.Uint64
 // capture it; never reassigned at runtime.
 var debugOut io.Writer = os.Stderr
 
+// DebugCategory names one class of dev-mode finding. Categories gate
+// the checks independently; see [DebugCategories].
+type DebugCategory uint32
+
+const (
+	// DebugDuplicates reports two shapes sharing one ID.
+	DebugDuplicates DebugCategory = 1 << iota
+	// DebugMissingIDs reports a focusable, scrollable, or
+	// OnMouseLeave-bearing shape with no ID, whose behaviour silently
+	// does not work.
+	DebugMissingIDs
+	// DebugUnconsumed reports a callback that acted on an event without
+	// consuming it while an ancestor also received it.
+	DebugUnconsumed
+	// DebugListBoxNoHeight reports a scrollable listbox that resolved to
+	// height 0, which disables virtualization so every row builds each
+	// frame.
+	DebugListBoxNoHeight
+
+	// DebugAll is every category, the set [Debug] turns on.
+	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
+		DebugListBoxNoHeight
+)
+
 func init() {
 	// GOGUI_DEBUG is the general gate. GOGUI_FOCUS_DEBUG is the
 	// original focus-only spelling, still honoured so existing
-	// workflows keep working.
+	// workflows keep working. Either enables every category.
 	if envTruthy("GOGUI_DEBUG") || envTruthy("GOGUI_FOCUS_DEBUG") {
-		debugEnabled.Store(true)
+		debugMask.Store(uint32(DebugAll))
 		debugGen.Store(1)
 	}
 }
@@ -68,15 +93,16 @@ func envTruthy(name string) bool {
 	return err == nil && b
 }
 
-// Debug turns dev-mode diagnostics on or off. When on, each frame is
-// checked for widgets whose identity is broken in a way that produces
-// no error otherwise:
+// Debug turns dev-mode diagnostics on or off. When on, every category
+// of finding is checked:
 //
 //   - two shapes sharing one ID
 //   - a focusable shape with no ID (never keyboard-reachable)
 //   - a scrollable shape with no ID (scroll offset shared with every
 //     other ID-less scrollable in the window)
 //   - a shape with an OnMouseLeave and no ID (the callback never fires)
+//   - a scrollable listbox that resolved to height 0 (virtualization
+//     off, every row builds each frame)
 //
 // It also reports, from dispatch rather than from the frame audit, any
 // consume-class callback that relies on automatic handling while an
@@ -84,8 +110,11 @@ func envTruthy(name string) bool {
 // silently start firing twice under the one-rule event model. See
 // debug_event.go.
 //
-// Findings go to stderr, once per finding per window. Turning the
-// gate off and on again clears that memory, so a re-enabled gate
+// [DebugCategories] enables these classes independently; Debug is the
+// same API with both extremes (all on, all off).
+//
+// Findings go to stderr, once per finding per window. Turning a
+// category off and on again clears that memory, so a re-enabled gate
 // reports the state of the frame in front of it.
 //
 // The gate is also set at startup by GOGUI_DEBUG=1.
@@ -93,15 +122,41 @@ func envTruthy(name string) bool {
 // Not for production: the checks walk the whole layout tree every
 // frame and allocate while doing it.
 func Debug(on bool) {
-	if on && debugEnabled.CompareAndSwap(false, true) {
-		debugGen.Add(1)
-		return
+	if on {
+		DebugCategories(DebugAll)
+	} else {
+		DebugCategories(0)
 	}
-	debugEnabled.Store(on)
 }
 
-// DebugEnabled reports whether dev-mode diagnostics are on.
-func DebugEnabled() bool { return debugEnabled.Load() }
+// DebugCategories sets which classes of dev-mode finding are reported.
+// Each category gates its checks independently, so an app that
+// deliberately lets events bubble can keep the identity audits without
+// the unconsumed-event noise.
+//
+// A zero mask is everything off; [DebugAll] is everything on. Turning a
+// category on after it was off clears that category's warn-once memory,
+// so a re-enabled category reports the frame in front of it.
+func DebugCategories(mask DebugCategory) {
+	for {
+		cur := debugMask.Load()
+		next := uint32(mask)
+		if next == cur {
+			return
+		}
+		if debugMask.CompareAndSwap(cur, next) {
+			// An off -> on transition moves the generation, discarding
+			// warn-once memory built under a narrower gate.
+			if cur == 0 && next != 0 {
+				debugGen.Add(1)
+			}
+			return
+		}
+	}
+}
+
+// DebugEnabled reports whether any dev-mode category is on.
+func DebugEnabled() bool { return debugMask.Load() != 0 }
 
 // debugCheck identifies one class of finding. Warn-once state is
 // keyed by (check, subject), so a window reports each distinct defect
@@ -120,6 +175,23 @@ const (
 	// rather than from the layout audit; see listBoxVisibleRange.
 	debugCheckListBoxNoHeight
 )
+
+// checkCategory maps an internal check to the public category that
+// gates it. debugWarn consults this so every finding site stays behind
+// the mask even when reached outside the gated entry points.
+func checkCategory(check debugCheck) DebugCategory {
+	switch check {
+	case debugCheckDupID:
+		return DebugDuplicates
+	case debugCheckFocusNoID, debugCheckScrollNoID, debugCheckMouseLeaveNoID:
+		return DebugMissingIDs
+	case debugCheckUnconsumed:
+		return DebugUnconsumed
+	case debugCheckListBoxNoHeight:
+		return DebugListBoxNoHeight
+	}
+	return 0
+}
 
 // debugWarnKey is the warn-once key. For the ID-less checks the
 // subject is the shape's path in the layout tree ("0/3/1"), because
@@ -141,19 +213,18 @@ type debugState struct {
 }
 
 // debugAudit runs the dev-mode checks over one frame's composed
-// layout tree. No-op unless [Debug] is on.
+// layout tree. No-op unless an audit category is on.
+//
+// The tree walk is skipped unless a category that audits the frame —
+// duplicates or missing IDs — is on; the unconsumed check runs from
+// dispatch and the listbox check from the view phase, so they gate
+// themselves.
 //
 // Called from updateLayoutLocked after composeLayout, so it sees the
 // same tree the renderer does, including floating and overlay layers.
 func (w *Window) debugAudit(root *Layout) {
-	if !debugEnabled.Load() {
+	if DebugCategory(debugMask.Load())&(DebugDuplicates|DebugMissingIDs) == 0 {
 		return
-	}
-	// Discard warn-once memory built under an older generation of the
-	// gate, so Debug(false) then Debug(true) re-reports.
-	if gen := debugGen.Load(); w.debug.gen != gen {
-		w.debug.gen = gen
-		w.debug.warned = nil
 	}
 	// ids maps an ID to the path of the shape that claimed it first,
 	// so a duplicate can name both sites. Frame-scoped, unlike
@@ -245,7 +316,7 @@ func (w *Window) TestDuplicateIDs() []string {
 		return nil
 	}
 	var found []string
-	prevOn := debugEnabled.Load()
+	prevOn := DebugEnabled()
 	// A fresh warn-once map: a sweep should report the window in front
 	// of it, not skip what an earlier sweep or a stray frame reported.
 	prevWarned := w.debug.warned
@@ -263,7 +334,23 @@ func (w *Window) TestDuplicateIDs() []string {
 
 // debugWarn prints a finding to stderr the first time this window
 // sees it. subject is the warn-once discriminator within check.
+//
+// The mask gates here, at the sink, so a finding is never reported (and
+// never remembered) while its category is off — turning the category on
+// later reports fresh. The generation discard also happens here, not in
+// the audit walk, because dispatch-side checks (unconsumed) warn with no
+// walk in between.
 func (w *Window) debugWarn(check debugCheck, subject, format string, args ...any) {
+	if DebugCategory(debugMask.Load())&checkCategory(check) == 0 {
+		return
+	}
+	// Discard warn-once memory built under an older generation of the
+	// gate, so Debug(false) then Debug(true) — or re-enabling a single
+	// category — re-reports.
+	if gen := debugGen.Load(); w.debug.gen != gen {
+		w.debug.gen = gen
+		w.debug.warned = nil
+	}
 	key := debugWarnKey{check: check, subject: subject}
 	if _, seen := w.debug.warned[key]; seen {
 		return

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -28,6 +28,7 @@ import "strconv"
 //
 // Turn it on with gui.Debug(true) or GOGUI_DEBUG=1, exercise the app,
 // and read the findings off stderr. Each is reported once per window.
+// [DebugCategories] can enable this check without the frame audits.
 
 // debugUnconsumed reports one dispatch where a callback acted on an
 // event, did not consume it, and an ancestor will therefore also
@@ -36,7 +37,7 @@ import "strconv"
 // Called from callRelative, executeFocusCallback and the gesture
 // dispatch after every named callback.
 //
-// No-op unless [Debug] is on, which is one atomic load.
+// No-op unless the unconsumed category is on, which is one atomic load.
 func debugUnconsumed(
 	class evClass, layout *Layout, e *Event, w *Window,
 ) {
@@ -46,7 +47,8 @@ func debugUnconsumed(
 	if !class.named() {
 		return
 	}
-	if !debugEnabled.Load() || w == nil || e == nil {
+	if DebugCategory(debugMask.Load())&DebugUnconsumed == 0 || w == nil ||
+		e == nil {
 		return
 	}
 	// A consumed event is going nowhere, so there is nothing to report.
@@ -204,7 +206,7 @@ func (w *Window) TestUnconsumedEvents() []string {
 		return nil
 	}
 	var found []string
-	prevOn := debugEnabled.Load()
+	prevOn := DebugEnabled()
 	// A fresh warn-once map: a sweep should report the window in front
 	// of it, not skip what an earlier sweep or a stray frame reported.
 	prevWarned := w.debug.warned

--- a/gui/debug_event_test.go
+++ b/gui/debug_event_test.go
@@ -93,6 +93,34 @@ func TestCollapseRespectsAncestorClickButton(t *testing.T) {
 	}
 }
 
+// Re-enabling the unconsumed category must re-report like the audit
+// categories: the generation discard happens at the warn sink, not in
+// the per-frame walk, which never runs for a dispatch-only mask.
+func TestCollapseToggleResetsWarnOnce(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	buf := captureDebug(t)
+	DebugCategories(DebugUnconsumed)
+	w := &Window{}
+
+	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, w)
+	first := buf.String()
+	if !strings.Contains(first, `OnClick on "inner"`) {
+		t.Fatalf("want a finding on the first dispatch, got %q", first)
+	}
+
+	DebugCategories(0)
+	buf.Reset()
+	DebugCategories(DebugUnconsumed)
+	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, w)
+	if n := strings.Count(buf.String(), "OnClick on"); n != 1 {
+		t.Fatalf("want the finding re-reported once, got %d occurrences (%q)",
+			n, buf.String())
+	}
+}
+
 // The check is diagnostics only; with the gate off it must not fire.
 func TestCollapseSilentWhenDebugOff(t *testing.T) {
 	root := collapseTree(
@@ -104,6 +132,28 @@ func TestCollapseSilentWhenDebugOff(t *testing.T) {
 	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, &Window{})
 	if got := buf.String(); got != "" {
 		t.Errorf("gate off must be silent, got %q", got)
+	}
+}
+
+// The unconsumed check is its own category: an identity-only mask must
+// stay silent at dispatch, and the category alone must fire.
+func TestCollapseGatedByUnconsumedCategory(t *testing.T) {
+	root := collapseTree(
+		&eventHandlers{OnClick: func(EventCtx) {}},
+		&eventHandlers{OnClick: func(EventCtx) {}},
+	)
+	buf := captureDebug(t)
+	DebugCategories(DebugDuplicates)
+	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, &Window{})
+	if got := buf.String(); got != "" {
+		t.Errorf("identity-only mask must be silent at dispatch, got %q", got)
+	}
+
+	buf.Reset()
+	DebugCategories(DebugUnconsumed)
+	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, &Window{})
+	if !strings.Contains(buf.String(), `OnClick on "inner"`) {
+		t.Errorf("want a collapse finding under the unconsumed category, got %q", buf.String())
 	}
 }
 

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -5,18 +5,24 @@ import (
 	"testing"
 )
 
-// captureDebug turns the gate on, redirects findings to a buffer, and
-// restores both on cleanup. Returns the buffer.
+// captureDebug turns every category on, redirects findings to a buffer,
+// and restores both on cleanup. Returns the buffer.
 func captureDebug(t *testing.T) *strings.Builder {
+	return captureDebugMask(t, DebugAll)
+}
+
+// captureDebugMask turns the given categories on, redirects findings to
+// a buffer, and restores both on cleanup. Returns the buffer.
+func captureDebugMask(t *testing.T, mask DebugCategory) *strings.Builder {
 	t.Helper()
 	var buf strings.Builder
 	prevOut := debugOut
-	prevOn := debugEnabled.Load()
+	prevMask := debugMask.Load()
 	debugOut = &buf
-	Debug(true)
+	DebugCategories(mask)
 	t.Cleanup(func() {
 		debugOut = prevOut
-		Debug(prevOn)
+		DebugCategories(DebugCategory(prevMask))
 	})
 	return &buf
 }
@@ -165,6 +171,95 @@ func TestDebugAuditNoopWhenOff(t *testing.T) {
 	}
 	if DebugEnabled() {
 		t.Fatal("DebugEnabled must report false")
+	}
+}
+
+// The point of the mask: identity checks run without the unconsumed
+// noise and vice versa. Each category reports only its own findings.
+func TestDebugCategoriesGateIndependently(t *testing.T) {
+	buf := captureDebug(t)
+	DebugCategories(DebugDuplicates)
+	w := &Window{}
+	tree := debugTree(&Shape{Focusable: true}, &Shape{ID: "dup"}, &Shape{ID: "dup"})
+
+	w.debugAudit(&tree)
+	got := buf.String()
+	if !strings.Contains(got, "duplicate ID") || strings.Contains(got, "focusable shape") {
+		t.Fatalf("want only the duplicate finding, got %q", got)
+	}
+
+	DebugCategories(DebugMissingIDs)
+	buf.Reset()
+	w.debugAudit(&tree)
+	got = buf.String()
+	if !strings.Contains(got, "focusable shape at 0") || strings.Contains(got, "duplicate ID") {
+		t.Fatalf("want only the missing-ID finding, got %q", got)
+	}
+}
+
+// A category that is off must never warn, and must not remember either:
+// turning it on later reports the frame in front of it, like cycling
+// the whole gate.
+func TestDebugCategoriesToggleResetsWarnOnce(t *testing.T) {
+	buf := captureDebug(t)
+	DebugCategories(DebugMissingIDs)
+	w := &Window{}
+	tree := debugTree(&Shape{Focusable: true})
+
+	w.debugAudit(&tree)
+	first := buf.String()
+	if first == "" {
+		t.Fatal("want a finding with the category on")
+	}
+
+	DebugCategories(0)
+	buf.Reset()
+	DebugCategories(DebugMissingIDs)
+	w.debugAudit(&tree)
+	// Re-reported, not the stale silence: the finding appears exactly
+	// once again in a buffer that was empty before the re-enable.
+	if n := strings.Count(buf.String(), "focusable shape"); n != 1 {
+		t.Fatalf("want the finding re-reported once, got %d occurrences (%q)",
+			n, buf.String())
+	}
+}
+
+// The tree walk exists for the frame audit categories only, so a mask
+// of dispatch-side categories must skip it entirely.
+func TestDebugCategoriesAuditSkippedWhenOnlyUnconsumed(t *testing.T) {
+	buf := captureDebug(t)
+	DebugCategories(DebugUnconsumed)
+	w := &Window{}
+	tree := debugTree(&Shape{Focusable: true}, &Shape{ID: "dup"}, &Shape{ID: "dup"})
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("audit must stay silent under a dispatch-only mask, got %q", got)
+	}
+}
+
+// Every internal check belongs to exactly one category, and DebugAll
+// covers them all, so no check can fall through a mask as unmaskable.
+func TestCheckCategoryMapping(t *testing.T) {
+	tests := []struct {
+		check debugCheck
+		want  DebugCategory
+	}{
+		{debugCheckDupID, DebugDuplicates},
+		{debugCheckFocusNoID, DebugMissingIDs},
+		{debugCheckScrollNoID, DebugMissingIDs},
+		{debugCheckMouseLeaveNoID, DebugMissingIDs},
+		{debugCheckUnconsumed, DebugUnconsumed},
+		{debugCheckListBoxNoHeight, DebugListBoxNoHeight},
+	}
+	for _, tc := range tests {
+		if got := checkCategory(tc.check); got != tc.want {
+			t.Errorf("checkCategory(%d) = %v, want %v", tc.check, got, tc.want)
+		}
+	}
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight {
+		t.Fatal("DebugAll must cover every category")
 	}
 }
 
@@ -374,15 +469,14 @@ func TestTestDuplicateIDsRestoresDebugState(t *testing.T) {
 	// inherit it, and must not drop it either.
 	sentinel := debugWarnKey{check: debugCheckDupID, subject: "sentinel"}
 	w.debug.warned = map[debugWarnKey]struct{}{sentinel: {}}
-	prevOn := debugEnabled.Load()
+	prevOn := DebugEnabled()
 
 	if got := w.TestDuplicateIDs(); len(got) != 0 {
 		t.Fatalf("want no findings, got %q", got)
 	}
 
-	if debugEnabled.Load() != prevOn {
-		t.Errorf("debug gate left at %v, want %v",
-			debugEnabled.Load(), prevOn)
+	if DebugEnabled() != prevOn {
+		t.Errorf("debug gate left at %v, want %v", DebugEnabled(), prevOn)
 	}
 	if _, ok := w.debug.warned[sentinel]; !ok {
 		t.Error("warn-once memory not restored")

--- a/gui/view_listbox_test.go
+++ b/gui/view_listbox_test.go
@@ -377,3 +377,34 @@ func TestListBoxNoHeightWarning(t *testing.T) {
 		t.Fatalf("warning repeated: %v", found)
 	}
 }
+
+// The listbox warning is its own category: a mask without it must stay
+// silent at the site, and the category alone must fire.
+func TestListBoxNoHeightGatedByCategory(t *testing.T) {
+	prevMask := DebugCategory(debugMask.Load())
+	defer DebugCategories(prevMask)
+	w := newTestWindow()
+	cfg := ListBoxCfg{
+		ID:         "lb-cat",
+		Scrollable: true,
+		Data:       listBoxTestData(500),
+	}
+	v := ListBox(cfg)
+
+	DebugCategories(DebugMissingIDs)
+	var found []string
+	w.debug.collect = &found
+	layout := generateViewLayout(v, w)
+	layout.Shape.Height = 0
+	layout.Shape.events.AmendLayout(EventCtx{&layout, nil, w})
+	generateViewLayout(v, w)
+	if len(found) != 0 {
+		t.Fatalf("missing-ID mask must not warn, got %v", found)
+	}
+
+	DebugCategories(DebugListBoxNoHeight)
+	generateViewLayout(v, w)
+	if len(found) != 1 {
+		t.Fatalf("listbox category must warn, got %d findings: %v", len(found), found)
+	}
+}


### PR DESCRIPTION
Implements #217.

## Change

`gui.Debug(true)` was all-or-nothing: duplicate-ID, missing-ID, and unconsumed-event audits all fired together, and the unconsumed check is chatty for apps that deliberately let events bubble.

Adds `DebugCategories(mask)` with a `DebugCategory` bitmask:

- `DebugDuplicates` — two shapes sharing one ID
- `DebugMissingIDs` — focusable/scrollable/OnMouseLeave shape with no ID
- `DebugUnconsumed` — callback acted on an event without consuming while an ancestor also received it
- `DebugListBoxNoHeight` — scrollable listbox resolved to height 0 (virtualization off)
- `DebugAll` — the set `Debug(true)` enables

`Debug(bool)`, `DebugEnabled()`, and `GOGUI_DEBUG=1` are unchanged. The generation (warn-once reset) discard moves from the frame audit into `debugWarn` so re-enabling a dispatch-side category re-reports; the per-frame tree walk is skipped unless an audit category is on.

## Tests

- Category gate independence (audit + dispatch + listbox sites)
- Mask toggle resets warn-once for both walk and dispatch checks
- Audit walk skipped under a dispatch-only mask
- check->category mapping completeness
- Regression: `TestCollapseToggleResetsWarnOnce` (fails before the sink-discard fix)

Also ships the widget-id per-scope uniqueness spec draft superseding decisions 1-2 in `widget-id-scoping.md` (user-requested include).

Verified: go build, go test ./..., golangci-lint clean.