### PR TITLE
feat(gui)!: per-scope widget ID uniqueness via effective IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,60 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **Widget IDs are per-scope, not window-global (breaking).** `Shape.ID` is now
+  a **leaf**; the identity every store and lookup keys on is the **effective
+  ID** — the leaf joined to the IDs of its ID-bearing ancestors. Two panels may
+  each hold `Input{ID: "name"}`; they resolve to `settings:name` and
+  `profile:name` and keep separate focus, scroll, hover and per-widget state.
+  Only explicit ancestor IDs join — never tree position, never a child index —
+  so identity survives a reorder and changes only when an app changes an
+  ancestor's ID. A leaf that already contains `:` is **absolute** and is left
+  alone, which is why existing `ScopeID` composites keep working.
+
+  **Semantic break:** `SetFocus`, `ScrollVerticalTo`, `FindByID`, `IsFocus`, and
+  the `Test*` helpers take the effective ID. A call that passes a bare leaf
+  stops matching as soon as an ancestor of that widget carries an ID — pass the
+  full path (`"settings:name"`). Signatures are unchanged, so the compiler will
+  not find these; `(*Window).TestDuplicateIDs` and `GOGUI_DEBUG=1` report the
+  identities a frame actually has. `gui/datagrid` is unchanged: its children are
+  absolute multi-part IDs by design (a header cell's column is recovered by
+  reverse-parsing its ID), so two grids sharing a `cfg.ID` still collide. See
+  `docs/specs/widget-id-per-scope-uniqueness.md`.
+
+  Identity resolution is allocation-neutral: the joins are memoized per window,
+  so `BenchmarkViewFrame` holds its previous allocs/op. `Shape` itself grew by
+  one string (280 → 296 bytes), which crosses a size class and costs 32 bytes
+  per shape.
+
+- **Framework-internal identities are absolute.** The inspector tree
+  (`gui:inspector:tree`), the RTF link menu (`gui:rtf:link_menu`) and the
+  dialog's focus ID are written from event handlers, outside layout generation,
+  so they cannot be resolved against the tree they are mounted in. They now
+  carry `:` and are therefore their own identity wherever they are mounted.
+  Without this the inspector's wireframe followed a pick while its tree never
+  selected the row, and dialog focus landed on nothing.
+
+- **Accessibility labels announce a name, not a path.** Where a widget falls
+  back to its ID for `A11YLabel`, only the last segment is announced —
+  `settings:name` is read as "name". An explicit `A11YLabel` is untouched,
+  including one containing a colon.
+
 ### Added
+
+- **`(*Window).EffID` and `EventCtx.EffID`.** Resolve a leaf ID to the identity
+  the framework's stores use. `w.EffID(cfg.ID)` is for a widget that reads its
+  own state _during_ `GenerateLayout` — a combobox's open flag decides the
+  subtree it returns, so it cannot wait for the resolve pass. `ctx.EffID(leaf)`
+  is for a factory that builds its tree eagerly, with no `Window` in hand
+  (`Input`), and resolves against the shape the event is on.
+
+- **`gui.DebugUnscopedIDs`.** Opt-in dev-mode category reporting a focusable or
+  scrollable widget with no ID-bearing ancestor — its leaf is still a
+  window-global name, so it cannot be reused elsewhere in the window.
+  Deliberately outside `DebugAll`: it reports a design property, not a defect.
+  Enable with `gui.DebugCategories(gui.DebugUnscopedIDs)`.
 
 - **`gui.ScopeID` and `gui.ScopeIDN`.** The one way to compose an inner widget's
   ID. An ID is now a `:`-joined path (`grid:header:name:resize`); the owner may

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,27 @@ Focus requires **both** `Focusable: true` **and** a non-empty `ID`
 (`isFocusedTarget`, `gui/event_traversal.go`); tab order additionally needs
 `!FocusSkip && !Disabled` (`layout_query.go`). `Focusable: true` without an `ID`
 is a silent no-op — the widget renders and clicks but never joins the tab order.
-The `requiredid` analyzer flags this. IDs must be unique per window.
+The `requiredid` analyzer flags this.
+
+**`Shape.ID` is a leaf; identity is the effective ID.** `resolveShapeIDs`
+(`gui/id_resolve.go`, run from `layoutArrange` before the layout passes) stamps
+`Shape.effID` = the leaf joined to the IDs of its **ID-bearing ancestors**, and
+every ID-keyed store and lookup uses that — read `shape.idKey()`, never
+`shape.ID`, at a keying site. So `Input{ID:"name"}` under `Panel{ID:"settings"}`
+is `settings:name`, and the same leaf under `profile` is a different widget.
+Only explicit IDs join (never position, never child index); an ID-less container
+adds no scope, and its children collide as loudly as before. A leaf already
+containing `:` is **absolute** and is not joined again. Effective IDs must be
+unique per window.
+
+Public APIs (`SetFocus`, `FindByID`, `IsFocus`, `ScrollVerticalTo`, `Test*`)
+take the **effective** ID. Two seams exist for widget code: `w.EffID(cfg.ID)`
+for state read during `GenerateLayout` (the read decides the subtree, so it
+cannot wait for the pass), and `ctx.EffID(leaf)` for handlers in factories that
+build eagerly with no `Window`. Both go through `resolveLeaf`, so they cannot
+drift from the pass. `gui/datagrid` is the documented exception — its child IDs
+are absolute by design (reverse-parsed) and stay window-global. See
+`docs/specs/widget-id-per-scope-uniqueness.md`.
 
 **Compose inner IDs with `gui.ScopeID` / `gui.ScopeIDN`, never by hand.** An ID
 is a `:`-joined path (`grid:header:name:resize`); the owner may itself be

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -1,21 +1,83 @@
 # Spec: per-scope uniqueness (framework-computed effective IDs)
 
-Status: draft — pending approval. Written 2026-08-09; revised after review (round 2:
-generation-time scope for widget state, datagrid exception, migration-list gaps). Source:
-"Remaining work" in [`widget-id-scoping.md`](widget-id-scoping.md). Target: major version
-(semantic break; signatures unchanged).
+Status: **implemented** (phases A, B and C). Written 2026-08-09; revised after
+review (round 2: generation-time scope for widget state, datagrid exception,
+migration-list gaps); implemented 2026-08-09. Source: "Remaining work" in
+[`widget-id-scoping.md`](widget-id-scoping.md). Target: major version (semantic
+break; signatures unchanged).
 
-This document is the normative spec for the change. Implementation phases follow the
-decisions below. Parent doc [`widget-id-scoping.md`](widget-id-scoping.md) keeps the `:`
-grammar, `ScopeID` / `ScopeIDN`, and no-escaping rules.
+## What shipped, and where it differs from this spec
+
+Read this section first: three decisions below were changed during
+implementation, and the code is the authority.
+
+1. **The resolve pass runs from `layoutArrange`, not from `layoutPipeline`, and
+   floats are _not_ a scope boundary.** `resolveShapeIDs` walks the whole main
+   tree **before** `layoutRemoveFloatingLayouts` extracts the floats, then each
+   injected overlay (toast, dialog, inspector) is resolved separately as its own
+   root. Consequence: a float written inside an ID-bearing panel — a combobox
+   dropdown, a popover — **keeps that panel's scope**, where the "each float is
+   its own pipeline root with an empty scope" rule would have stripped it. That
+   rule was a consequence of _where_ the pass ran, not a goal, and keeping the
+   scope is strictly better: it removes a class of cross-panel collision, and it
+   lets the generation-time scope and the pass agree with no float special case
+   (a widget cannot know its shape is a float before it builds it). Injected
+   overlays still start from an empty scope, so the spec's statement about
+   tooltips and menus injected from outside the tree holds.
+2. **`EventCtx.EffID` was added.** Decision 7 assumed a stateful widget always
+   has a `*Window` while it composes. Several do not: `Input`, `Slider`,
+   `Splitter`, `ProgressBar`, `Skeleton` and `Scrollbar` build their trees in
+   plain factories and capture `cfg.ID` as a leaf. Their handlers resolve at
+   dispatch time instead, walking the ancestor chain for the shape that carries
+   the leaf. Same `resolveLeaf`, so the two paths cannot drift.
+3. **The "still globally competing" warning is a debug category, not an
+   ergoaudit mode.** "Has no ID-bearing ancestor" is a property of the composed
+   tree, which the AST does not have. It is `gui.DebugUnscopedIDs`, deliberately
+   **outside** `DebugAll` — it reports a design property, not a defect, and
+   would fire on most widgets in a small app. Enable it with
+   `gui.DebugCategories(gui.DebugUnscopedIDs)`.
+
+Phase A.4 (producer simplification) was applied where a composite's own nesting
+already mirrors `ScopeID(cfg.ID, part)` — combobox and select now set a plain
+`"dropdown"` leaf. Composites whose inner IDs are reverse-parsed or whose owner
+is not an ancestor keep absolute IDs, and the remaining stateful widgets resolve
+`cfg.ID` once (`cfg.ID = w.EffID(cfg.ID)`) so their composed children are
+absolute strings equal to their own effective paths. Datagrid is untouched, as
+decided below.
+
+**Phase C is done, and the benchmark decided it.** Without a cache the join cost
+one allocation per ID-bearing widget per frame, measured on `BenchmarkViewFrame`
+as 202 → 252 allocs/op (rows_50) and 802 → 1002 (rows_200) — exactly +1 per row.
+`(*Window).joinLeaf` memoizes `(scope, leaf) → joined` in a bounded map shared
+by both paths, which puts every one of those numbers back on its baseline;
+`TestJoinLeafCachedIsAllocationFree` gates it. A hit is always correct and an
+eviction only recomputes, because the key is identity, not position — the
+objection to a positional cache never applied here.
+
+One cost remains and cannot be cached away: `effID` moved `Shape` from 280 to
+296 bytes, across a size-class boundary (288 → 320), so every shape allocates 32
+bytes more. On an 11k-shape frame that is ~355 KB of extra transient garbage.
+`focusOwner` is resolved **in place** rather than in a second field to avoid
+paying that again — a second string would leave only 8 bytes of headroom before
+the next size class.
+
+One behavioural detail worth recording: `a11yLabel` now announces only the last
+segment when it falls back to an ID. The fallback is a widget ID, IDs are now
+paths, and a screen reader must hear `name`, not `settings:name`. An explicit
+`A11YLabel` is never touched.
+
+This document is the normative spec for the change. Implementation phases follow
+the decisions below. Parent doc [`widget-id-scoping.md`](widget-id-scoping.md)
+keeps the `:` grammar, `ScopeID` / `ScopeIDN`, and no-escaping rules.
 
 ## Problem
 
 Nothing crashes. The remaining limit is **composability**.
 
-Today every `Shape.ID` is a **window-global** key for focus, scroll, hover, hero, and
-per-widget state. Two shapes with the same ID in one frame share one slot.
-`TestDuplicateIDs` and the debug audit report that. They do not make reuse safe.
+Today every `Shape.ID` is a **window-global** key for focus, scroll, hover,
+hero, and per-widget state. Two shapes with the same ID in one frame share one
+slot. `TestDuplicateIDs` and the debug audit report that. They do not make reuse
+safe.
 
 This is illegal (or fragile) even when the widgets sit in different panels:
 
@@ -25,20 +87,23 @@ Panel{ID: "profile",  Content: Input{ID: "name", ...}}
 ```
 
 Both claim `"name"`. Authors must hand-namespace every nested control
-(`ScopeID("settings", "name")`, …). In a large app, every leaf ID is a global name.
+(`ScopeID("settings", "name")`, …). In a large app, every leaf ID is a global
+name.
 
-The showcase reuses `"input-text"` across demos only because those demos do not appear in
-the same frame. That is mutual exclusion, not scoping. Reuse under two ID-bearing panels
-becomes safe only after this change, and only if those panels actually carry IDs.
+The showcase reuses `"input-text"` across demos only because those demos do not
+appear in the same frame. That is mutual exclusion, not scoping. Reuse under two
+ID-bearing panels becomes safe only after this change, and only if those panels
+actually carry IDs.
 
 [`widget-id-scoping.md`](widget-id-scoping.md) already fixed the other half: one
-separator, `ScopeID`, and framework self-collisions (`focusOwner`, markdown ownership).
-**Per-scope uniqueness** is the leftover: can two panels each use `"name"` if the
-framework joins ancestor IDs into an effective key?
+separator, `ScopeID`, and framework self-collisions (`focusOwner`, markdown
+ownership). **Per-scope uniqueness** is the leftover: can two panels each use
+`"name"` if the framework joins ancestor IDs into an effective key?
 
 ## Why raw IDs and tree position both fail
 
-Per-container uniqueness is only meaningful if the **framework** computes identity:
+Per-container uniqueness is only meaningful if the **framework** computes
+identity:
 
 | Approach                             | Result                                                                                                     |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
@@ -47,8 +112,8 @@ Per-container uniqueness is only meaningful if the **framework** computes identi
 
 ## Invariant
 
-**Effective identity** (`effID`) is window-unique. **Leaf** `Shape.ID` may repeat across
-scopes.
+**Effective identity** (`effID`) is window-unique. **Leaf** `Shape.ID` may
+repeat across scopes.
 
 ```
 effID(shape) =
@@ -61,70 +126,78 @@ effID(shape) =
 
 Rules:
 
-- **ID-bearing** means non-empty `Shape.ID`. Join only on those ancestors. Never position,
-  never count.
-- ID-less ancestors add no scope. Children under them stay flat; collisions stay loud, as
-  today.
-- An absolute ancestor still contributes its full `effID` as the join prefix: leaf
-  `"name"` under `"app:settings"` → `"app:settings:name"`.
-- A leaf that already contains `:` is an **absolute** identity. The resolution pass does
-  not join further. That is the compatibility path for today's `ScopeID` results.
-- Absolute (`:`) is not an opt-out that keeps a bare global leaf under an ID'd ancestor.
-  Under an ID'd ancestor, a plain leaf always becomes `ancestor:leaf`. There is no "stay
-  bare `ok` under panel `p`" mode.
-- **Joined vs absolute can collide:** leaf `"b"` under ID-bearing ancestor `"a"` yields
-  `"a:b"`, which an absolute root leaf `"a:b"` also yields. Same stance as the parent
-  spec's escaping note: it is a duplicate ID, reported loudly by `TestDuplicateIDs` and
-  the debug audit, never silent.
+- **ID-bearing** means non-empty `Shape.ID`. Join only on those ancestors. Never
+  position, never count.
+- ID-less ancestors add no scope. Children under them stay flat; collisions stay
+  loud, as today.
+- An absolute ancestor still contributes its full `effID` as the join prefix:
+  leaf `"name"` under `"app:settings"` → `"app:settings:name"`.
+- A leaf that already contains `:` is an **absolute** identity. The resolution
+  pass does not join further. That is the compatibility path for today's
+  `ScopeID` results.
+- Absolute (`:`) is not an opt-out that keeps a bare global leaf under an ID'd
+  ancestor. Under an ID'd ancestor, a plain leaf always becomes `ancestor:leaf`.
+  There is no "stay bare `ok` under panel `p`" mode.
+- **Joined vs absolute can collide:** leaf `"b"` under ID-bearing ancestor `"a"`
+  yields `"a:b"`, which an absolute root leaf `"a:b"` also yields. Same stance
+  as the parent spec's escaping note: it is a duplicate ID, reported loudly by
+  `TestDuplicateIDs` and the debug audit, never silent.
 
 `TestDuplicateIDs` and the debug audit key on `effID`, not on the leaf.
 
 ## Decisions
 
-These supersede parent Decisions 1–2 for identity resolution. The `:` grammar and
-no-escaping rules stay.
+These supersede parent Decisions 1–2 for identity resolution. The `:` grammar
+and no-escaping rules stay.
 
-This is **not** a widget-side ID stack inside `GenerateLayout`. Widget factories still set
-leaf `Shape.ID` (plain or absolute); scope is the framework's job. A post-build resolve
-pass stamps `effID` before any ID-keyed store or match that runs after layout generation.
-Widget-internal state read **during** `GenerateLayout` cannot wait for that pass —
-Decision 7 gives widgets their scope at generation time instead.
+This is **not** a widget-side ID stack inside `GenerateLayout`. Widget factories
+still set leaf `Shape.ID` (plain or absolute); scope is the framework's job. A
+post-build resolve pass stamps `effID` before any ID-keyed store or match that
+runs after layout generation. Widget-internal state read **during**
+`GenerateLayout` cannot wait for that pass — Decision 7 gives widgets their
+scope at generation time instead.
 
-1. **Framework join on ID-bearing ancestors.** Containers with an ID push a namespace for
-   descendants that use plain leaf IDs. Moving a widget under a differently-named ID'd
-   container **changes** its `effID` (and its state slot). That is intentional: the app
-   changed an explicit ancestor ID. Reorder under the same ancestor keeps identity stable.
-2. **Public APIs take effective IDs.** `SetFocus`, `ScrollVerticalTo`, `FindByID`, and
-   test helpers keep the same signatures (flat `string`). The string they match is
-   `effID`, not the leaf. Call sites that pass a bare leaf after an ancestor gains an ID
-   must pass the full path (or keep composing with `ScopeID` and rely on the absolute
-   escape). This is a **semantic** API break on a major version.
-3. **`Shape.ID` is the leaf; `Shape.effID` is the resolved path.** New unexported field.
-   Do not rewrite `ID` in the pass — that breaks debug paths and mid-frame reads that
-   still mean the leaf.
-4. **No bare global leaf under an ID'd ancestor.** Answer to the opt-out question: the `:`
-   absolute form is sufficient; a separate opt-out is not.
-5. **Hero stays identity-keyed.** Same leaf under different ancestor IDs does **not**
-   hero-match across a transition. Apps that need a shared hero key must use the same
-   absolute (`:`-bearing) ID on both sides, or share an ID-bearing ancestor path.
-6. **`focusOwner` / `focusKey` resolve to `effID`.** Today `focusOwner` is a string copy
-   of the owner's leaf ID; `focusKey()` returns that string or `s.ID`. After stores key on
-   `effID`, that leaf string is wrong under a scoped ancestor (`"name"` vs
-   `"settings:name"`). The resolve pass (or `focusKey`) must return the **owner's
-   `effID`**. Preferred: stamp an unexported owner effective key during resolve (or turn
-   `focusOwner` into a `*Shape` and read `owner.effID`). Do not leave `focusKey` returning
-   a bare leaf while focus / input-state / spell-check maps hold `effID`.
-7. **Generation-time scope for widget-state keys.** Widgets that read `StateMap` inside
-   `GenerateLayout` (combobox open/query/highlight/items, theme-picker select, tree /
-   sidebar / listbox state, …) cannot wait for the resolve pass — their tree shape depends
-   on the read. `generateViewLayout` maintains a framework-side scope: before recursing
-   into a child it pushes the child's `effID`; `w.EffID(leaf)` joins the current scope
-   with the leaf (absolute `:` leaves pass through unchanged). Stateful widgets key every
-   `ns*` map on `w.EffID(cfg.ID)`, reads and writes alike (event handlers close the key
-   over at generation; it stays valid while ancestor IDs do). The float boundary resets
-   scope to `""` at each float root during generation, matching the resolve pass. One
-   `resolveLeaf(scope, leaf)` helper implements both paths so they cannot drift. Cost: one
-   `:`-join per stateful widget per frame — Phase C's memo is shared with this path.
+1. **Framework join on ID-bearing ancestors.** Containers with an ID push a
+   namespace for descendants that use plain leaf IDs. Moving a widget under a
+   differently-named ID'd container **changes** its `effID` (and its state
+   slot). That is intentional: the app changed an explicit ancestor ID. Reorder
+   under the same ancestor keeps identity stable.
+2. **Public APIs take effective IDs.** `SetFocus`, `ScrollVerticalTo`,
+   `FindByID`, and test helpers keep the same signatures (flat `string`). The
+   string they match is `effID`, not the leaf. Call sites that pass a bare leaf
+   after an ancestor gains an ID must pass the full path (or keep composing with
+   `ScopeID` and rely on the absolute escape). This is a **semantic** API break
+   on a major version.
+3. **`Shape.ID` is the leaf; `Shape.effID` is the resolved path.** New
+   unexported field. Do not rewrite `ID` in the pass — that breaks debug paths
+   and mid-frame reads that still mean the leaf.
+4. **No bare global leaf under an ID'd ancestor.** Answer to the opt-out
+   question: the `:` absolute form is sufficient; a separate opt-out is not.
+5. **Hero stays identity-keyed.** Same leaf under different ancestor IDs does
+   **not** hero-match across a transition. Apps that need a shared hero key must
+   use the same absolute (`:`-bearing) ID on both sides, or share an ID-bearing
+   ancestor path.
+6. **`focusOwner` / `focusKey` resolve to `effID`.** Today `focusOwner` is a
+   string copy of the owner's leaf ID; `focusKey()` returns that string or
+   `s.ID`. After stores key on `effID`, that leaf string is wrong under a scoped
+   ancestor (`"name"` vs `"settings:name"`). The resolve pass (or `focusKey`)
+   must return the **owner's `effID`**. Preferred: stamp an unexported owner
+   effective key during resolve (or turn `focusOwner` into a `*Shape` and read
+   `owner.effID`). Do not leave `focusKey` returning a bare leaf while focus /
+   input-state / spell-check maps hold `effID`.
+7. **Generation-time scope for widget-state keys.** Widgets that read `StateMap`
+   inside `GenerateLayout` (combobox open/query/highlight/items, theme-picker
+   select, tree / sidebar / listbox state, …) cannot wait for the resolve pass —
+   their tree shape depends on the read. `generateViewLayout` maintains a
+   framework-side scope: before recursing into a child it pushes the child's
+   `effID`; `w.EffID(leaf)` joins the current scope with the leaf (absolute `:`
+   leaves pass through unchanged). Stateful widgets key every `ns*` map on
+   `w.EffID(cfg.ID)`, reads and writes alike (event handlers close the key over
+   at generation; it stays valid while ancestor IDs do). The float boundary
+   resets scope to `""` at each float root during generation, matching the
+   resolve pass. One `resolveLeaf(scope, leaf)` helper implements both paths so
+   they cannot drift. Cost: one `:`-join per stateful widget per frame — Phase
+   C's memo is shared with this path.
 
 ## Worked examples
 
@@ -148,12 +221,13 @@ Panel{ID: "profile",  Content: ColorPicker{ID: "palette"}} // owner → profile:
 // each still emits ScopeID("palette", "scroll") → "palette:scroll" (absolute)
 ```
 
-A composite whose own container nesting already mirrors `ScopeID(owner, part)` **must**
-drop that `ScopeID` and set a plain leaf (no `:`) once `resolveShapeIDs` exists. Until
-those producers simplify, reuse under ID'd ancestors is **not** safe for that widget —
-`TestDuplicateIDs` will still report the absolute children. Leave absolute only when the
-leaf needs `:` (`ScopeIDN`) or the owner is not an ancestor ID (synthetic prefixes, toast,
-command-button scopes).
+A composite whose own container nesting already mirrors `ScopeID(owner, part)`
+**must** drop that `ScopeID` and set a plain leaf (no `:`) once
+`resolveShapeIDs` exists. Until those producers simplify, reuse under ID'd
+ancestors is **not** safe for that widget — `TestDuplicateIDs` will still report
+the absolute children. Leave absolute only when the leaf needs `:` (`ScopeIDN`)
+or the owner is not an ancestor ID (synthetic prefixes, toast, command-button
+scopes).
 
 ```go
 // App content under ID'd panels — the composability win
@@ -170,111 +244,119 @@ ID: "scroll"                          // after: leaf; effID → palette:scroll
 ID: ScopeIDN(cfg.ID, "opt", i)        // "group:opt:2" — do not strip
 ```
 
-`ScopeIDN("", "opt", i)` is **not** a valid simplification: it yields `"opt:2"`, which
-contains `:` and therefore skips the join.
+`ScopeIDN("", "opt", i)` is **not** a valid simplification: it yields `"opt:2"`,
+which contains `:` and therefore skips the join.
 
-**Datagrid is the canonical cannot-simplify composite.** Its children are absolute
-multi-part IDs by design: `dataGridHeaderColIDFromLayoutID` reverse- parses a header cell
-ID by trimming `dataGridHeaderPrefix(gridID)` off a `ScopeID(gridID, "header", col)` leaf
-(`gui/datagrid/view_data_grid_header.go`), and row keys (`ScopeID(cfg.ID, "row", rowID)`)
-and the scroll child (`dataGridScrollID`) are likewise multi-part. Absolute leaves skip
-the join, so two grids with the same `cfg.ID` under different ID'd panels **still collide
-on every child ID** — the composability win does not extend to datagrid, and the children
-must stay absolute because the reverse parse requires it. The grid root's own leaf becomes
-`panel:grid`; audit its leaf-ID consumers (`FindByID(cfg.ID)`, `IsFocus(cfg.ID)`,
-reverse-parse callers) as migration work. A future per-grid prefix fix would parse against
-the grid's `effID`.
+**Datagrid is the canonical cannot-simplify composite.** Its children are
+absolute multi-part IDs by design: `dataGridHeaderColIDFromLayoutID` reverse-
+parses a header cell ID by trimming `dataGridHeaderPrefix(gridID)` off a
+`ScopeID(gridID, "header", col)` leaf (`gui/datagrid/view_data_grid_header.go`),
+and row keys (`ScopeID(cfg.ID, "row", rowID)`) and the scroll child
+(`dataGridScrollID`) are likewise multi-part. Absolute leaves skip the join, so
+two grids with the same `cfg.ID` under different ID'd panels **still collide on
+every child ID** — the composability win does not extend to datagrid, and the
+children must stay absolute because the reverse parse requires it. The grid
+root's own leaf becomes `panel:grid`; audit its leaf-ID consumers
+(`FindByID(cfg.ID)`, `IsFocus(cfg.ID)`, reverse-parse callers) as migration
+work. A future per-grid prefix fix would parse against the grid's `effID`.
 
 ## Resolution pass
 
-`resolveShapeIDs(layout, scope string)` runs **first** in every `layoutPipeline` call
-(`gui/layout_pipeline.go`) — before width/height passes and before `applyLayoutTransition`
-/ `applyHeroTransition`. It stamps `effID` on every shape before any ID-keyed store or
-match that runs after layout generation.
+`resolveShapeIDs(layout, scope string)` runs **first** in every `layoutPipeline`
+call (`gui/layout_pipeline.go`) — before width/height passes and before
+`applyLayoutTransition` / `applyHeroTransition`. It stamps `effID` on every
+shape before any ID-keyed store or match that runs after layout generation.
 
-Wire it for **every root** `layoutArrange` feeds the pipeline (`gui/layout_arrange.go`):
-main layout and each floating layout. A miss on any root is a silent break.
+Wire it for **every root** `layoutArrange` feeds the pipeline
+(`gui/layout_arrange.go`): main layout and each floating layout. A miss on any
+root is a silent break.
 
-**Float scope boundary:** each float/dialog is its own pipeline root with an empty initial
-scope. It does **not** inherit ID-bearing ancestors from the main tree. Injected
-tooltips/menus only pick up scope from ID'd ancestors **inside their own tree**. Authors
-who need the triggering panel's prefix must set an absolute ID (or put an ID'd ancestor in
-the float tree).
+**Float scope boundary:** each float/dialog is its own pipeline root with an
+empty initial scope. It does **not** inherit ID-bearing ancestors from the main
+tree. Injected tooltips/menus only pick up scope from ID'd ancestors **inside
+their own tree**. Authors who need the triggering panel's prefix must set an
+absolute ID (or put an ID'd ancestor in the float tree).
 
-The Decision 7 generation-time scope resets identically: a `Float` layout's subtree
-generates with empty scope, so a widget inside a float reads the same keys the resolve
-pass produces. Both rules go through the shared `resolveLeaf(scope, leaf)` helper.
+The Decision 7 generation-time scope resets identically: a `Float` layout's
+subtree generates with empty scope, so a widget inside a float reads the same
+keys the resolve pass produces. Both rules go through the shared
+`resolveLeaf(scope, leaf)` helper.
 
 ## Migrate keying and match sites
 
-Switch `shape.ID` → `effID` at stores and matches that run after layout, and `cfg.ID` →
-`w.EffID(cfg.ID)` for widget-state keys read during `GenerateLayout`, one commit each with
-a test:
+Switch `shape.ID` → `effID` at stores and matches that run after layout, and
+`cfg.ID` → `w.EffID(cfg.ID)` for widget-state keys read during `GenerateLayout`,
+one commit each with a test:
 
 - **Stores:** hover map (`gui/layout_pipeline.go`), focus `seen` map
-  (`gui/layout_query.go`), focus store `w.viewState.focusID` (`gui/window_focus.go`),
-  overflow map (`nsOverflow`, `gui/state_registry.go`), debug audit `ids` map
-  (`gui/debug.go`), layout-transition snapshots (`gui/animation_layout.go`), hero
-  snapshots/apply (`gui/animation_hero.go`), scroll matching / `findScrollLayout`,
-  **StateMap** entries keyed by widget identity:
+  (`gui/layout_query.go`), focus store `w.viewState.focusID`
+  (`gui/window_focus.go`), overflow map (`nsOverflow`, `gui/state_registry.go`),
+  debug audit `ids` map (`gui/debug.go`), layout-transition snapshots
+  (`gui/animation_layout.go`), hero snapshots/apply (`gui/animation_hero.go`),
+  scroll matching / `findScrollLayout`, **StateMap** entries keyed by widget
+  identity:
   - read **after** layout (input-state, spell-check, focus paint) → `effID`
-  - read **during** `GenerateLayout` (combobox, theme picker, tree, sidebar, listbox, date
-    picker, …) → `w.EffID(cfg.ID)` (Decision 7)
+  - read **during** `GenerateLayout` (combobox, theme picker, tree, sidebar,
+    listbox, date picker, …) → `w.EffID(cfg.ID)` (Decision 7)
 - **Matches:** `FindByID`, `FindLayoutByFocusID`, `FindLayoutByScrollID`,
   `gui/event_handlers.go`, `gui/view_slider.go`, `gui/view_tooltip.go`.
 - **`reservedDialogID`:** keep comparing the **leaf** sentinel
-  (`"___dialog_reserved_do_not_use___"`). Dialogs are separate float roots, so leaf and
-  `effID` stay equal under empty scope. Do not fold this into the FindByID migration;
-  optionally make the constant absolute later if dialogs ever nest under ID'd ancestors in
-  the same tree.
-- **Also migrate** any widget code that compares `cfg.ID` or `Shape.ID` to the focus /
-  scroll / hover / StateMap store (`IsFocus`, focus paint, input-state, spell-check).
-  After the change those stores hold `effID`. "Already a full path string" is not enough
-  once producers emit plain leaves. Fix `focusKey()` per Decision 6 so Input's inner text
-  keeps working. Note the `AmendLayout` `IsFocus` call sites that pass the leaf today —
-  e.g. the combobox's `AmendLayout` uses `ctx.Layout.Shape.ID` (`gui/view_combobox.go`) —
-  they become `effID` (or `w.EffID`).
+  (`"___dialog_reserved_do_not_use___"`). Dialogs are separate float roots, so
+  leaf and `effID` stay equal under empty scope. Do not fold this into the
+  FindByID migration; optionally make the constant absolute later if dialogs
+  ever nest under ID'd ancestors in the same tree.
+- **Also migrate** any widget code that compares `cfg.ID` or `Shape.ID` to the
+  focus / scroll / hover / StateMap store (`IsFocus`, focus paint, input-state,
+  spell-check). After the change those stores hold `effID`. "Already a full path
+  string" is not enough once producers emit plain leaves. Fix `focusKey()` per
+  Decision 6 so Input's inner text keeps working. Note the `AmendLayout`
+  `IsFocus` call sites that pass the leaf today — e.g. the combobox's
+  `AmendLayout` uses `ctx.Layout.Shape.ID` (`gui/view_combobox.go`) — they
+  become `effID` (or `w.EffID`).
 
 ## Implementation phases
 
 ### Phase A — per-scope uniqueness
 
 1. Land this spec (done as draft).
-2. Add `effID` + `resolveShapeIDs`; call it first in every `layoutPipeline` (main +
-   floats). Implement Decision 6 (`focusKey` → owner `effID`) and Decision 7
-   (generation-time scope, `w.EffID`, shared `resolveLeaf`).
-3. Migrate stores/matches as above (including StateMap — post-layout keys to `effID`,
-   `GenerateLayout`-time keys to `w.EffID`; exclude `reservedDialogID` leaf sentinel).
+2. Add `effID` + `resolveShapeIDs`; call it first in every `layoutPipeline`
+   (main + floats). Implement Decision 6 (`focusKey` → owner `effID`) and
+   Decision 7 (generation-time scope, `w.EffID`, shared `resolveLeaf`).
+3. Migrate stores/matches as above (including StateMap — post-layout keys to
+   `effID`, `GenerateLayout`-time keys to `w.EffID`; exclude `reservedDialogID`
+   leaf sentinel).
 4. **Required before the composability claim:** simplify every nesting-mirroring
-   `ScopeID(cfg.ID, part)` producer to a plain leaf. Leave absolute leaves that cannot
-   simplify. Until this lands, two instances of the same composite under different ID'd
-   panels still collide on absolute children.
-5. Ergoaudit `ids` mode: warn on state-keyed shapes (focusable / scrollable / stateful)
-   with a plain leaf and no ID-bearing ancestor (still globally competing).
-6. Docs: CLAUDE.md Focus section; parent Remaining work pointer; showcase regression.
-   Showcase win requires ID-bearing demo/panel ancestors.
+   `ScopeID(cfg.ID, part)` producer to a plain leaf. Leave absolute leaves that
+   cannot simplify. Until this lands, two instances of the same composite under
+   different ID'd panels still collide on absolute children.
+5. Ergoaudit `ids` mode: warn on state-keyed shapes (focusable / scrollable /
+   stateful) with a plain leaf and no ID-bearing ancestor (still globally
+   competing).
+6. Docs: CLAUDE.md Focus section; parent Remaining work pointer; showcase
+   regression. Showcase win requires ID-bearing demo/panel ancestors.
 
 ### Phase B — hero
 
-Constraint, not a feature: join depends only on explicit IDs, so paths stay stable across
-view transitions when ancestors stay the same. Key hero and layout snapshots on `effID`.
-Add a test with an ID-bearing ancestor. Document that different ancestor IDs do not match
-(Decision 5).
+Constraint, not a feature: join depends only on explicit IDs, so paths stay
+stable across view transitions when ancestors stay the same. Key hero and layout
+snapshots on `effID`. Add a test with an ID-bearing ancestor. Document that
+different ancestor IDs do not match (Decision 5).
 
 ### Phase C — ID caching
 
-The positional-cache objection dissolves: a cross-frame memo keyed by **(ownerEffectiveID,
-leafID) → string** is identity-keyed. Eviction recomputes; it never hands the wrong ID to
-the wrong row. The memo lives on `Window` and is shared with Decision 7's generation-time
-joins — same key, same pure function, so a miss recomputes identically.
+The positional-cache objection dissolves: a cross-frame memo keyed by
+**(ownerEffectiveID, leafID) → string** is identity-keyed. Eviction recomputes;
+it never hands the wrong ID to the wrong row. The memo lives on `Window` and is
+shared with Decision 7's generation-time joins — same key, same pure function,
+so a miss recomputes identically.
 
-1. Benchmark two frames (allocs/op + ns/op): (a) today's absolute datagrid path — Phase A
-   adds nothing for `:` leaves; (b) a scoped-panel tree after Phase A.4, where joins run
-   inside `resolveShapeIDs`; (c) a stateful-widget tree (combobox-style), where Decision 7
-   joins run during `GenerateLayout`. Closing "no cache" on (a) alone is wrong once (b)
-   and (c) exist.
-2. If (b) or (c) shows: bounded (LRU) memo in the resolve pass **and** the generation-time
-   join path, alloc-gate test, invalidation note here.
+1. Benchmark two frames (allocs/op + ns/op): (a) today's absolute datagrid path
+   — Phase A adds nothing for `:` leaves; (b) a scoped-panel tree after Phase
+   A.4, where joins run inside `resolveShapeIDs`; (c) a stateful-widget tree
+   (combobox-style), where Decision 7 joins run during `GenerateLayout`. Closing
+   "no cache" on (a) alone is wrong once (b) and (c) exist.
+2. If (b) or (c) shows: bounded (LRU) memo in the resolve pass **and** the
+   generation-time join path, alloc-gate test, invalidation note here.
 3. If not: record "no cache" here and close the item.
 
 ## Relation to `widget-id-scoping.md`
@@ -287,16 +369,18 @@ joins — same key, same pure function, so a miss recomputes identically.
 
 ## Closed questions
 
-1. **Version:** major. Semantic break for callers that pass leaf IDs into public APIs once
-   ancestors are ID'd.
+1. **Version:** major. Semantic break for callers that pass leaf IDs into public
+   APIs once ancestors are ID'd.
 2. **`effID` field:** new unexported field. Do not rewrite `ID`.
-3. **Opt-out:** no separate opt-out. `:` means absolute; plain leaf under an ID'd ancestor
-   always joins.
-4. **`focusOwner`:** resolve to owner's `effID` (Decision 6). Preferred stamp during
-   resolve or `*Shape` reference; bare leaf `focusKey` is invalid after stores migrate.
-5. **Widget-state keys read during `GenerateLayout`:** migrate to `w.EffID(cfg.ID)`
-   (Decision 7) — the resolve pass alone cannot serve reads that happen before it.
-6. **Datagrid:** stays a permanent absolute-leaf exception; the composability claim
-   explicitly excludes it until a per-grid `effID`-based parse exists.
-7. **Joined vs absolute collision** (`"a:b"` from two spellings): allowed, reported loudly
-   by the duplicate-ID check; no escaping, per parent spec.
+3. **Opt-out:** no separate opt-out. `:` means absolute; plain leaf under an
+   ID'd ancestor always joins.
+4. **`focusOwner`:** resolve to owner's `effID` (Decision 6). Preferred stamp
+   during resolve or `*Shape` reference; bare leaf `focusKey` is invalid after
+   stores migrate.
+5. **Widget-state keys read during `GenerateLayout`:** migrate to
+   `w.EffID(cfg.ID)` (Decision 7) — the resolve pass alone cannot serve reads
+   that happen before it.
+6. **Datagrid:** stays a permanent absolute-leaf exception; the composability
+   claim explicitly excludes it until a per-grid `effID`-based parse exists.
+7. **Joined vs absolute collision** (`"a:b"` from two spellings): allowed,
+   reported loudly by the duplicate-ID check; no escaping, per parent spec.

--- a/docs/specs/widget-id-scoping.md
+++ b/docs/specs/widget-id-scoping.md
@@ -179,14 +179,15 @@ the duplicate audit rather than passing silently.
 
 ## Remaining work
 
-Drafted in [`widget-id-per-scope-uniqueness.md`](widget-id-per-scope-uniqueness.md)
-(pending approval). That spec supersedes Decisions 1–2 here for identity
-resolution once implemented:
+**Done.** Specified and implemented in
+[`widget-id-per-scope-uniqueness.md`](widget-id-per-scope-uniqueness.md), which
+supersedes Decisions 1–2 here for identity resolution:
 
-- **Per-scope uniqueness** — framework-computed `effID` from ID-bearing
-  ancestors; leaf `Shape.ID` may repeat across scopes; uniqueness stays on the
-  effective key.
-- **Hero animations** — key on `effID`; same leaf under different ancestors does
-  not match (constraint of ID-only join).
-- **Caching composed IDs across frames** — benchmark first; identity-keyed memo
-  only if allocs show (positional cache still rejected).
+- **Per-scope uniqueness** (shipped) — framework-computed `effID` from
+  ID-bearing ancestors; leaf `Shape.ID` may repeat across scopes; uniqueness
+  stays on the effective key.
+- **Hero animations** (shipped) — keyed on `effID`; same leaf under different
+  ancestors does not match (constraint of ID-only join).
+- **Caching composed IDs across frames** (shipped) — the benchmark showed +1
+  alloc per widget per frame, so the identity-keyed memo landed
+  (`(*Window).joinLeaf`); a positional cache is still rejected.

--- a/gui/animation_hero.go
+++ b/gui/animation_hero.go
@@ -82,7 +82,11 @@ func propagateOpacity(layout *Layout, opacity float32) {
 
 func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map[string]posSnapshot) {
 	if layout.Shape.Hero && layout.Shape.ID != "" {
-		id := layout.Shape.ID
+		// Hero matching is identity-keyed: the same leaf under two
+		// different ID-bearing ancestors is two widgets and does not
+		// morph across a transition. A shared hero needs the same
+		// effective path on both sides.
+		id := layout.Shape.idKey()
 		morphProgress := f32Min(1, progress*2)
 		fadeProgress := f32Max(0, (progress-0.5)*2)
 

--- a/gui/animation_layout.go
+++ b/gui/animation_layout.go
@@ -59,8 +59,11 @@ func captureLayoutSnapshots(layout Layout) map[string]posSnapshot {
 }
 
 func captureSnapshots(layout *Layout, snapshots map[string]posSnapshot, heroOnly bool) {
+	// Snapshots key on the effective ID, so a widget keeps its identity
+	// across a transition only while its ID-bearing ancestors do — the
+	// same rule the stores use.
 	if layout.Shape.ID != "" && (!heroOnly || layout.Shape.Hero) {
-		snapshots[layout.Shape.ID] = posSnapshot{
+		snapshots[layout.Shape.idKey()] = posSnapshot{
 			x:      layout.Shape.X,
 			y:      layout.Shape.Y,
 			width:  layout.Shape.Width,
@@ -100,7 +103,7 @@ func applyLayoutTransition(layout *Layout, w *Window) {
 
 func applyTransitionRecursive(layout *Layout, lt *LayoutTransition) {
 	if layout.Shape.ID != "" {
-		if old, ok := lt.snapshots[layout.Shape.ID]; ok {
+		if old, ok := lt.snapshots[layout.Shape.idKey()]; ok {
 			t := lt.progress
 			layout.Shape.X = Lerp(old.x, layout.Shape.X, t)
 			layout.Shape.Y = Lerp(old.y, layout.Shape.Y, t)

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -67,7 +67,21 @@ const (
 	// frame.
 	DebugListBoxNoHeight
 
-	// DebugAll is every category, the set [Debug] turns on.
+	// DebugUnscopedIDs reports a focusable or scrollable shape whose ID
+	// resolves to itself — no ID-bearing ancestor above it — so its
+	// identity competes in the window-global namespace and cannot be
+	// reused elsewhere in the window.
+	//
+	// Advisory, not a defect: a top-level widget legitimately has no
+	// scope, which is why this is the one category [Debug] does not turn
+	// on. Ask for it explicitly with
+	// [DebugCategories](DebugUnscopedIDs) when auditing a screen for
+	// reusability.
+	DebugUnscopedIDs
+
+	// DebugAll is every category [Debug] turns on. DebugUnscopedIDs is
+	// deliberately absent: it reports a design property, not a bug, and
+	// would fire on most widgets in a small app.
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
 		DebugListBoxNoHeight
 )
@@ -174,6 +188,9 @@ const (
 	// debugCheckListBoxNoHeight fires from the listbox view phase
 	// rather than from the layout audit; see listBoxVisibleRange.
 	debugCheckListBoxNoHeight
+	// debugCheckUnscopedID reports an identity that has no ID-bearing
+	// ancestor, so it is still a window-global name.
+	debugCheckUnscopedID
 )
 
 // checkCategory maps an internal check to the public category that
@@ -189,6 +206,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugUnconsumed
 	case debugCheckListBoxNoHeight:
 		return DebugListBoxNoHeight
+	case debugCheckUnscopedID:
+		return DebugUnscopedIDs
 	}
 	return 0
 }
@@ -223,7 +242,9 @@ type debugState struct {
 // Called from updateLayoutLocked after composeLayout, so it sees the
 // same tree the renderer does, including floating and overlay layers.
 func (w *Window) debugAudit(root *Layout) {
-	if DebugCategory(debugMask.Load())&(DebugDuplicates|DebugMissingIDs) == 0 {
+	const walkCategories = DebugDuplicates | DebugMissingIDs |
+		DebugUnscopedIDs
+	if DebugCategory(debugMask.Load())&walkCategories == 0 {
 		return
 	}
 	// ids maps an ID to the path of the shape that claimed it first,
@@ -253,14 +274,31 @@ func (w *Window) debugWalk(layout *Layout, path *[]int, ids map[string]string) {
 // each ID this frame.
 func (w *Window) debugCheckShape(s *Shape, path []int, ids map[string]string) {
 	if s.ID != "" {
-		if first, dup := ids[s.ID]; dup {
-			w.debugWarn(debugCheckDupID, s.ID,
+		// Uniqueness is on the *effective* ID: the same leaf under two
+		// different ID-bearing ancestors is two identities and is not a
+		// duplicate. The message names the effective path, since that is
+		// the string the stores and the public APIs use.
+		key := s.idKey()
+		if first, dup := ids[key]; dup {
+			w.debugWarn(debugCheckDupID, key,
 				"duplicate ID %q at %s, first claimed at %s; ID is the "+
 					"identity key for focus, scroll, and per-widget state, so "+
 					"the two collapse to one tab stop and one state slot",
-				s.ID, debugPath(path), first)
+				key, debugPath(path), first)
 		} else {
-			ids[s.ID] = debugPath(path)
+			ids[key] = debugPath(path)
+		}
+		// An identity that resolves to itself has no ID-bearing ancestor
+		// to scope it, so the leaf is still a window-global name and the
+		// widget cannot be dropped into a second panel as it stands.
+		// Only state-keyed shapes are worth reporting: an ID on a plain
+		// container is documentation, not a key.
+		if key == s.ID && (s.Focusable || s.Scrollable) {
+			w.debugWarn(debugCheckUnscopedID, key,
+				"ID %q at %s has no ID-bearing ancestor, so it is a "+
+					"window-global name; give an ancestor an ID to scope "+
+					"it and the leaf becomes reusable elsewhere",
+				key, debugPath(path))
 		}
 		return
 	}

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -265,7 +265,10 @@ func (w *Window) sweepShape(root, l *Layout) {
 	// window focused on whatever it happened to visit last.
 	if ev.OnChar != nil && s.ID != "" {
 		prev := w.FocusID()
-		w.SetFocus(s.ID)
+		// idKey, not ID: focus is keyed by resolved identity, and
+		// focusing a bare leaf under a scoped ancestor would deliver the
+		// probe nowhere and silently under-report.
+		w.SetFocus(s.idKey())
 		charHandler(root, &Event{CharCode: 'x'}, w)
 		w.SetFocus(prev)
 	}

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -252,14 +252,21 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckMouseLeaveNoID, DebugMissingIDs},
 		{debugCheckUnconsumed, DebugUnconsumed},
 		{debugCheckListBoxNoHeight, DebugListBoxNoHeight},
+		{debugCheckUnscopedID, DebugUnscopedIDs},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
 			t.Errorf("checkCategory(%d) = %v, want %v", tc.check, got, tc.want)
 		}
 	}
+	// DebugAll covers every category Debug(true) turns on.
+	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
+	// a design property, not a defect.
 	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight {
-		t.Fatal("DebugAll must cover every category")
+		t.Fatal("DebugAll must cover every category Debug(true) enables")
+	}
+	if DebugAll&DebugUnscopedIDs != 0 {
+		t.Fatal("DebugUnscopedIDs must stay opt-in, outside DebugAll")
 	}
 }
 
@@ -427,10 +434,10 @@ func TestTestDuplicateIDsCompositeWidgetsAreQuiet(t *testing.T) {
 	}
 }
 
-// A genuine collision — a widget nested inside another with the same
-// ID — must still be reported. This is the case the "descendants may
-// reuse an ancestor's ID" shortcut would have hidden.
-func TestTestDuplicateIDsReportsNestedCollision(t *testing.T) {
+// A leaf repeated inside an ID-bearing ancestor is no longer a
+// collision: the framework scopes it, so the inner bar is "dup:dup",
+// a different identity from the button's "dup".
+func TestTestDuplicateIDsScopesNestedLeaf(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
 	w.UpdateView(func(_ *Window) View {
 		return Column(ContainerCfg{
@@ -446,9 +453,58 @@ func TestTestDuplicateIDsReportsNestedCollision(t *testing.T) {
 		})
 	})
 
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("want no findings — the nested leaf scopes to "+
+			"\"dup:dup\" — got %q", got)
+	}
+}
+
+// Two leaves under one ID-less parent share a scope, so they still
+// collide. Scoping joins explicit ancestor IDs and nothing else.
+func TestTestDuplicateIDsReportsSameScopeCollision(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				ProgressBar(ProgressBarCfg{ID: "dup", Percent: 50}),
+				ProgressBar(ProgressBarCfg{ID: "dup", Percent: 60}),
+			},
+		})
+	})
+
 	got := w.TestDuplicateIDs()
 	if len(got) != 1 || !strings.Contains(got[0], `duplicate ID "dup"`) {
-		t.Fatalf("want one duplicate-ID finding for the nested bar, got %q", got)
+		t.Fatalf("want one duplicate-ID finding for the sibling bars, "+
+			"got %q", got)
+	}
+}
+
+// A joined identity and an absolute one can spell the same string.
+// There is no escaping, so this stays a duplicate — reported loudly
+// rather than silently sharing a slot.
+func TestTestDuplicateIDsReportsJoinedVsAbsolute(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Button(ButtonCfg{
+					ID: "a",
+					Content: []View{
+						// Joins to "a:b".
+						ProgressBar(ProgressBarCfg{ID: "b", Percent: 50}),
+					},
+				}),
+				// Absolute: already "a:b", no further join.
+				ProgressBar(ProgressBarCfg{ID: "a:b", Percent: 60}),
+			},
+		})
+	})
+
+	got := w.TestDuplicateIDs()
+	if len(got) != 1 || !strings.Contains(got[0], `duplicate ID "a:b"`) {
+		t.Fatalf("want one duplicate-ID finding for \"a:b\", got %q", got)
 	}
 }
 
@@ -483,5 +539,53 @@ func TestTestDuplicateIDsRestoresDebugState(t *testing.T) {
 	}
 	if w.debug.collect != nil {
 		t.Error("collect sink not cleared")
+	}
+}
+
+// DebugUnscopedIDs is the reusability advisory: a state-keyed widget
+// with no ID-bearing ancestor still owns a window-global name.
+func TestDebugUnscopedIDsReportsGlobalLeaf(t *testing.T) {
+	buf := captureDebug(t)
+	DebugCategories(DebugUnscopedIDs)
+	w := &Window{}
+	tree := debugTree(&Shape{ID: "save", Focusable: true})
+	resolveShapeIDs(&tree, w)
+
+	w.debugAudit(&tree)
+	if got := buf.String(); !strings.Contains(got, `ID "save"`) ||
+		!strings.Contains(got, "no ID-bearing ancestor") {
+		t.Fatalf("want the unscoped-ID finding, got %q", got)
+	}
+
+	// Scoped: the same widget under a panel resolves to "panel:save"
+	// and is no longer competing globally.
+	scoped := Layout{Shape: &Shape{}}
+	scoped.Children = append(scoped.Children, Layout{
+		Shape: &Shape{ID: "panel"},
+		Children: []Layout{
+			{Shape: &Shape{ID: "save", Focusable: true}},
+		},
+	})
+	resolveShapeIDs(&scoped, w)
+	buf.Reset()
+	w.debug.warned = nil
+	w.debugAudit(&scoped)
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no finding for a scoped ID, got %q", got)
+	}
+}
+
+// The advisory is opt-in: Debug(true) must not turn it on, or every
+// small app would report most of its widgets.
+func TestDebugAllExcludesUnscopedIDs(t *testing.T) {
+	buf := captureDebug(t)
+	Debug(true)
+	w := &Window{}
+	tree := debugTree(&Shape{ID: "save", Focusable: true})
+	resolveShapeIDs(&tree, w)
+
+	w.debugAudit(&tree)
+	if got := buf.String(); strings.Contains(got, "no ID-bearing ancestor") {
+		t.Fatalf("Debug(true) reported the advisory: %q", got)
 	}
 }

--- a/gui/event_ctx.go
+++ b/gui/event_ctx.go
@@ -38,6 +38,42 @@ func (c EventCtx) Handled() bool {
 	return c.Event != nil && c.Event.IsHandled
 }
 
+// EffID resolves a leaf ID a handler closed over to the effective ID
+// the framework's stores are keyed by (see gui/id_resolve.go).
+//
+// A widget factory that builds its tree eagerly — Input, for one — has
+// no Window when it captures cfg.ID, so it cannot call
+// [Window.EffID] at generation time. Its handlers resolve here instead:
+// the leaf names this shape or one of its ancestors, and by the time an
+// event is dispatched every shape carries its resolved identity.
+//
+// An absolute leaf (one containing IDSep) and a leaf naming nothing in
+// the ancestor chain both resolve exactly as the resolve pass would
+// resolve them in this position.
+func (c EventCtx) EffID(leaf string) string {
+	if leaf == "" || c.Layout == nil {
+		return leaf
+	}
+	// The leaf usually names this shape or the composite's outer
+	// container, so the walk stops within a step or two.
+	scope := ""
+	for p := c.Layout; p != nil; p = p.Parent {
+		s := p.Shape
+		if s == nil || s.ID == "" {
+			continue
+		}
+		if s.ID == leaf {
+			return s.idKey()
+		}
+		if scope == "" {
+			// Nearest ID-bearing ancestor: the scope a leaf in this
+			// position would join to, kept for the fallback below.
+			scope = s.idKey()
+		}
+	}
+	return c.Window.joinLeaf(scope, leaf)
+}
+
 // evClass names which event is being dispatched.
 //
 // It no longer carries a dispatch rule. Until v0.55.0 there were two

--- a/gui/event_handlers.go
+++ b/gui/event_handlers.go
@@ -215,7 +215,7 @@ func mouseDownHandler(
 	if layout.Shape.PointInShape(e.MouseX, e.MouseY) {
 		if layout.Shape.Focusable && layout.Shape.ID != "" &&
 			e.MouseButton != MouseRight {
-			w.SetFocus(layout.Shape.ID)
+			w.SetFocus(layout.Shape.idKey())
 			e.IsHandled = true
 		}
 		var onClick ShapeCallback

--- a/gui/event_traversal.go
+++ b/gui/event_traversal.go
@@ -17,7 +17,11 @@ func isFocusedTarget(layout *Layout, w *Window) bool {
 	if !layout.Shape.Focusable || layout.Shape.ID == "" {
 		return false
 	}
-	return w.IsFocus(layout.Shape.ID)
+	// The focus store holds effective IDs, so compare on idKey, not on
+	// the leaf the widget was written with. reservedDialogID above stays
+	// a leaf comparison: a dialog is its own float root, where leaf and
+	// effID are equal.
+	return w.IsFocus(layout.Shape.idKey())
 }
 
 // executeFocusCallback delivers a keyboard event to the focused

--- a/gui/id_resolve.go
+++ b/gui/id_resolve.go
@@ -1,0 +1,249 @@
+package gui
+
+import (
+	"slices"
+	"strings"
+)
+
+// Effective IDs — per-scope uniqueness.
+//
+// Shape.ID is a *leaf* name. The identity a store or a match keys on is
+// the leaf joined to the IDs of its ID-bearing ancestors:
+//
+//	Panel{ID: "settings"} -> Input{ID: "name"}   // effID settings:name
+//	Panel{ID: "profile"}  -> Input{ID: "name"}   // effID profile:name
+//
+// so the same leaf may appear under two different scopes without the
+// two collapsing onto one focus slot, one scroll offset, one state
+// entry. Only explicit IDs contribute — never tree position, never a
+// child index — so identity survives a reorder and changes only when an
+// app changes an ancestor's ID.
+//
+// A leaf that already contains IDSep is *absolute*: it is the whole
+// identity and no further join happens. That is what today's
+// ScopeID(cfg.ID, part) composites produce, which is why they keep
+// working unchanged.
+//
+// Two paths compute the join, and they must not drift, so both go
+// through resolveLeaf:
+//
+//   - resolveShapeIDs stamps Shape.effID over a built tree, from
+//     layoutArrange, before the layout passes run. It serves everything
+//     that happens after layout generation: focus traversal, hover,
+//     scroll, hero, the duplicate audit.
+//   - (*Window).EffID serves a widget that reads its own state *during*
+//     GenerateLayout — a combobox whose open/closed flag decides the
+//     subtree it returns cannot wait for a pass that runs afterwards.
+//     generateViewLayout maintains the scope for it.
+//
+// See docs/specs/widget-id-per-scope-uniqueness.md.
+
+// resolveLeaf joins one leaf to the enclosing scope. It is the single
+// definition of the rule; both the resolve pass and the generation-time
+// scope call it.
+//
+// An empty leaf stays empty: an ID-less shape has no identity and adds
+// no scope. An absolute leaf (one containing IDSep) passes through
+// untouched.
+func resolveLeaf(scope, leaf string) string {
+	if leaf == "" || scope == "" {
+		return leaf
+	}
+	if strings.Contains(leaf, IDSep) {
+		return leaf
+	}
+	return ScopeID(scope, leaf)
+}
+
+// idJoinKey memoizes one join. The value depends on nothing but these
+// two strings, so a hit is always correct and an eviction only costs a
+// recomputation — the objection to a *positional* cache does not apply.
+type idJoinKey struct {
+	scope string
+	leaf  string
+}
+
+// joinLeaf is resolveLeaf with a cross-frame memo.
+//
+// The join is one allocation, and it runs once per ID-bearing widget
+// per frame on both paths — generation and the resolve pass — which
+// measured as +1 alloc per row on BenchmarkViewFrame. Scope and leaf
+// repeat frame to frame (a row's leaf is a constant or a stable key,
+// and the scope is the parent's memoized result), so the memo turns
+// that back into a map hit.
+//
+// Bounded, and correctness never depends on a hit: a frame with more
+// distinct identities than the cache holds recomputes some of them.
+//
+// SAFETY: main-goroutine only, like the other per-window caches. Every
+// caller is in the view phase, the layout pipeline, or event dispatch,
+// all of which run there (see the StateRegistry doc).
+func (w *Window) joinLeaf(scope, leaf string) string {
+	// Everything the rule answers without allocating — an empty side, an
+	// absolute leaf — is answered by the rule itself, and never reaches
+	// the map. Only the joining case is worth a lookup.
+	if w == nil || leaf == "" || scope == "" ||
+		strings.Contains(leaf, IDSep) {
+		return resolveLeaf(scope, leaf)
+	}
+	key := idJoinKey{scope: scope, leaf: leaf}
+	m := lazyBoundedMap(&w.idJoinCache, capIDJoin)
+	if joined, ok := m.Get(key); ok {
+		return joined
+	}
+	joined := ScopeID(scope, leaf)
+	m.Set(key, joined)
+	return joined
+}
+
+// EffID resolves a leaf ID against the scope currently being generated.
+//
+// Call it in a widget factory that keys per-widget state on cfg.ID and
+// reads that state inside GenerateLayout, for both the read and the
+// write, so the key matches the effID the resolve pass will stamp on
+// the same shape:
+//
+//	key := w.EffID(cfg.ID)
+//	open := StateReadOr(w, nsCombobox, key, false)
+//
+// A widget with several keys resolves once instead, over its own copy
+// of the cfg, and everything downstream — state slots, focus checks,
+// inner IDs composed with ScopeID, the shape's own ID — reads the
+// resolved value:
+//
+//	cfg.ID = w.EffID(cfg.ID)
+//
+// That is idempotent: the result contains IDSep under an ID-bearing
+// ancestor, so resolving it again returns it unchanged, and the resolve
+// pass treats the shape's ID as absolute and leaves it exactly as
+// computed here.
+//
+// Handlers may close over the resolved key: it stays valid for as long
+// as the ancestor IDs above the widget do, and when one of those
+// changes the widget's identity has changed by design.
+//
+// Outside layout generation the scope is empty, so EffID returns the
+// leaf unchanged.
+func (w *Window) EffID(leaf string) string {
+	if w == nil {
+		return leaf
+	}
+	return w.joinLeaf(w.viewState.idScope, leaf)
+}
+
+// childScopeID returns the scope a shape's children generate and
+// resolve under. Only an ID-bearing shape opens a scope; an ID-less one
+// passes its own through, which keeps its children flat and keeps their
+// collisions as loud as they are today.
+//
+// A float is not a boundary. It is written inside the tree, so it keeps
+// the scope of the panel it was written in — two panels may each hold a
+// combobox with the same leaf and get distinct dropdowns. That works
+// because layoutArrange resolves before it extracts the floats; an
+// *injected* overlay (toast, dialog, inspector) is generated outside
+// the tree and so starts from an empty scope either way.
+func childScopeID(w *Window, scope string, s *Shape) string {
+	if s == nil || s.ID == "" {
+		return scope
+	}
+	return w.joinLeaf(scope, s.ID)
+}
+
+// idFrame is one ID-bearing ancestor on the resolve stack, holding the
+// leaf it was written as and the identity it resolved to. focusOwner
+// names an ancestor by its leaf, so resolving that reference needs both.
+type idFrame struct {
+	leaf string
+	eff  string
+}
+
+// resolveShapeIDs stamps effID on every shape in one tree.
+//
+// Called from layoutArrange: once on the whole main tree before the
+// floats are extracted, and once on each injected overlay. Both start
+// from an empty scope. Missing a root would leave a whole layer keyed
+// on leaves.
+func resolveShapeIDs(layout *Layout, w *Window) {
+	if layout == nil {
+		return
+	}
+	var frames []idFrame
+	if w != nil {
+		// Generation is over by the time this runs, so the view phase's
+		// scope must be back at "". Clear it rather than assume: a view
+		// function that panics past the restore in generateViewLayout
+		// would otherwise poison every later frame's keys with a stale
+		// prefix, which is silent and window-wide.
+		w.viewState.idScope = ""
+		// Reuse the backing array across frames: the stack is at most as
+		// deep as the ID-bearing nesting, so it stops growing after the
+		// first few frames.
+		frames = w.idScopeStack[:0]
+	}
+	frames = resolveShapeIDsWalk(w, layout, "", frames)
+	if w != nil {
+		// Drop a backing array one pathologically deep frame grew, so a
+		// transient tree cannot pin memory for the window's lifetime.
+		if cap(frames) > maxIDScopeStackKeep {
+			frames = nil
+		}
+		w.idScopeStack = frames[:0]
+	}
+}
+
+// maxIDScopeStackKeep bounds the ancestor stack retained between
+// frames. Depth beyond this is pathological, not a layout worth
+// optimising for, so its buffer is released instead of pinned.
+const maxIDScopeStackKeep = 256
+
+// resolveShapeIDsWalk resolves one node and its children, returning the
+// frame stack so a grown backing array survives to the next sibling.
+func resolveShapeIDsWalk(
+	w *Window, layout *Layout, scope string, frames []idFrame,
+) []idFrame {
+	s := layout.Shape
+	if s == nil {
+		for i := range layout.Children {
+			frames = resolveShapeIDsWalk(w, &layout.Children[i], scope, frames)
+		}
+		return frames
+	}
+
+	s.effID = w.joinLeaf(scope, s.ID)
+	if s.focusOwner != "" {
+		// In place: after this pass focusOwner is the owner's effID,
+		// which is what focusKey hands to the stores. See Shape.
+		s.focusOwner = resolveOwnerID(w, frames, scope, s.focusOwner)
+	}
+
+	childScope := childScopeID(w, scope, s)
+	pushed := false
+	if s.ID != "" {
+		frames = append(frames, idFrame{leaf: s.ID, eff: s.effID})
+		pushed = true
+	}
+	for i := range layout.Children {
+		frames = resolveShapeIDsWalk(w, &layout.Children[i], childScope, frames)
+	}
+	if pushed {
+		frames = frames[:len(frames)-1]
+	}
+	return frames
+}
+
+// resolveOwnerID resolves a focusOwner reference to the owner's effID.
+//
+// focusOwner holds an ancestor's leaf, so the innermost frame carrying
+// that leaf is the owner. A reference that names no ancestor — a
+// composite pointing at a widget elsewhere in the tree — falls back to
+// the same join a leaf in this position would get.
+func resolveOwnerID(
+	w *Window, frames []idFrame, scope, owner string,
+) string {
+	for _, f := range slices.Backward(frames) {
+		if f.leaf == owner {
+			return f.eff
+		}
+	}
+	return w.joinLeaf(scope, owner)
+}

--- a/gui/id_resolve_test.go
+++ b/gui/id_resolve_test.go
@@ -1,0 +1,496 @@
+package gui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Per-scope uniqueness (docs/specs/widget-id-per-scope-uniqueness.md).
+//
+// The claim under test is composability: the same leaf ID may be used
+// in two places as long as the places are told apart by explicit
+// ancestor IDs. Everything else here guards the edges of that rule —
+// what does *not* open a scope, what is left alone, and that the two
+// resolution paths (the layout pass and the generation-time scope)
+// agree on the string.
+
+func TestResolveLeafRules(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope string
+		leaf  string
+		want  string
+	}{
+		{"joins under a scope", "settings", "name", "settings:name"},
+		{"no scope leaves the leaf", "", "name", "name"},
+		{"empty leaf has no identity", "settings", "", ""},
+		{"absolute leaf skips the join", "settings", "a:b", "a:b"},
+		{"nested scope is the full path",
+			"app:settings", "name", "app:settings:name"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolveLeaf(c.scope, c.leaf); got != c.want {
+				t.Fatalf("resolveLeaf(%q, %q) = %q, want %q",
+					c.scope, c.leaf, got, c.want)
+			}
+		})
+	}
+}
+
+// The headline case: one leaf, two panels, two identities.
+func TestEffIDScopesLeafByAncestor(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	root := w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					ID:      "settings",
+					Content: []View{Input(InputCfg{ID: "name"})},
+				}),
+				Column(ContainerCfg{
+					ID:      "profile",
+					Content: []View{Input(InputCfg{ID: "name"})},
+				}),
+			},
+		})
+	})
+	if root == nil {
+		t.Fatal("TestRender returned nil")
+	}
+
+	for _, id := range []string{"settings:name", "profile:name"} {
+		if _, ok := root.FindByID(id); !ok {
+			t.Fatalf("FindByID(%q) = false, want the scoped input", id)
+		}
+	}
+	// The bare leaf addresses neither: under an ID-bearing ancestor a
+	// plain leaf always joins. There is no "stay global" mode.
+	if _, ok := root.FindByID("name"); ok {
+		t.Fatal("FindByID(\"name\") found a widget; the leaf is not an " +
+			"identity once an ancestor carries an ID")
+	}
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("want no duplicate findings, got %q", got)
+	}
+}
+
+// Focus is keyed on the effective ID end to end: the store holds it,
+// tab traversal reports it, and the widget paints from it.
+func TestFocusUsesEffectiveID(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					ID:      "settings",
+					Content: []View{Input(InputCfg{ID: "name"})},
+				}),
+				Column(ContainerCfg{
+					ID:      "profile",
+					Content: []View{Input(InputCfg{ID: "name"})},
+				}),
+			},
+		})
+	})
+
+	if err := w.TestFocus("settings:name"); err != nil {
+		t.Fatalf("TestFocus(settings:name) = %v, want nil", err)
+	}
+	if got := w.FocusID(); got != "settings:name" {
+		t.Fatalf("FocusID() = %q, want %q", got, "settings:name")
+	}
+	next, err := w.TestTab(TabForward)
+	if err != nil {
+		t.Fatalf("TestTab = %v, want nil", err)
+	}
+	if next != "profile:name" {
+		t.Fatalf("tab moved to %q, want %q", next, "profile:name")
+	}
+}
+
+// An ID-less container is not a scope. Two leaves under one add no
+// prefix and still collide — scoping joins explicit IDs and nothing
+// else, so a reorder or an added wrapper cannot silently re-identify a
+// widget.
+func TestIDLessAncestorAddsNoScope(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	root := w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					Content: []View{Input(InputCfg{ID: "name"})},
+				}),
+			},
+		})
+	})
+	if _, ok := root.FindByID("name"); !ok {
+		t.Fatal("FindByID(\"name\") = false; an ID-less ancestor must " +
+			"not add a prefix")
+	}
+}
+
+// Input's inner text shape references the owner through focusOwner
+// rather than repeating its ID. That reference has to resolve to the
+// owner's *effective* ID, or the caret and selection would be read
+// from a key nothing writes.
+func TestFocusOwnerResolvesToOwnerEffID(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	root := w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					ID:      "settings",
+					Content: []View{Input(InputCfg{ID: "name"})},
+				}),
+			},
+		})
+	})
+
+	txt, ok := root.FindShape(func(l Layout) bool {
+		return l.Shape != nil && l.Shape.focusOwner != ""
+	})
+	if !ok {
+		t.Fatal("no shape with a focusOwner; the Input's text shape " +
+			"should carry one")
+	}
+	if got := txt.focusKey(); got != "settings:name" {
+		t.Fatalf("focusKey() = %q, want %q", got, "settings:name")
+	}
+}
+
+// Two stateful widgets with one leaf, in two scopes, keep separate
+// state. This is what the generation-time scope (w.EffID) buys: the
+// combobox reads its open flag while building its own subtree, before
+// the resolve pass has run.
+func TestStatefulWidgetStateIsPerScope(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	view := func(_ *Window) View {
+		panel := func(id string) View {
+			return Column(ContainerCfg{
+				ID: id,
+				Content: []View{
+					Combobox(ComboboxCfg{
+						ID:      "cb",
+						Options: []string{"a", "b"},
+						OnSelect: func(string, EventCtx) {
+						},
+					}),
+				},
+			})
+		}
+		return Column(ContainerCfg{
+			Sizing:  FillFill,
+			Content: []View{panel("settings"), panel("profile")},
+		})
+	}
+	w.TestRender(view)
+
+	// Click the first one open, through the real dispatch path.
+	if err := w.TestClick("settings:cb"); err != nil {
+		t.Fatalf("TestClick(settings:cb) = %v, want nil", err)
+	}
+	// nil: re-run the installed generator. Passing the view again
+	// reinstalls it, which resets the per-window state this asserts on.
+	w.TestRender(nil)
+
+	if !StateReadOr(w, nsCombobox, "settings:cb", false) {
+		t.Fatal("settings:cb should be open")
+	}
+	if StateReadOr(w, nsCombobox, "profile:cb", false) {
+		t.Fatal("profile:cb opened too; the two comboboxes share a " +
+			"state slot")
+	}
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("want no duplicate findings, got %q", got)
+	}
+}
+
+// A float is written inside the tree, so it keeps the scope it was
+// written in. Identity is resolved before the floats are split into
+// their own layers, which is what makes that possible.
+func TestFloatKeepsAncestorScope(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	root := w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					ID: "panel",
+					Content: []View{
+						Column(ContainerCfg{
+							ID:     "popup",
+							Float:  true,
+							Width:  50,
+							Height: 50,
+							Sizing: FixedFixed,
+						}),
+					},
+				}),
+			},
+		})
+	})
+	if _, ok := root.FindByID("panel:popup"); !ok {
+		t.Fatal("FindByID(\"panel:popup\") = false; a float must keep " +
+			"the scope it was written in")
+	}
+}
+
+// The two paths must produce the same string for the same widget: the
+// key a widget computes while generating (w.EffID) and the identity the
+// pass stamps on its shape.
+func TestGenerationScopeMatchesResolvePass(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	var generated string
+	root := w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					ID: "outer",
+					Content: []View{
+						Column(ContainerCfg{
+							ID: "inner",
+							Content: []View{
+								ViewFunc(func(w *Window) View {
+									generated = w.EffID("leaf")
+									return Column(ContainerCfg{ID: "leaf"})
+								}),
+							},
+						}),
+					},
+				}),
+			},
+		})
+	})
+
+	want := "outer:inner:leaf"
+	if generated != want {
+		t.Fatalf("w.EffID(\"leaf\") = %q, want %q", generated, want)
+	}
+	ly, ok := root.FindByID(want)
+	if !ok {
+		t.Fatalf("FindByID(%q) = false", want)
+	}
+	if got := ly.Shape.ID; got != "leaf" {
+		t.Fatalf("Shape.ID = %q, want the leaf %q — the pass stamps "+
+			"effID and must not rewrite ID", got, "leaf")
+	}
+}
+
+// The scope is restored on the way out of a subtree: a sibling that
+// follows an ID-bearing container must not inherit that container's
+// scope.
+func TestGenerationScopeRestoredForSiblings(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	var sibling string
+	w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{
+					ID:      "first",
+					Content: []View{Column(ContainerCfg{ID: "child"})},
+				}),
+				ViewFunc(func(w *Window) View {
+					sibling = w.EffID("after")
+					return Column(ContainerCfg{ID: "after"})
+				}),
+			},
+		})
+	})
+	if sibling != "after" {
+		t.Fatalf("sibling scope leaked: w.EffID(\"after\") = %q, want %q",
+			sibling, "after")
+	}
+}
+
+// EventCtx.EffID is the seam for factories that build eagerly, so it
+// has to answer for a leaf naming this shape, a leaf naming an
+// ancestor, an absolute leaf, and a leaf naming nothing at all.
+func TestEventCtxEffID(t *testing.T) {
+	// panel(outer) -> input(name) -> inner(no ID). Handlers hang off the
+	// inner shape, which is where Input's OnClick actually runs.
+	inner := Layout{Shape: &Shape{}}
+	input := Layout{Shape: &Shape{ID: "name"}, Children: []Layout{inner}}
+	panel := Layout{Shape: &Shape{ID: "outer"}, Children: []Layout{input}}
+	root := Layout{Shape: &Shape{}, Children: []Layout{panel}}
+	layoutParents(&root, nil)
+	w := &Window{}
+	resolveShapeIDs(&root, w)
+
+	innerLy := &root.Children[0].Children[0].Children[0]
+	ctx := EventCtx{Layout: innerLy, Window: w}
+
+	tests := []struct {
+		name string
+		leaf string
+		want string
+	}{
+		{"names an ancestor", "name", "outer:name"},
+		{"names a further ancestor", "outer", "outer"},
+		{"absolute passes through", "a:b", "a:b"},
+		{"empty stays empty", "", ""},
+		{"names nothing joins the enclosing scope", "scroll",
+			"outer:name:scroll"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ctx.EffID(tc.leaf); got != tc.want {
+				t.Fatalf("ctx.EffID(%q) = %q, want %q", tc.leaf, got, tc.want)
+			}
+		})
+	}
+
+	// A context with no layout has nothing to resolve against and must
+	// hand the leaf back rather than panic.
+	if got := (EventCtx{}).EffID("name"); got != "name" {
+		t.Fatalf("EffID on an empty ctx = %q, want %q", got, "name")
+	}
+}
+
+// The memo must be invisible: same answer as the pure rule, every time,
+// including after eviction has thrown entries away.
+func TestJoinLeafMemoMatchesPureRule(t *testing.T) {
+	w := &Window{}
+	cases := [][2]string{
+		{"settings", "name"},
+		{"", "name"},
+		{"settings", ""},
+		{"settings", "a:b"},
+		{"app:settings", "name"},
+	}
+	for _, c := range cases {
+		want := resolveLeaf(c[0], c[1])
+		// Twice: the second call is the memo hit.
+		for range 2 {
+			if got := w.joinLeaf(c[0], c[1]); got != want {
+				t.Fatalf("joinLeaf(%q, %q) = %q, want %q",
+					c[0], c[1], got, want)
+			}
+		}
+	}
+
+	// Overflow the cache, then re-ask for the first key: eviction costs a
+	// recomputation, never a wrong answer.
+	for i := range capIDJoin * 2 {
+		w.joinLeaf("scope", "leaf"+strconv.Itoa(i))
+	}
+	if got := w.joinLeaf("settings", "name"); got != "settings:name" {
+		t.Fatalf("after eviction joinLeaf = %q, want %q",
+			got, "settings:name")
+	}
+}
+
+// The join is one allocation, once per distinct identity. A frame that
+// re-resolves the identities it already has must allocate nothing, or
+// the per-widget-per-frame cost this memo exists to remove is back.
+func TestJoinLeafCachedIsAllocationFree(t *testing.T) {
+	w := &Window{}
+	w.joinLeaf("settings", "name") // warm
+	got := testing.AllocsPerRun(100, func() {
+		sinkEffID = w.joinLeaf("settings", "name")
+	})
+	if got != 0 {
+		t.Fatalf("cached joinLeaf allocated %v times per run, want 0", got)
+	}
+}
+
+// sinkEffID keeps the compiler from optimising away the call under
+// test.
+var sinkEffID string
+
+// focusOwner is resolved in place, so resolving twice — two frames over
+// a retained tree, or an extra pass — must not compound the prefix.
+func TestResolveShapeIDsIsIdempotent(t *testing.T) {
+	txt := Layout{Shape: &Shape{focusOwner: "name"}}
+	input := Layout{Shape: &Shape{ID: "name"}, Children: []Layout{txt}}
+	panel := Layout{Shape: &Shape{ID: "settings"}, Children: []Layout{input}}
+	root := Layout{Shape: &Shape{}, Children: []Layout{panel}}
+	w := &Window{}
+
+	resolveShapeIDs(&root, w)
+	txtShape := root.Children[0].Children[0].Children[0].Shape
+	first := txtShape.focusKey()
+	if first != "settings:name" {
+		t.Fatalf("focusKey() = %q, want %q", first, "settings:name")
+	}
+
+	resolveShapeIDs(&root, w)
+	if got := txtShape.focusKey(); got != first {
+		t.Fatalf("second resolve changed focusKey to %q, want %q",
+			got, first)
+	}
+	if got := root.Children[0].Children[0].Shape.idKey(); got != "settings:name" {
+		t.Fatalf("second resolve changed effID to %q, want %q",
+			got, "settings:name")
+	}
+}
+
+// A view function that escapes generation without restoring the scope
+// (a panic recovered upstream) must not prefix every later frame. The
+// resolve pass clears it at the start of each arrange.
+func TestResolveShapeIDsClearsGenerationScope(t *testing.T) {
+	w := &Window{}
+	w.viewState.idScope = "stale"
+	root := Layout{Shape: &Shape{ID: "root"}}
+	resolveShapeIDs(&root, w)
+
+	if w.viewState.idScope != "" {
+		t.Fatalf("idScope = %q after resolve, want empty",
+			w.viewState.idScope)
+	}
+	if got := w.EffID("name"); got != "name" {
+		t.Fatalf("EffID after clear = %q, want %q", got, "name")
+	}
+}
+
+// idKey falls back to the leaf on a tree that has never been arranged,
+// so hand-built layouts in tests and any pre-pipeline read still work.
+func TestIDKeyFallsBackBeforeResolve(t *testing.T) {
+	s := &Shape{ID: "name"}
+	if got := s.idKey(); got != "name" {
+		t.Fatalf("idKey() = %q on an unresolved shape, want %q", got, "name")
+	}
+	if got := (&Shape{}).idKey(); got != "" {
+		t.Fatalf("idKey() = %q on an ID-less shape, want empty", got)
+	}
+}
+
+// Framework-internal identities that are written from *outside* layout
+// generation — an event handler calling SetFocus, a state helper
+// keyed by a constant — must be absolute.
+//
+// A plain leaf is resolved against wherever the framework happens to
+// mount the widget, so the shape ends up under one key while the helper
+// keeps writing another. Nothing errors: the inspector's wireframe
+// tracked the pick while its tree never selected the row, and the
+// dialog focused a widget that did not exist. Containing IDSep opts
+// these out of joining, which is what makes the constant the identity.
+func TestInternalIdentityConstantsAreAbsolute(t *testing.T) {
+	constants := map[string]string{
+		"inspectorTreeID":      inspectorTreeID,
+		"inspectorScrollPanel": inspectorScrollPanel,
+		"rtfLinkMenuFocusID":   rtfLinkMenuFocusID,
+	}
+	for name, id := range constants {
+		if !strings.Contains(id, IDSep) {
+			t.Errorf("%s = %q has no %q, so it joins with whatever "+
+				"ID-bearing ancestor it is mounted under and stops "+
+				"matching the helpers that write it", name, id, IDSep)
+		}
+	}
+
+	// The dialog's focus ID is composed rather than declared, so assert
+	// the composition, not the raw constant.
+	cfg := DialogCfg{}
+	applyDialogDefaults(&cfg)
+	if !strings.Contains(cfg.FocusID, IDSep) {
+		t.Errorf("dialog FocusID = %q has no %q", cfg.FocusID, IDSep)
+	}
+}

--- a/gui/inspector.go
+++ b/gui/inspector.go
@@ -8,9 +8,17 @@ import (
 )
 
 const (
-	capInspector            = 8
-	inspectorScrollPanel    = "gui:inspector:panel"
-	inspectorTreeID         = "__inspector_tree__"
+	capInspector         = 8
+	inspectorScrollPanel = "gui:inspector:panel"
+	// Absolute, and it has to be. The tree is a child of the ID-bearing
+	// panel above, so a plain leaf would resolve to
+	// "gui:inspector:panel:<leaf>" — while inspectorSelect and the
+	// expansion helpers, which run from event handlers rather than from
+	// generation, would keep writing the bare constant. The wireframe
+	// would still follow the pick (it keys on nsInspector) and the tree
+	// would never show the row. Containing IDSep makes this the identity
+	// the Tree widget stores under, so both halves agree.
+	inspectorTreeID         = "gui:inspector:tree"
 	inspectorPanelMinWidth  = float32(300)
 	inspectorResizeStep     = float32(50)
 	inspectorMargin         = float32(10)
@@ -482,8 +490,11 @@ func inspectorSnapshotProps(layout *Layout) inspectorNodeProps {
 	}
 
 	props := inspectorNodeProps{
-		TypeName:    inspectorTypeName(shape),
-		ID:          shape.ID,
+		TypeName: inspectorTypeName(shape),
+		// The effective ID, not the leaf: it is the string SetFocus,
+		// FindByID and the test helpers take, so it is the one worth
+		// copying out of the inspector.
+		ID:          shape.idKey(),
 		X:           shape.X,
 		Y:           shape.Y,
 		Width:       shape.Width,
@@ -516,8 +527,8 @@ func inspectorNodeLabel(shape *Shape) string {
 	label := inspectorTypeName(shape) + " " +
 		strconv.Itoa(int(shape.Width)) + "x" +
 		strconv.Itoa(int(shape.Height))
-	if shape.ID != "" {
-		label += " #" + shape.ID
+	if id := shape.idKey(); id != "" {
+		label += " #" + id
 	}
 	return label
 }

--- a/gui/inspector_test.go
+++ b/gui/inspector_test.go
@@ -391,3 +391,25 @@ func TestInspectorLazyBuilding(t *testing.T) {
 		t.Fatalf("expanded node should have 2 children, got %d", len(nodes[0].Nodes))
 	}
 }
+
+// The inspector's helpers key tree focus and expansion on the
+// inspectorTreeID constant, while the Tree widget keys them on the
+// identity it resolves to. If the constant is not that identity, the
+// wireframe still tracks the pick (it uses nsInspector) but the tree
+// never shows the selected row — the two halves write different slots.
+func TestInspectorTreeIDIsTheRenderedIdentity(t *testing.T) {
+	requireInspector(t)
+	w := NewTestWindow(WindowCfg{})
+	w.inspectorEnabled = true
+	root := w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{Sizing: FillFill})
+	})
+	if root == nil {
+		t.Fatal("TestRender returned nil")
+	}
+	if _, ok := root.FindByID(inspectorTreeID); !ok {
+		t.Fatalf("no layout with the inspector tree's key %q; the "+
+			"constant the selection helpers write is not the identity "+
+			"the tree stores under", inspectorTreeID)
+	}
+}

--- a/gui/layout_arrange.go
+++ b/gui/layout_arrange.go
@@ -12,6 +12,14 @@ func layoutArrange(layout *Layout, w *Window) []Layout {
 	// Set parent pointers.
 	layoutParents(layout, nil)
 
+	// Resolve identities before anything reads one, and before the
+	// floats are split out: a float written inside an ID-bearing panel
+	// keeps that panel's scope, which it could not if it were resolved
+	// after extraction as a bare root. Every pass downstream — sizing's
+	// overflow map, scroll, hover, focus, the transition and hero
+	// snapshots, the debug audit — keys on what this stamps.
+	resolveShapeIDs(layout, w)
+
 	// Extract floating layouts from main tree.
 	floatingLayouts := w.scratch.takeFloatingLayouts(len(layout.Children))
 	defer func() {
@@ -80,5 +88,9 @@ func injectFloatingLayer(v View, w *Window, floatingLayouts *[]*Layout) {
 	l := generateViewLayout(v, w)
 	heap := w.scratch.allocFloatingLayout(l)
 	layoutParents(heap, nil)
+	// An injected overlay is generated outside the main tree, so it is
+	// its own scope root: it picks up prefixes only from ID-bearing
+	// shapes inside itself. Generation saw the same empty scope.
+	resolveShapeIDs(heap, w)
 	*floatingLayouts = append(*floatingLayouts, heap)
 }

--- a/gui/layout_overflow.go
+++ b/gui/layout_overflow.go
@@ -56,14 +56,15 @@ func layoutOverflow(layout *Layout, w *Window) {
 	}
 
 	om := w.overflow()
-	old, ok := om.Get(layout.Shape.ID)
+	id := layout.Shape.idKey()
+	old, ok := om.Get(id)
 	if !ok {
 		old = -1
 	}
 	if old != visibleCount {
-		om.Set(layout.Shape.ID, visibleCount)
+		om.Set(id, visibleCount)
 		ss := StateMap[string, bool](w, nsSelect, capModerate)
-		ss.Delete(layout.Shape.ID)
+		ss.Delete(id)
 		w.refreshLayout = true
 	}
 }

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -10,6 +10,11 @@ import (
 // layoutPipeline runs all layout passes in order on a single
 // layout tree.
 func layoutPipeline(layout *Layout, w *Window) {
+	// Identities are already stamped: layoutArrange resolves the whole
+	// tree before it splits the floats out, and each injected overlay as
+	// it is generated. Resolving here instead would see a float as its
+	// own root and strip the scope its ancestors gave it.
+
 	// Width passes.
 	layoutWidths(layout)
 	w.scratch.beginFillPass()
@@ -120,9 +125,10 @@ func layoutMouseLeave(layout *Layout, w *Window) {
 		return
 	}
 	sm := w.hoverInside()
+	key := shape.idKey()
 	inside := shape.PointInShape(w.viewState.mousePosX, w.viewState.mousePosY)
 	// Default false: absent entry means cursor was not previously in shape.
-	wasInside := sm.GetOr(shape.ID, false)
+	wasInside := sm.GetOr(key, false)
 	if wasInside && !inside {
 		w.scratch.hoverEvent = Event{
 			MouseX:      w.viewState.mousePosX,
@@ -133,9 +139,9 @@ func layoutMouseLeave(layout *Layout, w *Window) {
 		shape.events.OnMouseLeave(EventCtx{layout, &w.scratch.hoverEvent, w})
 	}
 	if inside {
-		sm.Set(shape.ID, true)
+		sm.Set(key, true)
 	} else {
-		sm.Delete(shape.ID)
+		sm.Delete(key)
 	}
 }
 

--- a/gui/layout_position.go
+++ b/gui/layout_position.go
@@ -68,10 +68,11 @@ func layoutChildStartPos(
 	if layout.Shape.Scrollable {
 		sx := w.scrollX()
 		sy := w.scrollY()
-		if v, ok := sx.Get(layout.Shape.ID); ok {
+		id := layout.Shape.idKey()
+		if v, ok := sx.Get(id); ok {
 			x += v
 		}
-		if v, ok := sy.Get(layout.Shape.ID); ok {
+		if v, ok := sy.Get(id); ok {
 			y += v
 		}
 	}
@@ -219,7 +220,7 @@ func layoutSetShapeClips(layout *Layout, clip drawClip) {
 
 // layoutAdjustScrollOffsets ensures scroll offsets are in range.
 func layoutAdjustScrollOffsets(layout *Layout, w *Window) {
-	id := layout.Shape.ID
+	id := layout.Shape.idKey()
 	if layout.Shape.Scrollable && id != "" {
 		sx := w.scrollX()
 		sy := w.scrollY()

--- a/gui/layout_query.go
+++ b/gui/layout_query.go
@@ -27,8 +27,12 @@ func (layout *Layout) FindLayout(predicate func(Layout) bool) (*Layout, bool) {
 }
 
 // FindLayoutByFocusID recursively searches for a layout with matching focus ID.
+//
+// id is an effective ID (see gui/id_resolve.go): the full path a widget
+// resolves to under its ID-bearing ancestors, which is what the focus
+// store holds.
 func FindLayoutByFocusID(layout *Layout, id string) (*Layout, bool) {
-	if id != "" && layout.Shape.Focusable && layout.Shape.ID == id {
+	if id != "" && layout.Shape.Focusable && layout.Shape.idKey() == id {
 		return layout, true
 	}
 	for i := range layout.Children {
@@ -40,9 +44,10 @@ func FindLayoutByFocusID(layout *Layout, id string) (*Layout, bool) {
 }
 
 // FindLayoutByScrollID recursively searches for a Scrollable layout
-// with matching scroll ID. An empty id never matches.
+// with matching scroll ID. An empty id never matches. id is an
+// effective ID, as in [FindLayoutByFocusID].
 func FindLayoutByScrollID(layout *Layout, id string) (*Layout, bool) {
-	if id != "" && layout.Shape.Scrollable && layout.Shape.ID == id {
+	if id != "" && layout.Shape.Scrollable && layout.Shape.idKey() == id {
 		return layout, true
 	}
 	for i := range layout.Children {
@@ -57,6 +62,10 @@ func FindLayoutByScrollID(layout *Layout, id string) (*Layout, bool) {
 // An empty id never matches — a widget without an ID cannot be
 // addressed — matching the id != "" guards in FindLayoutByScrollID and
 // FindLayoutByFocusID.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing ancestor
+// is addressed by its full path ("settings:name"), not by the leaf its
+// Cfg was written with. See gui/id_resolve.go.
 // A nil Shape means the layout tree has not been built yet (no frame
 // has been laid out), so there is nothing to find. Guarding here rather
 // than in each caller matches findScrollLayout, which already treats a
@@ -68,7 +77,7 @@ func (layout *Layout) FindByID(id string) (*Layout, bool) {
 	if layout.Shape == nil {
 		return nil, false
 	}
-	if layout.Shape.ID == id {
+	if layout.Shape.idKey() == id {
 		return layout, true
 	}
 	for i := range layout.Children {
@@ -87,13 +96,17 @@ type focusCandidate struct {
 func collectFocusCandidates(layout *Layout, candidates *[]focusCandidate, seen map[string]struct{}) {
 	s := layout.Shape
 	if s.Focusable && !s.FocusSkip && !s.Disabled && s.ID != "" {
+		// Candidates carry the effective ID: it is what the focus store
+		// holds, so it is what focusFindNext/Previous compare against.
+		//
 		// A duplicate ID collapses to a single tab stop; the extra
 		// widget is skipped. Reported by the debug gate's duplicate-ID
 		// check (debug.go), which sees every ID, not only focusable ones.
-		if _, ok := seen[s.ID]; !ok {
-			seen[s.ID] = struct{}{}
+		key := s.idKey()
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
 			*candidates = append(*candidates, focusCandidate{
-				id:    s.ID,
+				id:    key,
 				shape: s,
 			})
 		}

--- a/gui/markdown_select.go
+++ b/gui/markdown_select.go
@@ -70,7 +70,7 @@ func markdownBlockAmendSel(l *Layout, w *Window) {
 // It walks all RTF descendants belonging to this markdown widget, rebuilds the
 // block-position list in the StateMap, and triggers per-block selection update.
 func markdownContainerAmendLayout(ctx EventCtx) {
-	mdID := ctx.Layout.Shape.ID
+	mdID := ctx.Layout.Shape.idKey()
 	if mdID == "" {
 		return
 	}
@@ -236,7 +236,7 @@ func mdHitAbsRune(
 // markdownContainerOnKeyDown handles keyboard events for the markdown container.
 // Supports Ctrl+A (select all) and Ctrl+C (copy).
 func markdownContainerOnKeyDown(ctx EventCtx) {
-	mdID := ctx.Layout.Shape.ID
+	mdID := ctx.Layout.Shape.idKey()
 	if mdID == "" || !ctx.Window.IsFocus(mdID) {
 		return
 	}

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -26,9 +26,10 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 
 	// Skip cache when ID is empty to avoid collisions between
 	// multiple ID-less DrawCanvas widgets.
-	if shape.ID != "" {
+	key := shape.idKey()
+	if key != "" {
 		var ok bool
-		cached, ok = sm.Get(shape.ID)
+		cached, ok = sm.Get(key)
 		if ok && cached.Version == shape.Version &&
 			cached.TessWidth == cw && cached.TessHeight == ch &&
 			cached.Scale == scale {
@@ -53,8 +54,8 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 			Texts:      dc.texts,
 			Images:     dc.images,
 		}
-		if shape.ID != "" {
-			sm.Set(shape.ID, cached)
+		if key != "" {
+			sm.Set(key, cached)
 		}
 	}
 

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -66,7 +66,7 @@ func inputScrollCursorIntoView(
 	}
 
 	is := StateReadOr(w, nsInput,
-		layout.Shape.ID, InputState{})
+		layout.Shape.idKey(), InputState{})
 	runeLen := utf8RuneCount(text)
 	pos := is.CursorPos
 	pos = min(pos, runeLen)
@@ -118,7 +118,7 @@ func textScrollCursorIntoView(layout *Layout, w *Window) {
 	if scrollParent == nil {
 		return
 	}
-	scrollID := scrollParent.Shape.ID
+	scrollID := scrollParent.Shape.idKey()
 
 	text := shape.TC.Text
 	style := textStyleOrDefault(shape)
@@ -128,7 +128,7 @@ func textScrollCursorIntoView(layout *Layout, w *Window) {
 	}
 
 	is := StateReadOr(
-		w, nsInput, shape.ID, InputState{})
+		w, nsInput, shape.idKey(), InputState{})
 	runeLen := utf8RuneCount(text)
 	pos := is.CursorPos
 	pos = min(pos, runeLen)
@@ -189,7 +189,7 @@ func scrollMaxOffsetY(layout *Layout) float32 {
 // used by the precise/trackpad and keyboard paths. The discrete
 // mouse-wheel path eases via scrollSmoothBy instead.
 func scrollHorizontal(layout *Layout, delta float32, w *Window) bool {
-	id := layout.Shape.ID
+	id := layout.Shape.idKey()
 	if !layout.Shape.Scrollable || id == "" ||
 		layout.Shape.ScrollMode == ScrollVerticalOnly {
 		return false
@@ -214,7 +214,7 @@ func scrollHorizontal(layout *Layout, delta float32, w *Window) bool {
 // used by the precise/trackpad and keyboard paths. The discrete
 // mouse-wheel path eases via scrollSmoothBy instead.
 func scrollVertical(layout *Layout, delta float32, w *Window) bool {
-	id := layout.Shape.ID
+	id := layout.Shape.idKey()
 	if !layout.Shape.Scrollable || id == "" ||
 		layout.Shape.ScrollMode == ScrollHorizontalOnly {
 		return false
@@ -245,7 +245,7 @@ func (w *Window) ScrollToView(id string) {
 	for p.Parent != nil {
 		p = p.Parent
 		if p.Shape.Scrollable {
-			scrollID := p.Shape.ID
+			scrollID := p.Shape.idKey()
 			// Default 0: unscrolled position when no offset
 			// recorded yet.
 			sy := w.scrollY()

--- a/gui/scroll_nested_test.go
+++ b/gui/scroll_nested_test.go
@@ -21,6 +21,12 @@ import "testing"
 // Written against the phase-2 test API (TestScroll/TestScrollOffset),
 // which is why the gate could not be discharged before now.
 
+// innerID is the inner container's *effective* ID: its leaf is written
+// "inner", and the ID-bearing "outer" it sits in scopes it to
+// "outer:inner". The test APIs take effective IDs (see
+// gui/id_resolve.go), so that is what addresses it here.
+const innerID = "outer:inner"
+
 // newNestedScrollWindow builds an outer scrollable containing a short
 // inner scrollable plus enough sibling filler that the outer can scroll
 // too. Both are taller than their viewports, so both have somewhere to
@@ -72,10 +78,10 @@ func newNestedScrollWindow(t *testing.T) *Window {
 // pass for the wrong reason (inner never receiving anything).
 func TestNestedScrollInnerConsumesWhileItCan(t *testing.T) {
 	w := newNestedScrollWindow(t)
-	if err := w.TestScroll("inner", 0, -5); err != nil {
+	if err := w.TestScroll(innerID, 0, -5); err != nil {
 		t.Fatalf("TestScroll(inner) = %v, want nil", err)
 	}
-	_, inner, err := w.TestScrollOffset("inner")
+	_, inner, err := w.TestScrollOffset(innerID)
 	if err != nil {
 		t.Fatalf("TestScrollOffset(inner) = %v, want nil", err)
 	}
@@ -109,7 +115,7 @@ func TestNestedScrollCascadesToParentAtLimit(t *testing.T) {
 	for range 100 {
 		// Snapshot both offsets, then scroll. The gesture of interest
 		// is the one after which the inner has not moved.
-		_, innerBefore, err := w.TestScrollOffset("inner")
+		_, innerBefore, err := w.TestScrollOffset(innerID)
 		if err != nil {
 			t.Fatalf("TestScrollOffset(inner) = %v, want nil", err)
 		}
@@ -120,10 +126,10 @@ func TestNestedScrollCascadesToParentAtLimit(t *testing.T) {
 		// Errors are not assertable here: once the inner declines, the
 		// outer accepts, so the event is still handled and the return is
 		// still nil. The offsets are the signal.
-		if err = w.TestScroll("inner", 0, -20); err != nil {
+		if err = w.TestScroll(innerID, 0, -20); err != nil {
 			t.Fatalf("TestScroll(inner) = %v, want nil", err)
 		}
-		_, innerNow, err := w.TestScrollOffset("inner")
+		_, innerNow, err := w.TestScrollOffset(innerID)
 		if err != nil {
 			t.Fatalf("TestScrollOffset(inner) = %v, want nil", err)
 		}

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -144,7 +144,7 @@ func scrollSmoothBy(w *Window, layout *Layout, axis scrollAxis, delta float32) b
 		return false
 	}
 	increment := delta * guiTheme.ScrollMultiplier
-	return scrollSmoothArm(w, layout.Shape.ID, axis, displayed, maxOffset, increment, true)
+	return scrollSmoothArm(w, layout.Shape.idKey(), axis, displayed, maxOffset, increment, true)
 }
 
 // scrollSmoothTo arms the smoother toward an absolute offset
@@ -156,13 +156,13 @@ func scrollSmoothTo(w *Window, layout *Layout, axis scrollAxis, offset float32) 
 	if !ok {
 		return false
 	}
-	return scrollSmoothArm(w, layout.Shape.ID, axis, displayed, maxOffset, offset, false)
+	return scrollSmoothArm(w, layout.Shape.idKey(), axis, displayed, maxOffset, offset, false)
 }
 
 // scrollSmoothParams validates that layout can ease on axis and
 // returns the displayed offset and scroll bound. Main goroutine only.
 func scrollSmoothParams(w *Window, layout *Layout, axis scrollAxis) (displayed, maxOffset float32, ok bool) {
-	id := layout.Shape.ID
+	id := layout.Shape.idKey()
 	if !layout.Shape.Scrollable || id == "" {
 		return 0, 0, false
 	}

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"math/rand/v2"
+	"strings"
 
 	"github.com/go-gui-org/go-glyph"
 )
@@ -27,7 +28,19 @@ type Shape struct {
 	// ID is a user-assigned string identifier. Used for event routing,
 	// form field lookup, and debugging. Optional but recommended for
 	// interactive widgets.
+	//
+	// ID is the *leaf* name. The window-unique identity is effID, which
+	// resolveShapeIDs derives by joining the IDs of ID-bearing ancestors
+	// (see id_resolve.go). Read idKey() — never ID — when using a shape
+	// as a key into focus, scroll, hover or per-widget state.
 	ID string
+
+	// effID is the resolved, window-unique identity: the leaf joined to
+	// the enclosing scope. Stamped by resolveShapeIDs, which runs from
+	// layoutArrange before any pass reads an identity, so it is empty
+	// only on a tree that has not been arranged — idKey() falls back to
+	// ID there.
+	effID string
 
 	// focusOwner is the ID of the widget this shape renders for. A
 	// composite widget sets it on an inner shape that must consult the
@@ -36,6 +49,16 @@ type Shape struct {
 	// container — without claiming the owner's identity. ID is an
 	// identity and must be unique per window; focusOwner is a
 	// reference and deliberately is not.
+	//
+	// The widget writes the owner's *leaf*; resolveShapeIDs rewrites it
+	// in place to the owner's effID, because that is the key the focus
+	// and input-state stores hold. In place rather than in a second
+	// field: adding effID already moved Shape from the 288-byte size
+	// class to the 320-byte one, and a second string would leave only 8
+	// bytes of headroom before the next jump. It is safe on two counts —
+	// the view phase rebuilds every shape each frame, and resolving an
+	// already-effective value is a no-op (it contains IDSep, so it is
+	// absolute).
 	focusOwner string
 
 	// Resource is an image file path, SVG source string, or data URI.
@@ -502,15 +525,30 @@ func (s *Shape) hasEvents() bool {
 	return s.events != nil
 }
 
+// idKey returns the identity this shape is keyed by in every ID-keyed
+// store and match: the resolved effID, falling back to the leaf ID on a
+// tree resolveShapeIDs has not walked yet (a hand-built Layout in a
+// test). Under an empty scope the two are equal, so the fallback only
+// ever matters before the pipeline runs.
+func (s *Shape) idKey() string {
+	if s.effID != "" {
+		return s.effID
+	}
+	return s.ID
+}
+
 // focusKey returns the ID whose focus and per-widget state this shape
 // renders from: focusOwner when the shape belongs to a composite
 // widget, otherwise its own ID. Empty for a shape that participates in
 // neither, which is the signal to render no caret or selection.
+//
+// Both arms return an *effective* ID, because that is what the focus,
+// input-state and spell-check stores hold.
 func (s *Shape) focusKey() string {
 	if s.focusOwner != "" {
 		return s.focusOwner
 	}
-	return s.ID
+	return s.idKey()
 }
 
 // rendersFocusState reports whether this shape draws caret, selection
@@ -560,9 +598,21 @@ func makeA11YInfo(label, desc string) *AccessInfo {
 }
 
 // a11yLabel returns label if set, otherwise falls back to text.
+//
+// The fallback is often a widget's ID, and an ID may be a scoped path
+// ("settings:name") once its widget resolves its identity. A screen
+// reader must announce a name, not a path, so only the last segment
+// survives the fallback. An explicit A11YLabel is returned untouched —
+// a colon an author wrote is part of the label.
 func a11yLabel(label, text string) string {
 	if label != "" {
 		return label
+	}
+	// A trailing separator leaves nothing to announce, so the whole
+	// string is better than silence.
+	if i := strings.LastIndex(text, IDSep); i >= 0 &&
+		i+len(IDSep) < len(text) {
+		return text[i+len(IDSep):]
 	}
 	return text
 }

--- a/gui/state_registry.go
+++ b/gui/state_registry.go
@@ -113,6 +113,7 @@ func (w *Window) scrollYRead() *BoundedMap[string, float32] {
 // clearHotMaps nils out the cached BoundedMap pointers so they are
 // recreated on next access. Call alongside registry.Clear().
 func (w *Window) clearHotMaps() {
+	w.idJoinCache = nil
 	w.hoverInsideMap = nil
 	w.scrollXMap = nil
 	w.scrollYMap = nil
@@ -244,4 +245,8 @@ const (
 	capMany       = 100
 	capScroll     = 200
 	capImageCache = 500
+	// capIDJoin bounds the ID-join memo. Sized well above the number of
+	// distinct identities a normal screen holds so the common frame is
+	// all hits; a bigger frame simply recomputes what does not fit.
+	capIDJoin = 512
 )

--- a/gui/view.go
+++ b/gui/view.go
@@ -79,6 +79,17 @@ func generateViewLayout(view View, w *Window) Layout {
 		copy(grown, layout.Children)
 		layout.Children = grown
 	}
+	// Children generate under this node's scope, so a widget that reads
+	// its own state during GenerateLayout (w.EffID) keys on the same
+	// identity resolveShapeIDs will later stamp on its shape. Saved and
+	// restored rather than recomputed on the way out: the recursion is
+	// the only writer, and a sibling must not inherit a child's scope.
+	scoped := w != nil && len(children) > 0
+	saved := ""
+	if scoped {
+		saved = w.viewState.idScope
+		w.viewState.idScope = childScopeID(w, saved, layout.Shape)
+	}
 	for _, child := range children {
 		if child == nil {
 			continue
@@ -87,6 +98,9 @@ func generateViewLayout(view View, w *Window) Layout {
 			layout.Children,
 			generateViewLayout(child, w),
 		)
+	}
+	if scoped {
+		w.viewState.idScope = saved
 	}
 	return layout
 }

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -75,7 +75,7 @@ func buttonAmendLayout(ctx EventCtx) {
 		ctx.Layout.Shape.events.OnClick == nil {
 		return
 	}
-	if ctx.Window.IsFocus(ctx.Layout.Shape.ID) {
+	if ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 		ctx.Layout.Shape.Color = ctx.Layout.Shape.bc.ColorFocus
 		ctx.Layout.Shape.ColorBorder = ctx.Layout.Shape.bc.ColorBorderFocus
 	}
@@ -91,7 +91,7 @@ func buttonOnHover(ctx EventCtx) {
 		return
 	}
 	ctx.Window.setMouseCursor(CursorPointingHand)
-	if !ctx.Window.IsFocus(ctx.Layout.Shape.ID) {
+	if !ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 		ctx.Layout.Shape.Color = ctx.Layout.Shape.bc.ColorHover
 	}
 	if ctx.Event.MouseButton == MouseLeft {

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -47,6 +47,9 @@ func (cv *colorPickerView) Content() []View { return nil }
 
 func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 	cfg := &cv.cfg
+
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
 	style := cfg.Style
 
 	// Get or init HSV state.

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -78,16 +78,21 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 	dn := &DefaultComboboxStyle
 	sizeBorder := cfg.SizeBorder.Get(dn.SizeBorder)
 	radius := cfg.Radius.Get(dn.Radius)
-	isOpen := StateReadOr(w, nsCombobox, cfg.ID, false)
-	query := StateReadOr(w, nsComboboxQuery, cfg.ID, "")
-	highlighted := StateReadOr(w, nsComboboxHighlight, cfg.ID, 0)
+	// Per-widget state is keyed by the widget's *effective* ID, so two
+	// comboboxes written with the same leaf under different ID-bearing
+	// panels keep separate open/query/highlight state. Handlers close
+	// over the resolved key; it stays valid while those ancestors do.
+	id := w.EffID(cfg.ID)
+	isOpen := StateReadOr(w, nsCombobox, id, false)
+	query := StateReadOr(w, nsComboboxQuery, id, "")
+	highlighted := StateReadOr(w, nsComboboxHighlight, id, 0)
 
 	cacheMap := StateMap[string, *comboboxItemsCache](
 		w, nsComboboxItems, capModerate)
-	cache, ok := cacheMap.Get(cfg.ID)
+	cache, ok := cacheMap.Get(id)
 	if !ok || cache == nil {
 		cache = &comboboxItemsCache{}
-		cacheMap.Set(cfg.ID, cache)
+		cacheMap.Set(id, cache)
 	}
 
 	// Convert options to core items only when options changed.
@@ -123,7 +128,11 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 	pad := cfg.Padding.Get(Padding{})
 	listH := cfg.MaxDropdownHeight - 2*sizeBorder - pad.Top - pad.Bottom
 	var scrollY float32
-	dropdownScrollID := ScopeID(cfg.ID, "dropdown")
+	// The dropdown is a child of the container that claims cfg.ID, so
+	// its shape carries the plain leaf below and the framework joins it.
+	// The key here is that same join, spelled out because this read
+	// happens during generation.
+	dropdownScrollID := ScopeID(id, "dropdown")
 	if cfg.Scrollable {
 		// Default 0: unscrolled dropdown before first scroll event.
 		scrollY = w.scrollY().GetOr(dropdownScrollID, 0)
@@ -132,7 +141,6 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 
 	// Build dropdown content.
 	onSelect := cfg.OnSelect
-	cfgID := cfg.ID
 	coreCfg := listCoreCfg{
 		TextStyle:      cfg.TextStyle,
 		ColorHighlight: cfg.ColorHighlight,
@@ -143,7 +151,7 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 			if onSelect != nil {
 				onSelect(itemID, EventCtx{nil, ctx.Event, ctx.Window})
 			}
-			comboboxClose(cfgID, ctx.Window)
+			comboboxClose(id, ctx.Window)
 		},
 	}
 
@@ -211,7 +219,7 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 			cache.viewKey = viewKey
 		}
 		content = append(content, Column(ContainerCfg{
-			ID:           dropdownScrollID,
+			ID:           "dropdown",
 			SizeBorder:   Some(sizeBorder),
 			Radius:       Some(radius),
 			ColorBorder:  cfg.ColorBorder,
@@ -248,7 +256,6 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 
 	colorFocus := cfg.ColorFocus
 	colorBorderFocus := cfg.ColorBorderFocus
-	focusID := cfg.ID
 
 	ccfg := ContainerCfg{
 		ID:          cfg.ID,
@@ -269,18 +276,19 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 			if ctx.Layout.Shape.Disabled {
 				return
 			}
-			if ctx.Window.IsFocus(ctx.Layout.Shape.ID) {
+			if ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 				ctx.Layout.Shape.Color = colorFocus
 				ctx.Layout.Shape.ColorBorder = colorBorderFocus
 			}
 		},
-		OnKeyDown: makeComboboxOnKeyDown(cfg.ID, onSelect, focusID, filteredIDs, dropdownScrollID, rowH, listH),
-		OnChar:    makeComboboxOnChar(cfg.ID),
+		OnKeyDown: makeComboboxOnKeyDown(id, onSelect, id, filteredIDs,
+			dropdownScrollID, rowH, listH),
+		OnChar: makeComboboxOnChar(id),
 		OnClick: func(ctx EventCtx) {
 			if isOpen {
-				comboboxClose(cfgID, ctx.Window)
+				comboboxClose(id, ctx.Window)
 			} else {
-				comboboxOpen(cfgID, focusID, ctx.Window)
+				comboboxOpen(id, id, ctx.Window)
 			}
 		},
 	}

--- a/gui/view_combobox_test.go
+++ b/gui/view_combobox_test.go
@@ -298,8 +298,11 @@ func TestComboboxScrollEndToEnd(t *testing.T) {
 	})
 	layout := generateViewLayout(v, w)
 
-	// Set parent pointers.
+	// Set parent pointers, then resolve identities — layoutArrange does
+	// both before it extracts the floats, and the dropdown's scroll key
+	// is the join of the combobox's ID with its "dropdown" leaf.
 	layoutParents(&layout, nil)
+	resolveShapeIDs(&layout, w)
 
 	// Extract float (dropdown) like layoutArrange does.
 	var floats []*Layout
@@ -311,7 +314,7 @@ func TestComboboxScrollEndToEnd(t *testing.T) {
 	// Find the dropdown float (has IDScroll).
 	var dropdown *Layout
 	for _, f := range floats {
-		if f.Shape.Scrollable && f.Shape.ID == idScroll {
+		if f.Shape.Scrollable && f.Shape.idKey() == idScroll {
 			dropdown = f
 			break
 		}

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -75,20 +75,25 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 	dn := &DefaultCommandPaletteStyle
 	sizeBorder := cfg.SizeBorder.Get(dn.SizeBorder)
 	radius := cfg.Radius.Get(dn.Radius)
-	visible := StateReadOr(w, nsCmdPalette, cfg.ID, false)
+	// Palette state is keyed by the effective ID. The public helpers
+	// (CommandPaletteShow and friends) take effective IDs too, so an app
+	// that nests a palette under an ID-bearing panel passes the full
+	// path — the same string this resolves to.
+	id := w.EffID(cfg.ID)
+	visible := StateReadOr(w, nsCmdPalette, id, false)
 	if !visible {
 		return generateViewLayout(Row(ContainerCfg{Padding: NoPadding}), w)
 	}
 
-	query := StateReadOr(w, nsCmdPaletteQuery, cfg.ID, "")
-	highlighted := StateReadOr(w, nsCmdPaletteHighlight, cfg.ID, 0)
+	query := StateReadOr(w, nsCmdPaletteQuery, id, "")
+	highlighted := StateReadOr(w, nsCmdPaletteHighlight, id, 0)
 
 	cacheMap := StateMap[string, *cmdPaletteItemsCache](
 		w, nsCmdPaletteItems, capModerate)
-	cache, ok := cacheMap.Get(cfg.ID)
+	cache, ok := cacheMap.Get(id)
 	if !ok || cache == nil {
 		cache = &cmdPaletteItemsCache{}
-		cacheMap.Set(cfg.ID, cache)
+		cacheMap.Set(id, cache)
 	}
 
 	// Convert to core items only when source items changed.
@@ -119,7 +124,7 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 
 	// Virtualization.
 	rowH := listCoreRowHeightEstimate(cfg.TextStyle, PaddingTwoFive)
-	scrollID := ScopeID(cfg.ID, "scroll")
+	scrollID := ScopeID(id, "scroll")
 	var scrollY float32
 	if cfg.Scrollable {
 		// Default 0: unscrolled list before first scroll event.
@@ -128,7 +133,7 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 	first, last := listCoreVisibleRange(len(filtered), rowH, cfg.MaxHeight, scrollY)
 
 	onAction := cfg.OnAction
-	paletteID := cfg.ID
+	paletteID := id
 	onDismiss := cfg.OnDismiss
 
 	coreCfg := listCoreCfg{
@@ -214,12 +219,12 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 						SizeBorder: NoBorder,
 						Content: []View{
 							Input(InputCfg{
-								ID:            ScopeID(cfg.ID, "input"),
+								ID:            ScopeID(id, "input"),
 								Text:          query,
 								Placeholder:   cfg.Placeholder,
 								TextStyle:     cfg.TextStyle,
 								Sizing:        FillFit,
-								OnTextChanged: makePaletteOnTextChanged(cfg.ID),
+								OnTextChanged: makePaletteOnTextChanged(id),
 								OnKeyDown:     makePaletteOnKeyDown(paletteID, onAction, onDismiss, filtered, filteredIDs),
 								OnEnter:       makePaletteOnEnter(paletteID, onAction, onDismiss, filtered, filteredIDs),
 							}),

--- a/gui/view_context_menu.go
+++ b/gui/view_context_menu.go
@@ -55,6 +55,9 @@ func ContextMenu(w *Window, cfg ContextMenuCfg) View {
 	checkForDuplicateMenuIDs(cfg.Items)
 	applyContextMenuDefaults(&cfg)
 
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
+
 	st := StateReadOr(
 		w, nsContextMenu, cfg.ID, contextMenuState{})
 

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -105,6 +105,9 @@ func (dv *datePickerView) Content() []View { return nil }
 
 func (dv *datePickerView) GenerateLayout(w *Window) Layout {
 	cfg := &dv.cfg
+
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
 	dn := &DefaultDatePickerStyle
 	cellSpacing := cfg.CellSpacing.Get(dn.CellSpacing)
 	radiusBorder := cfg.RadiusBorder.Get(dn.RadiusBorder)

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -286,6 +286,15 @@ func applyDialogDefaults(cfg *DialogCfg) {
 	if cfg.FocusID == "" {
 		cfg.FocusID = dialogBaseFocusID
 	}
+	// The dialog's controls hang off a container carrying
+	// reservedDialogID, so a plain-leaf focus ID resolves under it —
+	// while SetFocus and retainDialogFocus, which run outside layout
+	// generation, would keep passing the bare leaf and focus nothing.
+	// Scoping it here makes it absolute, so the shape's identity is
+	// exactly this string, and it keeps the ScopeIDN-derived siblings
+	// (":1", ":2") in the same namespace instead of a separate one.
+	// Idempotent, and it leaves a caller's already-composed ID alone.
+	cfg.FocusID = resolveLeaf(reservedDialogID, cfg.FocusID)
 	// HAlignStart is 0 (zero value), so explicit HAlignStart cannot be
 	// distinguished from unset. Use HAlignLeft for left alignment.
 	if cfg.AlignButtons == HAlignStart {

--- a/gui/view_dialog_test.go
+++ b/gui/view_dialog_test.go
@@ -85,9 +85,12 @@ func TestDialogCfgDefaults(t *testing.T) {
 	if !cfg.Color.IsSet() {
 		t.Error("expected non-zero Color")
 	}
-	if cfg.FocusID != dialogBaseFocusID {
-		t.Errorf("expected FocusID=%q, got %q",
-			dialogBaseFocusID, cfg.FocusID)
+	// Scoped under the dialog container, which is where the control
+	// carrying it actually sits — a bare leaf would resolve under that
+	// container while SetFocus kept passing the leaf.
+	wantFocus := ScopeID(reservedDialogID, dialogBaseFocusID)
+	if cfg.FocusID != wantFocus {
+		t.Errorf("expected FocusID=%q, got %q", wantFocus, cfg.FocusID)
 	}
 	if cfg.MinWidth.IsSet() {
 		t.Error("expected MinWidth unset (resolved from style)")
@@ -129,9 +132,8 @@ func TestDialogShowDismissLifecycle(t *testing.T) {
 	if !w.DialogIsVisible() {
 		t.Error("expected dialog visible after Dialog()")
 	}
-	if w.FocusID() != dialogBaseFocusID {
-		t.Errorf("expected focus=%q, got %q",
-			dialogBaseFocusID, w.FocusID())
+	if want := ScopeID(reservedDialogID, dialogBaseFocusID); w.FocusID() != want {
+		t.Errorf("expected focus=%q, got %q", want, w.FocusID())
 	}
 
 	w.DialogDismiss()
@@ -425,5 +427,49 @@ func TestDialogConfirmView(t *testing.T) {
 	layout := generateViewLayout(v, w)
 	if len(layout.Children) == 0 {
 		t.Error("expected children for confirm dialog")
+	}
+}
+
+// The dialog's controls sit under a container carrying
+// reservedDialogID, while SetFocus and retainDialogFocus run outside
+// layout generation and pass dialogFocusID directly. If those two
+// disagree the dialog renders but keyboard focus lands nowhere: Enter
+// does not trigger the default button and a prompt swallows typing.
+// Every dialog shape must therefore be addressable by the ID the focus
+// path uses.
+func TestDialogFocusTargetIsAddressable(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  DialogCfg
+	}{
+		{"message", DialogCfg{Title: "t", Body: "m"}},
+		{"confirm", DialogCfg{
+			Title: "t", Body: "m", DialogType: DialogConfirm}},
+		{"confirm defaulting to yes", DialogCfg{
+			Title:      "t",
+			DialogType: DialogConfirm,
+			// The Yes button is the ScopeIDN-composed sibling, so this
+			// covers the composed arm of dialogFocusID too.
+			DefaultButton: DialogButtonYes,
+		}},
+		{"prompt", DialogCfg{Title: "t", DialogType: DialogPrompt}},
+		{"caller-supplied focus id", DialogCfg{
+			Title: "t", Body: "m", FocusID: "mine"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewTestWindow(WindowCfg{})
+			w.Dialog(tc.cfg)
+			root := w.TestRender(func(_ *Window) View {
+				return Column(ContainerCfg{Sizing: FillFill})
+			})
+			want := dialogFocusID(w.dialogCfg)
+			if _, ok := root.FindByID(want); !ok {
+				t.Fatalf("no shape with the focus ID %q", want)
+			}
+			if got := w.FocusID(); got != want {
+				t.Fatalf("FocusID() = %q, want %q", got, want)
+			}
+		})
 	}
 }

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -61,6 +61,10 @@ func newDockLayoutCore(cfg *DockLayoutCfg) *dockLayoutCore {
 func DockLayout(cfg DockLayoutCfg) View {
 	applyDockLayoutDefaults(&cfg)
 	return ViewFunc(func(w *Window) View {
+		// One resolved identity for every key below; see (*Window).EffID.
+		// cfg is captured by this per-frame closure, so re-resolving it
+		// each frame is fine: the join is idempotent.
+		cfg.ID = w.EffID(cfg.ID)
 		core := newDockLayoutCore(&cfg)
 		drag := dockDragGet(w, cfg.ID)
 

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -270,7 +270,9 @@ func Input(cfg InputCfg) View {
 		OnKeyUp:         makeInputOnKeyUp(hcfg),
 		OnHover: func(ctx EventCtx) {
 			ctx.Window.setMouseCursor(CursorIBeam)
-			if !ctx.Window.IsFocus(focusID) {
+			// This handler sits on the container that claims cfg.ID, so
+			// its resolved identity is the focus key.
+			if !ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 				ctx.Layout.Shape.Color = colorHover
 			}
 		},
@@ -399,12 +401,18 @@ func inputScrollIDFor(cfg *InputCfg) string {
 // input, which still tracks a cursor but never takes focus. Both are
 // passed in rather than read off the text shape, which carries no ID
 // of its own (see Shape.focusOwner).
-func inputOnClick(focusID, scrollID string, canFocus bool) func(EventCtx) {
+func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 	return func(ctx EventCtx) {
 		if len(ctx.Layout.Children) < 1 {
 			// No inner text shape: not ours
 			return
 		}
+		// Input builds its tree eagerly, with no Window in hand, so the
+		// captured IDs are leaves. Resolve them here: the owning
+		// container is this shape's parent, and by dispatch time every
+		// shape carries its effective identity.
+		focusID := ctx.EffID(leafID)
+		scrollID := ctx.EffID(leafScrollID)
 		ly := ctx.Layout.Children[0]
 		if canFocus && focusID != "" {
 			ctx.Window.SetFocus(focusID)
@@ -518,8 +526,12 @@ func inputAmendLayout(
 		if !ctx.Layout.Shape.Focusable || ctx.Layout.Shape.ID == "" {
 			return
 		}
+		// This callback runs on the container that claims cfg.ID, so its
+		// own resolved identity is the key for focus, blur tracking,
+		// selection and spell-check state.
+		key := ctx.Layout.Shape.idKey()
 		focused := !ctx.Layout.Shape.Disabled &&
-			ctx.Window.IsFocus(ctx.Layout.Shape.ID)
+			ctx.Window.IsFocus(key)
 		if focused {
 			ctx.Layout.Shape.ColorBorder = colorBorderFocus
 		}
@@ -528,8 +540,8 @@ func inputAmendLayout(
 		focusMap := StateMap[string, bool](
 			ctx.Window, nsInputFocus, capMany)
 		// Default false: absent entry means not previously focused.
-		wasFocused := focusMap.GetOr(ctx.Layout.Shape.ID, false)
-		focusMap.Set(ctx.Layout.Shape.ID, focused)
+		wasFocused := focusMap.GetOr(key, false)
+		focusMap.Set(key, focused)
 		if wasFocused && !focused {
 			text := inputTextFromLayout(ctx.Layout)
 			if normalized := hcfg.normalizeOnCommit(
@@ -542,8 +554,7 @@ func inputAmendLayout(
 				hcfg.OnTextCommit(text, CommitBlur, ctx)
 			}
 			if spellChk {
-				spellCheckClear(
-					ctx.Layout.Shape.ID, ctx.Window)
+				spellCheckClear(key, ctx.Window)
 			}
 			if onBlur != nil {
 				onBlur(ctx)
@@ -557,8 +568,7 @@ func inputAmendLayout(
 				txt := &inner.Children[0]
 				if txt.Shape.TC != nil {
 					is := StateReadOr(ctx.Window, nsInput,
-						ctx.Layout.Shape.ID,
-						InputState{})
+						key, InputState{})
 					txt.Shape.TC.TextSelBeg = is.SelectBeg
 					txt.Shape.TC.TextSelEnd = is.SelectEnd
 				}
@@ -569,10 +579,9 @@ func inputAmendLayout(
 		// disabled.
 		if spellChk && focused {
 			text := inputTextFromLayout(ctx.Layout)
-			spellCheckTrigger(
-				ctx.Layout.Shape.ID, text, ctx.Window)
+			spellCheckTrigger(key, text, ctx.Window)
 		} else if !spellChk {
-			spellCheckClear(ctx.Layout.Shape.ID, ctx.Window)
+			spellCheckClear(key, ctx.Window)
 		}
 	}
 }

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -39,7 +39,11 @@ func inputTextChange(hcfg inputHandlerCfg, layout *Layout, text, ins string, id 
 
 func makeInputOnChar(hcfg inputHandlerCfg) func(EventCtx) {
 	return func(ctx EventCtx) {
-		if hcfg.FocusID == "" || !ctx.Window.IsFocus(hcfg.FocusID) {
+		// The captured IDs are leaves (Input builds its tree with no
+		// Window in hand); ctx.EffID turns them into the identities the
+		// focus and state stores hold.
+		id := ctx.EffID(hcfg.FocusID)
+		if id == "" || !ctx.Window.IsFocus(id) {
 			// Not our field: let the character travel on
 			return
 		}
@@ -50,7 +54,6 @@ func makeInputOnChar(hcfg inputHandlerCfg) func(EventCtx) {
 			return
 		}
 		ch := ctx.Event.CharCode
-		id := hcfg.FocusID
 
 		// Control characters are handled by OnKeyDown.
 		if ch < CharSpace {
@@ -69,7 +72,7 @@ func makeInputOnChar(hcfg inputHandlerCfg) func(EventCtx) {
 			resetBlinkCursorVisible(ctx.Window)
 			hcfg.fireTextChanged(ctx.Layout, text, ctx.Window)
 			inputScrollCursorIntoView(
-				hcfg.ScrollID, text, ctx.Layout, ctx.Window,
+				ctx.EffID(hcfg.ScrollID), text, ctx.Layout, ctx.Window,
 			)
 		}
 		ctx.Consume()
@@ -100,14 +103,14 @@ func inputKeyMutatesText(e *Event, mode InputMode) bool {
 func makeInputOnKeyDown(hcfg inputHandlerCfg) func(EventCtx) {
 	mask := hcfg.CompiledMask
 	return func(ctx EventCtx) {
-		if hcfg.FocusID == "" || !ctx.Window.IsFocus(hcfg.FocusID) {
+		id := ctx.EffID(hcfg.FocusID)
+		if id == "" || !ctx.Window.IsFocus(id) {
 			return
 		}
 		if hcfg.ReadOnly && inputKeyMutatesText(ctx.Event, hcfg.Mode) {
 			ctx.Consume()
 			return
 		}
-		id := hcfg.FocusID
 		imap := StateMap[string, InputState](ctx.Window, nsInput, capMany)
 		// Default InputState{}: zero CursorOffset/CursorTrailing seed
 		// initial state; both are immediately overwritten below.
@@ -192,7 +195,7 @@ func makeInputOnKeyDown(hcfg inputHandlerCfg) func(EventCtx) {
 				hcfg.fireTextChanged(ctx.Layout, text, ctx.Window)
 			}
 			inputScrollCursorIntoView(
-				hcfg.ScrollID, text, ctx.Layout, ctx.Window,
+				ctx.EffID(hcfg.ScrollID), text, ctx.Layout, ctx.Window,
 			)
 			ctx.Consume()
 		} else if hcfg.OnKeyDown != nil {
@@ -203,7 +206,8 @@ func makeInputOnKeyDown(hcfg inputHandlerCfg) func(EventCtx) {
 
 func makeInputOnKeyUp(hcfg inputHandlerCfg) func(EventCtx) {
 	return func(ctx EventCtx) {
-		if hcfg.FocusID == "" || !ctx.Window.IsFocus(hcfg.FocusID) {
+		id := ctx.EffID(hcfg.FocusID)
+		if id == "" || !ctx.Window.IsFocus(id) {
 			return
 		}
 		if hcfg.OnKeyUp != nil {

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -176,6 +176,9 @@ func (lv *listBoxView) Content() []View { return nil }
 func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 	cfg := &lv.cfg
 
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
+
 	dn := &DefaultListBoxStyle
 	sizeBorder := cfg.SizeBorder.Get(dn.SizeBorder)
 	radius := cfg.Radius.Get(dn.Radius)

--- a/gui/view_menu.go
+++ b/gui/view_menu.go
@@ -11,6 +11,9 @@ func Menu(w *Window, cfg MenubarCfg) View {
 	RequireID("Menu", cfg.ID)
 	checkForDuplicateMenuIDs(cfg.Items)
 
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
+
 	// Auto-select first item on focus.
 	if w.IsFocus(cfg.ID) {
 		sel := StateReadOr(

--- a/gui/view_overflow_panel.go
+++ b/gui/view_overflow_panel.go
@@ -30,12 +30,15 @@ type OverflowPanelCfg struct {
 func OverflowPanel(w *Window, cfg OverflowPanelCfg) View {
 	applyOverflowDefaults(&cfg)
 
-	visibleCount, ok := w.overflow().Get(cfg.ID)
+	// The overflow count and the menu-open flag are keyed by the panel's
+	// effective ID — the same key layoutOverflow writes from the shape.
+	id := w.EffID(cfg.ID)
+	visibleCount, ok := w.overflow().Get(id)
 	if !ok {
 		visibleCount = len(cfg.Items)
 	}
 	isOpen := StateReadOr(
-		w, nsSelect, cfg.ID, false)
+		w, nsSelect, id, false)
 
 	content := make([]View, 0, len(cfg.Items)+2)
 
@@ -56,7 +59,6 @@ func OverflowPanel(w *Window, cfg OverflowPanelCfg) View {
 		}
 	}
 
-	id := cfg.ID
 	content = append(content, Button(ButtonCfg{
 		// Namespaced by the panel's ID: a toolbar can hold several
 		// overflow panels, each with its own trigger.
@@ -91,7 +93,7 @@ func OverflowPanel(w *Window, cfg OverflowPanelCfg) View {
 		}
 
 		content = append(content, Menu(w, MenubarCfg{
-			ID:           ScopeID(cfg.ID, "menu"),
+			ID:           ScopeID(id, "menu"),
 			Items:        menuItems,
 			Float:        true,
 			FloatAnchor:  cfg.FloatAnchor,

--- a/gui/view_progress_bar.go
+++ b/gui/view_progress_bar.go
@@ -84,7 +84,6 @@ func ProgressBar(cfg ProgressBarCfg) View {
 	textShow := cfg.TextShow
 	vertical := cfg.Vertical
 	indefinite := cfg.Indefinite
-	id := cfg.ID
 
 	size := guiTheme.ProgressBarStyle.Size
 
@@ -129,9 +128,12 @@ func ProgressBar(cfg ProgressBarCfg) View {
 		HAlign:     HAlignCenter,
 		VAlign:     VAlignMiddle,
 		AmendLayout: func(ctx EventCtx) {
+			// Keyed by the effective ID: the indefinite animation and
+			// its progress slot belong to this bar, not to every bar
+			// that happens to share the leaf.
 			progressBarAmendLayout(ctx.Layout, ctx.Window,
 				barPercent, textShow, vertical,
-				indefinite, id)
+				indefinite, ctx.Layout.Shape.idKey())
 		},
 		Content: content,
 	}

--- a/gui/view_radio.go
+++ b/gui/view_radio.go
@@ -94,7 +94,7 @@ func Radio(cfg RadioCfg) View {
 			if len(ctx.Layout.Children) == 0 {
 				return
 			}
-			if ctx.Window.IsFocus(ctx.Layout.Shape.ID) {
+			if ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 				ctx.Layout.Children[0].Shape.ColorBorder = colorBorderFocus
 			}
 		},

--- a/gui/view_rtf.go
+++ b/gui/view_rtf.go
@@ -518,7 +518,12 @@ type rtfLinkMenuState struct {
 	Open     bool
 }
 
-const rtfLinkMenuFocusID = "rtf_link_menu"
+// Absolute: the popup is generated as a child of the RTF block, so a
+// plain leaf would resolve under that block's identity — while
+// showLinkContextMenu and the dismiss check, which run from event
+// handlers, would keep using the bare constant and never match. See
+// gui/id_resolve.go.
+const rtfLinkMenuFocusID = "gui:rtf:link_menu"
 
 // showLinkContextMenu opens a context menu for an RTF link.
 func showLinkContextMenu(

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -13,7 +13,7 @@ func rtfSelectAmendLayout(ctx EventCtx) {
 	if ctx.Layout.Shape.ID == "" || !ctx.Layout.Shape.Focusable || ctx.Layout.Shape.TC == nil {
 		return
 	}
-	is := StateReadOr(ctx.Window, nsInput, ctx.Layout.Shape.ID, InputState{})
+	is := StateReadOr(ctx.Window, nsInput, ctx.Layout.Shape.idKey(), InputState{})
 	ctx.Layout.Shape.TC.TextSelBeg = is.SelectBeg
 	ctx.Layout.Shape.TC.TextSelEnd = is.SelectEnd
 }
@@ -36,7 +36,7 @@ func rtfSelectOnClick(ctx EventCtx) {
 	if shape.TC == nil || !shape.hasRtfLayout() || shape.ID == "" || !shape.Focusable {
 		return
 	}
-	ctx.Window.SetFocus(shape.ID)
+	ctx.Window.SetFocus(shape.idKey())
 
 	gl := shape.TC.RTFLayout
 	flatText := shape.TC.RTFFlatText
@@ -44,7 +44,7 @@ func rtfSelectOnClick(ctx EventCtx) {
 	byteIdx := gl.GetClosestOffset(ctx.Event.MouseX, ctx.Event.MouseY)
 	runePos := byteToRuneIndex(flatText, byteIdx)
 
-	focusID := shape.ID
+	focusID := shape.idKey()
 	imap := StateMap[string, InputState](ctx.Window, nsInput, capMany)
 	// Default InputState{}: zero value seeds initial selection/cursor state.
 	is := imap.GetOr(focusID, InputState{})
@@ -83,7 +83,7 @@ func rtfSelectOnClick(ctx EventCtx) {
 	maxScrollNeg := float32(0)
 	for p := ctx.Layout.Parent; p != nil; p = p.Parent {
 		if p.Shape != nil && p.Shape.Scrollable {
-			scrollID = p.Shape.ID
+			scrollID = p.Shape.idKey()
 			sy := ctx.Window.scrollY()
 			// Default 0: unscrolled container before first scroll event.
 			dragScrollY0 = sy.GetOr(scrollID, 0)
@@ -191,10 +191,10 @@ func rtfSelectOnClick(ctx EventCtx) {
 func rtfSelectOnKeyDown(ctx EventCtx) {
 	shape := ctx.Layout.Shape
 	if shape.TC == nil || shape.ID == "" || !shape.Focusable ||
-		!ctx.Window.IsFocus(shape.ID) {
+		!ctx.Window.IsFocus(shape.idKey()) {
 		return
 	}
-	id := shape.ID
+	id := shape.idKey()
 	flatText := shape.TC.RTFFlatText
 	gl := *shape.TC.RTFLayout
 

--- a/gui/view_scrollbar.go
+++ b/gui/view_scrollbar.go
@@ -107,7 +107,7 @@ func scrollbarThumb(cfg ScrollbarCfg) View {
 
 func makeScrollbarAmendLayout(cfg ScrollbarCfg) func(EventCtx) {
 	return func(ctx EventCtx) {
-		scrollbarAmendLayout(cfg, ctx.Layout, ctx.Window)
+		scrollbarAmendLayout(cfg, ctx, ctx.Layout, ctx.Window)
 	}
 }
 
@@ -124,10 +124,18 @@ func makeScrollbarOnHover(cfg ScrollbarCfg) func(EventCtx) {
 	}
 }
 
-func scrollbarAmendLayout(cfg ScrollbarCfg, layout *Layout, w *Window) {
+func scrollbarAmendLayout(
+	cfg ScrollbarCfg, ctx EventCtx, layout *Layout, w *Window,
+) {
 	if layout.Parent == nil || len(layout.Children) == 0 {
 		return
 	}
+	// ScrollID names the scrollable this bar drives, and it arrives as
+	// the leaf its container was written with. The scroll maps are keyed
+	// by effective ID, so resolve it against this shape's ancestors —
+	// the scrollable is one of them. cfg is already a copy, so this
+	// costs nothing beyond the lookup.
+	cfg.ScrollID = ctx.EffID(cfg.ScrollID)
 	parent := layout.Parent
 
 	if cfg.Orientation == ScrollbarHorizontal {
@@ -215,8 +223,9 @@ func scrollbarAmendLayout(cfg ScrollbarCfg, layout *Layout, w *Window) {
 // that initiates a drag via MouseLock.
 func makeScrollbarOnMouseDown(cfg ScrollbarCfg) func(EventCtx) {
 	orientation := cfg.Orientation
-	scrollID := cfg.ScrollID
+	leafScrollID := cfg.ScrollID
 	return func(ctx EventCtx) {
+		scrollID := ctx.EffID(leafScrollID)
 		ctx.Window.MouseLock(MouseLockCfg{
 			MouseMove: func(ctx EventCtx) {
 				scrollbarMouseMove(orientation, scrollID, ctx.Layout, ctx.Event, ctx.Window)
@@ -234,8 +243,9 @@ func makeScrollbarOnMouseDown(cfg ScrollbarCfg) func(EventCtx) {
 // for continued dragging.
 func makeScrollbarGutterClick(cfg ScrollbarCfg) func(EventCtx) {
 	orientation := cfg.Orientation
-	scrollID := cfg.ScrollID
+	leafScrollID := cfg.ScrollID
 	return func(ctx EventCtx) {
+		scrollID := ctx.EffID(leafScrollID)
 		if ctx.Window.MouseIsLocked() {
 			// A drag already owns the pointer, so this click is not the
 			// gutter's to act on — but it is still not the enclosing

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -67,8 +67,14 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 	dn := &DefaultSelectStyle
 	sizeBorder := cfg.SizeBorder.Get(dn.SizeBorder)
 	radius := cfg.Radius.Get(dn.Radius)
-	isOpen := StateReadOr(w, nsSelect, cfg.ID, false)
-	dropdownScrollID := ScopeID(cfg.ID, "dropdown")
+	// Open/highlight state is keyed by the widget's effective ID, so two
+	// selects written with the same leaf under different ID-bearing
+	// panels do not share one dropdown. The dropdown itself is a child
+	// of this widget's container, so its shape carries the plain
+	// "dropdown" leaf and the framework joins it to the same string.
+	id := w.EffID(cfg.ID)
+	isOpen := StateReadOr(w, nsSelect, id, false)
+	dropdownScrollID := ScopeID(id, "dropdown")
 
 	empty := len(cfg.Selected) == 0 || len(cfg.Selected[0]) == 0
 	clip := cfg.SelectMultiple && cfg.NoWrap
@@ -115,7 +121,7 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 
 	if isOpen {
 		highlightedIdx := StateReadOr(
-			w, nsSelectHL, cfg.ID, 0)
+			w, nsSelectHL, id, 0)
 		options := make([]View, 0, len(cfg.Options))
 		for i, option := range cfg.Options {
 			if isSelectSubheader(option) {
@@ -123,12 +129,12 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 					selectSubHeaderView(cfg, option))
 			} else {
 				options = append(options,
-					selectOptionView(cfg, option, i,
+					selectOptionView(cfg, id, option, i,
 						i == highlightedIdx))
 			}
 		}
 		content = append(content, Column(ContainerCfg{
-			ID:            dropdownScrollID,
+			ID:            "dropdown",
 			SizeBorder:    Some(sizeBorder),
 			Radius:        Some(radius),
 			ColorBorder:   cfg.ColorBorder,
@@ -151,7 +157,6 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 		}))
 	}
 
-	id := cfg.ID
 	colorFocus := cfg.ColorFocus
 	colorBorderFocus := cfg.ColorBorderFocus
 
@@ -177,12 +182,12 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 			if ctx.Layout.Shape.Disabled {
 				return
 			}
-			if ctx.Window.IsFocus(ctx.Layout.Shape.ID) {
+			if ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 				ctx.Layout.Shape.Color = colorFocus
 				ctx.Layout.Shape.ColorBorder = colorBorderFocus
 			}
 		},
-		OnKeyDown: makeSelectOnKeyDown(&sv.cfg, dropdownScrollID),
+		OnKeyDown: makeSelectOnKeyDown(&sv.cfg, id, dropdownScrollID),
 		OnClick: func(ctx EventCtx) {
 			ss := StateMap[string, bool](
 				ctx.Window, nsSelect, capModerate)
@@ -206,13 +211,13 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 }
 
 // selectOptionView builds a single option row.
-func selectOptionView(cfg *SelectCfg, option string, index int, highlighted bool) View {
+func selectOptionView(
+	cfg *SelectCfg, id, option string, index int, highlighted bool,
+) View {
 	selectMultiple := cfg.SelectMultiple
 	onSelect := cfg.OnSelect
 	selectArray := cfg.Selected
 	colorSelect := cfg.ColorSelect
-	cfgID := cfg.ID
-
 	optColor := ColorTransparent
 	if highlighted {
 		optColor = cfg.ColorSelect
@@ -268,9 +273,9 @@ func selectOptionView(cfg *SelectCfg, option string, index int, highlighted bool
 			sh := StateMap[string, int](
 				ctx.Window, nsSelectHL, capModerate)
 			// Default 0: absent entry gets zero index, checked immediately.
-			cur := sh.GetOr(cfgID, 0)
+			cur := sh.GetOr(id, 0)
 			if cur != index {
-				sh.Set(cfgID, index)
+				sh.Set(id, index)
 			}
 		},
 	})
@@ -320,9 +325,11 @@ func selectSubHeaderView(cfg *SelectCfg, option string) View {
 	})
 }
 
-func makeSelectOnKeyDown(cfg *SelectCfg, scrollID string) func(EventCtx) {
+func makeSelectOnKeyDown(
+	cfg *SelectCfg, id, scrollID string,
+) func(EventCtx) {
 	return func(ctx EventCtx) {
-		selectOnKeyDown(cfg, scrollID, ctx.Event, ctx.Window)
+		selectOnKeyDown(cfg, id, scrollID, ctx.Event, ctx.Window)
 	}
 }
 
@@ -339,7 +346,9 @@ func selectInitialHighlight(selected, options []string) int {
 	return 0
 }
 
-func selectOnKeyDown(cfg *SelectCfg, scrollID string, e *Event, w *Window) {
+func selectOnKeyDown(
+	cfg *SelectCfg, id, scrollID string, e *Event, w *Window,
+) {
 	if len(cfg.Options) == 0 {
 		return
 	}
@@ -347,12 +356,12 @@ func selectOnKeyDown(cfg *SelectCfg, scrollID string, e *Event, w *Window) {
 	ss := StateMap[string, bool](w, nsSelect, capModerate)
 	sh := StateMap[string, int](w, nsSelectHL, capModerate)
 	// Default false: absent entry means dropdown not open.
-	isOpen := ss.GetOr(cfg.ID, false)
+	isOpen := ss.GetOr(id, false)
 
 	// Open on space/enter.
 	if (e.KeyCode == KeySpace || e.KeyCode == KeyEnter) && !isOpen {
-		ss.Set(cfg.ID, true)
-		sh.Set(cfg.ID, selectInitialHighlight(
+		ss.Set(id, true)
+		sh.Set(id, selectInitialHighlight(
 			cfg.Selected, cfg.Options))
 		e.IsHandled = true
 		return
@@ -370,7 +379,7 @@ func selectOnKeyDown(cfg *SelectCfg, scrollID string, e *Event, w *Window) {
 	}
 
 	// Default 0: first item highlighted; bounds-checked before use.
-	currentIdx := sh.GetOr(cfg.ID, 0)
+	currentIdx := sh.GetOr(id, 0)
 	action := listCoreNavigate(e.KeyCode, len(cfg.Options))
 
 	if action == listCoreSelectItem {
@@ -403,7 +412,7 @@ func selectOnKeyDown(cfg *SelectCfg, scrollID string, e *Event, w *Window) {
 				cfg.Options, len(cfg.Options)-1, -1)
 		}
 		if nextIdx >= 0 {
-			sh.Set(cfg.ID, nextIdx)
+			sh.Set(id, nextIdx)
 			selectScrollTo(cfg, scrollID, nextIdx, w)
 			e.IsHandled = true
 		}
@@ -418,7 +427,7 @@ func selectOnKeyDown(cfg *SelectCfg, scrollID string, e *Event, w *Window) {
 		nextIdx := selectNextSelectable(
 			cfg.Options, currentIdx+dir, dir)
 		if nextIdx >= 0 {
-			sh.Set(cfg.ID, nextIdx)
+			sh.Set(id, nextIdx)
 			selectScrollTo(cfg, scrollID, nextIdx, w)
 			e.IsHandled = true
 		}

--- a/gui/view_select_test.go
+++ b/gui/view_select_test.go
@@ -87,7 +87,7 @@ func TestSelectOptionViewOnClickFires(t *testing.T) {
 		TextStyle: DefaultTextStyle,
 	}
 	applySelectDefaults(cfg)
-	v := selectOptionView(cfg, "B", 1, false)
+	v := selectOptionView(cfg, cfg.ID, "B", 1, false)
 	cv := v.(*containerView)
 
 	w := &Window{}
@@ -132,7 +132,7 @@ func TestSelectKeyboardNavigation(t *testing.T) {
 
 	// Open via space.
 	e := &Event{KeyCode: KeySpace}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 	if !e.IsHandled {
 		t.Error("expected space open to be handled")
 	}
@@ -144,7 +144,7 @@ func TestSelectKeyboardNavigation(t *testing.T) {
 
 	// Navigate down.
 	e = &Event{KeyCode: KeyDown}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 	if !e.IsHandled {
 		t.Error("expected down navigation to be handled")
 	}
@@ -156,7 +156,7 @@ func TestSelectKeyboardNavigation(t *testing.T) {
 
 	// Close via escape.
 	e = &Event{KeyCode: KeyEscape}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 	if !e.IsHandled {
 		t.Error("expected escape close to be handled")
 	}
@@ -181,11 +181,11 @@ func TestSelectKeyboardSelectItem(t *testing.T) {
 
 	// Open.
 	e := &Event{KeyCode: KeySpace}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 
 	// Select current (A at index 0).
 	e = &Event{KeyCode: KeyEnter}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 	if !e.IsHandled {
 		t.Error("expected enter select to be handled")
 	}
@@ -206,11 +206,11 @@ func TestSelectSkipsSubHeaders(t *testing.T) {
 
 	// Open.
 	e := &Event{KeyCode: KeySpace}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 
 	// Navigate down past subheader.
 	e = &Event{KeyCode: KeyDown}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 	if !e.IsHandled {
 		t.Error("expected navigation to be handled")
 	}
@@ -234,11 +234,11 @@ func TestSelectHomeEndKeys(t *testing.T) {
 
 	// Open.
 	e := &Event{KeyCode: KeySpace}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 
 	// End → last selectable (C at index 3).
 	e = &Event{KeyCode: KeyEnd}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 	if !e.IsHandled {
 		t.Error("expected End to be handled")
 	}
@@ -250,7 +250,7 @@ func TestSelectHomeEndKeys(t *testing.T) {
 
 	// Home → first selectable (A at index 0).
 	e = &Event{KeyCode: KeyHome}
-	selectOnKeyDown(&cfg, idScroll, e, w)
+	selectOnKeyDown(&cfg, cfg.ID, idScroll, e, w)
 	if !e.IsHandled {
 		t.Error("expected Home to be handled")
 	}

--- a/gui/view_sidebar.go
+++ b/gui/view_sidebar.go
@@ -59,6 +59,9 @@ func (w *Window) Sidebar(cfg SidebarCfg) View {
 		return invisibleContainerView()
 	}
 
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
+
 	animW := sidebarAnimatedWidth(w, cfg)
 	p := cfg.Padding.Get(Padding{})
 	padW := p.Left + p.Right

--- a/gui/view_skeleton.go
+++ b/gui/view_skeleton.go
@@ -46,7 +46,6 @@ func Skeleton(cfg SkeletonCfg) View {
 		label = "Loading"
 	}
 
-	id := cfg.ID
 	colorBase := cfg.Color
 	colorHL := cfg.ColorHighlight
 
@@ -72,8 +71,12 @@ func Skeleton(cfg SkeletonCfg) View {
 		Sizing:     cfg.Sizing,
 		Padding:    NoPadding,
 		AmendLayout: func(ctx EventCtx) {
-			skeletonAmendLayout(ctx.Layout, ctx.Window, id,
-				colorBase, colorHL)
+			// The shimmer's animation and state are keyed by this
+			// shape's effective ID, so two skeletons written with the
+			// same leaf under different ID-bearing panels shimmer
+			// independently.
+			skeletonAmendLayout(ctx.Layout, ctx.Window,
+				ctx.Layout.Shape.idKey(), colorBase, colorHL)
 		},
 	}
 

--- a/gui/view_slider.go
+++ b/gui/view_slider.go
@@ -120,7 +120,6 @@ func Slider(cfg SliderCfg) View {
 	colorFocus := cfg.ColorFocus
 	colorHover := cfg.ColorHover
 	disabled := cfg.Disabled
-	focusID := cfg.ID
 
 	trackSizing := FillFixed
 	if cfg.Vertical {
@@ -158,8 +157,13 @@ func Slider(cfg SliderCfg) View {
 		VAlign:    VAlignMiddle,
 		axis:      wrapperAxis,
 		OnClick: func(ctx EventCtx) {
+			// Press state is keyed by the wrapper's effective ID — the
+			// same key sliderAmendLayoutSlide reads off the shape. The
+			// captured sliderID is only a leaf: Slider builds its tree
+			// with no Window in hand.
+			pressID := ctx.Layout.Shape.idKey()
 			ps := StateMap[string, bool](ctx.Window, nsSliderPress, capModerate)
-			ps.Set(sliderID, true)
+			ps.Set(pressID, true)
 			ev := *ctx.Event
 			ev.MouseX = ctx.Event.MouseX + ctx.Layout.Shape.X
 			ev.MouseY = ctx.Event.MouseY + ctx.Layout.Shape.Y
@@ -174,7 +178,7 @@ func Slider(cfg SliderCfg) View {
 				},
 				MouseUp: func(ctx EventCtx) {
 					ps := StateMap[string, bool](ctx.Window, nsSliderPress, capModerate)
-					ps.Set(sliderID, false)
+					ps.Set(pressID, false)
 					ctx.Window.MouseUnlock()
 				},
 			})
@@ -188,8 +192,8 @@ func Slider(cfg SliderCfg) View {
 		AmendLayout: func(ctx EventCtx) {
 			sliderAmendLayoutSlide(ctx.Layout, ctx.Window,
 				onChange, value, minVal, maxVal, size, szBorder,
-				vertical, colorFocus, cfg.ColorLeft, disabled, focusID,
-				roundValue)
+				vertical, colorFocus, cfg.ColorLeft, disabled,
+				ctx.Layout.Shape.idKey(), roundValue)
 		},
 		OnHover: func(ctx EventCtx) {
 			ctx.Window.SetMouseCursorPointingHand()
@@ -285,7 +289,7 @@ func sliderAmendLayoutSlide(
 	if w != nil {
 		ps := StateMapRead[string, bool](w, nsSliderPress)
 		if ps != nil {
-			if pressed, ok := ps.Get(layout.Shape.ID); ok && pressed {
+			if pressed, ok := ps.Get(layout.Shape.idKey()); ok && pressed {
 				thumb.Shape.Color = colorLeft
 				return
 			}

--- a/gui/view_splitter.go
+++ b/gui/view_splitter.go
@@ -314,6 +314,14 @@ func splitterAmendLayout(core *splitterCore, layout *Layout, w *Window) {
 	if len(layout.Children) < 3 {
 		return
 	}
+	// Splitter builds its tree with no Window in hand, so the core holds
+	// leaf IDs. Amend runs on the splitter's own shape, every frame,
+	// before any handler that looks the splitter up (FindByID) or moves
+	// focus to it — so this is where the leaves become identities.
+	core.id = layout.Shape.idKey()
+	if core.focusID != "" {
+		core.focusID = core.id
+	}
 
 	mainSz := splitterMainSize(layout, core.orientation)
 	computed := splitterCompute(core, mainSz)

--- a/gui/view_switch.go
+++ b/gui/view_switch.go
@@ -131,7 +131,7 @@ func Switch(cfg SwitchCfg) View {
 			if len(ctx.Layout.Children) == 0 {
 				return
 			}
-			if ctx.Window.IsFocus(ctx.Layout.Shape.ID) {
+			if ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 				ctx.Layout.Children[0].Shape.Color = colorFocus
 				ctx.Layout.Children[0].Shape.ColorBorder = colorBorderFocus
 			}

--- a/gui/view_tab_control.go
+++ b/gui/view_tab_control.go
@@ -197,6 +197,9 @@ func makeTabDragClick(
 //nolint:gocyclo // complex widget layout
 func (tv *tabControlView) GenerateLayout(w *Window) Layout {
 	cfg := &tv.cfg
+
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
 	s := &DefaultTabControlStyle
 
 	// Resolve Opt fields.

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -158,6 +158,9 @@ func tableView(cfg TableCfg, w *Window) View {
 	}
 	applyTableDefaults(&cfg)
 
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
+
 	if len(cfg.Data) == 0 {
 		return Column(ContainerCfg{
 			ID:      cfg.ID,

--- a/gui/view_test.go
+++ b/gui/view_test.go
@@ -930,6 +930,33 @@ func TestA11YLabelFallback(t *testing.T) {
 	}
 }
 
+// The fallback is frequently a widget's ID, and an ID may be a scoped
+// path once the widget resolves its identity. A screen reader must hear
+// a name, not a path.
+func TestA11YLabelFallbackStripsIDScope(t *testing.T) {
+	tests := []struct {
+		name  string
+		label string
+		text  string
+		want  string
+	}{
+		{"scoped id announces the leaf", "", "settings:name", "name"},
+		{"deep path announces the leaf", "", "app:settings:name", "name"},
+		{"unscoped id is unchanged", "", "name", "name"},
+		{"explicit label keeps its colon", "Time: now", "id", "Time: now"},
+		{"trailing separator keeps the whole string", "", "name:", "name:"},
+		{"empty stays empty", "", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := a11yLabel(tc.label, tc.text); got != tc.want {
+				t.Fatalf("a11yLabel(%q, %q) = %q, want %q",
+					tc.label, tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
 // --- PointerOverApp tests ---
 
 func TestPointerOverApp(t *testing.T) {

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -19,7 +19,7 @@ func textOnClick(ctx EventCtx) {
 	if shape.TC == nil || shape.ID == "" || !shape.Focusable {
 		return
 	}
-	ctx.Window.SetFocus(shape.ID)
+	ctx.Window.SetFocus(shape.idKey())
 
 	text := shape.TC.Text
 	style := textStyleOrDefault(shape)
@@ -45,7 +45,7 @@ func textOnClick(ctx EventCtx) {
 		runePos = intClamp(runePos, 0, runeLen)
 	}
 
-	focusID := shape.ID
+	focusID := shape.idKey()
 	imap := StateMap[string, InputState](
 		ctx.Window, nsInput, capMany,
 	)
@@ -100,7 +100,7 @@ func textOnClick(ctx EventCtx) {
 	maxScrollNeg := float32(0)
 	for p := ctx.Layout.Parent; p != nil; p = p.Parent {
 		if p.Shape != nil && p.Shape.Scrollable {
-			scrollID = p.Shape.ID
+			scrollID = p.Shape.idKey()
 			sy := ctx.Window.scrollY()
 			// Default 0: unscrolled position when no offset recorded yet.
 			dragScrollY0 = sy.GetOr(scrollID, 0)
@@ -237,10 +237,10 @@ func textOnClick(ctx EventCtx) {
 func textOnKeyDown(ctx EventCtx) {
 	shape := ctx.Layout.Shape
 	if shape.TC == nil || shape.ID == "" || !shape.Focusable ||
-		!ctx.Window.IsFocus(shape.ID) {
+		!ctx.Window.IsFocus(shape.idKey()) {
 		return
 	}
-	id := shape.ID
+	id := shape.idKey()
 	text := shape.TC.Text
 	imap := StateMap[string, InputState](
 		ctx.Window, nsInput, capMany,
@@ -355,7 +355,7 @@ func textAmendLayout(ctx EventCtx) {
 		return
 	}
 	is := StateReadOr(
-		ctx.Window, nsInput, ctx.Layout.Shape.ID, InputState{},
+		ctx.Window, nsInput, ctx.Layout.Shape.idKey(), InputState{},
 	)
 	ctx.Layout.Shape.TC.TextSelBeg = is.SelectBeg
 	ctx.Layout.Shape.TC.TextSelEnd = is.SelectEnd

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -28,12 +28,17 @@ func (tv *themePickerView) Content() []View { return nil }
 
 func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 	cfg := &tv.cfg
-	isOpen := StateReadOr(w, nsSelect, cfg.ID, false)
-	id := cfg.ID
+	// Everything this widget keys on hangs off its effective ID, so a
+	// second picker under a different ID-bearing panel gets its own
+	// open flag, its own listbox focus, its own dropdown scroll. The
+	// inner IDs stay absolute (they already contain IDSep), which is
+	// what keeps them identical to the keys computed here.
+	id := w.EffID(cfg.ID)
+	isOpen := StateReadOr(w, nsSelect, id, false)
 	currentName := guiTheme.Name
-	focusID := cfg.ID
+	focusID := id
 	onSel := cfg.OnSelect
-	lbID := cfg.ID + "lb"
+	lbID := ScopeID(id, "lb")
 
 	content := make([]View, 0, 2)
 
@@ -50,7 +55,7 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 			data[i] = NewListBoxOption(name, name, name)
 		}
 		content = append(content, Column(ContainerCfg{
-			ID:            cfg.ID + "dropdown",
+			ID:            ScopeID(id, "dropdown"),
 			Float:         true,
 			FloatAutoFlip: true,
 			FloatAnchor:   cfg.FloatAnchor,

--- a/gui/view_toggle.go
+++ b/gui/view_toggle.go
@@ -133,7 +133,7 @@ func Toggle(cfg ToggleCfg) View {
 			if len(ctx.Layout.Children) == 0 {
 				return
 			}
-			if ctx.Window.IsFocus(ctx.Layout.Shape.ID) {
+			if ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 				ctx.Layout.Children[0].Shape.Color = colorFocus
 				ctx.Layout.Children[0].Shape.ColorBorder = colorBorderFocus
 			}

--- a/gui/view_tooltip.go
+++ b/gui/view_tooltip.go
@@ -136,6 +136,11 @@ func WithTooltip(w *Window, cfg WithTooltipCfg) View {
 	if tipID == "" {
 		tipID = cfg.Text
 	}
+	// Scope the tooltip's identity like any other widget key, so the
+	// same label used in two ID-bearing panels tracks hover separately.
+	// Both the state writes and the popup's shape ID derive from this
+	// one string, so they cannot disagree.
+	tipID = w.EffID(tipID)
 
 	delay := cfg.Delay
 	if delay == 0 {

--- a/gui/view_tree.go
+++ b/gui/view_tree.go
@@ -164,6 +164,9 @@ func (tv *treeView) Content() []View { return nil }
 func (tv *treeView) GenerateLayout(w *Window) Layout {
 	cfg := &tv.cfg
 
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
+
 	expanded := treeExpandedState(w, cfg.ID)
 	lazyState := StateMap[string, bool](w, nsTreeLazy, capMany)
 

--- a/gui/window.go
+++ b/gui/window.go
@@ -212,6 +212,16 @@ type Window struct {
 	scrollYMap     *BoundedMap[string, float32]
 	overflowMap    *BoundedMap[string, int]
 
+	// idJoinCache memoizes (scope, leaf) -> joined identity, so the one
+	// allocation a join costs is paid once per distinct identity rather
+	// than once per widget per frame. See (*Window).joinLeaf.
+	idJoinCache *BoundedMap[idJoinKey, string]
+
+	// idScopeStack is the ancestor stack resolveShapeIDs walks with,
+	// kept here so its backing array is reused frame to frame rather
+	// than allocated per pipeline root. See gui/id_resolve.go.
+	idScopeStack []idFrame
+
 	// scrollSmooth eases discrete mouse-wheel scrolling toward a
 	// target offset. Guarded by animMu (see gui/scroll_smooth.go).
 	scrollSmooth *scrollSmoothAnimation
@@ -308,10 +318,15 @@ type ViewState struct {
 	tooltip        tooltipState
 
 	// Markdown caches (lazy-init: nil until first use).
-	markdownTheme            string
-	rtfLayoutTheme           string
-	diagramRequestSeq        uint64
-	focusID                  string
+	markdownTheme     string
+	rtfLayoutTheme    string
+	diagramRequestSeq uint64
+	focusID           string
+
+	// idScope is the effective ID of the innermost ID-bearing shape
+	// currently being generated. Maintained by generateViewLayout and
+	// read by (*Window).EffID; empty outside the view phase.
+	idScope                  string
 	mousePosX                float32
 	mousePosY                float32
 	mouseCursor              MouseCursor

--- a/gui/window_event.go
+++ b/gui/window_event.go
@@ -131,11 +131,11 @@ func (w *Window) handleKeyDownEvent(layout *Layout, e *Event) {
 	if !e.IsHandled && e.KeyCode == KeyTab &&
 		e.Modifiers == ModShift {
 		if shape, ok := layout.PreviousFocusable(w); ok {
-			w.SetFocus(shape.ID)
+			w.SetFocus(shape.idKey())
 		}
 	} else if !e.IsHandled && e.KeyCode == KeyTab {
 		if shape, ok := layout.NextFocusable(w); ok {
-			w.SetFocus(shape.ID)
+			w.SetFocus(shape.idKey())
 		}
 	}
 	// Non-global commands fire as fallback.


### PR DESCRIPTION
Implements `docs/specs/widget-id-per-scope-uniqueness.md` (phases A, B and C).

## What changes

`Shape.ID` is now a **leaf**. The identity every store and lookup keys on is the
**effective ID** — the leaf joined with `:` to the IDs of its ID-bearing
ancestors:

```go
Panel{ID: "settings"} -> Input{ID: "name"}   // settings:name
Panel{ID: "profile"}  -> Input{ID: "name"}   // profile:name
```

Two panels can now each hold the same widget without sharing one focus slot,
scroll offset, hover state or state entry. Only explicit IDs join — never tree
position, never child index — so identity survives a reorder and changes only
when an app changes an ancestor's ID. A leaf already containing `:` is
**absolute** and is not joined again, which is why existing `ScopeID`
composites keep working unchanged.

## How

Two paths compute the join, and both go through `resolveLeaf` so they cannot
drift:

- `resolveShapeIDs` stamps `Shape.effID` over the built tree from
  `layoutArrange` — **before** float extraction, so a float keeps the scope of
  the panel it was written in, and no float special case is needed. An
  *injected* overlay (toast, dialog, inspector) is generated outside the tree
  and resolves from an empty scope either way.
- `(*Window).EffID` serves a widget that reads its own state *during*
  `GenerateLayout` — a combobox whose open flag decides the subtree it returns
  cannot wait for a pass that runs afterwards.
- `EventCtx.EffID` is the third seam, for factories that build eagerly with no
  `*Window` (Input, Slider, Splitter, ProgressBar, Skeleton, Scrollbar).

Read `shape.idKey()`, never `shape.ID`, at a keying site.

## Bugs fixed along the way

Three framework-internal identity constants were plain leaves mounted under
ID-bearing ancestors, so the widget stored state under the scoped ID while
handlers kept writing the bare one — two halves, two map slots, no error
anywhere:

- **Inspector tree** — selection never highlighted. The wireframe still worked
  because it keys on a different namespace, which is exactly the split that got
  reported.
- **Dialog focus** — `SetFocus`/`retainDialogFocus` targeted a widget that did
  not exist, so Enter on a confirm dialog and typing into a prompt both failed.
  The buttons were also inconsistent with each other: `cfg.FocusID` got scoped
  while its `ScopeIDN` siblings were already absolute.
- **RTF link context menu** — same pattern.

`TestInternalIdentityConstantsAreAbsolute` guards the class so a future internal
widget cannot reintroduce it.

## Performance

Phase C shipped because the benchmark demanded it. Uncached, the join cost one
allocation per ID-bearing widget per frame — `BenchmarkViewFrame` 202 → 252
allocs/op (rows_50) and 802 → 1002 (rows_200), exactly +1 per row.
`(*Window).joinLeaf` memoizes `(scope, leaf) → joined` in a bounded map shared
by both paths, putting every one of those numbers back on baseline;
`TestJoinLeafCachedIsAllocationFree` gates it. The key is identity, not
position, so a hit is always correct and an eviction only recomputes.

One cost cannot be cached away: `effID` moves `Shape` from 280 to 296 bytes,
across the 288 → 320 size class, so every shape allocates 32 bytes more (~355 KB
transient on an 11k-shape frame). `focusOwner` is resolved **in place** rather
than into a second field to avoid paying that twice.

## Breaking

Public APIs (`SetFocus`, `FindByID`, `IsFocus`, `ScrollVerticalTo`, `Test*`)
take the **effective** ID. Code passing a bare leaf for a widget under an
ID-bearing ancestor no longer matches. `gui.DebugCategories(gui.DebugUnscopedIDs)`
and `(*Window).TestDuplicateIDs` are the audit tools.

`a11yLabel` now announces only the last segment when it falls back to an ID — a
screen reader must hear `name`, not `settings:name`. An explicit `A11YLabel` is
never touched.

## Known follow-up

`gui/datagrid` still keys window-global leaf IDs — a documented permanent
exception, but under an ID-bearing panel its `FindByID(cfg.ID)` will silently
stop matching. Separate issue, separate diff.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues),
`go vet`, `make ergo-audit`, `gofmt`, prettier — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)