### PR TITLE
feat(exportaudit): enforce the surface gate in CI, codify internal-class policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,18 @@ jobs:
       - name: Run gate checks
         run: make vet deps-doc-check large-files generate-check
 
+      # The export-audit gate needs the sibling consumer repos present to
+      # be authoritative (an export used only there would misclassify as
+      # internal-only). Shallow-clone them beside the checkout and run the
+      # consumer scan; the in-repo run alone cannot fail anything.
+      - name: Run export-audit (authoritative)
+        run: |
+          for repo in go-charts go-edit go-kite go-term go-map; do
+            git clone --quiet --depth 1 https://github.com/go-gui-org/$repo.git ../$repo
+          done
+          go run ./tools/exportaudit/ -mode gate -gui . \
+            ../go-charts ../go-edit ../go-kite ../go-term ../go-map
+
   examples:
     name: Build examples
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to
   advisory. 449 files changed; consumers at v0.56.0 are unaffected unless they
   referenced internal-only names.
 
+### Added
+
+- **`make export-audit` now actually fails the build when the gate trips.**
+  The authoritative consumer scan previously ran under `|| true`, so a real
+  gate failure (offenders found with siblings present) exited zero. It now
+  only tolerates missing sibling repos; CI shallow-clones the five consumers
+  into `../` and runs the authoritative scan, so the freeze is enforced on
+  every PR. See `docs/specs/exportaudit-surface-policy.md` for the accepted
+  `internal`-class policy.
+
 ## [v0.56.0] - 2026-08-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,9 @@ Backend injects at startup. Nil in tests:
 - After touching the exported surface of `gui/`, run `make export-audit`
   (tools/exportaudit): every export must be referenced from outside gui/ or
   carry a `// exportaudit:keep` marker. The consumer scan is authoritative; the
-  in-repo run is advisory.
+  in-repo run is advisory. `internal`-class exports (shared between gui/
+  packages) are accepted by policy, not hard failures; the deferred list is in
+  the gate advisory. See `docs/specs/exportaudit-surface-policy.md`.
 - Native/CGo or focus/activation bugs: confirm root cause with instrumented
   logging (evidence) before editing. Reproduce before, verify symptom gone
   after. Never leave the app non-launching. See `gui/backend/CLAUDE.md` for the

--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,13 @@ ergo-fix:
 # the external test package — or carry a // exportaudit:keep marker.
 # The consumer scan is authoritative: without the sibling repos an export
 # used only there would misclassify, so the in-repo run is advisory.
+# Only the "siblings missing" case is suppressed; a real gate failure
+# (offenders found with siblings present) must exit non-zero.
 export-audit:
 	go run ./tools/exportaudit/ -mode gate -gui . .
-	go run ./tools/exportaudit/ -mode gate -gui . \
-	  ../go-charts ../go-edit ../go-kite ../go-term ../go-map || \
-	  (echo "exportaudit: sibling repos not found at ../go-*; run from a checkout with siblings present" >&2; true)
+	@if [ -d ../go-charts ] && [ -d ../go-edit ] && [ -d ../go-kite ] && [ -d ../go-term ] && [ -d ../go-map ]; then \
+	  go run ./tools/exportaudit/ -mode gate -gui . \
+	    ../go-charts ../go-edit ../go-kite ../go-term ../go-map; \
+	else \
+	  echo "exportaudit: sibling repos not found at ../go-*; run from a checkout with siblings present" >&2; \
+	fi

--- a/docs/specs/exportaudit-surface-policy.md
+++ b/docs/specs/exportaudit-surface-policy.md
@@ -1,0 +1,61 @@
+# Exported API surface policy (exportaudit)
+
+Status: accepted (v0.56.0 freeze follow-up)
+
+## Purpose
+
+`tools/exportaudit` gates the exported surface of `gui/` so that what
+stays exported is deliberate. This spec records the classification, the
+gate contract, and the one accepted-deferred class.
+
+## Classes
+
+Every export in a scanned gui/ package is ranked by the widest circle
+that references it:
+
+| class    | referenced by                                   | gate (with consumers) |
+|----------|-------------------------------------------------|-----------------------|
+| none     | nothing                                         | hard failure          |
+| self     | its own package only                            | hard failure          |
+| selftest | its own package or its tests                    | hard failure          |
+| internal | other gui/ packages                             | accepted (deferred)   |
+| testext  | gui/ external test packages                     | pass                  |
+| example  | examples/                                       | pass                  |
+| consumer | sibling repos (go-charts, go-edit, go-kite,     | pass                  |
+|          | go-term, go-map)                                |                       |
+
+`maxClass` is the highest class with any reference. A hard failure means
+`make export-audit` exits non-zero: the symbol is internal-only and must
+be unexported or carry a `// exportaudit:keep` marker explaining why
+(json reflection, stdlib interface conformance, name collision,
+signature reachability, documented API).
+
+The consumer scan is authoritative; without the sibling repos an export
+used only there would misclassify as none/self, so the in-repo run alone
+can only report (it never hard-fails). `make export-audit` clones
+nothing: it uses `../go-*` checkouts when present, and CI shallow-clones
+the five sibling repos into `../` so the gate is authoritative there.
+
+## Internal class: accepted by policy
+
+`internal` — used by other gui/ packages — is deliberately not a hard
+failure. These exports are shared implementation between the root `gui`
+package and its leaf subpackages (backend, datagrid, svg, markdown,
+highlight, shader). The architecture keeps the root package as the hub
+that subpackages import (`gui/backend → gui`, `gui/svg → gui`), so
+unexporting them is not possible without an `gui/internal/` package
+move, which the flat-leaf design rejects. They are reported in the gate
+advisory and listed fully by `-mode report`; keep markers are not
+required for this class.
+
+## Contract for future changes
+
+- Any new export whose references stay inside gui/ (none/self/selftest)
+  fails the gate; unexport it or keep-mark it.
+- Any export that starts being used by a sibling repo moves out of
+  enforcement automatically; the consumer scan reclassifies it.
+- Removing a consumer's export is caught by CI: the authoritative scan
+  sees the sibling reference vanish and reclassifies the export down
+  into enforcement.
+- `-mode report` output is stable (fixed section order) so two runs can
+  be diffed; use it before and after a sweep.

--- a/tools/exportaudit/main.go
+++ b/tools/exportaudit/main.go
@@ -163,7 +163,15 @@ func main() {
 	case "gate":
 		failures, advisory := gate(exports, len(consumers) > 0)
 		if advisory != "" {
-			fmt.Fprintln(os.Stderr, advisory)
+			if failures != "" {
+				// Context for the offenders: show what is deferred too.
+				fmt.Fprintln(os.Stderr, advisory)
+			} else {
+				// Clean surface; the deferred list is one line, the
+				// full per-export list lives in -mode report.
+				first, _, _ := strings.Cut(advisory, "\n")
+				fmt.Fprintln(os.Stderr, first+" (see -mode report for the list)")
+			}
 		}
 		if failures != "" {
 			fmt.Fprint(os.Stderr, failures)
@@ -651,8 +659,16 @@ func gate(exports map[string]*export, hasConsumers bool) (failures, advisory str
 		b.Reset()
 	}
 	if len(adv) > 0 {
-		fmt.Fprintf(&b, "exportaudit: %d exports need a consumer scan to classify (advisory, deferred):\n%s",
-			len(adv), strings.Join(adv, "\n"))
+		if hasConsumers {
+			// With consumers scanned these are classified (internal):
+			// shared implementation between gui/ packages, accepted by
+			// policy — see docs/specs/exportaudit-surface-policy.md.
+			fmt.Fprintf(&b, "exportaudit: %d internal-class exports shared with gui/ subpackages (accepted, deferred):\n%s",
+				len(adv), strings.Join(adv, "\n"))
+		} else {
+			fmt.Fprintf(&b, "exportaudit: %d exports need a consumer scan to classify (advisory, deferred):\n%s",
+				len(adv), strings.Join(adv, "\n"))
+		}
 		advisory = b.String()
 	}
 	return failures, advisory


### PR DESCRIPTION
The v0.56.0 freeze shipped a gate that could never fail: the Makefile
target ran the authoritative consumer scan under `|| true`, so a real
gate failure exited zero, and CI never ran export-audit at all. This
closes both holes:

- make export-audit now only tolerates missing sibling repos; a genuine
  gate failure (offenders found with siblings present) exits non-zero.
- CI's gate job shallow-clones the five consumer repos (go-charts,
  go-edit, go-kite, go-term, go-map) into ../ and runs the authoritative
  consumer scan on every PR, so the freeze is enforced.
- The gate advisory is summarized when the surface is clean (full list
  stays in -mode report) and its wording distinguishes the accepted
  internal class from the needs-consumer-scan case.
- docs/specs/exportaudit-surface-policy.md records the classification,
  the gate contract, and why internal-class exports (gui/ <-> gui/*
  plumbing) are accepted by policy rather than hard failures.
