### PR TITLE
feat(gl): Win32 IME preedit via IMM32

### DIFF
--- a/gui/backend/gl/events_win32.go
+++ b/gui/backend/gl/events_win32.go
@@ -115,6 +115,14 @@ func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
 		return b.mouseWheel(notchesToChars(hiWordS(wparam)), 0, lparam)
 
 	case wmKeyDown, wmSysKeyDown:
+		// VK_PROCESSKEY means the input method consumed the keystroke:
+		// TranslateMessage has already handed it to IMM, and the WM_IME_*
+		// messages that follow carry its effect. Emitting it as well would
+		// let a widget act on an Enter or an arrow the IME owns, which is
+		// the suppression the X11 path gets from imeProcessKey.
+		if wparam == vkProcessKey {
+			return 0, true
+		}
 		b.emit(gui.Event{
 			Type:      gui.EventKeyDown,
 			KeyCode:   winkey.MapVKey(wparam),
@@ -123,6 +131,9 @@ func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
 		})
 		return 0, true
 	case wmKeyUp, wmSysKeyUp:
+		if wparam == vkProcessKey {
+			return 0, true
+		}
 		b.emit(gui.Event{
 			Type:      gui.EventKeyUp,
 			KeyCode:   winkey.MapVKey(wparam),
@@ -132,6 +143,10 @@ func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
 
 	case wmChar:
 		return b.charInput(wparam)
+
+	case wmIMEStartComposition, wmIMEComposition, wmIMEEndComposition,
+		wmIMESetContext, wmIMEChar:
+		return b.imeMessage(msg, wparam, lparam)
 
 	case wmSize:
 		if wparam == sizeMinimized {

--- a/gui/backend/gl/ime_win32.go
+++ b/gui/backend/gl/ime_win32.go
@@ -1,0 +1,455 @@
+//go:build windows && !js
+
+package gl
+
+import (
+	"unicode/utf16"
+	"unicode/utf8"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// --- IMM32 bindings ---
+//
+// Loaded lazily from System32 like the kernel32/user32 procs in
+// platform_win32.go, so the IME path stays cgo-free and matches the rest
+// of the backend.
+var (
+	imm32 = windows.NewLazySystemDLL("imm32.dll")
+
+	pImmGetContext            = imm32.NewProc("ImmGetContext")
+	pImmReleaseContext        = imm32.NewProc("ImmReleaseContext")
+	pImmGetCompositionStringW = imm32.NewProc("ImmGetCompositionStringW")
+	pImmSetCompositionWindow  = imm32.NewProc("ImmSetCompositionWindow")
+	pImmSetCandidateWindow    = imm32.NewProc("ImmSetCandidateWindow")
+	pImmAssociateContextEx    = imm32.NewProc("ImmAssociateContextEx")
+)
+
+// Win32 IME messages and IMM32 flags.
+const (
+	wmIMEStartComposition = 0x010D
+	wmIMEEndComposition   = 0x010E
+	wmIMEComposition      = 0x010F
+	wmIMESetContext       = 0x0281
+	wmIMEChar             = 0x0286
+
+	// vkProcessKey is the virtual-key code WM_KEYDOWN carries once the
+	// input method has claimed a keystroke.
+	vkProcessKey = 0xE5
+
+	gcsCompStr   = 0x0008
+	gcsCompAttr  = 0x0010
+	gcsCursorPos = 0x0080
+	gcsResultStr = 0x0800
+
+	// iscShowUICompositionWindow asks DefWindowProc to draw the IME's own
+	// floating composition window. Cleared before forwarding, because the
+	// preedit is drawn inline instead.
+	iscShowUICompositionWindow = 0x80000000
+
+	// attrTargetConverted marks the clause the IME has selected for
+	// conversion. Unlike the IBus attribute conventions on X11 this is
+	// specified, so no guessing at engine behaviour is needed.
+	attrTargetConverted = 1
+
+	iaceDefault = 0x0010
+
+	cfsPoint        = 0x0002
+	cfsCandidatePos = 0x0040
+	cfsExclude      = 0x0080
+
+	// maxIMECompChars bounds a composition-string read. The length comes
+	// from the input method, which is out-of-process; cap the allocation
+	// the way maxClipboardChars caps a clipboard read. A preedit is a
+	// phrase, so 4096 UTF-16 units is far past any real composition.
+	maxIMECompChars = 4096
+)
+
+// compositionForm mirrors COMPOSITIONFORM.
+type compositionForm struct {
+	dwStyle      uint32
+	ptCurrentPos pointW
+	rcArea       rectW
+}
+
+// candidateForm mirrors CANDIDATEFORM.
+type candidateForm struct {
+	dwIndex      uint32
+	dwStyle      uint32
+	ptCurrentPos pointW
+	rcArea       rectW
+}
+
+// --- message handling ---
+
+// imeMessage handles the WM_IME_* family. Composition messages are never
+// forwarded to DefWindowProc: doing so both draws the IME's own floating
+// composition window and synthesizes a WM_CHAR for the commit, which
+// charInput would then insert on top of the commit emitted here.
+//
+// charInput is deliberately left unguarded. Owning every message that
+// DefWindowProc would translate is what keeps WM_CHAR out of a
+// composition; a "currently composing" flag on top of that would add a
+// second way for ordinary typing to break — one stuck flag and every
+// keystroke is swallowed — in exchange for nothing this path does not
+// already cover.
+func (b *Backend) imeMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
+	switch msg {
+	case wmIMEStartComposition:
+		// Handled without DefWindowProc purely to suppress the IME's own
+		// floating composition window; the preedit is drawn inline.
+		return 0, true
+
+	case wmIMEComposition:
+		b.imeComposition(lparam)
+		return 0, true
+
+	case wmIMEEndComposition:
+		b.emit(gui.Event{Type: gui.EventIMEComposition})
+		return 0, true
+
+	case wmIMESetContext:
+		// The preedit is rendered inline, so suppress the IME's UI before
+		// letting DefWindowProc set up the context. handleMessage cannot
+		// rewrite lParam on the way out, so the forward happens here.
+		r, _, _ := pDefWindowProcW.Call(
+			b.plat.hwnd, msg, wparam, lparam&^iscShowUICompositionWindow)
+		return r, true
+
+	case wmIMEChar:
+		// Swallowed: the commit is emitted from GCS_RESULTSTR. Letting
+		// DefWindowProc translate this into WM_CHAR is what inserts every
+		// committed character twice.
+		return 0, true
+	}
+	return 0, false
+}
+
+// imeComposition turns one WM_IME_COMPOSITION into gui events. The
+// commit is dispatched before the preedit update so text lands in the
+// order the user produced it.
+func (b *Backend) imeComposition(lparam uintptr) {
+	himc, _, _ := pImmGetContext.Call(b.plat.hwnd)
+	if himc == 0 {
+		return
+	}
+	defer pImmReleaseContext.Call(b.plat.hwnd, himc)
+
+	committed := false
+	if lparam&gcsResultStr != 0 {
+		var ok bool
+		b.plat.imeBufW, ok = imeReadString(
+			himc, gcsResultStr, b.plat.imeBufW)
+		if ok {
+			b.emitCommit(b.plat.imeBufW)
+			committed = true
+		}
+	}
+
+	if lparam&gcsCompStr != 0 {
+		var ok bool
+		b.plat.imeBufW, ok = imeReadString(himc, gcsCompStr, b.plat.imeBufW)
+		if ok {
+			b.plat.imeAttr = imeReadAttr(himc, b.plat.imeAttr)
+			b.emit(imeCompositionEvent(
+				b.plat.imeBufW, b.plat.imeAttr, imeCursorPos(himc)))
+			return
+		}
+		// The preedit went empty — backspacing off the last character
+		// asks for a composition string of length zero. Fall through to
+		// the clear below.
+	}
+
+	// Either a commit with no surviving preedit, or a preedit erased down
+	// to nothing. Clear it explicitly rather than waiting for
+	// WM_IME_ENDCOMPOSITION, which some input methods defer.
+	if committed || lparam&gcsCompStr != 0 {
+		b.emit(gui.Event{Type: gui.EventIMEComposition})
+	}
+}
+
+// emitCommit dispatches committed text as a single EventChar. CharCode
+// carries the first rune and IMEText the whole string, which is what
+// Input inserts — a multi-rune CJK commit is one insert and one undo
+// step. Committed text is plain input, so no modifiers apply.
+func (b *Backend) emitCommit(u []uint16) {
+	s := imeDecode(u)
+	if s == "" {
+		return
+	}
+	first, _ := utf8.DecodeRuneInString(s)
+	b.emit(gui.Event{
+		Type:     gui.EventChar,
+		CharCode: uint32(first),
+		IMEText:  s,
+	})
+}
+
+// --- IMM32 reads ---
+
+// imeReadString reads one composition-string component into dst,
+// reusing its capacity so a keystroke costs no allocation. Reports
+// false when the component is absent, empty, or unreadable.
+func imeReadString(himc, index uintptr, dst []uint16) ([]uint16, bool) {
+	n, ok := imeStringLen(himc, index)
+	if !ok {
+		return dst[:0], false
+	}
+	if cap(dst) < n {
+		dst = make([]uint16, n)
+	}
+	dst = dst[:n]
+	r, _, _ := pImmGetCompositionStringW.Call(
+		himc, index, uintptr(unsafe.Pointer(&dst[0])), uintptr(n*2))
+	if int32(r) <= 0 {
+		return dst[:0], false
+	}
+	// Trust the second length over the first: the composition can change
+	// between the two calls.
+	if got := int(int32(r)) / 2; got < n {
+		dst = dst[:got]
+	}
+	return dst, len(dst) > 0
+}
+
+// imeStringLen queries a component's length in UTF-16 units, clamped to
+// maxIMECompChars.
+func imeStringLen(himc, index uintptr) (int, bool) {
+	r, _, _ := pImmGetCompositionStringW.Call(himc, index, 0, 0)
+	// The result is a signed byte count; negative values are IMM error
+	// codes (IMM_ERROR_NODATA, IMM_ERROR_GENERAL).
+	nBytes := int32(r)
+	if nBytes <= 0 {
+		return 0, false
+	}
+	n := min(int(nBytes)/2, maxIMECompChars)
+	return n, n > 0
+}
+
+// imeReadAttr reads GCS_COMPATTR, one byte per UTF-16 unit of the
+// preedit. A missing or unreadable attribute list only costs the clause
+// highlight, so failure yields an empty slice rather than dropping the
+// composition.
+func imeReadAttr(himc uintptr, dst []byte) []byte {
+	r, _, _ := pImmGetCompositionStringW.Call(himc, gcsCompAttr, 0, 0)
+	// One byte per UTF-16 unit, so the same cap applies as to the
+	// composition string; negative values are IMM error codes.
+	n := min(int(int32(r)), maxIMECompChars)
+	if n <= 0 {
+		return dst[:0]
+	}
+	if cap(dst) < n {
+		dst = make([]byte, n)
+	}
+	dst = dst[:n]
+	r, _, _ = pImmGetCompositionStringW.Call(
+		himc, gcsCompAttr, uintptr(unsafe.Pointer(&dst[0])), uintptr(n))
+	if got := int32(r); got <= 0 {
+		return dst[:0]
+	} else if int(got) < len(dst) {
+		dst = dst[:got]
+	}
+	return dst
+}
+
+// imeCursorPos reads GCS_CURSORPOS, which IMM returns as the value
+// rather than through the buffer. The offset is in UTF-16 units.
+func imeCursorPos(himc uintptr) int {
+	r, _, _ := pImmGetCompositionStringW.Call(himc, gcsCursorPos, 0, 0)
+	if n := int32(r); n > 0 {
+		return int(n)
+	}
+	return 0
+}
+
+// --- pure helpers ---
+
+// imeDecode converts a UTF-16 composition buffer to a string, dropping
+// U+FFFD so a decoding failure upstream never reaches a widget.
+func imeDecode(u []uint16) string {
+	if len(u) == 0 {
+		return ""
+	}
+	runes := utf16.Decode(u)
+	out := runes[:0]
+	for _, r := range runes {
+		if r != 0xFFFD {
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}
+
+// imeCompositionEvent builds the EventIMEComposition for a preedit.
+//
+// IMM reports both the cursor and the clause bounds in UTF-16 units,
+// while Event.IMEStart and Event.IMELength are in characters, so every
+// offset is converted. Skipping that step is the bug PR #210 fixed on
+// macOS.
+func imeCompositionEvent(comp []uint16, attr []byte, cursor int) gui.Event {
+	e := gui.Event{
+		Type:    gui.EventIMEComposition,
+		IMEText: imeDecode(comp),
+	}
+	if start, end, ok := imeClauseRange(attr); ok {
+		rs := imeRuneIndex(comp, start)
+		e.IMEStart = rs
+		e.IMELength = imeRuneIndex(comp, end) - rs
+		return e
+	}
+	e.IMEStart = imeRuneIndex(comp, cursor)
+	return e
+}
+
+// imeClauseRange returns the half-open UTF-16 range of the clause the
+// IME has selected for conversion: the first run of
+// ATTR_TARGET_CONVERTED in a GCS_COMPATTR buffer. Reports false when no
+// clause is marked, which is the state before the user presses convert.
+func imeClauseRange(attr []byte) (start, end int, ok bool) {
+	start = -1
+	for i, a := range attr {
+		switch {
+		case a == attrTargetConverted && start < 0:
+			start = i
+		case a != attrTargetConverted && start >= 0:
+			return start, i, true
+		}
+	}
+	if start >= 0 {
+		return start, len(attr), true
+	}
+	return 0, 0, false
+}
+
+// imeRuneIndex converts a UTF-16 code-unit offset into u to a rune
+// offset, clamping to the buffer. Low surrogates do not advance the
+// count, so a non-BMP character costs one rune rather than two.
+func imeRuneIndex(u []uint16, n int) int32 {
+	if n > len(u) {
+		n = len(u)
+	}
+	count := int32(0)
+	for i := 0; i < n; i++ {
+		if u[i] >= 0xDC00 && u[i] <= 0xDFFF {
+			continue // low surrogate: same rune as the high one
+		}
+		count++
+	}
+	return count
+}
+
+// imeCaretBound caps a caret coordinate. Win32 window coordinates
+// historically live in int16 range, and no real caret sits outside it;
+// the cap exists so a NaN or infinity that became a garbage int32 in
+// Window.IMESetRect's float conversion cannot propagate into IMM.
+const imeCaretBound = 32767
+
+// imePixel converts a scaled logical coordinate to a bounded pixel.
+// NaN fails both comparisons and lands on zero.
+func imePixel(v float32) int32 {
+	switch {
+	case v > imeCaretBound:
+		return imeCaretBound
+	case v < -imeCaretBound:
+		return -imeCaretBound
+	case v >= -imeCaretBound && v <= imeCaretBound:
+		return int32(v)
+	default:
+		return 0 // NaN
+	}
+}
+
+// --- NativePlatform ---
+
+// IMEStart re-associates the window's default IME context. The context
+// is detached at window creation, so composition only becomes possible
+// once a text widget takes focus.
+func (n *nativePlatform) IMEStart() {
+	imeAssociate(n.b.plat.hwnd, iaceDefault)
+}
+
+// IMEStop detaches the IME context. No composition event is emitted
+// here: the gui layer already clears its own state on a focus change
+// (Window.setFocusID), and re-entering EventFn from inside an event
+// handler would clobber the event being dispatched.
+func (n *nativePlatform) IMEStop() {
+	imeAssociate(n.b.plat.hwnd, 0)
+	n.b.plat.imeHaveRect = false
+}
+
+// imeAssociate attaches (iaceDefault) or detaches (0) the window's IME
+// context.
+func imeAssociate(hwnd, flags uintptr) {
+	if hwnd == 0 {
+		return
+	}
+	pImmAssociateContextEx.Call(hwnd, 0, flags)
+}
+
+// IMESetRect anchors the candidate window to the caret. The gui layer
+// works in logical points relative to the client area; IMM wants
+// physical client pixels.
+//
+// renderIMEPreeditUnderline calls this every frame while composing, so
+// an unchanged rect skips the three syscalls.
+func (n *nativePlatform) IMESetRect(x, y, w, h int32) {
+	b := n.b
+	if b.plat.hwnd == 0 {
+		return
+	}
+	s := b.dpiScale
+	if s <= 0 {
+		s = 1
+	}
+	// Scaled in float32 and clamped on the way back: x+w in int32 can
+	// overflow, and the caret rect is derived from glyph layout, which a
+	// degenerate style (zero font size, collapsed container) can drive to
+	// a nonsensical magnitude. IMM must not be handed either.
+	rc := rectW{
+		left:   imePixel(float32(x) * s),
+		top:    imePixel(float32(y) * s),
+		right:  imePixel((float32(x) + float32(w)) * s),
+		bottom: imePixel((float32(y) + float32(h)) * s),
+	}
+	// A negative width or height would invert the rect, and CFS_EXCLUDE
+	// on an inverted rcArea has no defined meaning.
+	if rc.right < rc.left {
+		rc.right = rc.left
+	}
+	if rc.bottom < rc.top {
+		rc.bottom = rc.top
+	}
+	if b.plat.imeHaveRect && b.plat.imeRect == rc {
+		return
+	}
+
+	himc, _, _ := pImmGetContext.Call(b.plat.hwnd)
+	if himc == 0 {
+		return
+	}
+	defer pImmReleaseContext.Call(b.plat.hwnd, himc)
+
+	// Cached only once a context exists: recording a rect that was never
+	// applied would short-circuit the next call and leave the composition
+	// window stranded until the caret moves.
+	b.plat.imeRect, b.plat.imeHaveRect = rc, true
+
+	cf := compositionForm{
+		dwStyle:      cfsPoint,
+		ptCurrentPos: pointW{x: rc.left, y: rc.top},
+		rcArea:       rc,
+	}
+	pImmSetCompositionWindow.Call(himc, uintptr(unsafe.Pointer(&cf)))
+
+	// CFS_EXCLUDE keeps the candidate list off the text being composed
+	// instead of merely placing its corner at the caret.
+	can := candidateForm{
+		dwStyle:      cfsCandidatePos | cfsExclude,
+		ptCurrentPos: pointW{x: rc.left, y: rc.bottom},
+		rcArea:       rc,
+	}
+	pImmSetCandidateWindow.Call(himc, uintptr(unsafe.Pointer(&can)))
+}

--- a/gui/backend/gl/ime_win32_test.go
+++ b/gui/backend/gl/ime_win32_test.go
@@ -1,0 +1,431 @@
+//go:build windows && !js
+
+package gl
+
+import (
+	"math"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestIMEClauseRange(t *testing.T) {
+	const conv = attrTargetConverted
+	const notConv = 3 // ATTR_TARGET_NOTCONVERTED
+
+	cases := []struct {
+		name       string
+		attr       []byte
+		start, end int
+		ok         bool
+	}{
+		{"nil", nil, 0, 0, false},
+		{"no target run", []byte{notConv, notConv}, 0, 0, false},
+		{"leading run", []byte{conv, conv, notConv, notConv}, 0, 2, true},
+		{"middle run", []byte{notConv, conv, conv, notConv}, 1, 3, true},
+		{"trailing run", []byte{notConv, notConv, conv}, 2, 3, true},
+		{"whole string", []byte{conv, conv, conv}, 0, 3, true},
+		{"single unit", []byte{conv}, 0, 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := imeClauseRange(tc.attr)
+			if ok != tc.ok || start != tc.start || end != tc.end {
+				t.Errorf("imeClauseRange(%v) = (%d, %d, %v), want (%d, %d, %v)",
+					tc.attr, start, end, ok, tc.start, tc.end, tc.ok)
+			}
+		})
+	}
+}
+
+// TestIMEClauseRangeFirstRunWins pins the "first run" rule: an IME that
+// marks two disjoint converted runs must not yield a range spanning the
+// gap between them.
+func TestIMEClauseRangeFirstRunWins(t *testing.T) {
+	const conv = attrTargetConverted
+	attr := []byte{conv, 3, conv, conv}
+	start, end, ok := imeClauseRange(attr)
+	if !ok || start != 0 || end != 1 {
+		t.Errorf("imeClauseRange = (%d, %d, %v), want (0, 1, true)",
+			start, end, ok)
+	}
+}
+
+func TestIMERuneIndex(t *testing.T) {
+	bmp := utf16.Encode([]rune("にほんご"))
+	// U+1F600 is a surrogate pair, so "あ😀い" is 3 runes in 4 units.
+	mixed := utf16.Encode([]rune("あ😀い"))
+
+	cases := []struct {
+		name string
+		u    []uint16
+		n    int
+		want int32
+	}{
+		{"zero", bmp, 0, 0},
+		{"bmp mid", bmp, 2, 2},
+		{"bmp end", bmp, 4, 4},
+		{"past end clamps", bmp, 99, 4},
+		{"before pair", mixed, 1, 1},
+		{"inside pair", mixed, 2, 2},
+		{"after pair", mixed, 3, 2},
+		{"pair end", mixed, 4, 3},
+		{"empty buffer", nil, 3, 0},
+		{"negative", bmp, -1, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := imeRuneIndex(tc.u, tc.n); got != tc.want {
+				t.Errorf("imeRuneIndex(%q, %d) = %d, want %d",
+					string(utf16.Decode(tc.u)), tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIMEDecodeDropsReplacementChar(t *testing.T) {
+	u := []uint16{'a', 0xFFFD, 'b'}
+	if got := imeDecode(u); got != "ab" {
+		t.Errorf("imeDecode = %q, want %q", got, "ab")
+	}
+	if got := imeDecode(nil); got != "" {
+		t.Errorf("imeDecode(nil) = %q, want empty", got)
+	}
+}
+
+// TestIMEDecodeDropsLoneSurrogate covers a malformed composition buffer:
+// utf16.Decode turns an unpaired surrogate into U+FFFD, which must not
+// reach a widget as a visible replacement glyph.
+func TestIMEDecodeDropsLoneSurrogate(t *testing.T) {
+	if got := imeDecode([]uint16{0xD800, 'a'}); got != "a" {
+		t.Errorf("imeDecode(lone high surrogate) = %q, want %q", got, "a")
+	}
+	if got := imeDecode([]uint16{'a', 0xDC00}); got != "a" {
+		t.Errorf("imeDecode(lone low surrogate) = %q, want %q", got, "a")
+	}
+}
+
+func TestIMEDecodeKeepsNonBMP(t *testing.T) {
+	u := utf16.Encode([]rune("😀"))
+	if got := imeDecode(u); got != "😀" {
+		t.Errorf("imeDecode = %q, want %q", got, "😀")
+	}
+}
+
+// TestIMECompositionEventClause covers the converted-clause case: the
+// second of two clauses is selected, and the reported range must be
+// absolute (see gui/event.go's IMEStart/IMELength contract), not a
+// cursor plus a length.
+func TestIMECompositionEventClause(t *testing.T) {
+	const conv = attrTargetConverted
+	comp := utf16.Encode([]rune("にほんご"))
+	attr := []byte{3, 3, conv, conv}
+
+	e := imeCompositionEvent(comp, attr, 2)
+	if e.Type != gui.EventIMEComposition {
+		t.Fatalf("Type = %v, want EventIMEComposition", e.Type)
+	}
+	if e.IMEText != "にほんご" {
+		t.Errorf("IMEText = %q, want %q", e.IMEText, "にほんご")
+	}
+	if e.IMEStart != 2 || e.IMELength != 2 {
+		t.Errorf("clause = (%d, %d), want (2, 2)", e.IMEStart, e.IMELength)
+	}
+}
+
+// TestIMECompositionEventNoClause covers the pre-conversion state: no
+// attribute marks a clause, so IMEStart falls back to the cursor and
+// IMELength stays zero.
+func TestIMECompositionEventNoClause(t *testing.T) {
+	comp := utf16.Encode([]rune("にほん"))
+	e := imeCompositionEvent(comp, nil, 3)
+	if e.IMEText != "にほん" {
+		t.Errorf("IMEText = %q, want %q", e.IMEText, "にほん")
+	}
+	if e.IMEStart != 3 || e.IMELength != 0 {
+		t.Errorf("clause = (%d, %d), want (3, 0)", e.IMEStart, e.IMELength)
+	}
+}
+
+// TestIMECompositionEventNonBMPOffsets is the PR #210 regression in its
+// Win32 form: IMM reports UTF-16 offsets, gui.Event wants characters, so
+// a surrogate pair before the clause must not shift the range by one.
+func TestIMECompositionEventNonBMPOffsets(t *testing.T) {
+	const conv = attrTargetConverted
+	comp := utf16.Encode([]rune("😀にほ")) // 4 UTF-16 units, 3 runes
+	attr := []byte{3, 3, conv, conv}    // clause covers "にほ"
+
+	e := imeCompositionEvent(comp, attr, 2)
+	if e.IMEStart != 1 || e.IMELength != 2 {
+		t.Errorf("clause = (%d, %d), want (1, 2)", e.IMEStart, e.IMELength)
+	}
+}
+
+// TestIMECursorPastEndClamps guards the render path: a hostile or
+// confused input method must not report an offset beyond the preedit.
+func TestIMECursorPastEndClamps(t *testing.T) {
+	comp := utf16.Encode([]rune("あい"))
+	e := imeCompositionEvent(comp, nil, 99)
+	if e.IMEStart != 2 {
+		t.Errorf("IMEStart = %d, want 2", e.IMEStart)
+	}
+}
+
+func TestEmitCommitSingleEventFullText(t *testing.T) {
+	b := newCharTestBackend(t)
+	b.plat.evt = gui.Event{Type: gui.EventInvalid}
+	b.emitCommit(utf16.Encode([]rune("日本語")))
+
+	if b.plat.evt.Type != gui.EventChar {
+		t.Fatalf("Type = %v, want EventChar", b.plat.evt.Type)
+	}
+	if b.plat.evt.IMEText != "日本語" {
+		t.Errorf("IMEText = %q, want %q", b.plat.evt.IMEText, "日本語")
+	}
+	if b.plat.evt.CharCode != uint32('日') {
+		t.Errorf("CharCode = %#x, want %#x", b.plat.evt.CharCode, '日')
+	}
+	if b.plat.evt.Modifiers != 0 {
+		t.Errorf("Modifiers = %v, want none", b.plat.evt.Modifiers)
+	}
+}
+
+// TestEmitCommitNonBMP checks the commit path preserves astral
+// characters on its own: it bypasses charInput's surrogate reassembly.
+func TestEmitCommitNonBMP(t *testing.T) {
+	b := newCharTestBackend(t)
+	b.plat.evt = gui.Event{Type: gui.EventInvalid}
+	b.emitCommit(utf16.Encode([]rune("😀")))
+
+	if b.plat.evt.IMEText != "😀" {
+		t.Errorf("IMEText = %q, want %q", b.plat.evt.IMEText, "😀")
+	}
+	if b.plat.evt.CharCode != 0x1F600 {
+		t.Errorf("CharCode = %#x, want 0x1F600", b.plat.evt.CharCode)
+	}
+}
+
+func TestEmitCommitEmptyEmitsNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		u    []uint16
+	}{
+		{"empty", nil},
+		{"all replacement chars", []uint16{0xFFFD, 0xFFFD}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newCharTestBackend(t)
+			b.plat.evt = gui.Event{Type: gui.EventInvalid}
+			b.emitCommit(tc.u)
+			if b.plat.evt.Type != gui.EventInvalid {
+				t.Errorf("emitted %v, want no event", b.plat.evt.Type)
+			}
+		})
+	}
+}
+
+// TestIMEMessageEndCompositionClears asserts WM_IME_ENDCOMPOSITION emits
+// the empty composition that resets Window.IMEComposing.
+func TestIMEMessageEndCompositionClears(t *testing.T) {
+	b := newCharTestBackend(t)
+	b.plat.evt = gui.Event{Type: gui.EventInvalid}
+
+	res, handled := b.imeMessage(wmIMEEndComposition, 0, 0)
+	if res != 0 || !handled {
+		t.Fatalf("imeMessage = (%d, %v), want (0, true)", res, handled)
+	}
+	if b.plat.evt.Type != gui.EventIMEComposition || b.plat.evt.IMEText != "" {
+		t.Errorf("event = {%v, %q}, want {EventIMEComposition, \"\"}",
+			b.plat.evt.Type, b.plat.evt.IMEText)
+	}
+}
+
+// TestIMEMessageStartAndCharAreOwned pins the two messages that must not
+// reach DefWindowProc: WM_IME_STARTCOMPOSITION (which would draw the
+// IME's own composition window) and WM_IME_CHAR (which DefWindowProc
+// turns into the WM_CHAR that double-inserts every commit).
+func TestIMEMessageStartAndCharAreOwned(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  uintptr
+	}{
+		{"start composition", wmIMEStartComposition},
+		{"ime char", wmIMEChar},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newCharTestBackend(t)
+			b.plat.evt = gui.Event{Type: gui.EventInvalid}
+			res, handled := b.imeMessage(tc.msg, 'あ', 0)
+			if res != 0 || !handled {
+				t.Fatalf("imeMessage = (%d, %v), want (0, true)", res, handled)
+			}
+			if b.plat.evt.Type != gui.EventInvalid {
+				t.Errorf("emitted %v, want no event", b.plat.evt.Type)
+			}
+		})
+	}
+}
+
+func TestIMEPixelBounds(t *testing.T) {
+	inf := float32(math.Inf(1))
+	cases := []struct {
+		name string
+		in   float32
+		want int32
+	}{
+		{"zero", 0, 0},
+		{"ordinary", 120.7, 120},
+		{"negative", -40.2, -40},
+		{"at bound", imeCaretBound, imeCaretBound},
+		{"past bound", 1e9, imeCaretBound},
+		{"past negative bound", -1e9, -imeCaretBound},
+		{"positive infinity", inf, imeCaretBound},
+		{"negative infinity", -inf, -imeCaretBound},
+		{"nan", float32(math.NaN()), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := imePixel(tc.in); got != tc.want {
+				t.Errorf("imePixel(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIMEReadersRejectEmpty covers the degenerate buffers the pure
+// helpers must survive: an input method is out-of-process and can report
+// anything, and these feed the render path.
+func TestIMEReadersRejectEmpty(t *testing.T) {
+	if s, e, ok := imeClauseRange(nil); ok || s != 0 || e != 0 {
+		t.Errorf("imeClauseRange(nil) = (%d, %d, %v), want (0, 0, false)", s, e, ok)
+	}
+	if got := imeRuneIndex(nil, 5); got != 0 {
+		t.Errorf("imeRuneIndex(nil, 5) = %d, want 0", got)
+	}
+	e := imeCompositionEvent(nil, nil, 0)
+	if e.Type != gui.EventIMEComposition || e.IMEText != "" {
+		t.Errorf("empty composition = {%v, %q}, want cleared", e.Type, e.IMEText)
+	}
+}
+
+// TestIMECompositionEventAttrLongerThanText guards the case where IMM
+// reports an attribute buffer inconsistent with the composition string:
+// the clause range must stay inside the text rather than index past it.
+func TestIMECompositionEventAttrLongerThanText(t *testing.T) {
+	const conv = attrTargetConverted
+	comp := utf16.Encode([]rune("あ"))
+	attr := []byte{conv, conv, conv, conv}
+
+	e := imeCompositionEvent(comp, attr, 0)
+	if e.IMEStart != 0 || e.IMELength != 1 {
+		t.Errorf("clause = (%d, %d), want (0, 1)", e.IMEStart, e.IMELength)
+	}
+	if e.IMEStart+e.IMELength > 1 {
+		t.Errorf("clause runs past the preedit: %d", e.IMEStart+e.IMELength)
+	}
+}
+
+// TestIMECompositionEventLengthNeverNegative pins the invariant
+// gui.imeUpdate's slice arithmetic depends on.
+func TestIMECompositionEventLengthNeverNegative(t *testing.T) {
+	const conv = attrTargetConverted
+	for _, attr := range [][]byte{
+		{conv},
+		{conv, conv, 3},
+		{3, conv},
+		{3, 3, 3},
+		{},
+	} {
+		e := imeCompositionEvent(utf16.Encode([]rune("にほ")), attr, 0)
+		if e.IMELength < 0 || e.IMEStart < 0 {
+			t.Errorf("attr %v gave negative range (%d, %d)",
+				attr, e.IMEStart, e.IMELength)
+		}
+	}
+}
+
+func TestIMEMessageDeclinesUnrelated(t *testing.T) {
+	b := newCharTestBackend(t)
+	if _, handled := b.imeMessage(wmChar, 'a', 0); handled {
+		t.Error("imeMessage claimed WM_CHAR")
+	}
+}
+
+// TestIMECompositionWithoutContextEmitsNothing pins the ImmGetContext
+// failure path: no context means no composition to read, and the message
+// must still be owned rather than falling through to DefWindowProc,
+// which would draw the IME's own composition window.
+func TestIMECompositionWithoutContextEmitsNothing(t *testing.T) {
+	b := newCharTestBackend(t) // hwnd stays 0, so ImmGetContext fails
+	b.plat.evt = gui.Event{Type: gui.EventInvalid}
+
+	res, handled := b.imeMessage(wmIMEComposition, 0, gcsResultStr|gcsCompStr)
+	if res != 0 || !handled {
+		t.Fatalf("imeMessage = (%d, %v), want (0, true)", res, handled)
+	}
+	if b.plat.evt.Type != gui.EventInvalid {
+		t.Errorf("emitted %v, want no event", b.plat.evt.Type)
+	}
+}
+
+// TestKeyProcessKeyIsSuppressed pins the VK_PROCESSKEY gate: while the
+// input method owns a keystroke, the widget must not also see it as a
+// key event.
+func TestKeyProcessKeyIsSuppressed(t *testing.T) {
+	for _, msg := range []uintptr{
+		wmKeyDown, wmSysKeyDown, wmKeyUp, wmSysKeyUp,
+	} {
+		b := newCharTestBackend(t)
+		b.plat.evt = gui.Event{Type: gui.EventInvalid}
+		res, handled := b.handleMessage(msg, vkProcessKey, 0)
+		if res != 0 || !handled {
+			t.Fatalf("handleMessage(%#x) = (%d, %v), want (0, true)",
+				msg, res, handled)
+		}
+		if b.plat.evt.Type != gui.EventInvalid {
+			t.Errorf("msg %#x emitted %v, want no event", msg, b.plat.evt.Type)
+		}
+	}
+}
+
+// TestKeyDownStillEmitsOrdinaryKeys is the counterpart: the
+// VK_PROCESSKEY gate must not swallow ordinary typing.
+func TestKeyDownStillEmitsOrdinaryKeys(t *testing.T) {
+	b := newCharTestBackend(t)
+	b.plat.evt = gui.Event{Type: gui.EventInvalid}
+	if _, handled := b.handleMessage(wmKeyDown, 'A', 0); !handled {
+		t.Fatal("handleMessage declined WM_KEYDOWN")
+	}
+	if b.plat.evt.Type != gui.EventKeyDown || b.plat.evt.KeyCode != gui.KeyA {
+		t.Errorf("event = {%v, %v}, want {EventKeyDown, KeyA}",
+			b.plat.evt.Type, b.plat.evt.KeyCode)
+	}
+}
+
+// TestIMESetRectWithoutWindowIsNoop guards the pre-creation and
+// post-destroy paths: no hwnd means no IMM context, and nothing may be
+// cached that would short-circuit a later, real call.
+func TestIMESetRectWithoutWindowIsNoop(t *testing.T) {
+	b := newCharTestBackend(t)
+	n := &nativePlatform{b: b}
+	n.IMESetRect(10, 20, 2, 16)
+	if b.plat.imeHaveRect {
+		t.Error("cached a rect that was never applied")
+	}
+}
+
+// TestIMEStopClearsCachedRect asserts the caret cache does not survive a
+// focus change: the next IMEStart must re-report the rect even if the
+// caret happens to land in the same place.
+func TestIMEStopClearsCachedRect(t *testing.T) {
+	b := newCharTestBackend(t)
+	b.plat.imeRect = rectW{left: 1, top: 2, right: 3, bottom: 4}
+	b.plat.imeHaveRect = true
+
+	n := &nativePlatform{b: b}
+	n.IMEStop()
+	if b.plat.imeHaveRect {
+		t.Error("IMEStop left the caret rect cached")
+	}
+}

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -192,6 +192,14 @@ type platformState struct {
 	w         *gui.Window
 	evt       gui.Event // reused per message to avoid per-event allocation
 	highSurr  uint16    // pending UTF-16 high surrogate for WM_CHAR
+
+	// IME state. The two buffers are reused across composition messages
+	// so a keystroke costs no allocation; imeRect caches the last caret
+	// rect reported to IMM, which the render path re-reports every frame.
+	imeBufW     []uint16
+	imeAttr     []byte
+	imeRect     rectW
+	imeHaveRect bool
 }
 
 func (p *platformState) wake() {
@@ -447,6 +455,10 @@ func New(w *gui.Window) (*Backend, error) {
 	b := &Backend{}
 	b.plat.hwnd = hwnd
 	registerWindow(hwnd, b)
+	// Detach the IME until a text widget takes focus and IMEStart
+	// re-attaches it, matching the focus gating on macOS and X11. Without
+	// this a composition can begin with nothing to render the preedit.
+	imeAssociate(hwnd, 0)
 	setWindowIcon(hwnd, cfg, &b.plat)
 
 	hdc, _, _ := pGetDC.Call(hwnd)
@@ -645,9 +657,3 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		}
 	}
 }
-
-// --- IME (stub; WM_CHAR still yields EventChar) ---
-
-func (n *nativePlatform) IMEStart()                   {}
-func (n *nativePlatform) IMEStop()                    {}
-func (n *nativePlatform) IMESetRect(_, _, _, _ int32) {}


### PR DESCRIPTION
## Summary

Windows had three no-op IME stubs (`IMEStart`/`IMEStop`/`IMESetRect`), so composing input methods produced no preedit — only whatever `WM_CHAR` happened to deliver. This wires up IMM32 so CJK and other composing IMEs show a preedit and commit through the same event path already used on macOS and X11.

## Changes

- **`ime_win32.go` (new)** — IMM32 bindings, `WM_IME_*` handling, composition/result-string reads, clause and cursor decoding, and the real `NativePlatform` IME methods.
- **`events_win32.go`** — route `WM_IME_*` to `imeMessage`; suppress `VK_PROCESSKEY` on key down/up so a widget cannot act on an Enter or arrow key the IME owns. This is the same suppression the X11 path gets from `imeProcessKey`.
- **`platform_win32.go`** — per-window IME buffers reused across composition messages (no per-keystroke allocation) plus a cached caret rect; IMM is detached at window creation so composition only begins once a text widget takes focus, matching macOS/X11 focus gating.

UTF-16 decoding drops lone surrogates and replacement chars, and IMM byte offsets are converted to rune indices, so non-BMP composition reports correct cursor and clause bounds.

## Testing

25 new tests in `ime_win32_test.go` cover the pure helpers (clause range, rune index, decode, pixel clamping), the message handlers (commit, end-composition clear, unrelated-message decline, composition without a context), and the focus/rect lifecycle. All pass on Windows:

```
ok  github.com/go-gui-org/go-gui/gui/backend/gl  3.975s
```

`go build ./...` and `go test ./...` are green.

## Lint note

`golangci-lint` run **on Windows** reports `errcheck` on the unchecked `LazyProc.Call` returns in the new file. This matches a pre-existing baseline — the same pattern appears 46 times across the untouched `*_win32.go` / `*_windows.go` siblings, and the CI lint job runs on `ubuntu-latest`, which never compiles these files. The new code follows the established idiom rather than introducing an inconsistent `//nolint` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
