### PR TITLE
fix(ci): clear the Windows lint baseline and stop it recurring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,18 @@ jobs:
         with:
           version: v2.12
 
+      # The step above analyses the GOOS=linux build only, so every
+      # //go:build windows file (27 of them: gl/, sni/, filedialog/,
+      # hicon/) was never linted by CI and had accumulated a baseline
+      # nothing would flag. Linting is a type-check, not an execution,
+      # so the windows build analyses fine from this runner.
+      - name: Lint (GOOS=windows)
+        uses: golangci/golangci-lint-action@v9
+        env:
+          GOOS: windows
+        with:
+          version: v2.12
+
       - name: Required-ID check
         run: go run ./tools/requiredid/cmd/requiredid ./...
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,23 @@ linters:
     - perfsprint
     - gosmopolitan
   settings:
+    errcheck:
+      # The Win32 syscall wrappers return GetLastError() as their third
+      # value, and syscall.Errno is a uintptr boxed into a non-nil error
+      # interface — a successful call yields Errno(0), which stringifies
+      # to "The operation completed successfully." and still compares
+      # != nil. So `if err != nil` is always true and is never a valid
+      # success test for these; the result code (r1) is. Call sites that
+      # care already gate on r1 and use the errno only on that failure
+      # path. Requiring a check here would mean writing one that lies.
+      # Both wrapper families are in use: syscall.LazyProc in filedialog/
+      # and sni/, golang.org/x/sys/windows.LazyProc in gl/.
+      exclude-functions:
+        - (*syscall.LazyProc).Call
+        - (*syscall.Proc).Call
+        - syscall.SyscallN
+        - (*golang.org/x/sys/windows.LazyProc).Call
+        - (*golang.org/x/sys/windows.Proc).Call
     gocyclo:
       min-complexity: 30
     cyclop:

--- a/gui/backend/filedialog/dialog_windows.go
+++ b/gui/backend/filedialog/dialog_windows.go
@@ -188,7 +188,7 @@ func ShowSaveDialog(title, startDir, defaultName, defaultExt string,
 		return gui.PlatformDialogResult{Status: gui.DialogCancel}
 	}
 
-	path := syscall.UTF16ToString(buf[:])
+	path := syscall.UTF16ToString(buf)
 	return gui.PlatformDialogResult{
 		Status: gui.DialogOK,
 		Paths:  []gui.PlatformPath{{Path: path}},

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -3,6 +3,7 @@
 package gl
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"runtime"
@@ -464,7 +465,7 @@ func New(w *gui.Window) (*Backend, error) {
 	hdc, _, _ := pGetDC.Call(hwnd)
 	if hdc == 0 {
 		b.plat.destroy()
-		return nil, fmt.Errorf("gl: GetDC failed")
+		return nil, errors.New("gl: GetDC failed")
 	}
 	b.plat.hdc = hdc
 
@@ -518,14 +519,13 @@ func (b *Backend) Run(w *gui.Window) {
 	}
 	w.SetWakeMainFn(b.plat.wake)
 
-	rendered := true
 	var msg msgW
 	for {
 		pumpMessages(&msg)
 		if w.CloseRequested() {
 			break
 		}
-		rendered = w.FrameFn()
+		rendered := w.FrameFn()
 		if rendered {
 			b.renderFrame(w)
 		}
@@ -605,7 +605,6 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		}
 	}
 
-	rendered := true
 	var msg msgW
 	for {
 		// Drain pending window opens.
@@ -642,7 +641,7 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		}
 
 		// Frame + render each window.
-		rendered = false
+		rendered := false
 		for _, b := range backends {
 			w := b.plat.w
 			if w.FrameFn() {

--- a/gui/backend/internal/hicon/hicon.go
+++ b/gui/backend/internal/hicon/hicon.go
@@ -6,6 +6,7 @@ package hicon
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"image/png"
 	"syscall"
@@ -76,7 +77,7 @@ func FromPNG(pngData []byte, maxDim int) (uintptr, error) {
 	w := bounds.Dx()
 	h := bounds.Dy()
 	if w <= 0 || h <= 0 {
-		return 0, fmt.Errorf("empty icon")
+		return 0, errors.New("empty icon")
 	}
 	if w > maxDim || h > maxDim {
 		return 0, fmt.Errorf("icon too large: %dx%d (max %d)",
@@ -86,8 +87,8 @@ func FromPNG(pngData []byte, maxDim int) (uintptr, error) {
 	// Build 32-bit BGRA pixel buffer (GDI expects BGR order).
 	stride := w * 4
 	pixels := make([]byte, stride*h)
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
+	for y := range h {
+		for x := range w {
 			r, g, b, a := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
 			off := y*stride + x*4
 			pixels[off+0] = byte(b >> 8)
@@ -100,7 +101,7 @@ func FromPNG(pngData []byte, maxDim int) (uintptr, error) {
 	// Get screen DC for DIB creation.
 	hdc, _, _ := procGetDC.Call(0)
 	if hdc == 0 {
-		return 0, fmt.Errorf("GetDC failed")
+		return 0, errors.New("GetDC failed")
 	}
 	defer procReleaseDC.Call(0, hdc)
 
@@ -125,7 +126,7 @@ func FromPNG(pngData []byte, maxDim int) (uintptr, error) {
 		uintptr(unsafe.Pointer(&bits)),
 		0, 0)
 	if hbm == 0 {
-		return 0, fmt.Errorf("CreateDIBSection failed")
+		return 0, errors.New("CreateDIBSection failed")
 	}
 	defer procDeleteObject.Call(hbm)
 
@@ -144,7 +145,7 @@ func FromPNG(pngData []byte, maxDim int) (uintptr, error) {
 	hIcon, _, _ := procCreateIconIndirect.Call(
 		uintptr(unsafe.Pointer(&ii)))
 	if hIcon == 0 {
-		return 0, fmt.Errorf("CreateIconIndirect failed")
+		return 0, errors.New("CreateIconIndirect failed")
 	}
 
 	return hIcon, nil

--- a/gui/backend/sni/tray_windows.go
+++ b/gui/backend/sni/tray_windows.go
@@ -6,6 +6,7 @@ package sni
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"sync"
 	"syscall"
@@ -24,12 +25,10 @@ var (
 	procCreateWindowExW     = user32.NewProc("CreateWindowExW")
 	procDefWindowProcW      = user32.NewProc("DefWindowProcW")
 	procRegisterClassExW    = user32.NewProc("RegisterClassExW")
-	procUnregisterClassW    = user32.NewProc("UnregisterClassW")
 	procGetMessageW         = user32.NewProc("GetMessageW")
 	procTranslateMessage    = user32.NewProc("TranslateMessage")
 	procDispatchMessageW    = user32.NewProc("DispatchMessageW")
 	procPostMessageW        = user32.NewProc("PostMessageW")
-	procDestroyWindow       = user32.NewProc("DestroyWindow")
 	procCreatePopupMenu     = user32.NewProc("CreatePopupMenu")
 	procAppendMenuW         = user32.NewProc("AppendMenuW")
 	procTrackPopupMenu      = user32.NewProc("TrackPopupMenu")
@@ -196,7 +195,7 @@ func (t *Tray) initWindow() error {
 	atom, _, _ := procRegisterClassExW.Call(
 		uintptr(unsafe.Pointer(&wc)))
 	if atom == 0 {
-		return fmt.Errorf("sni: RegisterClassExW failed")
+		return errors.New("sni: RegisterClassExW failed")
 	}
 
 	hwnd, _, _ := procCreateWindowExW.Call(
@@ -211,7 +210,7 @@ func (t *Tray) initWindow() error {
 		0,           // lpParam
 	)
 	if hwnd == 0 {
-		return fmt.Errorf("sni: CreateWindowExW failed")
+		return errors.New("sni: CreateWindowExW failed")
 	}
 	t.hwnd = hwnd
 	t.done = make(chan struct{})
@@ -409,7 +408,7 @@ func (t *Tray) Create(
 		if hMenu != 0 {
 			procDestroyMenu.Call(hMenu)
 		}
-		return 0, fmt.Errorf("sni: Shell_NotifyIcon(NIM_ADD) failed")
+		return 0, errors.New("sni: Shell_NotifyIcon(NIM_ADD) failed")
 	}
 
 	t.mu.Lock()


### PR DESCRIPTION
## Problem

CI's only `golangci-lint` step analyses the **`GOOS=linux` build**. The 27 `//go:build windows` files were therefore never linted, and had quietly accumulated **60 issues** while CI stayed green the entire time.

Fixing the code alone would just reset the clock, so this also adds a `Lint (GOOS=windows)` step.

## errcheck (50 of 60) — a false positive, not 50 defects

Every one was on a Win32 syscall wrapper. These return `GetLastError()` as their third value, and `syscall.Errno` is a `uintptr` boxed into a non-nil `error` interface. Probing a call that **succeeds**:

```
r1=7152  err==nil? false  err="The operation completed successfully."  type=syscall.Errno
```

`Errno(0)` still compares `!= nil`, so **`if err != nil` is always true** — it can never be a valid success test for these APIs. The result code `r1` is, and the call sites that care already gate on it (`wgl_windows.go:161`: `if r, _, e := pWglMakeCurrent.Call(...); r == 0`).

Writing 50 `_, _, _ =` assignments would have been noise wrapped around a check that cannot work. Instead `.golangci.yml` excludes the five syscall entry points, with the reasoning recorded in the config. Two wrapper families are in use — `syscall.LazyProc` in `filedialog/`+`sni/`, `golang.org/x/sys/windows.LazyProc` in `gl/` — which is why both are listed.

The exclusion targets those functions specifically, so genuine errcheck findings in the same files (an ignored `os.WriteFile`, say) still fail.

## The other 10 — real, fixed in code

- **`platform_win32.go`** — two dead `rendered := true` stores. The variable is unconditionally reassigned at the top of each iteration before any read, so it is scoped into the loop body. No behaviour change.
- **`hicon.go`** — 4× `fmt.Errorf`→`errors.New`, 2× range-over-int
- **`tray_windows.go`** — 3× `errors.New`; removed `procUnregisterClassW` and `procDestroyWindow`, declared-only with zero references tree-wide (`NewProc` is lazy, so no runtime effect)
- **`dialog_windows.go`** — redundant `buf[:]` on an existing slice

## Verification

`golangci-lint`'s defaults (`max-same-issues: 3`, `max-issues-per-linter: 50`) **hide** findings — new ones surfaced as others were fixed, so the original count was an undercount. All checks below used `--max-same-issues=0 --max-issues-per-linter=0`:

- **0 issues** natively on Windows
- **0 issues** under CI's exact `CGO_ENABLED=0 GOOS=windows` condition — which matters, because lint type-checks test files that the existing cross-compile build step does not
- `go build ./...` clean, `go test ./...` all pass, `gofmt` clean

The new CI step needs no extra runner: linting is a type-check, not an execution, so the Windows build analyses fine from the Ubuntu box.

## Follow-up

`js` (70 files), `darwin` (60), `android` (46) and `ios` (53) are still unlinted, each with its own baseline. Tracked in #233 — including two known `js` findings and the reason `darwin` can't simply be another `env: GOOS:` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
