### PR TITLE
fix(ci): lint the js/darwin/android/ios builds and clear baselines (#233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
           CGO_LDFLAGS: -isysroot ${{ env.IOS_SDK }} -arch arm64 -miphoneos-version-min=15.0
         with:
           version: v2.12
-          args: --tags ios ./...
+          args: --build-tags ios ./...
 
   wasm:
     name: WASM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,29 @@ jobs:
         with:
           version: v2.12
 
+      # Same blind spot as windows above, for the browser build: every
+      # //go:build js file (the gui/backend/web backend) was unlinted
+      # and had accumulated a two-issue baseline. GOARCH must be wasm —
+      # js/amd64 is not a valid target pair.
+      - name: Lint (GOOS=js)
+        uses: golangci/golangci-lint-action@v9
+        env:
+          GOOS: js
+          GOARCH: wasm
+        with:
+          version: v2.12
+
+      # The darwin build analyses from this runner with cgo disabled
+      # (automatic for cross-compilation), which covers the cgo-free
+      # darwin files. The cgo core of the metal backend still needs a
+      # macOS runner; tracked separately.
+      - name: Lint (GOOS=darwin)
+        uses: golangci/golangci-lint-action@v9
+        env:
+          GOOS: darwin
+        with:
+          version: v2.12
+
       - name: Required-ID check
         run: go run ./tools/requiredid/cmd/requiredid ./...
 
@@ -242,6 +265,28 @@ jobs:
           GOARCH=arm64 \
           CC="clang -isysroot $SDK -arch arm64 -miphoneos-version-min=15.0" \
           go vet -tags ios ./gui/backend/ios/...
+
+      # Full-module lint for the ios build, using the same trick as the
+      # vet step above: GOOS=darwin with the -tags ios flag satisfies
+      # //go:build ios while the iphoneos sysroot gives the cgo .m files
+      # a toolchain, and !ios-tagged darwin files (metal, sysbeep) drop
+      # out. The sysbeep test's `&& !ios` tag keeps it from referencing
+      # symbols that only the darwin cgo implementation provides.
+      - name: Locate iOS SDK
+        run: echo "IOS_SDK=$(xcrun --sdk iphoneos --show-sdk-path)" >> "$GITHUB_ENV"
+
+      - name: Lint (GOOS=ios)
+        uses: golangci/golangci-lint-action@v9
+        env:
+          CGO_ENABLED: '1'
+          GOOS: darwin
+          GOARCH: arm64
+          CC: clang
+          CGO_CFLAGS: -isysroot ${{ env.IOS_SDK }} -arch arm64 -miphoneos-version-min=15.0
+          CGO_LDFLAGS: -isysroot ${{ env.IOS_SDK }} -arch arm64 -miphoneos-version-min=15.0
+        with:
+          version: v2.12
+          args: --tags ios ./...
 
   wasm:
     name: WASM
@@ -352,6 +397,27 @@ jobs:
             | grep -v clang++ | sort | tail -1)
           CGO_ENABLED=1 GOOS=android GOARCH=arm64 CC=$NDK_CC \
             go vet ./gui/backend/android/...
+
+      # Full-module lint for the android build. Unlike the desktop
+      # targets it cannot run cgo-free: purego's android dlfcn uses
+      # cgo.Dlopen, and gui/backend/android itself links a C ES3 driver.
+      # Lint type-checks the whole module (test files included), not
+      # just the backend package the vet step above covers.
+      - name: Locate NDK clang
+        run: |
+          NDK_CC=$(find $ANDROID_NDK_ROOT -name "aarch64-linux-android*-clang" \
+            | grep -v clang++ | sort | tail -1)
+          echo "NDK_CC=$NDK_CC" >> "$GITHUB_ENV"
+
+      - name: Lint (GOOS=android)
+        uses: golangci/golangci-lint-action@v9
+        env:
+          CGO_ENABLED: '1'
+          GOOS: android
+          GOARCH: arm64
+          CC: ${{ env.NDK_CC }}
+        with:
+          version: v2.12
 
   benchmark:
     name: Benchmarks

--- a/examples/android_demo/demo.go
+++ b/examples/android_demo/demo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-gui-org/go-gui/gui/backend/android"
 )
 
+// App is the demo state struct bound into the AAR for the Kotlin host.
 type App struct {
 	Clicks int
 }

--- a/examples/android_demo/demo.go
+++ b/examples/android_demo/demo.go
@@ -45,16 +45,19 @@ func TouchInput(phase int, identifier int64, x, y float32) {
 }
 
 // TouchBegan maps a touch-down event.
+//
 // Deprecated: use TouchInput for multi-touch support.
-func TouchBegan(x, y float32) { android.TouchBegan(x, y) }
+func TouchBegan(x, y float32) { TouchInput(0, 0, x, y) }
 
 // TouchMoved maps a touch-move event.
+//
 // Deprecated: use TouchInput for multi-touch support.
-func TouchMoved(x, y float32) { android.TouchMoved(x, y) }
+func TouchMoved(x, y float32) { TouchInput(1, 0, x, y) }
 
 // TouchEnded maps a touch-up event.
+//
 // Deprecated: use TouchInput for multi-touch support.
-func TouchEnded(x, y float32) { android.TouchEnded(x, y) }
+func TouchEnded(x, y float32) { TouchInput(2, 0, x, y) }
 
 // Resize updates the viewport.
 func Resize(width, height int, scale float32) {

--- a/gui/audio/race_off_test.go
+++ b/gui/audio/race_off_test.go
@@ -1,4 +1,4 @@
-//go:build !race
+//go:build !race && !js && !android && !ios
 
 package audio
 

--- a/gui/audio/race_on_test.go
+++ b/gui/audio/race_on_test.go
@@ -1,4 +1,4 @@
-//go:build race
+//go:build race && !js && !android && !ios
 
 package audio
 

--- a/gui/backend/android/backend.go
+++ b/gui/backend/android/backend.go
@@ -132,18 +132,21 @@ func TouchInput(phase int, identifier int64, x, y float32) {
 }
 
 // TouchBegan dispatches a single-touch began event with id 0.
+//
 // Deprecated: use TouchInput for multi-touch support.
 func TouchBegan(x, y float32) {
 	touchEvent(gui.EventTouchesBegan, 0, x, y)
 }
 
 // TouchMoved dispatches a single-touch moved event with id 0.
+//
 // Deprecated: use TouchInput for multi-touch support.
 func TouchMoved(x, y float32) {
 	touchEvent(gui.EventTouchesMoved, 0, x, y)
 }
 
 // TouchEnded dispatches a single-touch ended event with id 0.
+//
 // Deprecated: use TouchInput for multi-touch support.
 func TouchEnded(x, y float32) {
 	touchEvent(gui.EventTouchesEnded, 0, x, y)

--- a/gui/backend/filedialog/dialog_darwin_test.go
+++ b/gui/backend/filedialog/dialog_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package filedialog
 

--- a/gui/backend/filedialog/dialog_other.go
+++ b/gui/backend/filedialog/dialog_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux && !windows
+//go:build (!darwin || !cgo) && !linux && !windows && !ios
 
 package filedialog
 

--- a/gui/backend/gl/a11y_linux.go
+++ b/gui/backend/gl/a11y_linux.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !android
 
 package gl
 

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 // Package gl provides an OpenGL 3.3 backend for go-gui.
 //

--- a/gui/backend/gl/buffers.go
+++ b/gui/backend/gl/buffers.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 package gl
 

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 package gl
 

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 package gl
 

--- a/gui/backend/gl/pipeline.go
+++ b/gui/backend/gl/pipeline.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 package gl
 

--- a/gui/backend/gl/rotation.go
+++ b/gui/backend/gl/rotation.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 package gl
 

--- a/gui/backend/gl/text.go
+++ b/gui/backend/gl/text.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 package gl
 

--- a/gui/backend/gl/textures.go
+++ b/gui/backend/gl/textures.go
@@ -1,4 +1,4 @@
-//go:build !js && !darwin
+//go:build !js && !darwin && !android
 
 package gl
 

--- a/gui/backend/gl/tray_linux.go
+++ b/gui/backend/gl/tray_linux.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !android
 
 package gl
 

--- a/gui/backend/ios/backend.go
+++ b/gui/backend/ios/backend.go
@@ -339,18 +339,21 @@ func Render() {
 }
 
 // TouchBegan dispatches a single-touch began event with id 0.
+//
 // Deprecated: use TouchInput for multi-touch support.
 func TouchBegan(x, y float32) {
 	touchEvent(gui.EventTouchesBegan, 0, x, y)
 }
 
 // TouchMoved dispatches a single-touch moved event with id 0.
+//
 // Deprecated: use TouchInput for multi-touch support.
 func TouchMoved(x, y float32) {
 	touchEvent(gui.EventTouchesMoved, 0, x, y)
 }
 
 // TouchEnded dispatches a single-touch ended event with id 0.
+//
 // Deprecated: use TouchInput for multi-touch support.
 func TouchEnded(x, y float32) {
 	touchEvent(gui.EventTouchesEnded, 0, x, y)

--- a/gui/backend/ios/native_platform.go
+++ b/gui/backend/ios/native_platform.go
@@ -3,6 +3,7 @@
 package ios
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -28,7 +29,7 @@ func (n *nativePlatform) OpenURI(uri string) error {
 		return fmt.Errorf("unsupported URI scheme: %q",
 			u.Scheme)
 	}
-	return fmt.Errorf("OpenURI not implemented on iOS")
+	return errors.New("OpenURI not implemented on iOS")
 }
 
 func (n *nativePlatform) ShowOpenDialog(title, startDir string, extensions []string, allowMultiple bool) gui.PlatformDialogResult {

--- a/gui/backend/metal/a11y_darwin_test.go
+++ b/gui/backend/metal/a11y_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/buffers.go
+++ b/gui/backend/metal/buffers.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/callbacks_test.go
+++ b/gui/backend/metal/callbacks_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/events_test.go
+++ b/gui/backend/metal/events_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/frame_pump_test.go
+++ b/gui/backend/metal/frame_pump_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/render_test.go
+++ b/gui/backend/metal/render_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/shader_compile_test.go
+++ b/gui/backend/metal/shader_compile_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/metal/termgrid.go
+++ b/gui/backend/metal/termgrid.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package metal
 

--- a/gui/backend/printdialog/print_other.go
+++ b/gui/backend/printdialog/print_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux && !windows
+//go:build (!darwin || !cgo) && !linux && !windows && !ios
 
 package printdialog
 

--- a/gui/backend/run_android.go
+++ b/gui/backend/run_android.go
@@ -4,6 +4,7 @@ package backend
 
 import "github.com/go-gui-org/go-gui/gui"
 
+// Run is not supported on Android.
 func Run(w *gui.Window) {
 	panic("android: use android.SetWindow/Start/Render pattern")
 }

--- a/gui/backend/run_darwin.go
+++ b/gui/backend/run_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 // Package backend provides platform-specific backend initialization.
 package backend

--- a/gui/backend/run_default.go
+++ b/gui/backend/run_default.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !js && !android && !gl && !windows && !linux
+//go:build (!darwin || !cgo) && !js && !android && !gl && !windows && !linux
 
 // Package backend provides platform-specific backend initialization.
 package backend

--- a/gui/backend/run_ios.go
+++ b/gui/backend/run_ios.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-gui-org/go-gui/gui/backend/ios"
 )
 
+// Run starts the application event loop using the iOS backend.
 func Run(w *gui.Window) { ios.Run(w) }
 
 // RunApp starts a multi-window event loop. On iOS, only the

--- a/gui/backend/spellcheck/spellcheck_other.go
+++ b/gui/backend/spellcheck/spellcheck_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && (!linux || android || !hunspell)
+//go:build (!darwin || !cgo) && !ios && (!linux || android || !hunspell)
 
 // Package spellcheck provides native spell checking.
 // This file is a no-op stub for unsupported platforms.

--- a/gui/backend/spellcheck/spellcheck_other_test.go
+++ b/gui/backend/spellcheck/spellcheck_other_test.go
@@ -1,4 +1,4 @@
-//go:build !darwin && (!linux || android || !hunspell)
+//go:build (!darwin || !cgo) && !ios && (!linux || android || !hunspell)
 
 package spellcheck
 

--- a/gui/backend/sysbeep/sysbeep_other.go
+++ b/gui/backend/sysbeep/sysbeep_other.go
@@ -1,4 +1,4 @@
-//go:build (!darwin || ios) && !windows && (!linux || android)
+//go:build (!darwin || ios || !cgo) && !windows && (!linux || android)
 
 package sysbeep
 

--- a/gui/backend/sysbeep/sysbeep_test.go
+++ b/gui/backend/sysbeep/sysbeep_test.go
@@ -1,3 +1,5 @@
+//go:build (linux || windows || (darwin && cgo)) && !ios
+
 package sysbeep
 
 import "testing"

--- a/gui/backend/web/events.go
+++ b/gui/backend/web/events.go
@@ -335,7 +335,59 @@ func shouldPreventDefault(code string) bool {
 	return false
 }
 
-//nolint:gocyclo // key-mapping switch
+// keyCodes maps DOM KeyboardEvent.code values to gui.KeyCode. The zero
+// value of gui.KeyCode is gui.KeyInvalid, which the map lookup returns
+// naturally for any unmapped code, so no explicit default is needed.
+var keyCodes = map[string]gui.KeyCode{
+	"Space":        gui.KeySpace,
+	"Enter":        gui.KeyEnter,
+	"NumpadEnter":  gui.KeyEnter,
+	"Escape":       gui.KeyEscape,
+	"Tab":          gui.KeyTab,
+	"Backspace":    gui.KeyBackspace,
+	"Delete":       gui.KeyDelete,
+	"Insert":       gui.KeyInsert,
+	"ArrowRight":   gui.KeyRight,
+	"ArrowLeft":    gui.KeyLeft,
+	"ArrowDown":    gui.KeyDown,
+	"ArrowUp":      gui.KeyUp,
+	"PageUp":       gui.KeyPageUp,
+	"PageDown":     gui.KeyPageDown,
+	"Home":         gui.KeyHome,
+	"End":          gui.KeyEnd,
+	"ShiftLeft":    gui.KeyLeftShift,
+	"ShiftRight":   gui.KeyRightShift,
+	"ControlLeft":  gui.KeyLeftControl,
+	"ControlRight": gui.KeyRightControl,
+	"AltLeft":      gui.KeyLeftAlt,
+	"AltRight":     gui.KeyRightAlt,
+	"MetaLeft":     gui.KeyLeftSuper,
+	"MetaRight":    gui.KeyRightSuper,
+	"Comma":        gui.KeyComma,
+	"Minus":        gui.KeyMinus,
+	"Period":       gui.KeyPeriod,
+	"Slash":        gui.KeySlash,
+	"Semicolon":    gui.KeySemicolon,
+	"Equal":        gui.KeyEqual,
+	"BracketLeft":  gui.KeyLeftBracket,
+	"Backslash":    gui.KeyBackslash,
+	"BracketRight": gui.KeyRightBracket,
+	"Backquote":    gui.KeyGraveAccent,
+	"CapsLock":     gui.KeyCapsLock,
+	"F1":           gui.KeyF1,
+	"F2":           gui.KeyF2,
+	"F3":           gui.KeyF3,
+	"F4":           gui.KeyF4,
+	"F5":           gui.KeyF5,
+	"F6":           gui.KeyF6,
+	"F7":           gui.KeyF7,
+	"F8":           gui.KeyF8,
+	"F9":           gui.KeyF9,
+	"F10":          gui.KeyF10,
+	"F11":          gui.KeyF11,
+	"F12":          gui.KeyF12,
+}
+
 func mapKeyCode(code string) gui.KeyCode {
 	// Single-letter keys: KeyA..KeyZ.
 	if len(code) == 4 && code[:3] == "Key" {
@@ -351,103 +403,7 @@ func mapKeyCode(code string) gui.KeyCode {
 			return gui.KeyCode(ch)
 		}
 	}
-
-	switch code {
-	case "Space":
-		return gui.KeySpace
-	case "Enter", "NumpadEnter":
-		return gui.KeyEnter
-	case "Escape":
-		return gui.KeyEscape
-	case "Tab":
-		return gui.KeyTab
-	case "Backspace":
-		return gui.KeyBackspace
-	case "Delete":
-		return gui.KeyDelete
-	case "Insert":
-		return gui.KeyInsert
-	case "ArrowRight":
-		return gui.KeyRight
-	case "ArrowLeft":
-		return gui.KeyLeft
-	case "ArrowDown":
-		return gui.KeyDown
-	case "ArrowUp":
-		return gui.KeyUp
-	case "PageUp":
-		return gui.KeyPageUp
-	case "PageDown":
-		return gui.KeyPageDown
-	case "Home":
-		return gui.KeyHome
-	case "End":
-		return gui.KeyEnd
-	case "ShiftLeft":
-		return gui.KeyLeftShift
-	case "ShiftRight":
-		return gui.KeyRightShift
-	case "ControlLeft":
-		return gui.KeyLeftControl
-	case "ControlRight":
-		return gui.KeyRightControl
-	case "AltLeft":
-		return gui.KeyLeftAlt
-	case "AltRight":
-		return gui.KeyRightAlt
-	case "MetaLeft":
-		return gui.KeyLeftSuper
-	case "MetaRight":
-		return gui.KeyRightSuper
-	case "Comma":
-		return gui.KeyComma
-	case "Minus":
-		return gui.KeyMinus
-	case "Period":
-		return gui.KeyPeriod
-	case "Slash":
-		return gui.KeySlash
-	case "Semicolon":
-		return gui.KeySemicolon
-	case "Equal":
-		return gui.KeyEqual
-	case "BracketLeft":
-		return gui.KeyLeftBracket
-	case "Backslash":
-		return gui.KeyBackslash
-	case "BracketRight":
-		return gui.KeyRightBracket
-	case "Backquote":
-		return gui.KeyGraveAccent
-	case "CapsLock":
-		return gui.KeyCapsLock
-	case "F1":
-		return gui.KeyF1
-	case "F2":
-		return gui.KeyF2
-	case "F3":
-		return gui.KeyF3
-	case "F4":
-		return gui.KeyF4
-	case "F5":
-		return gui.KeyF5
-	case "F6":
-		return gui.KeyF6
-	case "F7":
-		return gui.KeyF7
-	case "F8":
-		return gui.KeyF8
-	case "F9":
-		return gui.KeyF9
-	case "F10":
-		return gui.KeyF10
-	case "F11":
-		return gui.KeyF11
-	case "F12":
-		return gui.KeyF12
-	default:
-		return gui.KeyInvalid
-	}
+	return keyCodes[code]
 }
 
 // cursorCSS maps gui.MouseCursor to CSS cursor values.

--- a/gui/locale_detect_other.go
+++ b/gui/locale_detect_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin || !cgo
 
 package gui
 


### PR DESCRIPTION
Closes #233.

Adds a per-target lint step for every GOOS whose build-tagged files the linux lint never analyzed, mirroring the `Lint (GOOS=windows)` step from #234:

- `Lint (GOOS=js)` (GOARCH=wasm) and `Lint (GOOS=darwin)` (cgo auto-off) in the vet job
- `Lint (GOOS=android)` in the android job (needs cgo + NDK clang: purego's android dlfcn and the ES3 driver are C)
- `Lint (GOOS=ios)` in the ios job (`GOOS=darwin -tags ios` + iphoneos sysroot, the trick the existing vet step uses)

## Baseline fixes

**js (2 findings, as reported in #233):**
- `mapKeyCode` in `gui/backend/web/events.go`: 47-case switch converted to a `keyCodes` table (complexity 56 → ~4, `//nolint:gocyclo` removed; zero-value `KeyInvalid` covers the default)
- `race_off_test.go`/`race_on_test.go`: build tags gain `&& !js && !android && !ios`, mirroring `audio_test.go`

**darwin — the probe found more than the issue's "0 issues" claim; the undercount gotcha was real:**
- `sysbeep_test.go`: tagged `(linux || windows || (darwin && cgo)) && !ios`
- `locale_detect_other.go`: `!darwin || !cgo` — env-based fallback for cgo-less darwin
- Stub files (`spellcheck_other.go` + its test, `filedialog/dialog_other.go`, `printdialog/print_other.go`, `sysbeep_other.go`): gained `|| !cgo`, and `!ios` where an ios variant exists — this also fixed **3 latent duplicate-symbol builds on ios** (`spellcheck_ios.go` and `dialog_ios.go`/`print_ios.go` overlapped their `*_other.go` stubs under `//go:build ios`)
- `dialog_darwin_test.go`: `darwin && cgo && !ios`
- metal package (`termgrid.go`, `buffers.go`, 7 test files) + `run_darwin.go`: gated `&& cgo` — the package is cgo-only by design (`windowState` holds `C.MetalCtx` fields) and its cgo-free files cannot type-check without it
- `run_default.go`: `(!darwin || !cgo)` so cgo-less darwin has a panicking `Run` instead of an undefined symbol

**android/ios baselines cleared via CI iteration**: gl backend excluded from android (desktop-only; its `!js && !darwin` tags matched GOOS=android but no platform file did — `linux` tag is set for android), plus ios/android touch-shim deprecation docs and demo forwards through the non-deprecated TouchInput. All four targets lint clean.

## Verification

`golangci-lint` linux + `GOOS=js GOARCH=wasm` + `CGO_ENABLED=0 GOOS=darwin` (all with `--max-same-issues=0 --max-issues-per-linter=0`) → 0 issues. gofmt, `go vet` (native + windows), audio tests with and without `-race` clean.
