### PR TITLE
fix(gl): cancel an in-flight drag when Win32 revokes mouse capture (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,27 @@ and this project adheres to
   advisory. 449 files changed; consumers at v0.56.0 are unaffected unless they
   referenced internal-only names.
 
+### Fixed
+
+- **Windows: a revoked mouse capture no longer leaves a drag stuck (#110).**
+  Win32 can take capture away without ever sending the matching button-up — a
+  system modal or UAC prompt, Ctrl+Alt+Del, Win+L, another process calling
+  `SetCapture`, a debugger breaking in. `WM_CAPTURECHANGED` was unhandled, so
+  the `MouseLock` never cleared and every later mouse move kept driving the
+  drag with no button held (text selection tracking the cursor, a splitter or
+  slider still following it). The message now cancels the drag. Our own
+  `ReleaseCapture` raises the same message, so the backend tracks capture
+  ownership and only cancels on an involuntary loss.
+
 ### Added
+
+- **`MouseLockCfg.Cancel`** — a `func(*Window)` hook that unwinds a drag ending
+  without a release. `MouseUp` cannot serve: it *commits*, so synthesising one
+  on capture loss would dock a panel or reorder a list the user never dropped.
+  `(*Window).MouseCancel` unlocks and runs the hook; widgets whose state is
+  just the lock need no hook. Wired for text/RTF/input selection (stops the
+  edge-scroll animation), sliders, the color picker, datagrid column resize,
+  dock drags, and drag-reorder.
 
 - **`make export-audit` now actually fails the build when the gate trips.**
   The authoritative consumer scan previously ran under `|| true`, so a real

--- a/docs/specs/mouse-lock-cancel.md
+++ b/docs/specs/mouse-lock-cancel.md
@@ -1,0 +1,91 @@
+# Cancelling an in-flight `MouseLock`
+
+Status: implemented. Issue #110.
+
+## Problem
+
+`MouseLock` is cleared only by an explicit `MouseUnlock`, and for every
+widget that call lives in the lock's `MouseUp`. That is correct exactly as
+long as a press is always followed by a release the app can see.
+
+Windows does not guarantee that. `SetCapture`/`ReleaseCapture` are paired
+with the button state in `mouseButton` (`gui/backend/gl/events_win32.go`),
+but Win32 can revoke capture on its own — another process calls
+`SetCapture`, a system modal or UAC prompt appears, Ctrl+Alt+Del or Win+L
+fires, a debugger breaks in. The window then gets `WM_CAPTURECHANGED` and
+no `WM_LBUTTONUP`. The message was unhandled, so the lock survived and
+`mouseMoveHandler` kept routing every later move into the drag callback:
+text selection tracking a cursor with no button held, cleared only by a
+fresh click.
+
+macOS had the same symptom from a different cause (a resize-border press
+whose mouse-up AppKit swallowed), fixed separately in
+`metal_window_darwin.m`. X11 is not affected: reparenting WMs own the
+resize borders on the frame window, and X's implicit passive grab
+guarantees the matching `ButtonRelease`.
+
+## Why not synthesise a `MouseUp`
+
+`MouseUp` is the *commit*. Dock drops call `onLayoutChange`, drag-reorder
+calls `onReorder`. Feeding a fake release on capture loss would docks a
+panel or reorder a list the user never dropped — a data mutation from an
+event that did not happen. Cancellation is a distinct outcome and needs a
+distinct hook.
+
+## Design
+
+`MouseLockCfg.Cancel func(*Window)`, plus `(*Window).MouseCancel()`:
+
+```go
+func (w *Window) MouseCancel() {
+	if !w.mouseIsLocked() {
+		return
+	}
+	cancel := w.viewState.mouseLock.Cancel
+	w.MouseUnlock()
+	if cancel != nil {
+		cancel(w)
+	}
+	w.UpdateWindow()
+}
+```
+
+Three properties the tests pin (`gui/mouse_cancel_test.go`):
+
+- **Unlocks unconditionally.** `Cancel` is optional — a widget whose only
+  drag state *is* the lock (scrollbar, splitter, markdown selection) needs
+  no hook, and the default already restores it.
+- **Clears the lock before the hook runs.** The existing escape-key
+  unwinds (`dockDragCancel`, `dragReorderCancel`) call `MouseUnlock`
+  themselves; clearing first makes that a no-op instead of a race.
+- **Runs the hook at most once.** The guard makes a second cancel inert,
+  so a duplicate capture-loss report cannot double-unwind.
+
+`Cancel` takes `*Window`, not `EventCtx`, unlike the other three callbacks.
+There is no event to carry, and every other lock callback reads
+`ctx.Event` — handing them a nil one would be a footgun rather than
+consistency.
+
+## Backend contract
+
+A backend calls `MouseCancel` when the platform ends a drag without a
+release. On Win32 that is `WM_CAPTURECHANGED`, with one wrinkle: our own
+`ReleaseCapture` raises it too, so an unguarded handler would cancel after
+every normal mouse-up. `platformState.capturing` tracks ownership and is
+cleared *before* `ReleaseCapture` — that call reenters the wndproc
+synchronously, so a flag cleared afterwards would still read as an
+involuntary loss.
+
+## Wired hooks
+
+| Site | Cancel does |
+| --- | --- |
+| text / RTF / input selection | remove the edge-scroll animation, which nothing else stops once the lock is gone |
+| slider | clear the pressed flag; the value keeps what the last move set |
+| color picker (SV area) | restore the cursor the drag hid |
+| datagrid column resize | clear the active flag; the column keeps its dragged width, focus is not moved |
+| dock drag | `dockDragCancel` — drop nothing, hide the zone overlay |
+| drag-reorder | `dragReorderCancel` — hide ghost and gap, leave the order alone |
+
+Scrollbar, splitter and markdown selection are deliberately hookless: the
+default unlock is their whole teardown.

--- a/gui/backend/gl/capture_win32_test.go
+++ b/gui/backend/gl/capture_win32_test.go
@@ -1,0 +1,110 @@
+//go:build windows && !js
+
+package gl
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// Issue #110: Win32 can revoke mouse capture without ever sending the
+// matching button-up. Unhandled, that left a MouseLock drag locked for
+// good — every later move kept driving it with no button held.
+//
+// The window is driven through gui.Window's exported surface, so these
+// assert what a widget actually observes: whether moves keep arriving.
+
+// dragCounts records what an in-flight MouseLock saw.
+type dragCounts struct{ moves, ups, cancels int }
+
+// newCaptureTestBackend returns a Backend over a headless window with a
+// MouseLock in flight, plus the counters that lock feeds.
+func newCaptureTestBackend(t *testing.T) (*Backend, *dragCounts) {
+	t.Helper()
+	b := newCharTestBackend(t)
+	c := &dragCounts{}
+	b.plat.w.MouseLock(gui.MouseLockCfg{
+		MouseMove: func(gui.EventCtx) { c.moves++ },
+		MouseUp:   func(ctx gui.EventCtx) { c.ups++; ctx.Window.MouseUnlock() },
+		Cancel:    func(*gui.Window) { c.cancels++ },
+	})
+	return b, c
+}
+
+// moveForTest feeds a mouse move the way the message pump would.
+func moveForTest(b *Backend) {
+	b.emit(gui.Event{Type: gui.EventMouseMove, MouseX: 10, MouseY: 10})
+}
+
+func TestCaptureChangedCancelsInFlightDrag(t *testing.T) {
+	b, c := newCaptureTestBackend(t)
+	b.plat.capturing = true
+
+	moveForTest(b)
+	if c.moves != 1 {
+		t.Fatalf("locked move not delivered: moves = %d", c.moves)
+	}
+
+	if _, handled := b.handleMessage(wmCaptureChanged, 0, 0); !handled {
+		t.Error("WM_CAPTURECHANGED fell through to DefWindowProc")
+	}
+	if c.cancels != 1 {
+		t.Errorf("Cancel ran %d times, want 1", c.cancels)
+	}
+	if c.ups != 0 {
+		t.Error("cancel synthesised a MouseUp; that would commit the drag")
+	}
+	if b.plat.capturing {
+		t.Error("capturing still set after capture was revoked")
+	}
+
+	// The point of the fix: the drag is over, so moves stop.
+	moveForTest(b)
+	if c.moves != 1 {
+		t.Errorf("drag still tracking after cancel: moves = %d", c.moves)
+	}
+}
+
+// Our own ReleaseCapture on button-up also raises WM_CAPTURECHANGED.
+// That one must not cancel — MouseUp already ended the drag, and a
+// spurious cancel would unwind a dock drop or reorder after the fact.
+func TestCaptureChangedAfterOwnReleaseDoesNotCancel(t *testing.T) {
+	b, c := newCaptureTestBackend(t)
+	b.plat.capturing = false // cleared by mouseButton before ReleaseCapture
+
+	b.handleMessage(wmCaptureChanged, 0, 0)
+	if c.cancels != 0 {
+		t.Errorf("deliberate release cancelled the lock: cancels = %d", c.cancels)
+	}
+	moveForTest(b)
+	if c.moves != 1 {
+		t.Errorf("lock did not survive a deliberate release: moves = %d", c.moves)
+	}
+}
+
+// mouseButton owns the capturing flag, and must clear it *before*
+// ReleaseCapture — that call reenters this wndproc synchronously, so a
+// flag cleared afterwards would read as an involuntary loss.
+func TestMouseButtonTracksCaptureOwnership(t *testing.T) {
+	b, c := newCaptureTestBackend(t)
+
+	b.mouseButton(gui.EventMouseDown, gui.MouseLeft, 0, true)
+	if !b.plat.capturing {
+		t.Error("button down did not take capture")
+	}
+
+	// Button up releases capture, then Windows delivers the message.
+	b.mouseButton(gui.EventMouseUp, gui.MouseLeft, 0, false)
+	if b.plat.capturing {
+		t.Error("button up did not give up capture")
+	}
+	b.handleMessage(wmCaptureChanged, 0, 0)
+	if c.ups != 1 {
+		t.Errorf("MouseUp ran %d times, want 1", c.ups)
+	}
+	if c.cancels != 0 {
+		t.Errorf("release-driven WM_CAPTURECHANGED cancelled: cancels = %d",
+			c.cancels)
+	}
+}

--- a/gui/backend/gl/events_win32.go
+++ b/gui/backend/gl/events_win32.go
@@ -33,7 +33,10 @@ const (
 	wmMButtonUp   = 0x0208
 	wmMouseWheel  = 0x020A
 	wmMouseHWheel = 0x020E
-	wmApp         = 0x8000
+
+	wmCaptureChanged = 0x0215
+
+	wmApp = 0x8000
 
 	htClient      = 1
 	sizeMinimized = 1
@@ -108,6 +111,23 @@ func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
 		return b.mouseButton(gui.EventMouseDown, gui.MouseMiddle, lparam, true)
 	case wmMButtonUp:
 		return b.mouseButton(gui.EventMouseUp, gui.MouseMiddle, lparam, false)
+
+	case wmCaptureChanged:
+		// Win32 can revoke mouse capture without ever sending the
+		// matching button-up: another process calls SetCapture, a
+		// system modal or UAC prompt appears, Ctrl+Alt+Del or Win+L
+		// fires, a debugger breaks in. The drag is over, but nothing
+		// tells the gui layer, so a MouseLock would stay locked and
+		// every later move would keep driving it with no button held.
+		//
+		// capturing is cleared *before* our own ReleaseCapture, whose
+		// WM_CAPTURECHANGED reenters this wndproc synchronously — so
+		// reaching here with it still set means the loss was involuntary.
+		if b.plat.capturing {
+			b.plat.capturing = false
+			w.MouseCancel()
+		}
+		return 0, true
 
 	case wmMouseWheel:
 		return b.mouseWheel(0, notchesToLines(hiWordS(wparam)), lparam)
@@ -200,8 +220,13 @@ func (b *Backend) mouseButton(t gui.EventType, btn gui.MouseButton,
 	lparam uintptr, down bool) (uintptr, bool) {
 
 	if down {
+		b.plat.capturing = true
 		pSetCapture.Call(b.plat.hwnd)
-	} else {
+	} else if b.plat.capturing {
+		// Clear first: ReleaseCapture sends WM_CAPTURECHANGED back
+		// through this wndproc before it returns, and that handler
+		// must read a deliberate release, not a revoked one.
+		b.plat.capturing = false
 		pReleaseCapture.Call()
 	}
 	x, y := b.logicalXY(loWordS(lparam), hiWordS(lparam))

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -194,6 +194,11 @@ type platformState struct {
 	evt       gui.Event // reused per message to avoid per-event allocation
 	highSurr  uint16    // pending UTF-16 high surrogate for WM_CHAR
 
+	// capturing tracks whether this window holds mouse capture, so
+	// WM_CAPTURECHANGED can tell our own ReleaseCapture from a
+	// revocation. See the wmCaptureChanged case in events_win32.go.
+	capturing bool
+
 	// IME state. The two buffers are reused across composition messages
 	// so a keystroke costs no allocation; imeRect caches the last caret
 	// rect reported to IMM, which the render path re-reports every frame.

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -393,6 +393,13 @@ func dataGridStartResize(gridID string, columns []GridColumnCfg, rows []GridRow,
 				ctx.Window.SetFocus(focusID)
 			}
 		},
+		Cancel: func(w *gg.Window) {
+			// Clear the active flag so the header stops drawing the
+			// resize affordance. The column keeps its dragged width,
+			// as it would on release; focus is not moved, since that
+			// is a response to the user letting go.
+			dataGridEndResize(gridID, w)
+		},
 	})
 	e.IsHandled = true
 }

--- a/gui/dock_layout_drag.go
+++ b/gui/dock_layout_drag.go
@@ -107,6 +107,12 @@ func dockDragStart(
 		MouseUp: func(ctx EventCtx) {
 			dockDragOnMouseUp(dockID, root, onLayoutChange, ctx.Window)
 		},
+		Cancel: func(w *Window) {
+			// Capture lost mid-drag: drop the panel where it was.
+			// Committing the hovered zone would dock a panel the
+			// user never released over it.
+			dockDragCancel(dockID, w)
+		},
 	})
 }
 

--- a/gui/dock_layout_drag_test.go
+++ b/gui/dock_layout_drag_test.go
@@ -90,6 +90,47 @@ func TestDockDragGetSetClear(t *testing.T) {
 	}
 }
 
+// Issue #110: losing mouse capture over a drop zone must not dock the
+// panel. Only releasing the button is a drop. Run the same state both
+// ways so the contrast, not just the silence, is asserted.
+func TestDockDragCaptureLossDoesNotDrop(t *testing.T) {
+	setup := func(dropped *bool) *Window {
+		w := &Window{}
+		w.layout = Layout{Shape: &Shape{ID: "dock"}}
+		root := DockPanelGroup("g1", []string{"p1", "p2"}, "p1")
+		dockDragStart("dock", "p1", "g1", root,
+			func(*DockNode, EventCtx) { *dropped = true },
+			&Layout{Shape: &Shape{ID: "tab"}}, &Event{}, w)
+		// Hovering a drop zone: a release here would dock the panel.
+		state := dockDragGet(w, "dock")
+		state.active = true
+		state.hoverZone = dockDropRight
+		state.hoverGroupID = "g1"
+		dockDragSet(w, "dock", state)
+		return w
+	}
+
+	upDropped := false
+	wUp := setup(&upDropped)
+	mouseUpHandler(&Layout{Shape: &Shape{}}, &Event{}, wUp)
+	if !upDropped {
+		t.Fatal("setup does not drop on release; the cancel case proves nothing")
+	}
+
+	dropped := false
+	w := setup(&dropped)
+	w.MouseCancel()
+	if dropped {
+		t.Error("panel docked by a drag the user never released")
+	}
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after capture loss")
+	}
+	if dockDragGet(w, "dock").active {
+		t.Error("drag state left active; the drop-zone overlay would persist")
+	}
+}
+
 func TestDockDragMultipleDocks(t *testing.T) {
 	w := &Window{}
 	dockDragSet(w, "d1", dockDragState{panelID: "p1"})

--- a/gui/drag_reorder.go
+++ b/gui/drag_reorder.go
@@ -318,6 +318,12 @@ func dragReorderMakeLock(
 			dragReorderOnMouseUp(
 				dragKey, itemIDs, onReorder, ctx.Window)
 		},
+		Cancel: func(w *Window) {
+			// Same unwind as the escape key: hide ghost and gap,
+			// leave the list order alone. OnReorder must not fire
+			// for a drag the user never released.
+			dragReorderCancel(dragKey, w)
+		},
 	}
 }
 

--- a/gui/drag_reorder_test.go
+++ b/gui/drag_reorder_test.go
@@ -153,6 +153,51 @@ func TestDragReorderEscapeCancelsStartedDrag(t *testing.T) {
 	}
 }
 
+// Issue #110: losing mouse capture mid-drag must unwind the reorder,
+// not commit it. The same setup is run twice — once released, once
+// cancelled — so the assertion is that the two differ, not just that
+// the cancel path is quiet.
+func TestDragReorderCaptureLossDoesNotReorder(t *testing.T) {
+	setup := func(w *Window, dragKey string, fired *bool) {
+		w.layout = Layout{Shape: &Shape{ID: "root"}}
+		dragReorderStart(dragReorderStartCfg{
+			DragKey: dragKey, Index: 0, ItemID: "a",
+			Axis: dragReorderVertical, ItemIDs: []string{"a", "b", "c"},
+			ItemLayoutIDs: []string{"a", "b", "c"},
+			OnReorder:     func(string, string, EventCtx) { *fired = true },
+			Layout:        &Layout{Shape: &Shape{ID: "a"}},
+			Event:         &Event{},
+		}, w)
+		// A drag that has moved far enough to commit on release.
+		state := dragReorderGet(w, dragKey)
+		state.active = true
+		state.currentIndex = 2
+		dragReorderSet(w, dragKey, state)
+	}
+
+	wUp := &Window{}
+	upFired := false
+	setup(wUp, "drag_release", &upFired)
+	mouseUpHandler(&Layout{Shape: &Shape{}}, &Event{}, wUp)
+	if !upFired {
+		t.Fatal("setup does not commit on release; the cancel case proves nothing")
+	}
+
+	w := &Window{}
+	fired := false
+	setup(w, "drag_capture_loss", &fired)
+	w.MouseCancel()
+	if fired {
+		t.Error("OnReorder fired for a drag the user never released")
+	}
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after capture loss")
+	}
+	if state := dragReorderGet(w, "drag_capture_loss"); state.active {
+		t.Error("drag state left active; ghost and gap would keep rendering")
+	}
+}
+
 func TestDragReorderStartSetsLayoutValidity(t *testing.T) {
 	w := &Window{}
 	w.layout = Layout{

--- a/gui/mouse_cancel_test.go
+++ b/gui/mouse_cancel_test.go
@@ -1,0 +1,102 @@
+package gui
+
+import "testing"
+
+// MouseCancel is the seam backends use when the platform revokes
+// mouse capture mid-drag (issue #110). It must unlock unconditionally
+// and let the widget unwind without committing the drag.
+
+func TestMouseCancelRunsHookAndUnlocks(t *testing.T) {
+	t.Parallel()
+	w := &Window{}
+	cancelled := 0
+	w.MouseLock(MouseLockCfg{
+		MouseMove: func(EventCtx) {},
+		MouseUp:   func(EventCtx) { t.Error("MouseUp ran on cancel") },
+		Cancel:    func(*Window) { cancelled++ },
+	})
+	w.MouseCancel()
+	if cancelled != 1 {
+		t.Errorf("Cancel ran %d times, want 1", cancelled)
+	}
+	if w.mouseIsLocked() {
+		t.Error("still locked after MouseCancel")
+	}
+}
+
+func TestMouseCancelUnlocksWithoutHook(t *testing.T) {
+	t.Parallel()
+	w := &Window{}
+	w.MouseLock(MouseLockCfg{MouseMove: func(EventCtx) {}})
+	w.MouseCancel()
+	if w.mouseIsLocked() {
+		t.Error("a lock with no Cancel hook must still unlock")
+	}
+}
+
+// The lock is cleared before the hook runs, so hooks that unlock
+// themselves — the escape-key cancel paths do — stay correct.
+func TestMouseCancelClearsLockBeforeHook(t *testing.T) {
+	t.Parallel()
+	w := &Window{}
+	lockedInHook := true
+	w.MouseLock(MouseLockCfg{
+		MouseMove: func(EventCtx) {},
+		Cancel: func(cw *Window) {
+			lockedInHook = cw.mouseIsLocked()
+			cw.MouseUnlock() // idempotent, as the real hooks do
+		},
+	})
+	w.MouseCancel()
+	if lockedInHook {
+		t.Error("hook observed the lock still set")
+	}
+	if w.mouseIsLocked() {
+		t.Error("still locked after MouseCancel")
+	}
+}
+
+func TestMouseCancelUnlockedIsNoOp(t *testing.T) {
+	t.Parallel()
+	w := &Window{}
+	w.MouseCancel() // must not panic
+	if w.mouseIsLocked() {
+		t.Error("MouseCancel locked an unlocked window")
+	}
+}
+
+// A second cancel must not re-run the hook: capture loss can be
+// reported more than once, and dock/reorder unwinds are not idempotent
+// with respect to their own UpdateWindow ordering.
+func TestMouseCancelTwiceRunsHookOnce(t *testing.T) {
+	t.Parallel()
+	w := &Window{}
+	runs := 0
+	w.MouseLock(MouseLockCfg{
+		MouseMove: func(EventCtx) {},
+		Cancel:    func(*Window) { runs++ },
+	})
+	w.MouseCancel()
+	w.MouseCancel()
+	if runs != 1 {
+		t.Errorf("Cancel ran %d times, want 1", runs)
+	}
+}
+
+// A cancelled drag must not keep receiving moves — the stuck-drag
+// symptom in issue #110 was exactly this.
+func TestMouseCancelStopsMoveDelivery(t *testing.T) {
+	t.Parallel()
+	w := &Window{windowWidth: 800, windowHeight: 600}
+	moves := 0
+	w.MouseLock(MouseLockCfg{
+		MouseMove: func(EventCtx) { moves++ },
+	})
+	root := &Layout{Shape: &Shape{}}
+	mouseMoveHandler(root, &Event{MouseX: 10, MouseY: 10}, w)
+	w.MouseCancel()
+	mouseMoveHandler(root, &Event{MouseX: 20, MouseY: 20}, w)
+	if moves != 1 {
+		t.Errorf("MouseMove ran %d times, want 1 (pre-cancel only)", moves)
+	}
+}

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -199,6 +199,10 @@ func cpSVArea(
 							ctx.Window.MouseUnlock()
 							ctx.Window.SetMouseCursorArrow()
 						},
+						Cancel: func(w *Window) {
+							// Restore the cursor the drag hid.
+							w.SetMouseCursorArrow()
+						},
 					})
 					// Same as the hue strip: nested in the focusable
 					// picker root, so consume to keep the focus where

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -277,5 +277,8 @@ func startInputDrag(d *inputDragState, w *Window) {
 			ctx.Window.AnimationRemove(animIDDragScroll)
 			ctx.Window.MouseUnlock()
 		},
+		Cancel: func(w *Window) {
+			w.AnimationRemove(animIDDragScroll)
+		},
 	})
 }

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -184,6 +184,9 @@ func rtfSelectOnClick(ctx EventCtx) {
 			ctx.Window.AnimationRemove(animIDTextDragScroll)
 			ctx.Window.MouseUnlock()
 		},
+		Cancel: func(w *Window) {
+			w.AnimationRemove(animIDTextDragScroll)
+		},
 	})
 }
 

--- a/gui/view_slider.go
+++ b/gui/view_slider.go
@@ -181,6 +181,12 @@ func Slider(cfg SliderCfg) View {
 					ps.Set(pressID, false)
 					ctx.Window.MouseUnlock()
 				},
+				Cancel: func(w *Window) {
+					// Clear the pressed look; the value keeps
+					// whatever the last move set, as on release.
+					ps := StateMap[string, bool](w, nsSliderPress, capModerate)
+					ps.Set(pressID, false)
+				},
 			})
 			// A press on the track sets the value and starts a drag.
 			// Consume it: a slider nested in a focusable container (the

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -229,6 +229,12 @@ func textOnClick(ctx EventCtx) {
 			ctx.Window.AnimationRemove(animIDTextDragScroll)
 			ctx.Window.MouseUnlock()
 		},
+		Cancel: func(w *Window) {
+			// Stop the edge-scroll animation. Nothing else unwinds
+			// it once the lock is gone, so it would keep scrolling
+			// and extending the selection on its own.
+			w.AnimationRemove(animIDTextDragScroll)
+		},
 	})
 }
 

--- a/gui/window.go
+++ b/gui/window.go
@@ -301,6 +301,20 @@ type MouseLockCfg struct {
 	mouseDown func(EventCtx)
 	MouseMove func(EventCtx)
 	MouseUp   func(EventCtx)
+
+	// Cancel unwinds a drag that ended without a button release —
+	// the platform revoked mouse capture (a system modal, a lock
+	// screen, another process grabbing capture) so no MouseUp will
+	// ever arrive. Synthesising one is wrong: MouseUp *commits* a
+	// dock drop or a reorder, and a cancellation must not.
+	//
+	// It takes *Window, not EventCtx, precisely because there is no
+	// event to carry — the other callbacks all read ctx.Event.
+	// Optional: MouseCancel unlocks either way, so only a widget
+	// with state beyond the lock itself (a pending drop, a pressed
+	// flag, a drag-scroll animation) needs one.
+	Cancel func(*Window)
+
 	CursorPos int
 }
 
@@ -456,6 +470,27 @@ func (w *Window) MouseLock(cfg MouseLockCfg) {
 // MouseUnlock returns mouse handling events to normal behavior.
 func (w *Window) MouseUnlock() {
 	w.viewState.mouseLock = MouseLockCfg{}
+}
+
+// MouseCancel aborts an in-flight drag: it unlocks the mouse and
+// runs the lock's Cancel hook, if any. Backends call it when the
+// platform takes mouse capture away without delivering a button
+// release, which would otherwise leave the lock in place forever —
+// every later move keeps driving the drag with no button held.
+//
+// No-op when the mouse is not locked. The lock is cleared before
+// Cancel runs, so a hook that calls MouseUnlock itself (the
+// escape-key cancel paths do) stays correct.
+func (w *Window) MouseCancel() {
+	if !w.mouseIsLocked() {
+		return
+	}
+	cancel := w.viewState.mouseLock.Cancel
+	w.MouseUnlock()
+	if cancel != nil {
+		cancel(w)
+	}
+	w.UpdateWindow()
 }
 
 // SetTextMeasurer sets the text measurement backend.


### PR DESCRIPTION
Fixes #110.

## The bug

Win32 can revoke mouse capture without ever sending the matching button-up —
another process calls `SetCapture`, a system modal or UAC prompt appears,
Ctrl+Alt+Del or Win+L fires, a debugger breaks in. `handleMessage` had no case
for `WM_CAPTURECHANGED`, so it fell through to `DefWindowProc` and the gui layer
never learned the drag ended. Since `MouseLock` is cleared only by an explicit
`MouseUnlock` — which for every widget lives in the lock's `MouseUp` — the lock
survived and `mouseMoveHandler` kept routing every later move into the drag
callback: text selection tracking a cursor with no button held, cleared only by
a fresh click. Affects every `MouseLock` user, not just text selection.

The issue was filed from code inspection and never reproduced on hardware. It is
now reproduced in a test: disabling the new case makes
`TestCaptureChangedCancelsInFlightDrag` report the drag still tracking after
capture is revoked.

## Backend

`handleMessage` handles `wmCaptureChanged` (0x0215) and calls `w.MouseCancel()`.

One wrinkle the issue didn't cover: our own `ReleaseCapture` on button-up raises
the same message, so an unguarded handler would cancel after *every* normal
mouse-up. `platformState.capturing` tracks ownership and is cleared **before**
`ReleaseCapture` — that call reenters the wndproc synchronously, so a flag
cleared afterwards would still read as an involuntary loss.

## gui layer

Took the `Cancel` hook the issue proposed over synthesising a `MouseUp`.
`MouseUp` is the *commit*: faking one would dock a panel or reorder a list the
user never dropped — a data mutation from an event that did not happen.

- `MouseLockCfg.Cancel func(*Window)` + `(*Window).MouseCancel()`.
- Unlocks unconditionally, so the hook is optional.
- Clears the lock **before** running the hook — the existing escape-key unwinds
  call `MouseUnlock` themselves, and clearing first makes that a no-op.
- Runs the hook at most once, so a duplicate capture-loss report can't
  double-unwind.
- `*Window` rather than `EventCtx` deliberately: there is no event to carry, and
  every other lock callback dereferences `ctx.Event`.

Hooks wired where teardown is more than the lock: dock drags and drag-reorder
(reusing the existing escape-key unwinds), text/RTF/input selection (stops the
edge-scroll animation, which nothing else halts once the lock is gone), sliders,
the color picker, datagrid column resize. Scrollbar, splitter and markdown
selection stay hookless — the default unlock is their whole teardown.

Spec: `docs/specs/mouse-lock-cancel.md`.

## Tests

`gui/mouse_cancel_test.go` pins the `MouseCancel` contract;
`gui/backend/gl/capture_win32_test.go` covers the message handling and that a
deliberate release does *not* cancel. The dock and reorder tests run the same
state twice — once released, once cancelled — and fail if the release path
doesn't commit, so the cancel assertion can't pass vacuously.

`go build ./...`, `go test ./...` (41 packages), and `golangci-lint run ./...`
(0 issues) all pass locally on Windows, rebased on efd0348.

## Not covered

`WM_KILLFOCUS` is untouched. Alt+Tab mid-drag should revoke capture and route
through this same path, but that is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
