### PR TITLE
fix(windows): create icon mask so CreateIconIndirect succeeds (#235)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 
@@ -25,9 +25,17 @@ jobs:
           install-linux-deps: 'true'
 
       - name: Test
+        # -race needs cgo, and mingw is not on PATH on Windows runners.
+        # Windows runs the suite un-raced (the suite only reached Windows
+        # CI with #235); race coverage stays on Linux/macOS.
+        shell: bash
         run: |
-          CGO_LDFLAGS="$(go env CGO_LDFLAGS)" \
-            go test -count=2 -race -timeout=10m ./gui/...
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            go test -count=2 -timeout=10m ./gui/...
+          else
+            CGO_LDFLAGS="$(go env CGO_LDFLAGS)" \
+              go test -count=2 -race -timeout=10m ./gui/...
+          fi
 
   coverage:
     name: Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to
 
 ### Fixed
 
+- **Windows: window and tray icons now render (#235).** `hicon.FromPNG`
+  passed a NULL `hbmMask` to `CreateIconIndirect`, which Win32 requires —
+  the call always failed, so the title bar, taskbar, alt-tab, and SNI tray
+  icons fell back to the shell's generic icon whether or not the app set
+  `WindowCfg.IconPNG`. The function now creates a zeroed 1bpp mask (fully
+  opaque), letting the 32bpp color bitmap's alpha shape the icon, so Windows
+  honors `IconPNG` like the other platforms.
+
 - **Windows: a revoked mouse capture no longer leaves a drag stuck (#110).**
   Win32 can take capture away without ever sending the matching button-up — a
   system modal or UAC prompt, Ctrl+Alt+Del, Win+L, another process calling

--- a/gui/backend/internal/hicon/hicon.go
+++ b/gui/backend/internal/hicon/hicon.go
@@ -22,6 +22,7 @@ var (
 	procReleaseDC          = user32.NewProc("ReleaseDC")
 	procCreateDIBSection   = gdi32.NewProc("CreateDIBSection")
 	procDeleteObject       = gdi32.NewProc("DeleteObject")
+	procCreateBitmap       = gdi32.NewProc("CreateBitmap")
 	procCreateIconIndirect = user32.NewProc("CreateIconIndirect")
 )
 
@@ -134,13 +135,29 @@ func FromPNG(pngData []byte, maxDim int) (uintptr, error) {
 	dst := unsafe.Slice((*byte)(bits), len(pixels))
 	copy(dst, pixels)
 
-	// Create icon from bitmap (nil mask = use alpha channel).
+	// Create a 1bpp monochrome mask. CreateIconIndirect requires a
+	// non-NULL mask for fIcon; an all-zero mask is fully opaque, so
+	// the 32bpp color bitmap's alpha does the shaping.
+	// CreateBitmap with a NULL lpBits leaves the bits undefined, so
+	// pass an explicitly zeroed buffer.
+	maskStride := ((w + 15) / 16) * 2 // 1bpp rows are word-aligned
+	zeroMask := make([]byte, maskStride*h)
+	hMask, _, _ := procCreateBitmap.Call(
+		uintptr(w), uintptr(h), 1, 1,
+		uintptr(unsafe.Pointer(&zeroMask[0])))
+	if hMask == 0 {
+		return 0, errors.New("CreateBitmap failed")
+	}
+	// CreateIconIndirect copies both bitmaps, so the mask (like the
+	// color DIB above) can be deleted once the icon exists.
+	defer procDeleteObject.Call(hMask)
+
 	ii := iconInfo{
 		fIcon:    1, // TRUE
 		xHotspot: 0,
 		yHotspot: 0,
 		hbmColor: hbm,
-		hbmMask:  0, // NULL — alpha in color bitmap
+		hbmMask:  hMask,
 	}
 	hIcon, _, _ := procCreateIconIndirect.Call(
 		uintptr(unsafe.Pointer(&ii)))

--- a/gui/backend/internal/hicon/hicon_test.go
+++ b/gui/backend/internal/hicon/hicon_test.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package hicon
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+// smallIconPNG builds an 16x16 RGBA PNG with an opaque center and a
+// fully transparent corner, the shape a real app icon has.
+func smallIconPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, 16, 16))
+	for y := range 16 {
+		for x := range 16 {
+			a := uint8(255)
+			if x == 0 && y == 0 {
+				a = 0 // fully transparent corner pixel
+			}
+			img.SetNRGBA(x, y, color.NRGBA{R: 200, G: 100, B: 50, A: a})
+		}
+	}
+	return encodePNG(t, img)
+}
+
+func encodePNG(t *testing.T, img image.Image) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestFromPNG exercises the only path through this package: a valid
+// PNG must yield a real HICON (issue #235: a NULL mask made
+// CreateIconIndirect fail silently, returning an error here).
+func TestFromPNG(t *testing.T) {
+	h, err := FromPNG(smallIconPNG(t), 32)
+	if err != nil {
+		t.Fatalf("FromPNG: %v", err)
+	}
+	if h == 0 {
+		t.Fatal("FromPNG returned a zero HICON")
+	}
+	Destroy(h)
+}
+
+// TestFromPNGOddWidth covers an odd-width icon, which exercises the
+// mask stride rounding (1bpp rows are word-aligned).
+func TestFromPNGOddWidth(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 17, 5))
+	for y := range 5 {
+		for x := range 17 {
+			img.SetNRGBA(x, y, color.NRGBA{R: 10, G: 20, B: 30, A: 255})
+		}
+	}
+	h, err := FromPNG(encodePNG(t, img), 32)
+	if err != nil {
+		t.Fatalf("FromPNG: %v", err)
+	}
+	if h == 0 {
+		t.Fatal("FromPNG returned a zero HICON")
+	}
+	Destroy(h)
+}
+
+func TestFromPNGBadData(t *testing.T) {
+	if h, err := FromPNG([]byte("not a png"), 32); err == nil {
+		Destroy(h)
+		t.Fatal("FromPNG accepted garbage bytes")
+	}
+}
+
+func TestFromPNGTooLarge(t *testing.T) {
+	h, err := FromPNG(smallIconPNG(t), 8)
+	if err == nil {
+		Destroy(h)
+		t.Fatal("FromPNG accepted an icon larger than maxDim")
+	}
+}


### PR DESCRIPTION
## Summary

`hicon.FromPNG` passed a NULL `hbmMask` to `CreateIconIndirect`, which Win32 requires — the call always failed, so every Windows icon surface fell back to the shell's generic icon: title bar, taskbar, alt-tab, and the SNI tray. The fallback path was equally broken, so apps got the default icon whether or not they set `WindowCfg.IconPNG`.

## Fix

- Create a zeroed 1bpp monochrome mask (fully opaque) and pass it as `hbmMask`; the 32bpp color DIB's alpha does the shaping.
- `CreateBitmap` with NULL `lpBits` leaves mask bits *undefined* (random holes) — the issue's suggested snippet corrected: buffer is explicitly zeroed.
- Mask deleted after `CreateIconIndirect` copies it, mirroring the existing color-DIB defer.

## Tests

- New `gui/backend/internal/hicon/hicon_test.go` (windows-only; the package had zero tests): valid PNG → real HICON, odd-width icon exercises the 1bpp stride rounding, garbage data and oversized icons error.
- CI test matrix gains `windows-latest` — first Windows test execution in CI. Runs un-raced there (race detector needs cgo; mingw not on PATH).

Closes #235