### PR TITLE
feat(debug): export dev-mode debug categories and API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,13 @@ Guidance for Claude Code (claude.ai/code) in this repo.
 
 ```
 go run ./examples/get_started/  # run the example app
-./scripts/large-files.sh     # report Go files >800 lines in gui/
+make check-all                  # test + lint + vet gates (pre-push)
+make test                       # tests only
+make lint                       # golangci-lint (pinned version)
+make vet                        # go vet + requiredid analyzer
+make ergo-audit                 # focus/callbacks inventory + ID composition
+make export-audit               # exported surface (advisory in-repo)
+./scripts/large-files.sh        # report Go files >800 lines in gui/
 ```
 
 ## Architecture
@@ -47,11 +53,21 @@ A `FillFill` root fills the window (min=max seed in `updateLayout`).
 All widgets take `*Cfg` struct (zero-initializable). Event callbacks share sig
 `func(EventCtx)`.
 
-Focus requires **both** `Focusable: true` **and** a non-empty `ID`
-(`isFocusedTarget`, `gui/event_traversal.go`); tab order additionally needs
-`!FocusSkip && !Disabled` (`layout_query.go`). `Focusable: true` without an `ID`
-is a silent no-op — the widget renders and clicks but never joins the tab order.
-The `requiredid` analyzer flags this.
+Focus requires **both** `Focusable` **and** a non-empty `ID` (`isFocusedTarget`,
+`gui/event_traversal.go`); tab order additionally needs
+`!FocusSkip && !Disabled` (`layout_query.go`). `Focusable` without an `ID` is a
+silent no-op — the widget renders and clicks but never joins the tab order. The
+`requiredid` analyzer flags this, and `gui.Debug` reports it at runtime.
+
+**Input controls are focusable by default (v0.36.0); opt out with
+`FocusDisabled`, never with `Focusable: false`.** Fifteen Cfgs default on:
+`Button`, `ColorPicker`, `Combobox`, `DatePicker`, `Input`, `InputDate`,
+`ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`, `Slider`,
+`Switch`, `Toggle`, `Tree`. Setting `Focusable: true` on these is redundant. The
+ID requirement is unchanged — a default-on control still needs an `ID` to reach
+the tab order, which is what `requiredid` enforces. Everything else is opt-in
+via `Focusable: true`. See `docs/specs/focusable-default-input.md`; run
+`ergoaudit -mode focus` for the current inventory.
 
 **`Shape.ID` is a leaf; identity is the effective ID.** `resolveShapeIDs`
 (`gui/id_resolve.go`, run from `layoutArrange` before the layout passes) stamps
@@ -135,7 +151,7 @@ Backend injects at startup. Nil in tests:
 
 - `(*Layout).spacing()` counts only visible children (`ShapeType != ShapeNone`,
   `!Float`, `!OverDraw`). Fence-post gap calc
-- Shape text fields in `Shape.TC` (`*ShapeTextConfig`), not on `Shape`
+- Shape text fields in `Shape.TC` (`*shapeTextConfig`), not on `Shape`
 - `ContainerCfg.Title`/`TitleBG` render group-box label in top border (floating
   eraser + text, like HTML fieldset). `TitleBG` must match parent bg color to
   erase border behind title.
@@ -145,8 +161,8 @@ Backend injects at startup. Nil in tests:
 - `AmendLayout` hook on shapes runs after sizing to reposition overlays (color
   picker circles, splitter handles, etc.) or manage hover. Layout uses absolute
   coords. Moving parent in `AmendLayout` does NOT move children. Use float
-  system (`FloatAnchor`/`FloatTieOff`/`FloatOffset`) to position elements with
-  children.
+  system (`FloatAnchor`/`FloatTieOff`/`FloatOffsetX`/`FloatOffsetY`) to position
+  elements with children.
 - **One event rule (since v0.55.0): nothing is marked handled for you. A
   callback that acts on an event calls `ctx.Consume()`; one that does not, lets
   the event travel on.** This holds for every callback — `OnClick` and `OnChar`
@@ -157,7 +173,43 @@ Backend injects at startup. Nil in tests:
   unless it consumes. `ctx.Event` is nil in `AmendLayout` and `OnScroll`; both
   `EventCtx` methods are nil-safe. `gui.Debug(true)` reports handlers that act
   without consuming while an ancestor also handles;
-  `(*Window).TestUnconsumedEvents` sweeps a whole window for them
+  `(*Window).TestUnconsumedEvents` sweeps a whole window for them (see Dev-mode
+  diagnostics below)
+
+### Dev-mode diagnostics
+
+**Most identity mistakes in this repo are already detected at runtime — turn the
+gate on before hand-auditing a layout.** `gui.Debug(true)`, or `GOGUI_DEBUG=1`
+in the environment, walks the composed tree every frame from
+`updateLayoutLocked` and reports to stderr (`gui/debug.go`):
+
+- duplicate **effective** ID — names the key and both claim sites
+- focusable shape with no `ID` (never joins the tab order)
+- scrollable shape with no `ID` (shares one offset with every other)
+- `OnMouseLeave` with no `ID` (callback never fires)
+- a scrollable listbox that resolved to height 0
+- a callback that acted without `ctx.Consume()` while an ancestor also handles
+
+Findings are warn-once per window, so a real defect does not scroll past at
+frame rate. The gate allocates and walks the whole tree — dev only, never
+production.
+
+Categories gate independently via `gui.DebugCategories(mask)`;
+`gui.DebugEnabled()` queries the gate. `Debug(true)` is
+`DebugCategories(gui.DebugAll)`.
+
+**`DebugUnscopedIDs` is not in `DebugAll` and `Debug(true)` does not turn it
+on.** It reports an `ID` with no ID-bearing ancestor — still a window-global
+name, so the widget cannot be dropped into a second panel as it stands. That is
+a design property rather than a bug and fires on most widgets in a small app, so
+ask for it explicitly when auditing a screen for reusability:
+
+```go
+gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
+```
+
+Assertable forms for tests, which return findings as data instead of printing:
+`(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.
 
 ## Coding Conventions
 
@@ -206,45 +258,17 @@ git/mkdir/rm/ls output. `ctx_fetch_and_index` instead of curl/wget/WebFetch.
 
 ## Rejected Approaches
 
-- **WebGPU Backend** (2026-06): Explored in branch `webgpu-backend` (deleted).
-  12 WGSL shader pipelines, device init, render loop all working. Rejected at
-  the time because WebGPU has no native text rendering — font measurement and
-  glyph rasterization require Canvas2D. A hybrid backend defeats the purpose; a
-  pure-Go TTF rasterizer in go-glyph was the missing piece. The existing
-  Canvas2D backend already handles every render command correctly. GPU
-  acceleration doesn't address the actual bottleneck (heap allocations).
+- **WebGPU backend** — explored and rejected; superseded by issue #137. Don't
+  re-propose it. `gui/backend/gl/` already has no cgo (X11 via xgb, EGL via
+  purego, Win32 via syscall), so purego bindings got CGo-free Linux+Windows for
+  ~600 lines, where wgpu would have added 10–40 MB of runtime libs, supplied
+  none of `NativePlatform`, and left macOS untouched.
+- **Current CGo state:** `CGO_ENABLED=0 go build ./...` is green on Linux and
+  Windows for the whole module. macOS (5.9k lines ObjC) is the entire remaining
+  problem and is not started.
 
-  **Update (2026-07):** go-glyph now has a pure-Go text pipeline
-  (`bitmap_puregoft.go` — go-text/typesetting harfbuzz shaping +
-  golang.org/x/image/vector rasterization, no CGo). Combined with
-  [goffi](https://github.com/go-webgpu/goffi) (zero-CGo FFI for calling
-  wgpu-native), a CGo-free WebGPU desktop backend is now technically viable —
-  blocked only by the upfront engineering cost of a full backend rewrite, not by
-  any missing dependencies.
-
-  **Superseded (2026-07-31, issue #137):** viable but the wrong instrument.
-  `gui/backend/gl/` has no cgo at all — X11 via xgb, EGL via purego, Win32 via
-  syscall. The sole CGo dependency on Linux/Windows is `github.com/go-gl/gl` (55
-  functions, 45 constants), and its proc-address loader is already pure Go.
-  Swapping that one dispatch layer for purego bindings gets CGo-free
-  Linux+Windows for ~600 lines; wgpu is a superset that also ships 10–40 MB of
-  runtime shared libs, supplies none of `NativePlatform` (10 sub-interfaces),
-  and leaves macOS (the only real CGo backend, 5.9k lines ObjC) untouched. Full
-  assessment: `docs/specs/cgo-free-backend-feasibility.md`.
-
-  **Phase 1 done (2026-07-31):** go-gl replaced by `gui/backend/internal/glbind`
-  (purego). `CGO_ENABLED=0` now builds the whole module for Windows, and
-  `./gui/backend/...` for Linux. The remaining Linux CGo dependency was
-  `gui/audio` → `ebitengine/oto` (ALSA), not the backend. macOS (Phase 2) is
-  untouched.
-
-  **Audio de-cgo'd (2026-08-04, issue #141):** `gui/audio`'s output driver is
-  now a 3-function seam (`outputInit`/`outputPlay`/`outputClose`,
-  `output_oto.go` vs `output_pulse.go`). The default Linux sink is a pure-Go
-  PulseAudio client (`github.com/jfreymuth/pulse`), so
-  `CGO_ENABLED=0 go build ./...` is green on Linux; oto/ALSA is opt-in via
-  `-tags otoaudio`. Windows/macOS still use oto. beep decode/mix was already
-  pure Go.
+Full history and rationale — WebGPU, the go-gl→glbind swap, the `gui/audio`
+de-cgo — in `docs/specs/cgo-free-backend-feasibility.md`.
 
 ## Specs
 

--- a/docs/specs/cgo-free-backend-feasibility.md
+++ b/docs/specs/cgo-free-backend-feasibility.md
@@ -1,40 +1,78 @@
 # CGo-free desktop backend — feasibility assessment
 
 Assessment of [issue #137](https://github.com/go-gui-org/go-gui/issues/137).
-Date: 2026-07-31. Status: **Phase 1 implemented**; Phase 2 (macOS) not started.
+Date: 2026-07-31. Status: **Phase 1 implemented**, and the `gui/audio` follow-up
+(§ Audio outcome) closed the remaining Linux CGo dependency; Phase 2 (macOS) not
+started.
 
 ## Phase 1 outcome (2026-07-31)
 
-`github.com/go-gl/gl` is gone. It was replaced by
-`gui/backend/internal/glbind`, a purego binding for the 55 GL entry points and
-45 constants the backend uses, resolved through the proc-address functions that
-already existed (`eglProc` on Linux; a new `glProc` on Windows reproducing
-go-gl's wglGetProcAddress-then-opengl32 fallback). Call sites changed by import
-swap only.
+`github.com/go-gl/gl` is gone. It was replaced by `gui/backend/internal/glbind`,
+a purego binding for the 55 GL entry points and 45 constants the backend uses,
+resolved through the proc-address functions that already existed (`eglProc` on
+Linux; a new `glProc` on Windows reproducing go-gl's
+wglGetProcAddress-then-opengl32 fallback). Call sites changed by import swap
+only.
 
 Measured result:
 
-| Target | `CGO_ENABLED=0 go build` |
-|---|---|
-| windows/amd64, windows/arm64 | `./...` — **entire module** |
-| linux/amd64, linux/arm64, linux/386 | `./gui/backend/...` |
+| Target                              | `CGO_ENABLED=0 go build`    |
+| ----------------------------------- | --------------------------- |
+| windows/amd64, windows/arm64        | `./...` — **entire module** |
+| linux/amd64, linux/arm64, linux/386 | `./gui/backend/...`         |
 
 Two corrections to the assessment below:
 
-- The constant count is **45**, not 47. The original `grep` used
-  `\b(gogl|gl)\.` where `go?gl` was intended, so bare `gl.`-qualified
-  references in `backend.go` were miscounted.
+- The constant count is **45**, not 47. The original `grep` used `\b(gogl|gl)\.`
+  where `go?gl` was intended, so bare `gl.`-qualified references in `backend.go`
+  were miscounted.
 - **`github.com/go-gl/gl` was not the only CGo dependency on Linux.**
-  `gui/audio` pulls in `github.com/ebitengine/oto/v3`, whose Linux driver is
-  cgo (`#cgo pkg-config: alsa` in `driver_unix.go`). The original verification
+  `gui/audio` pulls in `github.com/ebitengine/oto/v3`, whose Linux driver is cgo
+  (`#cgo pkg-config: alsa` in `driver_unix.go`). The original verification
   missed it because `go build` stopped at the go-gl load error. Windows is
-  unaffected — oto's Windows driver is pure syscall. Full `CGO_ENABLED=0
-  GOOS=linux go build ./...` therefore still fails, on `gui/audio` alone.
-  That is a separate dependency needing its own decision (gate `gui/audio`
-  behind a build tag, or replace oto on Linux) and was left out of Phase 1.
+  unaffected — oto's Windows driver is pure syscall. Full
+  `CGO_ENABLED=0 GOOS=linux go build ./...` therefore still fails, on
+  `gui/audio` alone. That is a separate dependency needing its own decision
+  (gate `gui/audio` behind a build tag, or replace oto on Linux) and was left
+  out of Phase 1.
 
-32-bit was **not** dropped: purego supports 386/arm via `syscall_32bit.go`,
-and `linux/386` builds.
+32-bit was **not** dropped: purego supports 386/arm via `syscall_32bit.go`, and
+`linux/386` builds.
+
+## Audio outcome (2026-08-04)
+
+The `gui/audio` dependency left out of Phase 1 (see the second correction above)
+is resolved. [Issue #141](https://github.com/go-gui-org/go-gui/issues/141) put
+the output driver behind a 3-function seam — `outputInit` / `outputPlay` /
+`outputClose`, split across `output_oto.go` and `output_pulse.go`.
+
+The default Linux sink is now a pure-Go PulseAudio client
+(`github.com/jfreymuth/pulse`), so `CGO_ENABLED=0 go build ./...` is green on
+Linux for the **entire module**, not just `./gui/backend/...`. oto/ALSA remains
+available on Linux, opt-in via `-tags otoaudio`. Windows and macOS still use
+oto. beep decode/mix was already pure Go and did not change.
+
+## Why not WebGPU (2026-06 → 2026-07-31)
+
+Recorded here because it is the question this assessment supersedes.
+
+A WebGPU backend was explored on branch `webgpu-backend` (since deleted): 12
+WGSL shader pipelines, device init, and the render loop all worked. It was
+rejected at the time because WebGPU has no native text rendering — font
+measurement and glyph rasterization required Canvas2D, and a hybrid backend
+defeats the purpose. GPU acceleration also does not address this project's
+actual bottleneck, which is heap allocation rather than throughput.
+
+By 2026-07 both original blockers were gone: go-glyph gained a pure-Go text
+pipeline (`bitmap_puregoft.go` — go-text/typesetting harfbuzz shaping plus
+`golang.org/x/image/vector` rasterization, no CGo), and
+[goffi](https://github.com/go-webgpu/goffi) supplies zero-CGo FFI for calling
+wgpu-native. A CGo-free WebGPU desktop backend became technically viable.
+
+It remains the wrong instrument, for the reasons in §4: wgpu is a superset that
+ships 10–40 MB of runtime shared libraries, supplies none of `NativePlatform`
+(10 sub-interfaces), and leaves macOS — the only real CGo backend, 5.9k lines of
+ObjC — untouched. Phase 1 got CGo-free Linux and Windows for ~600 lines instead.
 
 ## Summary
 
@@ -45,7 +83,7 @@ shaders."
 Both of the issue's premises verify. Its scoping does not.
 
 Linux and Windows are already CGo-free apart from **one** dependency
-(`github.com/go-gl/gl`), whose surface area in this repo is 55 functions and 47
+(`github.com/go-gl/gl`), whose surface area in this repo is 55 functions and 45
 constants — and whose proc-address loader is already written in pure Go. The
 wgpu path is a superset of that work, does not address macOS (the only real CGo
 backend), and trades a build-time C toolchain for a runtime shared-library
@@ -60,9 +98,9 @@ The issue is correct on both counts.
 **Pure-Go text.** The go-glyph root package has zero `import "C"`.
 `bitmap_puregoft.go`, `context_puregoft.go`, `layout_ft.go`, and
 `grapheme_ft.go` all build under `//go:build linux || darwin || windows` with no
-cgo tag gate — the pure-Go path is the *default*, not an opt-in.
-`go-glyph/go.mod` requires only go-text/typesetting, x/image, uniseg, and x/text.
-CGo in go-glyph is confined to `backend/gpu/`, `backend/android/`,
+cgo tag gate — the pure-Go path is the _default_, not an opt-in.
+`go-glyph/go.mod` requires only go-text/typesetting, x/image, uniseg, and
+x/text. CGo in go-glyph is confined to `backend/gpu/`, `backend/android/`,
 `backend/ios/`, and examples.
 
 **Zero-CGo FFI.** goffi is real: 8 desktop targets, crosscall2 C-thread
@@ -72,12 +110,12 @@ callbacks, full struct ABI, 88–114 ns/call.
 
 `gui/backend/gl/` contains no `import "C"` in any file. It already uses:
 
-| Concern | Mechanism | File |
-|---|---|---|
-| X11 windowing / events | `github.com/jezek/xgb` (pure Go) | `platform_x11.go` |
-| EGL context creation    | `github.com/ebitengine/purego` | `egl_linux.go:65` |
-| Win32 / WGL             | `golang.org/x/sys` syscall     | `platform_win32.go`, `wgl_windows.go` |
-| GL dispatch             | **`github.com/go-gl/gl` (cgo)** | 8 files |
+| Concern                | Mechanism                        | File                                  |
+| ---------------------- | -------------------------------- | ------------------------------------- |
+| X11 windowing / events | `github.com/jezek/xgb` (pure Go) | `platform_x11.go`                     |
+| EGL context creation   | `github.com/ebitengine/purego`   | `egl_linux.go:65`                     |
+| Win32 / WGL            | `golang.org/x/sys` syscall       | `platform_win32.go`, `wgl_windows.go` |
+| GL dispatch            | **`github.com/go-gl/gl` (cgo)**  | 8 files                               |
 
 The last row is the only CGo dependency. Confirmed by build — both targets fail
 with exactly one error, and it is that import:
@@ -88,9 +126,9 @@ package .../gui/backend
     imports github.com/go-gl/gl/v3.3-core/gl: build constraints exclude all Go files
 ```
 
-Surface area to port: **55 distinct GL functions, 47 constants**. Crucially, the
-proc-address plumbing needed to bind them is already written and already pure
-Go — `platform_x11.go:287` calls `gl.InitWithProcAddrFunc(eglProc)`, where
+Surface area to port: **55 distinct GL functions, 45 constants**. Crucially, the
+proc-address plumbing needed to bind them is already written and already pure Go
+— `platform_x11.go:287` calls `gl.InitWithProcAddrFunc(eglProc)`, where
 `eglProc` comes from a purego-loaded `eglGetProcAddress`; `wgl_windows.go` has
 the Windows equivalent.
 
@@ -106,7 +144,7 @@ bindings. No shader rewrite, no wgpu, no GLFW, no windowing changes.
   `filedialog/dialog_darwin.go`, `printdialog/print_darwin.go`,
   `spellcheck/spellcheck_darwin.go`, `sysbeep/sysbeep_darwin.go`,
   `gui/locale_detect_darwin.go`.
-- The Linux/Windows counterparts of those services are *already* pure Go:
+- The Linux/Windows counterparts of those services are _already_ pure Go:
   `dialog_linux.go` (396 lines, portal/zenity), `dialog_windows.go` (369 lines,
   syscall), `spellcheck_linux.go` (244 lines), godbus for SNI and AT-SPI.
 
@@ -125,14 +163,15 @@ and beep, and the android/ios backends are themselves cgo (`import "C"` in
 
 **CGo-free is not dependency-free.** Today's Linux/Windows build bundles no
 native library — it dlopens the system's `libEGL`/`libGL`/`opengl32`. A
-wgpu-native + GLFW backend replaces a *build-time* C toolchain requirement with a
-*runtime* obligation to ship and load ~10–40 MB of platform-specific shared
+wgpu-native + GLFW backend replaces a _build-time_ C toolchain requirement with
+a _runtime_ obligation to ship and load ~10–40 MB of platform-specific shared
 objects. That is a net regression for distribution, not an improvement.
 
-**goffi is pre-1.0.** v0.6.0 is in progress; API stability is planned for v1.0.0.
-It also has a documented duplicate-`_cgo_init` symbol conflict with purego, which
-go-gui already depends on (`go.mod`: `github.com/ebitengine/purego v0.10.1`).
-Adopting goffi would force `-tags nofakecgo` on every downstream consumer.
+**goffi is pre-1.0.** v0.6.0 is in progress; API stability is planned for
+v1.0.0. It also has a documented duplicate-`_cgo_init` symbol conflict with
+purego, which go-gui already depends on (`go.mod`:
+`github.com/ebitengine/purego v0.10.1`). Adopting goffi would force
+`-tags nofakecgo` on every downstream consumer.
 
 **The cost is strictly larger.** 12 WGSL shaders, device/surface init, and
 windowing glue, on top of the same GL-dispatch problem — and macOS still
@@ -145,7 +184,7 @@ unsolved at the end of it.
 Replace `github.com/go-gl/gl/v3.3-core/gl` with an internal purego-backed GL
 binding.
 
-- New package `gui/backend/internal/glbind/`: 55 function pointers plus the 47
+- New package `gui/backend/internal/glbind/`: 55 function pointers plus the 45
   referenced constants, bound through the existing proc-address callbacks.
 - Reuse the `purego.Dlopen` / `purego.RegisterLibFunc` pattern already in
   `gui/backend/gl/egl_linux.go`, and the existing `eglProc` / WGL proc lookups.
@@ -154,8 +193,8 @@ binding.
   `pipeline.go`, `buffers.go`, `textures.go`, `text.go`, `platform_x11.go`,
   `platform_win32.go`). Import swap only — call sites keep their signatures.
 - Watch items:
-  - `gogl.Strs` returns a free func; reimplement as a null-terminated
-    byte-slice helper.
+  - `gogl.Strs` returns a free func; reimplement as a null-terminated byte-slice
+    helper.
   - `VertexAttribPointerWithOffset` — offset marshaling.
   - `GetShaderiv` / `GetShaderInfoLog` / `GetProgramiv` / `GetProgramInfoLog`
     out-params need explicit pointer marshaling under purego.
@@ -168,12 +207,13 @@ Evaluate `github.com/ebitengine/purego/objc` for hosting an `NSView` /
 class registration. Gate the decision on two questions:
 
 1. Does purego work under `CGO_ENABLED=0` on darwin/arm64 for the
-   *class-registration* path, not just plain function calls?
+   _class-registration_ path, not just plain function calls?
 2. Can the ObjC be ported service-by-service, or does the NSApplication/NSView
    delegate graph force an all-or-nothing rewrite?
 
-If either answer is bad, macOS stays cgo. That is an acceptable outcome: macOS is
-the one platform where a C toolchain (Xcode CLT) is universally present anyway.
+If either answer is bad, macOS stays cgo. That is an acceptable outcome: macOS
+is the one platform where a C toolchain (Xcode CLT) is universally present
+anyway.
 
 ### Out of scope
 
@@ -193,9 +233,12 @@ grep -rl 'import "C"' --include='*.go' gui/backend/gl/   # empty
 env CGO_ENABLED=0 GOOS=linux go build -tags gl ./gui/...
 env CGO_ENABLED=0 GOOS=windows go build ./gui/...
 
-# 3. GL surface area to port (55 functions, 47 constants)
-grep -rhoE '\b(gogl|gl)\.[A-Z][A-Za-z0-9_]*\(' gui/backend/gl/ --include='*.go' | sort -u | wc -l
-grep -rhoE '\b(gogl|gl)\.[A-Z][A-Z0-9_]+\b'    gui/backend/gl/ --include='*.go' | sort -u | wc -l
+# 3. GL surface area to port (55 functions, 45 constants)
+# Historical: run before Phase 1, when gui/backend/gl/ still imported go-gl.
+# The regex is go?gl\. — the original used \b(gogl|gl)\. and over-counted
+# constants as 47; see the correction under "Phase 1 outcome" above.
+grep -rhoE '\bgo?gl\.[A-Z][A-Za-z0-9_]*\(' gui/backend/gl/ --include='*.go' | sort -u | wc -l
+grep -rhoE '\bgo?gl\.[A-Z][A-Z0-9_]+\b'    gui/backend/gl/ --include='*.go' | sort -u | wc -l
 
 # 4. macOS native surface
 grep -rl 'import "C"' --include='*.go' gui/backend/metal/ | wc -l   # 9

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -55,11 +55,13 @@ type DebugCategory uint32
 
 const (
 	// DebugDuplicates reports two shapes sharing one ID.
-	debugDuplicates DebugCategory = 1 << iota
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugDuplicates DebugCategory = 1 << iota
 	// DebugMissingIDs reports a focusable, scrollable, or
 	// OnMouseLeave-bearing shape with no ID, whose behaviour silently
 	// does not work.
-	debugMissingIDs
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugMissingIDs
 	// DebugUnconsumed reports a callback that acted on an event without
 	// consuming it while an ancestor also received it.
 	// exportaudit:keep — const name collides with the debugUnconsumed helper
@@ -67,7 +69,8 @@ const (
 	// DebugListBoxNoHeight reports a scrollable listbox that resolved to
 	// height 0, which disables virtualization so every row builds each
 	// frame.
-	debugListBoxNoHeight
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugListBoxNoHeight
 
 	// DebugUnscopedIDs reports a focusable or scrollable shape whose ID
 	// resolves to itself — no ID-bearing ancestor above it — so its
@@ -76,16 +79,17 @@ const (
 	//
 	// Advisory, not a defect: a top-level widget legitimately has no
 	// scope, which is why this is the one category [Debug] does not turn
-	// on. Ask for it explicitly with
-	// [DebugCategories](DebugUnscopedIDs) when auditing a screen for
-	// reusability.
-	debugUnscopedIDs
+	// on. Ask for it explicitly by passing it to [DebugCategories] when
+	// auditing a screen for reusability.
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugUnscopedIDs
 
-	// DebugAll is every category [Debug] turns on. DebugUnscopedIDs is
+	// DebugAll is every category [Debug] turns on. [DebugUnscopedIDs] is
 	// deliberately absent: it reports a design property, not a bug, and
 	// would fire on most widgets in a small app.
-	debugAll = debugDuplicates | debugMissingIDs | DebugUnconsumed |
-		debugListBoxNoHeight
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
+		DebugListBoxNoHeight
 )
 
 func init() {
@@ -93,7 +97,7 @@ func init() {
 	// original focus-only spelling, still honoured so existing
 	// workflows keep working. Either enables every category.
 	if envTruthy("GOGUI_DEBUG") || envTruthy("GOGUI_FOCUS_DEBUG") {
-		debugMask.Store(uint32(debugAll))
+		debugMask.Store(uint32(DebugAll))
 		debugGen.Store(1)
 	}
 }
@@ -140,9 +144,9 @@ func envTruthy(name string) bool {
 // exportaudit:keep — collides with the internal debugMask state var
 func Debug(on bool) {
 	if on {
-		debugCategories(debugAll)
+		DebugCategories(DebugAll)
 	} else {
-		debugCategories(0)
+		DebugCategories(0)
 	}
 }
 
@@ -151,10 +155,12 @@ func Debug(on bool) {
 // deliberately lets events bubble can keep the identity audits without
 // the unconsumed-event noise.
 //
-// A zero mask is everything off; [DebugAll] is everything on. Turning a
-// category on after it was off clears that category's warn-once memory,
-// so a re-enabled category reports the frame in front of it.
-func debugCategories(mask DebugCategory) {
+// A zero mask is everything off; [DebugAll] is every category [Debug]
+// turns on, which excludes [DebugUnscopedIDs]. Turning a category on
+// after it was off clears that category's warn-once memory, so a
+// re-enabled category reports the frame in front of it.
+// exportaudit:keep — dev-diagnostic API for app authors
+func DebugCategories(mask DebugCategory) {
 	for {
 		cur := debugMask.Load()
 		next := uint32(mask)
@@ -173,7 +179,8 @@ func debugCategories(mask DebugCategory) {
 }
 
 // DebugEnabled reports whether any dev-mode category is on.
-func debugEnabled() bool { return debugMask.Load() != 0 }
+// exportaudit:keep — dev-diagnostic API for app authors
+func DebugEnabled() bool { return debugMask.Load() != 0 }
 
 // debugCheck identifies one class of finding. Warn-once state is
 // keyed by (check, subject), so a window reports each distinct defect
@@ -202,15 +209,15 @@ const (
 func checkCategory(check debugCheck) DebugCategory {
 	switch check {
 	case debugCheckDupID:
-		return debugDuplicates
+		return DebugDuplicates
 	case debugCheckFocusNoID, debugCheckScrollNoID, debugCheckMouseLeaveNoID:
-		return debugMissingIDs
+		return DebugMissingIDs
 	case debugCheckUnconsumed:
 		return DebugUnconsumed
 	case debugCheckListBoxNoHeight:
-		return debugListBoxNoHeight
+		return DebugListBoxNoHeight
 	case debugCheckUnscopedID:
-		return debugUnscopedIDs
+		return DebugUnscopedIDs
 	}
 	return 0
 }
@@ -245,8 +252,8 @@ type debugState struct {
 // Called from updateLayoutLocked after composeLayout, so it sees the
 // same tree the renderer does, including floating and overlay layers.
 func (w *Window) debugAudit(root *Layout) {
-	const walkCategories = debugDuplicates | debugMissingIDs |
-		debugUnscopedIDs
+	const walkCategories = DebugDuplicates | DebugMissingIDs |
+		DebugUnscopedIDs
 	if DebugCategory(debugMask.Load())&walkCategories == 0 {
 		return
 	}
@@ -357,7 +364,7 @@ func (w *Window) TestDuplicateIDs() []string {
 		return nil
 	}
 	var found []string
-	prevOn := debugEnabled()
+	prevOn := DebugEnabled()
 	// A fresh warn-once map: a sweep should report the window in front
 	// of it, not skip what an earlier sweep or a stray frame reported.
 	prevWarned := w.debug.warned

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -207,7 +207,7 @@ func (w *Window) TestUnconsumedEvents() []string {
 		return nil
 	}
 	var found []string
-	prevOn := debugEnabled()
+	prevOn := DebugEnabled()
 	// A fresh warn-once map: a sweep should report the window in front
 	// of it, not skip what an earlier sweep or a stray frame reported.
 	prevWarned := w.debug.warned

--- a/gui/debug_event_test.go
+++ b/gui/debug_event_test.go
@@ -102,7 +102,7 @@ func TestCollapseToggleResetsWarnOnce(t *testing.T) {
 		&eventHandlers{OnClick: func(EventCtx) {}},
 	)
 	buf := captureDebug(t)
-	debugCategories(DebugUnconsumed)
+	DebugCategories(DebugUnconsumed)
 	w := &Window{}
 
 	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, w)
@@ -111,9 +111,9 @@ func TestCollapseToggleResetsWarnOnce(t *testing.T) {
 		t.Fatalf("want a finding on the first dispatch, got %q", first)
 	}
 
-	debugCategories(0)
+	DebugCategories(0)
 	buf.Reset()
-	debugCategories(DebugUnconsumed)
+	DebugCategories(DebugUnconsumed)
 	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, w)
 	if n := strings.Count(buf.String(), "OnClick on"); n != 1 {
 		t.Fatalf("want the finding re-reported once, got %d occurrences (%q)",
@@ -143,14 +143,14 @@ func TestCollapseGatedByUnconsumedCategory(t *testing.T) {
 		&eventHandlers{OnClick: func(EventCtx) {}},
 	)
 	buf := captureDebug(t)
-	debugCategories(debugDuplicates)
+	DebugCategories(DebugDuplicates)
 	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, &Window{})
 	if got := buf.String(); got != "" {
 		t.Errorf("identity-only mask must be silent at dispatch, got %q", got)
 	}
 
 	buf.Reset()
-	debugCategories(DebugUnconsumed)
+	DebugCategories(DebugUnconsumed)
 	mouseDownHandler(root, false, &Event{MouseX: 5, MouseY: 5}, &Window{})
 	if !strings.Contains(buf.String(), `OnClick on "inner"`) {
 		t.Errorf("want a collapse finding under the unconsumed category, got %q", buf.String())

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -8,7 +8,7 @@ import (
 // captureDebug turns every category on, redirects findings to a buffer,
 // and restores both on cleanup. Returns the buffer.
 func captureDebug(t *testing.T) *strings.Builder {
-	return captureDebugMask(t, debugAll)
+	return captureDebugMask(t, DebugAll)
 }
 
 // captureDebugMask turns the given categories on, redirects findings to
@@ -19,10 +19,10 @@ func captureDebugMask(t *testing.T, mask DebugCategory) *strings.Builder {
 	prevOut := debugOut
 	prevMask := debugMask.Load()
 	debugOut = &buf
-	debugCategories(mask)
+	DebugCategories(mask)
 	t.Cleanup(func() {
 		debugOut = prevOut
-		debugCategories(DebugCategory(prevMask))
+		DebugCategories(DebugCategory(prevMask))
 	})
 	return &buf
 }
@@ -169,7 +169,7 @@ func TestDebugAuditNoopWhenOff(t *testing.T) {
 	if got := buf.String(); got != "" {
 		t.Fatalf("gate off must be silent, got %q", got)
 	}
-	if debugEnabled() {
+	if DebugEnabled() {
 		t.Fatal("DebugEnabled must report false")
 	}
 }
@@ -178,7 +178,7 @@ func TestDebugAuditNoopWhenOff(t *testing.T) {
 // noise and vice versa. Each category reports only its own findings.
 func TestDebugCategoriesGateIndependently(t *testing.T) {
 	buf := captureDebug(t)
-	debugCategories(debugDuplicates)
+	DebugCategories(DebugDuplicates)
 	w := &Window{}
 	tree := debugTree(&Shape{Focusable: true}, &Shape{ID: "dup"}, &Shape{ID: "dup"})
 
@@ -188,7 +188,7 @@ func TestDebugCategoriesGateIndependently(t *testing.T) {
 		t.Fatalf("want only the duplicate finding, got %q", got)
 	}
 
-	debugCategories(debugMissingIDs)
+	DebugCategories(DebugMissingIDs)
 	buf.Reset()
 	w.debugAudit(&tree)
 	got = buf.String()
@@ -202,7 +202,7 @@ func TestDebugCategoriesGateIndependently(t *testing.T) {
 // the whole gate.
 func TestDebugCategoriesToggleResetsWarnOnce(t *testing.T) {
 	buf := captureDebug(t)
-	debugCategories(debugMissingIDs)
+	DebugCategories(DebugMissingIDs)
 	w := &Window{}
 	tree := debugTree(&Shape{Focusable: true})
 
@@ -212,9 +212,9 @@ func TestDebugCategoriesToggleResetsWarnOnce(t *testing.T) {
 		t.Fatal("want a finding with the category on")
 	}
 
-	debugCategories(0)
+	DebugCategories(0)
 	buf.Reset()
-	debugCategories(debugMissingIDs)
+	DebugCategories(DebugMissingIDs)
 	w.debugAudit(&tree)
 	// Re-reported, not the stale silence: the finding appears exactly
 	// once again in a buffer that was empty before the re-enable.
@@ -228,7 +228,7 @@ func TestDebugCategoriesToggleResetsWarnOnce(t *testing.T) {
 // of dispatch-side categories must skip it entirely.
 func TestDebugCategoriesAuditSkippedWhenOnlyUnconsumed(t *testing.T) {
 	buf := captureDebug(t)
-	debugCategories(DebugUnconsumed)
+	DebugCategories(DebugUnconsumed)
 	w := &Window{}
 	tree := debugTree(&Shape{Focusable: true}, &Shape{ID: "dup"}, &Shape{ID: "dup"})
 
@@ -246,13 +246,13 @@ func TestCheckCategoryMapping(t *testing.T) {
 		check debugCheck
 		want  DebugCategory
 	}{
-		{debugCheckDupID, debugDuplicates},
-		{debugCheckFocusNoID, debugMissingIDs},
-		{debugCheckScrollNoID, debugMissingIDs},
-		{debugCheckMouseLeaveNoID, debugMissingIDs},
+		{debugCheckDupID, DebugDuplicates},
+		{debugCheckFocusNoID, DebugMissingIDs},
+		{debugCheckScrollNoID, DebugMissingIDs},
+		{debugCheckMouseLeaveNoID, DebugMissingIDs},
 		{debugCheckUnconsumed, DebugUnconsumed},
-		{debugCheckListBoxNoHeight, debugListBoxNoHeight},
-		{debugCheckUnscopedID, debugUnscopedIDs},
+		{debugCheckListBoxNoHeight, DebugListBoxNoHeight},
+		{debugCheckUnscopedID, DebugUnscopedIDs},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
@@ -262,10 +262,10 @@ func TestCheckCategoryMapping(t *testing.T) {
 	// DebugAll covers every category Debug(true) turns on.
 	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
 	// a design property, not a defect.
-	if debugAll != debugDuplicates|debugMissingIDs|DebugUnconsumed|debugListBoxNoHeight {
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight {
 		t.Fatal("DebugAll must cover every category Debug(true) enables")
 	}
-	if debugAll&debugUnscopedIDs != 0 {
+	if DebugAll&DebugUnscopedIDs != 0 {
 		t.Fatal("DebugUnscopedIDs must stay opt-in, outside DebugAll")
 	}
 }
@@ -525,14 +525,14 @@ func TestTestDuplicateIDsRestoresDebugState(t *testing.T) {
 	// inherit it, and must not drop it either.
 	sentinel := debugWarnKey{check: debugCheckDupID, subject: "sentinel"}
 	w.debug.warned = map[debugWarnKey]struct{}{sentinel: {}}
-	prevOn := debugEnabled()
+	prevOn := DebugEnabled()
 
 	if got := w.TestDuplicateIDs(); len(got) != 0 {
 		t.Fatalf("want no findings, got %q", got)
 	}
 
-	if debugEnabled() != prevOn {
-		t.Errorf("debug gate left at %v, want %v", debugEnabled(), prevOn)
+	if DebugEnabled() != prevOn {
+		t.Errorf("debug gate left at %v, want %v", DebugEnabled(), prevOn)
 	}
 	if _, ok := w.debug.warned[sentinel]; !ok {
 		t.Error("warn-once memory not restored")
@@ -546,7 +546,7 @@ func TestTestDuplicateIDsRestoresDebugState(t *testing.T) {
 // with no ID-bearing ancestor still owns a window-global name.
 func TestDebugUnscopedIDsReportsGlobalLeaf(t *testing.T) {
 	buf := captureDebug(t)
-	debugCategories(debugUnscopedIDs)
+	DebugCategories(DebugUnscopedIDs)
 	w := &Window{}
 	tree := debugTree(&Shape{ID: "save", Focusable: true})
 	resolveShapeIDs(&tree, w)

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -340,7 +340,7 @@ func listBoxVisibleRange(
 	} else {
 		virtualize = false
 		if cfg.Scrollable && cache.hSeen &&
-			len(cfg.Data) > 0 && debugEnabled() {
+			len(cfg.Data) > 0 && DebugEnabled() {
 			// The layout has run at least once and still gave the
 			// list no height, so every row builds each frame.
 			w.debugWarn(debugCheckListBoxNoHeight, cfg.ID,

--- a/gui/view_listbox_test.go
+++ b/gui/view_listbox_test.go
@@ -341,7 +341,7 @@ func TestListBoxCacheRefreshIgnoresNameValue(t *testing.T) {
 }
 
 func TestListBoxNoHeightWarning(t *testing.T) {
-	prevOn := debugEnabled()
+	prevOn := DebugEnabled()
 	Debug(true)
 	defer Debug(prevOn)
 
@@ -382,7 +382,7 @@ func TestListBoxNoHeightWarning(t *testing.T) {
 // silent at the site, and the category alone must fire.
 func TestListBoxNoHeightGatedByCategory(t *testing.T) {
 	prevMask := DebugCategory(debugMask.Load())
-	defer debugCategories(prevMask)
+	defer DebugCategories(prevMask)
 	w := newTestWindow()
 	cfg := ListBoxCfg{
 		ID:         "lb-cat",
@@ -391,7 +391,7 @@ func TestListBoxNoHeightGatedByCategory(t *testing.T) {
 	}
 	v := ListBox(cfg)
 
-	debugCategories(debugMissingIDs)
+	DebugCategories(DebugMissingIDs)
 	var found []string
 	w.debug.collect = &found
 	layout := generateViewLayout(v, w)
@@ -402,7 +402,7 @@ func TestListBoxNoHeightGatedByCategory(t *testing.T) {
 		t.Fatalf("missing-ID mask must not warn, got %v", found)
 	}
 
-	debugCategories(debugListBoxNoHeight)
+	DebugCategories(DebugListBoxNoHeight)
 	generateViewLayout(v, w)
 	if len(found) != 1 {
 		t.Fatalf("listbox category must warn, got %d findings: %v", len(found), found)


### PR DESCRIPTION
Exports the dev-mode diagnostics as a public API:

- `DebugDuplicates`, `DebugMissingIDs`, `DebugListBoxNoHeight`, `DebugUnscopedIDs` category constants
- `DebugAll` mask
- `DebugCategories(mask)` setter (was `debugCategories`)
- `DebugEnabled()` query (was `debugEnabled`)

Renames internal helpers and updates call sites (`view_listbox.go`, `debug_event.go`, tests). Docs (`CLAUDE.md`, `docs/specs/cgo-free-backend-feasibility.md`) updated to the public spelling. All exports carry `exportaudit:keep` markers (dev-diagnostic API for app authors).