### PR TITLE
ci: gate ergoaudit (ids mode) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,13 @@ jobs:
       - name: Required-ID check
         run: go run ./tools/requiredid/cmd/requiredid ./...
 
+      # Gates on hand-rolled `:` composition of widget IDs, which is how
+      # scoping drifts between a producer and its lookup site. Only mode
+      # ids is pass/fail (focus/callbacks are advisory inventories), so
+      # unlike `make ergo-audit` the step runs ids alone.
+      - name: Ergo-audit IDs
+        run: go run ./tools/ergoaudit/ -mode ids .
+
   check:
     name: Check (gate)
     needs: [test, vet]


### PR DESCRIPTION
Fixes #239

Adds an `Ergo-audit IDs` step to the `vet` job, mirroring the sibling `Required-ID check` gate above it. It runs `go run ./tools/ergoaudit/ -mode ids .` — the only pass/fail mode.

`focus` and `callbacks` stay advisory: they always exit 0, so wiring them in would add a step that can never fail. `make ergo-audit` locally still runs all three modes.

The tree is currently clean (0 findings), so the gate lands green; it reds on the first hand-rolled `:` composition.

Verified locally: `-mode ids` exits 0, YAML parses.