### PR TITLE
docs: one-page DX cheat sheet for the implicit contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ A `FillFill` root fills the window (min=max seed in `updateLayout`).
 ### Widgets
 
 All widgets take `*Cfg` struct (zero-initializable). Event callbacks share sig
-`func(EventCtx)`.
+`func(EventCtx)`. Worked examples and failure modes for every rule below:
+`docs/dx-cheat-sheet.md`.
 
 Focus requires **both** `Focusable` **and** a non-empty `ID` (`isFocusedTarget`,
 `gui/event_traversal.go`); tab order additionally needs
@@ -63,18 +64,14 @@ silent no-op — the widget renders and clicks but never joins the tab order. Th
 `FocusDisabled`, never with `Focusable: false`.** Fifteen Cfgs default on:
 `Button`, `ColorPicker`, `Combobox`, `DatePicker`, `Input`, `InputDate`,
 `ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`, `Slider`,
-`Switch`, `Toggle`, `Tree`. Setting `Focusable: true` on these is redundant. The
-ID requirement is unchanged — a default-on control still needs an `ID` to reach
-the tab order, which is what `requiredid` enforces. Everything else is opt-in
-via `Focusable: true`. See `docs/specs/focusable-default-input.md`; run
-`ergonomics-audit -mode focus` for the current inventory.
+`Switch`, `Toggle`, `Tree`. Everything else is opt-in via `Focusable: true`.
+See `docs/specs/focusable-default-input.md`; run `ergonomics-audit -mode focus`
+for the current inventory.
 
 **`Shape.ID` is a leaf; identity is the effective ID.** `resolveShapeIDs`
-(`gui/id_resolve.go`, run from `layoutArrange` before the layout passes) stamps
-`Shape.effID` = the leaf joined to the IDs of its **ID-bearing ancestors**, and
-every ID-keyed store and lookup uses that — read `shape.idKey()`, never
-`shape.ID`, at a keying site. So `Input{ID:"name"}` under `Panel{ID:"settings"}`
-is `settings:name`, and the same leaf under `profile` is a different widget.
+(`gui/id_resolve.go`, run from `layoutArrange`) stamps `Shape.effID` = the leaf
+joined to the IDs of its **ID-bearing ancestors**, and every ID-keyed store and
+lookup uses that — read `shape.idKey()`, never `shape.ID`, at a keying site.
 Only explicit IDs join (never position, never child index); an ID-less container
 adds no scope, and its children collide as loudly as before. A leaf already
 containing `:` is **absolute** and is not joined again. Effective IDs must be
@@ -93,12 +90,11 @@ are absolute by design (reverse-parsed) and stay window-global. See
 is a `:`-joined path (`grid:header:name:resize`); the owner may itself be
 composed, and composition is associative. `ScopeIDN` appends a numeric segment
 without allocating for the number — use it for loop-derived identity. Both cost
-exactly one allocation; `gui/id_scope_test.go` asserts that. There is no
-escaping, so a **part** (a row key, a heading slug — a leaf value fed _into_ a
-composition) must not contain `:` and keeps its own spelling. Consumers matter
-as much as producers: rebuilding an ID at a lookup site is how the two drift.
-`make ergonomics-audit` (mode `ids`) fails on any hand-rolled composition; see
-`docs/specs/widget-id-scoping.md`.
+exactly one allocation; `gui/id_scope_test.go` asserts that. A **part** (a row
+key, a heading slug — a leaf value fed _into_ a composition) must not contain
+`:` and keeps its own spelling; rebuilding an ID at a lookup site is how
+producers and consumers drift. `make ergonomics-audit` (mode `ids`) fails on
+any hand-rolled composition; see `docs/specs/widget-id-scoping.md`.
 
 Uniqueness is strict, including within one widget: a composite widget's inner
 shape that needs the owning widget's focus or spell-check state sets
@@ -111,21 +107,16 @@ asserts a rendered window is clean.
 **Rule: types the repo owns self-flag; only primitives get `Opt`.**
 `Opt[T]` is for when the zero value is a legitimate user choice that must be
 distinguishable from "unset" — and only when the type cannot carry that
-distinction itself.
-
-`SizeBorder` is the worked example: a border width of `0` is something a caller
-means, so a plain `float32` cannot tell "no border" from "not specified" and
-silently applies the theme default. The same holds for `Radius`, `Spacing`,
-`Opacity`, and enum fields whose zero is a real member (`HAlignLeft == 0`).
-Where zero is not meaningful — most widths, heights, counts, and indices —
-`Opt` costs a wrapper call and buys nothing.
+distinction itself. `SizeBorder` is the canonical case: `0` is a border width a
+caller means, so a plain `float32` cannot tell "no border" from "not
+specified". Where zero is not meaningful — most widths, heights, counts, and
+indices — `Opt` costs a wrapper call and buys nothing.
 
 Owned struct types self-flag instead of wrapping: `Color` (`gui/color.go`) and
 `Padding` (`gui/padding.go`) carry a `set` field, so they are plain fields with
 `IsSet()`/`Or()` rather than `Opt[T]`. Build `Padding` values with
-`NewPadding`/`PadAll`/`PaddingNone` — a raw `Padding{...}` literal reads as
-unset and silently takes the theme default (ergoaudit mode `literals` gates
-this).
+`NewPadding`/`PadAll`/`PaddingNone`; a raw `Padding{...}` literal reads as
+unset (ergoaudit mode `literals` gates this).
 
 Decide this when authoring the field, not by copying whichever neighbor was
 nearest.
@@ -134,11 +125,10 @@ nearest.
 
 Use plain `Color`, never `Opt[Color]`. `Color` carries its own `set` flag
 (`gui/color.go`), so `Color{}` is unset and `ColorTransparent` is an explicit
-fully-transparent choice — the distinction `Opt` would add already exists, and
-wrapping gives the field two independent notions of unset. Build colors with
-`RGBA`/`RGB`/`Hex` — a raw `Color{...}` literal reads as unset and silently
-takes the theme default (ergoaudit mode `literals` gates this; the empty
-`Color{}` sentinel is exempt).
+fully-transparent choice — wrapping would give the field two notions of unset.
+Build colors with `RGBA`/`RGB`/`Hex`; a raw `Color{...}` literal reads as
+unset (ergoaudit mode `literals` gates this; the empty `Color{}` sentinel is
+exempt).
 
 `ColorSet` (`gui/color_set.go`) groups the per-state colors; `Flat(c)` is the
 "keep one appearance" case. **Precedence: an assigned flat `Color*` field wins

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -1,0 +1,111 @@
+# Developer Experience cheat sheet
+
+go-gui is one of the easiest GUI toolkits to use. A widget is a struct plus a
+callback, and most code works the first time. This page lists the few places
+where the obvious reading is misleading. Each one is subtle: the code compiles,
+the app runs, and one behavior is off. The linked specs explain the reasons, and
+the tooling at the bottom finds most of them in your app.
+
+## Focus
+
+A shape is a focus target when it has `Focusable: true` and an `ID`. Tab order
+also needs `!FocusSkip` and `!Disabled`.
+
+```go
+// No ID: renders and clicks, but never joins the tab order.
+Button{Label: "Save", OnClick: save}
+
+// Inputs are focusable by default. FocusDisabled opts out.
+Input{ID: "name", FocusDisabled: true} // not in the tab order
+```
+
+Most input controls are focusable by default: `Button`, `ColorPicker`,
+`Combobox`, `DatePicker`, `Input`, `InputDate`, `ListBox`, `NumericInput`,
+`RadioButtonGroup`, `Radio`, `Select`, `Slider`, `Switch`, `Toggle`, `Tree`.
+Everything else opts in with `Focusable: true`. If a control never answers the
+keyboard, the usual cause is a missing `ID`. The `requiredid` analyzer and the
+`DebugMissingIDs` gate report it. See `docs/specs/focusable-default-input.md`.
+
+## ID scoping
+
+`Shape.ID` is a leaf. The real identity is the effective ID: the leaf joined
+with `:` to the IDs of its ID-bearing ancestors. An ID-less container adds no
+scope. A leaf that already contains `:` is absolute. Effective IDs are unique
+per window.
+
+```go
+// Under Panel{ID:"settings"} this is "settings:name".
+// Under Panel{ID:"profile"} it is "profile:name".
+Input{ID: "name", ...}
+```
+
+Two panels can contain the same leaf ID. Each is a different widget. Compose
+IDs with `ScopeID` or `ScopeIDN`, never by hand. Public APIs — `SetFocus`,
+`FindByID`, `IsFocus`, `ScrollVerticalTo`, `Test*` — take the effective ID.
+
+A part (a row key, a heading slug) must not contain `:`. A composite widget's
+inner shape sets `Shape.focusOwner` to the owner's leaf instead of repeating
+its `ID`. Duplicates are loud: `gui.Debug` reports them, and
+`(*Window).TestDuplicateIDs` asserts a clean window. See
+`docs/specs/widget-id-scoping.md` and
+`docs/specs/widget-id-per-scope-uniqueness.md`.
+
+## `Opt[T]` vs plain fields
+
+`Opt[T]` distinguishes "zero" from "not set". Use it for primitives where
+zero is a real choice:
+
+- Zero is a real choice (a border width of 0): `Opt[float32]`.
+- Zero is not meaningful (widths, heights, counts): plain field.
+- The type knows whether it was set (`Color`, `Padding`): plain field.
+
+`SizeBorder` is the example: `0` means "no border", so a plain `float32`
+cannot tell that from "not specified". `Color` and `Padding` carry their own
+set flag and stay plain.
+
+## Colors
+
+Use plain `Color`, never `Opt[Color]`. Build values with `RGBA`, `RGB`, or
+`Hex`. `Color{}` is unset, and `ColorTransparent` is explicitly transparent.
+A `ColorSet` groups the per-state colors, and an assigned flat `Color` field
+wins over it.
+
+## `AmendLayout` and floats
+
+`AmendLayout` runs after sizing with absolute coordinates. Moving a parent
+there does not move its children. To move an element with its children, use
+the float fields: `FloatAnchor`, `FloatTieOff`, `FloatOffsetX`,
+`FloatOffsetY`.
+
+## Group-box titles
+
+`ContainerCfg.Title` draws a label in the top border, like an HTML fieldset.
+Set `TitleBG` to the parent's background color, so the border line disappears
+behind the label.
+
+```go
+// The label sits on a patch of the mismatched color.
+Column{Title: "Account", TitleBG: RGB(255, 255, 255), ...}
+```
+
+## The one-event rule
+
+Nothing is marked handled for you. A callback that acts on an event calls
+`ctx.Consume()`. One that declines lets the event travel on. `ctx.Event` is
+nil in `AmendLayout` and `OnScroll`, and both `EventCtx` methods are nil-safe.
+See `docs/specs/eventctx-callback-refactor.md`.
+
+## Find it early
+
+`gui.Debug(true)`, or `GOGUI_DEBUG=1`, checks the layout every frame. It
+reports duplicate IDs, focusable shapes without IDs, and handlers that act
+without consuming. Findings print once per window. In tests, use
+`(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.
+
+`DebugUnscopedIDs` is separate and opt-in: it is not part of `DebugAll`. It
+reports an ID with no ID-bearing ancestor — the widget cannot move into a
+second panel as it stands. Ask for it when you plan to reuse a screen:
+
+```go
+gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
+```


### PR DESCRIPTION
Closes #242.

Adds `docs/dx-cheat-sheet.md` — worked examples and failure modes for the
implicit contracts that are silent when broken:

- **Focus** — `Focusable` + non-empty `ID`, tab order needs `!FocusSkip && !Disabled`
- **ID scoping** — effective IDs, `: `-joined ancestors, `ScopeID`/`ScopeIDN`, parts vs scopes
- **`Opt[T]` vs plain** — the zero-value decision tree, `SizeBorder` canonical
- **Colors** — plain `Color`, never `Opt[Color]`; `ColorSet` precedence
- **`AmendLayout` vs floats** — absolute coords, children do not move with parent
- **`TitleBG`** — must match the parent background
- **The one-event rule** — `ctx.Consume()`, nothing pre-marked
- **Find it early** — debug gate, `TestDuplicateIDs`, `TestUnconsumedEvents`,
  the `DebugUnscopedIDs` opt-in trap

CLAUDE.md Widgets section shrinks 237 → 87 lines: rules stay, worked
examples move to the sheet, which CLAUDE.md links to.

Per the scoping comment on #242: the sheet is new prose, not a copy —
CLAUDE.md keeps the terse normative rules, the sheet holds the broken-code
examples and detection; dev-mode diagnostics are pointed at, not re-listed.
All claims verified against source (isFocusedTarget, resolveLeaf,
addGroupBoxTitle, debug.go gating).