### PR TITLE
feat(dev-loop): rebuild-and-relaunch wrapper (issue #218)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@ go test ./... && go vet ./... && golangci-lint run ./...
 go run ./tools/requiredid/cmd/requiredid ./...
 ```
 
+For a tight edit → rebuild → relaunch loop while iterating on an example app,
+see [docs/dev-loop.md](docs/dev-loop.md)
+(`./scripts/dev-loop.sh ./examples/get_started/`).
+
 `go vet` does not run the `requiredid` analyzer — it is a standalone
 framework-owned analyzer. CI runs it on every push, and `make vet` includes it.
 Adopter projects can invoke it the same way, standalone, without the Makefile:

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -1,0 +1,46 @@
+# Dev loop: rebuild-and-relaunch
+
+`scripts/dev-loop.sh` runs a Go GUI app and relaunches it whenever the module
+changes, so the edit → recompile → relaunch cycle is one save away.
+
+This is a convenience wrapper, not in-process reload: rebuilding and
+relaunching is the honest approach for a native Go GUI, and recompiling the
+app package covers its whole dependency tree (including `gui/`).
+
+## Usage
+
+```bash
+./scripts/dev-loop.sh <app path> [args...]
+```
+
+- `<app path>` is a Go package, e.g. `./examples/get_started/`.
+- Extra args are preserved and passed to every relaunched instance.
+
+The script is bash, but you can call it directly from Fish or any other shell:
+
+```fish
+./scripts/dev-loop.sh ./examples/get_started/
+```
+
+## Behavior
+
+1. **Initial build.** The app is built into `build/dev-loop/` (gitignored) and
+   launched. If the initial build fails, the script prints the error and
+   exits — there is no previous binary to keep running.
+2. **Watch.** Every 0.5 s (override with `DEV_LOOP_POLL_SECONDS`) the module
+   is scanned for changes to `*.go`, `go.mod`, or `go.sum` files. `build/`,
+   `.git/`, docs, and scripts are ignored.
+3. **On save.** The app is rebuilt. Success: the old process is killed and the
+   new binary launched with the original args. Failure: the error is printed,
+   the watcher keeps running, and the last good binary keeps running; the next
+   save retries the build.
+4. **Ctrl-C** kills the running app and removes the temp artifacts.
+
+## Limits
+
+- Changes are picked up only when the binary relaunches; there is no
+  in-process reload. State in the app (windows, focused widgets, running
+  goroutines) is lost on each relaunch.
+- Only Go source and module files trigger a rebuild. Assets read at runtime
+  (SVGs, images, fonts) are not watched — relaunch after replacing those, or
+  run the app with a manual asset reload.

--- a/scripts/dev-loop.sh
+++ b/scripts/dev-loop.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Dev loop: rebuild and relaunch a Go app whenever the module changes.
+#
+# Usage: scripts/dev-loop.sh <app path> [args...]
+#
+# - The app path is a Go package, e.g. ./examples/get_started/.
+# - Extra args are preserved and passed to every relaunched instance.
+# - On save: the app is rebuilt (app package + its dependency tree, which
+#   covers gui/), the old process is killed, and the new binary is launched.
+# - A failed build prints an error and keeps watching; the last good binary
+#   keeps running, and the next save retries the build.
+#
+# Bash script, but callable directly from Fish or any other shell:
+#   ./scripts/dev-loop.sh ./examples/get_started/
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Poll interval in seconds. A save landing between polls is picked up on the
+# next tick; rebuilding takes much longer than 0.5s, so edits coalesce.
+POLL_SECONDS="${DEV_LOOP_POLL_SECONDS:-0.5}"
+
+if [ "$#" -lt 1 ]; then
+	echo "usage: dev-loop.sh <app path> [args...]" >&2
+	exit 1
+fi
+
+APP="$1"
+shift
+APP_ARGS=("$@")
+
+# build/ is gitignored, so the binary and stamp never dirty the tree.
+WORKDIR="$ROOT/build/dev-loop"
+BIN="$WORKDIR/$(basename "$APP")"
+STAMP="$WORKDIR/.stamp"
+
+APP_PID=""
+
+cleanup() {
+	# Kill the running app, if any, and remove our artifacts.
+	if [ -n "$APP_PID" ]; then
+		kill "$APP_PID" 2>/dev/null || true
+		wait "$APP_PID" 2>/dev/null || true
+	fi
+	rm -rf "$WORKDIR"
+}
+
+# Exit on SIGINT/SIGTERM so the EXIT trap below always runs; a plain fatal
+# signal would leave the app orphaned. Ctrl-C (SIGINT) is the normal way out.
+trap 'exit 0' INT
+trap 'exit 1' TERM
+trap cleanup EXIT
+
+# Rebuild into a fresh temp file (never clobber the running binary), then
+# swap it in. Returns non-zero on build failure without touching anything.
+build_app() {
+	local tmpbin
+	tmpbin="$(mktemp "$WORKDIR/bin.XXXXXX")"
+	if ! go build -o "$tmpbin" "$APP"; then
+		rm -f "$tmpbin"
+		return 1
+	fi
+	mv "$tmpbin" "$BIN"
+	return 0
+}
+
+relaunch() {
+	# Kill the previous instance before starting the new one, so at most one
+	# app is alive at a time.
+	if [ -n "$APP_PID" ]; then
+		kill "$APP_PID" 2>/dev/null || true
+		wait "$APP_PID" 2>/dev/null || true
+	fi
+	"$BIN" "${APP_ARGS[@]}" &
+	APP_PID=$!
+	echo "relaunched $(basename "$BIN") (pid $APP_PID)"
+}
+
+# Files that trigger a rebuild: Go source plus the module files, which pin
+# dependency versions. Everything else (docs, scripts, .go files under build/
+# or .git) is ignored.
+changed_since_stamp() {
+	find . \
+		-path ./build -prune -o \
+		-path ./.git -prune -o \
+		\( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) \
+		-newer "$STAMP" -print -quit
+}
+
+mkdir -p "$WORKDIR"
+
+# Initial build: fail loudly and exit, since there is no previous binary to
+# keep running.
+if ! build_app; then
+	echo "initial build failed; nothing to run" >&2
+	exit 1
+fi
+touch "$STAMP"
+relaunch
+
+while true; do
+	sleep "$POLL_SECONDS"
+	if ! changed_since_stamp | grep -q .; then
+		continue
+	fi
+
+	echo "change detected; rebuilding..."
+	if ! build_app; then
+		# Keep watching: touching the stamp stops the failed build from
+		# retriggering itself every poll. The running app is untouched, and
+		# the next save attempts a fresh build.
+		echo "build failed; keeping previous binary and watching for changes" >&2
+		touch "$STAMP"
+		continue
+	fi
+	touch "$STAMP"
+	relaunch
+done


### PR DESCRIPTION
Closes #218

Framework-side DX is strong, but the edit → recompile → relaunch loop is
manual. Adds `scripts/dev-loop.sh` — a convenience wrapper, not in-process
reload (recompiling and relaunching is the honest approach for a native
Go GUI).

- `./scripts/dev-loop.sh <app path> [args...]` builds into gitignored
  `build/dev-loop/`, polls for `*.go`/`go.mod`/`go.sum` changes, kills the
  old process and relaunches with preserved args.
- Build failures print loudly and keep watching; the last good binary
  keeps running, next save retries.
- INT/TERM/EXIT traps kill the app and remove artifacts.
- Documented in `docs/dev-loop.md`, linked from CONTRIBUTING.md.

Verified live: rebuild+relaunch on save, loud failure without watcher
death, recovery on fix, Ctrl-C cleanup.