### PR TITLE
feat(text): plumb grid cell size + box-glyph opt-out through gui.TextStyle (issue #251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,39 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **`TextStyle.CellWidth`, `TextStyle.CellHeight` and
+  `TextStyle.NoBuiltinBoxGlyphs` (#251).** go-glyph draws box-drawing
+  (U+2500–257F) and block-element (U+2580–259F) characters procedurally at cell
+  size instead of through the font. Without a cell it derives one from the glyph
+  advance and the run's ascent+descent, which fixes the stroke weight and the
+  sub-pixel phase but leaves a sub-pixel overlap wherever the advance is
+  fractional. Grid callers (terminals) build a `gui.TextStyle`, never a
+  `glyph.TextStyle`, so they had no way to pass their real cell: setting
+  `CellWidth`/`CellHeight` is what makes neighbouring cells abut exactly.
+  `NoBuiltinBoxGlyphs` keeps the font's own glyphs instead. All three map
+  through both converters — the rich-text path (`toGlyphStyle`) and the
+  plain-text measure/render path (`glyphconv.GuiStyleToGlyphConfig`), which is
+  what `TermGrid` renders through. Zero/false keep today's behaviour.
+
 ## [v0.57.0] - 2026-08-10
 
 ### Changed
 
-- **`Padding` self-flags; `Opt[Padding]` and `SomeP` removed (breaking,
-  #243).** `Padding` carries a `set` flag like `Color`: the zero value is
-  "unset" (theme default applies), `PaddingNone` is an explicitly-set zero,
-  and values are built with `NewPadding` / `PadAll` / `PaddingNone`.
-  `IsSet()` and `Or(def)` replace `Opt[Padding]`'s `IsSet()`/`Get(def)` on
-  the 50 affected Cfg fields; read sites moved from `.Get(Padding{})` to
-  `.Or(PaddingNone)`. Raw `Padding{...}` or `Color{...}` literals read as
-  unset, so `make ergonomics-audit` now also runs the new `-mode literals`
-  gate over the whole tree (defining files and the empty `Color{}` sentinel
-  exempt); `-mode opt` exempts Padding-typed fields like it exempts Color.
-  `ThemeMaker` stamps the flag on its `cfg.Padding*` copies so a resolved
-  theme value never reads as unset. Breaking for consumers of `SomeP` and
-  `Opt[Padding]`: go-charts, go-edit, go-kite, go-map and go-term bump
-  together.
+- **`Padding` self-flags; `Opt[Padding]` and `SomeP` removed (breaking, #243).**
+  `Padding` carries a `set` flag like `Color`: the zero value is "unset" (theme
+  default applies), `PaddingNone` is an explicitly-set zero, and values are
+  built with `NewPadding` / `PadAll` / `PaddingNone`. `IsSet()` and `Or(def)`
+  replace `Opt[Padding]`'s `IsSet()`/`Get(def)` on the 50 affected Cfg fields;
+  read sites moved from `.Get(Padding{})` to `.Or(PaddingNone)`. Raw
+  `Padding{...}` or `Color{...}` literals read as unset, so
+  `make ergonomics-audit` now also runs the new `-mode literals` gate over the
+  whole tree (defining files and the empty `Color{}` sentinel exempt);
+  `-mode opt` exempts Padding-typed fields like it exempts Color. `ThemeMaker`
+  stamps the flag on its `cfg.Padding*` copies so a resolved theme value never
+  reads as unset. Breaking for consumers of `SomeP` and `Opt[Padding]`:
+  go-charts, go-edit, go-kite, go-map and go-term bump together.
 
 - **Exported API surface reduced (~1,400 symbols) as the v1.0 freeze
   (breaking).** `tools/exportaudit` classifies every export in `gui/` by who
@@ -42,40 +57,40 @@ and this project adheres to
 
 ### Fixed
 
-- **Windows: window and tray icons now render (#235).** `hicon.FromPNG`
-  passed a NULL `hbmMask` to `CreateIconIndirect`, which Win32 requires —
-  the call always failed, so the title bar, taskbar, alt-tab, and SNI tray
-  icons fell back to the shell's generic icon whether or not the app set
-  `WindowCfg.IconPNG`. The function now creates a zeroed 1bpp mask (fully
-  opaque), letting the 32bpp color bitmap's alpha shape the icon, so Windows
-  honors `IconPNG` like the other platforms.
+- **Windows: window and tray icons now render (#235).** `hicon.FromPNG` passed a
+  NULL `hbmMask` to `CreateIconIndirect`, which Win32 requires — the call always
+  failed, so the title bar, taskbar, alt-tab, and SNI tray icons fell back to
+  the shell's generic icon whether or not the app set `WindowCfg.IconPNG`. The
+  function now creates a zeroed 1bpp mask (fully opaque), letting the 32bpp
+  color bitmap's alpha shape the icon, so Windows honors `IconPNG` like the
+  other platforms.
 
 - **Windows: a revoked mouse capture no longer leaves a drag stuck (#110).**
   Win32 can take capture away without ever sending the matching button-up — a
   system modal or UAC prompt, Ctrl+Alt+Del, Win+L, another process calling
   `SetCapture`, a debugger breaking in. `WM_CAPTURECHANGED` was unhandled, so
-  the `MouseLock` never cleared and every later mouse move kept driving the
-  drag with no button held (text selection tracking the cursor, a splitter or
-  slider still following it). The message now cancels the drag. Our own
+  the `MouseLock` never cleared and every later mouse move kept driving the drag
+  with no button held (text selection tracking the cursor, a splitter or slider
+  still following it). The message now cancels the drag. Our own
   `ReleaseCapture` raises the same message, so the backend tracks capture
   ownership and only cancels on an involuntary loss.
 
 ### Added
 
 - **`MouseLockCfg.Cancel`** — a `func(*Window)` hook that unwinds a drag ending
-  without a release. `MouseUp` cannot serve: it *commits*, so synthesising one
+  without a release. `MouseUp` cannot serve: it _commits_, so synthesising one
   on capture loss would dock a panel or reorder a list the user never dropped.
-  `(*Window).MouseCancel` unlocks and runs the hook; widgets whose state is
-  just the lock need no hook. Wired for text/RTF/input selection (stops the
+  `(*Window).MouseCancel` unlocks and runs the hook; widgets whose state is just
+  the lock need no hook. Wired for text/RTF/input selection (stops the
   edge-scroll animation), sliders, the color picker, datagrid column resize,
   dock drags, and drag-reorder.
 
-- **`make export-audit` now actually fails the build when the gate trips.**
-  The authoritative consumer scan previously ran under `|| true`, so a real
-  gate failure (offenders found with siblings present) exited zero. It now
-  only tolerates missing sibling repos; CI shallow-clones the five consumers
-  into `../` and runs the authoritative scan, so the freeze is enforced on
-  every PR. See `docs/specs/exportaudit-surface-policy.md` for the accepted
+- **`make export-audit` now actually fails the build when the gate trips.** The
+  authoritative consumer scan previously ran under `|| true`, so a real gate
+  failure (offenders found with siblings present) exited zero. It now only
+  tolerates missing sibling repos; CI shallow-clones the five consumers into
+  `../` and runs the authoritative scan, so the freeze is enforced on every PR.
+  See `docs/specs/exportaudit-surface-policy.md` for the accepted
   `internal`-class policy.
 
 ## [v0.56.0] - 2026-08-09

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Go toolchain pin: `go 1.26.0`.
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends. |
-| `github.com/go-gui-org/go-glyph` | v1.19.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.20.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio decode + mixing (sound effects, music, mixer, fade) for `gui/audio`. |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/ebitengine/purego v0.10.1
-	github.com/go-gui-org/go-glyph v1.19.0
+	github.com/go-gui-org/go-glyph v1.20.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/ebitengine/oto/v3 v3.3.2 h1:VTWBsKX9eb+dXzaF4jEwQbs4yWIdXukJ0K40KgkpY
 github.com/ebitengine/oto/v3 v3.3.2/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/go-gui-org/go-glyph v1.19.0 h1:9QnmsFZ4+c4WckJbJH4e7i1x2HKV1BlKBqMz8RvOUgI=
-github.com/go-gui-org/go-glyph v1.19.0/go.mod h1:1Nta2shuXtETUdEXJJn0oFRisUXPxi1ToSVb0Sfi7kU=
+github.com/go-gui-org/go-glyph v1.20.0 h1:vREaWXi9J/WxvQQsXHgN7ITBTUvAtPgr9Xol/fwkR/E=
+github.com/go-gui-org/go-glyph v1.20.0/go.mod h1:1Nta2shuXtETUdEXJJn0oFRisUXPxi1ToSVb0Sfi7kU=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=

--- a/gui/backend/internal/glyphconv/conv.go
+++ b/gui/backend/internal/glyphconv/conv.go
@@ -27,9 +27,14 @@ func GuiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {
 			Strikethrough: s.Strikethrough,
 			LetterSpacing: s.LetterSpacing,
 			EmojiBoxWidth: s.EmojiBoxWidth,
-			StrokeWidth:   s.StrokeWidth,
-			StrokeColor:   glyph.Color{R: s.StrokeColor.R, G: s.StrokeColor.G, B: s.StrokeColor.B, A: s.StrokeColor.A},
-			Features:      s.Features,
+			// Grid cell size + box-glyph opt-out: rasterization inputs the plain
+			// text path must carry too, not just the rich-text path.
+			CellWidth:          s.CellWidth,
+			CellHeight:         s.CellHeight,
+			NoBuiltinBoxGlyphs: s.NoBuiltinBoxGlyphs,
+			StrokeWidth:        s.StrokeWidth,
+			StrokeColor:        glyph.Color{R: s.StrokeColor.R, G: s.StrokeColor.G, B: s.StrokeColor.B, A: s.StrokeColor.A},
+			Features:           s.Features,
 		},
 		Block: glyph.BlockStyle{
 			Align:       align,

--- a/gui/backend/internal/glyphconv/conv_test.go
+++ b/gui/backend/internal/glyphconv/conv_test.go
@@ -101,6 +101,33 @@ func TestGuiStyleToGlyphConfigFieldMapping(t *testing.T) {
 	}
 }
 
+// The plain-text path is the one a terminal grid actually renders through, so
+// the cell size and box-glyph opt-out must survive this conversion too.
+func TestGuiStyleToGlyphConfigGridGeometry(t *testing.T) {
+	t.Parallel()
+	s := gui.TextStyle{
+		Family:             "Mono",
+		Size:               14,
+		EmojiBoxWidth:      19,
+		CellWidth:          9.5,
+		CellHeight:         20,
+		NoBuiltinBoxGlyphs: true,
+	}
+	gc := GuiStyleToGlyphConfig(s)
+	if gc.Style.EmojiBoxWidth != 19 {
+		t.Errorf("EmojiBoxWidth: got %v, want 19", gc.Style.EmojiBoxWidth)
+	}
+	if gc.Style.CellWidth != 9.5 {
+		t.Errorf("CellWidth: got %v, want 9.5", gc.Style.CellWidth)
+	}
+	if gc.Style.CellHeight != 20 {
+		t.Errorf("CellHeight: got %v, want 20", gc.Style.CellHeight)
+	}
+	if !gc.Style.NoBuiltinBoxGlyphs {
+		t.Error("NoBuiltinBoxGlyphs should be true")
+	}
+}
+
 func TestGuiStyleToGlyphConfigFeaturesGradient(t *testing.T) {
 	t.Parallel()
 	feat := &glyph.FontFeatures{

--- a/gui/styles.go
+++ b/gui/styles.go
@@ -58,12 +58,22 @@ type TextStyle struct {
 	// box width (logical px), preserving aspect and centered. Grid callers
 	// (terminals) set it to cells×cellWidth. 0 = default emoji sizing.
 	EmojiBoxWidth float32
-	Color         Color
-	BgColor       Color
-	StrokeColor   Color
-	Align         TextAlignment
-	Underline     bool
-	Strikethrough bool
+	// CellWidth and CellHeight are the grid cell size in logical px. Grid callers
+	// (terminals) set them so the built-in box-drawing and block-element glyphs
+	// fill the cell exactly and neighbouring cells abut. 0 = derive the cell from
+	// the glyph advance and the run's ascent+descent, which leaves a sub-pixel
+	// overlap wherever the advance is fractional.
+	CellWidth   float32
+	CellHeight  float32
+	Color       Color
+	BgColor     Color
+	StrokeColor Color
+	Align       TextAlignment
+	Underline   bool
+	// NoBuiltinBoxGlyphs keeps the font's own glyphs for U+2500–257F and
+	// U+2580–259F instead of the built-in procedural rasterizer.
+	NoBuiltinBoxGlyphs bool
+	Strikethrough      bool
 }
 
 // mergeTextStyle fills zero fields in s from fallback.
@@ -86,12 +96,17 @@ func (ts TextStyle) toGlyphStyle() glyph.TextStyle {
 		Size:          ts.Size,
 		LetterSpacing: ts.LetterSpacing,
 		EmojiBoxWidth: ts.EmojiBoxWidth,
-		Features:      ts.Features,
-		Underline:     ts.Underline,
-		Strikethrough: ts.Strikethrough,
-		Typeface:      ts.Typeface,
-		StrokeWidth:   ts.StrokeWidth,
-		StrokeColor:   glyph.Color{R: ts.StrokeColor.R, G: ts.StrokeColor.G, B: ts.StrokeColor.B, A: ts.StrokeColor.A},
+		// Grid geometry and the box-glyph opt-out are rasterization inputs, like
+		// EmojiBoxWidth; glyph inherits them per run from the base style.
+		CellWidth:          ts.CellWidth,
+		CellHeight:         ts.CellHeight,
+		NoBuiltinBoxGlyphs: ts.NoBuiltinBoxGlyphs,
+		Features:           ts.Features,
+		Underline:          ts.Underline,
+		Strikethrough:      ts.Strikethrough,
+		Typeface:           ts.Typeface,
+		StrokeWidth:        ts.StrokeWidth,
+		StrokeColor:        glyph.Color{R: ts.StrokeColor.R, G: ts.StrokeColor.G, B: ts.StrokeColor.B, A: ts.StrokeColor.A},
 	}
 }
 

--- a/gui/styles_core_test.go
+++ b/gui/styles_core_test.go
@@ -87,6 +87,36 @@ func TestToGlyphStyleMapping(t *testing.T) {
 	}
 }
 
+// Grid geometry reaches glyph only through toGlyphStyle; a dropped field is
+// silent (box glyphs just fall back to advance-derived cells), so assert it.
+func TestToGlyphStyleGridGeometry(t *testing.T) {
+	ts := TextStyle{
+		Family:             "mono",
+		Size:               14,
+		CellWidth:          9.5,
+		CellHeight:         20,
+		NoBuiltinBoxGlyphs: true,
+	}
+	gs := ts.toGlyphStyle()
+	if gs.CellWidth != 9.5 {
+		t.Errorf("CellWidth: got %f, want 9.5", gs.CellWidth)
+	}
+	if gs.CellHeight != 20 {
+		t.Errorf("CellHeight: got %f, want 20", gs.CellHeight)
+	}
+	if !gs.NoBuiltinBoxGlyphs {
+		t.Error("NoBuiltinBoxGlyphs should be true")
+	}
+}
+
+// Zero values must stay zero so glyph keeps its derive-the-cell default.
+func TestToGlyphStyleGridGeometryUnset(t *testing.T) {
+	gs := TextStyle{Family: "mono", Size: 14}.toGlyphStyle()
+	if gs.CellWidth != 0 || gs.CellHeight != 0 || gs.NoBuiltinBoxGlyphs {
+		t.Errorf("unset grid fields leaked: %+v", gs)
+	}
+}
+
 func TestAffineIdentityCheck(t *testing.T) {
 	id := glyph.AffineIdentity()
 	if !affineTransformIsIdentity(id) {


### PR DESCRIPTION
Closes #251.

## What

Adds `CellWidth`, `CellHeight` and `NoBuiltinBoxGlyphs` to `gui.TextStyle` and maps them through **both** converters:

- rich-text path: `toGlyphStyle()` (`gui/styles.go`)
- plain-text measure/render path: `glyphconv.GuiStyleToGlyphConfig` — the path `TermGrid` renders through

Grid callers (terminals) build `gui.TextStyle`, never `glyph.TextStyle`, so they had no way to pass their real cell: setting `CellWidth`/`CellHeight` is what makes neighbouring box/block cells abut exactly (the derive-from-advance fallback leaves a sub-pixel overlap on fractional advances). `NoBuiltinBoxGlyphs` keeps the font's own glyphs instead.

Zero/false keep today's behaviour (glyph derives the cell).

## Why both paths

`EmojiBoxWidth` is the precedent: a rasterization input both paths carry. A dropped field in the plain-text path is silent — box glyphs just fall back to advance-derived cells — so both converters get mapping tests (set + unset).

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all green
- New tests: `TestToGlyphStyleGridGeometry`, `TestToGlyphStyleGridGeometryUnset`, `TestGuiStyleToGlyphConfigGridGeometry`

Note: the consumer-side benefit sequences after go-gui-org/go-glyph#102 (residual 1px-gap in coalesced runs), as noted in the issue.