### PR TITLE
perf(metal): present asynchronously outside live resize

### DIFF
--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -36,6 +36,9 @@ void metalTestResetIMEQueue(void);
 int metalTestPopTextEvent(void);
 int metalTestIMEClientConformance(void *windowHandle);
 int metalTestIMEKeySuppressedWhileComposing(void *windowHandle);
+void metalTestStartLiveResize(void *windowHandle);
+void metalTestEndLiveResize(void *windowHandle);
+int metalTestLayerPresentsWithTransaction(void *windowHandle);
 */
 import "C"
 import (
@@ -161,6 +164,25 @@ func testIMEKeySuppressedWhileComposing(handle C.GoGuiNSWindow) bool {
 
 func testWindowID(handle C.GoGuiNSWindow) uint32 {
 	return uint32(C.metalWindowGetID(handle))
+}
+
+// testStartLiveResize / testEndLiveResize fire the live-resize
+// delegate methods the way AppKit's tracking loop does. testLayer-
+// PresentsWithTransaction reports the layer's presentation mode:
+// 1 = transaction, 0 = async, -1 = no CAMetalLayer. Together they
+// verify the async-presentation switch without a real drag, which
+// AppKit does not expose programmatically.
+func testStartLiveResize(handle C.GoGuiNSWindow) {
+	C.metalTestStartLiveResize(unsafe.Pointer(handle))
+}
+
+func testEndLiveResize(handle C.GoGuiNSWindow) {
+	C.metalTestEndLiveResize(unsafe.Pointer(handle))
+}
+
+func testLayerPresentsWithTransaction(handle C.GoGuiNSWindow) int {
+	return int(C.metalTestLayerPresentsWithTransaction(
+		unsafe.Pointer(handle)))
 }
 
 // testActivateNow calls C.metalAppFinishLaunch directly to verify

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -163,4 +163,11 @@ func runMainThreadTests() {
 	// 10. Frames must keep flowing while a nested AppKit runloop (modal
 	//     dialog, open menu, live resize) blocks the Go event loop.
 	runFramePumpMainThreadTests()
+
+	// 11. The layer's presentation mode must follow the live-resize
+	//     switch — async outside the drag, transaction mode during it,
+	//     and back to async when it ends. Regression for the window
+	//     latching into per-frame main-thread blocking after its first
+	//     resize.
+	runLiveResizePresentationTests()
 }

--- a/gui/backend/metal/metal_darwin.m
+++ b/gui/backend/metal/metal_darwin.m
@@ -350,9 +350,21 @@ MetalCtx metalCtxCreate(void* layerPtr, const char* mslSrc) {
     ctx->layer.device = ctx->device;
     ctx->layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
     ctx->layer.framebufferOnly = YES;
-    // Synchronize presentation with the compositor resize
-    // transaction. Eliminates content shift during live resize.
-    ctx->layer.presentsWithTransaction = YES;
+    // Asynchronous presentation: the frame is handed to Metal and the main
+    // thread returns to the event loop immediately. presentsWithTransaction
+    // would instead require this thread to sit in waitUntilScheduled until
+    // the compositor has taken the frame — measured through go-term, a
+    // repaint queued from a background goroutine then waited a median
+    // 6.2 ms before the event loop could even dequeue it, because the loop
+    // was parked inside that block. Switching to async presentation cut
+    // that wait to 2.4 ms and 23% off end-to-end keystroke latency.
+    //
+    // Live resize still needs transaction mode — it is what stops content
+    // shifting inside the window during the drag — so the window's
+    // live-resize handlers switch it on for the duration of the gesture and
+    // back off at the end. metalEndFrame reads the layer each frame rather
+    // than caching, so the two modes cannot disagree.
+    ctx->layer.presentsWithTransaction = NO;
 
     ctx->queue = [ctx->device newCommandQueue];
 
@@ -662,9 +674,22 @@ void metalEndFrame(MetalCtx ctx_) {
         ctx->enc = nil;
     }
     if (ctx->drawable && ctx->cmdBuf) {
-        [ctx->cmdBuf commit];
-        [ctx->cmdBuf waitUntilScheduled];
-        [ctx->drawable present];
+        // The two presentation modes are not interchangeable at the call
+        // site: presentsWithTransaction requires the app to present the
+        // drawable itself, after the command buffer is scheduled, which is
+        // what makes the main thread block. Without it, presentation is
+        // scheduled on the command buffer and Metal performs it when the
+        // GPU is done. Read the layer rather than caching a flag, so the
+        // live-resize switch takes effect on the next frame and the branch
+        // cannot disagree with the layer's actual requirement.
+        if (ctx->layer.presentsWithTransaction) {
+            [ctx->cmdBuf commit];
+            [ctx->cmdBuf waitUntilScheduled];
+            [ctx->drawable present];
+        } else {
+            [ctx->cmdBuf presentDrawable:ctx->drawable];
+            [ctx->cmdBuf commit];
+        }
     }
     ctx->drawable = nil;
     ctx->cmdBuf   = nil;

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -215,8 +215,12 @@ static uint32_t _nextWindowID = 1;
     metalLayer.device = device;
     metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
     metalLayer.framebufferOnly = NO; // allow readback for filters
-    // Eliminate content shift during live window resize.
-    metalLayer.presentsWithTransaction = YES;
+    // Off outside live resize: transaction mode costs a main-thread block
+    // per frame, which delays every queued UI update. It is switched on
+    // only for the duration of a resize drag, where it is what stops
+    // content shifting inside the window — see windowWillStartLiveResize /
+    // windowDidEndLiveResize below and the rationale in metalCtxCreate.
+    metalLayer.presentsWithTransaction = NO;
 
     self = [super initWithFrame:frame];
     if (self) {
@@ -485,6 +489,34 @@ static uint32_t _nextWindowID = 1;
 // consumer in metalPollEvent.
 - (void)windowWillStartLiveResize:(NSNotification *)notification {
     _liveResizeStarted = 1;
+    [self setPresentsWithTransaction:YES];
+}
+
+// The other half of the presentation-mode switch. Without this the window
+// would latch into transaction mode after its first resize and keep the
+// per-frame main-thread block for the rest of the session.
+- (void)windowDidEndLiveResize:(NSNotification *)notification {
+    [self setPresentsWithTransaction:NO];
+}
+
+// setPresentsWithTransaction switches the content layer's presentation
+// mode. Safe between frames only, which is where both callers sit: the
+// live-resize notifications are delivered on the main thread, and
+// metalEndFrame re-reads the property each frame rather than caching it.
+- (void)setPresentsWithTransaction:(BOOL)on {
+    CALayer *layer = self.contentView.layer;
+    if ([layer isKindOfClass:[CAMetalLayer class]]) {
+        ((CAMetalLayer *)layer).presentsWithTransaction = on;
+    } else {
+        // Not reachable as written — the view installs a CAMetalLayer in
+        // initWithFrame: — but the failure is silent and would resurrect
+        // the content-shift bug this switch exists to preserve the fix
+        // for: no layer to set means resize runs the async path with no
+        // symptom until someone drags a window border.
+        NSLog(@"gogui: content layer is %@, not CAMetalLayer — live-resize "
+              @"presentation mode not applied",
+              NSStringFromClass([layer class]));
+    }
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
@@ -1462,6 +1494,47 @@ int metalTestIMEQueueDepth(void) { return _textQCount; }
 // Forward declaration: the conformance helpers below reset the queue
 // they dirty, and the definition sits after them.
 void metalTestResetIMEQueue(void);
+
+// Fire the windowWillStartLiveResize: / windowDidEndLiveResize:
+// delegate methods exactly as AppKit's resize tracking loop would —
+// the window is its own delegate, so posting the NSNotification to
+// NSNotificationCenter would not reach it. AppKit exposes no
+// programmatic API to start a real drag, so this is the only way to
+// exercise the live-resize presentation switch from a test.
+static void metalTestFireLiveResizeNotification(void *windowHandle,
+                                                BOOL start) {
+    if (!windowHandle) return;
+    GoGuiWindow *gw = (GoGuiWindow *)windowHandle;
+    if (!gw->nsWindow) return;
+    NSNotification *note = [NSNotification
+        notificationWithName:(start ? NSWindowWillStartLiveResizeNotification
+                                    : NSWindowDidEndLiveResizeNotification)
+                      object:gw->nsWindow];
+    if (start) {
+        [gw->nsWindow.delegate windowWillStartLiveResize:note];
+    } else {
+        [gw->nsWindow.delegate windowDidEndLiveResize:note];
+    }
+}
+
+void metalTestStartLiveResize(void *windowHandle) {
+    metalTestFireLiveResizeNotification(windowHandle, YES);
+}
+
+void metalTestEndLiveResize(void *windowHandle) {
+    metalTestFireLiveResizeNotification(windowHandle, NO);
+}
+
+// Report the content layer's presentation mode: 1 = transaction mode,
+// 0 = async, -1 = no CAMetalLayer to inspect.
+int metalTestLayerPresentsWithTransaction(void *windowHandle) {
+    if (!windowHandle) return -1;
+    GoGuiWindow *gw = (GoGuiWindow *)windowHandle;
+    if (!gw->nsWindow) return -1;
+    CALayer *layer = gw->nsWindow.contentView.layer;
+    if (![layer isKindOfClass:[CAMetalLayer class]]) return -1;
+    return ((CAMetalLayer *)layer).presentsWithTransaction ? 1 : 0;
+}
 
 // Drive keyDown: with a composition in progress and report whether the
 // raw key was claimed by the input method. A key that reaches the

--- a/gui/backend/metal/presentation_test.go
+++ b/gui/backend/metal/presentation_test.go
@@ -1,0 +1,77 @@
+//go:build darwin && cgo && !ios
+
+package metal
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// TestLiveResizePresentationGuard is a compile-time guard only; the
+// real check needs Cocoa on the initial main thread and runs from
+// TestMain via runMainThreadTests → runLiveResizePresentationTests.
+func TestLiveResizePresentationGuard(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Cocoa requires main thread; tested via TestMain")
+	}
+}
+
+// runLiveResizePresentationTests verifies the layer presentation mode
+// follows the live-resize switch: async outside the drag, transaction
+// mode during it, and back to async when it ends — with a real frame
+// rendered in each mode so both present paths in metalEndFrame run.
+// The latch check (end-of-drag back to async) guards the regression
+// that would otherwise leave every later frame paying the per-frame
+// main-thread block.
+//
+// A real resize drag cannot be synthesized programmatically — AppKit
+// exposes no API for it — so the test fires the same delegate methods
+// the resize tracking loop would.
+//
+// Panics on failure, matching runMainThreadTests.
+func runLiveResizePresentationTests() {
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  new(int),
+		Width:  200,
+		Height: 200,
+	})
+	w.UpdateView(func(_ *gui.Window) gui.View {
+		return gui.Rectangle(gui.RectangleCfg{
+			Width:  100,
+			Height: 50,
+			Color:  gui.Green,
+		})
+	})
+	b, err := New(w)
+	if err != nil {
+		panic("live resize: metal.New: " + err.Error())
+	}
+	defer b.Destroy()
+
+	// Default is async: frames must not block the main thread.
+	if got := testLayerPresentsWithTransaction(b.window); got != 0 {
+		panic(fmt.Sprintf("live resize: layer starts in mode %d, want 0 (async)", got))
+	}
+	if !w.FrameFn() {
+		panic("live resize: FrameFn returned false")
+	}
+	b.renderFrame(w)
+
+	// Drag start: transaction mode — the shift-free present path.
+	testStartLiveResize(b.window)
+	if got := testLayerPresentsWithTransaction(b.window); got != 1 {
+		panic(fmt.Sprintf("live resize: windowWillStartLiveResize left mode %d, want 1", got))
+	}
+	b.renderFrame(w)
+
+	// Drag end: back to async, or every later frame keeps the
+	// main-thread block for the rest of the session.
+	testEndLiveResize(b.window)
+	if got := testLayerPresentsWithTransaction(b.window); got != 0 {
+		panic(fmt.Sprintf("live resize: windowDidEndLiveResize left mode %d, want 0 (latch)", got))
+	}
+	b.renderFrame(w)
+}


### PR DESCRIPTION
## What

`presentsWithTransaction` was set for every frame. That forces `metalEndFrame` to block the main thread in `waitUntilScheduled` until the compositor has taken the frame — and the event loop is parked inside that block, so anything queued from a background goroutine waits behind it.

This switches to `presentDrawable:` outside live resize, where the main thread hands the frame to Metal and returns immediately.

## Measurement

Instrumented through go-term (`GOTERM_LATENCY`), typing into a full-screen TUI child. A/B in one binary, env-gated, same session:

| p50 | before | after |
|---|---|---|
| echo→wake (queued repaint → main thread dequeues it) | 6.2 ms | 2.4 ms |
| wake→paint (the frame itself) | 0.4 ms | 0.5 ms |
| **end-to-end keystroke** | **10.7 ms** | **8.2 ms** |

23% off end-to-end, and it confirms the mechanism: the main thread was not slow to draw, it was unavailable. p95 did not improve; the residual ~2.4 ms is most likely `nextDrawable`, still acquired at frame start, which late acquisition could address separately.

## Live resize

Transaction mode is what stops content shifting inside the window during a resize drag, so it is switched on for the gesture and back off at the end. `metalEndFrame` reads the layer each frame rather than caching a flag, so the branch cannot disagree with the layer's actual requirement.

`windowDidEndLiveResize:` is new. Without it the window latches into transaction mode after its first resize and pays the per-frame block for the rest of the session.

## Testing

`presentation_test.go` pins all three states — async at rest, transaction during the drag, async again after — rendering a frame in each so both present paths in `metalEndFrame` execute. A real drag cannot be synthesized (AppKit exposes no API), so it fires the same delegate methods the tracking loop fires, via new C test hooks.

Runs under the existing opt-in main-thread suite (`GO_GUI_MAIN_THREAD_TESTS=1`), since it needs a window server. Verified locally along with `go build ./...`, the full `go test ./...`, and `golangci-lint run ./...` (0 issues).

Manually verified as well: a real border drag switches modes as expected and shows no content shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)