### PR TITLE
fix(make): lint gate greps for v-prefixed golangci-lint version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,8 +270,9 @@ git/mkdir/rm/ls output. `ctx_fetch_and_index` instead of curl/wget/WebFetch.
   ~600 lines, where wgpu would have added 10–40 MB of runtime libs, supplied
   none of `NativePlatform`, and left macOS untouched.
 - **Current CGo state:** `CGO_ENABLED=0 go build ./...` is green on Linux and
-  Windows for the whole module. macOS (5.9k lines ObjC) is the entire remaining
-  problem and is not started.
+  Windows for the whole module. macOS (5.9k lines ObjC) stays cgo **by
+  decision** (2026-08-12) — the value argument inverts there; do not re-open
+  without a trigger. See `docs/specs/cgo-free-backend-feasibility.md` § Phase 2.
 
 Full history and rationale — WebGPU, the go-gl→glbind swap, the `gui/audio`
 de-cgo — in `docs/specs/cgo-free-backend-feasibility.md`.

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ vet:
 
 # Run golangci-lint (requires golangci-lint installed, pinned to LINT_VERSION).
 lint:
-	@golangci-lint --version | grep -q "$(LINT_VERSION)" || \
+	@golangci-lint --version | grep -q "$(LINT_VERSION:v%=%)" || \
 	  { echo "::error::golangci-lint $(LINT_VERSION) required. Run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(LINT_VERSION)"; exit 1; }
 	golangci-lint run ./...
 


### PR DESCRIPTION
The lint gate in `Makefile` greps `golangci-lint --version` for `v2.12.2` (with the `v`), but v2.12.2's binary reports `version 2.12.2` without it — so `make check-all`'s lint step always failed even with the pinned version installed. Strip the `v` prefix before grepping.

Also lands the uncommitted CLAUDE.md note documenting the 2026-08-12 decision to keep macOS cgo (per docs/specs/cgo-free-backend-feasibility.md § Phase 2).