### PR TITLE
chore: track git hooks, close spec backlog

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if gofmt -l ./gui/ ./examples/ 2>/dev/null | grep -q .; then
+    echo "pre-commit: gofmt check failed on:"
+    gofmt -l ./gui/ ./examples/
+    exit 1
+fi
+
+golangci-lint run ./gui/... ./examples/...

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Push gates, run from the repo root by git.
+# 1. Verify pkg-config paths for CGO deps actually exist on disk.
+#    Catches stale .pc files (e.g. harfbuzz Cellar path removed by brew cleanup).
+# 2. Run the full pre-push gate (make check-all: test + lint + vet + checks),
+#    matching what CLAUDE.md documents as the pre-push gate.
+
+set -e
+
+pkgs="freetype2 harfbuzz pango fontconfig"
+fail=0
+
+for p in $pkgs; do
+    if ! pkg-config --exists "$p" 2>/dev/null; then
+        echo "pre-push: pkg-config missing: $p" >&2
+        fail=1
+        continue
+    fi
+    libs=$(pkg-config --libs-only-L "$p" 2>/dev/null)
+    for l in $libs; do
+        dir=${l#-L}
+        if [ ! -d "$dir" ]; then
+            echo "pre-push: $p references missing dir: $dir" >&2
+            echo "  fix: brew reinstall $p" >&2
+            fail=1
+        fi
+    done
+done
+
+[ $fail -eq 0 ] || exit 1
+
+echo "pre-push: running make check-all (test + lint + vet + checks)..."
+make check-all

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 !Makefile
 !LICENSE
+!.githooks/pre-commit
+!.githooks/pre-push
 
 # Binaries
 main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Guidance for Claude Code (claude.ai/code) in this repo.
 ```
 go run ./examples/get_started/  # run the example app
 make check-all                  # test + lint + vet gates (pre-push)
+git config core.hooksPath .githooks  # enable tracked pre-commit/pre-push hooks
 make test                       # tests only
 make lint                       # golangci-lint (pinned version)
 make vet                        # go vet + requiredid analyzer

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -1,10 +1,11 @@
 # Developer ergonomics: assessment and improvement plan
 
-Status: accepted after three independent reviews; ready to implement. Two
-breaking phases: phase 1 (§4.2) shipped as v0.53.0, and §4.3/§4.4/ §4.7 target
-v0.54.0 with 18 sibling call sites affected (§7). Phases 2–3 ship as v0.53.x. §9
-Q1–Q8 all resolved; Q6 remains a phase-2 gate on phase 4. The original
-single-breaking-release plan and why it was wrong: see the correction in §6.
+Status: **implemented** — every row of the §6.1 progress table is done: phase 1
+shipped v0.53.0, the §4.3 callback/event collapse v0.55.0, the §4.4/§4.5 color
+and padding work across v0.56–v0.59, and §4.8's example audit closed. All of
+§9 Q1–Q8 resolved, including the Q6 nested-scroll gate
+(`gui/scroll_nested_test.go`). The §4.7 renames are part of that; the release
+plan below is historical, not pending.
 Base: `main` @ `80715d1`. Phase progress: §6.1.
 
 ## Context

--- a/docs/specs/focusable-default-input.md
+++ b/docs/specs/focusable-default-input.md
@@ -1,6 +1,9 @@
 # Spec: `Focusable` defaults true for input controls (`FocusDisabled` opt-out)
 
-Status: draft (pre-implementation)
+Status: **implemented** — Phase 1 shipped v0.36.0 (Input, Select, Slider,
+Toggle, Switch); Phase 2 shipped v0.37.0, dropping `Focusable bool` for
+`FocusDisabled bool` on the remaining nine controls. Both phases in CHANGELOG.
+
 Base: `main` @ `8522098`
 Target release: go-gui `v0.36.0` (breaking)
 

--- a/docs/specs/macos-native-backend.md
+++ b/docs/specs/macos-native-backend.md
@@ -1,5 +1,9 @@
 # Native macOS backend (SDL2 elimination)
 
+Status: **implemented** — SDL2 eliminated from macOS (`bead449`, #11): sdl2 is
+gone from go.mod and the Metal backend speaks Cocoa/AppKit directly. macOS stays
+cgo by decision (2026-08-12); see `cgo-free-backend-feasibility.md` § Phase 2.
+
 ## Summary
 
 Replace SDL2's window creation, event loop, clipboard, cursors, and IME in the

--- a/docs/specs/quit-dispatch-unify.md
+++ b/docs/specs/quit-dispatch-unify.md
@@ -1,5 +1,9 @@
 # Unify metal quit dispatch with gl/sdl2 backends
 
+Status: **implemented** — the Metal backend's two quit paths collapsed into the
+single `!cont` → `DispatchQuitRequest(app)` path (`gui/backend/metal/backend.go`),
+with the divergent `EventQuitRequested` broadcast removed.
+
 ## Problem
 
 The Metal backend has two quit paths, one dead, one inconsistent:


### PR DESCRIPTION
Tracked the pre-commit/pre-push gates in `.githooks/` so they ship with the repo, and closed the spec backlog by marking four specs implemented.

- **hooks** (`e8c190d`): move pre-commit (gofmt + golangci-lint) and pre-push (pkg-config check + `make check-all`) into `.githooks/`, un-ignore them, document `git config core.hooksPath .githooks` in CLAUDE.md
- **spec sweep** (`99f5bdf`): quit-dispatch-unify, macos-native-backend, focusable-default-input marked implemented with code evidence
- **spec sweep** (`305c907`): developer-ergonomics marked implemented (all phase rows + Q1-Q8 done)