### PR TITLE
changelog: add v0.59.2 (glyph 1.20.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.59.2] - 2026-08-13
+
+### Changed
+
+- **go-glyph bumped to v1.20.2** — the face LRU now idle-evicts and the
+  fallback cache evicts FIFO, so long sessions release font memory without
+  new face churn; single-codepoint emoji fallback is decided from cmap
+  coverage alone (PR #266).
+
 ## [v0.59.1] - 2026-08-12
 
 ### Fixed


### PR DESCRIPTION
Patch release of #266: go-glyph v1.20.2 (cache eviction + emoji fast path).