### PR TITLE
fix(gui): scope splitter part IDs under ID-bearing ancestors (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to
   the border width was already `sizeBorderDef` either way. For a custom
   theme the splitter's own three values were dead and now apply. An
   explicit `SomeF(0)` still means "no border".
+- **Splitter: part IDs now scope with the root (issue #264).** `Splitter`
+  composed its pane, handle and collapse-button IDs in the factory, where no
+  `Window` exists, so under an ID-bearing ancestor the root resolved to
+  `outer:sp` while every part stayed window-global (`sp:handle`, …) — two
+  splitters reusing one leaf ID collided on every part. The splitter is now a
+  struct view whose `GenerateLayout` resolves the effective ID
+  (`w.EffID(cfg.ID)`) and composes every part under that path. With no
+  ID-bearing ancestor the spellings are unchanged. API consequence: parts of
+  a nested splitter are addressed by scoped effective IDs (`outer:sp:handle`,
+  `outer:sp:pane:first`).
 
 ### Added
 

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -29,7 +29,12 @@ implementation, and the code is the authority.
    `Splitter`, `ProgressBar`, `Skeleton` and `Scrollbar` build their trees in
    plain factories and capture `cfg.ID` as a leaf. Their handlers resolve at
    dispatch time instead, walking the ancestor chain for the shape that carries
-   the leaf. Same `resolveLeaf`, so the two paths cannot drift.
+   the    leaf. Same `resolveLeaf`, so the two paths cannot drift. `Splitter` is
+   now converted (issue #264): it is a struct view whose `GenerateLayout`
+   resolves the effective ID once (`id := w.EffID(cfg.ID)`) and composes
+   every inner ID (panes, handle, collapse buttons) from that path — the
+   root shape stays on the plain leaf and the framework joins it to the
+   same string, while the composed children are absolute.
 3. **The "still globally competing" warning is a debug category, not an
    ergonomics-audit mode.** "Has no ID-bearing ancestor" is a property of the composed
    tree, which the AST does not have. It is `gui.DebugUnscopedIDs`, deliberately

--- a/gui/view_splitter.go
+++ b/gui/view_splitter.go
@@ -255,12 +255,38 @@ func applySplitterDefaults(cfg *SplitterCfg) {
 	}
 }
 
+// splitterView implements View for the splitter. The splitter is a
+// struct view rather than a plain factory because its inner IDs must be
+// composed from the widget's *effective* ID, which only exists once a
+// Window is in hand (see docs/specs/widget-id-per-scope-uniqueness.md).
+// Composing them in the factory produced absolute strings that
+// resolveShapeIDs never joins, so every part stayed window-global under
+// an ID-bearing ancestor (issue #264).
+type splitterView struct {
+	core *splitterCore
+	cfg  SplitterCfg
+}
+
 // Splitter creates a two-pane splitter with drag/keyboard/collapse.
 func Splitter(cfg SplitterCfg) View {
 	applySplitterDefaults(&cfg)
-	core := newSplitterCore(&cfg)
+	return &splitterView{cfg: cfg, core: newSplitterCore(&cfg)}
+}
 
-	return Canvas(ContainerCfg{
+func (sv *splitterView) Content() []View { return nil }
+
+func (sv *splitterView) GenerateLayout(w *Window) Layout {
+	cfg := &sv.cfg
+	core := sv.core
+	// Every part hangs off the splitter's effective ID, so two splitters
+	// written with the same leaf under different ID-bearing panels do not
+	// collide. With no ID-bearing ancestor, id == cfg.ID and the parts
+	// keep their historical spellings ("sp:handle", "sp:pane:first").
+	// The root shape carries the plain leaf; the framework joins it to
+	// the same string.
+	id := w.EffID(cfg.ID)
+
+	return generateViewLayout(Canvas(ContainerCfg{
 		ID:              cfg.ID,
 		Focusable:       cfg.Focusable,
 		A11YRole:        AccessRoleSplitter,
@@ -278,11 +304,11 @@ func Splitter(cfg SplitterCfg) View {
 			splitterAmendLayout(core, ctx.Layout, ctx.Window)
 		},
 		Content: []View{
-			splitterPane(ScopeID(cfg.ID, "pane", "first"), cfg.First.Content),
-			splitterHandleView(&cfg, core),
-			splitterPane(ScopeID(cfg.ID, "pane", "second"), cfg.Second.Content),
+			splitterPane(ScopeID(id, "pane", "first"), cfg.First.Content),
+			splitterHandleView(cfg, core, id),
+			splitterPane(ScopeID(id, "pane", "second"), cfg.Second.Content),
 		},
-	})
+	}), w)
 }
 
 func splitterPane(id string, content []View) View {
@@ -329,10 +355,11 @@ func splitterAmendLayout(core *splitterCore, layout *Layout, w *Window) {
 	if len(layout.Children) < 3 {
 		return
 	}
-	// Splitter builds its tree with no Window in hand, so the core holds
-	// leaf IDs. Amend runs on the splitter's own shape, every frame,
+	// The core is built in the factory and holds the leaf cfg.ID; only
+	// the resolve pass (via the shape's idKey) knows the effective path,
+	// so Amend — which runs on the splitter's own shape, every frame,
 	// before any handler that looks the splitter up (FindByID) or moves
-	// focus to it — so this is where the leaves become identities.
+	// focus to it — is where the leaf becomes the identity.
 	core.id = layout.Shape.idKey()
 	if core.focusID != "" {
 		core.focusID = core.id

--- a/gui/view_splitter_handle.go
+++ b/gui/view_splitter_handle.go
@@ -7,18 +7,21 @@ var splitterButtonSuffix = [3]string{
 	":button:2",
 }
 
-func splitterHandleView(cfg *SplitterCfg, core *splitterCore) View {
+// splitterHandleView builds the drag handle. id is the splitter's
+// effective ID, so the handle and its buttons are named under the same
+// path the framework stamps on the splitter's own shape.
+func splitterHandleView(cfg *SplitterCfg, core *splitterCore, id string) View {
 	content := make([]View, 0, 3)
 	if cfg.ShowCollapseButtons &&
 		(cfg.First.collapsible || cfg.Second.collapsible) {
 		if cfg.First.collapsible {
 			content = append(content,
-				splitterButton(cfg, core, SplitterCollapseFirst))
+				splitterButton(cfg, core, SplitterCollapseFirst, id))
 		}
 		content = append(content, splitterGrip(cfg))
 		if cfg.Second.collapsible {
 			content = append(content,
-				splitterButton(cfg, core, SplitterCollapseSecond))
+				splitterButton(cfg, core, SplitterCollapseSecond, id))
 		}
 	} else {
 		content = append(content, splitterGrip(cfg))
@@ -38,7 +41,7 @@ func splitterHandleView(cfg *SplitterCfg, core *splitterCore) View {
 	}
 
 	handleCfg := ContainerCfg{
-		ID:          ScopeID(cfg.ID, "handle"),
+		ID:          ScopeID(id, "handle"),
 		Sizing:      FixedFixed,
 		Width:       handleWidth,
 		Height:      handleHeight,
@@ -88,7 +91,7 @@ func splitterGrip(cfg *SplitterCfg) View {
 }
 
 func splitterButton(cfg *SplitterCfg, core *splitterCore,
-	target SplitterCollapsed) View {
+	target SplitterCollapsed, id string) View {
 	s := &defaultSplitterStyle
 	size := f32Max(4, cfg.HandleSize.Get(s.HandleSize)-2)
 	ts := TextStyle{
@@ -96,7 +99,7 @@ func splitterButton(cfg *SplitterCfg, core *splitterCore,
 		Size:  size,
 	}
 	return Button(ButtonCfg{
-		ID:      cfg.ID + splitterButtonSuffix[target],
+		ID:      id + splitterButtonSuffix[target],
 		Width:   size,
 		Height:  size,
 		Sizing:  FixedFixed,

--- a/gui/view_splitter_id_test.go
+++ b/gui/view_splitter_id_test.go
@@ -1,0 +1,134 @@
+package gui
+
+import "testing"
+
+// ID scoping for the splitter (issue #264). The splitter composes its
+// pane, handle and collapse-button IDs from its own effective ID inside
+// GenerateLayout, so the whole subtree scopes with the root instead of
+// staying window-global. These tests pin both halves of that contract:
+// the parts scope under an ID-bearing ancestor, and with no such
+// ancestor they keep the historical flat spellings.
+
+// splitterScopedPanel wraps a splitter in an ID-bearing Column, which is
+// what opens a scope for the splitter's effective ID.
+func splitterScopedPanel(id string, v View) View {
+	return Column(ContainerCfg{
+		ID:         id,
+		Sizing:     FillFill,
+		Padding:    NoPadding,
+		SizeBorder: NoBorder,
+		Content:    []View{v},
+	})
+}
+
+// TestSplitterPartsResolveUnderAncestorScope walks every part of a
+// nested splitter by its scoped public ID.
+func TestSplitterPartsResolveUnderAncestorScope(t *testing.T) {
+	w := NewTestWindow(WindowCfg{
+		Width:  splitterTestW,
+		Height: splitterTestH,
+	})
+	w.TestRender(func(_ *Window) View {
+		return splitterScopedPanel("outer",
+			Splitter(splitterCollapsibleCfg("sp")))
+	})
+
+	for _, id := range []string{
+		"outer:sp",
+		"outer:sp:pane:first",
+		"outer:sp:handle",
+		"outer:sp:pane:second",
+		"outer:sp:button:1",
+		"outer:sp:button:2",
+	} {
+		if _, ok := w.layout.FindByID(id); !ok {
+			t.Errorf("FindByID(%q) found nothing; part did not scope "+
+				"under its ancestor", id)
+		}
+	}
+	// The pre-#264 window-global spellings must be gone entirely.
+	for _, id := range []string{
+		"sp:pane:first", "sp:handle", "sp:pane:second", "sp:button:1",
+		"sp:button:2",
+	} {
+		if _, ok := w.layout.FindByID(id); ok {
+			t.Errorf("FindByID(%q) still resolves; the part is still "+
+				"window-global", id)
+		}
+	}
+}
+
+// TestSplitterSameLeafIDInTwoScopesDoesNotCollide is the composability
+// case scoping exists for: one splitter leaf ID reused under two
+// different ID-bearing panels in the same frame.
+func TestSplitterSameLeafIDInTwoScopesDoesNotCollide(t *testing.T) {
+	w := NewTestWindow(WindowCfg{
+		Width:  splitterTestW,
+		Height: splitterTestH,
+	})
+	w.TestRender(func(_ *Window) View {
+		return Row(ContainerCfg{
+			Sizing:     FillFill,
+			Padding:    NoPadding,
+			SizeBorder: NoBorder,
+			Content: []View{
+				splitterScopedPanel("settings",
+					Splitter(splitterCollapsibleCfg("sp"))),
+				splitterScopedPanel("profile",
+					Splitter(splitterCollapsibleCfg("sp"))),
+			},
+		})
+	})
+
+	if dups := w.TestDuplicateIDs(); len(dups) != 0 {
+		t.Errorf("duplicate effective IDs across two scopes: %v", dups)
+	}
+
+	settings, ok := w.layout.FindByID("settings:sp:handle")
+	if !ok {
+		t.Fatal("settings:sp:handle found nothing")
+	}
+	profile, ok := w.layout.FindByID("profile:sp:handle")
+	if !ok {
+		t.Fatal("profile:sp:handle found nothing")
+	}
+	// Distinct shapes, not one slot resolved twice. The panels sit
+	// side by side in a Row, so the second handle is to the right.
+	if settings.Shape == profile.Shape {
+		t.Fatal("both handles resolved to the same shape")
+	}
+	if settings.Shape.X >= profile.Shape.X {
+		t.Errorf("handle X: settings = %g, profile = %g; want the "+
+			"settings handle left of the profile one",
+			settings.Shape.X, profile.Shape.X)
+	}
+	for _, id := range []string{
+		"settings:sp:pane:first", "settings:sp:button:1",
+		"profile:sp:pane:first", "profile:sp:button:1",
+	} {
+		if _, found := w.layout.FindByID(id); !found {
+			t.Errorf("FindByID(%q) found nothing", id)
+		}
+	}
+}
+
+// TestSplitterUnscopedKeepsFlatIDs guards the no-collateral-break half:
+// with no ID-bearing ancestor the effective ID equals cfg.ID, so every
+// part keeps the exact spelling it had before #264.
+func TestSplitterUnscopedKeepsFlatIDs(t *testing.T) {
+	h := newSplitterHarness(t, splitterCollapsibleCfg("sp"))
+	// splitterFillParent's Row carries no ID, so it opens no scope.
+	for _, id := range []string{
+		"sp",
+		"sp:pane:first",
+		"sp:handle",
+		"sp:pane:second",
+		"sp:button:1",
+		"sp:button:2",
+	} {
+		if _, ok := h.w.layout.FindByID(id); !ok {
+			t.Errorf("FindByID(%q) found nothing; the legacy flat "+
+				"spelling changed", id)
+		}
+	}
+}

--- a/gui/view_splitter_interaction_test.go
+++ b/gui/view_splitter_interaction_test.go
@@ -409,17 +409,15 @@ func TestSplitterAmendLayoutStampsEffectiveID(t *testing.T) {
 	if _, ok := w.layout.FindByID("outer:sp"); !ok {
 		t.Fatal("nested splitter did not resolve to outer:sp")
 	}
-	// The inner IDs are composed eagerly in the factory, with no Window
-	// in hand, so they already contain ':' and resolveShapeIDs treats
-	// them as absolute — "sp:handle" stays window-global rather than
-	// becoming "outer:sp:handle". Asserted as-is; see issue #264.
-	ly, ok := w.layout.FindByID("sp:handle")
+	// The inner IDs are composed in GenerateLayout from the splitter's
+	// effective ID, so the handle scopes under its ancestor with the
+	// root (issue #264). The old unscoped spelling must be gone.
+	ly, ok := w.layout.FindByID("outer:sp:handle")
 	if !ok {
-		t.Fatal("handle did not resolve to the unscoped sp:handle")
+		t.Fatal("handle did not resolve to the scoped outer:sp:handle")
 	}
-	if _, nested := w.layout.FindByID("outer:sp:handle"); nested {
-		t.Error("handle now scopes under its ancestor: #264 appears " +
-			"fixed, so this test should expect outer:sp:handle")
+	if _, flat := w.layout.FindByID("sp:handle"); flat {
+		t.Error("handle still resolves to the unscoped sp:handle")
 	}
 	x, y := center(ly)
 	down := Event{


### PR DESCRIPTION
## Summary

Fixes #264. `Splitter` composed its inner IDs eagerly in a plain factory (`ScopeID(cfg.ID, "handle")`, `cfg.ID + ":button:N"`) into absolute strings before any `Window` existed, so under an ID-bearing ancestor the root resolved to `outer:sp` while every child stayed window-global — two splitters reusing the same leaf ID under different panels collided on `sp:handle`, `sp:pane:first`, `sp:button:1`, and public lookups needed inconsistent spellings for the root vs its parts.

**Fix:** restructured `Splitter` into a struct view (the `selectView` precedent, spec Decision 7) whose `GenerateLayout` resolves `id := w.EffID(cfg.ID)` and composes panes/handle/buttons from that effective path. The root keeps the plain leaf; the framework joins it to the same string. Result:

- No ID-bearing ancestor → spellings unchanged (`sp:handle`, `sp:pane:first`, …) — pinned by `TestSplitterUnscopedKeepsFlatIDs`
- Under an ID-bearing ancestor → parts resolve consistently (`outer:sp:handle`, …); same-leaf splitters under different panels no longer collide — `TestDuplicateIDs` reported 5 duplicate effIDs on the old code

No behavior change beyond ID composition: same tree shape, amend geometry, handlers, defaults. The only in-repo consumer (`view_dock_layout.go:188`) passes an absolute ID and is byte-identical.

## Tests

- `TestSplitterPartsResolveUnderAncestorScope` (new) — scoped part IDs resolve; flat spellings gone
- `TestSplitterSameLeafIDInTwoScopesDoesNotCollide` (new) — same leaf under `settings`/`profile` panels; distinct shapes; duplicate sweep quiet
- `TestSplitterUnscopedKeepsFlatIDs` (new) — legacy guard, passes on both old and new code
- `TestSplitterAmendLayoutStampsEffectiveID` (updated) — now expects the scoped `outer:sp:handle`, asserts flat `sp:handle` gone

All three scoped tests fail on the old code for the right reasons (verified by stash-free old-code run).

## Notes

- CHANGELOG `[Unreleased]` → Fixed bullet; API consequence noted (parts of a nested splitter are addressed by scoped effective IDs).
- `docs/specs/widget-id-per-scope-uniqueness.md` note 2 updated: Splitter removed from the plain-factory list, mechanism recorded.
- Independent review passed: no blockers, no should-fix; both nits applied (spec wording, test symmetry).

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green. Pre-commit hooks (gofmt + golangci-lint) passed.