### PR TITLE
fix(gui): collapsed splitter pane reaches its collapsed size, not a content sliver (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to
 
 ### Fixed
 
+- **Splitter: a collapsed pane with content now reaches its collapsed
+  size (issue #263).** `splitterLayoutChild` pinned the pane to the size
+  `splitterCompute` decided, then re-ran the fit passes, which recomputed
+  the pane from its content's minimum and overwrote the pin — so a pane
+  holding real content kept a sliver that drew underneath the handle. The
+  pin is now re-applied after the fit passes, so collapse is exact
+  (zero-width with the default `collapsedSize`, or exactly
+  `collapsedSize` when set). Contract note: pane sizes come from
+  ratio/min/max only; content larger than the computed pane size is
+  clipped (panes have `Clip: true`), never stretches the pane.
 - **Splitter: the spacebar toggles collapse again.** `splitterOnKeydown`
   tested `Event.CharCode`, which backends populate only on `EventChar` —
   a space keydown arrives with `KeyCode == KeySpace` and `CharCode == 0`,

--- a/gui/view_splitter.go
+++ b/gui/view_splitter.go
@@ -400,12 +400,7 @@ func splitterLayoutChild(
 ) {
 	splitterResetPositions(child, true, axisNone, 0, 0)
 	child.Shape.Sizing = FixedFixed
-	child.Shape.Width = f32Max(0, width)
-	child.Shape.Height = f32Max(0, height)
-	child.Shape.MinWidth = child.Shape.Width
-	child.Shape.MaxWidth = child.Shape.Width
-	child.Shape.MinHeight = child.Shape.Height
-	child.Shape.MaxHeight = child.Shape.Height
+	splitterPinShapeSize(child.Shape, width, height)
 	child.Shape.X = 0
 	child.Shape.Y = 0
 
@@ -414,9 +409,34 @@ func splitterLayoutChild(
 	layoutWrapText(child, w)
 	layoutHeights(child)
 	layoutFillHeights(child, &w.scratch)
+
+	// Re-apply the pin after the fit passes. The fit passes recompute
+	// the pane's size from its content's minimums, which grows a
+	// pinned-0 (collapsed) pane back into a sliver that draws underneath
+	// the handle (issue #263). The re-assert is what the downstream
+	// scroll, position, amend and render passes see, so a collapsed pane
+	// reaches exactly its computed size. For panes pinned >0 it is a
+	// no-op — those sizes already survived the fit passes — and it makes
+	// the sizing contract structural: pane sizes come from splitterCompute
+	// (ratio/min/max), never from content, which is clipped (Clip: true)
+	// when larger.
+	splitterPinShapeSize(child.Shape, width, height)
+
 	layoutAdjustScrollOffsets(child, w)
 	layoutPositions(child, x, y, w)
 	layoutAmend(child, w)
+}
+
+// splitterPinShapeSize pins a shape to the exact size splitterCompute
+// decided. Applied once before the fit passes (so the fixed sizing is
+// seeded) and re-applied after them; see splitterLayoutChild for why.
+func splitterPinShapeSize(shape *Shape, width, height float32) {
+	shape.Width = f32Max(0, width)
+	shape.Height = f32Max(0, height)
+	shape.MinWidth = shape.Width
+	shape.MaxWidth = shape.Width
+	shape.MinHeight = shape.Height
+	shape.MaxHeight = shape.Height
 }
 
 func splitterResetPositions(layout *Layout, isRoot bool,

--- a/gui/view_splitter_interaction_test.go
+++ b/gui/view_splitter_interaction_test.go
@@ -1,6 +1,9 @@
 package gui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Interaction-level coverage for the splitter: the AmendLayout geometry
 // pass, drag resize through the mouse lock, hover feedback, the keyboard
@@ -151,10 +154,11 @@ func splitterTwoPanes() (first, second SplitterPaneCfg) {
 		SplitterPaneCfg{Content: []View{Text(TextCfg{Text: "R"})}}
 }
 
-// splitterEmptyPanes is for geometry assertions that need a pane able to
-// reach zero width. A pane with content cannot: the fit pass floors it at
-// the content's own minimum (see
-// TestSplitterCollapsedPaneKeepsContentMinimum).
+// splitterEmptyPanes builds content-free panes for geometry assertions
+// that only care about the computed sizes. They were introduced as a
+// workaround for the collapsed-pane sliver (issue #263, since fixed) —
+// content panes now collapse fully too, so this helper is a convenience,
+// not a workaround.
 func splitterEmptyPanes() (first, second SplitterPaneCfg) {
 	return SplitterPaneCfg{}, SplitterPaneCfg{}
 }
@@ -290,13 +294,12 @@ func TestSplitterAmendLayoutCollapsedFirst(t *testing.T) {
 	nearF(t, "second width", second.Shape.Width, avail, 0.5)
 }
 
-// A collapsed pane is only as small as its content allows.
-// splitterLayoutChild pins the pane to width 0, but then re-runs the fit
-// pass on the subtree, which grows the pane back to its content's
-// minimum — so the "collapsed" pane keeps a sliver and draws underneath
-// the handle, which sits at x=0. Asserted as-is to pin the behavior;
-// see issue #263.
-func TestSplitterCollapsedPaneKeepsContentMinimum(t *testing.T) {
+// A collapsed pane with content reaches exactly its collapsed size:
+// splitterLayoutChild re-applies the pinned size after the fit passes,
+// which previously grew the pane back to its content's minimum and left
+// a sliver underneath the handle (issue #263). At width 0 the pane
+// occupies no pixels, so it shares none with the 9px handle at x=0.
+func TestSplitterCollapsedPaneReachesZeroWidthWithContent(t *testing.T) {
 	a, b := splitterTwoPanes()
 	a.collapsible = true
 	h := newSplitterHarness(t, SplitterCfg{
@@ -305,18 +308,116 @@ func TestSplitterCollapsedPaneKeepsContentMinimum(t *testing.T) {
 		First:     a,
 		Second:    b,
 	})
-	first, handle, _ := h.parts(t, "sp")
-	if first.Shape.Width <= 0 {
-		t.Errorf("collapsed pane width = %g: #263 appears fixed, so "+
-			"this test and the geometry cases using splitterEmptyPanes "+
-			"should be rewritten to expect a true zero-width collapse",
-			first.Shape.Width)
+	first, handle, second := h.parts(t, "sp")
+	avail := float32(splitterTestW - splitterTestHandle)
+	nearF(t, "collapsed first width", first.Shape.Width, 0, 0.01)
+	nearF(t, "first x", first.Shape.X, 0, 0.01)
+	nearF(t, "handle x", handle.Shape.X, 0, 0.01)
+	if first.Shape.X+first.Shape.Width > handle.Shape.X {
+		t.Errorf("collapsed pane spans %g..%g, handle starts at %g — "+
+			"the pane must not share pixels with the handle",
+			first.Shape.X, first.Shape.X+first.Shape.Width,
+			handle.Shape.X)
 	}
-	if first.Shape.X != handle.Shape.X {
-		t.Errorf("collapsed pane x = %g, handle x = %g: expected the "+
-			"residual pane to sit under the handle",
-			first.Shape.X, handle.Shape.X)
+	nearF(t, "second width", second.Shape.Width, avail, 0.5)
+}
+
+// A non-zero collapsedSize is the pin value the pane must respect even
+// with content: the pane collapses to its collapsedSize, the handle
+// follows it, and the remaining pane takes the rest.
+func TestSplitterCollapsedPaneRespectsCollapsedSizeWithContent(t *testing.T) {
+	a, b := splitterTwoPanes()
+	a.collapsible = true
+	a.collapsedSize = 24
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:        "sp",
+		Collapsed: SplitterCollapseFirst,
+		First:     a,
+		Second:    b,
+	})
+	first, handle, second := h.parts(t, "sp")
+	avail := float32(splitterTestW - splitterTestHandle)
+	nearF(t, "collapsed first width", first.Shape.Width, 24, 0.5)
+	nearF(t, "handle x", handle.Shape.X, 24, 0.5)
+	nearF(t, "second width", second.Shape.Width, avail-24, 0.5)
+}
+
+// The fix holds for the second pane too: collapsing it must leave it at
+// zero width at the right edge, not as a sliver under the handle.
+func TestSplitterCollapsedSecondPaneReachesZeroWidthWithContent(t *testing.T) {
+	a, b := splitterTwoPanes()
+	b.collapsible = true
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:        "sp",
+		Collapsed: SplitterCollapseSecond,
+		First:     a,
+		Second:    b,
+	})
+	first, handle, second := h.parts(t, "sp")
+	avail := float32(splitterTestW - splitterTestHandle)
+	nearF(t, "first width", first.Shape.Width, avail, 0.5)
+	nearF(t, "handle x", handle.Shape.X, avail, 0.5)
+	nearF(t, "collapsed second width", second.Shape.Width, 0, 0.01)
+	nearF(t, "second x", second.Shape.X, splitterTestW, 0.5)
+	if second.Shape.X < handle.Shape.X+handle.Shape.Width {
+		t.Errorf("collapsed second pane starts at %g, handle ends at %g — "+
+			"the pane must not share pixels with the handle",
+			second.Shape.X, handle.Shape.X+handle.Shape.Width)
 	}
+}
+
+// Pane sizes come from ratio/min/max, never from content: the pinned size
+// is re-applied after the fit passes, so a pane whose content wants more
+// room keeps the computed size and clips the overflow (the pane is built
+// with Clip: true) instead of stretching.
+func TestSplitterNormalPaneNotStretchedByContent(t *testing.T) {
+	a, b := splitterTwoPanes()
+	a.Content = []View{Text(TextCfg{Text: strings.Repeat("wide", 40)})}
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:     "sp",
+		Ratio:  SomeF(0.25),
+		First:  a,
+		Second: b,
+	})
+	first, _, _ := h.parts(t, "sp")
+	avail := float32(splitterTestW - splitterTestHandle)
+	want := avail * 0.25
+	nearF(t, "first width", first.Shape.Width, want, 0.5)
+	if !first.Shape.Clip {
+		t.Error("pane does not clip; content overflow would paint outside")
+	}
+	// The content really is wider than the pane, so the clip assertion
+	// above is not vacuous.
+	if text := first.Children[0].Shape; text.Width <= first.Shape.Width {
+		t.Errorf("content width %g does not exceed pane width %g",
+			text.Width, first.Shape.Width)
+	}
+}
+
+// Vertical orientation: a collapsed first pane with content reaches zero
+// height, so nothing draws beneath the handle at y=0.
+func TestSplitterCollapsedPaneVerticalReachesZeroHeightWithContent(t *testing.T) {
+	a, b := splitterTwoPanes()
+	a.collapsible = true
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:          "sp",
+		Orientation: SplitterVertical,
+		Collapsed:   SplitterCollapseFirst,
+		First:       a,
+		Second:      b,
+	})
+	first, handle, second := h.parts(t, "sp")
+	avail := float32(splitterTestH - splitterTestHandle)
+	nearF(t, "collapsed first height", first.Shape.Height, 0, 0.01)
+	nearF(t, "first y", first.Shape.Y, 0, 0.01)
+	nearF(t, "handle y", handle.Shape.Y, 0, 0.01)
+	if first.Shape.Y+first.Shape.Height > handle.Shape.Y {
+		t.Errorf("collapsed pane spans %g..%g, handle starts at %g — "+
+			"the pane must not share pixels with the handle",
+			first.Shape.Y, first.Shape.Y+first.Shape.Height,
+			handle.Shape.Y)
+	}
+	nearF(t, "second height", second.Shape.Height, avail, 0.5)
 }
 
 func TestSplitterAmendLayoutCollapsedSecondHonorsCollapsedSize(t *testing.T) {
@@ -366,6 +467,37 @@ func TestSplitterAmendLayoutOversizedHandle(t *testing.T) {
 	nearF(t, "handle width", handle.Shape.Width, splitterTestW, 0.01)
 	nearF(t, "first width", first.Shape.Width, 0, 0.01)
 	nearF(t, "second width", second.Shape.Width, 0, 0.01)
+}
+
+// Same degenerate geometry with real content in both panes, where both
+// are pinned to zero at once (the collapse tests cover one zero pane at a
+// time). The sliver fix (#263) must hold here too, or the panes grow to
+// their content minimum and draw over the full-width handle.
+func TestSplitterAmendLayoutOversizedHandleWithContent(t *testing.T) {
+	a, b := splitterTwoPanes()
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:         "sp",
+		HandleSize: SomeF(splitterTestW + 200),
+		First:      a,
+		Second:     b,
+	})
+	first, handle, second := h.parts(t, "sp")
+	nearF(t, "handle width", handle.Shape.Width, splitterTestW, 0.01)
+	nearF(t, "first width", first.Shape.Width, 0, 0.01)
+	nearF(t, "second width", second.Shape.Width, 0, 0.01)
+	// The panes occupy no pixels, so nothing draws under or beyond the
+	// full-width handle.
+	if first.Shape.X+first.Shape.Width > handle.Shape.X {
+		t.Errorf("first pane spans %g..%g, handle starts at %g — "+
+			"the pane must not share pixels with the handle",
+			first.Shape.X, first.Shape.X+first.Shape.Width,
+			handle.Shape.X)
+	}
+	if second.Shape.X < handle.Shape.X+handle.Shape.Width {
+		t.Errorf("second pane starts at %g, handle ends at %g — "+
+			"the pane must not share pixels with the handle",
+			second.Shape.X, handle.Shape.X+handle.Shape.Width)
+	}
 }
 
 // AmendLayout indexes Children[0..2] unconditionally after the length
@@ -783,9 +915,8 @@ func TestSplitterKeyHomeCollapsesFirst(t *testing.T) {
 		t.Errorf("collapsed = %v, want first", h.state.Collapsed)
 	}
 	// The collapse reaches layout, not just the reported state: the
-	// second pane is assigned the whole available span. That says
-	// nothing about the first pane, whose residual sliver overlaps the
-	// handle rather than shrinking the second (#263).
+	// second pane is assigned the whole available span and the first
+	// pane collapses to zero, so nothing overlaps the handle (#263).
 	_, _, second := h.parts(t, "sp")
 	nearF(t, "second width", second.Shape.Width,
 		splitterTestW-splitterTestHandle, 0.5)


### PR DESCRIPTION
## Summary

Fixes #263. A collapsed splitter pane holding content never reached zero width: `splitterLayoutChild` pinned the pane to 0 (Min=Max=Width=0) and then ran the fit passes, which recomputed the pane size from its content's minimum — a pane with a short `Text` collapsed to 9.6px at x=0, drawn underneath the 9px handle.

**Fix:** re-apply the pin (all six size fields, via a new `splitterPinShapeSize` helper) after the fit passes and before scroll/position/amend, so downstream layout, clipping, and rendering see the final collapsed size. The collapsed pane's render clip is 0×0. For panes pinned >0 the re-assert is a strict no-op (verified by branch reading and no moved assertions) — the sizing contract is unchanged: pane sizes come from ratio/min/max; content larger than the pane is clipped (`Clip: true`).

## Tests

- `TestSplitterCollapsedPaneReachesZeroWidthWithContent` (rewritten from the bug-pinning test) — width 0, no shared pixels with the handle, second pane takes the rest
- `TestSplitterCollapsedPaneRespectsCollapsedSizeWithContent` (new) — non-zero `collapsedSize` is respected (regression guard)
- `TestSplitterCollapsedSecondPaneReachesZeroWidthWithContent` (new)
- `TestSplitterCollapsedPaneVerticalReachesZeroHeightWithContent` (new)
- `TestSplitterNormalPaneNotStretchedByContent` (new) — contract guard
- `TestSplitterAmendLayoutOversizedHandleWithContent` (new) — both panes pinned 0 with real content

All three collapse tests fail on pre-fix code with exactly the sliver (9.6px horizontal, 22.4px vertical); the guards pass both ways.

## Notes

- CHANGELOG `[Unreleased]` → Fixed bullet with the contract note.
- The fix lives in the widget layer on purpose: the fit passes' Fixed-0 → content-sizing degradation is deliberate framework behavior (issue #94's clip-collapse fix), not a shared-machinery bug.
- Independent review passed: no blockers, no should-fix; all three nits applied (comment accuracy, pin-block dedupe, degenerate-case test).

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green. Pre-commit hooks (gofmt + golangci-lint) passed.