### PR TITLE
fix(gui): splitter handle shows its active color during drag (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ and this project adheres to
   ID-bearing ancestor the spellings are unchanged. API consequence: parts of
   a nested splitter are addressed by scoped effective IDs (`outer:sp:handle`,
   `outer:sp:pane:first`).
+- **Splitter: the handle's active (button-held) color now renders during a
+  drag (issue #265).** `splitterOnHandleHover` painted `colorHandleActive`
+  only while `Event.MouseButton == MouseLeft` — a branch no real frame could
+  reach, because `layoutHover` bails while the mouse is locked (and a
+  splitter drag runs under `MouseLock`) and always synthesizes hover events
+  with `MouseButton: MouseInvalid`. The active color is now driven from the
+  splitter's own drag state instead: the press paints the handle immediately
+  and records a pressed flag in window state, and `splitterAmendLayout`
+  re-paints the active color every frame while the lock is held, so the
+  pressed feedback survives the per-frame regeneration of the handle. The
+  flag is cleared on release and by the mouse lock's `Cancel` hook, and the
+  amend paint is additionally guarded by the window's actual lock state, so
+  capture lost without a release (issue #237) can never leave the handle
+  permanently active.
 
 ### Added
 

--- a/gui/state_registry.go
+++ b/gui/state_registry.go
@@ -204,6 +204,7 @@ const (
 	nsDatePicker          = "gui.date_picker"
 	nsColorPicker         = "gui.color_picker"
 	nsSliderPress         = "gui.slider.press"
+	nsSplitterDrag        = "gui.splitter.drag"
 	nsInputDate           = "gui.input_date"
 	nsInputDateText       = "gui.input_date.text"
 	nsDgColWidths         = "gui.dg.col_widths"

--- a/gui/view_splitter.go
+++ b/gui/view_splitter.go
@@ -168,6 +168,13 @@ type splitterCore struct {
 	orientation   splitterOrientation
 	collapsed     SplitterCollapsed
 	disabled      bool
+	// Handle colors resolved from the (defaulted) cfg. The drag state
+	// itself lives in window state (nsSplitterDrag), not on this core —
+	// the view function rebuilds the core every frame, so a field here
+	// would not survive a drag.
+	colorHandle       Color
+	colorHandleHover  Color
+	colorHandleActive Color
 }
 
 type splitterComputed struct {
@@ -199,10 +206,13 @@ func newSplitterCore(cfg *SplitterCfg) *splitterCore {
 			collapsible:   cfg.Second.collapsible,
 			collapsedSize: cfg.Second.collapsedSize,
 		},
-		handleSize:    cfg.HandleSize.Get(s.HandleSize),
-		dragStep:      cfg.dragStep.Get(s.dragStep),
-		dragStepLarge: cfg.dragStepLarge.Get(s.dragStepLarge),
-		disabled:      cfg.Disabled,
+		handleSize:        cfg.HandleSize.Get(s.HandleSize),
+		dragStep:          cfg.dragStep.Get(s.dragStep),
+		dragStepLarge:     cfg.dragStepLarge.Get(s.dragStepLarge),
+		disabled:          cfg.Disabled,
+		colorHandle:       cfg.colorHandle,
+		colorHandleHover:  cfg.colorHandleHover,
+		colorHandleActive: cfg.colorHandleActive,
 	}
 }
 
@@ -390,6 +400,25 @@ func splitterAmendLayout(core *splitterCore, layout *Layout, w *Window) {
 		splitterLayoutChild(&layout.Children[2], x,
 			y+computed.firstMain+computed.handleMain,
 			wid, computed.secondMain, w)
+	}
+
+	// The handle's active (button-held) color is painted here, in the
+	// last pass that can write the shape's color before the render:
+	// layoutHover bails while the mouse is locked (a splitter drag runs
+	// under MouseLock) and the lock's MouseMove handler paints nothing,
+	// so a click-time paint alone would be overwritten by the next
+	// frame's regeneration of the handle (which reseeds the base
+	// color). The pressed flag is keyed by the splitter's effective ID
+	// — the same key splitterOnHandleClick writes — and cleared on
+	// MouseUp and by the lock's Cancel hook (capture revoked without a
+	// release, issue #237). Guarding on the window's actual lock state
+	// makes a stale flag unable to pin the handle active even if some
+	// future path clears the lock without either.
+	ps := StateMapRead[string, bool](w, nsSplitterDrag)
+	if ps != nil && w.mouseIsLocked() {
+		if pressed, ok := ps.Get(layout.Shape.idKey()); ok && pressed {
+			layout.Children[1].Shape.Color = core.colorHandleActive
+		}
 	}
 }
 

--- a/gui/view_splitter_handle.go
+++ b/gui/view_splitter_handle.go
@@ -28,8 +28,6 @@ func splitterHandleView(cfg *SplitterCfg, core *splitterCore, id string) View {
 	}
 
 	orientation := cfg.Orientation
-	colorHover := cfg.colorHandleHover
-	colorActive := cfg.colorHandleActive
 
 	s := &defaultSplitterStyle
 	handleSize := cfg.HandleSize.Get(s.HandleSize)
@@ -54,11 +52,10 @@ func splitterHandleView(cfg *SplitterCfg, core *splitterCore, id string) View {
 		HAlign:      HAlignCenter,
 		VAlign:      VAlignMiddle,
 		OnClick: func(ctx EventCtx) {
-			splitterOnHandleClick(core, ctx.Event, ctx.Window)
+			splitterOnHandleClick(core, ctx.Layout, ctx.Event, ctx.Window)
 		},
 		OnHover: func(ctx EventCtx) {
-			splitterOnHandleHover(orientation, colorHover,
-				colorActive, ctx.Layout, ctx.Event, ctx.Window)
+			splitterOnHandleHover(core, ctx.Layout, ctx.Event, ctx.Window)
 		},
 		Content: content,
 	}
@@ -212,12 +209,24 @@ func splitterOnKeydown(core *splitterCore, e *Event, w *Window) {
 	}
 }
 
-func splitterOnHandleClick(core *splitterCore, e *Event, w *Window) {
+// splitterOnHandleClick arms the drag: it locks the mouse, records the
+// pressed flag the amend paint keys on, and paints the handle active
+// immediately (the press frame's amend pass already ran, so this is the
+// only write that colors this frame).
+func splitterOnHandleClick(core *splitterCore, layout *Layout, e *Event, w *Window) {
 	if core.disabled {
 		return
 	}
 	splitterSetCursor(core.orientation, w)
 	splitterFocus(core, w)
+
+	// Pressed state is keyed by the splitter's effective ID — stamped
+	// on the core by splitterAmendLayout and the same key the amend
+	// paint reads off the root shape. The core itself is rebuilt by the
+	// view function every frame, so cross-frame drag state lives in
+	// window state, mirroring the slider's nsSliderPress.
+	StateMap[string, bool](w, nsSplitterDrag, capModerate).Set(core.id, true)
+	layout.Shape.Color = core.colorHandleActive
 
 	focusID := core.focusID
 	w.MouseLock(MouseLockCfg{
@@ -225,25 +234,34 @@ func splitterOnHandleClick(core *splitterCore, e *Event, w *Window) {
 			splitterOnDragMove(core, ctx.Event, ctx.Window)
 		},
 		MouseUp: func(ctx EventCtx) {
+			// Clear the pressed look first; the unlock that follows
+			// lets hover take over painting the handle next frame.
+			StateMap[string, bool](ctx.Window, nsSplitterDrag, capModerate).
+				Set(core.id, false)
 			ctx.Window.MouseUnlock()
 			if focusID != "" {
 				ctx.Window.SetFocus(focusID)
 			}
 		},
+		Cancel: func(w *Window) {
+			// Capture revoked without a release (see MouseCancel,
+			// issue #237): the pressed flag must not pin the handle
+			// active forever.
+			StateMap[string, bool](w, nsSplitterDrag, capModerate).
+				Set(core.id, false)
+		},
 	})
 	e.IsHandled = true
 }
 
-func splitterOnHandleHover(
-	orientation splitterOrientation,
-	colorHover, colorActive Color,
-	layout *Layout, e *Event, w *Window,
-) {
-	splitterSetCursor(orientation, w)
-	layout.Shape.Color = colorHover
-	if e.MouseButton == MouseLeft {
-		layout.Shape.Color = colorActive
-	}
+// splitterOnHandleHover paints the hover color. The active color is not
+// this handler's job: layoutHover bails while the mouse is locked and
+// always synthesizes its event with MouseButton: MouseInvalid, so a
+// button branch here could never fire through the real pipeline
+// (issue #265) — the drag paint lives in splitterAmendLayout instead.
+func splitterOnHandleHover(core *splitterCore, layout *Layout, e *Event, w *Window) {
+	splitterSetCursor(core.orientation, w)
+	layout.Shape.Color = core.colorHandleHover
 	e.IsHandled = true
 }
 

--- a/gui/view_splitter_interaction_test.go
+++ b/gui/view_splitter_interaction_test.go
@@ -610,7 +610,7 @@ func TestSplitterHandleClickDisabledIsInert(t *testing.T) {
 	h := newSplitterHarness(t, SplitterCfg{ID: "sp"})
 	core := &splitterCore{id: "sp", disabled: true, handleSize: 9}
 	e := Event{Type: EventMouseDown, MouseButton: MouseLeft}
-	splitterOnHandleClick(core, &e, h.w)
+	splitterOnHandleClick(core, &Layout{Shape: &Shape{}}, &e, h.w)
 	if h.w.mouseIsLocked() {
 		t.Error("disabled splitter armed a drag")
 	}
@@ -792,25 +792,126 @@ func TestSplitterHandleHoverAwayKeepsBaseColor(t *testing.T) {
 	}
 }
 
-// The active (button-held) branch is exercised directly. layoutHover
-// bails while the mouse is locked and always synthesizes its hover event
-// with MouseButton: MouseInvalid, so no real frame can reach this branch
-// — see issue #265.
-func TestSplitterHandleHoverActiveColor(t *testing.T) {
-	h := newSplitterHarness(t, SplitterCfg{ID: "sp"})
-	layout := Layout{Shape: &Shape{}}
-	hover := RGBA(1, 2, 3, 255)
-	active := RGBA(4, 5, 6, 255)
-	e := Event{Type: EventMouseMove, MouseButton: MouseLeft}
-	splitterOnHandleHover(SplitterVertical, hover, active, &layout, &e, h.w)
-	if layout.Shape.Color != active {
-		t.Errorf("color = %v, want active %v", layout.Shape.Color, active)
+// The active (button-held) color is driven by the drag state, not the
+// hover event: layoutHover bails while the mouse is locked (a splitter
+// drag runs under MouseLock) and always synthesizes its hover event
+// with MouseButton: MouseInvalid, so no real frame could ever reach an
+// e.MouseButton == MouseLeft branch in the hover handler (issue #265).
+// The pressed flag is set on press, painted every frame by
+// splitterAmendLayout while the lock is held, and cleared on release —
+// all exercised here through real dispatch.
+func TestSplitterHandleDragShowsActiveColor(t *testing.T) {
+	a, b := splitterTwoPanes()
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:     "sp",
+		Ratio:  SomeF(0.5),
+		First:  a,
+		Second: b,
+	})
+	h.pressHandle(t, "sp")
+	h.move(120, 150)
+
+	_, handle, _ := h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandleActive {
+		t.Errorf("dragging handle color = %v, want active %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandleActive)
 	}
-	if !e.IsHandled {
-		t.Error("hover did not consume the event")
+
+	// A frame with no mouse event must keep the active color: the
+	// per-frame regeneration reseeds the base color, so only the amend
+	// paint can hold the pressed look through an idle frame.
+	h.w.TestRender(nil)
+	_, handle, _ = h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandleActive {
+		t.Errorf("handle color after idle frame = %v, want active %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandleActive)
 	}
-	if h.w.viewState.mouseCursor != CursorResizeNS {
-		t.Errorf("cursor = %v, want CursorResizeNS", h.w.viewState.mouseCursor)
+
+	// Release with the pointer still over the handle (a drag centers
+	// the handle on the cursor): the hover repaint takes over.
+	h.release(120, 150)
+	_, handle, _ = h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandleHover {
+		t.Errorf("handle color after release = %v, want hover %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandleHover)
+	}
+
+	// Moving away restores the base color.
+	h.move(5, 5)
+	_, handle, _ = h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandle {
+		t.Errorf("handle color after leaving = %v, want base %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandle)
+	}
+}
+
+// A press with no movement still shows the active color, and holds
+// through a frame with no mouse event.
+func TestSplitterHandleClickAloneShowsActiveColor(t *testing.T) {
+	a, b := splitterTwoPanes()
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:     "sp",
+		First:  a,
+		Second: b,
+	})
+	h.pressHandle(t, "sp")
+
+	_, handle, _ := h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandleActive {
+		t.Errorf("handle color after press = %v, want active %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandleActive)
+	}
+
+	h.w.TestRender(nil)
+	_, handle, _ = h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandleActive {
+		t.Errorf("handle color after idle frame = %v, want active %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandleActive)
+	}
+
+	// Release away from the handle: base color.
+	h.release(5, 5)
+	_, handle, _ = h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandle {
+		t.Errorf("handle color after release = %v, want base %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandle)
+	}
+}
+
+// Capture lost without a release (the platform revoking mouse capture,
+// issue #237) must not leave the handle active forever: MouseCancel
+// clears the lock and runs the lock's Cancel hook, which clears the
+// pressed flag.
+func TestSplitterHandleDragCancelRestoresColor(t *testing.T) {
+	a, b := splitterTwoPanes()
+	h := newSplitterHarness(t, SplitterCfg{
+		ID:     "sp",
+		First:  a,
+		Second: b,
+	})
+	h.pressHandle(t, "sp")
+	_, handle, _ := h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandleActive {
+		t.Fatalf("handle color after press = %v, want active %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandleActive)
+	}
+
+	h.w.MouseCancel()
+	h.w.settle()
+	if h.w.mouseIsLocked() {
+		t.Error("mouse still locked after MouseCancel")
+	}
+	_, handle, _ = h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandle {
+		t.Errorf("handle color after cancel = %v, want base %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandle)
+	}
+	// A further frame must not resurrect the active color.
+	h.w.TestRender(nil)
+	_, handle, _ = h.parts(t, "sp")
+	if handle.Shape.Color != defaultSplitterStyle.colorHandle {
+		t.Errorf("handle color after idle frame = %v, want base %v",
+			handle.Shape.Color, defaultSplitterStyle.colorHandle)
 	}
 }
 
@@ -1499,7 +1600,7 @@ func TestSplitterHandleReleaseWithoutIDStillUnlocks(t *testing.T) {
 	h.w.SetFocus("elsewhere")
 	core := &splitterCore{id: "sp", handleSize: splitterTestHandle}
 	e := Event{Type: EventMouseDown, MouseButton: MouseLeft}
-	splitterOnHandleClick(core, &e, h.w)
+	splitterOnHandleClick(core, &Layout{Shape: &Shape{}}, &e, h.w)
 	if !h.w.mouseIsLocked() {
 		t.Fatal("handle click did not lock the mouse")
 	}


### PR DESCRIPTION
## Summary

Fixes #265. `splitterOnHandleHover`'s active-color branch (`e.MouseButton == MouseLeft`) could never fire: `layoutHover` bails while the mouse is locked (a splitter drag runs under `MouseLock`) and synthesizes hover events with `MouseButton: MouseInvalid`. `colorHandleActive` therefore had no effect — the handle showed the plain hover color for the entire drag.

**Fix (widget-local):** the splitter now drives the active color from its own drag state instead of the hover event:

- Drag state lives in a per-window `StateMap` under a new `nsSplitterDrag` namespace, keyed by the splitter's effective ID — a `core` field can't survive per-frame core rebuilds in immediate mode (mirrors the `nsSliderPress` precedent).
- Handle click paints active immediately and arms `MouseLock` with `MouseUp` **and** `Cancel` hooks that clear the flag; `splitterAmendLayout` repaints the handle active every frame while the flag is set and the mouse is locked (amend is the last color writer before render while locked).
- Capture loss is safe: backends revoke capture via `MouseCancel()` → the new `Cancel` hook clears the flag, and the amend paint is additionally guarded by `w.mouseIsLocked()` so a stale flag can't render active without a real lock.
- The dead `MouseLeft` branch in `splitterOnHandleHover` is removed.

## Tests

- `TestSplitterHandleDragShowsActiveColor` (rewritten from the direct-call pin) — real pipeline: press+move → active; an idle frame keeps it active (proves the amend paint survives regeneration); release with pointer over handle → hover; move away → base
- `TestSplitterHandleClickAloneShowsActiveColor` (new) — press only → active, release → base
- `TestSplitterHandleDragCancelRestoresColor` (new) — `MouseCancel` → base, stays base across an idle frame

All three fail on pre-fix code with exactly the #265 symptom (handle stays base, never active during a locked drag).

## Notes

- CHANGELOG `[Unreleased]` → Fixed bullet.
- The same dead pattern exists in `button.go:97`, `expand_panel.go:116`, `switch.go:118`, `datagrid` header (`colorResizeActive`) — a framework-level concern (layoutHover lock bail + `MouseInvalid` synthesis), out of scope here; filed separately.
- Independent review passed: no blockers, no should-fix, report-only nits.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green. Pre-commit hooks (gofmt + golangci-lint) passed.