### PR TITLE
fix(layout): FillFill roots on axisNone containers fill the window (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to
 
 ### Fixed
 
+- **FillFill roots on axis-less containers resolve to the window size
+  (issue #262).** `updateLayoutLocked` pins a Fill root to the window
+  dimensions via `Min = Max`, but the width/height sizing passes only
+  consulted the pin on axis-bearing containers — so a `Splitter` (built
+  on a `Canvas`) returned directly as the root view resolved to 0x0 and
+  was invisible, despite `Sizing` defaulting to `FillFill`. The
+  `axisNone` branch of both passes now honors explicit min/max pins, so
+  `FillFill` is honest on axis-less roots and tracks window resize. It
+  also makes an explicit `MinWidth`/`MaxWidth` on a `Fit`-sized `Canvas`
+  take effect, which is the documented intent of those fields (Fill
+  roots keep the window pin; the fill distribution clamps nested Fill
+  children). Children of axis-less containers keep their sizing
+  semantics unchanged.
+
 - **Splitter: a collapsed pane with content now reaches its collapsed
   size (issue #263).** `splitterLayoutChild` pinned the pane to the size
   `splitterCompute` decided, then re-ran the fit passes, which recomputed

--- a/gui/layout_sizing.go
+++ b/gui/layout_sizing.go
@@ -409,6 +409,26 @@ func layoutWidths(layout *Layout) {
 		if layout.Shape.MaxWidth > 0 {
 			layout.Shape.Width = f32Min(layout.Shape.Width, layout.Shape.MaxWidth)
 		}
+	} else {
+		// axisNone: no children to distribute along the axis, so there
+		// is nothing to fit against. Honor explicit min/max pins only —
+		// the Fill root pin from updateLayoutLocked (Min = Max = window
+		// size) is the case that matters (issue #262): a FillFill root
+		// like a Splitter (Canvas) used to resolve to 0x0 because the
+		// pin was set and never read. Fixed sizing pins via
+		// applyFixedSizingConstraints (Min = Max = Width), where the
+		// clamp is a no-op; children keep today's sizing semantics.
+		// Invariant: the fill impls must stay size-neutral for axisNone
+		// — today they only recurse and cache contentW — or the pin
+		// would be overwritten after this pass (plan item: "making the
+		// fill passes distribute children of axisNone roots" is out of
+		// scope and must not drift in as a size writer).
+		if layout.Shape.MinWidth > 0 {
+			layout.Shape.Width = f32Max(layout.Shape.Width, layout.Shape.MinWidth)
+		}
+		if layout.Shape.MaxWidth > 0 {
+			layout.Shape.Width = f32Min(layout.Shape.Width, layout.Shape.MaxWidth)
+		}
 	}
 }
 
@@ -458,6 +478,18 @@ func layoutHeights(layout *Layout) {
 				layout.Shape.MinHeight = f32Max(layout.Shape.MinHeight, layout.Children[i].Shape.MinHeight+padding)
 			}
 		}
+		if layout.Shape.MinHeight > 0 {
+			layout.Shape.Height = f32Max(layout.Shape.Height, layout.Shape.MinHeight)
+		}
+		if layout.Shape.MaxHeight > 0 {
+			layout.Shape.Height = f32Min(layout.Shape.Height, layout.Shape.MaxHeight)
+		}
+	} else {
+		// axisNone: mirror layoutWidths — nothing to distribute, so
+		// honor explicit min/max pins only (the Fill root pin from
+		// updateLayoutLocked, issue #262). Same fill-impl size-neutral
+		// invariant as layoutWidths: the height fill impl must not gain
+		// an axisNone size writer.
 		if layout.Shape.MinHeight > 0 {
 			layout.Shape.Height = f32Max(layout.Shape.Height, layout.Shape.MinHeight)
 		}

--- a/gui/layout_sizing_test.go
+++ b/gui/layout_sizing_test.go
@@ -88,6 +88,98 @@ func TestLayoutHeightsMaxHeightClamp(t *testing.T) {
 	}
 }
 
+// axisNone has no children to fit against, so the pass only honors
+// explicit min/max pins — the Fill root pin from updateLayoutLocked
+// (issue #262). Without a pin the size must stay untouched.
+func TestLayoutWidthsAxisNoneHonorsMinMax(t *testing.T) {
+	root := &Layout{Shape: &Shape{Axis: axisNone}}
+	layoutWidths(root)
+	if root.Shape.Width != 0 {
+		t.Errorf("width: got %f, want 0 (no pin)", root.Shape.Width)
+	}
+
+	root.Shape.MinWidth = 400
+	root.Shape.MaxWidth = 400
+	layoutWidths(root)
+	if !f32AreClose(root.Shape.Width, 400) {
+		t.Errorf("width: got %f, want 400 (Fill root pin)", root.Shape.Width)
+	}
+}
+
+func TestLayoutHeightsAxisNoneHonorsMinMax(t *testing.T) {
+	root := &Layout{Shape: &Shape{Axis: axisNone}}
+	layoutHeights(root)
+	if root.Shape.Height != 0 {
+		t.Errorf("height: got %f, want 0 (no pin)", root.Shape.Height)
+	}
+
+	root.Shape.MinHeight = 300
+	root.Shape.MaxHeight = 300
+	layoutHeights(root)
+	if !f32AreClose(root.Shape.Height, 300) {
+		t.Errorf("height: got %f, want 300 (Fill root pin)", root.Shape.Height)
+	}
+}
+
+// An explicit max alone clamps an axisNone shape; a min below the
+// current size must not shrink it.
+func TestLayoutWidthsAxisNoneHonorsMax(t *testing.T) {
+	root := &Layout{
+		Shape: &Shape{
+			Axis:     axisNone,
+			Width:    500,
+			MaxWidth: 400,
+		},
+	}
+	layoutWidths(root)
+	if !f32AreClose(root.Shape.Width, 400) {
+		t.Errorf("width: got %f, want 400", root.Shape.Width)
+	}
+}
+
+// The axisNone branch must not grow into the children's job: children
+// of an axis-less container keep the sizes they arrived with (they are
+// positioned by the container's AmendLayout, e.g. the splitter), so the
+// pass recurses nowhere.
+func TestLayoutWidthsAxisNoneLeavesChildrenAlone(t *testing.T) {
+	root := &Layout{
+		Shape: &Shape{
+			Axis:     axisNone,
+			MinWidth: 400,
+			MaxWidth: 400,
+		},
+		Children: []Layout{
+			{Shape: &Shape{Width: 30}},
+			{Shape: &Shape{Width: 20}},
+		},
+	}
+	layoutWidths(root)
+	if root.Children[0].Shape.Width != 30 || root.Children[1].Shape.Width != 20 {
+		t.Error("axisNone fit pass must not re-size children (they keep " +
+			"their arrival sizes)")
+	}
+}
+
+// The general case of #262, through the full pipeline: a plain axis-less
+// FillFill root (a Canvas, not a splitter) resolves to the window size —
+// the fix lives in the sizing passes, not in the splitter.
+func TestCanvasFillFillRootFillsWindow(t *testing.T) {
+	w := NewTestWindow(WindowCfg{Width: 400, Height: 300})
+	w.TestRender(func(_ *Window) View {
+		return Canvas(ContainerCfg{
+			ID:      "c",
+			Sizing:  FillFill,
+			Content: []View{Text(TextCfg{Text: "content"})},
+		})
+	})
+	root, ok := w.layout.FindByID("c")
+	if !ok {
+		t.Fatal("canvas root not found")
+	}
+	nearF(t, "root width", root.Shape.Width, 400, 0.01)
+	nearF(t, "root height", root.Shape.Height, 300, 0.01)
+}
+
 func TestLayoutFillWidthsAllGrow(t *testing.T) {
 	root := &Layout{
 		Shape: &Shape{

--- a/gui/view_splitter_id_test.go
+++ b/gui/view_splitter_id_test.go
@@ -117,7 +117,8 @@ func TestSplitterSameLeafIDInTwoScopesDoesNotCollide(t *testing.T) {
 // part keeps the exact spelling it had before #264.
 func TestSplitterUnscopedKeepsFlatIDs(t *testing.T) {
 	h := newSplitterHarness(t, splitterCollapsibleCfg("sp"))
-	// splitterFillParent's Row carries no ID, so it opens no scope.
+	// The splitter is the root view, so it opens no scope: its effective
+	// ID equals cfg.ID.
 	for _, id := range []string{
 		"sp",
 		"sp:pane:first",

--- a/gui/view_splitter_interaction_test.go
+++ b/gui/view_splitter_interaction_test.go
@@ -21,7 +21,10 @@ const (
 )
 
 // splitterHarness renders a splitter as the whole window with the ratio
-// and collapse state owned by the test.
+// and collapse state owned by the test. The splitter is returned
+// directly as the root view: it defaults to FillFill and, since #262,
+// the framework pins a Fill root to the window size even on an
+// axis-less container, so the splitter fills the window on its own.
 //
 // The widget stores nothing: it reads cfg.Ratio every frame and reports a
 // new one through OnChange. A test that did not write the reported value
@@ -55,23 +58,9 @@ func newSplitterHarness(t *testing.T, cfg SplitterCfg) *splitterHarness {
 			h.state = SplitterState{Ratio: ratio, Collapsed: col}
 			h.changes++
 		}
-		return splitterFillParent(Splitter(c))
+		return Splitter(c)
 	})
 	return h
-}
-
-// splitterFillParent wraps a splitter in a Fill parent that fills the
-// window exactly. The splitter defaults to FillFill but Canvas has no
-// axis, and a Fill root with no parent to fill against resolves to 0x0 —
-// so a splitter used as the whole view collapses. Real apps put it inside
-// a Row/Column (see examples/showcase), which is what this reproduces.
-func splitterFillParent(v View) View {
-	return Row(ContainerCfg{
-		Sizing:     FillFill,
-		Padding:    NoPadding,
-		SizeBorder: NoBorder,
-		Content:    []View{v},
-	})
 }
 
 // find resolves an effective ID in the current tree. Every helper
@@ -161,6 +150,67 @@ func splitterTwoPanes() (first, second SplitterPaneCfg) {
 // not a workaround.
 func splitterEmptyPanes() (first, second SplitterPaneCfg) {
 	return SplitterPaneCfg{}, SplitterPaneCfg{}
+}
+
+// --- Root view (issue #262) ---
+
+// The #262 reproduction: a Splitter returned directly as the root view
+// resolves to the window size, and the panes/handle get the geometry
+// splitterCompute decides. Before the framework fix the Fill root pin
+// was set (Min = Max = window size) but never read on an axis-less
+// container, so the root stayed 0x0 and the widget was invisible.
+func TestSplitterAsRootViewFillsWindow(t *testing.T) {
+	a, b := splitterTwoPanes()
+	w := NewTestWindow(WindowCfg{Width: splitterTestW, Height: splitterTestH})
+	w.TestRender(func(_ *Window) View {
+		return Splitter(SplitterCfg{
+			ID: "sp", Ratio: SomeF(0.5), First: a, Second: b,
+		})
+	})
+	root, ok := w.layout.FindByID("sp")
+	if !ok {
+		t.Fatal("root splitter not found")
+	}
+	nearF(t, "root width", root.Shape.Width, splitterTestW, 0.01)
+	nearF(t, "root height", root.Shape.Height, splitterTestH, 0.01)
+
+	if len(root.Children) != 3 {
+		t.Fatalf("root children = %d, want 3", len(root.Children))
+	}
+	first, handle, second := root.Children[0], root.Children[1], root.Children[2]
+	avail := float32(splitterTestW - splitterTestHandle)
+	wantFirst := avail * 0.5
+	nearF(t, "first width", first.Shape.Width, wantFirst, 0.5)
+	nearF(t, "handle width", handle.Shape.Width, splitterTestHandle, 0.01)
+	nearF(t, "second width", second.Shape.Width, avail-wantFirst, 0.5)
+	for _, ly := range []*Layout{&first, &handle, &second} {
+		nearF(t, "child height", ly.Shape.Height, splitterTestH, 0.01)
+	}
+}
+
+// The root pin is re-applied per frame, so a FillFill root tracks window
+// resize: updateLayoutLocked re-pins Min = Max to the new window size on
+// every frame, and the axisNone branch must see it.
+func TestSplitterAsRootTracksWindowResize(t *testing.T) {
+	a, b := splitterTwoPanes()
+	h := newSplitterHarness(t, SplitterCfg{
+		ID: "sp", Ratio: SomeF(0.5), First: a, Second: b,
+	})
+	root := h.find(t, "sp")
+	nearF(t, "width", root.Shape.Width, splitterTestW, 0.01)
+	nearF(t, "height", root.Shape.Height, splitterTestH, 0.01)
+
+	h.w.windowWidth, h.w.windowHeight = 640, 480
+	h.w.TestRender(nil)
+	root = h.find(t, "sp")
+	nearF(t, "width after resize", root.Shape.Width, 640, 0.01)
+	nearF(t, "height after resize", root.Shape.Height, 480, 0.01)
+
+	// The panes follow the new window size on the next frame too.
+	first, _, second := h.parts(t, "sp")
+	avail := float32(640 - splitterTestHandle)
+	nearF(t, "first width after resize", first.Shape.Width, avail*0.5, 0.5)
+	nearF(t, "second width after resize", second.Shape.Width, avail*0.5, 0.5)
 }
 
 // --- AmendLayout geometry ---


### PR DESCRIPTION
## Summary

Fixes #262. A `FillFill` root on an axisNone container — `Splitter` (which defaults to `FillFill`), `Canvas`, `DrawCanvas` — resolved to 0×0. `updateLayoutLocked` pins Fill roots correctly (`MinWidth = MaxWidth = windowWidth`, `gui/window_update.go:261-269`), but `layoutWidths`/`layoutHeights` had no `axisNone` case, so the pin was never consulted on an axis-less container. A root has no parent to resolve Fill against, so the widget silently collapsed.

**Fix (framework-level):** new `axisNone` branch in `layoutWidths` and `layoutHeights` honoring the Min/Max pins. The branch fires only when Min/Max are set — today only the Fill-root pin (the bug) and `applyFixedSizingConstraints` (a no-op: Min=Max=size). Nested axisNone containers keep today's semantics (sized by their parent's distribution); children of axisNone are untouched. The splitter's `FillFill` default is now honest.

## Tests

- `TestSplitterAsRootViewFillsWindow` — the #262 repro: `Splitter` returned directly from `TestRender` → root 400×300, panes/handle per `splitterCompute` geometry
- `TestSplitterAsRootTracksWindowResize` — re-render at 640×480, root re-pins and panes follow
- `TestCanvasFillFillRootFillsWindow` — plain `Canvas` `FillFill` root through the full pipeline (pins the general fix)
- 4 pass-level tests: `TestLayoutWidthsAxisNoneHonorsMinMax`, `TestLayoutHeightsAxisNoneHonorsMinMax`, `TestLayoutWidthsAxisNoneHonorsMax`, `TestLayoutWidthsAxisNoneLeavesChildrenAlone` (semantics guard)

All fix-asserting tests fail on pre-fix code (root width 0); the semantics guard passes both ways.

## Notes

- The splitter suite's `splitterFillParent` helper (the `Row{FillFill}` workaround) is removed — the whole interaction suite now runs against splitter-as-root. Zero assertion changes; the two remaining wrappers are for ID scoping, not sizing.
- The fill impls remain size-neutral for axisNone (recursion + content cache only), with invariant comments pinning that.
- CHANGELOG `[Unreleased]` → Fixed bullet (notes explicit `MinWidth`/`MaxWidth` on a Fit-sized `Canvas` now take effect — documented intent).
- Independent review passed: no blockers, no should-fix; both nits applied.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green. Pre-commit hooks (gofmt + golangci-lint) passed.