### PR TITLE
test(gui): markdown selection suite; fix nested selection and stale source selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,44 @@ and this project adheres to
 
 ### Fixed
 
+- **Markdown: cross-block selection works under ID-bearing ancestors
+  (issue #273).** The document's blocks were stamped with the raw
+  `cfg.ID` at generation time, while the container's amend and key
+  handlers keyed on the *effective* ID the resolve pass stamps — so a
+  markdown nested in a panel with an ID collected an empty block list
+  (`nsMdBlocks` was keyed `panel:md`, the blocks matched `md`), and
+  cross-block drag, Ctrl+A, Ctrl+C and click focus were dead, with the
+  click writing selection state under a key nothing read. `Markdown` is
+  now a struct view whose `GenerateLayout` resolves the effective ID
+  once (`w.EffID(cfg.ID)`, the same mechanism the splitter uses) and
+  stamps it into every block and inner ID, so the container, the
+  blocks, the state slots and `SetFocus` all agree on one identity.
+  Flat documents are unchanged; two documents sharing a leaf under
+  different panels now keep separate selections.
+
+- **Markdown: a stale selection no longer survives a document content
+  change (issue #275).** `markdownContainerAmendLayout` now hashes the
+  block list (offsets, rune counts, flat text) each frame and resets
+  the per-widget selection when the hash changes: `SelBeg`/`SelEnd`
+  are rune offsets into the *previous* source, so a stale range would
+  highlight — and Ctrl+C would copy — the wrong runes of the new
+  text. A same-length rewrite of the document is caught too; a pure
+  layout change (resize, font) leaves the selection alone.
+
+### Added
+
+- **Markdown interaction test suite expands to the nested-document and
+  source-change cases** (`gui/markdown_select_interaction_test.go`):
+  effective-ID block collection, click focus, Ctrl+A/C, cross-block
+  drag and per-panel isolation under ID-bearing ancestors; offset-block
+  click accuracy (the click handlers receive shape-relative coordinates
+  via `callRelative`, so a click maps to the rune under the cursor
+  wherever the block sits); and selection reset on content change with
+  an idle-frame positive control. Plus diagram-cache async tests
+  (`gui/markdown_diagram_fetch_test.go`) and block-renderer tests
+  (`gui/view_markdown_blocks_test.go`). Package `gui/` moves from
+  81.0% to 82.4%.
+
 - **FillFill roots on axis-less containers resolve to the window size
   (issue #262).** `updateLayoutLocked` pins a Fill root to the window
   dimensions via `Min = Max`, but the width/height sizing passes only

--- a/gui/markdown_diagram_fetch_test.go
+++ b/gui/markdown_diagram_fetch_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -161,10 +162,22 @@ func TestFetchMermaidAsyncStoresReadyEntry(t *testing.T) {
 	if entry.pNGPath == "" {
 		t.Fatal("ready entry has no stored PNG path")
 	}
-	if _, err := os.Stat(entry.pNGPath); err != nil {
-		t.Errorf("stored PNG missing: %v", err)
+	if runtime.GOOS == "js" {
+		// The WASM build stores diagrams as data URLs, not temp
+		// files (diagram_store_js.go) — there is no filesystem to
+		// stat. Pin the wasm contract instead: the entry's "path" is
+		// a base64 data URL of the fetched PNG.
+		if !strings.HasPrefix(entry.pNGPath,
+			"data:image/png;base64,") {
+			t.Errorf("entry pNGPath = %q, want a PNG data URL on "+
+				"wasm", entry.pNGPath)
+		}
+	} else {
+		if _, err := os.Stat(entry.pNGPath); err != nil {
+			t.Errorf("stored PNG missing: %v", err)
+		}
+		t.Cleanup(func() { removeDiagramPNG(entry.pNGPath) })
 	}
-	t.Cleanup(func() { removeDiagramPNG(entry.pNGPath) })
 }
 
 // TestFetchMermaidAsyncFetcherErrorQueuesError asserts a fetcher

--- a/gui/markdown_diagram_fetch_test.go
+++ b/gui/markdown_diagram_fetch_test.go
@@ -1,0 +1,472 @@
+package gui
+
+// markdown_diagram_fetch_test.go covers the async diagram pipeline in
+// markdown_mermaid.go / markdown_math.go: the stale-result guard
+// (diagramCacheShouldApplyResult), the decode-and-store completion
+// path (finishDiagramFetch) driven through the injected fetcher seam,
+// and the two default HTTP fetchers (assessed as testable via a
+// swapped transport — they hit a fixed hostname but the shared
+// diagramHTTPClient can point at a stub transport, so no network is
+// touched).
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/png"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-gui-org/go-gui/gui/markdown"
+)
+
+// testPNGBytes encodes a solid-color RGBA image of the given size,
+// giving finishDiagramFetch a real PNG to decode.
+func testPNGBytes(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// waitForDiagramCommand polls until at least one command is queued
+// (finishDiagramFetch/queueDiagramError run on the fetcher goroutine,
+// so the queue fills asynchronously after the fetcher returns) and
+// then drains the queue with a frame.
+func waitForDiagramCommand(t *testing.T, w *Window) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		w.commandsMu.Lock()
+		pending := len(w.commands)
+		w.commandsMu.Unlock()
+		if pending > 0 {
+			w.FrameFn()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("diagram command never queued")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// newDiagramWindow returns a window with an empty diagram cache.
+func newDiagramWindow() *Window {
+	w := NewTestWindow(WindowCfg{Width: 100, Height: 100})
+	w.viewState.diagramCache = newBoundedDiagramCache(10)
+	return w
+}
+
+// --- diagramCacheShouldApplyResult ---
+
+func TestDiagramCacheShouldApplyResult(t *testing.T) {
+	// Nil cache: nothing to apply to.
+	if diagramCacheShouldApplyResult(nil, 1, 1) {
+		t.Error("nil cache accepted a result")
+	}
+
+	cache := newBoundedDiagramCache(10)
+
+	// Missing entry: a fetch that never started must not land.
+	if diagramCacheShouldApplyResult(cache, 1, 1) {
+		t.Error("missing entry accepted a result")
+	}
+
+	// Entry present but already ready: a late duplicate must not
+	// overwrite the stored diagram.
+	cache.Set(1, DiagramCacheEntry{
+		State:     diagramReady,
+		RequestID: 1,
+		Width:     10,
+	})
+	if diagramCacheShouldApplyResult(cache, 1, 1) {
+		t.Error("ready entry accepted a result")
+	}
+
+	// Loading but from a different request: the document re-rendered
+	// and re-issued, so this result is stale.
+	cache.Set(2, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: 7,
+	})
+	if diagramCacheShouldApplyResult(cache, 2, 8) {
+		t.Error("stale requestID accepted a result")
+	}
+
+	// The one case that must pass: entry still loading with the same
+	// request ID.
+	if !diagramCacheShouldApplyResult(cache, 2, 7) {
+		t.Error("matching loading entry rejected a result")
+	}
+}
+
+// --- finishDiagramFetch end to end ---
+
+// TestFetchMermaidAsyncStoresReadyEntry runs the full seam: a loading
+// cache entry, an injected fetcher returning a real PNG, and the
+// queued finishDiagramFetch command. The cache must end up ready with
+// the decoded dimensions and a stored temp file.
+func TestFetchMermaidAsyncStoresReadyEntry(t *testing.T) {
+	w := newDiagramWindow()
+
+	body := testPNGBytes(t, 60, 40)
+	hash := diagramCacheHash("graph TD\n  A-->B")
+	reqID := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: reqID,
+	})
+
+	var calls atomic.Int32
+	done := make(chan struct{})
+	fetchMermaidAsync(w, "graph TD\n  A-->B", hash, reqID,
+		func(_ context.Context, _ string) ([]byte, error) {
+			calls.Add(1)
+			close(done)
+			return body, nil
+		})
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("mermaid fetcher was not called")
+	}
+	waitForDiagramCommand(t, w)
+
+	entry, ok := w.viewState.diagramCache.Get(hash)
+	if !ok {
+		t.Fatal("diagram hash missing after fetch")
+	}
+	if entry.State != diagramReady {
+		t.Fatalf("entry state = %v, want ready (error: %q)",
+			entry.State, entry.Error)
+	}
+	if entry.Width != 60 || entry.Height != 40 {
+		t.Errorf("decoded size = %gx%g, want 60x40",
+			entry.Width, entry.Height)
+	}
+	if entry.RequestID != reqID {
+		t.Errorf("requestID = %d, want %d", entry.RequestID, reqID)
+	}
+	if entry.pNGPath == "" {
+		t.Fatal("ready entry has no stored PNG path")
+	}
+	if _, err := os.Stat(entry.pNGPath); err != nil {
+		t.Errorf("stored PNG missing: %v", err)
+	}
+	t.Cleanup(func() { removeDiagramPNG(entry.pNGPath) })
+}
+
+// TestFetchMermaidAsyncFetcherErrorQueuesError asserts a fetcher
+// failure lands as a diagramError entry (queueDiagramError's apply
+// path).
+func TestFetchMermaidAsyncFetcherErrorQueuesError(t *testing.T) {
+	w := newDiagramWindow()
+
+	hash := diagramCacheHash("graph TD\n  A-->B")
+	reqID := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: reqID,
+	})
+
+	done := make(chan struct{})
+	fetchMermaidAsync(w, "graph TD\n  A-->B", hash, reqID,
+		func(_ context.Context, _ string) ([]byte, error) {
+			close(done)
+			return nil, errors.New("kroki down")
+		})
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("mermaid fetcher was not called")
+	}
+	waitForDiagramCommand(t, w)
+
+	entry, _ := w.viewState.diagramCache.Get(hash)
+	if entry.State != diagramError {
+		t.Fatalf("entry state = %v, want error", entry.State)
+	}
+	if entry.Error != "kroki down" {
+		t.Errorf("error text = %q, want %q", entry.Error, "kroki down")
+	}
+}
+
+// TestFetchMermaidAsyncSourceTooLarge asserts the size guard fires
+// before the fetcher is consulted.
+func TestFetchMermaidAsyncSourceTooLarge(t *testing.T) {
+	w := newDiagramWindow()
+
+	hash := diagramCacheHash("x")
+	reqID := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: reqID,
+	})
+
+	var fetcherCalled atomic.Bool
+	fetchMermaidAsync(w, strings.Repeat("x", markdown.MaxMermaidSourceLen+1),
+		hash, reqID,
+		func(_ context.Context, _ string) ([]byte, error) {
+			fetcherCalled.Store(true)
+			return nil, nil
+		})
+
+	waitForDiagramCommand(t, w)
+	if fetcherCalled.Load() {
+		t.Error("fetcher called for an oversized source")
+	}
+	entry, _ := w.viewState.diagramCache.Get(hash)
+	if entry.State != diagramError {
+		t.Fatalf("entry state = %v, want error", entry.State)
+	}
+	if !strings.Contains(entry.Error, "too large") {
+		t.Errorf("error text = %q, want it to mention size",
+			entry.Error)
+	}
+}
+
+// TestFinishDiagramFetchBadPNGQueuesError asserts a body that is not a
+// PNG fails decode and lands as an error entry.
+func TestFinishDiagramFetchBadPNGQueuesError(t *testing.T) {
+	w := newDiagramWindow()
+
+	hash := diagramCacheHash("math1")
+	reqID := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: reqID,
+	})
+
+	finishDiagramFetch(w, []byte("not a png"), hash, reqID, 150, "math")
+	waitForDiagramCommand(t, w)
+
+	entry, _ := w.viewState.diagramCache.Get(hash)
+	if entry.State != diagramError {
+		t.Fatalf("entry state = %v, want error", entry.State)
+	}
+	if !strings.Contains(entry.Error, "PNG decode") {
+		t.Errorf("error text = %q, want it to mention PNG decode",
+			entry.Error)
+	}
+}
+
+// TestStaleDiagramResultDropped asserts the stale-request guard: when
+// the cache entry is replaced by a newer request before the fetch
+// lands, the queued completion must not overwrite it.
+func TestStaleDiagramResultDropped(t *testing.T) {
+	w := newDiagramWindow()
+
+	body := testPNGBytes(t, 10, 10)
+	hash := diagramCacheHash("stale")
+	oldReq := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: oldReq,
+	})
+
+	done := make(chan struct{})
+	fetchMermaidAsync(w, "stale", hash, oldReq,
+		func(_ context.Context, _ string) ([]byte, error) {
+			close(done)
+			return body, nil
+		})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetcher not called")
+	}
+
+	// The document re-rendered and issued a new request for the same
+	// diagram before the old one completed.
+	newReq := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: newReq,
+	})
+
+	waitForDiagramCommand(t, w)
+
+	entry, ok := w.viewState.diagramCache.Get(hash)
+	if !ok {
+		t.Fatal("entry missing")
+	}
+	if entry.State != diagramLoading || entry.RequestID != newReq {
+		t.Errorf("stale result overwrote the entry: state=%v "+
+			"requestID=%d, want loading/%d",
+			entry.State, entry.RequestID, newReq)
+	}
+	if entry.pNGPath != "" {
+		t.Error("stale result left a PNG path in the cache")
+	}
+}
+
+// TestStaleDiagramErrorDropped is the same guard on the error path:
+// queueDiagramError must also refuse a stale requestID.
+func TestStaleDiagramErrorDropped(t *testing.T) {
+	w := newDiagramWindow()
+
+	hash := diagramCacheHash("stale-err")
+	oldReq := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: oldReq,
+	})
+
+	done := make(chan struct{})
+	fetchMermaidAsync(w, "stale-err", hash, oldReq,
+		func(_ context.Context, _ string) ([]byte, error) {
+			close(done)
+			return nil, errors.New("boom")
+		})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetcher not called")
+	}
+
+	newReq := nextDiagramRequestID(w)
+	w.viewState.diagramCache.Set(hash, DiagramCacheEntry{
+		State:     diagramLoading,
+		RequestID: newReq,
+	})
+
+	waitForDiagramCommand(t, w)
+
+	entry, _ := w.viewState.diagramCache.Get(hash)
+	if entry.State != diagramLoading || entry.RequestID != newReq {
+		t.Errorf("stale error overwrote the entry: state=%v "+
+			"requestID=%d, want loading/%d",
+			entry.State, entry.RequestID, newReq)
+	}
+	if entry.Error != "" {
+		t.Errorf("stale error text = %q, want empty", entry.Error)
+	}
+}
+
+// --- Default HTTP fetchers ---
+
+// stubTransport returns a canned response for every request, recording
+// the URL so tests can assert the request the default fetcher builds.
+type stubTransport struct {
+	status int
+	body   []byte
+	urls   *[]string
+}
+
+func (s stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if s.urls != nil {
+		*s.urls = append(*s.urls, req.URL.String())
+	}
+	return &http.Response{
+		StatusCode: s.status,
+		Body:       io.NopCloser(bytes.NewReader(s.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// withStubHTTPClient swaps the shared diagramHTTPClient for one backed
+// by stub and restores it when the test ends. Safe because no other
+// test in the package uses t.Parallel while touching diagrams.
+func withStubHTTPClient(t *testing.T, status int, body []byte) *[]string {
+	t.Helper()
+	var urls []string
+	prev := diagramHTTPClient
+	diagramHTTPClient = &http.Client{
+		Timeout:   diagramFetchTimeout,
+		Transport: stubTransport{status: status, body: body, urls: &urls},
+	}
+	t.Cleanup(func() { diagramHTTPClient = prev })
+	return &urls
+}
+
+func TestDefaultMermaidFetcherHTTP(t *testing.T) {
+	body := testPNGBytes(t, 30, 20)
+	urls := withStubHTTPClient(t, 200, body)
+
+	got, err := defaultMermaidFetcher(context.Background(), "graph TD\n  A-->B")
+	if err != nil {
+		t.Fatalf("defaultMermaidFetcher: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Error("fetcher did not return the response body")
+	}
+	if len(*urls) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*urls))
+	}
+	if !strings.Contains((*urls)[0], "https://kroki.io/mermaid/png") {
+		t.Errorf("request URL = %q, want the kroki mermaid png "+
+			"endpoint", (*urls)[0])
+	}
+}
+
+func TestDefaultMermaidFetcherHTTPError(t *testing.T) {
+	withStubHTTPClient(t, 500, []byte("boom"))
+
+	_, err := defaultMermaidFetcher(context.Background(), "graph TD")
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("error = %v, want it to mention HTTP 500", err)
+	}
+}
+
+// TestDefaultMathFetcherHTTP asserts the URL construction: the DPI
+// clamp (10 → 24), the white-foreground color command (luminance > 128
+// requests \color{white}), and the body passthrough.
+func TestDefaultMathFetcherHTTP(t *testing.T) {
+	body := testPNGBytes(t, 25, 25)
+	urls := withStubHTTPClient(t, 200, body)
+
+	got, err := defaultMathFetcher(
+		context.Background(), "x^2", 10, RGB(255, 255, 255))
+	if err != nil {
+		t.Fatalf("defaultMathFetcher: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Error("fetcher did not return the response body")
+	}
+	if len(*urls) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*urls))
+	}
+	u := (*urls)[0]
+	if !strings.Contains(u, "https://latex.codecogs.com/png.image?") {
+		t.Errorf("request URL = %q, want the codecogs png endpoint", u)
+	}
+	if !strings.Contains(u, `\dpi{24}`) {
+		t.Errorf("request URL lacks the clamped \\dpi{24}: %q", u)
+	}
+	if !strings.Contains(u, `\color{white}`) {
+		t.Errorf("request URL lacks \\color{white} for a bright "+
+			"foreground: %q", u)
+	}
+	if !strings.Contains(u, "x%5E2") && !strings.Contains(u, "x^2") {
+		t.Errorf("request URL lacks the latex payload: %q", u)
+	}
+}
+
+// TestDefaultMathFetcherHTTPError covers the non-200 path.
+func TestDefaultMathFetcherHTTPError(t *testing.T) {
+	withStubHTTPClient(t, 503, []byte("unavailable"))
+
+	_, err := defaultMathFetcher(
+		context.Background(), "x^2", 150, RGB(0, 0, 0))
+	if err == nil {
+		t.Fatal("expected error for HTTP 503")
+	}
+	if !strings.Contains(err.Error(), "HTTP 503") {
+		t.Errorf("error = %v, want it to mention HTTP 503", err)
+	}
+}

--- a/gui/markdown_select.go
+++ b/gui/markdown_select.go
@@ -87,6 +87,51 @@ func markdownContainerAmendLayout(ctx EventCtx) {
 	// Persist for drag callbacks.
 	bm := StateMap[string, []mdBlockInfo](ctx.Window, nsMdBlocks, capMany)
 	bm.Set(mdID, blocks)
+
+	// Reset the selection when the document content changed since the
+	// last frame: SelBeg/SelEnd are rune offsets into the *previous*
+	// source, so a stale range would highlight — and Ctrl+C would
+	// copy — the wrong runes of the new text. The signature covers
+	// the block layout and full flat text, so any content change
+	// (including same-length rewrites) is caught; a mere layout
+	// change (resize, font) leaves the selection alone.
+	sig := mdBlocksSignature(blocks)
+	sm := StateMap[string, uint64](ctx.Window, nsMdSelSig, capMany)
+	if prev, ok := sm.Get(mdID); ok && prev != sig {
+		imap := StateMap[string, mdSelState](ctx.Window, nsMdSel, capMany)
+		// Default mdSelState{}: a cleared selection. Amend runs
+		// children-first, so a changed document shows the old
+		// highlight for the one frame being arranged — cosmetic
+		// only, the render after this frame already paints nothing.
+		imap.Set(mdID, mdSelState{})
+	}
+	sm.Set(mdID, sig)
+}
+
+// mdBlocksSignature hashes the block list — per-block rune offsets,
+// rune counts and full flat text — to detect document content changes
+// between frames. FNV-1a over the (small) total text; the per-frame
+// glyph shaping the blocks undergo anyway is far more expensive. Field
+// separators match the sibling FNV helpers in view_rtf.go.
+func mdBlocksSignature(blocks []mdBlockInfo) uint64 {
+	h := fnvOffset64
+	for _, b := range blocks {
+		h ^= uint64(b.StartRune)
+		h *= fnvPrime64
+		h ^= fnvFieldSep
+		h *= fnvPrime64
+		h ^= uint64(b.RuneLen)
+		h *= fnvPrime64
+		h ^= fnvFieldSep
+		h *= fnvPrime64
+		for i := range len(b.FlatText) {
+			h ^= uint64(b.FlatText[i])
+			h *= fnvPrime64
+		}
+		h ^= fnvFieldSep
+		h *= fnvPrime64
+	}
+	return h
 }
 
 // mdWalkBlocks recursively walks the layout tree to collect RTF blocks
@@ -129,7 +174,13 @@ func markdownBlockOnClick(ctx EventCtx) {
 	}
 	ctx.Window.SetFocus(mdID)
 
-	// Compute abs rune position within the markdown flat text.
+	// Compute abs rune position within the markdown flat text. OnClick
+	// is dispatched through callRelative, which already translates the
+	// event to shape-local coordinates — the glyph layout's char rects
+	// are in that same space, so no further translation (and no scroll
+	// accounting) is needed here. The drag path differs: MouseLock
+	// callbacks receive window coordinates, which is why mdHitAbsRune
+	// subtracts the block's ShapeX/ShapeY.
 	gl := shape.TC.rTFLayout
 	flatText := shape.TC.rTFFlatText
 	byteIdx := gl.GetClosestOffset(ctx.Event.MouseX, ctx.Event.MouseY)

--- a/gui/markdown_select_interaction_test.go
+++ b/gui/markdown_select_interaction_test.go
@@ -1,0 +1,1217 @@
+package gui
+
+// markdown_select_interaction_test.go drives the cross-block selection
+// cluster (markdown_select.go) through the real pipeline: a focusable
+// markdown document rendered as the whole window, with a stub text
+// measurer that shapes every RTF block into a deterministic glyph
+// layout so clicks map to exact runes. The sibling file
+// (markdown_select_test.go) covers the pure helpers; anything that
+// needs a real layout tree, event dispatch or the mouse lock lives
+// here.
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+// mdSelSource mixes the three RTF-producing block kinds: a heading, a
+// paragraph and a two-item list. Rune offsets accumulate across them:
+// heading "Heading" (7), paragraph "First paragraph text" (20), then
+// "item one" (8) and "item two" (8), for 43 runes total.
+const mdSelSource = "# Heading\n\nFirst paragraph text\n\n- item one\n- item two"
+
+// mdWordBoundaryLogAttrs marks word starts (first non-space byte after
+// a space) and word ends (the first space after a word, plus the end
+// of text), mirroring the convention glyph's shaping path uses so
+// GetWordAtIndex behaves like a real layout.
+func mdWordBoundaryLogAttrs(text string) (map[int]int, []glyph.LogAttr) {
+	byIndex := map[int]int{}
+	var attrs []glyph.LogAttr
+	add := func(i int, start, end bool) {
+		byIndex[i] = len(attrs)
+		attrs = append(attrs, glyph.LogAttr{
+			IsWordStart: start,
+			IsWordEnd:   end,
+		})
+	}
+	isSpace := func(i int) bool {
+		return text[i] == ' ' || text[i] == '\t'
+	}
+	for i := 0; i < len(text); i++ {
+		prevSpace := i == 0 || isSpace(i-1)
+		if !isSpace(i) && prevSpace {
+			add(i, true, false)
+		}
+		if isSpace(i) && !prevSpace {
+			add(i, false, true)
+		}
+	}
+	if len(text) > 0 && !isSpace(len(text)-1) {
+		add(len(text), false, true)
+	}
+	return byIndex, attrs
+}
+
+// mdCharLayoutForText builds a single-line glyph layout with one 10x20
+// character rect per BYTE (ASCII sources in these tests), word-boundary
+// log attributes, and a single line spanning the text. GetClosestOffset
+// and GetWordAtIndex — the two queries the selection code relies on —
+// work off CharRects/Lines and LogAttrs respectively, so this is a
+// complete stand-in for a real shaped layout.
+func mdCharLayoutForText(text string) glyph.Layout {
+	n := len(text)
+	charRects := make([]glyph.CharRect, 0, n)
+	charRectByIndex := make(map[int]int, n)
+	for i := range n {
+		charRectByIndex[i] = i
+		charRects = append(charRects, glyph.CharRect{
+			Rect:  glyph.Rect{X: float32(i) * 10, Y: 0, Width: 10, Height: 20},
+			Index: i,
+		})
+	}
+	byIndex, attrs := mdWordBoundaryLogAttrs(text)
+	return glyph.Layout{
+		Text:            text,
+		CharRects:       charRects,
+		CharRectByIndex: charRectByIndex,
+		LogAttrByIndex:  byIndex,
+		LogAttrs:        attrs,
+		Lines: []glyph.Line{{
+			StartIndex: 0,
+			Length:     n,
+			Rect:       glyph.Rect{X: 0, Y: 0, Width: float32(n) * 10, Height: 20},
+		}},
+		Width:  float32(n) * 10,
+		Height: 20,
+	}
+}
+
+// mdSelectTestMeasurer implements TextMeasurer (plus the optional
+// LayoutRichText capability) by shaping every rich text block into a
+// deterministic single-line char layout. With nil backends the layout
+// pipeline would leave rTFLayout empty, GetClosestOffset would always
+// return 0, and every click would land on the block's first rune —
+// useless for selection tests.
+type mdSelectTestMeasurer struct{}
+
+func (mdSelectTestMeasurer) TextWidth(text string, style TextStyle) float32 {
+	return float32(len(text)) * style.Size * 0.5
+}
+
+func (mdSelectTestMeasurer) TextHeight(_ string, style TextStyle) float32 {
+	return style.Size * 1.2
+}
+
+func (mdSelectTestMeasurer) FontAscent(style TextStyle) float32 {
+	return style.Size * 0.8
+}
+
+func (mdSelectTestMeasurer) FontHeight(style TextStyle) float32 {
+	return style.Size * 1.2
+}
+
+func (mdSelectTestMeasurer) LayoutText(
+	_ string, style TextStyle, _ float32,
+) (glyph.Layout, error) {
+	return glyph.Layout{Height: style.Size * 1.2}, nil
+}
+
+// LayoutRichText concatenates the run texts — the same flat text the
+// shape carries in rTFFlatText — and shapes it.
+func (mdSelectTestMeasurer) LayoutRichText(
+	rt glyph.RichText, _ glyph.TextConfig,
+) (glyph.Layout, error) {
+	var b strings.Builder
+	for _, r := range rt.Runs {
+		b.WriteString(r.Text)
+	}
+	return mdCharLayoutForText(b.String()), nil
+}
+
+// mdSelectHarness renders one focusable markdown document and exposes
+// block lookup and press/move/release helpers. The document is written
+// with the leaf ID "md" and, when nested, sits under Column{ID:"panel"}
+// — the arrangement that resolves its effective ID to "panel:md".
+// Rendering the document as the whole window (or the whole panel
+// content) keeps block coordinates equal to window coordinates; the
+// #274 regression tests push it sideways on purpose.
+type mdSelectHarness struct {
+	w      *Window
+	id     string // effective markdown ID: "md" flat, "panel:md" nested
+	source string
+	nested bool
+}
+
+func newMdSelectHarness(t *testing.T) *mdSelectHarness {
+	t.Helper()
+	h := &mdSelectHarness{
+		w:      NewTestWindow(WindowCfg{Width: 800, Height: 800}),
+		id:     "md",
+		source: mdSelSource,
+	}
+	h.w.textMeasurer = mdSelectTestMeasurer{}
+	h.render()
+	return h
+}
+
+func newMdSelectHarnessNested(t *testing.T) *mdSelectHarness {
+	t.Helper()
+	h := &mdSelectHarness{
+		w:      NewTestWindow(WindowCfg{Width: 800, Height: 800}),
+		id:     "panel:md",
+		source: mdSelSource,
+		nested: true,
+	}
+	h.w.textMeasurer = mdSelectTestMeasurer{}
+	h.render()
+	return h
+}
+
+// render installs the view generator. The generator reads h.source
+// every frame, so changing the source and calling TestRender(nil) is
+// how a live document is swapped between frames — TestRender(nil)
+// re-runs the installed generator without clearing the registry (a
+// fresh generator would go through UpdateView, which clears per-widget
+// state by design and would mask the signature reset under test).
+func (h *mdSelectHarness) render() {
+	h.w.TestRender(func(win *Window) View {
+		md := win.Markdown(MarkdownCfg{
+			ID:        "md",
+			Source:    h.source,
+			Style:     DefaultMarkdownStyle(),
+			Focusable: true,
+		})
+		if h.nested {
+			return Column(ContainerCfg{
+				ID:     "panel",
+				Sizing: FillFill,
+				Content: []View{
+					md,
+				},
+			})
+		}
+		return md
+	})
+}
+
+// blocks returns the nsMdBlocks list markdownContainerAmendLayout wrote
+// on the last frame.
+func (h *mdSelectHarness) blocks(t *testing.T) []mdBlockInfo {
+	t.Helper()
+	bm := StateMap[string, []mdBlockInfo](h.w, nsMdBlocks, capMany)
+	blocks := bm.GetOr(h.id, nil)
+	if len(blocks) == 0 {
+		t.Fatal("no markdown blocks recorded by amend")
+	}
+	return blocks
+}
+
+// blockByText resolves a block by its flat text, so tests can address
+// runes without hardcoding parse-dependent offsets.
+func (h *mdSelectHarness) blockByText(t *testing.T, text string) mdBlockInfo {
+	t.Helper()
+	for _, b := range h.blocks(t) {
+		if b.FlatText == text {
+			return b
+		}
+	}
+	t.Fatalf("no block with flat text %q", text)
+	return mdBlockInfo{}
+}
+
+// runePoint returns the window coordinate of the middle of localRune
+// in block b. The char rects start at the shape origin (X=0 in this
+// harness), so shapeX + byte*10 + 5 is the rune's center.
+func runePoint(b mdBlockInfo, localRune int) (float32, float32) {
+	byteIdx := runeToByteIndex(b.FlatText, localRune)
+	return b.ShapeX + float32(byteIdx)*10 + 5, b.ShapeY + 10
+}
+
+func (h *mdSelectHarness) press(x, y float32) Event {
+	e := Event{
+		Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	h.w.EventFn(&e)
+	h.w.settle()
+	return e
+}
+
+func (h *mdSelectHarness) move(x, y float32) Event {
+	e := Event{
+		Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x, MouseY: y,
+	}
+	h.w.EventFn(&e)
+	h.w.settle()
+	return e
+}
+
+func (h *mdSelectHarness) release(x, y float32) Event {
+	e := Event{
+		Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	h.w.EventFn(&e)
+	h.w.settle()
+	return e
+}
+
+func (h *mdSelectHarness) selState() mdSelState {
+	return StateReadOr(h.w, nsMdSel, h.id, mdSelState{})
+}
+
+// --- AmendLayout block collection ---
+
+// TestMarkdownAmendPopulatesBlockList asserts the amend pass records
+// one mdBlockInfo per RTF block in Y order, with rune offsets that
+// accumulate across blocks (the virtual flat-text coordinates selection
+// keys on).
+func TestMarkdownAmendPopulatesBlockList(t *testing.T) {
+	h := newMdSelectHarness(t)
+	blocks := h.blocks(t)
+
+	wantTexts := []string{
+		"Heading", "First paragraph text", "item one", "item two",
+	}
+	if len(blocks) != len(wantTexts) {
+		t.Fatalf("block count = %d, want %d",
+			len(blocks), len(wantTexts))
+	}
+	for i, b := range blocks {
+		if b.FlatText != wantTexts[i] {
+			t.Errorf("block[%d] text = %q, want %q",
+				i, b.FlatText, wantTexts[i])
+		}
+		if b.RuneLen == 0 {
+			t.Errorf("block[%d] (%q) has zero runes", i, b.FlatText)
+		}
+		if b.H <= 0 {
+			t.Errorf("block[%d] (%q) has non-positive height %g",
+				i, b.FlatText, b.H)
+		}
+		if i > 0 && b.ShapeY <= blocks[i-1].ShapeY {
+			t.Errorf("blocks not ordered by Y: block[%d] y=%g, "+
+				"block[%d] y=%g", i-1, blocks[i-1].ShapeY, i, b.ShapeY)
+		}
+	}
+
+	if blocks[0].StartRune != 0 {
+		t.Errorf("first block StartRune = %d, want 0",
+			blocks[0].StartRune)
+	}
+	for i := 1; i < len(blocks); i++ {
+		wantStart := blocks[i-1].StartRune + blocks[i-1].RuneLen
+		if blocks[i].StartRune != wantStart {
+			t.Errorf("block[%d] StartRune = %d, want %d (previous "+
+				"block end)", i, blocks[i].StartRune, wantStart)
+		}
+	}
+}
+
+// TestMarkdownWalkBlocksSkipsNonSelectableBlocks renders a document
+// whose non-RTF blocks (table, code, HR, image) outnumber the RTF ones
+// and asserts only the paragraph is collected — and that it starts at
+// rune 0, because non-RTF content consumes no rune offsets.
+func TestMarkdownWalkBlocksSkipsNonSelectableBlocks(t *testing.T) {
+	// The parser drops data-URL destinations (ImageSrc becomes ""),
+	// which trips Image's path validation and logs; a real temp PNG
+	// keeps the render quiet.
+	f, err := os.CreateTemp(t.TempDir(), "md_skip_*.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	imgPath := f.Name()
+	_ = f.Close()
+
+	source := strings.Join([]string{
+		"First paragraph",
+		"",
+		"| A | B |",
+		"|---|---|",
+		"| 1 | 2 |",
+		"",
+		"```go",
+		"code",
+		"```",
+		"",
+		"---",
+		"",
+		"![alt](" + imgPath + ")",
+		"",
+	}, "\n")
+
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = mdSelectTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		return win.Markdown(MarkdownCfg{
+			ID:        "md",
+			Source:    source,
+			Style:     DefaultMarkdownStyle(),
+			Focusable: true,
+		})
+	})
+
+	bm := StateMap[string, []mdBlockInfo](w, nsMdBlocks, capMany)
+	blocks := bm.GetOr("md", nil)
+	if len(blocks) != 1 {
+		t.Fatalf("block count = %d, want 1 (table/code/HR/image "+
+			"are not selectable)", len(blocks))
+	}
+	if blocks[0].FlatText != "First paragraph" {
+		t.Errorf("collected text = %q, want %q",
+			blocks[0].FlatText, "First paragraph")
+	}
+	if blocks[0].StartRune != 0 {
+		t.Errorf("StartRune = %d, want 0: non-selectable blocks "+
+			"must consume no rune offsets", blocks[0].StartRune)
+	}
+}
+
+// --- Click and word selection ---
+
+// TestMarkdownClickPlacesCursorAtRune asserts a single click collapses
+// the selection to the clicked rune, focuses the markdown container and
+// consumes the event.
+func TestMarkdownClickPlacesCursorAtRune(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	abs := p.StartRune + 2 // 'r'
+	x, y := runePoint(p, 2)
+	e := h.press(x, y)
+	h.release(x, y)
+
+	st := h.selState()
+	if st.SelBeg != abs || st.SelEnd != abs {
+		t.Errorf("selection = [%d,%d), want [%d,%d]",
+			st.SelBeg, st.SelEnd, abs, abs)
+	}
+	if !e.IsHandled {
+		t.Error("click on a block was not consumed")
+	}
+	if got := h.w.FocusID(); got != "md" {
+		t.Errorf("focus = %q, want %q (container must take focus)", got, "md")
+	}
+}
+
+// --- Nested document (#273) ---
+
+// TestMarkdownNestedAmendPopulatesBlockList asserts a markdown nested
+// under an ID-bearing container collects its blocks under the
+// *effective* ID: before the fix the container keyed on the resolved
+// "panel:md" while the blocks were stamped with the raw "md", so the
+// list came back empty and selection was dead.
+func TestMarkdownNestedAmendPopulatesBlockList(t *testing.T) {
+	h := newMdSelectHarnessNested(t)
+	blocks := h.blocks(t)
+
+	wantTexts := []string{
+		"Heading", "First paragraph text", "item one", "item two",
+	}
+	if len(blocks) != len(wantTexts) {
+		t.Fatalf("block count = %d, want %d",
+			len(blocks), len(wantTexts))
+	}
+	if blocks[0].StartRune != 0 {
+		t.Errorf("first block StartRune = %d, want 0",
+			blocks[0].StartRune)
+	}
+	for i, b := range blocks {
+		if b.FlatText != wantTexts[i] {
+			t.Errorf("block[%d] text = %q, want %q",
+				i, b.FlatText, wantTexts[i])
+		}
+		if i > 0 && b.StartRune !=
+			blocks[i-1].StartRune+blocks[i-1].RuneLen {
+			t.Errorf("block[%d] StartRune = %d, want previous end",
+				i, b.StartRune)
+		}
+	}
+	if _, ok := StateMapRead[string, []mdBlockInfo](
+		h.w, nsMdBlocks).Get("md"); ok {
+		t.Error("block list also stored under the raw leaf ID")
+	}
+}
+
+// TestMarkdownNestedClickSelectsAndFocuses asserts the click state and
+// focus both key on the effective ID under an ID-bearing ancestor.
+func TestMarkdownNestedClickSelectsAndFocuses(t *testing.T) {
+	h := newMdSelectHarnessNested(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	abs := p.StartRune + 2
+	x, y := runePoint(p, 2)
+	h.press(x, y)
+	h.release(x, y)
+
+	st := h.selState()
+	if st.SelBeg != abs || st.SelEnd != abs {
+		t.Errorf("selection = [%d,%d), want [%d,%d]",
+			st.SelBeg, st.SelEnd, abs, abs)
+	}
+	if got := h.w.FocusID(); got != "panel:md" {
+		t.Errorf("focus = %q, want %q (effective ID)",
+			got, "panel:md")
+	}
+}
+
+func TestMarkdownNestedCtrlASelectsAll(t *testing.T) {
+	h := newMdSelectHarnessNested(t)
+
+	if err := h.w.TestKey("panel:md", KeyA, ModCtrl); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	var total uint32
+	for _, b := range h.blocks(t) {
+		total += b.RuneLen
+	}
+	st := h.selState()
+	if st.SelBeg != 0 || st.SelEnd != total {
+		t.Errorf("Ctrl+A selection = [%d,%d), want [0,%d)",
+			st.SelBeg, st.SelEnd, total)
+	}
+}
+
+// TestMarkdownNestedCtrlCCopies asserts the copy path works through the
+// effective ID: select a word by double-click, then Ctrl+C.
+func TestMarkdownNestedCtrlCCopies(t *testing.T) {
+	h := newMdSelectHarnessNested(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	x, y := runePoint(p, 9) // inside "paragraph"
+	h.press(x, y)
+	h.release(x, y)
+	h.press(x, y)
+	h.release(x, y)
+
+	var got string
+	h.w.SetClipboardFn(func(s string) { got = s })
+	if err := h.w.TestKey("panel:md", KeyC, ModCtrl); err != nil {
+		t.Fatalf("TestKey(Ctrl+C): %v", err)
+	}
+	if got != "paragraph" {
+		t.Errorf("clipboard = %q, want %q", got, "paragraph")
+	}
+}
+
+// TestMarkdownNestedDragAcrossBlocks drags from the paragraph into the
+// first list item: the drag reads the block list by effective ID, so
+// cross-block extension must work nested.
+func TestMarkdownNestedDragAcrossBlocks(t *testing.T) {
+	h := newMdSelectHarnessNested(t)
+	p := h.blockByText(t, "First paragraph text")
+	li := h.blockByText(t, "item one")
+
+	x0, y0 := runePoint(p, 6)
+	h.press(x0, y0)
+	x1, y1 := runePoint(li, 4)
+	h.move(x1, y1)
+	h.release(x1, y1)
+
+	st := h.selState()
+	if st.SelBeg != p.StartRune+6 || st.SelEnd != li.StartRune+4 {
+		t.Errorf("drag selection = [%d,%d), want [%d,%d)",
+			st.SelBeg, st.SelEnd,
+			p.StartRune+6, li.StartRune+4)
+	}
+}
+
+// TestMarkdownSameLeafUnderTwoPanelsIsolates renders the same leaf ID
+// "md" under two ID-bearing panels — the collision #273 was about: two
+// documents with one leaf ID must keep separate selections, focus and
+// block lists.
+func TestMarkdownSameLeafUnderTwoPanelsIsolates(t *testing.T) {
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = mdSelectTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Column(ContainerCfg{ID: "a", Sizing: FillFit, Content: []View{
+					win.Markdown(MarkdownCfg{
+						ID: "md", Source: mdSelSource,
+						Style: DefaultMarkdownStyle(), Focusable: true,
+					}),
+				}}),
+				Column(ContainerCfg{ID: "b", Sizing: FillFit, Content: []View{
+					win.Markdown(MarkdownCfg{
+						ID: "md", Source: mdSelSource,
+						Style: DefaultMarkdownStyle(), Focusable: true,
+					}),
+				}}),
+			},
+		})
+	})
+
+	if dups := w.TestDuplicateIDs(); len(dups) > 0 {
+		t.Fatalf("duplicate IDs in window: %q", dups)
+	}
+
+	bm := StateMap[string, []mdBlockInfo](w, nsMdBlocks, capMany)
+	aBlocks := bm.GetOr("a:md", nil)
+	if len(aBlocks) != 4 {
+		t.Fatalf("panel a blocks = %d, want 4", len(aBlocks))
+	}
+	bBlocks := bm.GetOr("b:md", nil)
+	if len(bBlocks) != 4 {
+		t.Fatalf("panel b blocks = %d, want 4", len(bBlocks))
+	}
+
+	// Click rune 2 of panel a's paragraph; panel b must stay untouched.
+	x, y := runePoint(aBlocks[1], 2)
+	e := Event{
+		Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	w.EventFn(&e)
+	w.settle()
+	w.EventFn(&Event{
+		Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	})
+	w.settle()
+
+	stA := StateReadOr(w, nsMdSel, "a:md", mdSelState{})
+	want := aBlocks[1].StartRune + 2
+	if stA.SelBeg != want || stA.SelEnd != want {
+		t.Errorf("panel a selection = [%d,%d), want [%d,%d]",
+			stA.SelBeg, stA.SelEnd, want, want)
+	}
+	if got := w.FocusID(); got != "a:md" {
+		t.Errorf("focus = %q, want %q", got, "a:md")
+	}
+	if stB := StateReadOr(w, nsMdSel, "b:md", mdSelState{}); stB.SelEnd != 0 {
+		t.Errorf("panel b selection = [%d,%d), want untouched",
+			stB.SelBeg, stB.SelEnd)
+	}
+}
+
+// --- Offset blocks (#274) ---
+
+// TestMarkdownClickAtOffsetSelectsExactRune pushes the markdown to the
+// right of a fixed filler and asserts a click lands on the exact rune.
+// OnClick is dispatched through callRelative, which hands handlers
+// shape-local coordinates, so a click at the center of local rune 2
+// must select rune 2 regardless of where the block sits in the window.
+func TestMarkdownClickAtOffsetSelectsExactRune(t *testing.T) {
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = mdSelectTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		return Row(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Rectangle(RectangleCfg{
+					Sizing: FixedFill,
+					Width:  120,
+				}),
+				win.Markdown(MarkdownCfg{
+					ID: "md", Source: mdSelSource,
+					Style: DefaultMarkdownStyle(), Focusable: true,
+				}),
+			},
+		})
+	})
+
+	bm := StateMap[string, []mdBlockInfo](w, nsMdBlocks, capMany)
+	blocks := bm.GetOr("md", nil)
+	if len(blocks) == 0 {
+		t.Fatal("no blocks recorded")
+	}
+	p := blocks[1]
+	if p.ShapeX < 100 {
+		t.Fatalf("paragraph ShapeX = %g, want it offset from origin",
+			p.ShapeX)
+	}
+
+	x, y := runePoint(p, 2)
+	e := Event{
+		Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	w.EventFn(&e)
+	w.settle()
+	w.EventFn(&Event{
+		Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	})
+	w.settle()
+
+	st := StateReadOr(w, nsMdSel, "md", mdSelState{})
+	want := p.StartRune + 2
+	if st.SelBeg != want || st.SelEnd != want {
+		t.Errorf("selection = [%d,%d), want [%d,%d] — the click "+
+			"must map to the rune under the cursor",
+			st.SelBeg, st.SelEnd, want, want)
+	}
+}
+
+// TestRtfSelectClickAtOffsetSelectsExactRune is the same check for
+// standalone selectable RTF (rtfSelectOnClick), which shares the
+// callRelative coordinate contract.
+func TestRtfSelectClickAtOffsetSelectsExactRune(t *testing.T) {
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = mdSelectTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		return Row(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Rectangle(RectangleCfg{
+					Sizing: FixedFill,
+					Width:  120,
+				}),
+				RTF(RTFCfg{
+					ID:        "rtf",
+					Focusable: true,
+					RichText: RichText{Runs: []RichTextRun{
+						{Text: "hello world",
+							Style: TextStyle{Size: 14}},
+					}},
+				}),
+			},
+		})
+	})
+
+	ly, ok := w.layout.FindByID("rtf")
+	if !ok {
+		t.Fatal("no RTF shape")
+	}
+	if ly.Shape.X < 100 {
+		t.Fatalf("RTF ShapeX = %g, want it offset from origin",
+			ly.Shape.X)
+	}
+
+	// Click the middle of local rune 6 ('w').
+	gl := ly.Shape.TC.rTFLayout
+	bi := runeToByteIndex(ly.Shape.TC.rTFFlatText, 6)
+	x := ly.Shape.X + float32(bi)*10 + 5
+	y := ly.Shape.Y + 10
+	e := Event{
+		Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	w.EventFn(&e)
+	w.settle()
+	w.EventFn(&Event{
+		Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	})
+	w.settle()
+
+	is := StateReadOr(w, nsInput, "rtf", inputState{})
+	if is.selectBeg != 6 || is.selectEnd != 6 {
+		t.Errorf("selection = [%d,%d), want cursor at 6",
+			is.selectBeg, is.selectEnd)
+	}
+	_ = gl
+}
+
+// --- Source change (#275) ---
+
+// TestMarkdownSourceChangeClearsSelection asserts the selection is
+// reset when the document's content changes between frames: the stored
+// rune offsets point into the old source and would highlight or copy
+// the wrong runes of the new one.
+func TestMarkdownSourceChangeClearsSelection(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	x, y := runePoint(p, 2)
+	h.press(x, y)
+	h.release(x, y)
+	want := p.StartRune + 2
+	if st := h.selState(); st.SelBeg != want || st.SelEnd != want {
+		t.Fatalf("selection before change = [%d,%d), want [%d,%d]",
+			st.SelBeg, st.SelEnd, want, want)
+	}
+
+	h.source = "# Different\n\nchanged text"
+	h.w.TestRender(nil)
+
+	st := h.selState()
+	if st.SelBeg != 0 || st.SelEnd != 0 {
+		t.Errorf("selection after source change = [%d,%d), want "+
+			"[0,0] (stale offsets must not survive)",
+			st.SelBeg, st.SelEnd)
+	}
+
+	// Ctrl+C on the cleared selection must not touch the clipboard.
+	var copied bool
+	h.w.SetClipboardFn(func(string) { copied = true })
+	if err := h.w.TestKey("md", KeyC, ModCtrl); err != nil {
+		t.Fatalf("TestKey(Ctrl+C): %v", err)
+	}
+	if copied {
+		t.Error("Ctrl+C copied despite a cleared selection")
+	}
+}
+
+// TestMarkdownSameSourceKeepsSelection is the positive control for the
+// signature reset: an idle frame with identical content must keep the
+// selection (a reset would be a visible flicker on every frame).
+func TestMarkdownSameSourceKeepsSelection(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	x, y := runePoint(p, 2)
+	h.press(x, y)
+	h.release(x, y)
+	want := p.StartRune + 2
+
+	h.w.TestRender(nil)
+
+	st := h.selState()
+	if st.SelBeg != want || st.SelEnd != want {
+		t.Errorf("selection after idle re-render = [%d,%d), "+
+			"want [%d,%d]", st.SelBeg, st.SelEnd, want, want)
+	}
+}
+
+// TestMarkdownDoubleClickSelectsWord asserts two rapid clicks expand
+// the selection to the word under the cursor.
+func TestMarkdownDoubleClickSelectsWord(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	// Local rune 9 ('a') sits inside "paragraph" [6,15).
+	x, y := runePoint(p, 9)
+	h.press(x, y)
+	h.release(x, y)
+	if st := h.selState(); st.SelBeg != st.SelEnd {
+		t.Fatalf("first click selected [%d,%d), want a cursor",
+			st.SelBeg, st.SelEnd)
+	}
+
+	h.press(x, y)
+	h.release(x, y)
+
+	wantBeg, wantEnd := p.StartRune+6, p.StartRune+15
+	st := h.selState()
+	if st.SelBeg != wantBeg || st.SelEnd != wantEnd {
+		t.Errorf("word selection = [%d,%d), want [%d,%d)",
+			st.SelBeg, st.SelEnd, wantBeg, wantEnd)
+	}
+	if st.LastClickTime == 0 {
+		t.Error("LastClickTime not recorded")
+	}
+}
+
+// TestMarkdownClickIsolatedByDoubleClickThreshold splits the double
+// click across more than doubleClickThresholdMs so the second click
+// must be treated as a fresh cursor placement. Simulated by stubbing
+// LastClickTime in the past — the handler reads wall-clock time, so a
+// real sleep would be both slow and flaky.
+func TestMarkdownClickIsolatedByDoubleClickThreshold(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	imap := StateMap[string, mdSelState](h.w, nsMdSel, capMany)
+	imap.Set("md", mdSelState{
+		SelBeg: p.StartRune + 2, SelEnd: p.StartRune + 2,
+		LastClickTime: time.Now().UnixMilli() -
+			doubleClickThresholdMs - 1,
+	})
+
+	x, y := runePoint(p, 10)
+	h.press(x, y)
+	h.release(x, y)
+
+	st := h.selState()
+	if st.SelBeg != st.SelEnd || st.SelBeg != p.StartRune+10 {
+		t.Errorf("stale double-click window selected [%d,%d), "+
+			"want cursor at %d", st.SelBeg, st.SelEnd, p.StartRune+10)
+	}
+}
+
+// --- Drag selection ---
+
+// TestMarkdownDragSelectsAcrossBlocks presses in the paragraph and
+// drags into the first list item, asserting the selection spans the
+// block boundary and the mouse lock is released on mouse-up.
+func TestMarkdownDragSelectsAcrossBlocks(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+	li := h.blockByText(t, "item one")
+
+	anchor := p.StartRune + 6 // 'p' of "paragraph"
+	target := li.StartRune + 4
+
+	x0, y0 := runePoint(p, 6)
+	h.press(x0, y0)
+	if !h.w.mouseIsLocked() {
+		t.Fatal("press on a block did not lock the mouse")
+	}
+
+	x1, y1 := runePoint(li, 4)
+	h.move(x1, y1)
+	st := h.selState()
+	if st.SelBeg != anchor || st.SelEnd != target {
+		t.Fatalf("mid-drag selection = [%d,%d), want [%d,%d)",
+			st.SelBeg, st.SelEnd, anchor, target)
+	}
+
+	h.release(x1, y1)
+	if h.w.mouseIsLocked() {
+		t.Error("mouse still locked after release")
+	}
+	st = h.selState()
+	if st.SelBeg != anchor || st.SelEnd != target {
+		t.Errorf("selection after release = [%d,%d), want [%d,%d)",
+			st.SelBeg, st.SelEnd, anchor, target)
+	}
+}
+
+// TestMarkdownDragBackwardsInvertsSelection drags from a later rune to
+// an earlier one: the raw state keeps SelBeg at the press anchor and
+// SelEnd at the cursor, so SelBeg > SelEnd — the amend pass sorts
+// before stamping per-block highlights.
+func TestMarkdownDragBackwardsInvertsSelection(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	anchor := p.StartRune + 10
+	target := p.StartRune + 2
+
+	x0, y0 := runePoint(p, 10)
+	h.press(x0, y0)
+	x1, y1 := runePoint(p, 2)
+	h.move(x1, y1)
+	h.release(x1, y1)
+
+	st := h.selState()
+	if st.SelBeg != anchor || st.SelEnd != target {
+		t.Errorf("inverted selection = [%d,%d), want [%d,%d) "+
+			"(anchor held at press, cursor at release)",
+			st.SelBeg, st.SelEnd, anchor, target)
+	}
+
+	// The per-block highlight uses the normalized order: the block
+	// shape covers [2,10) locally.
+	ly := h.findBlockShape(t, p.StartRune)
+	if ly.Shape.TC.textSelBeg != 2 || ly.Shape.TC.textSelEnd != 10 {
+		t.Errorf("block highlight = [%d,%d), want [2,10)",
+			ly.Shape.TC.textSelBeg, ly.Shape.TC.textSelEnd)
+	}
+}
+
+// TestMarkdownRightClickLeavesSelectionUntouched asserts the right
+// button (reserved for the link context menu) never moves the
+// selection.
+func TestMarkdownRightClickLeavesSelectionUntouched(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	x, y := runePoint(p, 2)
+	h.press(x, y)
+	h.release(x, y)
+	want := p.StartRune + 2
+
+	xr, yr := runePoint(p, 12)
+	e := Event{
+		Type: EventMouseDown, MouseButton: MouseRight,
+		MouseX: xr, MouseY: yr,
+	}
+	h.w.EventFn(&e)
+	h.w.settle()
+	h.w.EventFn(&Event{
+		Type: EventMouseUp, MouseButton: MouseRight,
+		MouseX: xr, MouseY: yr,
+	})
+	h.w.settle()
+
+	st := h.selState()
+	if st.SelBeg != want || st.SelEnd != want {
+		t.Errorf("right click moved selection to [%d,%d), "+
+			"want it untouched at [%d,%d]",
+			st.SelBeg, st.SelEnd, want, want)
+	}
+}
+
+// --- Keyboard: select all and copy ---
+
+func TestMarkdownCtrlASelectsAll(t *testing.T) {
+	h := newMdSelectHarness(t)
+
+	if err := h.w.TestKey("md", KeyA, ModCtrl); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+
+	var total uint32
+	for _, b := range h.blocks(t) {
+		total += b.RuneLen
+	}
+	st := h.selState()
+	if st.SelBeg != 0 || st.SelEnd != total {
+		t.Errorf("Ctrl+A selection = [%d,%d), want [0,%d)",
+			st.SelBeg, st.SelEnd, total)
+	}
+}
+
+// TestMarkdownCtrlCWithoutModifierIgnored asserts plain C does nothing
+// (no consume, no clipboard write) — the shortcut requires Ctrl/Super.
+func TestMarkdownCtrlCWithoutModifierIgnored(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+	x, y := runePoint(p, 2)
+	h.press(x, y)
+	h.release(x, y)
+
+	var got string
+	h.w.SetClipboardFn(func(s string) { got = s })
+
+	ly, ok := h.w.layout.FindByID("md")
+	if !ok {
+		t.Fatal("no container shape with ID md")
+	}
+	e := Event{Type: EventKeyDown, KeyCode: KeyC}
+	markdownContainerOnKeyDown(EventCtx{Layout: ly, Event: &e, Window: h.w})
+	if e.IsHandled {
+		t.Error("bare C consumed the key event")
+	}
+	if got != "" {
+		t.Errorf("clipboard = %q, want empty for unmodified C", got)
+	}
+}
+
+// TestMarkdownCtrlCCopiesCrossBlockSelection drags from inside the
+// paragraph into the first list item and copies: the clipboard must
+// hold the extracted flat text with blocks joined by a newline. The
+// anchor sits at the start of "paragraph", so the drag spans the rest
+// of the paragraph ("paragraph text") and the first four runes of
+// "item one".
+func TestMarkdownCtrlCCopiesCrossBlockSelection(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+	li := h.blockByText(t, "item one")
+
+	x0, y0 := runePoint(p, 6)
+	h.press(x0, y0)
+	x1, y1 := runePoint(li, 4)
+	h.move(x1, y1)
+	h.release(x1, y1)
+
+	var got string
+	h.w.SetClipboardFn(func(s string) { got = s })
+
+	if err := h.w.TestKey("md", KeyC, ModCtrl); err != nil {
+		t.Fatalf("TestKey(Ctrl+C): %v", err)
+	}
+	if got != "paragraph text\nitem" {
+		t.Errorf("clipboard = %q, want %q",
+			got, "paragraph text\nitem")
+	}
+}
+
+// TestMarkdownCtrlCWithInvertedSelectionNormalizes drags from local
+// rune 10 back to local rune 2 of the paragraph, so the raw state is
+// inverted; the copy path must sort before extracting, yielding the
+// text between the two runes: "rst para".
+func TestMarkdownCtrlCWithInvertedSelectionNormalizes(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	x0, y0 := runePoint(p, 10)
+	h.press(x0, y0)
+	x1, y1 := runePoint(p, 2)
+	h.move(x1, y1)
+	h.release(x1, y1)
+
+	var got string
+	h.w.SetClipboardFn(func(s string) { got = s })
+
+	if err := h.w.TestKey("md", KeyC, ModCtrl); err != nil {
+		t.Fatalf("TestKey(Ctrl+C): %v", err)
+	}
+	if got != "rst para" {
+		t.Errorf("clipboard = %q, want %q", got, "rst para")
+	}
+}
+
+// --- Persistence and edge cases ---
+
+// TestMarkdownSelectionSurvivesIdleFrame asserts the selection state
+// (keyed by markdown ID in the StateMap) and the per-block highlight
+// stamps both persist across a frame with no input.
+func TestMarkdownSelectionSurvivesIdleFrame(t *testing.T) {
+	h := newMdSelectHarness(t)
+	p := h.blockByText(t, "First paragraph text")
+
+	x, y := runePoint(p, 2)
+	h.press(x, y)
+	h.release(x, y)
+	want := p.StartRune + 2
+
+	h.w.TestRender(nil)
+
+	st := h.selState()
+	if st.SelBeg != want || st.SelEnd != want {
+		t.Errorf("state after idle frame = [%d,%d), want [%d,%d]",
+			st.SelBeg, st.SelEnd, want, want)
+	}
+	ly := h.findBlockShape(t, p.StartRune)
+	if ly.Shape.TC.textSelBeg != 2 || ly.Shape.TC.textSelEnd != 2 {
+		t.Errorf("block highlight after idle frame = [%d,%d), "+
+			"want [2,2]", ly.Shape.TC.textSelBeg, ly.Shape.TC.textSelEnd)
+	}
+}
+
+// TestMarkdownSelectionStateIsPerWidget renders two markdown widgets
+// and asserts each keeps its own selection — the nsMdSel state is
+// keyed by widget ID, so a click in one must not disturb the other.
+func TestMarkdownSelectionStateIsPerWidget(t *testing.T) {
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = mdSelectTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				win.Markdown(MarkdownCfg{
+					ID: "md-a", Source: "alpha", Style: DefaultMarkdownStyle(),
+					Focusable: true,
+				}),
+				win.Markdown(MarkdownCfg{
+					ID: "md-b", Source: "beta", Style: DefaultMarkdownStyle(),
+					Focusable: true,
+				}),
+			},
+		})
+	})
+
+	if dups := w.TestDuplicateIDs(); len(dups) > 0 {
+		t.Fatalf("duplicate IDs in window: %q", dups)
+	}
+
+	// Click rune 2 of md-a; assert md-b's state is untouched.
+	bm := StateMap[string, []mdBlockInfo](w, nsMdBlocks, capMany)
+	aBlocks := bm.GetOr("md-a", nil)
+	if len(aBlocks) != 1 {
+		t.Fatalf("md-a blocks = %d, want 1", len(aBlocks))
+	}
+	x, y := runePoint(aBlocks[0], 2)
+	e := Event{
+		Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	}
+	w.EventFn(&e)
+	w.settle()
+	w.EventFn(&Event{
+		Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y,
+	})
+	w.settle()
+
+	stA := StateReadOr(w, nsMdSel, "md-a", mdSelState{})
+	if stA.SelBeg != 2 || stA.SelEnd != 2 {
+		t.Errorf("md-a selection = [%d,%d), want [2,2]",
+			stA.SelBeg, stA.SelEnd)
+	}
+	if stB := StateReadOr(w, nsMdSel, "md-b", mdSelState{}); stB.SelEnd != 0 {
+		t.Errorf("md-b selection = [%d,%d), want untouched",
+			stB.SelBeg, stB.SelEnd)
+	}
+}
+
+// TestMarkdownKeydownWhenNotFocusedIgnored asserts Ctrl+A dispatched
+// while the markdown does not hold focus changes nothing. The event
+// never reaches the handler: keydown dispatch targets the focused
+// shape (isFocusedTarget), so an unfocused container's OnKeyDown is
+// not invoked at all — this pins the end-to-end behavior, not the
+// handler's own guard.
+func TestMarkdownKeydownWhenNotFocusedIgnored(t *testing.T) {
+	h := newMdSelectHarness(t)
+	h.w.ClearFocus()
+
+	e := Event{Type: EventKeyDown, KeyCode: KeyA, Modifiers: ModCtrl}
+	h.w.EventFn(&e)
+	h.w.settle()
+
+	st := h.selState()
+	if st.SelBeg != 0 || st.SelEnd != 0 {
+		t.Errorf("unfocused Ctrl+A set selection to [%d,%d)",
+			st.SelBeg, st.SelEnd)
+	}
+}
+
+// TestMarkdownKeydownWithoutBlocksInert covers the handler's empty
+// block-list guard: a focusable markdown containing only non-RTF
+// blocks has nothing to select, so Ctrl+A must not consume.
+func TestMarkdownKeydownWithoutBlocksInert(t *testing.T) {
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.TestRender(func(win *Window) View {
+		return win.Markdown(MarkdownCfg{
+			ID:        "md",
+			Source:    "```go\ncode\n```",
+			Style:     DefaultMarkdownStyle(),
+			Focusable: true,
+		})
+	})
+
+	if err := w.TestKey("md", KeyA, ModCtrl); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	st := StateReadOr(w, nsMdSel, "md", mdSelState{})
+	if st.SelEnd != 0 {
+		t.Errorf("Ctrl+A selected [%d,%d) with no RTF blocks",
+			st.SelBeg, st.SelEnd)
+	}
+
+	// Direct call: the guard returns without consuming.
+	ly, ok := w.layout.FindByID("md")
+	if !ok {
+		t.Fatal("no container shape with ID md")
+	}
+	e := Event{Type: EventKeyDown, KeyCode: KeyA, Modifiers: ModCtrl}
+	markdownContainerOnKeyDown(EventCtx{Layout: ly, Event: &e, Window: w})
+	if e.IsHandled {
+		t.Error("Ctrl+A with no blocks consumed the key event")
+	}
+}
+
+// TestMarkdownAmendLayoutWithEmptyIDSkips asserts the amend hook bails
+// on an ID-less container instead of writing a block list.
+func TestMarkdownAmendLayoutWithEmptyIDSkips(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	e := &Event{}
+	markdownContainerAmendLayout(EventCtx{
+		Layout: &Layout{Shape: &Shape{}},
+		Event:  e,
+		Window: w,
+	})
+	if bm := StateMapRead[string, []mdBlockInfo](w, nsMdBlocks); bm != nil {
+		if _, ok := bm.Get(""); ok {
+			t.Error("amend wrote a block list for an ID-less container")
+		}
+	}
+}
+
+// findBlockShape walks the composed tree for the RTF shape whose
+// markdown block starts at startRune — the shape the amend pass stamps
+// the per-block highlight on.
+func (h *mdSelectHarness) findBlockShape(t *testing.T, startRune uint32) *Layout {
+	t.Helper()
+	var found *Layout
+	var walk func(*Layout)
+	walk = func(l *Layout) {
+		if found != nil {
+			return
+		}
+		if l.Shape != nil && l.Shape.TC != nil &&
+			l.Shape.TC.markdownID == h.id &&
+			l.Shape.TC.markdownBlockStart == startRune {
+			found = l
+			return
+		}
+		for i := range l.Children {
+			walk(&l.Children[i])
+		}
+	}
+	walk(&h.w.layout)
+	if found == nil {
+		t.Fatalf("no RTF shape with block start %d", startRune)
+	}
+	return found
+}

--- a/gui/state_registry.go
+++ b/gui/state_registry.go
@@ -237,6 +237,7 @@ const (
 	nsHoverInside         = "gui.hover.inside"
 	nsMdSel               = "gui.markdown.sel"
 	nsMdBlocks            = "gui.markdown.blocks"
+	nsMdSelSig            = "gui.markdown.sel_sig"
 )
 
 // Capacity tiers.

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -260,6 +260,40 @@ func (w *Window) Markdown(cfg MarkdownCfg) View {
 	if cfg.Invisible {
 		return invisibleContainerView()
 	}
+	return &markdownView{cfg: cfg}
+}
+
+// markdownView is the widget node for a Markdown document. It is a
+// struct view (like the splitter, issue #264) because the document has
+// several identities that must agree: the container claims cfg.ID, and
+// every block references the widget through TC.markdownID — both keyed
+// by the *effective* ID, which only exists during generation. The
+// factory runs before generation (no ancestor scope yet), so the
+// resolution happens here, in GenerateLayout, where w.EffID can see
+// the enclosing panel.
+type markdownView struct {
+	cfg MarkdownCfg
+}
+
+func (mv *markdownView) Content() []View { return nil }
+
+func (mv *markdownView) GenerateLayout(w *Window) Layout {
+	cfg := &mv.cfg
+	// The document's identity is the effective ID: the container claims
+	// it, the blocks stamp it into TC.markdownID, and every state slot
+	// (nsMdSel, nsMdBlocks) and focus move keys on it. Under an
+	// ID-bearing ancestor this resolves to "outer:md", so two documents
+	// written with the same leaf under different panels keep separate
+	// selections; flat, it is cfg.ID unchanged. The result contains
+	// IDSep, which the resolve pass treats as absolute, so the
+	// container's effID stays exactly what is stamped here — resolving
+	// is idempotent. The overwrite fixes the identity at first
+	// generation: a cached instance moved between differently-scoped
+	// ancestors keeps the old path (safe here — the view rebuilds its
+	// subtree from cfg every frame, and an app that re-roots a document
+	// creates a fresh MarkdownCfg).
+	cfg.ID = w.EffID(cfg.ID)
+
 	mode := cfg.Mode.Get(TextModeWrap)
 
 	// Cache lookup; invalidate on theme change.
@@ -280,10 +314,10 @@ func (w *Window) Markdown(cfg MarkdownCfg) View {
 	allowExternalAPIs := markdownExternalAPIsEnabled &&
 		!cfg.disableExternalAPIs
 	if allowExternalAPIs {
-		markdownTriggerMathFetches(blocks, cfg, w)
+		markdownTriggerMathFetches(blocks, *cfg, w)
 	}
 
-	content := markdownBuildContent(blocks, cfg, mode, w)
+	content := markdownBuildContent(blocks, *cfg, mode, w)
 
 	sizing := FitFit
 	if mode == TextModeWrap ||
@@ -327,7 +361,10 @@ func (w *Window) Markdown(cfg MarkdownCfg) View {
 		colCfg.AmendLayout = markdownContainerAmendLayout
 		colCfg.OnKeyDown = markdownContainerOnKeyDown
 	}
-	return Column(colCfg)
+	// Generate the container subtree here so the inner IDs (heading
+	// anchors, copy buttons) compose under the resolved scope, exactly
+	// as a composite widget's GenerateLayout does.
+	return generateViewLayout(Column(colCfg), w)
 }
 
 // markdownTriggerMathFetches starts async fetches for inline math

--- a/gui/view_markdown_blocks_test.go
+++ b/gui/view_markdown_blocks_test.go
@@ -1,0 +1,231 @@
+package gui
+
+// view_markdown_blocks_test.go covers the block renderers that the
+// interaction suite never reaches: HR, image and definition-list
+// blocks (view_markdown_blocks.go). These are pure view factories —
+// the interactive suite is the right place for click/keyboard
+// behavior, but a divider or a definition term has no behavior to
+// drive, so shape structure is asserted directly, in the style of
+// TestRenderMdMathErrorsWrap.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+func TestMdRenderHR(t *testing.T) {
+	style := DefaultMarkdownStyle()
+	layout := generateViewLayout(mdRenderHR(MarkdownCfg{
+		Style: style,
+	}), &Window{})
+
+	shape := layout.Shape
+	if shape == nil {
+		t.Fatal("expected shape")
+	}
+	if shape.Height != 1 {
+		t.Errorf("HR height = %g, want 1", shape.Height)
+	}
+	if shape.Color != style.hRColor {
+		t.Errorf("HR color = %v, want %v", shape.Color, style.hRColor)
+	}
+	if shape.Sizing != FillFixed {
+		t.Errorf("HR sizing = %v, want FillFixed", shape.Sizing)
+	}
+}
+
+// TestMdRenderImage asserts an image block becomes a shapeImage with
+// the configured path and dimensions. The source path must exist —
+// Image.GenerateLayout stats it — so the test points at a real temp
+// file.
+func TestMdRenderImage(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "md_render_image_*.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	_ = f.Close()
+
+	layout := generateViewLayout(mdRenderImage(markdownBlock{
+		IsImage:     true,
+		ImageSrc:    path,
+		ImageWidth:  123,
+		ImageHeight: 45,
+	}), &Window{})
+
+	shape := layout.Shape
+	if shape == nil {
+		t.Fatal("expected shape")
+	}
+	if shape.shapeType != shapeImage {
+		t.Errorf("shape type = %v, want shapeImage", shape.shapeType)
+	}
+	if shape.Resource != path {
+		t.Errorf("Resource = %q, want %q", shape.Resource, path)
+	}
+	if shape.Width != 123 || shape.Height != 45 {
+		t.Errorf("size = %gx%g, want 123x45",
+			shape.Width, shape.Height)
+	}
+}
+
+// mdDefListBlocks parses a definition list and returns its term and
+// value blocks, sharing the real parser so the renderers see exactly
+// what markdownBuildContent would hand them.
+func mdDefListBlocks(t *testing.T) (term, value markdownBlock) {
+	t.Helper()
+	style := DefaultMarkdownStyle()
+	blocks := markdownToBlocks("Term\n:   Definition text", style)
+	for _, b := range blocks {
+		switch {
+		case b.IsDefTerm:
+			term = b
+		case b.IsDefValue:
+			value = b
+		}
+	}
+	if !term.IsDefTerm || !value.IsDefValue {
+		t.Fatalf("definition list not parsed: term=%v value=%v",
+			term.IsDefTerm, value.IsDefValue)
+	}
+	return term, value
+}
+
+// TestMdRenderDefTerm asserts the term renders as an RTF block with
+// the term text, styled bold (styleMdBlock selects style.Bold for
+// terms), and stamps the markdown block context when one is supplied.
+func TestMdRenderDefTerm(t *testing.T) {
+	term, _ := mdDefListBlocks(t)
+	style := DefaultMarkdownStyle()
+
+	// No context: the block must not claim a markdown ID.
+	layout := generateViewLayout(
+		mdRenderDefTerm(term, TextModeSingleLine, nil), &Window{})
+	tc := layout.Shape.TC
+	if tc == nil {
+		t.Fatal("expected text config on term shape")
+	}
+	if tc.rTFFlatText != "Term" {
+		t.Errorf("term text = %q, want %q", tc.rTFFlatText, "Term")
+	}
+	if tc.markdownID != "" {
+		t.Error("term without mdBlockCtx claimed a markdown ID")
+	}
+	if term.baseStyle.Typeface != glyphBoldTypeface(style) {
+		t.Errorf("term base style typeface = %v, want bold",
+			term.baseStyle.Typeface)
+	}
+
+	// With context: the block joins the markdown's virtual flat text.
+	layout = generateViewLayout(mdRenderDefTerm(term,
+		TextModeSingleLine, &mdBlockCtx{ID: "md", Start: 42}), &Window{})
+	tc = layout.Shape.TC
+	if tc.markdownID != "md" {
+		t.Errorf("markdownID = %q, want %q", tc.markdownID, "md")
+	}
+	if tc.markdownBlockStart != 42 {
+		t.Errorf("markdownBlockStart = %d, want 42",
+			tc.markdownBlockStart)
+	}
+	if tc.markdownRuneLen != uint32(utf8RuneCount("Term")) {
+		t.Errorf("markdownRuneLen = %d, want %d",
+			tc.markdownRuneLen, utf8RuneCount("Term"))
+	}
+}
+
+// glyphBoldTypeface returns the bold typeface the theme uses, so the
+// assertion above stays tied to the theme rather than a magic value.
+func glyphBoldTypeface(style MarkdownStyle) glyph.Typeface {
+	return style.Bold.Typeface
+}
+
+// TestMdRenderDefValue asserts the value renders as an RTF block
+// indented by the style's nestIndent and carrying the value text with
+// the plain text style.
+func TestMdRenderDefValue(t *testing.T) {
+	_, value := mdDefListBlocks(t)
+	style := DefaultMarkdownStyle()
+
+	layout := generateViewLayout(mdRenderDefValue(value,
+		MarkdownCfg{Style: style}, TextModeSingleLine,
+		&mdBlockCtx{ID: "md", Start: 4}), &Window{})
+
+	shape := layout.Shape
+	if shape == nil {
+		t.Fatal("expected shape")
+	}
+	if shape.Padding.Left != style.nestIndent {
+		t.Errorf("value padding left = %g, want %g",
+			shape.Padding.Left, style.nestIndent)
+	}
+	if len(layout.Children) != 1 {
+		t.Fatalf("value children = %d, want 1 (the RTF)",
+			len(layout.Children))
+	}
+	tc := layout.Children[0].Shape.TC
+	if tc == nil || tc.rTFFlatText != "Definition text" {
+		t.Errorf("value text = %q, want %q",
+			tc.rTFFlatText, "Definition text")
+	}
+	if tc.markdownID != "md" || tc.markdownBlockStart != 4 {
+		t.Errorf("value block ctx = %q@%d, want md@4",
+			tc.markdownID, tc.markdownBlockStart)
+	}
+	if value.baseStyle.Typeface != glyphBoldTypeface(style) &&
+		value.baseStyle.Typeface != style.Text.Typeface {
+		t.Errorf("value base style typeface = %v, want plain %v",
+			value.baseStyle.Typeface, style.Text.Typeface)
+	}
+}
+
+// TestMdHeaderStyle pins the header-level → style mapping, including
+// the default fallback (h6) for out-of-range levels.
+func TestMdHeaderStyle(t *testing.T) {
+	style := DefaultMarkdownStyle()
+	tests := []struct {
+		level int
+		want  TextStyle
+	}{
+		{1, style.h1},
+		{2, style.H2},
+		{3, style.h3},
+		{4, style.h4},
+		{5, style.h5},
+		{6, style.h6},
+		{0, style.h6}, // not a heading
+		{7, style.h6}, // out of range
+	}
+	for _, tt := range tests {
+		if got := mdHeaderStyle(tt.level, style); got != tt.want {
+			t.Errorf("mdHeaderStyle(%d) = %v, want %v",
+				tt.level, got, tt.want)
+		}
+	}
+}
+
+// TestMarkdownBuildContentRendersHRInPipeline asserts an HR source
+// produces a divider shape through markdownBuildContent, the path a
+// rendered document actually takes (the direct mdRenderHR test above
+// pins the factory itself).
+func TestMarkdownBuildContentRendersHRInPipeline(t *testing.T) {
+	style := DefaultMarkdownStyle()
+	blocks := markdownToBlocks("before\n\n---\n\nafter", style)
+	content := markdownBuildContent(blocks, MarkdownCfg{
+		Style: style,
+	}, TextModeWrap, &Window{})
+
+	// "before", HR, "after" — three children; the HR is the middle one.
+	if len(content) != 3 {
+		t.Fatalf("content blocks = %d, want 3", len(content))
+	}
+	layout := generateViewLayout(content[1], &Window{})
+	if layout.Shape == nil || layout.Shape.Height != 1 {
+		t.Errorf("pipeline HR height = %v, want 1", layout.Shape)
+	}
+	if layout.Shape.Color != style.hRColor {
+		t.Errorf("pipeline HR color = %v, want %v",
+			layout.Shape.Color, style.hRColor)
+	}
+}

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -41,6 +41,12 @@ func rtfSelectOnClick(ctx EventCtx) {
 	gl := shape.TC.rTFLayout
 	flatText := shape.TC.rTFFlatText
 
+	// The glyph layout's char rects are in the same space as the click
+	// coordinates: OnClick arrives through callRelative, which already
+	// translated the event to shape-local coordinates (scroll offsets
+	// included — the shape's post-scroll position is subtracted). The
+	// drag path below handles its own translation because MouseLock
+	// callbacks receive window coordinates.
 	byteIdx := gl.GetClosestOffset(ctx.Event.MouseX, ctx.Event.MouseY)
 	runePos := byteToRuneIndex(flatText, byteIdx)
 


### PR DESCRIPTION
## Summary

Closes #273 and #275. (Closes #274 — closed invalid on the same evidence this branch pins.)

**Test suite** (41 tests, 3 new files): the Markdown widget's previously-uncovered renderer/selection cluster — cross-block selection through the real pipeline (click, double-click, drag, backwards drag, Ctrl+A/C, clipboard contents, per-widget isolation), block renderers (HR, image, definition lists), and the mermaid/math async-fetch paths via injected seams. Package `gui/` coverage 81.0% → 82.4%; all 10 target functions go from 0% to ≥86%.

**#273 — nested markdown selection was broken.** The factory stamped every block's `TC.markdownID` with the raw `cfg.ID` while the amend hook keyed the block list by the container's *effective* ID — under an ID-bearing ancestor the block list was empty: Ctrl+A/C dead, cross-block drag confined, focus failed. Fixed with the #264 mechanism: `Markdown()` is now a struct view (`markdownView`) whose `GenerateLayout` resolves `cfg.ID = w.EffID(cfg.ID)` before anything is stamped — container, blocks, anchors, buttons, state keys, and focus all agree on the effective ID end to end. Flat documents are byte-identical; the resolved string is absolute for the resolve pass (no double join).

**#275 — stale selection across source changes.** `markdownContainerAmendLayout` now computes an FNV-1a signature over the block list (offsets, rune counts, full flat text — same-length rewrites caught; layout-only changes don't reset) and clears the selection when it differs from the previous frame.

**#274 — closed invalid (with evidence):** click handlers already receive shape-local coordinates via `callRelative`; only `MouseLock` callbacks are window-absolute. The two coordinate spaces are documented at both call sites, and two regression tests pin the contract.

## Tests

- 7/41 fail on pre-fix code for the right reasons: five nested (#273) tests, two-panel isolation (duplicate `md:h:heading` effIDs), and the source-change reset.
- Offset-pinning tests pass on old code (the `callRelative` contract); all positive controls pass both ways.
- Stub TextMeasurer gives every RTF block a deterministic 10px/char layout so click/drag coordinates map to exact runes (non-vacuous).

## Notes

- CHANGELOG `[Unreleased]` → Fixed: #273, #275; Added: suite.
- Two decisions documented in the review: generation-time resolution over amend-time rewriting (dispatch/key consistency), and `cfg.ID` mutation over a local `id` (the block pipeline reads it at many deep sites; identity fixed at first generation, safe under rebuild-every-frame).
- Independent review passed: no blockers, no should-fix; all four nits (comment accuracy) applied.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green. Pre-commit hooks (gofmt + golangci-lint) passed.