### PR TITLE
fix(gui): resolve markdown in-document anchor links against the document scope (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to
 
 ### Fixed
 
+- **Markdown/RTF in-document anchor links (`#slug`) now scroll
+  (issue #278).** `rtfOnClick` scrolled the bare slug, but a heading's
+  ID is scoped to its document (`ScopeID(docID, "h", slug)` — e.g.
+  `md:h:slug`, or `panel:md:h:slug` nested), so `FindByID(slug)` missed
+  and the scroll silently no-opped — even at root. The `#` branch now
+  resolves through `rtfResolveAnchor`: for a markdown block (every
+  block carries the document's effective ID in `TC.markdownID`, now
+  stamped on non-focusable documents too), the document-scoped heading
+  spelling is tried first, then the bare slug — so arbitrary absolute
+  targets (`#view:bottom`) and standalone RTF links keep working. The
+  identity stamping and the selection machinery are separate flags now:
+  a non-focusable markdown document gains anchor resolution but keeps
+  its exact prior click behavior (no focus, no mouse lock, no
+  per-frame selection walk).
+
 - **Markdown: cross-block selection works under ID-bearing ancestors
   (issue #273).** The document's blocks were stamped with the raw
   `cfg.ID` at generation time, while the container's amend and key

--- a/gui/markdown_anchor_interaction_test.go
+++ b/gui/markdown_anchor_interaction_test.go
@@ -1,0 +1,239 @@
+package gui
+
+// markdown_anchor_interaction_test.go drives the in-document anchor
+// (#slug) resolution added for issue #278 through the real pipeline:
+// a markdown document with a link to one of its own headings, wrapped
+// in a scroll container, with the stub text measurer the markdown
+// selection suite uses. Covers the document-scoped lookup (the heading
+// ID is ScopeID(mdID, "h", slug)) for flat and nested documents, the
+// bare-ID fallback for non-heading targets, the rtfResolveAnchor
+// helper in isolation, and the selection inertness of non-focusable
+// documents.
+
+import (
+	"testing"
+)
+
+// mdAnchorSource is a document with a heading and a link to it. The
+// heading must sit at a nonzero Y inside the scroll container: the
+// click observably moves the scroll offset, because scrollToView pins
+// the target to the container's top.
+const mdAnchorSource = "# Heading\n\n[jump](#heading)"
+
+// mdAnchorFindBlock walks the layout tree for an RTF block that
+// belongs to markdown document mdID and whose flat text is text. The
+// selection suite's block list (nsMdBlocks) only exists for focusable
+// documents, so anchor tests resolve blocks from the tree directly.
+func mdAnchorFindBlock(layout *Layout, mdID, text string) (*Layout, bool) {
+	if layout.Shape != nil && layout.Shape.TC != nil &&
+		layout.Shape.TC.markdownID == mdID &&
+		layout.Shape.TC.rTFFlatText == text {
+		return layout, true
+	}
+	for i := range layout.Children {
+		if l, ok := mdAnchorFindBlock(&layout.Children[i], mdID, text); ok {
+			return l, true
+		}
+	}
+	return nil, false
+}
+
+// mdAnchorWindow renders the scroll container around an optional
+// markdown document: the 100px lead rectangle keeps the document's
+// heading away from the container top, the 900px tail keeps the
+// container scrollable, and the optional top-level "heading" rectangle
+// gives the bare-slug fallback a distinct shape to hit when it wins.
+func mdAnchorWindow(
+	t *testing.T, source string, nested, focusable, bareHeading bool,
+) *Window {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = mdSelectTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		md := win.Markdown(MarkdownCfg{
+			ID:        "md",
+			Source:    source,
+			Style:     DefaultMarkdownStyle(),
+			Focusable: focusable,
+		})
+		if nested {
+			md = Column(ContainerCfg{
+				ID:      "panel",
+				Sizing:  FillFit,
+				Content: []View{md},
+			})
+		}
+		view := Column(ContainerCfg{
+			ID: "view", Scrollable: true, Sizing: FillFill,
+			Content: []View{
+				Rectangle(RectangleCfg{Sizing: FixedFill,
+					Width: 50, Height: 100}),
+				md,
+				Rectangle(RectangleCfg{Sizing: FixedFill,
+					Width: 50, Height: 900}),
+			},
+		})
+		if bareHeading {
+			return Column(ContainerCfg{
+				Sizing: FillFill,
+				Content: []View{
+					Rectangle(RectangleCfg{ID: "heading",
+						Sizing: FixedFill, Width: 50, Height: 50}),
+					view,
+				},
+			})
+		}
+		return view
+	})
+	return w
+}
+
+// mdAnchorClick clicks the middle of the "jump" link run — the first
+// run of its block, 4 chars at 10px each — and settles the frame.
+func mdAnchorClick(t *testing.T, w *Window, docID string) {
+	t.Helper()
+	block, ok := mdAnchorFindBlock(&w.layout, docID, "jump")
+	if !ok {
+		t.Fatal("no link block in the window")
+	}
+	x, y := block.Shape.X+15, block.Shape.Y+10
+	e := Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y}
+	w.EventFn(&e)
+	w.settle()
+	if !e.IsHandled {
+		t.Error("anchor link click was not consumed")
+	}
+	w.EventFn(&Event{Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y})
+	w.settle()
+}
+
+// TestMarkdownAnchorLinkScrollsToView asserts a '#' link inside a
+// markdown document scrolls the owning scroll container to the
+// linked heading. The heading ID is scoped to the document's
+// effective ID (md:h:slug, or panel:md:h:slug nested), so the click
+// path must resolve the anchor against TC.markdownID rather than the
+// bare slug. Runs flat and nested, focusable and not: identity
+// stamping must not depend on selection being enabled.
+func TestMarkdownAnchorLinkScrollsToView(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		nested    bool
+		focusable bool
+	}{
+		{name: "flat"},
+		{name: "nested", nested: true},
+		{name: "flat_focusable", focusable: true},
+		{name: "nested_focusable", nested: true, focusable: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := mdAnchorWindow(t, mdAnchorSource,
+				tc.nested, tc.focusable, false)
+			docID := "view:md"
+			if tc.nested {
+				docID = "view:panel:md"
+			}
+
+			block, ok := mdAnchorFindBlock(&w.layout, docID, "jump")
+			if !ok {
+				t.Fatal("no link block in the window")
+			}
+			x, y := block.Shape.X+15, block.Shape.Y+10
+			down := Event{Type: EventMouseDown, MouseButton: MouseLeft,
+				MouseX: x, MouseY: y}
+			w.EventFn(&down)
+			w.settle()
+			// Selection-enabled documents lock the mouse on click to
+			// drive drag-select; plain documents must not.
+			if locked := w.mouseIsLocked(); locked != tc.focusable {
+				t.Errorf("mouse locked = %v, want %v",
+					locked, tc.focusable)
+			}
+			w.EventFn(&Event{Type: EventMouseUp, MouseButton: MouseLeft,
+				MouseX: x, MouseY: y})
+			w.settle()
+
+			if !down.IsHandled {
+				t.Error("anchor link click was not consumed")
+			}
+			_, sy, _ := w.TestScrollOffset("view")
+			if sy == 0 {
+				t.Error("anchor link did not scroll the container")
+			}
+			if got := w.IsFocus(docID); got != tc.focusable {
+				t.Errorf("document focus = %v, want %v",
+					got, tc.focusable)
+			}
+		})
+	}
+}
+
+// TestMarkdownAnchorLinkBareIDFallback asserts a '#' link naming an
+// arbitrary absolute ID that is not a heading of the document still
+// scrolls: the scoped lookup misses, the bare slug ("view:bottom")
+// hits. Non-focusable document, so the plain rtfOnClick path carries
+// the resolution.
+func TestMarkdownAnchorLinkBareIDFallback(t *testing.T) {
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = mdSelectTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		return Column(ContainerCfg{
+			ID: "view", Scrollable: true, Sizing: FillFill,
+			Content: []View{
+				win.Markdown(MarkdownCfg{
+					ID:     "md",
+					Source: "[jump](#view:bottom)",
+					Style:  DefaultMarkdownStyle(),
+				}),
+				Rectangle(RectangleCfg{Sizing: FixedFill,
+					Width: 50, Height: 900}),
+				Rectangle(RectangleCfg{ID: "bottom",
+					Sizing: FixedFill, Width: 50, Height: 100}),
+			},
+		})
+	})
+
+	mdAnchorClick(t, w, "view:md")
+
+	_, sy, _ := w.TestScrollOffset("view")
+	if sy == 0 {
+		t.Error("bare anchor link did not scroll the container")
+	}
+}
+
+// TestRtfResolveAnchor pins the resolution rule in isolation: for a
+// markdown block (markdownID non-empty) the document-scoped heading
+// spelling wins, the bare slug is the fallback, and a standalone RTF
+// (markdownID empty) never tries the scoped lookup. The window also
+// carries a top-level rectangle with the bare ID "heading" so a
+// regression that skipped the scoped lookup would resolve to it and
+// fail the first case.
+func TestRtfResolveAnchor(t *testing.T) {
+	w := mdAnchorWindow(t, mdAnchorSource, false, false, true)
+
+	for _, tc := range []struct {
+		mdID   string
+		slug   string
+		want   string
+		wantOK bool
+	}{
+		// Scoped lookup wins, even with a bare "heading" shape around.
+		{"view:md", "heading", "view:md:h:heading", true},
+		// Scoped miss falls back to the bare slug: "view" is the scroll
+		// container, not a heading of the document.
+		{"view:md", "view", "view", true},
+		// Both miss.
+		{"view:md", "missing", "", false},
+		// Standalone RTF: bare slug only.
+		{"", "heading", "heading", true},
+		{"", "missing", "", false},
+	} {
+		got, ok := rtfResolveAnchor(w, tc.mdID, tc.slug)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("rtfResolveAnchor(mdID=%q, slug=%q) = "+
+				"(%q, %v), want (%q, %v)",
+				tc.mdID, tc.slug, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}

--- a/gui/markdown_select.go
+++ b/gui/markdown_select.go
@@ -36,10 +36,13 @@ type mdBlockInfo struct {
 
 // mdBlockCtx carries the markdown widget ID and the current cumulative rune
 // offset so render functions can stamp each RTF block with its position within
-// the markdown's virtual flat text.
+// the markdown's virtual flat text. ID is stamped on every block — it is the
+// document identity anchor-resolution keys on — while Start is meaningful only
+// when Sel is set, which gates the selection machinery.
 type mdBlockCtx struct {
 	ID    string
 	Start uint32
+	Sel   bool
 }
 
 // markdownBlockAmendSel is called from rtfMarkdownAmendLayout for each RTF

--- a/gui/markdown_select_interaction_test.go
+++ b/gui/markdown_select_interaction_test.go
@@ -120,6 +120,29 @@ func (mdSelectTestMeasurer) LayoutText(
 	return glyph.Layout{Height: style.Size * 1.2}, nil
 }
 
+// mdRunItems emits one Item per run, the granularity glyph's shaping
+// produces, so link/tooltip hit tests (rtfOnClick, rtfMouseMove) only
+// answer for the run under the cursor. mdCharLayoutForText leaves Items
+// empty — selection never reads it, but the click path does. The
+// baseline sits at Y=16 with Ascent 12 / Descent 4, so the hit rect
+// spans [4,20) — inside the char-rect band [0,20) that GetClosestOffset
+// maps.
+func mdRunItems(runs []glyph.StyleRun) []glyph.Item {
+	items := make([]glyph.Item, 0, len(runs))
+	offset := 0
+	for _, r := range runs {
+		items = append(items, glyph.Item{
+			X: float64(offset) * 10, Y: 16,
+			Width:  float64(len(r.Text)) * 10,
+			Ascent: 12, Descent: 4,
+			StartIndex: offset,
+			RunText:    r.Text,
+		})
+		offset += len(r.Text)
+	}
+	return items
+}
+
 // LayoutRichText concatenates the run texts — the same flat text the
 // shape carries in rTFFlatText — and shapes it.
 func (mdSelectTestMeasurer) LayoutRichText(
@@ -129,7 +152,9 @@ func (mdSelectTestMeasurer) LayoutRichText(
 	for _, r := range rt.Runs {
 		b.WriteString(r.Text)
 	}
-	return mdCharLayoutForText(b.String()), nil
+	l := mdCharLayoutForText(b.String())
+	l.Items = mdRunItems(rt.Runs)
+	return l, nil
 }
 
 // mdSelectHarness renders one focusable markdown document and exposes

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -412,11 +412,20 @@ func markdownBuildContent(
 	runeOffset := uint32(0)
 	selEnabled := cfg.Focusable
 
+	// Every block is stamped with the document's identity (markdownID,
+	// which anchor resolution keys on), but the per-block rune offsets
+	// and selection flag belong to the focusable path only. Non-focusable
+	// documents therefore reuse one ctx for all blocks — one allocation
+	// per frame per document instead of one per block.
+	var sharedCtx *mdBlockCtx
 	makeCtx := func(block markdownBlock) *mdBlockCtx {
 		if !selEnabled {
-			return nil
+			if sharedCtx == nil {
+				sharedCtx = &mdBlockCtx{ID: cfg.ID}
+			}
+			return sharedCtx
 		}
-		ctx := &mdBlockCtx{ID: cfg.ID, Start: runeOffset}
+		ctx := &mdBlockCtx{ID: cfg.ID, Start: runeOffset, Sel: true}
 		runeOffset += uint32(rtfRuneCountFromRuns(&block.Content))
 		return ctx
 	}

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -296,6 +296,7 @@ func mdRenderHR(cfg MarkdownCfg) View {
 func applyMdCtx(cfg *RTFCfg, ctx *mdBlockCtx) {
 	if ctx != nil {
 		cfg.markdownID = ctx.ID
+		cfg.markdownSel = ctx.Sel
 		cfg.markdownBlockStart = ctx.Start
 	}
 }

--- a/gui/view_rtf.go
+++ b/gui/view_rtf.go
@@ -26,11 +26,16 @@ type RTFCfg struct {
 	Focusable       bool
 	hangingIndent   float32 // negative indent for wrapped lines
 
-	// markdownID > 0 when this block belongs to a markdown widget.
-	// markdownBlockStart is the rune offset of this block in the
-	// markdown's flat text. Both are set by view_markdown.go only.
+	// markdownID is non-empty when this block belongs to a markdown
+	// widget. markdownBlockStart is the rune offset of this block in
+	// the markdown's flat text. All three are set by view_markdown.go
+	// only: markdownID is stamped on every markdown block — it is the
+	// document identity anchor resolution keys on — while markdownSel
+	// gates the cross-block selection machinery and is set only for
+	// focusable documents.
 	markdownID         string
 	markdownBlockStart uint32
+	markdownSel        bool
 	Mode               textMode
 	Invisible          bool
 	Clip               bool
@@ -138,7 +143,7 @@ func (v *rtfView) GenerateLayout(w *Window) Layout {
 
 	var events *eventHandlers
 	switch {
-	case v.markdownID != "":
+	case v.markdownSel:
 		events = w.allocEventHandlers(eventHandlers{
 			OnClick:     markdownBlockOnClick,
 			OnMouseMove: rtfMouseMove,
@@ -498,7 +503,11 @@ func rtfOnClick(ctx EventCtx) {
 				}
 				if len(found.Link) > 0 &&
 					found.Link[0] == '#' {
-					ctx.Window.scrollToView(found.Link[1:])
+					if id, ok := rtfResolveAnchor(ctx.Window,
+						ctx.Layout.Shape.TC.markdownID,
+						found.Link[1:]); ok {
+						ctx.Window.scrollToView(id)
+					}
 				} else if ctx.Window.nativePlatform != nil {
 					_ = ctx.Window.nativePlatform.OpenURI(found.Link)
 				}
@@ -507,6 +516,31 @@ func rtfOnClick(ctx EventCtx) {
 			return
 		}
 	}
+}
+
+// rtfResolveAnchor resolves an in-document anchor ('#slug') to the
+// scrollable target it names. A link inside a markdown document (TC
+// markdownID non-empty) names a heading of that document, whose ID is
+// scoped to the document: ScopeID(markdownID, "h", slug) — the
+// "md:h:slug" (or "panel:md:h:slug") path the resolve pass treats as
+// absolute — so the scoped spelling is tried first. Targets that are
+// not headings keep working: an arbitrary absolute ID ("#view:bottom")
+// or a standalone RTF link (markdownID == "") falls back to the bare
+// slug. ok is false when neither lookup finds a shape.
+func rtfResolveAnchor(
+	w *Window, markdownID, slug string,
+) (id string, ok bool) {
+	if markdownID != "" {
+		if scoped := ScopeID(markdownID, "h", slug); scoped != "" {
+			if _, found := w.layout.FindByID(scoped); found {
+				return scoped, true
+			}
+		}
+	}
+	if _, found := w.layout.FindByID(slug); found {
+		return slug, true
+	}
+	return "", false
 }
 
 // rtfLinkMenuState holds state for the RTF link context menu.


### PR DESCRIPTION
## Summary

Closes #278. In-document anchor links (`#slug`) in markdown never scrolled: `rtfOnClick` passed the BARE slug to `scrollToView` while the heading's ID is the absolute `ScopeID(cfg.ID, "h", slug)` (`md:h:slug`, or `panel:md:h:slug` under an ID-bearing ancestor) — `FindByID` always missed, silently. Never worked, even at root.

**Fix:** new `rtfResolveAnchor(w, markdownID, slug)` — for markdown blocks, tries `ScopeID(markdownID, "h", slug)` first, falls back to the bare slug (arbitrary absolute IDs like `#view:bottom` keep working — pinned by the existing contract test); standalone RTF skips the scoped lookup. `rtfOnClick` calls `scrollToView` only when resolution succeeds.

**Identity/behavior split:** `TC.markdownID` was only stamped for *focusable* documents, so non-focusable markdown (the common case) had no scope to resolve against. Identity is now stamped for all markdown blocks (non-focusable docs reuse one shared ctx per doc per frame — 1 alloc/frame/doc, no per-block alloc; no benchmark measures the markdown path), while selection behavior stays gated on a new `RTFCfg.markdownSel` flag — non-focusable blocks are byte-identical: no `SetFocus`, no mouse lock, no per-frame selection walk (verified by wiring and stash-test).

## Tests

- `TestMarkdownAnchorLinkScrollsToView` — table: flat/nested (under `Column{ID:"panel"}`) × focusable/non-focusable; asserts scroll offset changes plus per-row lock/focus states
- `TestMarkdownAnchorLinkBareIDFallback` — scoped miss → bare hit
- `TestRtfResolveAnchor` — helper unit: scoped wins over a decoy bare heading; both-miss; standalone RTF bare hit/miss
- Existing `TestRtfOnClickAnchorLinkScrollsToView` green unchanged

Stash-tested: all scroll subtests + fallback fail on pre-fix code for the right reasons (bare-slug miss / missing stamp); contract test passes unchanged both ways.

## Notes

- Slug sanitization verified: `headingSlug` emits `[a-z0-9-]+` only, so `:` can never appear and `ScopeID`'s parts rule is safe. (Quirk, not fixed: link fragments are NOT slugified at parse time — a `#fragment` must already match the slugified heading text.)
- CHANGELOG `[Unreleased]` → Fixed bullet.
- Independent review passed: no blockers, no should-fix; three test-quality nits applied.
- Full WASM suite (`GOOS=js GOARCH=wasm go test ./gui/`) verified green locally.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green. Pre-commit hooks (gofmt + golangci-lint) passed.