### PR TITLE
fix(gui): preserve input selections on same-widget SetFocus re-assert (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to
 
 ### Fixed
 
+- **Re-asserting focus no longer clears input selections (issue
+  #277).** `setFocusLocked` called `clearInputSelections()` on every
+  `SetFocus`, unconditionally, while the IME clear next to it was
+  already guarded by `id != prev` (#156). Because consumers
+  legitimately re-assert focus from inside their View function — which
+  runs on every layout rebuild — an unconditional clear wiped every
+  `nsInput` selection window-wide on each re-assert, silently dropping
+  selections in the focused input and every unrelated field. The clear
+  is now guarded exactly like the IME clear: only a real focus change
+  drops selections (window-wide, as before); a same-widget re-assert
+  leaves them alone. Clicking an already-focused input still collapses
+  its selection to a caret at the click — that path sets the selection
+  itself and never depended on the clear.
+
 - **Markdown/RTF in-document anchor links (`#slug`) now scroll
   (issue #278).** `rtfOnClick` scrolled the bare slug, but a heading's
   ID is scoped to its document (`ScopeID(docID, "h", slug)` — e.g.

--- a/gui/rtf_select_interaction_test.go
+++ b/gui/rtf_select_interaction_test.go
@@ -291,15 +291,17 @@ func (h *rtfSelectHarness) release(x, y float32) Event {
 	return e
 }
 
-// key dispatches one key down/up pair without re-asserting focus. The
-// click that precedes it already focused the RTF; a SetFocus here would
-// call clearInputSelections (window.go) and wipe the selection the
-// sequence builds on.
-func (h *rtfSelectHarness) key(k KeyCode, mods Modifier) {
-	h.w.EventFn(&Event{Type: EventKeyDown, KeyCode: k, Modifiers: mods})
-	h.w.settle()
-	h.w.EventFn(&Event{Type: EventKeyUp, KeyCode: k, Modifiers: mods})
-	h.w.settle()
+// key dispatches one key down/up pair to the RTF via TestKey, which
+// re-asserts focus on the same id. Same-id re-asserts no longer clear
+// selections (issue #277), so chained calls build on the selection the
+// preceding click or key established. The original helper dispatched
+// raw EventFn pairs to dodge the old unconditional clear that
+// setFocusLocked ran on every re-assert; that workaround is obsolete.
+func (h *rtfSelectHarness) key(t *testing.T, k KeyCode, mods Modifier) {
+	t.Helper()
+	if err := h.w.TestKey(h.id, k, mods); err != nil {
+		t.Fatalf("TestKey(%s): %v", keyName(k), err)
+	}
 }
 
 // rtfRunePoint returns the window coordinate of the middle of localRune
@@ -541,35 +543,35 @@ func TestRtfSelectKeyNavArrows(t *testing.T) {
 	h.release(x, y)
 	expectRtfCursor(t, h, 4)
 
-	h.key(KeyRight, ModNone)
+	h.key(t, KeyRight, ModNone)
 	expectRtfCursor(t, h, 5)
-	h.key(KeyRight, ModNone)
+	h.key(t, KeyRight, ModNone)
 	expectRtfCursor(t, h, 6)
-	h.key(KeyLeft, ModNone)
+	h.key(t, KeyLeft, ModNone)
 	expectRtfCursor(t, h, 5)
 
 	// Word movement: from ' ' (5) Ctrl+Right lands on 'w' (6);
 	// Ctrl+Left from there lands on 'h' (0).
-	h.key(KeyRight, ModCtrl)
+	h.key(t, KeyRight, ModCtrl)
 	expectRtfCursor(t, h, 6)
-	h.key(KeyLeft, ModCtrl)
+	h.key(t, KeyLeft, ModCtrl)
 	expectRtfCursor(t, h, 0)
 
 	// Alt is a word modifier too, matching the Input/Text handlers.
-	h.key(KeyRight, ModAlt)
+	h.key(t, KeyRight, ModAlt)
 	expectRtfCursor(t, h, 6)
 
-	h.key(KeyHome, ModNone)
+	h.key(t, KeyHome, ModNone)
 	expectRtfCursor(t, h, 0)
-	h.key(KeyEnd, ModNone)
+	h.key(t, KeyEnd, ModNone)
 	expectRtfCursor(t, h, 11)
-	h.key(KeyHome, ModNone)
+	h.key(t, KeyHome, ModNone)
 	expectRtfCursor(t, h, 0)
 
 	// An unmodified arrow collapses the selection to its end.
-	h.key(KeyRight, ModShift)
+	h.key(t, KeyRight, ModShift)
 	expectRtfSel(t, h, 0, 1)
-	h.key(KeyRight, ModNone)
+	h.key(t, KeyRight, ModNone)
 	expectRtfSel(t, h, 0, 0)
 	expectRtfCursor(t, h, 1)
 }
@@ -583,15 +585,15 @@ func TestRtfSelectKeyShiftExtendsSelection(t *testing.T) {
 	h.press(x, y)
 	h.release(x, y)
 
-	h.key(KeyRight, ModShift)
+	h.key(t, KeyRight, ModShift)
 	expectRtfSel(t, h, 4, 5)
-	h.key(KeyRight, ModShift)
+	h.key(t, KeyRight, ModShift)
 	expectRtfSel(t, h, 4, 6)
-	h.key(KeyLeft, ModShift)
+	h.key(t, KeyLeft, ModShift)
 	expectRtfSel(t, h, 4, 5)
-	h.key(KeyLeft, ModShift)
+	h.key(t, KeyLeft, ModShift)
 	expectRtfSel(t, h, 4, 4)
-	h.key(KeyLeft, ModShift)
+	h.key(t, KeyLeft, ModShift)
 	expectRtfSel(t, h, 4, 3) // inverted: anchor stays at 4
 }
 
@@ -626,12 +628,12 @@ func TestRtfSelectCtrlASelectsAllAndCtrlCCopies(t *testing.T) {
 	h.press(x, y)
 	h.release(x, y)
 
-	h.key(KeyA, ModCtrl)
+	h.key(t, KeyA, ModCtrl)
 	expectRtfSel(t, h, 0, 11)
 
 	var got string
 	h.w.SetClipboardFn(func(s string) { got = s })
-	h.key(KeyC, ModCtrl)
+	h.key(t, KeyC, ModCtrl)
 	if got != "hello world" {
 		t.Errorf("clipboard = %q, want %q", got, "hello world")
 	}

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -1509,3 +1509,172 @@ func TestInputReadOnlyDoesNotRenderIMEPreedit(t *testing.T) {
 		t.Fatalf("read-only field dropped its text; got %q", readonly)
 	}
 }
+
+// --- SetFocus / selection contract (issue #277) ---
+
+// TestSetFocusReassertSameIDPreservesSelection pins the #277 fix: a
+// same-widget SetFocus re-assert must leave in-flight text selections
+// alone. Before the fix the unconditional clearInputSelections() in
+// setFocusLocked wiped every nsInput selection window-wide on every
+// re-assert, even when nothing changed. Real focus *changes* still
+// clear them (tested below).
+func TestSetFocusReassertSameIDPreservesSelection(t *testing.T) {
+	w := newTestWindow()
+	w.SetFocus("f900")
+	setInputState(w, "f900", inputState{
+		CursorPos: 5, selectBeg: 0, selectEnd: 5,
+	})
+	w.SetFocus("f900")
+	if is := getInputState(w, "f900"); is.selectBeg != 0 || is.selectEnd != 5 {
+		t.Fatalf("same-id re-assert dropped selection: [%d,%d), want [0,5)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// The #156 pattern: a View function that re-asserts focus on every
+// frame (documented as legitimate in window_focus.go). TestRender(nil)
+// re-runs the installed generator without clearing the registry
+// (UpdateView would), so the second frame observes the state the first
+// frame's re-assert must not have wiped.
+func TestSetFocusReassertFromViewPreservesSelection(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	view := func(win *Window) View {
+		w.SetFocus("f901")
+		return Input(InputCfg{ID: "f901", Text: "hello"})
+	}
+	w.TestRender(view)
+	setInputState(w, "f901", inputState{
+		CursorPos: 5, selectBeg: 0, selectEnd: 5,
+	})
+	w.TestRender(nil) // next frame: the View re-asserts focus on f901
+	if is := getInputState(w, "f901"); is.selectBeg != 0 || is.selectEnd != 5 {
+		t.Fatalf("frame re-assert dropped selection: [%d,%d), want [0,5)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// Real focus changes keep today's contract: every nsInput selection in
+// the window is cleared — the widget losing focus, the one gaining it,
+// and unrelated fields — not just the newly focused one.
+func TestSetFocusRealChangeClearsSelectionsWindowWide(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(win *Window) View {
+		return Column(ContainerCfg{Sizing: FillFill, Content: []View{
+			Input(InputCfg{ID: "f911", Text: "aaaa"}),
+			Input(InputCfg{ID: "f912", Text: "bbbb"}),
+			Input(InputCfg{ID: "f913", Text: "cccc"}),
+		}})
+	})
+	w.SetFocus("f911")
+	for _, id := range []string{"f911", "f912", "f913"} {
+		setInputState(w, id, inputState{
+			CursorPos: 4, selectBeg: 0, selectEnd: 4,
+		})
+	}
+	w.SetFocus("f912") // real change: f911 -> f912
+	for _, id := range []string{"f911", "f912", "f913"} {
+		if is := getInputState(w, id); is.selectBeg != 0 || is.selectEnd != 0 {
+			t.Errorf("%s selection survived real focus change: [%d,%d), want [0,0)",
+				id, is.selectBeg, is.selectEnd)
+		}
+	}
+}
+
+// Returning to a widget (empty focus -> widget) is a real transition:
+// selections that predate focus arrival must not survive it.
+func TestSetFocusFromEmptyClearsPreExistingSelections(t *testing.T) {
+	w := newTestWindow()
+	w.SetFocus("f920")
+	setInputState(w, "f920", inputState{
+		CursorPos: 4, selectBeg: 0, selectEnd: 4,
+	})
+	w.SetFocus("") // real change: f920 -> none
+	// Seed again while unfocused: a stale selection must not survive
+	// the empty -> widget transition below.
+	setInputState(w, "f920", inputState{
+		CursorPos: 4, selectBeg: 0, selectEnd: 4,
+	})
+	w.SetFocus("f920")
+	if is := getInputState(w, "f920"); is.selectBeg != 0 || is.selectEnd != 0 {
+		t.Fatalf("empty->widget transition kept selection: [%d,%d), want [0,0)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// inputSelTestMeasurer shapes plain text into the deterministic
+// 10x20-per-byte char-rect layout rtfSelCharLayout builds, so
+// inputOnClick's GetClosestOffset maps clicks to runes headlessly.
+// The metric methods are rtfSelTestMeasurer's; only the plain-text
+// shaper differs.
+type inputSelTestMeasurer struct {
+	rtfSelTestMeasurer
+}
+
+func (inputSelTestMeasurer) LayoutText(
+	text string, _ TextStyle, _ float32,
+) (glyph.Layout, error) {
+	return rtfSelCharLayout(text, nil), nil
+}
+
+// rtfSelCharLayout lays one char rect per byte at a fixed 10x20
+// pitch. The click coordinates below are derived from it, so they
+// stay consistent with the measurer that produced the layout.
+const (
+	inputSelCharW = 10
+	inputSelCharH = 20
+)
+
+// Condition-1 pin for #277: clicking an already-focused input must
+// collapse its selection to a caret at the click position. The input's
+// own click path (inputOnClick) sets selectBeg/selectEnd explicitly
+// from the click, so the fix — which leaves same-id re-asserts alone
+// — cannot regress it.
+func TestInputClickOnFocusedInputCollapsesSelectionToCaret(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.textMeasurer = inputSelTestMeasurer{}
+	w.TestRender(func(win *Window) View {
+		return Input(InputCfg{ID: "f930", Text: "hello world"})
+	})
+	w.SetFocus("f930")
+	setInputState(w, "f930", inputState{
+		CursorPos: 5, selectBeg: 0, selectEnd: 5,
+	})
+
+	ly, ok := w.layout.FindByID("f930")
+	if !ok {
+		t.Fatal("no input with effective ID f930")
+	}
+	if len(ly.Children) == 0 || len(ly.Children[0].Children) == 0 {
+		t.Fatal("input layout missing inner text child")
+	}
+	txt := ly.Children[0].Children[0].Shape
+	if txt.TC == nil {
+		t.Fatal("inner child is not a text shape")
+	}
+
+	// Click mid-rune-8 ('o' of "world"): char rects are inputSelCharW
+	// wide and start at the text shape origin, so X + 8*W + W/2 is
+	// the rune's center; Y + H/2 is the middle of the glyph line band.
+	clickX := txt.X + 8*inputSelCharW + inputSelCharW/2
+	clickY := txt.Y + inputSelCharH/2
+	down := Event{
+		Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: clickX, MouseY: clickY,
+	}
+	w.EventFn(&down)
+	w.settle()
+	w.EventFn(&Event{
+		Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: clickX, MouseY: clickY,
+	})
+	w.settle()
+
+	is := getInputState(w, "f930")
+	if is.selectBeg != 8 || is.selectEnd != 8 {
+		t.Fatalf("click on focused input left selection [%d,%d), want caret at 8",
+			is.selectBeg, is.selectEnd)
+	}
+	if is.CursorPos != 8 {
+		t.Fatalf("cursor = %d, want 8", is.CursorPos)
+	}
+}

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -9,9 +9,10 @@ func (w *Window) FocusID() string {
 	return w.viewState.focusID
 }
 
-// SetFocus sets the focused widget by its string ID and clears
-// input selections. Acquires both w.mu (focusID) and w.animMu
-// (animations). Use ClearFocus to remove focus.
+// SetFocus sets the focused widget by its string ID. A real focus
+// change clears input selections window-wide; re-asserting the widget
+// that already holds focus leaves selections alone. Acquires both w.mu
+// (focusID) and w.animMu (animations). Use ClearFocus to remove focus.
 func (w *Window) SetFocus(id string) {
 	w.mu.Lock()
 	w.animMu.Lock()
@@ -27,15 +28,15 @@ func (w *Window) ClearFocus() {
 
 func (w *Window) setFocusLocked(id string) {
 	prev := w.viewState.focusID
-	w.clearInputSelections()
-	// Re-focusing the widget that already has focus must leave an
-	// in-flight IME composition alone. Consumers legitimately re-assert
-	// focus from inside their View function, which runs on every layout
-	// rebuild — i.e. after every keystroke — so an unconditional clear
-	// here wiped the preedit between each composition update, and the
-	// IMEStart below re-activated the platform input context
-	// mid-composition. See go-gui-org/go-gui#156.
+	// Only a real focus *change* drops selections and clears the IME.
+	// Re-asserting focus on the widget that already holds it must leave
+	// an in-flight IME composition alone — see #156 — and, since #277,
+	// text selections too: consumers legitimately re-assert focus from
+	// inside their View function, which runs on every layout rebuild,
+	// so an unconditional selection clear wiped every nsInput selection
+	// window-wide on each re-assert. Real transitions still clear both.
 	if id != prev {
+		w.clearInputSelections()
 		w.imeClear()
 	}
 	w.viewState.focusID = id


### PR DESCRIPTION
## Summary

Closes #277. `setFocusLocked` called `clearInputSelections()` unconditionally on every `SetFocus`, so a same-widget re-assert — legitimate per the #156 precedent, apps re-assert focus from View functions on every frame — wiped all `nsInput` selections window-wide (including in inputs that never lost focus). The IME clear next to it was already guarded by `id != prev`; the selection clear was not.

**Fix:** `clearInputSelections()` moved inside the existing `if id != prev` guard, beside the IME clear. Real focus changes (`A→B`, `""→id`, `id→""`) keep today's window-wide clear; same-widget re-assert preserves selections.

Triage note: a hypothesis that the unconditional clear was the fix for the window-resize ghost-selection was disproven — that bug was fixed backend-side (commit 83ef8f1, "metal: drop mouse-down consumed by window resize drag (#111)"), and the clear predates it.

## Verification (all run, not assumed)

- Click paths are provably independent of the clear: `inputOnClick` (view_input.go:474-480), Text (view_text_select.go:72-79), RTF (view_rtf_select.go:67-74) and keyboard nav (`updateCursorAndSelection`, input_state.go:331-347) all set `selectBeg/selectEnd` explicitly — a regression test that passes on the UNFIXED code pins it.
- Stash-test (fix reverted, tests copied): exactly 5 failures with the right reasons — 2 preservation pins (selection dropped to [0,0); frame re-assert wiped) + 3 RTF harness tests; nothing else in the full suite depended on the unconditional clear.
- RTF harness workaround removed: `rtfSelectHarness.key` now delegates to `TestKey` (chained `TestKey` used to wipe selections per call); the three affected tests pass identically, and reverting the fix makes exactly them fail.
- Behavior note (deliberate, CHANGELOG-documented): clicking an already-focused non-input focusable no longer clears input selections elsewhere — the intended #277 contract, slightly wider than inputs alone.
- Capture-loss cancel paths don't clear partial selections — assessed equivalent to committed-drag behavior, filed as #281 (low priority).

## Tests

5 new in `gui/view_input_test.go` (deterministic char-rect measurer, dedup'd via embedding; named geometry constants): same-widget re-assert preserves selection (direct + per-frame View-function re-assert), real focus change clears window-wide, click on focused input collapses to caret, empty→widget transition clears.

## Notes

- CHANGELOG `[Unreleased]` → Fixed bullet (issue #277).
- Independent review passed: no blockers, no should-fix; both test nits applied.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green. Full WASM suite green locally. Pre-commit hooks (gofmt + golangci-lint) passed.