### PR TITLE
fix(gui): zero partial selection when selection drags are cancelled (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to
 
 ### Fixed
 
+- **Interrupted (capture-loss) selection drags no longer leave a stuck
+  selection (issue #281).** Input, Text and RTF selection drags hold a
+  mouse lock whose `Cancel` hook fired on capture loss — a mouse-up that
+  will never arrive (window-resize steal, alt-tab, the #237 class) —
+  but only removed the edge-scroll animation; the partial selection
+  survived as if committed. The three Cancel hooks now zero the dragged
+  widget's own `selectBeg`/`selectEnd` (scoped to its `nsInput` key,
+  never other widgets'), so an interrupted drag leaves nothing. A normal
+  release still commits even outside the widget — the lock delivers the
+  mouse-up anywhere; only capture loss goes through the Cancel hook.
+
 - **Re-asserting focus no longer clears input selections (issue
   #277).** `setFocusLocked` called `clearInputSelections()` on every
   `SetFocus`, unconditionally, while the IME clear next to it was

--- a/gui/rtf_select_interaction_test.go
+++ b/gui/rtf_select_interaction_test.go
@@ -531,6 +531,95 @@ func TestRtfSelectRightClickLeavesSelectionUntouched(t *testing.T) {
 	expectRtfSel(t, h, 2, 2)
 }
 
+// TestRtfSelectDragCancelZeroesSelection pins issue #281: capture
+// loss mid-drag (MouseCancel — the platform revoked the lock, no
+// release will come) must zero the partial selection instead of
+// leaving it stuck. The Cancel hook is scoped to the dragged RTF's
+// own nsInput key.
+func TestRtfSelectDragCancelZeroesSelection(t *testing.T) {
+	h := newRtfSelectHarness(t, rtfHelloWorld())
+
+	x0, y0 := rtfRunePoint(h.shape(t), 2)
+	h.press(x0, y0)
+	x1, y1 := rtfRunePoint(h.shape(t), 8)
+	h.move(x1, y1)
+	expectRtfSel(t, h, 2, 8)
+
+	h.w.MouseCancel()
+	h.w.settle()
+	if h.w.mouseIsLocked() {
+		t.Error("mouse still locked after MouseCancel")
+	}
+	expectRtfSel(t, h, 0, 0)
+}
+
+// TestRtfSelectDragCancelScopedToOwnState asserts the Cancel hook
+// zeroes only the dragged RTF's selection: a second widget's nsInput
+// entry written after the drag started survives the cancel. (A
+// selection present before the press would already have been cleared
+// by the RTF taking focus — a real focus change clears selections
+// window-wide by design, so the unrelated entry must be planted after
+// focus is established.)
+func TestRtfSelectDragCancelScopedToOwnState(t *testing.T) {
+	h := newRtfSelectHarness(t, rtfHelloWorld())
+
+	x0, y0 := rtfRunePoint(h.shape(t), 2)
+	h.press(x0, y0)
+	x1, y1 := rtfRunePoint(h.shape(t), 8)
+	h.move(x1, y1)
+	expectRtfSel(t, h, 2, 8)
+
+	setInputState(h.w, "other", inputState{CursorPos: 3, selectBeg: 1, selectEnd: 3})
+	h.w.MouseCancel()
+	h.w.settle()
+	expectRtfSel(t, h, 0, 0)
+	if is := getInputState(h.w, "other"); is.selectBeg != 1 || is.selectEnd != 3 {
+		t.Errorf("unrelated widget selection = [%d,%d), want [1,3)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// TestRtfSelectReleaseOutsideCommitsSelection pins the asymmetry that
+// makes cancel-zeros correct: a normal MouseUp — even at a point far
+// outside the widget — COMMITS the drag selection. The mouse lock
+// delivers the release regardless of position; only capture loss goes
+// through the Cancel hook.
+func TestRtfSelectReleaseOutsideCommitsSelection(t *testing.T) {
+	h := newRtfSelectHarness(t, rtfHelloWorld())
+
+	x0, y0 := rtfRunePoint(h.shape(t), 2)
+	h.press(x0, y0)
+	x1, y1 := rtfRunePoint(h.shape(t), 8)
+	h.move(x1, y1)
+	expectRtfSel(t, h, 2, 8)
+
+	h.release(700, 700) // outside the widget: commits
+	if h.w.mouseIsLocked() {
+		t.Error("mouse still locked after release")
+	}
+	expectRtfSel(t, h, 2, 8)
+}
+
+// TestRtfSelectDragCancelCollapsedSelectionHarmless asserts the
+// guard: a cancel when no selection is in progress (the press only
+// collapsed to a caret) leaves the state clean — no corruption, no
+// stuck lock.
+func TestRtfSelectDragCancelCollapsedSelectionHarmless(t *testing.T) {
+	h := newRtfSelectHarness(t, rtfHelloWorld())
+
+	x, y := rtfRunePoint(h.shape(t), 2)
+	h.press(x, y)
+	expectRtfSel(t, h, 2, 2)
+
+	h.w.MouseCancel()
+	h.w.settle()
+	if h.w.mouseIsLocked() {
+		t.Error("mouse still locked after MouseCancel")
+	}
+	expectRtfSel(t, h, 0, 0)
+	expectRtfCursor(t, h, 2)
+}
+
 // --- Keyboard navigation ---
 
 // TestRtfSelectKeyNavArrows walks the single-line key map: plain

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -488,14 +488,19 @@ func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 		}
 		ctx.Consume()
 
-		// Drag-to-select via MouseLock.
+		// Drag-to-select via MouseLock. The lock delivers mouse moves in
+		// window-absolute coordinates (event_handlers.go), so the drag
+		// offset must be the text shape's absolute position — subtracting
+		// the box-relative offset (txt.X - box.X) would leave the drag
+		// shifted by the input's window X. The click path derives the
+		// same text-relative frame from the box-relative event.
 		ds := &inputDragState{
 			anchorPos:   is.selectBeg,
 			anchorEnd:   is.selectEnd,
 			gl:          gl,
 			displayText: displayText,
-			txtOffX:     ly.Shape.X - ctx.Layout.Shape.X,
-			txtOffY:     ly.Shape.Y - ctx.Layout.Shape.Y,
+			txtOffX:     ly.Shape.X,
+			txtOffY:     ly.Shape.Y,
 			focusID:     focusID,
 			scrollID:    scrollID,
 		}

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -279,6 +279,15 @@ func startInputDrag(d *inputDragState, w *Window) {
 		},
 		Cancel: func(w *Window) {
 			w.AnimationRemove(animIDDragScroll)
+			// The drag was mutating this input's own nsInput state:
+			// zero the partial selection so a cancelled drag never
+			// leaves a stuck highlight (issue #281). Other widgets'
+			// selections are untouched — the key is d.focusID.
+			imap := StateMap[string, inputState](w, nsInput, capMany)
+			is := imap.GetOr(d.focusID, inputState{})
+			is.selectBeg = 0
+			is.selectEnd = 0
+			imap.Set(d.focusID, is)
 		},
 	})
 }

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -1678,3 +1678,179 @@ func TestInputClickOnFocusedInputCollapsesSelectionToCaret(t *testing.T) {
 		t.Fatalf("cursor = %d, want 8", is.CursorPos)
 	}
 }
+
+// --- Issue #281: capture-loss cancel zeroes the partial drag selection ---
+
+// newInputSelWindow renders a single-line input with the deterministic
+// measurer and returns the window plus the layout for ID.
+func newInputSelWindow(t *testing.T, cfg InputCfg) (*Window, *Layout) {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{})
+	w.textMeasurer = inputSelTestMeasurer{}
+	w.TestRender(func(win *Window) View { return Input(cfg) })
+	ly, ok := w.layout.FindByID(cfg.ID)
+	if !ok {
+		t.Fatalf("no input with effective ID %s", cfg.ID)
+	}
+	return w, ly
+}
+
+// inputTextShape walks the input layout to its inner text shape, whose
+// origin anchors the deterministic char rects.
+func inputTextShape(t *testing.T, ly *Layout) *Shape {
+	t.Helper()
+	if len(ly.Children) == 0 || len(ly.Children[0].Children) == 0 {
+		t.Fatal("input layout missing inner text child")
+	}
+	txt := ly.Children[0].Children[0].Shape
+	if txt.TC == nil {
+		t.Fatal("inner child is not a text shape")
+	}
+	return txt
+}
+
+// inputRunePoint returns the window-absolute center of localRune —
+// valid for both the click path (shape-relative after callRelative)
+// and the MouseLock drag path (window-absolute; the drag subtracts
+// the text shape's offset from the input box itself).
+func inputRunePoint(txt *Shape, localRune int) (float32, float32) {
+	return txt.X + float32(localRune)*inputSelCharW + inputSelCharW/2,
+		txt.Y + inputSelCharH/2
+}
+
+// TestInputDragCancelZeroesSelection pins issue #281: capture loss
+// mid-drag (MouseCancel — no release will ever arrive) must zero the
+// partial selection, not leave a stuck highlight.
+func TestInputDragCancelZeroesSelection(t *testing.T) {
+	w, ly := newInputSelWindow(t, InputCfg{ID: "f281", Text: "hello world"})
+	txt := inputTextShape(t, ly)
+
+	x0, y0 := inputRunePoint(txt, 2)
+	x1, y1 := inputRunePoint(txt, 8)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x0, MouseY: y0})
+	w.settle()
+	if !w.mouseIsLocked() {
+		t.Fatal("press on the input did not lock the mouse")
+	}
+	w.EventFn(&Event{Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x1, MouseY: y1})
+	w.settle()
+	is := getInputState(w, "f281")
+	if is.selectBeg != 2 || is.selectEnd != 8 {
+		t.Fatalf("drag selected [%d,%d), want [2,8)",
+			is.selectBeg, is.selectEnd)
+	}
+
+	w.MouseCancel()
+	w.settle()
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after MouseCancel")
+	}
+	is = getInputState(w, "f281")
+	if is.selectBeg != 0 || is.selectEnd != 0 {
+		t.Errorf("selection after cancel = [%d,%d), want [0,0)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// TestInputDragCancelScopedToOwnState asserts the Input Cancel hook
+// zeroes only the dragged input's nsInput entry: another widget's
+// state written after the drag started survives the cancel. (A state
+// written before the press would be wiped by the focus change.)
+func TestInputDragCancelScopedToOwnState(t *testing.T) {
+	w, ly := newInputSelWindow(t, InputCfg{ID: "f281", Text: "hello world"})
+	txt := inputTextShape(t, ly)
+
+	x0, y0 := inputRunePoint(txt, 2)
+	x1, y1 := inputRunePoint(txt, 8)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x0, MouseY: y0})
+	w.settle()
+	w.EventFn(&Event{Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x1, MouseY: y1})
+	w.settle()
+
+	setInputState(w, "other", inputState{CursorPos: 3, selectBeg: 1, selectEnd: 3})
+	w.MouseCancel()
+	w.settle()
+	if is := getInputState(w, "f281"); is.selectBeg != 0 || is.selectEnd != 0 {
+		t.Errorf("dragged input selection = [%d,%d), want [0,0)",
+			is.selectBeg, is.selectEnd)
+	}
+	if is := getInputState(w, "other"); is.selectBeg != 1 || is.selectEnd != 3 {
+		t.Errorf("unrelated widget selection = [%d,%d), want [1,3)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// TestInputReleaseOutsideCommitsSelection pins the asymmetry: a
+// normal MouseUp — even at a point far outside the fixed-size input —
+// COMMITS the drag selection. The lock delivers the release anywhere;
+// only capture loss goes through the Cancel hook.
+func TestInputReleaseOutsideCommitsSelection(t *testing.T) {
+	w, ly := newInputSelWindow(t, InputCfg{
+		ID: "f281", Text: "hello world",
+		Sizing: FixedFixed, Width: 200, Height: 30,
+	})
+	txt := inputTextShape(t, ly)
+
+	x0, y0 := inputRunePoint(txt, 2)
+	x1, y1 := inputRunePoint(txt, 8)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x0, MouseY: y0})
+	w.settle()
+	w.EventFn(&Event{Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x1, MouseY: y1})
+	w.settle()
+	if is := getInputState(w, "f281"); is.selectBeg != 2 || is.selectEnd != 8 {
+		t.Fatalf("drag selected [%d,%d), want [2,8)",
+			is.selectBeg, is.selectEnd)
+	}
+
+	w.EventFn(&Event{Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: 700, MouseY: 700})
+	w.settle()
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after release")
+	}
+	is := getInputState(w, "f281")
+	if is.selectBeg != 2 || is.selectEnd != 8 {
+		t.Errorf("selection after outside release = [%d,%d), want [2,8)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// TestInputDragCancelCollapsedSelectionHarmless asserts the guard:
+// a cancel when no selection is in progress (the press only collapsed
+// to a caret) leaves the state clean — no corruption, no stuck lock.
+func TestInputDragCancelCollapsedSelectionHarmless(t *testing.T) {
+	w, ly := newInputSelWindow(t, InputCfg{ID: "f281", Text: "hello world"})
+	txt := inputTextShape(t, ly)
+
+	x, y := inputRunePoint(txt, 2)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y})
+	w.settle()
+	if !w.mouseIsLocked() {
+		t.Fatal("press on the input did not lock the mouse")
+	}
+	if is := getInputState(w, "f281"); is.selectBeg != 2 || is.selectEnd != 2 {
+		t.Fatalf("press left selection [%d,%d), want caret at 2",
+			is.selectBeg, is.selectEnd)
+	}
+
+	w.MouseCancel()
+	w.settle()
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after MouseCancel")
+	}
+	is := getInputState(w, "f281")
+	if is.selectBeg != 0 || is.selectEnd != 0 {
+		t.Errorf("selection after cancel = [%d,%d), want [0,0)",
+			is.selectBeg, is.selectEnd)
+	}
+	if is.CursorPos != 2 {
+		t.Errorf("cursor = %d, want 2", is.CursorPos)
+	}
+}

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -192,6 +192,15 @@ func rtfSelectOnClick(ctx EventCtx) {
 		},
 		Cancel: func(w *Window) {
 			w.AnimationRemove(animIDTextDragScroll)
+			// Zero the partial selection the drag was mutating
+			// (nsInput keyed by this RTF's own ID, issue #281) —
+			// capture loss must not leave a stuck highlight, while
+			// a normal release still commits.
+			dim := StateMap[string, inputState](w, nsInput, capMany)
+			dis := dim.GetOr(focusID, inputState{})
+			dis.selectBeg = 0
+			dis.selectEnd = 0
+			dim.Set(focusID, dis)
 		},
 	})
 }

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -234,6 +234,15 @@ func textOnClick(ctx EventCtx) {
 			// it once the lock is gone, so it would keep scrolling
 			// and extending the selection on its own.
 			w.AnimationRemove(animIDTextDragScroll)
+			// Zero the partial selection the drag was mutating
+			// (nsInput keyed by the dragged text's own ID, issue
+			// #281) — capture loss must not leave a stuck
+			// highlight, while a normal release still commits.
+			dim := StateMap[string, inputState](w, nsInput, capMany)
+			dis := dim.GetOr(dragFocusID, inputState{})
+			dis.selectBeg = 0
+			dis.selectEnd = 0
+			dim.Set(dragFocusID, dis)
 		},
 	})
 }

--- a/gui/view_text_select_test.go
+++ b/gui/view_text_select_test.go
@@ -145,3 +145,167 @@ func TestTextEscapeClearsSelection(t *testing.T) {
 			is.selectBeg, is.selectEnd)
 	}
 }
+
+// --- Issue #281: capture-loss cancel zeroes the partial drag selection ---
+
+// textSelCharW is the fallback char width the text click/drag paths use
+// with no glyph backend: style.Size * 0.6 = 16 * 0.6 = 9.6.
+const textSelCharW = float32(16 * 0.6)
+
+// newTextSelWindow renders a focusable text widget and returns the
+// window plus its layout.
+func newTextSelWindow(t *testing.T, cfg TextCfg) (*Window, *Layout) {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(win *Window) View { return Text(cfg) })
+	ly, ok := w.layout.FindByID(cfg.ID)
+	if !ok {
+		t.Fatalf("no text with effective ID %s", cfg.ID)
+	}
+	return w, ly
+}
+
+// textRunePoint returns the window-absolute center of localRune — valid
+// for the click path (shape-relative after callRelative) and the
+// MouseLock drag path (window-absolute; the drag subtracts shape.X).
+func textRunePoint(shp *Shape, localRune int) (float32, float32) {
+	return shp.X + float32(localRune)*textSelCharW + textSelCharW/2,
+		shp.Y + 1
+}
+
+// TestTextDragCancelZeroesSelection pins issue #281: capture loss
+// mid-drag (MouseCancel — no release will ever arrive) must zero the
+// partial selection, not leave a stuck highlight.
+func TestTextDragCancelZeroesSelection(t *testing.T) {
+	w, ly := newTextSelWindow(t, TextCfg{
+		Text: "hello world", Focusable: true, ID: "f281",
+	})
+
+	x0, y0 := textRunePoint(ly.Shape, 2)
+	x1, y1 := textRunePoint(ly.Shape, 8)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x0, MouseY: y0})
+	w.settle()
+	if !w.mouseIsLocked() {
+		t.Fatal("press on the text did not lock the mouse")
+	}
+	w.EventFn(&Event{Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x1, MouseY: y1})
+	w.settle()
+	is := getInputState(w, "f281")
+	if is.selectBeg != 2 || is.selectEnd != 8 {
+		t.Fatalf("drag selected [%d,%d), want [2,8)",
+			is.selectBeg, is.selectEnd)
+	}
+
+	w.MouseCancel()
+	w.settle()
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after MouseCancel")
+	}
+	is = getInputState(w, "f281")
+	if is.selectBeg != 0 || is.selectEnd != 0 {
+		t.Errorf("selection after cancel = [%d,%d), want [0,0)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// TestTextDragCancelScopedToOwnState asserts the Text Cancel hook
+// zeroes only the dragged widget's nsInput entry: another widget's
+// state written after the drag started survives the cancel.
+func TestTextDragCancelScopedToOwnState(t *testing.T) {
+	w, ly := newTextSelWindow(t, TextCfg{
+		Text: "hello world", Focusable: true, ID: "f281",
+	})
+
+	x0, y0 := textRunePoint(ly.Shape, 2)
+	x1, y1 := textRunePoint(ly.Shape, 8)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x0, MouseY: y0})
+	w.settle()
+	w.EventFn(&Event{Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x1, MouseY: y1})
+	w.settle()
+
+	setInputState(w, "other", inputState{CursorPos: 3, selectBeg: 1, selectEnd: 3})
+	w.MouseCancel()
+	w.settle()
+	if is := getInputState(w, "f281"); is.selectBeg != 0 || is.selectEnd != 0 {
+		t.Errorf("dragged text selection = [%d,%d), want [0,0)",
+			is.selectBeg, is.selectEnd)
+	}
+	if is := getInputState(w, "other"); is.selectBeg != 1 || is.selectEnd != 3 {
+		t.Errorf("unrelated widget selection = [%d,%d), want [1,3)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// TestTextReleaseOutsideCommitsSelection pins the asymmetry: a normal
+// MouseUp — even at a point far outside the widget — COMMITS the drag
+// selection. The lock delivers the release anywhere; only capture loss
+// goes through the Cancel hook.
+func TestTextReleaseOutsideCommitsSelection(t *testing.T) {
+	w, ly := newTextSelWindow(t, TextCfg{
+		Text: "hello world", Focusable: true, ID: "f281",
+	})
+
+	x0, y0 := textRunePoint(ly.Shape, 2)
+	x1, y1 := textRunePoint(ly.Shape, 8)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x0, MouseY: y0})
+	w.settle()
+	w.EventFn(&Event{Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x1, MouseY: y1})
+	w.settle()
+	if is := getInputState(w, "f281"); is.selectBeg != 2 || is.selectEnd != 8 {
+		t.Fatalf("drag selected [%d,%d), want [2,8)",
+			is.selectBeg, is.selectEnd)
+	}
+
+	w.EventFn(&Event{Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: 700, MouseY: 700})
+	w.settle()
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after release")
+	}
+	is := getInputState(w, "f281")
+	if is.selectBeg != 2 || is.selectEnd != 8 {
+		t.Errorf("selection after outside release = [%d,%d), want [2,8)",
+			is.selectBeg, is.selectEnd)
+	}
+}
+
+// TestTextDragCancelCollapsedSelectionHarmless asserts the guard: a
+// cancel when no selection is in progress (the press only collapsed to
+// a caret) leaves the state clean — no corruption, no stuck lock.
+func TestTextDragCancelCollapsedSelectionHarmless(t *testing.T) {
+	w, ly := newTextSelWindow(t, TextCfg{
+		Text: "hello world", Focusable: true, ID: "f281",
+	})
+
+	x, y := textRunePoint(ly.Shape, 2)
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y})
+	w.settle()
+	if !w.mouseIsLocked() {
+		t.Fatal("press on the text did not lock the mouse")
+	}
+	if is := getInputState(w, "f281"); is.selectBeg != 2 || is.selectEnd != 2 {
+		t.Fatalf("press left selection [%d,%d), want caret at 2",
+			is.selectBeg, is.selectEnd)
+	}
+
+	w.MouseCancel()
+	w.settle()
+	if w.mouseIsLocked() {
+		t.Error("mouse still locked after MouseCancel")
+	}
+	is := getInputState(w, "f281")
+	if is.selectBeg != 0 || is.selectEnd != 0 {
+		t.Errorf("selection after cancel = [%d,%d), want [0,0)",
+			is.selectBeg, is.selectEnd)
+	}
+	if is.CursorPos != 2 {
+		t.Errorf("cursor = %d, want 2", is.CursorPos)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #281. Input, Text and RTF selection drags hold a mouse lock whose `Cancel` hook fires on capture loss — a mouse-up that will never arrive (window-resize steal, alt-tab, the #237 class). The hooks only removed the edge-scroll animation, leaving the partial selection stuck as if committed. The three Cancel hooks now zero the dragged widget's **own** `nsInput` entry (`selectBeg`/`selectEnd`, keyed by its own focus ID) — never other widgets'. A normal release still commits, even outside the widget: the lock delivers the release anywhere; only capture loss goes through the Cancel hook. That asymmetry is the standard desktop model.

**Secondary fix, surfaced by the new tests:** the input drag coordinate frame was off by the box's window X. MouseLock moves arrive window-absolute (`mouseMoveHandler` delivers raw, `MouseLockCfg` doc says so), but `inputDragState.txtOffX` subtracted the text shape's *box-relative* position (`txt.X - box.X`) — the click path uses the text-relative frame (`mx_abs - txt.X`). The RTF/Text drags already subtract absolute `shape.X` with passing drag tests, so input was the odd one out; an input at window X=300 would select ~30 runes past the cursor. Fixed to subtract the absolute text position; the drag and click paths now agree.

## Verification

- 12 new tests: per widget (Input/Text/RTF) — drag-cancel zeroes the selection, cancel scoped to own key (other widget's state survives), release-outside commits (contract pin), cancel with only a caret is harmless (cursor preserved).
- Independent stash-test (throwaway worktree, source reverted, tests kept): exactly 10/12 fail with the right reason (stuck `[2,8)` vs `[0,0)`; input drags fail at the `[2,9)`-vs-`[2,8)` drag step — the predicted off-by-one, confirming the old frame was measurably wrong). Both release-outside tests pass on reverted code — they pin unchanged commit behavior. No other test in the suite failed on reverted code. Re-applied: all green.
- Coordinate-frame analysis independently confirmed by review: raw lock-move delivery (event_handlers.go:236-240), window-absolute contract (window.go:299-300), no other consumers of `txtOffX`/`txtOffY`.
- Markdown's cross-block drag (`nsMdSel`) untouched by decision — separate concern.

## Tests

`gui/view_input_test.go` (+4), `gui/view_text_select_test.go` (+4), `gui/rtf_select_interaction_test.go` (+4).

## Notes

- CHANGELOG `[Unreleased]` → Fixed bullet (issue #281).
- Independent review: READY, no blockers.

## Verification

`go build ./...`, `go test ./gui/ -count=1` (and `-race`), `go vet`, `gofmt`, `golangci-lint` — all green. Full WASM suite green locally.