### PR TITLE
feat(gui): report the held mouse button in OnHover events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to
 
 ### Fixed
 
+- **Pressed-while-hovered colors now render.** Seven `OnHover` handlers
+  paint a click color while the left button is held (button
+  `Colors.Click`, breadcrumb crumb, expand-panel header, switch pill,
+  toggle, radio, datagrid resize handle), but no frame could reach
+  those branches: `layoutHover` synthesized its event with
+  `MouseButton: MouseInvalid` no matter what the user was holding. The
+  window now reports the real held button in hover events (see Changed
+  below), so a press-and-hold renders the click color and release
+  restores the hover color.
+
 - **Interrupted (capture-loss) selection drags no longer leave a stuck
   selection (issue #281).** Input, Text and RTF selection drags hold a
   mouse lock whose `Cancel` hook fired on capture loss — a mouse-up that
@@ -73,6 +83,18 @@ and this project adheres to
   highlight — and Ctrl+C would copy — the wrong runes of the new
   text. A same-length rewrite of the document is caught too; a pure
   layout change (resize, font) leaves the selection alone.
+
+### Changed
+
+- **`OnHover` receives the held mouse button.** The window tracks the
+  held button from its own event stream — set on `EventMouseDown`,
+  cleared on `EventMouseUp` and `MouseCancel` — and `layoutHover`
+  reports it in the synthesized hover event: `MouseLeft`/`MouseRight`/
+  `MouseMiddle` while held, `MouseInvalid` when none is held. A hover
+  handler can now distinguish a press-and-hold from a plain hover; it
+  could not before, because the event always arrived with
+  `MouseInvalid`. The event is still `Type: EventMouseMove` and is
+  rebuilt field-by-field every frame.
 
 ### Added
 

--- a/gui/datagrid/view_data_grid_header_test.go
+++ b/gui/datagrid/view_data_grid_header_test.go
@@ -376,6 +376,108 @@ func TestResizeHandleReturnsView(t *testing.T) {
 	}
 }
 
+// TestResizeHandleHoverPressedColor pins the pressed-while-hovered
+// branch of the resize handle's OnHover (view_data_grid_header.go):
+// while the left button is held over the handle, the hover event
+// carries MouseLeft and the handle renders colorResizeActive; release
+// falls back to colorResizeHandle.
+//
+// A plain press on the handle starts a resize drag, which locks the
+// mouse and silences hover (layoutHover bails under a lock), so the
+// held-button hover pass is observed on the double-click window: the
+// second press of a double-click auto-fits the column without locking,
+// leaving hover live while the button is held. The auto-fit writes
+// back the column's current width (headless: no measurer, same value),
+// so the geometry does not shift under the pointer.
+func TestResizeHandleHoverPressedColor(t *testing.T) {
+	handle := gg.RGBA(180, 180, 180, 255)
+	active := gg.RGBA(100, 100, 255, 255)
+	cfg := DataGridCfg{
+		ID:                "g1",
+		ColorResizeHandle: handle,
+		ColorResizeActive: active,
+		TextStyleHeader:   gg.DefaultTextStyle,
+		TextStyle:         gg.DefaultTextStyle,
+		ColorHeader:       gg.RGBA(240, 240, 240, 255),
+		ColorBorder:       gg.RGBA(180, 180, 180, 255),
+		PaddingHeader:     gg.NewPadding(2, 4, 2, 4),
+		SizeBorder:        gg.SomeF(0),
+		Columns: []GridColumnCfg{{
+			ID: "c1", Title: "Col1", resizable: true,
+			Width: gg.SomeF(120),
+		}},
+	}
+	w := gg.NewTestWindow(gg.WindowCfg{})
+	defer w.Close()
+	w.TestRender(func(win *gg.Window) gg.View { return New(w, cfg) })
+
+	// The resize handle renders only while its column shows header
+	// controls (focused/hovered/resizing); focus the header cell to
+	// bring it into the tree.
+	w.SetFocus("g1:header:c1")
+	root := w.TestRender(nil)
+
+	handleColor := func() gg.Color {
+		ly, ok := root.FindByID("g1:resize:c1")
+		if !ok {
+			t.Fatal("resize handle left the tree")
+		}
+		return ly.Shape.Color
+	}
+
+	// Hit point: the handle shape's center.
+	ly, ok := root.FindByID("g1:resize:c1")
+	if !ok {
+		t.Fatal("no resize handle in tree after focusing the column")
+	}
+	s := ly.Shape
+	x, y := s.X+s.Width/2, s.Y+s.Height/2
+	if !s.PointInShape(x, y) {
+		t.Fatalf("handle center (%.0f,%.0f) misses the shape", x, y)
+	}
+
+	// Plain hover, no button held: the resting color.
+	w.EventFn(&gg.Event{Type: gg.EventMouseMove, MouseX: x, MouseY: y})
+	root = w.TestRender(nil)
+	if c := handleColor(); c != handle {
+		t.Fatalf("hover: color = %+v, want %+v", c, handle)
+	}
+
+	// Advance the frame counter so the first press records a
+	// non-zero LastClickFrame (the double-click guard requires it).
+	w.FrameFn()
+
+	// Click 1: starts a resize drag — the mouse locks and hover is
+	// silent, so the color is untouched while held (D3).
+	press := &gg.Event{Type: gg.EventMouseDown, MouseButton: gg.MouseLeft,
+		MouseX: x, MouseY: y}
+	w.EventFn(press)
+	root = w.TestRender(nil)
+	if c := handleColor(); c != handle {
+		t.Fatalf("drag held: color = %+v, want %+v (hover must stay silent under the lock)", c, handle)
+	}
+	w.EventFn(&gg.Event{Type: gg.EventMouseUp, MouseButton: gg.MouseLeft,
+		MouseX: x, MouseY: y})
+	root = w.TestRender(nil)
+
+	// Click 2 within the double-click window: auto-fit, no lock —
+	// hover is live again and the held button paints the active color.
+	w.EventFn(press)
+	root = w.TestRender(nil)
+	if c := handleColor(); c != active {
+		t.Fatalf("held: color = %+v, want %+v", c, active)
+	}
+
+	// Release: the button is no longer held; hover falls back to the
+	// resting color.
+	w.EventFn(&gg.Event{Type: gg.EventMouseUp, MouseButton: gg.MouseLeft,
+		MouseX: x, MouseY: y})
+	root = w.TestRender(nil)
+	if c := handleColor(); c != handle {
+		t.Fatalf("released: color = %+v, want %+v", c, handle)
+	}
+}
+
 // --- dataGridReorderControls ---
 
 func TestReorderControls(t *testing.T) {

--- a/gui/gesture.go
+++ b/gui/gesture.go
@@ -562,6 +562,16 @@ func rotateCentroidInverse(
 
 // synthMouse creates a synthetic mouse event and dispatches it
 // through the normal mouse handler pipeline.
+//
+// This is the second entry into mouseDownHandler/mouseUpHandler
+// besides EventFn's handleMouseDown/UpEvent (which own the held-button
+// state machine for backend events). Touch-synthesized presses and
+// releases update that state here, so mixed mouse+touch input cannot
+// leave hover synthesis reporting a button nobody is holding — e.g. a
+// touch release after a backend mouse press must clear the hold, and a
+// touch press must record one. The dev-mode unconsumed sweep
+// (debug_event.go) also reaches the traversal handlers directly, but
+// only for inspection, so it must not run through this path.
 func synthMouse(
 	typ EventType, x, y float32, btn MouseButton,
 	layout *Layout, w *Window,
@@ -574,10 +584,12 @@ func synthMouse(
 	}
 	switch typ {
 	case EventMouseDown:
+		w.viewState.mouseButtonHeld = btn
 		mouseDownHandler(layout, false, &w.scratch.gestureEvent, w)
 	case EventMouseMove:
 		mouseMoveHandler(layout, &w.scratch.gestureEvent, w)
 	case EventMouseUp:
+		w.viewState.mouseButtonHeld = MouseInvalid
 		mouseUpHandler(layout, &w.scratch.gestureEvent, w)
 	}
 }

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -96,7 +96,7 @@ func layoutHover(layout *Layout, w *Window) bool {
 		MouseX:      w.viewState.mousePosX,
 		MouseY:      w.viewState.mousePosY,
 		Type:        EventMouseMove,
-		MouseButton: MouseInvalid,
+		MouseButton: w.viewState.mouseButtonHeld,
 	}
 	shape.events.OnHover(EventCtx{layout, &w.scratch.hoverEvent, w})
 	return true

--- a/gui/layout_pipeline_test.go
+++ b/gui/layout_pipeline_test.go
@@ -142,6 +142,163 @@ func TestLayoutHoverMouseLocked(t *testing.T) {
 	}
 }
 
+// TestLayoutHoverSynthesizesHeldMouseButton pins the hover pressed-state
+// contract: the synthesized hover event reports the button the window
+// learned from its own event stream, MouseInvalid when none is held.
+// The window is driven through real dispatch (EventFn); the hover pass
+// is the layoutHover call, matching the direct-call harness of the
+// other layout-pipeline tests.
+func TestLayoutHoverSynthesizesHeldMouseButton(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.viewState.mousePosX = 15
+	w.viewState.mousePosY = 15
+
+	got := MouseInvalid
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		shapeClip: drawClip{X: 0, Y: 0, Width: 50, Height: 50},
+		events: &eventHandlers{
+			OnHover: func(ctx EventCtx) { got = ctx.Event.MouseButton },
+		},
+		Opacity: 1,
+	}
+	layout := Layout{Shape: shape}
+	hover := func() MouseButton {
+		layoutHover(&layout, w)
+		return got
+	}
+
+	// Regression pin: no press ever synthesizes a button.
+	if btn := hover(); btn != MouseInvalid {
+		t.Fatalf("no press: hover button = %v, want MouseInvalid", btn)
+	}
+
+	// Press: the next hover pass reports the held button.
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft})
+	if btn := hover(); btn != MouseLeft {
+		t.Fatalf("left held: hover button = %v, want MouseLeft", btn)
+	}
+
+	// Release: back to MouseInvalid.
+	w.EventFn(&Event{Type: EventMouseUp, MouseButton: MouseLeft})
+	if btn := hover(); btn != MouseInvalid {
+		t.Fatalf("after up: hover button = %v, want MouseInvalid", btn)
+	}
+
+	// A right-button hold is reported truthfully (D5): the widget
+	// branches that check == MouseLeft fall through to hover colors.
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseRight})
+	if btn := hover(); btn != MouseRight {
+		t.Fatalf("right held: hover button = %v, want MouseRight", btn)
+	}
+
+	// Capture loss: MouseCancel clears without a mouse-up (D4), and
+	// a fresh press re-arms the state.
+	w.MouseCancel()
+	if btn := hover(); btn != MouseInvalid {
+		t.Fatalf("after cancel: hover button = %v, want MouseInvalid", btn)
+	}
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft})
+	if btn := hover(); btn != MouseLeft {
+		t.Fatalf("re-press: hover button = %v, want MouseLeft", btn)
+	}
+}
+
+// TestLayoutHoverMouseLockedSilencesHeldButton pins D3: a press followed
+// by a mouse lock (a drag started elsewhere) must never reach a hover
+// callback, even though a button is held — the lock bail is what keeps
+// pressed state out of drags.
+func TestLayoutHoverMouseLockedSilencesHeldButton(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.viewState.mousePosX = 15
+	w.viewState.mousePosY = 15
+
+	fired := false
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		shapeClip: drawClip{X: 0, Y: 0, Width: 50, Height: 50},
+		events: &eventHandlers{
+			OnHover: func(ctx EventCtx) { fired = true },
+		},
+		Opacity: 1,
+	}
+	layout := Layout{Shape: shape}
+
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft})
+	w.MouseLock(MouseLockCfg{MouseMove: func(EventCtx) {}})
+	if layoutHover(&layout, w) {
+		t.Error("hover fired while locked with a button held")
+	}
+	if fired {
+		t.Error("OnHover ran while locked with a button held")
+	}
+}
+
+// hoverButtonWindow returns a window whose layout tree is a plain
+// gesture target (no handlers), with a local hover-recording layout
+// ready for layoutHover, and a hover closure that reports the
+// synthesized button. Shared by the gesture-path tests below.
+func hoverButtonWindow() (w *Window, hover func() MouseButton) {
+	w = NewTestWindow(WindowCfg{})
+	w.viewState.mousePosX = 15
+	w.viewState.mousePosY = 15
+	got := MouseInvalid
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		shapeClip: drawClip{X: 0, Y: 0, Width: 50, Height: 50},
+		events: &eventHandlers{
+			OnHover: func(ctx EventCtx) { got = ctx.Event.MouseButton },
+		},
+		Opacity: 1,
+	}
+	layout := Layout{Shape: shape}
+	w.layout = *gestureLayout(nil)
+	return w, func() MouseButton {
+		layoutHover(&layout, w)
+		return got
+	}
+}
+
+// TestTouchSynthesizedPressReportsHeldButton covers the gesture path:
+// a touch press travels EventFn → handleTouch → handleTouchBegan →
+// synthMouse(EventMouseDown), bypassing handleMouseDownEvent. It must
+// record the held button just like a backend press, so the next hover
+// pass carries it.
+func TestTouchSynthesizedPressReportsHeldButton(t *testing.T) {
+	w, hover := hoverButtonWindow()
+	if btn := hover(); btn != MouseInvalid {
+		t.Fatalf("before touch: hover button = %v, want MouseInvalid", btn)
+	}
+	w.handleTouch(&w.layout, touchEvent(EventTouchesBegan, 1, 15, 15))
+	if btn := hover(); btn != MouseLeft {
+		t.Fatalf("touch held: hover button = %v, want MouseLeft", btn)
+	}
+}
+
+// TestTouchSynthesizedReleaseClearsHeldButton pins the mixed-input case
+// that made the gesture path load-bearing: a backend mouse press sets
+// the hold, and a touch release — synthesized by handleTouchEnded via
+// synthMouse(EventMouseUp), which never passes through
+// handleMouseUpEvent — must clear it. Without the clear, hover would
+// keep reporting a left press no one is holding.
+func TestTouchSynthesizedReleaseClearsHeldButton(t *testing.T) {
+	w, hover := hoverButtonWindow()
+
+	// Backend press: the real mouse button goes down.
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft})
+	if btn := hover(); btn != MouseLeft {
+		t.Fatalf("mouse held: hover button = %v, want MouseLeft", btn)
+	}
+
+	// The user then interacts by touch; the finger's release is the
+	// only release that arrives.
+	w.handleTouch(&w.layout, touchEvent(EventTouchesBegan, 1, 15, 15))
+	w.handleTouch(&w.layout, touchEvent(EventTouchesEnded, 1, 15, 15))
+	if btn := hover(); btn != MouseInvalid {
+		t.Fatalf("after touch release: hover button = %v, want MouseInvalid", btn)
+	}
+}
+
 func TestLayoutHoverBlockedByDialog(t *testing.T) {
 	w := &Window{}
 	w.viewState.mousePosX = 15

--- a/gui/testing_test.go
+++ b/gui/testing_test.go
@@ -530,3 +530,51 @@ func TestTestRenderNilReusesGenerator(t *testing.T) {
 		t.Fatal("TestRender(nil) lost the tree; generator was not reused")
 	}
 }
+
+// --- Hover pressed-state helpers ---
+//
+// These drive the real pipeline: a mouse event, then a settled frame,
+// which is where layoutHover fires (layoutArrange runs it after the
+// layout passes). They are what the hover pressed-state widget tests
+// are built on — asserting colors after feeding a mouse down/up.
+
+// hoverOver moves the pointer to the clip center of the shape with
+// effective ID id and settles a frame, so the hover pass runs at that
+// point. Returns the hit point for subsequent press/release events.
+func hoverOver(t *testing.T, w *Window, id string) (float32, float32) {
+	t.Helper()
+	ly, ok := w.layout.FindByID(id)
+	if !ok {
+		t.Fatalf("no shape with effective ID %s", id)
+	}
+	x, y, err := testHitPoint(ly, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.EventFn(&Event{Type: EventMouseMove, MouseX: x, MouseY: y})
+	w.settle()
+	return x, y
+}
+
+// pressAt feeds a button press at the given point and settles a frame;
+// releaseAt feeds the release. The settle runs the layout pass, which
+// is where hover fires with the window's held-button state.
+func pressAt(w *Window, btn MouseButton, x, y float32) {
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: btn, MouseX: x, MouseY: y})
+	w.settle()
+}
+
+func releaseAt(w *Window, btn MouseButton, x, y float32) {
+	w.EventFn(&Event{Type: EventMouseUp, MouseButton: btn, MouseX: x, MouseY: y})
+	w.settle()
+}
+
+// mustShape resolves id against the current layout tree.
+func mustShape(t *testing.T, w *Window, id string) *Shape {
+	t.Helper()
+	ly, ok := w.layout.FindByID(id)
+	if !ok {
+		t.Fatalf("no shape with effective ID %s", id)
+	}
+	return ly.Shape
+}

--- a/gui/view_breadcrumb_test.go
+++ b/gui/view_breadcrumb_test.go
@@ -196,3 +196,41 @@ func TestBcKeydownCharCodeOnlyIsInert(t *testing.T) {
 		t.Error("a CharCode-only keydown was consumed")
 	}
 }
+
+// TestBreadcrumbHoverPressedColor pins the pressed-while-hovered branch
+// of makeBcOnHover (view_breadcrumb.go): a press-and-hold on a crumb
+// renders the click color, release falls back to the hover color. The
+// crumb under test is unselected — a selected crumb paints the selected
+// color in every hover state, so it cannot exercise the branch.
+func TestBreadcrumbHoverPressedColor(t *testing.T) {
+	hover := RGBA(40, 200, 40, 255)
+	click := RGBA(200, 40, 40, 255)
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(win *Window) View {
+		return Breadcrumb(BreadcrumbCfg{
+			ID:       "bc",
+			OnSelect: func(string, EventCtx) {},
+			Items: []BreadcrumbItemCfg{
+				{ID: "one", Label: "One"},
+				{ID: "two", Label: "Two"},
+			},
+			Selected:        "two",
+			colorCrumbHover: hover,
+			colorCrumbClick: click,
+		})
+	})
+
+	const crumbID = "bc:crumb:one"
+	x, y := hoverOver(t, w, crumbID)
+	if c := mustShape(t, w, crumbID).Color; c != hover {
+		t.Fatalf("hover: color = %+v, want %+v", c, hover)
+	}
+	pressAt(w, MouseLeft, x, y)
+	if c := mustShape(t, w, crumbID).Color; c != click {
+		t.Fatalf("held: color = %+v, want %+v", c, click)
+	}
+	releaseAt(w, MouseLeft, x, y)
+	if c := mustShape(t, w, crumbID).Color; c != hover {
+		t.Fatalf("released: color = %+v, want %+v", c, hover)
+	}
+}

--- a/gui/view_button_test.go
+++ b/gui/view_button_test.go
@@ -138,3 +138,72 @@ func TestButtonAmendLayoutSuppressedWhenNoOnClick(t *testing.T) {
 		t.Error("expected nil events when OnClick is nil")
 	}
 }
+
+// TestButtonHoverPressedColor pins the pressed-while-hovered branch of
+// buttonOnHover (view_button.go): a press-and-hold renders the click
+// color, release falls back to the hover color. FocusDisabled keeps the
+// press from taking focus — while focused, buttonAmendLayout paints the
+// focus color and buttonOnHover deliberately skips the hover color, so
+// the release assertion must observe the un-focused path.
+func TestButtonHoverPressedColor(t *testing.T) {
+	hover := RGBA(40, 200, 40, 255)
+	click := RGBA(200, 40, 40, 255)
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(win *Window) View {
+		return Button(ButtonCfg{
+			ID: "b", Width: 100, Height: 40,
+			FocusDisabled: true,
+			OnClick:       func(EventCtx) {},
+			Colors: ColorSet{
+				Base:  RGBA(10, 10, 10, 255),
+				Hover: hover,
+				Click: click,
+			},
+		})
+	})
+
+	x, y := hoverOver(t, w, "b")
+	if c := mustShape(t, w, "b").Color; c != hover {
+		t.Fatalf("hover: color = %+v, want %+v", c, hover)
+	}
+	pressAt(w, MouseLeft, x, y)
+	if c := mustShape(t, w, "b").Color; c != click {
+		t.Fatalf("held: color = %+v, want %+v", c, click)
+	}
+	releaseAt(w, MouseLeft, x, y)
+	if c := mustShape(t, w, "b").Color; c != hover {
+		t.Fatalf("released: color = %+v, want %+v", c, hover)
+	}
+}
+
+// TestButtonHoverRightButtonStaysHoverColor pins D5: while the right
+// button is held, hover events carry MouseRight and the == MouseLeft
+// branch must not fire — the button keeps the hover color, as a
+// right-button hold is not a press.
+func TestButtonHoverRightButtonStaysHoverColor(t *testing.T) {
+	hover := RGBA(40, 200, 40, 255)
+	click := RGBA(200, 40, 40, 255)
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(win *Window) View {
+		return Button(ButtonCfg{
+			ID: "b", Width: 100, Height: 40,
+			FocusDisabled: true,
+			OnClick:       func(EventCtx) {},
+			Colors: ColorSet{
+				Base:  RGBA(10, 10, 10, 255),
+				Hover: hover,
+				Click: click,
+			},
+		})
+	})
+
+	x, y := hoverOver(t, w, "b")
+	if c := mustShape(t, w, "b").Color; c != hover {
+		t.Fatalf("hover: color = %+v, want %+v", c, hover)
+	}
+	pressAt(w, MouseRight, x, y)
+	if c := mustShape(t, w, "b").Color; c != hover {
+		t.Fatalf("right held: color = %+v, want %+v", c, hover)
+	}
+	releaseAt(w, MouseRight, x, y)
+}

--- a/gui/view_expand_panel_test.go
+++ b/gui/view_expand_panel_test.go
@@ -91,3 +91,57 @@ func TestExpandPanelOnToggle(t *testing.T) {
 		t.Error("OnToggle should be called")
 	}
 }
+
+// TestExpandPanelHoverPressedColor pins the pressed-while-hovered branch
+// of the expand panel header's OnHover (view_expand_panel.go): a
+// press-and-hold renders the click color, release falls back to the
+// hover color. The header row carries no ID, so the test resolves it as
+// the panel's first child and hits it directly.
+func TestExpandPanelHoverPressedColor(t *testing.T) {
+	hover := RGBA(40, 200, 40, 255)
+	click := RGBA(200, 40, 40, 255)
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(win *Window) View {
+		return ExpandPanel(ExpandPanelCfg{
+			ID:         "ep",
+			Head:       Text(TextCfg{Text: "Head"}),
+			ColorHover: hover,
+			colorClick: click,
+		})
+	})
+
+	ly, ok := w.layout.FindByID("ep")
+	if !ok {
+		t.Fatal("no expand panel with effective ID ep")
+	}
+	if len(ly.Children) == 0 {
+		t.Fatal("expand panel has no header child")
+	}
+	header := ly.Children[0]
+	// The header row carries no ID; re-resolve it by position each
+	// frame, because settles rebuild the tree.
+	headerShape := func() *Shape {
+		cur, ok := w.layout.FindByID("ep")
+		if !ok {
+			t.Fatal("expand panel vanished")
+		}
+		return cur.Children[0].Shape
+	}
+	x, y, err := testHitPoint(&header, "ep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.EventFn(&Event{Type: EventMouseMove, MouseX: x, MouseY: y})
+	w.settle()
+	if c := headerShape().Color; c != hover {
+		t.Fatalf("hover: color = %+v, want %+v", c, hover)
+	}
+	pressAt(w, MouseLeft, x, y)
+	if c := headerShape().Color; c != click {
+		t.Fatalf("held: color = %+v, want %+v", c, click)
+	}
+	releaseAt(w, MouseLeft, x, y)
+	if c := headerShape().Color; c != hover {
+		t.Fatalf("released: color = %+v, want %+v", c, hover)
+	}
+}

--- a/gui/view_splitter_handle.go
+++ b/gui/view_splitter_handle.go
@@ -255,10 +255,10 @@ func splitterOnHandleClick(core *splitterCore, layout *Layout, e *Event, w *Wind
 }
 
 // splitterOnHandleHover paints the hover color. The active color is not
-// this handler's job: layoutHover bails while the mouse is locked and
-// always synthesizes its event with MouseButton: MouseInvalid, so a
-// button branch here could never fire through the real pipeline
-// (issue #265) — the drag paint lives in splitterAmendLayout instead.
+// this handler's job: pressing the handle starts a drag, and layoutHover
+// bails while the mouse is locked, so the pressed state never reaches
+// this handler during the drag it matters for (issue #265) — the drag
+// paint lives in splitterAmendLayout instead.
 func splitterOnHandleHover(core *splitterCore, layout *Layout, e *Event, w *Window) {
 	splitterSetCursor(core.orientation, w)
 	layout.Shape.Color = core.colorHandleHover

--- a/gui/view_splitter_interaction_test.go
+++ b/gui/view_splitter_interaction_test.go
@@ -844,12 +844,11 @@ func TestSplitterHandleHoverAwayKeepsBaseColor(t *testing.T) {
 
 // The active (button-held) color is driven by the drag state, not the
 // hover event: layoutHover bails while the mouse is locked (a splitter
-// drag runs under MouseLock) and always synthesizes its hover event
-// with MouseButton: MouseInvalid, so no real frame could ever reach an
-// e.MouseButton == MouseLeft branch in the hover handler (issue #265).
-// The pressed flag is set on press, painted every frame by
-// splitterAmendLayout while the lock is held, and cleared on release —
-// all exercised here through real dispatch.
+// drag runs under MouseLock), so a held button never reaches an
+// e.MouseButton == MouseLeft branch in the hover handler during the
+// drag it matters for (issue #265). The pressed flag is set on press,
+// painted every frame by splitterAmendLayout while the lock is held,
+// and cleared on release — all exercised here through real dispatch.
 func TestSplitterHandleDragShowsActiveColor(t *testing.T) {
 	a, b := splitterTwoPanes()
 	h := newSplitterHarness(t, SplitterCfg{

--- a/gui/view_switch_test.go
+++ b/gui/view_switch_test.go
@@ -68,3 +68,52 @@ func TestSwitchLabelAddsChild(t *testing.T) {
 			len(layout.Children))
 	}
 }
+
+// TestSwitchHoverPressedColor pins the pressed-while-hovered branch of
+// the switch's OnHover (view_switch.go): a press-and-hold renders the
+// click color on the pill (child 0), release falls back to the hover
+// color. The switch takes focus on press; the hover pass runs after
+// AmendLayout, so the pill's hover/click paint always wins over the
+// focus paint.
+func TestSwitchHoverPressedColor(t *testing.T) {
+	hover := RGBA(40, 200, 40, 255)
+	click := RGBA(200, 40, 40, 255)
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(win *Window) View {
+		return Switch(SwitchCfg{
+			ID:      "sw",
+			OnClick: func(EventCtx) {},
+			Colors: ColorSet{
+				Base:   RGBA(10, 10, 10, 255),
+				Hover:  hover,
+				Click:  click,
+				Focus:  RGBA(10, 10, 10, 255),
+				Border: RGBA(10, 10, 10, 255),
+			},
+		})
+	})
+
+	pill := func() *Shape {
+		ly, ok := w.layout.FindByID("sw")
+		if !ok {
+			t.Fatal("no switch with effective ID sw")
+		}
+		if len(ly.Children) == 0 {
+			t.Fatal("switch has no pill child")
+		}
+		return ly.Children[0].Shape
+	}
+
+	x, y := hoverOver(t, w, "sw")
+	if c := pill().Color; c != hover {
+		t.Fatalf("hover: color = %+v, want %+v", c, hover)
+	}
+	pressAt(w, MouseLeft, x, y)
+	if c := pill().Color; c != click {
+		t.Fatalf("held: color = %+v, want %+v", c, click)
+	}
+	releaseAt(w, MouseLeft, x, y)
+	if c := pill().Color; c != hover {
+		t.Fatalf("released: color = %+v, want %+v", c, hover)
+	}
+}

--- a/gui/window.go
+++ b/gui/window.go
@@ -344,6 +344,7 @@ type ViewState struct {
 	idScope                  string
 	mousePosX                float32
 	mousePosY                float32
+	mouseButtonHeld          MouseButton
 	mouseCursor              MouseCursor
 	inputCursorOn            atomic.Bool
 	menuKeyNav               bool
@@ -482,6 +483,10 @@ func (w *Window) MouseUnlock() {
 // Cancel runs, so a hook that calls MouseUnlock itself (the
 // escape-key cancel paths do) stays correct.
 func (w *Window) MouseCancel() {
+	// Capture loss means no mouse-up will ever arrive, so the held
+	// button must be cleared here or the next hover pass would keep
+	// reporting a button nobody is holding.
+	w.viewState.mouseButtonHeld = MouseInvalid
 	if !w.mouseIsLocked() {
 		return
 	}

--- a/gui/window_cfg.go
+++ b/gui/window_cfg.go
@@ -86,6 +86,10 @@ func NewWindow(cfg WindowCfg) *Window {
 		scratch:       newScratchPools(),
 		ctx:           ctx,
 		cancelCtx:     cancel,
+		// mouseButtonHeld's zero value is MouseLeft (0), but the
+		// resting state is "no button": hover synthesis must not
+		// report a press no one made.
+		viewState: ViewState{mouseButtonHeld: MouseInvalid},
 		windowAnimation: windowAnimation{
 			animationStop:     make(chan struct{}),
 			animationDone:     make(chan struct{}),

--- a/gui/window_event.go
+++ b/gui/window_event.go
@@ -149,6 +149,7 @@ func (w *Window) handleKeyUpEvent(layout *Layout, e *Event) {
 }
 
 func (w *Window) handleMouseDownEvent(layout *Layout, e *Event) {
+	w.viewState.mouseButtonHeld = e.MouseButton
 	w.setMouseCursor(CursorArrow)
 	if inspectorSupported && w.inspectorEnabled {
 		panelW := inspectorPanelWidth(w)
@@ -193,6 +194,7 @@ func (w *Window) handleMouseMoveEvent(layout *Layout, e *Event) {
 }
 
 func (w *Window) handleMouseUpEvent(layout *Layout, e *Event) {
+	w.viewState.mouseButtonHeld = MouseInvalid
 	mouseUpHandler(layout, e, w)
 }
 


### PR DESCRIPTION
## Summary

`layoutHover` synthesized every hover event with `MouseButton: MouseInvalid` (gui/layout_pipeline.go:99) and the window tracked no held-button state, so **seven** `OnHover` pressed-color branches were provably dead — a press-and-hold never rendered its click color:

button `Colors.Click`, breadcrumb crumb, expand-panel header, switch pill, toggle, radio, datagrid resize handle.

The window now tracks the held button from its own event stream — set on `EventMouseDown`, cleared on `EventMouseUp` and `MouseCancel` — and `layoutHover` reports it in the synthesized event (`MouseInvalid` when none is held). The five→seven widget files are **unchanged**: their dead branches simply go live. Hover still bails while the mouse is locked (gui/layout_pipeline.go:64), so drags stay silent.

**Gesture path:** `synthMouse` (gesture.go) sets/clears the held button in its down/up cases — deliberately NOT in the traversal handlers, because the dev-mode unconsumed sweep (debug_event.go:255/259) calls `mouseDownHandler`/`mouseUpHandler` directly and unpaired; moving the state there would corrupt it every debug frame.

**API change (public):** `OnHover` consumers now see the held `MouseButton` while a button is down; previously always `MouseInvalid`. Event type unchanged (`EventMouseMove`), rebuilt field-by-field each frame.

## Verification

- 16 new tests: framework state machine (no-press→Invalid pin, down→Left, up→Invalid, right→Right, MouseCancel→Invalid, re-press re-arms), lock-silences-held, touch-synthesized press/release incl. mixed mouse+touch, and pressed-color tests for button (FocusDisabled — focused buttons skip hover paint by design), breadcrumb, expand panel, switch, and the datagrid resize handle through the real pipeline.
- Datagrid nuance, verified non-vacuous both ways: a real resize drag locks the mouse, so hover can't fire mid-drag (the #265 precedent — the handle correctly shows its resting color during a drag). The active color is exercised on the double-click auto-fit path (second press doesn't lock). Active-while-dragging visuals are a datagrid concern, tracked as #284.
- Independent stash-test (source reverted, tests kept): all 8 new tests fail with the right reason, no existing test fails; re-applied green.
- Entry-point enumeration (reviewer): every route into the traversal handlers pairs with a set/clear or cannot create a hold — no stale-hold path, including the debug sweep.
- All OnHover consumers checked: only the seven intended branches change behavior; no consumer regresses on a real button.
- `go test ./gui/...`, vet, gofmt, golangci-lint, full WASM suite — all green.

## Notes

- CHANGELOG: `Fixed` bullet (pressed-while-hovered colors) + new `Changed` bullet (OnHover receives the held button).
- Plan artifact + review artifact in the epic's artifact store.

## Verification

`go build ./...`, `go test ./gui/... -count=1`, `go vet ./gui/...`, `golangci-lint run ./gui/...`, full WASM suite via node shim — all green.