### PR TITLE
fix(datagrid): resize handle renders active color during a resize drag (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to
 
 ### Fixed
 
+- **The datagrid column-resize handle now renders its active color
+  during a resize drag (issue #284).** A drag holds a mouse lock and
+  `layoutHover` bails under a lock, so the handle's pressed color —
+  painted only from `OnHover` — could not fire mid-drag and the handle
+  showed its resting color while resizing. The handle's color now comes
+  from the resize state read at generation time
+  (`dataGridActiveResizeColID`), live for the whole drag and reverting
+  on release or cancel.
+
 - **Pressed-while-hovered colors now render.** Seven `OnHover` handlers
   paint a click color while the left button is held (button
   `Colors.Click`, breadcrumb crumb, expand-panel header, switch pill,

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -14,7 +14,7 @@ func dataGridHeaderRow(cfg *DataGridCfg, columns []GridColumnCfg, columnWidths m
 	for idx, col := range columns {
 		width := dataGridColumnWidthFor(col, columnWidths)
 		showControls := dataGridShowHeaderControls(col.ID, hoveredColID, resizingColID, focusedColID)
-		cells = append(cells, dataGridHeaderCell(cfg, col, idx, len(columns), width, focusID, showControls))
+		cells = append(cells, dataGridHeaderCell(cfg, col, idx, len(columns), width, focusID, showControls, resizingColID))
 	}
 	return gg.Row(gg.ContainerCfg{
 		Height:      dataGridHeaderHeight(cfg),
@@ -28,7 +28,7 @@ func dataGridHeaderRow(cfg *DataGridCfg, columns []GridColumnCfg, columnWidths m
 	})
 }
 
-func dataGridHeaderCell(cfg *DataGridCfg, col GridColumnCfg, colIdx, colCount int, width float32, focusID string, showControls bool) gg.View {
+func dataGridHeaderCell(cfg *DataGridCfg, col GridColumnCfg, colIdx, colCount int, width float32, focusID string, showControls bool, resizingColID string) gg.View {
 	hasReorder := showControls && cfg.onColumnOrderChange != nil && col.Reorderable
 	hasPin := showControls && cfg.onColumnPinChange != nil
 	headerControls := dataGridHeaderControlState(width, cfg.PaddingHeader.Or(gg.PaddingNone), hasReorder, hasPin, showControls && col.resizable)
@@ -74,7 +74,7 @@ func dataGridHeaderCell(cfg *DataGridCfg, col GridColumnCfg, colIdx, colCount in
 		content = append(content, dataGridPinControl(cfg, col))
 	}
 	if headerControls.showResize {
-		content = append(content, dataGridResizeHandle(cfg, col, headerFocusID))
+		content = append(content, dataGridResizeHandle(cfg, col, headerFocusID, resizingColID))
 	}
 
 	onQueryChange := cfg.OnQueryChange
@@ -129,7 +129,7 @@ func dataGridHeaderCell(cfg *DataGridCfg, col GridColumnCfg, colIdx, colCount in
 	})
 }
 
-func dataGridResizeHandle(cfg *DataGridCfg, col GridColumnCfg, focusID string) gg.View {
+func dataGridResizeHandle(cfg *DataGridCfg, col GridColumnCfg, focusID string, resizingColID string) gg.View {
 	gridID := cfg.ID
 	columns := cfg.Columns
 	rows := cfg.Rows
@@ -141,12 +141,23 @@ func dataGridResizeHandle(cfg *DataGridCfg, col GridColumnCfg, focusID string) g
 
 	disabled := cfg.Disabled
 
+	// The handle's resting color follows the resize state, not hover:
+	// an active drag holds a mouse lock, so layoutHover bails
+	// (gui/layout_pipeline.go:64) and the OnHover active-color branch
+	// below cannot fire. dataGridActiveResizeColID is read at
+	// generation time each frame, so this paints the active color for
+	// the whole drag and reverts on release or cancel.
+	handleColor := colorResizeHandle
+	if resizingColID == col.ID {
+		handleColor = colorResizeActive
+	}
+
 	return gg.Row(gg.ContainerCfg{
 		ID:      gg.ScopeID(gridID, "resize", col.ID),
 		Width:   dataGridResizeHandleWidth,
 		Sizing:  gg.FixedFill,
 		Padding: gg.NoPadding,
-		Color:   colorResizeHandle,
+		Color:   handleColor,
 		OnClick: func(ctx gg.EventCtx) {
 			if disabled {
 				// A disabled handle must not eat the click

--- a/gui/datagrid/view_data_grid_header_test.go
+++ b/gui/datagrid/view_data_grid_header_test.go
@@ -370,7 +370,7 @@ func TestResizeHandleReturnsView(t *testing.T) {
 		Columns:           []GridColumnCfg{{ID: "c1"}},
 	}
 	col := GridColumnCfg{ID: "c1"}
-	v := dataGridResizeHandle(cfg, col, "")
+	v := dataGridResizeHandle(cfg, col, "", "")
 	if v == nil {
 		t.Fatal("resize handle should return a view")
 	}
@@ -448,13 +448,15 @@ func TestResizeHandleHoverPressedColor(t *testing.T) {
 	w.FrameFn()
 
 	// Click 1: starts a resize drag — the mouse locks and hover is
-	// silent, so the color is untouched while held (D3).
+	// silent, so OnHover cannot paint; the handle renders its
+	// generation-time color instead, which is the active color while
+	// the resize state is set (issue #284).
 	press := &gg.Event{Type: gg.EventMouseDown, MouseButton: gg.MouseLeft,
 		MouseX: x, MouseY: y}
 	w.EventFn(press)
 	root = w.TestRender(nil)
-	if c := handleColor(); c != handle {
-		t.Fatalf("drag held: color = %+v, want %+v (hover must stay silent under the lock)", c, handle)
+	if c := handleColor(); c != active {
+		t.Fatalf("drag held: color = %+v, want %+v (resize state drives the mid-drag color)", c, active)
 	}
 	w.EventFn(&gg.Event{Type: gg.EventMouseUp, MouseButton: gg.MouseLeft,
 		MouseX: x, MouseY: y})
@@ -475,6 +477,150 @@ func TestResizeHandleHoverPressedColor(t *testing.T) {
 	root = w.TestRender(nil)
 	if c := handleColor(); c != handle {
 		t.Fatalf("released: color = %+v, want %+v", c, handle)
+	}
+}
+
+// TestResizeHandleActiveDuringDrag pins the generation-time color of
+// the resize handle while a resize drag is in flight: the handle's
+// resting color must come from the resize state
+// (dataGridActiveResizeColID), not from hover, because the drag holds
+// a mouse lock and layoutHover bails under a lock
+// (gui/layout_pipeline.go) — the OnHover active-color branch cannot
+// fire mid-drag. Press starts the drag, the handle renders
+// colorResizeActive; release ends the drag and the handle reverts to
+// colorResizeHandle.
+func TestResizeHandleActiveDuringDrag(t *testing.T) {
+	handle := gg.RGBA(180, 180, 180, 255)
+	active := gg.RGBA(100, 100, 255, 255)
+	cfg := DataGridCfg{
+		ID:                "g1",
+		ColorResizeHandle: handle,
+		ColorResizeActive: active,
+		TextStyleHeader:   gg.DefaultTextStyle,
+		TextStyle:         gg.DefaultTextStyle,
+		ColorHeader:       gg.RGBA(240, 240, 240, 255),
+		ColorBorder:       gg.RGBA(180, 180, 180, 255),
+		PaddingHeader:     gg.NewPadding(2, 4, 2, 4),
+		SizeBorder:        gg.SomeF(0),
+		Columns: []GridColumnCfg{{
+			ID: "c1", Title: "Col1", resizable: true,
+			Width: gg.SomeF(120),
+		}},
+	}
+	w := gg.NewTestWindow(gg.WindowCfg{})
+	defer w.Close()
+	w.TestRender(func(win *gg.Window) gg.View { return New(w, cfg) })
+
+	// Bring the header controls (and the handle) into the tree by
+	// focusing the header cell.
+	w.SetFocus("g1:header:c1")
+	root := w.TestRender(nil)
+
+	ly, ok := root.FindByID("g1:resize:c1")
+	if !ok {
+		t.Fatal("no resize handle in tree after focusing the column")
+	}
+	s := ly.Shape
+	x, y := s.X+s.Width/2, s.Y+s.Height/2
+
+	handleColor := func() gg.Color {
+		ly, ok := root.FindByID("g1:resize:c1")
+		if !ok {
+			t.Fatal("resize handle left the tree")
+		}
+		return ly.Shape.Color
+	}
+
+	w.FrameFn()
+
+	// Press: starts the resize drag and locks the mouse. The next
+	// generation paints the active color because the resize state says
+	// this column is being resized.
+	w.EventFn(&gg.Event{Type: gg.EventMouseDown, MouseButton: gg.MouseLeft,
+		MouseX: x, MouseY: y})
+	root = w.TestRender(nil)
+	if c := handleColor(); c != active {
+		t.Fatalf("during drag: color = %+v, want %+v", c, active)
+	}
+
+	// Drag a few px: the lock routes the move into the drag handler,
+	// and the next generation still paints the active color.
+	w.EventFn(&gg.Event{Type: gg.EventMouseMove, MouseX: x + 5, MouseY: y})
+	root = w.TestRender(nil)
+	if c := handleColor(); c != active {
+		t.Fatalf("after drag: color = %+v, want %+v", c, active)
+	}
+
+	// Release: the resize state clears and the handle reverts to the
+	// resting color.
+	w.EventFn(&gg.Event{Type: gg.EventMouseUp, MouseButton: gg.MouseLeft,
+		MouseX: x + 5, MouseY: y})
+	root = w.TestRender(nil)
+	if c := handleColor(); c != handle {
+		t.Fatalf("after release: color = %+v, want %+v", c, handle)
+	}
+}
+
+// TestResizeHandleRestingAfterCancel pins the Cancel hook's state
+// clear: capture loss (window-resize steal, alt-tab, the #281 class)
+// cancels an in-flight resize drag, and the handle must not stay
+// pinned in the active color once the drag is gone.
+func TestResizeHandleRestingAfterCancel(t *testing.T) {
+	handle := gg.RGBA(180, 180, 180, 255)
+	active := gg.RGBA(100, 100, 255, 255)
+	cfg := DataGridCfg{
+		ID:                "g1",
+		ColorResizeHandle: handle,
+		ColorResizeActive: active,
+		TextStyleHeader:   gg.DefaultTextStyle,
+		TextStyle:         gg.DefaultTextStyle,
+		ColorHeader:       gg.RGBA(240, 240, 240, 255),
+		ColorBorder:       gg.RGBA(180, 180, 180, 255),
+		PaddingHeader:     gg.NewPadding(2, 4, 2, 4),
+		SizeBorder:        gg.SomeF(0),
+		Columns: []GridColumnCfg{{
+			ID: "c1", Title: "Col1", resizable: true,
+			Width: gg.SomeF(120),
+		}},
+	}
+	w := gg.NewTestWindow(gg.WindowCfg{})
+	defer w.Close()
+	w.TestRender(func(win *gg.Window) gg.View { return New(w, cfg) })
+
+	w.SetFocus("g1:header:c1")
+	root := w.TestRender(nil)
+
+	ly, ok := root.FindByID("g1:resize:c1")
+	if !ok {
+		t.Fatal("no resize handle in tree after focusing the column")
+	}
+	s := ly.Shape
+	x, y := s.X+s.Width/2, s.Y+s.Height/2
+
+	w.FrameFn()
+
+	// Press: starts the drag — the handle paints the active color.
+	w.EventFn(&gg.Event{Type: gg.EventMouseDown, MouseButton: gg.MouseLeft,
+		MouseX: x, MouseY: y})
+	root = w.TestRender(nil)
+	ly, ok = root.FindByID("g1:resize:c1")
+	if !ok {
+		t.Fatal("resize handle left the tree")
+	}
+	if c := ly.Shape.Color; c != active {
+		t.Fatalf("during drag: color = %+v, want %+v", c, active)
+	}
+
+	// Capture loss: the Cancel hook clears the resize state; the next
+	// generation paints the resting color, not a stale active one.
+	w.MouseCancel()
+	root = w.TestRender(nil)
+	ly, ok = root.FindByID("g1:resize:c1")
+	if !ok {
+		t.Fatal("resize handle left the tree")
+	}
+	if c := ly.Shape.Color; c != handle {
+		t.Fatalf("after cancel: color = %+v, want %+v", c, handle)
 	}
 }
 
@@ -568,7 +714,7 @@ func TestHeaderCellReturnsView(t *testing.T) {
 		ColorHeaderHover: gg.RGBA(220, 220, 220, 255),
 	}
 	col := GridColumnCfg{ID: "c1", Title: "Column 1"}
-	v := dataGridHeaderCell(cfg, col, 0, 2, 100, "", false)
+	v := dataGridHeaderCell(cfg, col, 0, 2, 100, "", false, "")
 	if v == nil {
 		t.Fatal("header cell should return a view")
 	}
@@ -590,7 +736,7 @@ func TestHeaderCellWithControls(t *testing.T) {
 		ID: "c1", Title: "Column 1",
 		Reorderable: true, resizable: true, pin: gridColumnPinNone,
 	}
-	v := dataGridHeaderCell(cfg, col, 0, 2, 300, "", true)
+	v := dataGridHeaderCell(cfg, col, 0, 2, 300, "", true, "")
 	if v == nil {
 		t.Fatal("header cell with controls should return a view")
 	}


### PR DESCRIPTION
## Summary

Closes #284. The column-resize handle's active color only ever rendered from its `OnHover` branch — but a real resize drag locks the mouse, and `layoutHover` bails while locked (gui/layout_pipeline.go:64), so hover cannot fire mid-drag and the handle showed its resting color while resizing.

The handle's birth color now comes from the existing generation-time resize state: `dataGridStartResize` sets `nsDgResize {Active, ColID}` (view_data_grid_header.go:377), `dataGridActiveResizeColID` feeds `resizingColID` into `dataGridHeaderRow` every frame (view_data_grid.go:503,567), and `dataGridResizeHandle` now paints `colorResizeActive` when its column is the resizing one. No AmendLayout hook needed — the datagrid's established read point is generation-time.

- `OnHover` branch untouched — it still covers the pre-lock press window (#285).
- Cancel hook already cleared the resize state (`dataGridEndResize`), so capture loss cannot pin the handle active — now pinned by a test.
- Generation-only threading: `resizingColID` passes `dataGridHeaderRow → dataGridHeaderCell → dataGridResizeHandle`, single comparison point inside the handle.

## Deviation from PR #285's tests (reviewed and validated)

`TestResizeHandleHoverPressedColor`'s mid-drag assertion changed from expecting the **resting** color to the **active** color — the old pin encoded the #284 bug itself (resting mid-drag was the defect). The framework invariant is unaffected and still pinned elsewhere (`TestLayoutHoverMouseLocked`, `TestLayoutHoverMouseLockedSilencesHeldButton`): hover genuinely does not fire under the lock; the rendered color now comes from generation state instead. No other #285 assertions moved. Independent review confirmed the changed assertion fails on reverted code with the right reason — it pins the fix, not a tautology.

## Tests

- `TestResizeHandleActiveDuringDrag` — press → drag +5px → `colorResizeActive`; release → resting.
- `TestResizeHandleRestingAfterCancel` — press → `MouseCancel` → resting (pins the cancel-chain state clear).
- Stash-test on reverted source: exactly the 3 expected failures (both new tests + the changed assertion), nothing else across the full `./gui/...` suite.

## Notes

- CHANGELOG `[Unreleased]` → Fixed bullet (issue #284).
- 3 existing direct call sites updated for the `resizingColID` parameter (mechanical).

## Verification

`go test ./gui/...`, `go vet ./gui/...`, `gofmt`, `golangci-lint` — all green. Full WASM suite (node shim) green for all packages.