### PR TITLE
test(gui): expand coverage across input, locale, theme, and view widgets

### DIFF
--- a/gui/input_mask_test.go
+++ b/gui/input_mask_test.go
@@ -120,3 +120,39 @@ func TestInputMaskCustomTokenTransform(t *testing.T) {
 		t.Fatalf("got %q, want %q", res.Text, "AB-12")
 	}
 }
+
+// --- mask token predicates ---
+
+func TestIsMaskLetter(t *testing.T) {
+	cases := []struct {
+		r    rune
+		want bool
+	}{
+		{'a', true}, {'Z', true}, {'é', true}, {'中', true},
+		{'0', false}, {'9', false}, {'-', false}, {'_', false},
+		{' ', false}, {'.', false},
+	}
+	for _, tc := range cases {
+		if got := isMaskLetter(tc.r); got != tc.want {
+			t.Errorf("isMaskLetter(%q) = %v, want %v",
+				tc.r, got, tc.want)
+		}
+	}
+}
+
+func TestIsMaskAlnum(t *testing.T) {
+	cases := []struct {
+		r    rune
+		want bool
+	}{
+		{'a', true}, {'Z', true}, {'0', true}, {'9', true},
+		{'é', true}, {'中', true}, {'٣', true}, // Arabic-Indic digit: unicode.IsNumber
+		{'-', false}, {'_', false}, {' ', false}, {'.', false},
+	}
+	for _, tc := range cases {
+		if got := isMaskAlnum(tc.r); got != tc.want {
+			t.Errorf("isMaskAlnum(%q) = %v, want %v",
+				tc.r, got, tc.want)
+		}
+	}
+}

--- a/gui/input_state_test.go
+++ b/gui/input_state_test.go
@@ -350,3 +350,65 @@ func TestInputCfgMaskedInsertDelete(t *testing.T) {
 		t.Fatalf("got %q, want %q", res2.Text, "(555) 123-456")
 	}
 }
+
+// --- proposed text (no state mutation) ---
+
+func TestInputProposedText(t *testing.T) {
+	w := newTestWindow()
+	id := "f-prop"
+	setInputState(w, id, inputState{CursorPos: 2})
+
+	if got := inputProposedText("hello", "X", id, w); got != "heXllo" {
+		t.Fatalf("insert at cursor = %q, want heXllo", got)
+	}
+	// Empty insert is a passthrough.
+	if got := inputProposedText("hello", "", id, w); got != "hello" {
+		t.Fatalf("empty insert = %q, want hello", got)
+	}
+	// State must be untouched by a propose.
+	if is := getInputState(w, id); is.CursorPos != 2 {
+		t.Fatalf("state cursor = %d, want 2 (unchanged)", is.CursorPos)
+	}
+}
+
+func TestInputProposedTextReplacesSelection(t *testing.T) {
+	w := newTestWindow()
+	id := "f-prop-sel"
+	setInputState(w, id, inputState{CursorPos: 3, selectBeg: 1, selectEnd: 3})
+
+	if got := inputProposedText("hello", "XX", id, w); got != "hXXlo" {
+		t.Fatalf("insert over selection = %q, want hXXlo", got)
+	}
+}
+
+func TestInputProposedTextClampsHugeInsert(t *testing.T) {
+	w := newTestWindow()
+	id := "f-prop-big"
+	setInputState(w, id, inputState{CursorPos: 0})
+
+	big := make([]rune, inputMaxInsertRunes+1000)
+	for i := range big {
+		big[i] = 'x'
+	}
+	got := inputProposedText("", string(big), id, w)
+	if utf8RuneCount(got) != inputMaxInsertRunes {
+		t.Fatalf("proposed rune count = %d, want %d (clamped)",
+			utf8RuneCount(got), inputMaxInsertRunes)
+	}
+}
+
+func TestInputSetTextAndCursorAtEnd(t *testing.T) {
+	w := newTestWindow()
+	id := "f-setend"
+	setInputState(w, id, inputState{CursorPos: 0})
+
+	inputSetTextAndCursorAtEnd("old", "新しい", id, w)
+	is := getInputState(w, id)
+	if is.CursorPos != utf8RuneCount("新しい") {
+		t.Fatalf("cursor = %d, want %d (end of new text)",
+			is.CursorPos, utf8RuneCount("新しい"))
+	}
+	if is.Undo == nil {
+		t.Fatal("undo stack must be pushed with the old text")
+	}
+}

--- a/gui/list_core_test.go
+++ b/gui/list_core_test.go
@@ -186,6 +186,69 @@ func TestVisibleRangeSingleItem(t *testing.T) {
 	}
 }
 
+// --- ListVisibleRange (exported, tunable overscan) ---
+
+func TestListVisibleRangeDegenerate(t *testing.T) {
+	// Zero items, zero/negative row height, and zero list height all
+	// return the empty range (0, -1).
+	for _, tc := range []struct {
+		name     string
+		count    int
+		rowH, lH float32
+	}{
+		{"zero items", 0, 20, 100},
+		{"zero row height", 10, 0, 100},
+		{"zero list height", 10, 20, 0},
+	} {
+		first, last := ListVisibleRange(tc.count, tc.rowH, tc.lH, 0, 2)
+		if first != 0 || last != -1 {
+			t.Errorf("%s: got %d,%d, want 0,-1", tc.name, first, last)
+		}
+	}
+}
+
+func TestListVisibleRangeNoScroll(t *testing.T) {
+	// visibleRows = 100/20+1 = 6; overscan 4 → firstVisible 0,
+	// lastVisible = min(99, 0+6+4) = 10.
+	first, last := ListVisibleRange(100, 20, 100, 0, 4)
+	if first != 0 || last != 10 {
+		t.Errorf("got %d,%d, want 0,10", first, last)
+	}
+}
+
+func TestListVisibleRangeScrolled(t *testing.T) {
+	// Scroll 60px into 100 items at 20px each, overscan 2.
+	// absScroll=60 → first=3 → firstVisible 1, lastVisible 11.
+	first, last := ListVisibleRange(100, 20, 100, -60, 2)
+	if first != 1 || last != 11 {
+		t.Errorf("got %d,%d, want 1,11", first, last)
+	}
+}
+
+func TestListVisibleRangeClampsAtEnd(t *testing.T) {
+	// Scrolling deep must clamp last to the final item, and first
+	// must not overshoot past it.
+	first, last := ListVisibleRange(20, 20, 100, -5000, 4)
+	if first < 0 || first >= 20 {
+		t.Errorf("first = %d, want in [0, 20)", first)
+	}
+	if last != 19 {
+		t.Errorf("last = %d, want 19", last)
+	}
+}
+
+func TestListVisibleRangeCustomOverscan(t *testing.T) {
+	// Overscan 0 must produce a tighter window than overscan 4.
+	first0, last0 := ListVisibleRange(100, 20, 100, 0, 0)
+	first4, last4 := ListVisibleRange(100, 20, 100, 0, 4)
+	if first0 != 0 || last0 != 6 {
+		t.Errorf("overscan 0: got %d,%d, want 0,6", first0, last0)
+	}
+	if first4 != 0 || last4 != 10 {
+		t.Errorf("overscan 4: got %d,%d, want 0,10", first4, last4)
+	}
+}
+
 // --- listCoreFilter (additional) ---
 
 func TestFilterNoMatches(t *testing.T) {

--- a/gui/locale_bundle_test.go
+++ b/gui/locale_bundle_test.go
@@ -1,6 +1,10 @@
 package gui
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestLocaleParseFull(t *testing.T) {
 	json := `{
@@ -184,5 +188,60 @@ func TestLocaleParseCurrencyDecimals(t *testing.T) {
 	}
 	if l.Currency.Decimals != 0 {
 		t.Fatalf("Decimals = %d, want 0", l.Currency.Decimals)
+	}
+}
+
+// --- LocaleLoad (file-based) ---
+
+func TestLocaleLoadFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fr.json")
+	content := `{
+		"id": "fr-FR",
+		"number": {"decimal_sep": ",", "group_sep": " "},
+		"date": {"short_date": "DD/MM/YYYY", "first_day_of_week": 1},
+		"currency": {"symbol": "€", "code": "EUR", "position": "suffix"},
+		"strings": {"ok": "D'accord", "cancel": "Annuler"}
+	}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	l, err := LocaleLoad(path)
+	if err != nil {
+		t.Fatalf("LocaleLoad() error = %v", err)
+	}
+	if l.ID != "fr-FR" {
+		t.Fatalf("ID = %q, want fr-FR", l.ID)
+	}
+	if l.Number.DecimalSep != ',' {
+		t.Fatalf("DecimalSep = %c, want ','", l.Number.DecimalSep)
+	}
+	if l.Date.ShortDate != "DD/MM/YYYY" {
+		t.Fatalf("ShortDate = %q", l.Date.ShortDate)
+	}
+	if l.Currency.Code != "EUR" || l.Currency.Symbol != "\u20AC" {
+		t.Fatalf("currency = %s/%s, want EUR/€",
+			l.Currency.Code, l.Currency.Symbol)
+	}
+	if l.strOK != "D'accord" || l.StrCancel != "Annuler" {
+		t.Fatalf("strings = %q/%q", l.strOK, l.StrCancel)
+	}
+}
+
+func TestLocaleLoadMissingFile(t *testing.T) {
+	if _, err := LocaleLoad(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Fatal("LocaleLoad(missing) must return an error")
+	}
+}
+
+func TestLocaleLoadInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte(`{"id": "x",`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := LocaleLoad(path); err == nil {
+		t.Fatal("LocaleLoad(invalid JSON) must return an error")
 	}
 }

--- a/gui/locale_registry_test.go
+++ b/gui/locale_registry_test.go
@@ -1,6 +1,8 @@
 package gui
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 )
@@ -111,5 +113,98 @@ func TestLocalePresetFields(t *testing.T) {
 		if l.MonthsFull[0] == "" {
 			t.Errorf("%s: MonthsFull[0] empty", tt.id)
 		}
+	}
+}
+
+// --- LocaleLoadDir ---
+
+const testLocaleDirJSON = `{
+  "id": "test-dir-locale",
+  "number": {"decimal_sep": ",", "group_sep": "."},
+  "date": {"first_day_of_week": 1},
+  "currency": {"symbol": "T", "code": "TST", "position": "suffix"},
+  "strings": {"ok": "Ja", "cancel": "Nein"}
+}`
+
+func writeLocaleJSON(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name),
+		[]byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestLocaleLoadDirRegistersAll(t *testing.T) {
+	dir := t.TempDir()
+	writeLocaleJSON(t, dir, "aa.json",
+		`{"id": "test-aa", "strings": {"ok": "A"}}`)
+	writeLocaleJSON(t, dir, "bb.json",
+		`{"id": "test-bb", "strings": {"ok": "B"}}`)
+
+	if err := LocaleLoadDir(dir); err != nil {
+		t.Fatalf("LocaleLoadDir() error = %v", err)
+	}
+	if _, ok := LocaleGet("test-aa"); !ok {
+		t.Error("test-aa not registered after LocaleLoadDir")
+	}
+	if _, ok := LocaleGet("test-bb"); !ok {
+		t.Error("test-bb not registered after LocaleLoadDir")
+	}
+}
+
+func TestLocaleLoadDirBadJSON(t *testing.T) {
+	dir := t.TempDir()
+	// Glob order is sorted, so name the good file first: it must be
+	// registered before the bad file aborts the directory load.
+	writeLocaleJSON(t, dir, "a-good.json",
+		`{"id": "test-good", "strings": {"ok": "G"}}`)
+	writeLocaleJSON(t, dir, "z-bad.json", `{"id": "test-bad",`)
+
+	err := LocaleLoadDir(dir)
+	if err == nil {
+		t.Fatal("LocaleLoadDir with a bad bundle must return an error")
+	}
+	// The good file must still have been registered.
+	if _, ok := LocaleGet("test-good"); !ok {
+		t.Error("a-good.json should be registered before the failure")
+	}
+	// The bad file's locale must not be registered.
+	if _, ok := LocaleGet("test-bad"); ok {
+		t.Error("z-bad.json must not be registered")
+	}
+}
+
+func TestLocaleLoadDirEmptyDir(t *testing.T) {
+	if err := LocaleLoadDir(t.TempDir()); err != nil {
+		t.Fatalf("LocaleLoadDir(empty) error = %v", err)
+	}
+}
+
+func TestLocaleLoadDirLoadsFields(t *testing.T) {
+	dir := t.TempDir()
+	writeLocaleJSON(t, dir, "tl.json", testLocaleDirJSON)
+
+	if err := LocaleLoadDir(dir); err != nil {
+		t.Fatalf("LocaleLoadDir() error = %v", err)
+	}
+	l, ok := LocaleGet("test-dir-locale")
+	if !ok {
+		t.Fatal("test-dir-locale not registered")
+	}
+	if l.ID != "test-dir-locale" {
+		t.Fatalf("ID = %q", l.ID)
+	}
+	if l.Number.DecimalSep != ',' || l.Number.GroupSep != '.' {
+		t.Fatalf("number = %c/%c, want ,/.", l.Number.DecimalSep, l.Number.GroupSep)
+	}
+	if l.Date.FirstDayOfWeek != 1 {
+		t.Fatalf("FirstDayOfWeek = %d, want 1", l.Date.FirstDayOfWeek)
+	}
+	if l.Currency.Code != "TST" || l.Currency.Symbol != "T" {
+		t.Fatalf("currency = %s/%s, want TST/T",
+			l.Currency.Code, l.Currency.Symbol)
+	}
+	if l.strOK != "Ja" || l.StrCancel != "Nein" {
+		t.Fatalf("strings = %q/%q, want Ja/Nein", l.strOK, l.StrCancel)
 	}
 }

--- a/gui/locale_test.go
+++ b/gui/locale_test.go
@@ -94,3 +94,55 @@ func TestLocalePresets(t *testing.T) {
 			localeDeDE.Date.FirstDayOfWeek)
 	}
 }
+
+// --- public locale-switching API ---
+
+func TestWindowSetLocale(t *testing.T) {
+	old := ActiveLocale
+	defer func() { ActiveLocale = old }()
+
+	w := &Window{}
+	w.SetLocale(localeDeDE)
+	if ActiveLocale.ID != "de-DE" {
+		t.Fatalf("ActiveLocale.ID = %q, want de-DE", ActiveLocale.ID)
+	}
+	// The locale swap must have requested a window refresh.
+	if !w.refreshLayout {
+		t.Fatal("SetLocale should mark the window for a layout refresh")
+	}
+}
+
+func TestWindowSetLocaleIDKnown(t *testing.T) {
+	old := ActiveLocale
+	defer func() { ActiveLocale = old }()
+
+	// Use the built-in registry entry; do not mutate the registry.
+	w := &Window{}
+	if err := w.SetLocaleID("de-DE"); err != nil {
+		t.Fatalf("SetLocaleID(de-DE) error = %v", err)
+	}
+	if ActiveLocale.ID != "de-DE" {
+		t.Fatalf("ActiveLocale.ID = %q, want de-DE", ActiveLocale.ID)
+	}
+	if !w.refreshLayout {
+		t.Fatal("SetLocaleID should mark the window for a layout refresh")
+	}
+}
+
+func TestWindowSetLocaleIDUnknown(t *testing.T) {
+	old := ActiveLocale
+	defer func() { ActiveLocale = old }()
+
+	w := &Window{}
+	err := w.SetLocaleID("xx-XX")
+	if err == nil {
+		t.Fatal("SetLocaleID(unknown) must return an error")
+	}
+	if ActiveLocale.ID != old.ID {
+		t.Fatalf("ActiveLocale changed to %q on a failed lookup",
+			ActiveLocale.ID)
+	}
+	if w.refreshLayout {
+		t.Fatal("failed lookup must not request a window refresh")
+	}
+}

--- a/gui/theme_test.go
+++ b/gui/theme_test.go
@@ -244,3 +244,48 @@ func TestThemeMakerTreeStyle(t *testing.T) {
 			theme.treeStyle.indent)
 	}
 }
+
+func TestThemeWithPadding(t *testing.T) {
+	t.Parallel()
+	cfg := baseDarkCfg()
+	cfg.Padding = PadAll(4)
+	cfg.PaddingSmall = PadAll(3)
+	cfg.PaddingMedium = PadAll(6)
+	cfg.PaddingLarge = PadAll(8)
+	cfg.SizeBorder = 2
+	cfg.Radius = 5
+	cfg.RadiusSmall = 3
+	cfg.RadiusMedium = 6
+	cfg.RadiusLarge = 10
+	theme := ThemeMaker(cfg)
+
+	// Off: every padding/radius/border is zeroed.
+	flat := theme.WithPadding(false)
+	if flat.Cfg.Padding != PaddingNone ||
+		flat.Cfg.PaddingSmall != PaddingNone ||
+		flat.Cfg.PaddingMedium != PaddingNone ||
+		flat.Cfg.PaddingLarge != PaddingNone {
+		t.Error("WithPadding(false) must zero all paddings")
+	}
+	if flat.Cfg.SizeBorder != 0 {
+		t.Errorf("SizeBorder = %v, want 0", flat.Cfg.SizeBorder)
+	}
+	if flat.Cfg.Radius != radiusNone ||
+		flat.Cfg.RadiusSmall != radiusNone ||
+		flat.Cfg.RadiusMedium != radiusNone ||
+		flat.Cfg.RadiusLarge != radiusNone {
+		t.Error("WithPadding(false) must zero all radii")
+	}
+	// Non-padding fields survive.
+	if flat.Name != theme.Name {
+		t.Error("WithPadding(false) must not touch the theme name")
+	}
+
+	// On: rebuild from the stored config, restoring the values.
+	restored := theme.WithPadding(true)
+	if restored.Cfg.Padding != cfg.Padding ||
+		restored.Cfg.SizeBorder != cfg.SizeBorder ||
+		restored.Cfg.Radius != cfg.Radius {
+		t.Error("WithPadding(true) must restore the stored config")
+	}
+}

--- a/gui/theme_with_test.go
+++ b/gui/theme_with_test.go
@@ -61,3 +61,16 @@ func TestWithTextStyleUsesTextStyleDefField(t *testing.T) {
 		t.Error("WithTextStyle should set TextStyleDef field")
 	}
 }
+
+func TestWithInspectorStyle(t *testing.T) {
+	var base Theme
+	s := InspectorStyle{ColorPanel: RGB(10, 20, 30)}
+	got := base.WithInspectorStyle(s)
+	if got.inspectorStyle.ColorPanel != s.ColorPanel {
+		t.Error("WithInspectorStyle should set the inspector style")
+	}
+	// Value semantics: the receiver stays untouched.
+	if base.inspectorStyle.ColorPanel != (Color{}) {
+		t.Error("WithInspectorStyle must not mutate the receiver")
+	}
+}

--- a/gui/view_breadcrumb_test.go
+++ b/gui/view_breadcrumb_test.go
@@ -41,6 +41,22 @@ func TestBreadcrumbWithContent(t *testing.T) {
 	}
 }
 
+func TestNewBreadcrumbItem(t *testing.T) {
+	content := []View{Text(TextCfg{Text: "x"})}
+	item := NewBreadcrumbItem("id-1", "Label", content)
+	if item.ID != "id-1" || item.Label != "Label" {
+		t.Fatalf("item = %+v, want ID id-1 Label Label", item)
+	}
+	if len(item.Content) != 1 {
+		t.Fatalf("Content = %d views, want 1", len(item.Content))
+	}
+	// Empty content is a valid call (text-only crumb).
+	empty := NewBreadcrumbItem("id-2", "L", nil)
+	if empty.ID != "id-2" || empty.Content != nil {
+		t.Fatalf("empty-content item = %+v", empty)
+	}
+}
+
 func TestBcSelectedIndex(t *testing.T) {
 	items := []BreadcrumbItemCfg{
 		{ID: "a", Label: "A"},
@@ -232,5 +248,123 @@ func TestBreadcrumbHoverPressedColor(t *testing.T) {
 	releaseAt(w, MouseLeft, x, y)
 	if c := mustShape(t, w, crumbID).Color; c != hover {
 		t.Fatalf("released: color = %+v, want %+v", c, hover)
+	}
+}
+
+// --- bcOnKeydown guard paths ---
+
+func TestBcKeydownDisabled(t *testing.T) {
+	items := []BreadcrumbItemCfg{{ID: "a", Label: "A"}}
+	fired := false
+	onSelect := func(_ string, _ EventCtx) { fired = true }
+	w := &Window{}
+	e := &Event{KeyCode: KeyRight}
+	bcOnKeydown(true, items, "a", onSelect, "", e, w)
+	if fired {
+		t.Error("disabled breadcrumb must not fire OnSelect")
+	}
+	if e.IsHandled {
+		t.Error("disabled breadcrumb must not consume the event")
+	}
+}
+
+func TestBcKeydownEmptyItems(t *testing.T) {
+	fired := false
+	w := &Window{}
+	e := &Event{KeyCode: KeyRight}
+	bcOnKeydown(false, nil, "", func(_ string, _ EventCtx) { fired = true }, "", e, w)
+	if fired || e.IsHandled {
+		t.Error("empty breadcrumb must be inert")
+	}
+}
+
+func TestBcKeydownModifierGuard(t *testing.T) {
+	items := []BreadcrumbItemCfg{{ID: "a", Label: "A"}, {ID: "b", Label: "B"}}
+	fired := false
+	w := &Window{}
+	e := &Event{KeyCode: KeyRight, Modifiers: ModCtrl}
+	bcOnKeydown(false, items, "a", func(_ string, _ EventCtx) { fired = true }, "", e, w)
+	if fired {
+		t.Error("modified key must not navigate the breadcrumb")
+	}
+	if e.IsHandled {
+		t.Error("modified key must not be consumed")
+	}
+}
+
+func TestBcKeydownHomeEnd(t *testing.T) {
+	items := []BreadcrumbItemCfg{
+		{ID: "a", Label: "A", Disabled: true},
+		{ID: "b", Label: "B"},
+		{ID: "c", Label: "C"},
+	}
+	var selected string
+	onSelect := func(id string, _ EventCtx) { selected = id }
+	w := &Window{}
+
+	// Home jumps to the first enabled crumb (skips disabled "a" → "b").
+	bcOnKeydown(false, items, "c", onSelect, "", &Event{KeyCode: KeyHome}, w)
+	if selected != "b" {
+		t.Errorf("Home selected %q, want b", selected)
+	}
+	// End jumps to the last enabled crumb.
+	bcOnKeydown(false, items, "b", onSelect, "", &Event{KeyCode: KeyEnd}, w)
+	if selected != "c" {
+		t.Errorf("End selected %q, want c", selected)
+	}
+}
+
+func TestBcKeydownLeftNoSelection(t *testing.T) {
+	// With no selection, the breadcrumb anchors on the last enabled
+	// item, so Left moves to the previous one from there.
+	items := []BreadcrumbItemCfg{{ID: "a", Label: "A"}, {ID: "b", Label: "B"}}
+	var selected string
+	onSelect := func(id string, _ EventCtx) { selected = id }
+	w := &Window{}
+	bcOnKeydown(false, items, "", onSelect, "", &Event{KeyCode: KeyLeft}, w)
+	if selected != "a" {
+		t.Errorf("Left without selection = %q, want a (prev of last enabled)", selected)
+	}
+}
+
+func TestBcKeydownEnterRefires(t *testing.T) {
+	// Enter on the already-selected crumb re-fires (activation).
+	items := []BreadcrumbItemCfg{{ID: "a", Label: "A"}, {ID: "b", Label: "B"}}
+	fires := 0
+	onSelect := func(_ string, _ EventCtx) { fires++ }
+	w := &Window{}
+	e := &Event{KeyCode: KeyEnter}
+	bcOnKeydown(false, items, "b", onSelect, "", e, w)
+	if fires != 1 {
+		t.Errorf("Enter fires = %d, want 1", fires)
+	}
+	if !e.IsHandled {
+		t.Error("Enter should be handled")
+	}
+}
+
+func TestBcKeydownSetsFocus(t *testing.T) {
+	items := []BreadcrumbItemCfg{{ID: "a", Label: "A"}}
+	w := &Window{}
+	e := &Event{KeyCode: KeyRight}
+	bcOnKeydown(false, items, "", nil, "bc-focus", e, w)
+	if w.FocusID() != "bc-focus" {
+		t.Errorf("focus = %q, want bc-focus", w.FocusID())
+	}
+	if !e.IsHandled {
+		t.Error("navigating key should be handled")
+	}
+}
+
+func TestBcKeydownEmptyTargetID(t *testing.T) {
+	// An item with an empty ID cannot be selected: no OnSelect, but
+	// the event is still consumed (the key was a navigation key).
+	items := []BreadcrumbItemCfg{{ID: "", Label: "No ID"}}
+	fired := false
+	w := &Window{}
+	e := &Event{KeyCode: KeyRight}
+	bcOnKeydown(false, items, "", func(_ string, _ EventCtx) { fired = true }, "", e, w)
+	if fired {
+		t.Error("empty target ID must not fire OnSelect")
 	}
 }

--- a/gui/view_date_picker_roller_test.go
+++ b/gui/view_date_picker_roller_test.go
@@ -134,6 +134,93 @@ func TestRollerAdjustDayNilOnChange(_ *testing.T) {
 	rollerAdjustDay(1, sel, 1900, 2100, nil, &Window{})
 }
 
+// rollerDrumAdjust is the dispatcher every roller interaction goes
+// through — clicks, scrolls, and the embedded date-picker roller.
+func TestRollerDrumAdjustDay(t *testing.T) {
+	sel := time.Date(2025, 3, 15, 0, 0, 0, 0, time.Local)
+	var got time.Time
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
+	w := &Window{}
+
+	rollerDrumAdjust("day", 1, sel, 1900, 2100, onChange, w, false)
+	if got.Day() != 16 {
+		t.Errorf("day drum +1 = %d, want 16", got.Day())
+	}
+	// Month boundary: March 31 + 1 day → April 1.
+	sel = time.Date(2025, 3, 31, 0, 0, 0, 0, time.Local)
+	rollerDrumAdjust("day", 1, sel, 1900, 2100, onChange, w, false)
+	if got.Month() != 4 || got.Day() != 1 {
+		t.Errorf("day drum month rollover = %v, want Apr 1", got)
+	}
+}
+
+func TestRollerDrumAdjustMonth(t *testing.T) {
+	sel := time.Date(2025, 1, 15, 0, 0, 0, 0, time.Local)
+	var got time.Time
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
+	w := &Window{}
+
+	rollerDrumAdjust("month", 1, sel, 1900, 2100, onChange, w, false)
+	if got.Month() != 2 {
+		t.Errorf("month drum +1 = %v, want February", got)
+	}
+	// December + 1 wraps to January next year.
+	sel = time.Date(2025, 12, 10, 0, 0, 0, 0, time.Local)
+	rollerDrumAdjust("month", 1, sel, 1900, 2100, onChange, w, false)
+	if got.Month() != 1 || got.Year() != 2026 {
+		t.Errorf("month drum year wrap = %v, want Jan 2026", got)
+	}
+	// Month-end clamping: Jan 31 + 1 month → Feb 28.
+	sel = time.Date(2025, 1, 31, 0, 0, 0, 0, time.Local)
+	rollerDrumAdjust("month", 1, sel, 1900, 2100, onChange, w, false)
+	if got.Month() != 2 || got.Day() != 28 {
+		t.Errorf("month drum clamp = %v, want Feb 28", got)
+	}
+}
+
+func TestRollerDrumAdjustYear(t *testing.T) {
+	sel := time.Date(2025, 3, 15, 0, 0, 0, 0, time.Local)
+	var got time.Time
+	onChange := func(d time.Time, ctx EventCtx) { got = d }
+	w := &Window{}
+
+	rollerDrumAdjust("year", 1, sel, 1900, 2100, onChange, w, false)
+	if got.Year() != 2026 {
+		t.Errorf("year drum +1 = %d, want 2026", got.Year())
+	}
+	// Out of bounds without wrap → no change.
+	rollerDrumAdjust("year", 1, time.Date(2100, 3, 15, 0, 0, 0, 0, time.Local),
+		1900, 2100, onChange, w, false)
+	if got.Year() != 2026 {
+		t.Errorf("year drum past max changed to %d, want unchanged", got.Year())
+	}
+	// Wrapping year: max + 1 wraps to min.
+	rollerDrumAdjust("year", 1, time.Date(2100, 3, 15, 0, 0, 0, 0, time.Local),
+		1900, 2100, onChange, w, true)
+	if got.Year() != 1900 {
+		t.Errorf("year drum wrap = %d, want 1900", got.Year())
+	}
+}
+
+func TestRollerDrumAdjustUnknownDrumNoop(t *testing.T) {
+	sel := time.Date(2025, 3, 15, 0, 0, 0, 0, time.Local)
+	fired := false
+	onChange := func(time.Time, EventCtx) { fired = true }
+	rollerDrumAdjust("unknown", 1, sel, 1900, 2100, onChange, &Window{}, false)
+	if fired {
+		t.Error("unknown drum name must not fire onChange")
+	}
+}
+
+func TestRollerDrumAdjustNilOnChange(_ *testing.T) {
+	sel := time.Date(2025, 3, 15, 0, 0, 0, 0, time.Local)
+	// All drum names, nil callback: must not panic.
+	rollerDrumAdjust("day", 1, sel, 1900, 2100, nil, &Window{}, false)
+	rollerDrumAdjust("month", 1, sel, 1900, 2100, nil, &Window{}, false)
+	rollerDrumAdjust("year", 1, sel, 1900, 2100, nil, &Window{}, true)
+	rollerDrumAdjust("year", 1, sel, 1900, 2100, nil, &Window{}, false)
+}
+
 func TestRollerAdjustMonth(t *testing.T) {
 	sel := time.Date(2025, 1, 15, 0, 0, 0, 0, time.Local)
 	var got time.Time

--- a/gui/view_date_picker_test.go
+++ b/gui/view_date_picker_test.go
@@ -399,3 +399,157 @@ func TestDatePickerKeyboardNav(t *testing.T) {
 		t.Errorf("focus after Home = %d", s.FocusDay)
 	}
 }
+
+// --- DatePickerReset and the embedded month/year roller ---
+
+func TestDatePickerReset(t *testing.T) {
+	w := &Window{}
+	cfg := DatePickerCfg{
+		ID:    "dp-reset",
+		Dates: []time.Time{time.Date(2025, 3, 15, 0, 0, 0, 0, time.Local)},
+	}
+	// GenerateLayout seeds the per-instance state.
+	generateViewLayout(DatePicker(cfg), w)
+	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
+	if _, ok := sm.Get("dp-reset"); !ok {
+		t.Fatal("state should be seeded by layout generation")
+	}
+
+	w.DatePickerReset("dp-reset")
+	if _, ok := sm.Get("dp-reset"); ok {
+		t.Fatal("DatePickerReset must delete the instance state")
+	}
+
+	// A fresh layout regenerates state from the configured dates,
+	// not from the old view month.
+	layout := generateViewLayout(DatePicker(cfg), w)
+	s, ok := sm.Get("dp-reset")
+	if !ok {
+		t.Fatal("state should be re-seeded after reset")
+	}
+	if s.ViewMonth != 3 || s.ViewYear != 2025 {
+		t.Fatalf("re-seeded view = %d/%d, want 3/2025",
+			s.ViewMonth, s.ViewYear)
+	}
+	if layout.Shape.ID != "dp-reset" {
+		t.Fatalf("layout ID = %q", layout.Shape.ID)
+	}
+}
+
+func TestDatePickerResetUnknownIDNoop(t *testing.T) {
+	w := &Window{}
+	// Must not panic, and must not disturb other instances.
+	w.Toast(ToastCfg{Title: "unrelated"}) // any prior state is untouched
+	w.DatePickerReset("never-existed")
+}
+
+func TestDatePickerYearMonthPickerView(t *testing.T) {
+	// The year/month picker embeds a month-year roller fed by the
+	// picker's view state.
+	cfg := DatePickerCfg{ID: "dp-ym"}
+	applyDatePickerDefaults(&cfg)
+	state := datePickerState{ViewMonth: 6, ViewYear: 2025}
+
+	v := datePickerYearMonthPicker(&cfg, state)
+	layout := generateViewLayout(v, &Window{})
+	if layout.Shape.ID != "dp-ym:roller" {
+		t.Fatalf("roller ID = %q, want dp-ym:roller", layout.Shape.ID)
+	}
+	if layout.Shape.A11YRole != AccessRoleDateField {
+		t.Fatalf("roller role = %d, want DateField", layout.Shape.A11YRole)
+	}
+	// MonthYear mode → two drums (month, year).
+	if got := len(layout.Children); got != 2 {
+		t.Fatalf("drums = %d, want 2", got)
+	}
+}
+
+func TestDatePickerRollerKeyDownEscape(t *testing.T) {
+	w := &Window{}
+	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
+	s := datePickerState{ViewMonth: 6, ViewYear: 2025, ShowYearMonthPicker: true}
+	sm.Set("dp-roller", s)
+
+	e := &Event{KeyCode: KeyEscape, Modifiers: ModNone}
+	datePickerRollerKeyDown(sm, "dp-roller", s, e, w)
+	if !e.IsHandled {
+		t.Fatal("Escape should be handled")
+	}
+	got, _ := sm.Get("dp-roller")
+	if got.ShowYearMonthPicker {
+		t.Fatal("Escape should close the year/month picker")
+	}
+	if got.ViewMonth != 6 || got.ViewYear != 2025 {
+		t.Fatalf("Escape must not move the view: %d/%d",
+			got.ViewMonth, got.ViewYear)
+	}
+}
+
+func TestDatePickerRollerKeyDownMonthNav(t *testing.T) {
+	w := &Window{}
+	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
+	s := datePickerState{ViewMonth: 1, ViewYear: 2025}
+
+	// Up: January wraps to December of the previous year.
+	e := &Event{KeyCode: KeyUp, Modifiers: ModNone}
+	datePickerRollerKeyDown(sm, "dp-roller", s, e, w)
+	got, _ := sm.Get("dp-roller")
+	if got.ViewMonth != 12 || got.ViewYear != 2024 {
+		t.Fatalf("Up from Jan = %d/%d, want 12/2024",
+			got.ViewMonth, got.ViewYear)
+	}
+	if !e.IsHandled {
+		t.Fatal("Up should be handled")
+	}
+
+	// Down: December wraps to January of the next year.
+	s = datePickerState{ViewMonth: 12, ViewYear: 2025}
+	e = &Event{KeyCode: KeyDown, Modifiers: ModNone}
+	datePickerRollerKeyDown(sm, "dp-roller", s, e, w)
+	got, _ = sm.Get("dp-roller")
+	if got.ViewMonth != 1 || got.ViewYear != 2026 {
+		t.Fatalf("Down from Dec = %d/%d, want 1/2026",
+			got.ViewMonth, got.ViewYear)
+	}
+}
+
+func TestDatePickerRollerKeyDownYearNav(t *testing.T) {
+	w := &Window{}
+	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
+	s := datePickerState{ViewMonth: 6, ViewYear: 2025}
+
+	// Shift+Up: year-1.
+	e := &Event{KeyCode: KeyUp, Modifiers: ModShift}
+	datePickerRollerKeyDown(sm, "dp-roller", s, e, w)
+	got, _ := sm.Get("dp-roller")
+	if got.ViewYear != 2024 || got.ViewMonth != 6 {
+		t.Fatalf("Shift+Up = %d/%d, want 2024/6",
+			got.ViewYear, got.ViewMonth)
+	}
+
+	// Shift+Down: year+1.
+	e = &Event{KeyCode: KeyDown, Modifiers: ModShift}
+	datePickerRollerKeyDown(sm, "dp-roller", s, e, w)
+	got, _ = sm.Get("dp-roller")
+	if got.ViewYear != 2026 {
+		t.Fatalf("Shift+Down = %d, want 2026", got.ViewYear)
+	}
+}
+
+func TestDatePickerRollerKeyDownIgnoresOtherKeys(t *testing.T) {
+	w := &Window{}
+	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
+	s := datePickerState{ViewMonth: 6, ViewYear: 2025}
+	sm.Set("dp-roller", s)
+
+	e := &Event{KeyCode: KeyA, Modifiers: ModNone}
+	datePickerRollerKeyDown(sm, "dp-roller", s, e, w)
+	if e.IsHandled {
+		t.Fatal("unrecognized key must not be handled")
+	}
+	got, _ := sm.Get("dp-roller")
+	if got.ViewMonth != 6 || got.ViewYear != 2025 {
+		t.Fatalf("unrecognized key mutated state: %d/%d",
+			got.ViewMonth, got.ViewYear)
+	}
+}

--- a/gui/view_image_test.go
+++ b/gui/view_image_test.go
@@ -171,3 +171,32 @@ func TestImageA11Y(t *testing.T) {
 			layout.Shape.a11Y.Label)
 	}
 }
+
+func TestDownloadingPlaceholder(t *testing.T) {
+	// Neutral rectangle shown while a remote image download is in
+	// flight: default 100x100, theme background, carries the ID.
+	layout := downloadingPlaceholder(&ImageCfg{ID: "img-remote"})
+	if layout.Shape.shapeType != shapeRectangle {
+		t.Fatalf("placeholder shapeType = %d, want rectangle",
+			layout.Shape.shapeType)
+	}
+	if layout.Shape.ID != "img-remote" {
+		t.Fatalf("placeholder ID = %q, want img-remote", layout.Shape.ID)
+	}
+	if layout.Shape.Width != 100 || layout.Shape.Height != 100 {
+		t.Fatalf("placeholder size = %fx%f, want 100x100",
+			layout.Shape.Width, layout.Shape.Height)
+	}
+
+	// Explicit dimensions and opacity are honored.
+	cfg := ImageCfg{ID: "img2", Width: 200, Height: 50, Opacity: SomeF(0.5)}
+	layout2 := downloadingPlaceholder(&cfg)
+	if layout2.Shape.Width != 200 || layout2.Shape.Height != 50 {
+		t.Fatalf("placeholder size = %fx%f, want 200x50",
+			layout2.Shape.Width, layout2.Shape.Height)
+	}
+	if layout2.Shape.Opacity != 0.5 {
+		t.Fatalf("placeholder opacity = %v, want 0.5",
+			layout2.Shape.Opacity)
+	}
+}

--- a/gui/view_input_layout_test.go
+++ b/gui/view_input_layout_test.go
@@ -1,0 +1,399 @@
+package gui
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+// inputLayoutWithText builds the Column → Row → Text shape structure
+// inputTextFromLayout / inputSetTextInLayout / inputGlyphLayoutWithText
+// navigate, carrying the given text and an optional cached glyph layout.
+func inputLayoutWithText(t *testing.T, text string, gl *glyph.Layout) *Layout {
+	t.Helper()
+	style := DefaultTextStyle
+	tc := &shapeTextConfig{
+		Text:            text,
+		TextStyle:       &style,
+		TextMode:        TextModeSingleLine,
+		textLayout:      gl,
+		textLayoutText:  text,
+		textLayoutStyle: style,
+		textLayoutMode:  TextModeSingleLine,
+		textLayoutValid: gl != nil,
+		textLayoutWidth: 0,
+	}
+	txt := &Shape{TC: tc}
+	return &Layout{Children: []Layout{{
+		Children: []Layout{{Shape: txt}},
+	}}}
+}
+
+func TestInputTextFromLayout(t *testing.T) {
+	l := inputLayoutWithText(t, "hello", nil)
+	if got := inputTextFromLayout(l); got != "hello" {
+		t.Fatalf("inputTextFromLayout() = %q, want %q", got, "hello")
+	}
+
+	// Empty inner structure yields empty text.
+	if got := inputTextFromLayout(&Layout{}); got != "" {
+		t.Fatalf("inputTextFromLayout(empty) = %q, want \"\"", got)
+	}
+
+	// Placeholder content is not user text.
+	lp := inputLayoutWithText(t, "Type here", nil)
+	lp.Children[0].Children[0].Shape.TC.textIsPlaceholder = true
+	if got := inputTextFromLayout(lp); got != "" {
+		t.Fatalf("inputTextFromLayout(placeholder) = %q, want \"\"", got)
+	}
+}
+
+func TestInputSetTextInLayout(t *testing.T) {
+	l := inputLayoutWithText(t, "old", nil)
+	l.Children[0].Children[0].Shape.TC.textIsPlaceholder = true
+
+	inputSetTextInLayout(l, "new")
+	if got := l.Children[0].Children[0].Shape.TC.Text; got != "new" {
+		t.Fatalf("text after write = %q, want %q", got, "new")
+	}
+	if l.Children[0].Children[0].Shape.TC.textIsPlaceholder {
+		t.Fatal("placeholder flag must be cleared by write-back")
+	}
+	// A follow-up read returns the typed text, not the placeholder.
+	if got := inputTextFromLayout(l); got != "new" {
+		t.Fatalf("read after write = %q, want %q", got, "new")
+	}
+
+	// Degenerate layouts are no-ops.
+	inputSetTextInLayout(&Layout{}, "x")
+}
+
+func TestInputGlyphLayoutWithText(t *testing.T) {
+	w := newTestWindow()
+	// No measurer → not available, no panic.
+	if _, ok := inputGlyphLayoutWithText("x", inputLayoutWithText(t, "x", nil), w); ok {
+		t.Fatal("glyph layout must be unavailable without a measurer")
+	}
+
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	// Missing inner shapes → unavailable.
+	if _, ok := inputGlyphLayoutWithText("x", &Layout{}, w); ok {
+		t.Fatal("glyph layout must be unavailable for an empty layout")
+	}
+
+	// Cached glyph layout is returned when present.
+	gl := &glyph.Layout{Height: 20}
+	l := inputLayoutWithText(t, "hello", gl)
+	got, ok := inputGlyphLayoutWithText("hello", l, w)
+	if !ok || got.Height != 20 {
+		t.Fatalf("cached layout = (%v, %v), want height 20, ok", got.Height, ok)
+	}
+}
+
+func TestTrailingLineStart(t *testing.T) {
+	lines := []glyph.Line{
+		{StartIndex: 0, Length: 5},
+		{StartIndex: 5, Length: 4},
+		{StartIndex: 9, Length: 3},
+	}
+	// At the boundary of line 2 → start of line 1.
+	if got := trailingLineStart(lines, 5, -1); got != 0 {
+		t.Fatalf("trailingLineStart(5) = %d, want 0", got)
+	}
+	// At the boundary of line 3 → start of line 2.
+	if got := trailingLineStart(lines, 9, -1); got != 5 {
+		t.Fatalf("trailingLineStart(9) = %d, want 5", got)
+	}
+	// Not a boundary → fallback.
+	if got := trailingLineStart(lines, 7, 42); got != 42 {
+		t.Fatalf("trailingLineStart(7) = %d, want fallback 42", got)
+	}
+	// Cursor at line 1 start is not a wrap boundary.
+	if got := trailingLineStart(lines, 0, -1); got != -1 {
+		t.Fatalf("trailingLineStart(0) = %d, want fallback -1", got)
+	}
+}
+
+func TestTrailingLineEnd(t *testing.T) {
+	lines := []glyph.Line{
+		{StartIndex: 0, Length: 5},
+		{StartIndex: 5, Length: 4},
+	}
+	// End of the previous visual line = start + length.
+	if got := trailingLineEnd(lines, 5, -1); got != 5 {
+		t.Fatalf("trailingLineEnd(5) = %d, want 5", got)
+	}
+	// Not a boundary → fallback.
+	if got := trailingLineEnd(lines, 3, 99); got != 99 {
+		t.Fatalf("trailingLineEnd(3) = %d, want fallback 99", got)
+	}
+}
+
+// glyphCursorLayout builds a minimal glyph layout whose valid cursor
+// positions are exactly the given byte indices — the same positions a
+// shaped layout would expose at grapheme boundaries.
+func glyphCursorLayout(text string, cursors []int) *glyph.Layout {
+	attrs := make([]glyph.LogAttr, len(cursors))
+	byIndex := make(map[int]int, len(cursors))
+	for i, c := range cursors {
+		attrs[i] = glyph.LogAttr{IsCursorPosition: true}
+		byIndex[c] = i
+	}
+	return &glyph.Layout{
+		Text:           text,
+		LogAttrs:       attrs,
+		LogAttrByIndex: byIndex,
+	}
+}
+
+func TestInputDeleteGraphemeCombining(t *testing.T) {
+	// "a" + combining acute (U+0301) + "b": one grapheme is a+U+0301.
+	// Backspace at the cursor (after a+U+0301) must delete the whole
+	// cluster, not just the combining mark.
+	text := "a\u0301b"
+	w := newTestWindow()
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	layout := inputLayoutWithText(t, text,
+		glyphCursorLayout(text, []int{0, 3, 4}))
+	focusID := "f-grapheme"
+	imap := StateMap[string, inputState](w, nsInput, capMany)
+	imap.Set(focusID, inputState{CursorPos: 2}) // runes: a, U+0301, b
+
+	got, changed := inputDeleteGrapheme(text, focusID, false, layout, w)
+	if !changed || got != "b" {
+		t.Fatalf("backspace = (%q, %v), want (\"b\", true)", got, changed)
+	}
+	is := inputStateOrDefault(focusID, w)
+	if is.CursorPos != 0 {
+		t.Fatalf("cursor = %d, want 0", is.CursorPos)
+	}
+
+	// Backspace again deletes the remaining a+U+0301 cluster.
+	text2 := "a\u0301"
+	imap.Set(focusID, inputState{CursorPos: 2})
+	got, changed = inputDeleteGrapheme(text2, focusID, false,
+		inputLayoutWithText(t, text2, glyphCursorLayout(text2, []int{0, 3})), w)
+	if !changed || got != "" {
+		t.Fatalf("backspace cluster = (%q, %v), want (\"\", true)", got, changed)
+	}
+}
+
+func TestInputDeleteGraphemeEmojiZWJ(t *testing.T) {
+	// 👨👩👧 is a single grapheme cluster (family emoji, ZWJ-joined).
+	// One backspace must remove the whole cluster, not one rune.
+	text := "👨\u200d👩\u200d👧"
+	w := newTestWindow()
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	layout := inputLayoutWithText(t, text,
+		glyphCursorLayout(text, []int{0, len(text)}))
+	focusID := "f-zwj"
+	StateMap[string, inputState](w, nsInput, capMany).Set(
+		focusID, inputState{CursorPos: utf8RuneCount(text)})
+
+	got, changed := inputDeleteGrapheme(text, focusID, false, layout, w)
+	if !changed || got != "" {
+		t.Fatalf("backspace ZWJ = (%q, %v), want (\"\", true)", got, changed)
+	}
+}
+
+func TestInputDeleteGraphemeForward(t *testing.T) {
+	// Delete at the start of "a\u0301b" removes the a+U+0301 cluster.
+	text := "a\u0301b"
+	w := newTestWindow()
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	layout := inputLayoutWithText(t, text,
+		glyphCursorLayout(text, []int{0, 3, 4}))
+	focusID := "f-fwd"
+	StateMap[string, inputState](w, nsInput, capMany).Set(
+		focusID, inputState{CursorPos: 0})
+
+	got, changed := inputDeleteGrapheme(text, focusID, true, layout, w)
+	if !changed || got != "b" {
+		t.Fatalf("forward delete = (%q, %v), want (\"b\", true)", got, changed)
+	}
+	if is := inputStateOrDefault(focusID, w); is.CursorPos != 0 {
+		t.Fatalf("cursor = %d, want 0", is.CursorPos)
+	}
+}
+
+func TestInputDeleteGraphemeFallbackRunes(t *testing.T) {
+	// Without a text measurer, deletion falls back to rune-based
+	// inputDelete — still removes exactly one rune, no panic.
+	w := newTestWindow() // no textMeasurer
+	layout := inputLayoutWithText(t, "ab", nil)
+	focusID := "f-fallback"
+	StateMap[string, inputState](w, nsInput, capMany).Set(
+		focusID, inputState{CursorPos: 1})
+
+	got, changed := inputDeleteGrapheme("ab", focusID, false, layout, w)
+	if !changed || got != "b" {
+		t.Fatalf("fallback backspace = (%q, %v), want (\"b\", true)", got, changed)
+	}
+}
+
+func TestInputDeleteGraphemeSelection(t *testing.T) {
+	// An active selection deletes the selected range regardless of
+	// grapheme clusters, exactly like inputDelete.
+	text := "a\u0301b"
+	w := newTestWindow()
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	layout := inputLayoutWithText(t, text,
+		glyphCursorLayout(text, []int{0, 3, 4}))
+	focusID := "f-sel"
+	StateMap[string, inputState](w, nsInput, capMany).Set(
+		focusID, inputState{CursorPos: 3, selectBeg: 1, selectEnd: 3})
+
+	got, changed := inputDeleteGrapheme(text, focusID, false, layout, w)
+	if !changed || got != "a" {
+		t.Fatalf("selection delete = (%q, %v), want (\"a\", true)", got, changed)
+	}
+}
+
+func TestInputDragStateComputeRunePos(t *testing.T) {
+	// Two visual lines; the drag state must map the pointer to the
+	// correct rune, honouring the recorded scroll delta.
+	text := "abcd"
+	gl := &glyph.Layout{
+		Lines: []glyph.Line{
+			{StartIndex: 0, Length: 2, Rect: glyph.Rect{X: 0, Y: 0, Width: 20, Height: 9}},
+			{StartIndex: 2, Length: 2, Rect: glyph.Rect{X: 0, Y: 9, Width: 20, Height: 11}},
+		},
+		CharRectByIndex: map[int]int{0: 0, 1: 1, 2: 2, 3: 3},
+		CharRects: []glyph.CharRect{
+			{Rect: glyph.Rect{X: 0, Y: 0, Width: 10, Height: 9}, Index: 0},
+			{Rect: glyph.Rect{X: 10, Y: 0, Width: 10, Height: 9}, Index: 1},
+			{Rect: glyph.Rect{X: 0, Y: 9, Width: 10, Height: 11}, Index: 2},
+			{Rect: glyph.Rect{X: 10, Y: 9, Width: 10, Height: 11}, Index: 3},
+		},
+	}
+	w := newTestWindow()
+
+	// No scroll: y=0 lands on the first line.
+	d0 := &inputDragState{displayText: text, gl: *gl}
+	if got := d0.computeRunePos(5, 5, w); got != 0 {
+		t.Fatalf("computeRunePos(5,5) = %d, want 0", got)
+	}
+
+	// Scroll -10: the view has moved down one line, so y=0 maps to
+	// the start of the second line.
+	w.scrollY().Set("inp", -10)
+	d1 := &inputDragState{
+		displayText: text, gl: *gl,
+		scrollID: "inp", scrollY0: 0,
+	}
+	if got := d1.computeRunePos(5, 0, w); got != 2 {
+		t.Fatalf("computeRunePos(5,0) scrolled = %d, want 2", got)
+	}
+}
+
+func TestInputDragStateUpdateSelection(t *testing.T) {
+	w := newTestWindow()
+	focusID := "f-drag"
+
+	// Plain drag: anchor at rune 1, pointer at rune 3.
+	d := &inputDragState{focusID: focusID, anchorPos: 1}
+	d.updateSelection(3, w)
+	is := inputStateOrDefault(focusID, w)
+	if is.CursorPos != 3 || is.selectBeg != 1 || is.selectEnd != 3 {
+		t.Fatalf("plain drag state = %+v, want cursor 3, sel 1..3", is)
+	}
+
+	// Double-click word drag: anchor inside "hello", pointer moves
+	// into the word → selection expands to the whole word forward.
+	dw := &inputDragState{
+		focusID:   focusID,
+		runes:     []rune("hello world"),
+		anchorPos: 0, anchorEnd: 5,
+	}
+	dw.updateSelection(3, w)
+	is = inputStateOrDefault(focusID, w)
+	if is.CursorPos != 5 || is.selectBeg != 0 || is.selectEnd != 5 {
+		t.Fatalf("word drag forward state = %+v, want cursor 5, sel 0..5", is)
+	}
+
+	// Word drag backwards: pointer before the anchor → selection
+	// runs from the word start back to the anchor end.
+	dw2 := &inputDragState{
+		focusID:   focusID,
+		runes:     []rune("hello world"),
+		anchorPos: 6, anchorEnd: 11,
+	}
+	dw2.updateSelection(1, w)
+	is = inputStateOrDefault(focusID, w)
+	if is.CursorPos != 0 || is.selectBeg != 11 || is.selectEnd != 0 {
+		t.Fatalf("word drag backward state = %+v, want cursor 0, sel 11..0", is)
+	}
+}
+
+func TestInputDragStateScrollCallback(t *testing.T) {
+	text := "abcd"
+	gl := &glyph.Layout{
+		Lines: []glyph.Line{
+			{StartIndex: 0, Length: 4, Rect: glyph.Rect{X: 0, Y: 0, Width: 40, Height: 10}},
+		},
+		CharRectByIndex: map[int]int{0: 0, 1: 1, 2: 2, 3: 3},
+		CharRects: []glyph.CharRect{
+			{Rect: glyph.Rect{X: 0, Y: 0, Width: 10, Height: 10}, Index: 0},
+			{Rect: glyph.Rect{X: 10, Y: 0, Width: 10, Height: 10}, Index: 1},
+			{Rect: glyph.Rect{X: 20, Y: 0, Width: 10, Height: 10}, Index: 2},
+			{Rect: glyph.Rect{X: 30, Y: 0, Width: 10, Height: 10}, Index: 3},
+		},
+	}
+	w := newTestWindow()
+	focusID := "f-scroll"
+	StateMap[string, inputState](w, nsInput, capMany).Set(
+		focusID, inputState{CursorPos: 0})
+
+	// Pointer above the viewport → scrolls up (toward less negative)
+	// and re-selects from the recomputed rune position.
+	d := &inputDragState{
+		displayText:  text,
+		gl:           *gl,
+		focusID:      focusID,
+		lastMouseX:   15,
+		lastMouseY:   5,
+		viewTop:      20,
+		viewBot:      80,
+		scrollID:     "inp",
+		scrollY0:     0,
+		maxScrollNeg: -100,
+	}
+	w.scrollY().Set("inp", -10)
+	d.scrollCallback(nil, w)
+	if got := w.scrollY().GetOr("inp", 0); got >= 0 {
+		t.Fatalf("scrollY after above-viewport callback = %v, want < 0", got)
+	}
+	is := inputStateOrDefault(focusID, w)
+	if is.CursorPos == 0 && is.selectEnd == 0 {
+		t.Fatal("scroll callback must update the selection from the recomputed position")
+	}
+
+	// Pointer inside the viewport → stops the drag-scroll animation.
+	w.AnimationAdd(&Animate{AnimID: animIDDragScroll, Delay: 1})
+	d.viewTop, d.viewBot = 0, 100
+	d.lastMouseY = 50
+	d.scrollCallback(nil, w)
+	if w.HasAnimation(animIDDragScroll) {
+		t.Fatal("drag-scroll animation must be removed while the pointer is inside")
+	}
+
+	// Pointer below the viewport but already at the scroll floor:
+	// the clamped target equals the current scroll, so nothing moves.
+	d2 := &inputDragState{
+		displayText:  text,
+		gl:           *gl,
+		focusID:      focusID,
+		lastMouseX:   15,
+		lastMouseY:   200,
+		viewTop:      20,
+		viewBot:      80,
+		scrollID:     "inp",
+		scrollY0:     -5.5,
+		maxScrollNeg: -5.5,
+	}
+	before := w.scrollY().GetOr("inp", 0)
+	d2.scrollCallback(nil, w)
+	if got := w.scrollY().GetOr("inp", 0); got != before {
+		t.Fatalf("scrollY changed without room to scroll: %v → %v", before, got)
+	}
+}

--- a/gui/view_listbox_test.go
+++ b/gui/view_listbox_test.go
@@ -408,3 +408,171 @@ func TestListBoxNoHeightGatedByCategory(t *testing.T) {
 		t.Fatalf("listbox category must warn, got %d findings: %v", len(found), found)
 	}
 }
+
+// --- drag-reorder plumbing ---
+
+func TestListBoxDragIndexByRowDisabled(t *testing.T) {
+	// Non-reorderable lists build no drag index map at all.
+	got := listBoxDragIndexByRow(&ListBoxCfg{}, false)
+	if got != nil {
+		t.Fatalf("canReorder=false: got %v, want nil", got)
+	}
+}
+
+func TestListBoxDragIndexByRowSkipsSubheadings(t *testing.T) {
+	cfg := &ListBoxCfg{Data: []ListBoxOption{
+		{ID: "a", Name: "A"},
+		NewListBoxSubheading("h", "Header"),
+		{ID: "b", Name: "B"},
+		{ID: "c", Name: "C"},
+		NewListBoxSubheading("h2", "Header 2"),
+		{ID: "d", Name: "D"},
+	}}
+	got := listBoxDragIndexByRow(cfg, true)
+	want := []int{0, -1, 1, 2, -1, 3}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dragIdx[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestListBoxDragIndexByRowAllSubheadings(t *testing.T) {
+	cfg := &ListBoxCfg{Data: []ListBoxOption{
+		NewListBoxSubheading("h1", "One"),
+		NewListBoxSubheading("h2", "Two"),
+	}}
+	got := listBoxDragIndexByRow(cfg, true)
+	if len(got) != 2 || got[0] != -1 || got[1] != -1 {
+		t.Fatalf("got %v, want [-1 -1]", got)
+	}
+}
+
+func TestListBoxItemLayoutIDsDisabled(t *testing.T) {
+	lids, moff := listBoxItemLayoutIDs(&ListBoxCfg{}, false, 0, 0)
+	if lids != nil || moff != 0 {
+		t.Fatalf("canReorder=false: got (%v, %d), want (nil, 0)", lids, moff)
+	}
+}
+
+func TestListBoxItemLayoutIDsVirtualized(t *testing.T) {
+	// Five rows, one subheading between row 0 and 1; the virtual
+	// window shows data rows 1..3 (flat indices 1..3).
+	cfg := &ListBoxCfg{
+		ID: "lb",
+		Data: []ListBoxOption{
+			{ID: "a", Name: "A"},
+			{ID: "b", Name: "B"},
+			NewListBoxSubheading("h", "Header"),
+			{ID: "c", Name: "C"},
+			{ID: "d", Name: "D"},
+		},
+	}
+	lids, moff := listBoxItemLayoutIDs(cfg, true, 1, 3)
+	// Row 0 ("a") is a draggable row above the window → midsOffset 1.
+	// Inside the window: b (1), h skipped, c (2) → two layout IDs.
+	if moff != 1 {
+		t.Fatalf("midsOffset = %d, want 1", moff)
+	}
+	want := []string{"lb:item:b", "lb:item:c"}
+	if len(lids) != len(want) {
+		t.Fatalf("layoutIDs = %v, want %v", lids, want)
+	}
+	for i := range want {
+		if lids[i] != want[i] {
+			t.Fatalf("layoutIDs = %v, want %v", lids, want)
+		}
+	}
+}
+
+func TestListBoxItemID(t *testing.T) {
+	if got := listBoxItemID("lb", "opt"); got != "lb:item:opt" {
+		t.Fatalf("listBoxItemID() = %q, want lb:item:opt", got)
+	}
+}
+
+func TestListBoxReorderItemView(t *testing.T) {
+	// The reorder row carries its layout ID and a11y role.
+	cfg := ListBoxCfg{ID: "lb"}
+	view := listBoxReorderItemView(
+		ListBoxOption{ID: "a", Name: "Alpha"},
+		cfg,
+		nil,
+		0,
+		[]string{"a"},
+		[]string{"lb:item:a"},
+		0,
+		"",
+	)
+	w := newTestWindow()
+	w.layout = Layout{Shape: &Shape{ID: "root"}}
+	layout := generateViewLayout(view, w)
+	if layout.Shape.ID != "lb:item:a" {
+		t.Fatalf("row ID = %q, want lb:item:a", layout.Shape.ID)
+	}
+	if layout.Shape.A11YRole != AccessRoleListItem {
+		t.Fatalf("row role = %d, want ListItem", layout.Shape.A11YRole)
+	}
+	if layout.Shape.events == nil || layout.Shape.events.OnClick == nil {
+		t.Fatal("reorder row must carry an OnClick handler")
+	}
+}
+
+func TestListBoxReorderItemViewSelectedState(t *testing.T) {
+	cfg := ListBoxCfg{ID: "lb", SelectedIDs: []string{"a"}}
+	view := listBoxReorderItemView(
+		ListBoxOption{ID: "a", Name: "Alpha"},
+		cfg,
+		listCoreSelectedSet(cfg.SelectedIDs),
+		0,
+		[]string{"a"},
+		[]string{"lb:item:a"},
+		0,
+		"",
+	)
+	layout := generateViewLayout(view, newTestWindow())
+	if !layout.Shape.A11YState.Has(AccessStateSelected) {
+		t.Fatal("selected row should expose AccessStateSelected")
+	}
+}
+
+func TestListBoxReorderItemViewClickArmsDrag(t *testing.T) {
+	// Clicking a reorderable row arms the drag-reorder state and
+	// reports the selection through OnSelect.
+	cfg := ListBoxCfg{
+		ID: "lb-drag",
+	}
+	var selected []string
+	cfg.OnSelect = func(ids []string, ctx EventCtx) { selected = ids }
+	view := listBoxReorderItemView(
+		ListBoxOption{ID: "a", Name: "A"},
+		cfg,
+		nil,
+		0,
+		[]string{"a", "b"},
+		[]string{"lb-drag:item:a", "lb-drag:item:b"},
+		0,
+		"",
+	)
+	w := newTestWindow()
+	w.layout = Layout{Shape: &Shape{ID: "root"}}
+	layout := generateViewLayout(view, w)
+
+	e := &Event{MouseX: 5, MouseY: 5}
+	layout.Shape.events.OnClick(EventCtx{&layout, e, w})
+
+	state := dragReorderGet(w, "lb-drag")
+	if !state.started {
+		t.Fatal("click should arm the drag-reorder state")
+	}
+	if state.itemID != "a" || state.sourceIndex != 0 {
+		t.Fatalf("drag state = %+v, want itemID a at index 0", state)
+	}
+	// Single-select: the clicked row becomes the selection.
+	if len(selected) != 1 || selected[0] != "a" {
+		t.Fatalf("onSelect = %v, want [a]", selected)
+	}
+}

--- a/gui/view_progress_bar_test.go
+++ b/gui/view_progress_bar_test.go
@@ -17,6 +17,40 @@ func TestProgressBarDefaultLayout(t *testing.T) {
 	}
 }
 
+func TestProgressBarCenterLabel(t *testing.T) {
+	// The label must be centered on both axes inside the parent,
+	// shifting its own child to keep the offset consistent.
+	parent := &Shape{X: 100, Y: 50, Width: 200, Height: 40}
+	lbl := &Layout{
+		Shape: &Shape{X: 0, Y: 0, Width: 60, Height: 20},
+		Children: []Layout{
+			{Shape: &Shape{X: 5, Y: 5, Width: 50, Height: 10}},
+		},
+	}
+
+	progressBarCenterLabel(parent, lbl)
+	// Center of parent (200, 70) minus half the label (30, 10).
+	if lbl.Shape.X != 170 || lbl.Shape.Y != 60 {
+		t.Fatalf("label at (%v, %v), want (170, 60)",
+			lbl.Shape.X, lbl.Shape.Y)
+	}
+	// The inner child follows the label's translation: it moved from
+	// (5,5) to (175, 65) — a shift of +170 x, +55 y.
+	inner := &lbl.Children[0]
+	if inner.Shape.X != 175 || inner.Shape.Y != 65 {
+		t.Fatalf("inner child at (%v, %v), want (175, 65)",
+			inner.Shape.X, inner.Shape.Y)
+	}
+
+	// A label without children still centers (no child shift).
+	lbl2 := &Layout{Shape: &Shape{X: 0, Y: 0, Width: 40, Height: 10}}
+	progressBarCenterLabel(parent, lbl2)
+	if lbl2.Shape.X != 180 || lbl2.Shape.Y != 65 {
+		t.Fatalf("childless label at (%v, %v), want (180, 65)",
+			lbl2.Shape.X, lbl2.Shape.Y)
+	}
+}
+
 func TestProgressBarVertical(t *testing.T) {
 	v := ProgressBar(ProgressBarCfg{
 		ID:       "pb-test",

--- a/gui/view_slider_test.go
+++ b/gui/view_slider_test.go
@@ -231,3 +231,192 @@ func TestSliderVerticalMouseDedup(t *testing.T) {
 			callCount)
 	}
 }
+
+// sliderTestLayout builds the wrapper → track → [leftBar, thumb]
+// tree sliderAmendLayoutSlide navigates, with the geometry a laid-out
+// slider would have.
+func sliderTestLayout() Layout {
+	track := Layout{
+		Shape: &Shape{Width: 200, Height: 20},
+		Children: []Layout{
+			{Shape: &Shape{}},
+			{Shape: &Shape{}},
+		},
+	}
+	return Layout{
+		Shape:    &Shape{ID: "rs", Width: 200, Height: 20},
+		Children: []Layout{track},
+	}
+}
+
+func TestSliderAmendLayoutSlideHorizontal(t *testing.T) {
+	layout := sliderTestLayout()
+	onChange := func(float32, EventCtx) {}
+	sliderAmendLayoutSlide(&layout, nil,
+		onChange, 50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "rs", false)
+
+	leftBar := &layout.Children[0].Children[0]
+	// 50% of 200 width = 100; height = size - 2*border = 16.
+	if leftBar.Shape.Width != 100 {
+		t.Errorf("left bar width = %v, want 100", leftBar.Shape.Width)
+	}
+	if leftBar.Shape.Height != 16 {
+		t.Errorf("left bar height = %v, want 16", leftBar.Shape.Height)
+	}
+	// A scroll handler must have been attached.
+	if layout.Shape.events == nil || layout.Shape.events.OnMouseScroll == nil {
+		t.Error("slider shape should carry an OnMouseScroll handler")
+	}
+}
+
+func TestSliderAmendLayoutSlideVertical(t *testing.T) {
+	layout := sliderTestLayout()
+	sliderAmendLayoutSlide(&layout, nil, nil,
+		25, 0, 100, 20, 2, true,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "rs", false)
+
+	leftBar := &layout.Children[0].Children[0]
+	// 25% of 20 height = 5; width = size - 2*border = 16.
+	if leftBar.Shape.Height != 5 {
+		t.Errorf("left bar height = %v, want 5", leftBar.Shape.Height)
+	}
+	if leftBar.Shape.Width != 16 {
+		t.Errorf("left bar width = %v, want 16", leftBar.Shape.Width)
+	}
+}
+
+func TestSliderAmendLayoutSlideClamps(t *testing.T) {
+	layout := sliderTestLayout()
+	// Value above max must not overflow the track.
+	sliderAmendLayoutSlide(&layout, nil, nil,
+		250, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "rs", false)
+	leftBar := &layout.Children[0].Children[0]
+	if leftBar.Shape.Width != 200 {
+		t.Errorf("left bar width = %v, want 200 (clamped)", leftBar.Shape.Width)
+	}
+
+	// Value below min clamps to zero.
+	layout2 := sliderTestLayout()
+	sliderAmendLayoutSlide(&layout2, nil, nil,
+		-50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "rs", false)
+	leftBar2 := &layout2.Children[0].Children[0]
+	if leftBar2.Shape.Width != 0 {
+		t.Errorf("left bar width = %v, want 0 (clamped)", leftBar2.Shape.Width)
+	}
+}
+
+func TestSliderAmendLayoutSlideFocused(t *testing.T) {
+	w := &Window{}
+	layout := sliderTestLayout()
+	sliderAmendLayoutSlide(&layout, w, nil,
+		50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "rs", false)
+
+	// Not focused yet: thumb keeps its original color.
+	thumb := &layout.Children[0].Children[1]
+	if thumb.Shape.Color == RGB(255, 0, 0) {
+		t.Error("thumb should not be focus-colored before focus")
+	}
+
+	w.SetFocus("rs")
+	sliderAmendLayoutSlide(&layout, w, nil,
+		50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "rs", false)
+	if thumb.Shape.Color != RGB(255, 0, 0) {
+		t.Error("thumb should be focus-colored while focused")
+	}
+}
+
+func TestSliderAmendLayoutSlidePressed(t *testing.T) {
+	w := &Window{}
+	layout := sliderTestLayout()
+	// Press state is keyed by the shape's idKey.
+	ps := StateMap[string, bool](w, nsSliderPress, capModerate)
+	ps.Set(layout.Shape.idKey(), true)
+
+	sliderAmendLayoutSlide(&layout, w, nil,
+		50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "rs", false)
+	thumb := &layout.Children[0].Children[1]
+	if thumb.Shape.Color != RGB(0, 0, 255) {
+		t.Error("thumb should be press-colored while pressed")
+	}
+}
+
+func TestSliderAmendLayoutSlideDisabled(t *testing.T) {
+	w := &Window{}
+	w.SetFocus("rs")
+	layout := sliderTestLayout()
+	sliderAmendLayoutSlide(&layout, w, nil,
+		50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), true, "rs", false)
+
+	thumb := &layout.Children[0].Children[1]
+	if thumb.Shape.Color == RGB(255, 0, 0) {
+		t.Error("disabled slider must not paint the focus color")
+	}
+}
+
+func TestSliderAmendLayoutSlideDegenerate(t *testing.T) {
+	// Empty and short layouts are no-ops, not panics.
+	sliderAmendLayoutSlide(&Layout{Shape: &Shape{}}, nil, nil,
+		50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "", false)
+	sliderAmendLayoutSlide(&Layout{
+		Shape:    &Shape{},
+		Children: []Layout{{Shape: &Shape{}}},
+	}, nil, nil,
+		50, 0, 100, 20, 2, false,
+		RGB(255, 0, 0), RGB(0, 0, 255), false, "", false)
+}
+
+func TestSliderAmendLayoutThumbHorizontal(t *testing.T) {
+	parent := &Layout{Shape: &Shape{X: 10, Y: 5, Width: 200, Height: 20}}
+	thumb := Layout{Shape: &Shape{X: 10, Y: 5}, Parent: parent}
+	sliderAmendLayoutThumb(&thumb, nil, 50, 0, 100, 12, false)
+
+	// Thumb radius = 6. Center at 50% of 200 → x = 10+100-6 = 104;
+	// y centered on the track: 5 + 10 - 6 = 9.
+	if thumb.Shape.X != 104 {
+		t.Errorf("thumb X = %v, want 104", thumb.Shape.X)
+	}
+	if thumb.Shape.Y != 9 {
+		t.Errorf("thumb Y = %v, want 9", thumb.Shape.Y)
+	}
+}
+
+func TestSliderAmendLayoutThumbVertical(t *testing.T) {
+	parent := &Layout{Shape: &Shape{X: 10, Y: 5, Width: 200, Height: 20}}
+	thumb := Layout{Shape: &Shape{X: 10, Y: 5}, Parent: parent}
+	sliderAmendLayoutThumb(&thumb, nil, 50, 0, 100, 12, true)
+
+	// Vertical: y = parent.Y + 50% of 20 - 6 = 9; x centered on
+	// parent width: 10 + 100 - 6 = 104.
+	if thumb.Shape.Y != 9 {
+		t.Errorf("thumb Y = %v, want 9", thumb.Shape.Y)
+	}
+	if thumb.Shape.X != 104 {
+		t.Errorf("thumb X = %v, want 104", thumb.Shape.X)
+	}
+}
+
+func TestSliderAmendLayoutThumbClamped(t *testing.T) {
+	parent := &Layout{Shape: &Shape{X: 0, Y: 0, Width: 100, Height: 10}}
+	thumb := Layout{Shape: &Shape{X: 0, Y: 0}, Parent: parent}
+	// Value above max must clamp to the far edge, not overflow.
+	sliderAmendLayoutThumb(&thumb, nil, 999, 0, 100, 10, false)
+	if thumb.Shape.X != 95 {
+		t.Errorf("thumb X = %v, want 95 (edge minus radius)", thumb.Shape.X)
+	}
+}
+
+func TestSliderAmendLayoutThumbNoParent(t *testing.T) {
+	thumb := Layout{Shape: &Shape{}}
+	sliderAmendLayoutThumb(&thumb, nil, 50, 0, 100, 12, false)
+	if thumb.Shape.X != 0 || thumb.Shape.Y != 0 {
+		t.Error("thumb without parent must be left untouched")
+	}
+}

--- a/gui/view_table_test.go
+++ b/gui/view_table_test.go
@@ -230,6 +230,26 @@ func TestTableSelection(t *testing.T) {
 	}
 }
 
+func TestCopySelected(t *testing.T) {
+	// Non-nil input is copied deeply: mutating the copy must not
+	// touch the original.
+	orig := map[int]bool{1: true, 3: true}
+	cp := copySelected(orig)
+	if len(cp) != 2 || !cp[1] || !cp[3] {
+		t.Fatalf("copy = %v, want {1:true, 3:true}", cp)
+	}
+	cp[3] = false
+	delete(cp, 1)
+	if !orig[1] || !orig[3] {
+		t.Fatal("mutating the copy must not affect the source")
+	}
+
+	// Nil input yields an empty, usable map.
+	if got := copySelected(nil); got == nil || len(got) != 0 {
+		t.Fatalf("copySelected(nil) = %v, want empty non-nil map", got)
+	}
+}
+
 type tableTestMeasurer struct{}
 
 func (m *tableTestMeasurer) TextWidth(text string, _ TextStyle) float32 {

--- a/gui/view_test.go
+++ b/gui/view_test.go
@@ -167,6 +167,29 @@ func TestGenerateViewLayoutFlat(t *testing.T) {
 	}
 }
 
+// The exported GenerateViewLayout is the supported entry point for
+// composite widgets; it must behave exactly like the internal builder.
+func TestGenerateViewLayoutExported(t *testing.T) {
+	v := &stubView{
+		id: "parent",
+		children: []View{
+			&stubView{id: "child1"},
+			&stubView{id: "child2"},
+		},
+	}
+	layout := GenerateViewLayout(v, &Window{})
+	if layout.Shape.ID != "parent" {
+		t.Fatalf("root ID = %q, want parent", layout.Shape.ID)
+	}
+	if len(layout.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(layout.Children))
+	}
+	if layout.Children[0].Shape.ID != "child1" ||
+		layout.Children[1].Shape.ID != "child2" {
+		t.Fatal("child IDs mismatched")
+	}
+}
+
 func TestGenerateViewLayoutWithChildren(t *testing.T) {
 	v := &stubView{
 		id: "parent",

--- a/gui/view_toast_test.go
+++ b/gui/view_toast_test.go
@@ -290,3 +290,154 @@ func TestToastAnimID(t *testing.T) {
 		t.Errorf("expected 'dismiss:toast:0', got %q", got)
 	}
 }
+
+// --- dismiss flow ---
+
+func TestToastStartDismissTimerPersistentNoAnimation(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, cfg: ToastCfg{Duration: toastPersistent}, phase: toastVisible},
+	}
+	toastStartDismissTimer(w, 1)
+	if w.HasAnimation(toastAnimID("dismiss", 1)) {
+		t.Error("persistent toast must not arm a dismiss timer")
+	}
+}
+
+func TestToastStartDismissTimerArms(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, cfg: ToastCfg{Duration: 5 * time.Second}, phase: toastVisible},
+	}
+	toastStartDismissTimer(w, 1)
+
+	a, ok := w.animations[toastAnimID("dismiss", 1)]
+	if !ok {
+		t.Fatal("dismiss timer animation not registered")
+	}
+	anim, ok := a.(*Animate)
+	if !ok {
+		t.Fatalf("dismiss timer = %T, want *Animate", a)
+	}
+	if anim.Delay != 5*time.Second {
+		t.Errorf("delay = %v, want 5s", anim.Delay)
+	}
+}
+
+func TestToastStartDismissTimerCallbackExits(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, cfg: ToastCfg{Duration: time.Second}, phase: toastVisible},
+	}
+	toastStartDismissTimer(w, 1)
+	a := w.animations[toastAnimID("dismiss", 1)].(*Animate)
+
+	// Fire the timer: toast is not hovered → starts exit.
+	a.Callback(a, w)
+	if w.toasts[0].phase != toastExiting {
+		t.Error("non-hovered toast should exit when the timer fires")
+	}
+}
+
+func TestToastStartDismissTimerCallbackHoveredResets(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, cfg: ToastCfg{Duration: time.Second}, phase: toastVisible, hovered: true},
+	}
+	toastStartDismissTimer(w, 1)
+	a := w.animations[toastAnimID("dismiss", 1)].(*Animate)
+
+	// Fire the timer while hovered: hover cleared, timer re-armed,
+	// toast stays visible.
+	a.Callback(a, w)
+	if w.toasts[0].phase != toastVisible {
+		t.Error("hovered toast must not exit when the timer fires")
+	}
+	if w.toasts[0].hovered {
+		t.Error("hovered flag should be cleared by the timer callback")
+	}
+	if !w.HasAnimation(toastAnimID("dismiss", 1)) {
+		t.Error("dismiss timer should be re-armed after a hovered fire")
+	}
+}
+
+func TestToastStartDismissTimerHoveredResetThenExits(t *testing.T) {
+	// Simulate the natural sequence: timer fires while hovered
+	// (re-arms), then fires again once the pointer left — exit starts.
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, cfg: ToastCfg{Duration: time.Second}, phase: toastVisible, hovered: true},
+	}
+	toastStartDismissTimer(w, 1)
+	a := w.animations[toastAnimID("dismiss", 1)].(*Animate)
+
+	a.Callback(a, w) // hovered → re-arm
+	second := w.animations[toastAnimID("dismiss", 1)].(*Animate)
+	second.Callback(second, w) // not hovered anymore → exit
+	if w.toasts[0].phase != toastExiting {
+		t.Error("toast should exit on the second timer fire")
+	}
+}
+
+func TestToastDismiss(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, cfg: ToastCfg{Title: "A"}, phase: toastVisible},
+		{id: 2, cfg: ToastCfg{Title: "B"}, phase: toastVisible},
+	}
+	w.ToastDismiss(1)
+	if w.toasts[0].phase != toastExiting {
+		t.Error("dismissed toast should be exiting")
+	}
+	if w.toasts[1].phase != toastVisible {
+		t.Error("other toast must be untouched")
+	}
+	if !w.HasAnimation(toastAnimID("exit", 1)) {
+		t.Error("exit animation should be registered")
+	}
+}
+
+func TestToastDismissUnknownIDNoop(t *testing.T) {
+	w := &Window{}
+	w.toasts = []toastNotification{
+		{id: 1, cfg: ToastCfg{Title: "A"}, phase: toastVisible},
+	}
+	w.ToastDismiss(99)
+	if w.toasts[0].phase != toastVisible {
+		t.Error("dismissing an unknown id must not touch existing toasts")
+	}
+	if len(w.animations) != 0 {
+		t.Errorf("unknown dismiss registered animations: %d", len(w.animations))
+	}
+}
+
+func TestToastFullLifecycle(t *testing.T) {
+	// Toast → enter → dismiss timer → exit → removed, driven through
+	// the animation callbacks so no timers run.
+	w := &Window{}
+	id := w.Toast(ToastCfg{Title: "T"})
+
+	// Enter animation registered on creation.
+	enter, ok := w.animations[toastAnimID("enter", id)].(*TweenAnimation)
+	if !ok {
+		t.Fatal("enter animation not registered")
+	}
+	// Finish enter → visible + dismiss timer armed.
+	enter.OnDone(w)
+	if w.toasts[0].phase != toastVisible {
+		t.Fatal("toast should be visible after enter completes")
+	}
+	dismiss := w.animations[toastAnimID("dismiss", id)].(*Animate)
+
+	// Fire dismiss → exiting.
+	dismiss.Callback(dismiss, w)
+	if w.toasts[0].phase != toastExiting {
+		t.Fatal("toast should be exiting after dismiss fires")
+	}
+	// Finish exit → removed.
+	exit := w.animations[toastAnimID("exit", id)].(*TweenAnimation)
+	exit.OnDone(w)
+	if len(w.toasts) != 0 {
+		t.Fatalf("toasts = %d, want 0 after exit completes", len(w.toasts))
+	}
+}

--- a/gui/view_tree_rows_test.go
+++ b/gui/view_tree_rows_test.go
@@ -1,0 +1,137 @@
+package gui
+
+import "testing"
+
+func TestTreeEstimateRowHeightNilWindow(t *testing.T) {
+	// Without a text measurer the estimate falls back to the style
+	// size, then adds the fixed padding and the configured spacing.
+	cfg := TreeCfg{Spacing: Some(float32(4))}
+	got := treeEstimateRowHeight(cfg, nil)
+	want := defaultTreeStyle.TextStyle.Size +
+		PaddingTwoFive.Height() + 4
+	if got != want {
+		t.Fatalf("treeEstimateRowHeight() = %v, want %v", got, want)
+	}
+}
+
+func TestTreeEstimateRowHeightWithMeasurer(t *testing.T) {
+	w := newTestWindow()
+	w.textMeasurer = &stubTextMeasurer{fontHeight: 22}
+	cfg := TreeCfg{Spacing: Some(float32(0))}
+	got := treeEstimateRowHeight(cfg, w)
+	want := float32(22) + PaddingTwoFive.Height() + 0
+	if got != want {
+		t.Fatalf("treeEstimateRowHeight() = %v, want %v", got, want)
+	}
+}
+
+func TestTreeSiblingIndex(t *testing.T) {
+	sibs := []string{"a", "b", "c"}
+	if got := treeSiblingIndex(sibs, "b"); got != 1 {
+		t.Fatalf("treeSiblingIndex(b) = %d, want 1", got)
+	}
+	if got := treeSiblingIndex(sibs, "zz"); got != -1 {
+		t.Fatalf("treeSiblingIndex(missing) = %d, want -1", got)
+	}
+	if got := treeSiblingIndex(nil, "a"); got != -1 {
+		t.Fatalf("treeSiblingIndex(nil) = %d, want -1", got)
+	}
+}
+
+func TestTreeDragRowViewLoadingDelegates(t *testing.T) {
+	// A loading placeholder row must render through treeRowView with
+	// no drag arm, so no layout ID is attached.
+	cfg := TreeCfg{ID: "tree", Spacing: Some(float32(0))}
+	view := treeDragRowView(
+		cfg,
+		treeFlatRow{ID: "load", IsLoading: true, Text: "Loading..."},
+		16, "",
+		0, nil, nil, 0, "",
+	)
+	w := newTestWindow()
+	layout := generateViewLayout(view, w)
+	if layout.Shape.ID != "" {
+		t.Fatalf("loading row layout ID = %q, want empty", layout.Shape.ID)
+	}
+	// The loading branch renders through treeRowView's minimal
+	// container, which carries no a11y role.
+	if layout.Shape.A11YRole != AccessRoleNone {
+		t.Fatalf("loading row role = %d, want None", layout.Shape.A11YRole)
+	}
+}
+
+func TestTreeDragRowViewArmsDrag(t *testing.T) {
+	// A reorderable row must carry its layout ID and arm the
+	// drag-reorder state when clicked.
+	cfg := TreeCfg{ID: "tree", Spacing: Some(float32(0))}
+	view := treeDragRowView(
+		cfg,
+		treeFlatRow{ID: "a", Text: "A"},
+		16, "",
+		0, []string{"a"}, []string{"tree:row:a"}, 0, "",
+	)
+	w := newTestWindow()
+	w.layout = Layout{Shape: &Shape{ID: "root"}}
+	layout := generateViewLayout(view, w)
+	if layout.Shape.ID != "tree:row:a" {
+		t.Fatalf("row layout ID = %q, want tree:row:a", layout.Shape.ID)
+	}
+	if layout.Shape.events == nil || layout.Shape.events.OnClick == nil {
+		t.Fatal("reorderable row must have an OnClick handler")
+	}
+	e := &Event{MouseX: 5, MouseY: 5}
+	layout.Shape.events.OnClick(EventCtx{&layout, e, w})
+	state := dragReorderGet(w, "tree")
+	if !state.started {
+		t.Fatal("click on reorderable row should arm drag-reorder state")
+	}
+	if state.itemID != "a" || state.sourceIndex != 0 {
+		t.Fatalf("drag state = %+v, want itemID a at index 0", state)
+	}
+}
+
+func TestTreeRowContent(t *testing.T) {
+	// treeRowContent builds the ghost content for a drag — a row
+	// container with the tree's icon + text children.
+	cfg := TreeCfg{ID: "tree", Spacing: Some(float32(0))}
+	view := treeRowContent(
+		cfg,
+		treeFlatRow{ID: "a", Text: "Alpha", HasChildren: true},
+		16, "a",
+	)
+	w := newTestWindow()
+	layout := generateViewLayout(view, w)
+	// treeRowContent is the drag ghost's inner content — no a11y role
+	// of its own; it is nested under the floating ghost container.
+	if layout.Shape.A11YRole != AccessRoleNone {
+		t.Fatalf("ghost row role = %d, want None", layout.Shape.A11YRole)
+	}
+	// Icon spacer + icon + text.
+	if got := len(layout.Children); got != 3 {
+		t.Fatalf("ghost row children = %d, want 3", got)
+	}
+}
+
+func TestTreeScrollTo(t *testing.T) {
+	w := newTestWindow()
+	treeScrollTo("list", 5, 20, 100, w)
+	// Row 5 spans 100..120 in content space; the viewport shows
+	// 0..100, so the scroll must bring the row's bottom into view.
+	if got := w.scrollY().GetOr("list", 0); got != -20 {
+		t.Fatalf("scrollY = %v, want -20", got)
+	}
+
+	// Empty scrollID is a no-op, including on an uninitialized window.
+	w2 := newTestWindow()
+	treeScrollTo("", 5, 20, 100, w2)
+	if got := w2.scrollY().GetOr("", 0); got != 0 {
+		t.Fatalf("no-op scroll wrote %v", got)
+	}
+
+	// Zero row height is a no-op.
+	w3 := newTestWindow()
+	treeScrollTo("list", 5, 0, 100, w3)
+	if got := w3.scrollY().GetOr("list", 0); got != 0 {
+		t.Fatalf("zero row height wrote %v", got)
+	}
+}

--- a/gui/view_tree_test.go
+++ b/gui/view_tree_test.go
@@ -509,3 +509,228 @@ func TestTreeItemPathsPrecedence(t *testing.T) {
 			len(layout.Children))
 	}
 }
+
+// --- tree build maps and drag-reorder scaffolding ---
+
+func TestTreeBuildParentMapsDisabled(t *testing.T) {
+	// Non-reorderable trees must not build the drag maps at all.
+	parentOf, siblings := treeBuildParentMaps(
+		[]treeFlatRow{{ID: "a", ParentID: ""}, {ID: "b", ParentID: "a"}},
+		[]string{"a", "b"},
+		false,
+	)
+	if parentOf != nil || siblings != nil {
+		t.Fatalf("canReorder=false: got (%v, %v), want (nil, nil)",
+			parentOf, siblings)
+	}
+}
+
+func TestTreeBuildParentMapsSkipsLoadingRows(t *testing.T) {
+	parentOf, siblings := treeBuildParentMaps(
+		[]treeFlatRow{
+			{ID: "a", ParentID: ""},
+			{ID: "loading", ParentID: "a", IsLoading: true},
+			{ID: "b", ParentID: "a"},
+			{ID: "c", ParentID: ""},
+		},
+		[]string{"a", "b", "c"},
+		true,
+	)
+	if parentOf["a"] != "" || parentOf["b"] != "a" || parentOf["c"] != "" {
+		t.Fatalf("parentOf = %v, want a->\"\", b->a, c->\"\"", parentOf)
+	}
+	if _, ok := parentOf["loading"]; ok {
+		t.Fatal("loading placeholder must be excluded from parentOf")
+	}
+	if got := siblings[""]; len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Fatalf("siblings[\"\"] = %v, want [a c]", got)
+	}
+	if got := siblings["a"]; len(got) != 1 || got[0] != "b" {
+		t.Fatalf("siblings[\"a\"] = %v, want [b]", got)
+	}
+}
+
+func TestTreeBuildSiblingInfoDisabled(t *testing.T) {
+	idx, lids, moff := treeBuildSiblingInfo(
+		"tree", []treeFlatRow{{ID: "a"}}, nil, false, 0, 0)
+	if idx != nil || lids != nil || moff != nil {
+		t.Fatalf("canReorder=false: got (%v, %v, %v), want all nil",
+			idx, lids, moff)
+	}
+}
+
+func TestTreeBuildSiblingInfoVirtualized(t *testing.T) {
+	// Five root rows; virtualization window shows rows 1..3 (flat
+	// indices 1..3). Sibling 0 is above the window, siblings 1-3 are
+	// inside, sibling 4 is below.
+	rows := make([]treeFlatRow, 5)
+	for i := range rows {
+		rows[i] = treeFlatRow{ID: string(rune('a' + i)), ParentID: ""}
+	}
+	idx, lids, moff := treeBuildSiblingInfo(
+		"tree", rows,
+		map[string][]string{"": {"a", "b", "c", "d", "e"}},
+		true, 1, 3,
+	)
+	if idx["a"] != 0 || idx["e"] != 4 {
+		t.Fatalf("siblingIdx = %v, want a->0, e->4", idx)
+	}
+	if moff[""] != 1 {
+		t.Fatalf("midsOffset = %d, want 1 (one sibling above window)",
+			moff[""])
+	}
+	wantLids := []string{"tree:row:b", "tree:row:c", "tree:row:d"}
+	if len(lids[""]) != len(wantLids) {
+		t.Fatalf("layoutIDs = %v, want %v", lids[""], wantLids)
+	}
+	for i := range wantLids {
+		if lids[""][i] != wantLids[i] {
+			t.Fatalf("layoutIDs = %v, want %v", lids[""], wantLids)
+		}
+	}
+}
+
+func TestTreeRowID(t *testing.T) {
+	if got := treeRowID("tree", "node"); got != "tree:row:node" {
+		t.Fatalf("treeRowID() = %q, want %q", got, "tree:row:node")
+	}
+	// Nested scope composes without a trailing separator.
+	if got := treeRowID("tree:row:node", "child"); got != "tree:row:node:row:child" {
+		t.Fatalf("nested treeRowID() = %q", got)
+	}
+}
+
+func TestTreeBuildRowsVirtualizedSpacers(t *testing.T) {
+	rows := make([]treeFlatRow, 5)
+	for i := range rows {
+		rows[i] = treeFlatRow{ID: string(rune('a' + i))}
+	}
+	cfg := &TreeCfg{ID: "tree", Spacing: Some(float32(0))}
+	views, ghost := treeBuildRows(
+		cfg, rows, "", 16,
+		nil, nil, nil, nil, nil, "",
+		false, false, dragReorderState{}, "",
+		true, 10, 1, 3,
+	)
+	if ghost != nil {
+		t.Fatal("no drag: ghost content must be nil")
+	}
+	// 1 leading spacer + 3 visible rows + 1 trailing spacer.
+	if len(views) != 5 {
+		t.Fatalf("len(views) = %d, want 5 (2 spacers + 3 rows)", len(views))
+	}
+	leading := generateViewLayout(views[0], newTestWindow())
+	if leading.Shape.Height != 10 {
+		t.Fatalf("leading spacer height = %v, want 10", leading.Shape.Height)
+	}
+	trailing := generateViewLayout(views[4], newTestWindow())
+	if trailing.Shape.Height != 10 {
+		t.Fatalf("trailing spacer height = %v, want 10", trailing.Shape.Height)
+	}
+}
+
+func TestTreeBuildRowsDragGapAndGhost(t *testing.T) {
+	// Three root siblings; dragging "a" (index 0) currently at index 2.
+	// Row "a" becomes ghost content, row "c" is preceded by the gap.
+	rows := []treeFlatRow{
+		{ID: "a", ParentID: ""},
+		{ID: "b", ParentID: ""},
+		{ID: "c", ParentID: ""},
+	}
+	cfg := &TreeCfg{ID: "tree", Spacing: Some(float32(0))}
+	drag := dragReorderState{
+		itemID:       "a",
+		sourceIndex:  0,
+		currentIndex: 2,
+		active:       true,
+		itemHeight:   20,
+	}
+	views, ghost := treeBuildRows(
+		cfg, rows, "", 16,
+		map[string]string{"a": "", "b": "", "c": ""},
+		map[string][]string{"": {"a", "b", "c"}},
+		map[string]int{"a": 0, "b": 1, "c": 2},
+		map[string][]string{"": {"tree:row:a", "tree:row:b", "tree:row:c"}},
+		map[string]int{"": 0},
+		"",
+		true, true, drag, "",
+		false, 0, 0, 2,
+	)
+	if ghost == nil {
+		t.Fatal("drag: ghost content must be captured from the source row")
+	}
+	// a skipped, b, gap, c → 3 views.
+	if len(views) != 3 {
+		t.Fatalf("len(views) = %d, want 3 (b, gap, c)", len(views))
+	}
+	gap := generateViewLayout(views[1], newTestWindow())
+	if gap.Shape.ID != "drag_reorder_gap" {
+		t.Fatalf("views[1] = %q, want drag gap", gap.Shape.ID)
+	}
+	last := generateViewLayout(views[2], newTestWindow())
+	if last.Shape.ID != "tree:row:c" {
+		t.Fatalf("views[2] = %q, want row c", last.Shape.ID)
+	}
+}
+
+func TestTreeGenerateLayoutReorderable(t *testing.T) {
+	// A reorderable tree must produce drag row views keyed by
+	// treeRowID and honour Alt+Arrow keyboard reorder.
+	w := newTestWindow()
+	var moved, before string
+	reordered := false
+	layout := generateViewLayout(Tree(TreeCfg{
+		ID:          "tree-reo",
+		Reorderable: true,
+		OnReorder: func(m, b string, _ EventCtx) {
+			moved, before, reordered = m, b, true
+		},
+		Nodes: []TreeNodeCfg{
+			{ID: "a", Text: "A"},
+			{ID: "b", Text: "B"},
+		},
+	}), w)
+	if got := len(layout.Children); got != 2 {
+		t.Fatalf("children = %d, want 2", got)
+	}
+	if got := layout.Children[0].Shape.ID; got != "tree-reo:row:a" {
+		t.Fatalf("row[0] ID = %q, want tree-reo:row:a", got)
+	}
+
+	// Alt+Down on focused "a" moves it past "b": before = "" (end).
+	w.layout = Layout{Shape: &Shape{ID: "root"}}
+	treeFocusedSet(w, "tree-reo", "a")
+	e := &Event{KeyCode: KeyDown, Modifiers: ModAlt}
+	layout.Shape.events.OnKeyDown(EventCtx{&layout, e, w})
+	if !reordered {
+		t.Fatal("Alt+Down should trigger OnReorder")
+	}
+	if moved != "a" || before != "" {
+		t.Fatalf("OnReorder(%q, %q), want (a, \"\")", moved, before)
+	}
+	if !e.IsHandled {
+		t.Fatal("Alt+Down should be consumed")
+	}
+}
+
+func TestTreeGenerateLayoutEscapeCancelsDrag(t *testing.T) {
+	w := newTestWindow()
+	w.layout = Layout{Shape: &Shape{ID: "root"}}
+	dragReorderSet(w, "tree-esc", dragReorderState{started: true})
+
+	layout := generateViewLayout(Tree(TreeCfg{
+		ID:          "tree-esc",
+		Reorderable: true,
+		OnReorder:   func(string, string, EventCtx) {},
+		Nodes:       []TreeNodeCfg{{ID: "a", Text: "A"}},
+	}), w)
+
+	e := &Event{KeyCode: KeyEscape}
+	layout.Shape.events.OnKeyDown(EventCtx{&layout, e, w})
+	if !e.IsHandled {
+		t.Fatal("Escape during a drag must be consumed")
+	}
+	if state := dragReorderGet(w, "tree-esc"); state.started || state.active {
+		t.Fatal("drag state should be cleared after Escape")
+	}
+}

--- a/gui/window_accessors_test.go
+++ b/gui/window_accessors_test.go
@@ -184,3 +184,54 @@ func TestSetWakeMainFnAcceptsNil(t *testing.T) {
 	w.SetWakeMainFn(func() {})
 	w.SetWakeMainFn(nil)
 }
+
+func TestSetStateTyped(t *testing.T) {
+	w := newTestWindow()
+	type appState struct{ count int }
+	w.setState(&appState{count: 7})
+
+	got := State[appState](w)
+	if got.count != 7 {
+		t.Fatalf("State().count = %d, want 7", got.count)
+	}
+}
+
+func TestStatePanicsOnTypeMismatch(t *testing.T) {
+	w := newTestWindow()
+	w.setState("string-state")
+	defer func() {
+		if recover() == nil {
+			t.Fatal("State[int] on a string state must panic")
+		}
+	}()
+	_ = State[int](w)
+}
+
+func TestFrameCount(t *testing.T) {
+	w := newTestWindow()
+	if got := w.FrameCount(); got != 0 {
+		t.Fatalf("FrameCount before frames = %d, want 0", got)
+	}
+	w.FrameFn()
+	w.FrameFn()
+	w.FrameFn()
+	if got := w.FrameCount(); got != 3 {
+		t.Fatalf("FrameCount after 3 FrameFn = %d, want 3", got)
+	}
+}
+
+func TestSetPrimaryGetFn(t *testing.T) {
+	w := newTestWindow()
+	if got := w.GetPrimary(); got != "" {
+		t.Fatalf("GetPrimary without fn = %q, want \"\"", got)
+	}
+	w.SetPrimaryGetFn(func() string { return "sel" })
+	if got := w.GetPrimary(); got != "sel" {
+		t.Fatalf("GetPrimary = %q, want sel", got)
+	}
+	// Clearing the fn falls back to empty.
+	w.SetPrimaryGetFn(nil)
+	if got := w.GetPrimary(); got != "" {
+		t.Fatalf("GetPrimary after nil fn = %q, want \"\"", got)
+	}
+}

--- a/gui/window_event_test.go
+++ b/gui/window_event_test.go
@@ -381,3 +381,185 @@ func TestKeyUpEventFlow_WindowToInput(t *testing.T) {
 		t.Error("Event should be marked as handled by input widget")
 	}
 }
+
+// --- IME composition and file-drop routing ---
+
+func TestEventFnRoutesIMEComposition(t *testing.T) {
+	w := newEventTestWindow()
+	w.layout = Layout{Shape: &Shape{}}
+
+	e := &Event{
+		Type:      EventIMEComposition,
+		IMEText:   "かん",
+		IMEStart:  0,
+		IMELength: 1,
+	}
+	w.EventFn(e)
+
+	if !w.IMEComposing() {
+		t.Fatal("IME composition state should be set")
+	}
+	if w.IMECompText() != "かん" {
+		t.Fatalf("IMECompText = %q, want かん", w.IMECompText())
+	}
+	if !e.IsHandled {
+		t.Error("IME composition event should be marked handled")
+	}
+}
+
+func TestEventFnIMECompositionEmptyClears(t *testing.T) {
+	w := newEventTestWindow()
+	w.layout = Layout{Shape: &Shape{}}
+	w.imeUpdate(&Event{Type: EventIMEComposition, IMEText: "字"})
+	if !w.IMEComposing() {
+		t.Fatal("precondition: composing")
+	}
+
+	// An empty preedit commits/clears the composition.
+	w.EventFn(&Event{Type: EventIMEComposition, IMEText: ""})
+	if w.IMEComposing() {
+		t.Fatal("empty composition event should clear the preedit")
+	}
+}
+
+func TestHandleIMECompositionEventDirect(t *testing.T) {
+	// The window-level wrapper updates IME state and marks the event
+	// handled, matching imeCompositionHandler.
+	w := newEventTestWindow()
+	e := &Event{
+		Type:      EventIMEComposition,
+		IMEText:   "abc",
+		IMEStart:  1,
+		IMELength: 2,
+	}
+	w.handleIMECompositionEvent(&Layout{Shape: &Shape{}}, e)
+	if w.IMECompText() != "abc" {
+		t.Fatalf("IMECompText = %q, want abc", w.IMECompText())
+	}
+	if w.IMECompCursor() != 1 || w.IMECompSelLen() != 2 {
+		t.Fatalf("clause = %d/%d, want 1/2",
+			w.IMECompCursor(), w.IMECompSelLen())
+	}
+	if !e.IsHandled {
+		t.Error("wrapper must mark the event handled")
+	}
+}
+
+func TestEventFnRoutesFileDropped(t *testing.T) {
+	w := newEventTestWindow()
+	var gotPath string
+	w.layout = Layout{
+		Shape: &Shape{},
+		Children: []Layout{
+			{Shape: &Shape{
+				shapeClip: drawClip{X: 0, Y: 0, Width: 100, Height: 100},
+				events: &eventHandlers{
+					OnFileDrop: func(ctx EventCtx) {
+						gotPath = ctx.Event.FilePath
+						ctx.Consume()
+					},
+				},
+			}},
+		},
+	}
+
+	e := &Event{
+		Type:     EventFileDropped,
+		MouseX:   50,
+		MouseY:   50,
+		FilePath: "/tmp/dropped.txt",
+	}
+	w.EventFn(e)
+
+	if gotPath != "/tmp/dropped.txt" {
+		t.Fatalf("OnFileDrop received %q, want /tmp/dropped.txt", gotPath)
+	}
+	if !e.IsHandled {
+		t.Error("file drop should be marked handled")
+	}
+}
+
+func TestEventFnFileDroppedAllowedWhenUnfocused(t *testing.T) {
+	// eventAllowed admits file drops to an unfocused window: drags
+	// land before any focus transfer.
+	w := newEventTestWindow()
+	w.focused = false
+	called := false
+	w.layout = Layout{
+		Shape: &Shape{},
+		Children: []Layout{
+			{Shape: &Shape{
+				shapeClip: drawClip{X: 0, Y: 0, Width: 100, Height: 100},
+				events: &eventHandlers{
+					OnFileDrop: func(ctx EventCtx) { called = true },
+				},
+			}},
+		},
+	}
+	w.EventFn(&Event{
+		Type:     EventFileDropped,
+		MouseX:   50,
+		MouseY:   50,
+		FilePath: "/tmp/x.txt",
+	})
+	if !called {
+		t.Error("file drop must reach the layout while unfocused")
+	}
+}
+
+func TestHandleFileDroppedEventDirect(t *testing.T) {
+	// The window-level wrapper routes to the topmost enabled child
+	// under the pointer.
+	w := newEventTestWindow()
+	var hit string
+	layout := &Layout{
+		Shape: &Shape{},
+		Children: []Layout{
+			{Shape: &Shape{
+				shapeClip: drawClip{X: 0, Y: 0, Width: 50, Height: 50},
+				events: &eventHandlers{
+					OnFileDrop: func(ctx EventCtx) { hit = "first" },
+				},
+			}},
+			{Shape: &Shape{
+				shapeClip: drawClip{X: 0, Y: 0, Width: 100, Height: 100},
+				events: &eventHandlers{
+					OnFileDrop: func(ctx EventCtx) {
+						hit = "second"
+						ctx.Consume()
+					},
+				},
+			}},
+		},
+	}
+	e := &Event{MouseX: 75, MouseY: 75, FilePath: "/tmp/a.txt"}
+	w.handleFileDroppedEvent(layout, e)
+	if hit != "second" {
+		t.Fatalf("hit = %q, want second (topmost under pointer)", hit)
+	}
+	if !e.IsHandled {
+		t.Error("wrapper should propagate IsHandled")
+	}
+}
+
+func TestEventFnFileDroppedFrozen(t *testing.T) {
+	// Time-travel freeze gates every user event, including drops.
+	w := newEventTestWindow()
+	w.frozen.Store(true)
+	called := false
+	w.layout = Layout{
+		Shape: &Shape{},
+		Children: []Layout{
+			{Shape: &Shape{
+				shapeClip: drawClip{X: 0, Y: 0, Width: 100, Height: 100},
+				events: &eventHandlers{
+					OnFileDrop: func(ctx EventCtx) { called = true },
+				},
+			}},
+		},
+	}
+	w.EventFn(&Event{Type: EventFileDropped, MouseX: 50, MouseY: 50})
+	if called {
+		t.Error("file drop must be gated while frozen")
+	}
+}


### PR DESCRIPTION
Expands test coverage in `gui/`:

- 21 existing test files extended (+1873 lines) and 2 new test files added (`view_input_layout_test.go`, `view_tree_rows_test.go`)
- Covers: input mask/state, list core, locale bundle/registry, theme (+with), view breadcrumb, date picker (+roller), image, listbox, progress bar, slider, table, toast, tree, window accessors/events

All gates green locally: `go build ./...`, `go test ./...`, `golangci-lint run ./...`.