### PR TITLE
refactor(backend): extract shared render-frame state helpers (issue #287)

### DIFF
--- a/gui/backend/android/backend.go
+++ b/gui/backend/android/backend.go
@@ -17,11 +17,12 @@ import (
 	"os"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/go-gui-org/go-glyph"
 
 	"github.com/go-gui-org/go-gui/gui"
-	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/framestate"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/imgpath"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/tempfont"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/texcache"
@@ -47,39 +48,32 @@ var (
 	androidWindow  *gui.Window
 )
 
+// glesBridge implements framestate.Bridge with the GLES C calls.
+type glesBridge struct{}
+
+func (glesBridge) SetPipeline(pipe int, mvp *[16]float32) {
+	C.glesSetPipeline(C.int(pipe))
+	C.glesSetMVP((*C.float)(unsafe.Pointer(mvp)))
+}
+
+func (glesBridge) Resize(physW, physH int32) {
+	C.glesResize(C.int(physW), C.int(physH))
+}
+
 // Backend is the Android GLES3 backend for go-gui.
+// Embeds framestate.FrameState for all shared render-frame
+// state; platform-specific resources stay on the Backend.
 type Backend struct {
-	textSys  *glyph.TextSystem
-	dpiScale float32
-	physW    int32
-	physH    int32
-	mvp      [16]float32
+	framestate.FrameState
 
-	mvpStack [][16]float32
+	textSys      *glyph.TextSystem
+	textures     texcache.Cache[string, glesTexture]
+	glyphBack    *glesGlyphBackend
+	customCache  texcache.Cache[uint64, C.int]
+	iconFontPath string
 
-	// Reusable buffers.
-	svgVerts           []gpu.Vertex
-	textPathPlacements []glyph.GlyphPlacement
-	normBuf            []gui.GradientStop
-	sampledBuf         []gui.GradientStop
-
-	textures          texcache.Cache[string, glesTexture]
-	glyphBack         *glesGlyphBackend
-	filterBlur        float32
-	filterLayer       int
-	filterColorMatrix *[16]float32
-	customCache       texcache.Cache[uint64, C.int]
-	iconFontPath      string
-
-	allowedImageRoots []string
-	imagePathCache    texcache.Cache[string, string]
-	maxImageBytes     int64
-	maxImagePixels    int64
-
-	// Pipeline state tracking to skip redundant CGo calls.
-	lastPipe   int
-	mvpDirty   bool
-	textQueued bool
+	maxImageBytes  int64
+	maxImagePixels int64
 }
 
 // --- Pattern B only (no Pattern A / Run) ---
@@ -188,28 +182,21 @@ func initBackend(w, h int32, scale float32) {
 		panic(fmt.Sprintf("android: glesInit failed: %d", rc))
 	}
 
-	physW := int32(float32(w) * scale)
-	physH := int32(float32(h) * scale)
-	C.glesResize(C.int(physW), C.int(physH))
-
 	cfg := androidWindow.Config
 	b := &Backend{
-		dpiScale: scale,
-		physW:    physW,
-		physH:    physH,
+		FrameState: *framestate.New(
+			int(pipeSolid), int(pipeGlyphTex), glesBridge{}),
 		textures: newGLESTexCacheLRU(128),
 		customCache: texcache.New[uint64, C.int](
 			maxCustomPipelines,
 			func(idx C.int) { C.glesDeleteCustomPipeline(idx) },
 		),
-		imagePathCache: texcache.New[string, string](1024, nil),
 		maxImageBytes:  cfg.MaxImageBytes,
 		maxImagePixels: cfg.MaxImagePixels,
-		lastPipe:       -1,
 	}
-	b.allowedImageRoots = imgpath.NormalizeRoots(
+	b.AllowedImageRoots = imgpath.NormalizeRoots(
 		cfg.AllowedImageRoots)
-	b.updateProjection()
+	b.HandleResize(int32(w), int32(h), scale)
 
 	// Initialize glyph text system with GLES backend.
 	b.glyphBack = newGLESGlyphBackend(scale)
@@ -260,49 +247,27 @@ func initBackend(w, h int32, scale float32) {
 // renderFrame clears the screen, draws the current layout, and
 // flushes the GL pipeline.
 func (b *Backend) renderFrame(w *gui.Window) {
-	bg := w.Config.BgColor
-	if bg == (gui.Color{}) {
-		t := gui.CurrentTheme()
-		bg = t.ColorBackground
-	}
+	r, g, bl, a := b.FrameBg(w)
 
 	C.glesBeginFrame(
-		C.float(float32(bg.R)/255.0),
-		C.float(float32(bg.G)/255.0),
-		C.float(float32(bg.B)/255.0),
-		C.float(float32(bg.A)/255.0),
+		C.float(r), C.float(g), C.float(bl), C.float(a),
 	)
 
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(b.SolidPipe)
 
 	w.Lock()
 	b.renderersDraw(w)
 	w.Unlock()
 
 	// Flush queued text.
-	if b.textQueued {
-		b.useGlyphPipeline()
-		b.textSys.Commit()
-		b.textQueued = false
-	}
+	b.FlushText(b.textSys)
 
 	C.glesEndFrame()
 }
 
 func (b *Backend) handleResize(w, h int32, scale float32) {
-	b.dpiScale = scale
-	b.physW = int32(float32(w) * scale)
-	b.physH = int32(float32(h) * scale)
-	C.glesResize(C.int(b.physW), C.int(b.physH))
-	b.updateProjection()
-}
-
-func (b *Backend) updateProjection() {
-	gpu.Ortho(&b.mvp,
-		0, float32(b.physW),
-		float32(b.physH), 0,
-		-1, 1)
+	b.HandleResize(w, h, scale)
 }
 
 // Destroy releases all backend resources.
@@ -320,29 +285,6 @@ func (b *Backend) Destroy() {
 		b.iconFontPath = ""
 	}
 	C.glesDestroy()
-}
-
-// setPipeline sets GLES pipeline and MVP, skipping redundant
-// CGo calls when unchanged.
-func (b *Backend) setPipeline(pipe int) {
-	if pipe == b.lastPipe && !b.mvpDirty {
-		return
-	}
-	C.glesSetPipeline(C.int(pipe))
-	C.glesSetMVP((*C.float)(&b.mvp[0]))
-	b.lastPipe = pipe
-	b.mvpDirty = false
-}
-
-// invalidatePipelineState forces the next setPipeline to issue
-// CGo calls.
-func (b *Backend) invalidatePipelineState() {
-	b.lastPipe = -1
-}
-
-// useGlyphPipeline sets up GLES state for glyph text rendering.
-func (b *Backend) useGlyphPipeline() {
-	b.setPipeline(pipeGlyphTex)
 }
 
 // --- OpenURI bridge ---

--- a/gui/backend/android/draw.go
+++ b/gui/backend/android/draw.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
-	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
 )
 
 // renderersDraw iterates render commands and draws them.
@@ -85,29 +84,29 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 // --- Individual draw commands ---
 
 func (b *Backend) drawClip(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	x := int32(r.X * s)
 	y := int32(r.Y * s)
 	w := int32(r.W * s)
 	h := int32(r.H * s)
 	C.glesSetScissor(C.int(x), C.int(y), C.int(w), C.int(h),
-		C.int(b.physH))
+		C.int(b.PhysH))
 }
 
 func (b *Backend) drawRect(r *gui.RenderCmd) {
 	if !r.Fill {
 		return
 	}
-	s := b.dpiScale
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		r.Color, r.Radius*s, 0)
 	C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
 func (b *Backend) drawStrokeRect(r *gui.RenderCmd) {
-	s := b.dpiScale
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		r.Color, r.Radius*s, r.Thickness*s)
 	C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
@@ -117,9 +116,9 @@ func (b *Backend) drawCircle(r *gui.RenderCmd) {
 	if !r.Fill || r.Radius <= 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	rad := r.Radius * s
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(
 		(r.X-r.Radius)*s,
 		(r.Y-r.Radius)*s,
@@ -129,7 +128,7 @@ func (b *Backend) drawCircle(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawLine(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	x0 := r.X * s
 	y0 := r.Y * s
 	x1 := r.OffsetX * s
@@ -154,12 +153,12 @@ func (b *Backend) drawLine(r *gui.RenderCmd) {
 		{X: x0 - nx, Y: y0 - ny, Z: 0, U: -1, V: 1, R: cr, G: cg, B: cb, A: ca},
 	}
 
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
 func (b *Backend) drawShadow(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	x := (r.X + r.OffsetX) * s
 	y := (r.Y + r.OffsetY) * s
 	w := r.W * s
@@ -173,7 +172,7 @@ func (b *Backend) drawShadow(r *gui.RenderCmd) {
 	qw := w + 2*expand
 	qh := h + 2*expand
 
-	b.setPipeline(pipeShadow)
+	b.SetPipeline(pipeShadow)
 
 	tm := gpu.IdentityTM()
 	tm[12] = r.OffsetX * s
@@ -185,12 +184,12 @@ func (b *Backend) drawShadow(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawBlur(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	blur := r.BlurRadius * s
 	rad := r.Radius * s
 	expand := blur * 1.5
 
-	b.setPipeline(pipeBlur)
+	b.SetPipeline(pipeBlur)
 	tm := gpu.IdentityTM()
 	C.glesSetTM((*C.float)(&tm[0]))
 
@@ -206,7 +205,7 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 		r.W <= 0 || r.H <= 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s
 	w := r.W * s
@@ -214,14 +213,14 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	rad := r.Radius * s
 
 	stops := gui.NormalizeGradientStopsInto(
-		r.Gradient.Stops, &b.normBuf, &b.sampledBuf)
+		r.Gradient.Stops, &b.NormBuf, &b.SampledBuf)
 	if len(stops) == 0 {
 		return
 	}
 
 	tm := gpu.PackGradientUniforms(r.Gradient, stops, w, h)
 
-	b.setPipeline(pipeGradient)
+	b.SetPipeline(pipeGradient)
 	C.glesSetTM((*C.float)(&tm[0]))
 
 	verts := gpu.BuildQuad(x, y, w, h, gui.White, rad, 0)
@@ -232,9 +231,9 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 	if r.Gradient == nil || len(r.Gradient.Stops) == 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	rects := gui.GradientBorderRects(r)
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	for i := range 4 {
 		rc := &rects[i]
 		verts := gpu.BuildQuad(rc.X*s, rc.Y*s, rc.W*s, rc.H*s,
@@ -244,18 +243,7 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	path, ok := b.imagePathCache.Get(r.Resource)
-	if !ok {
-		var err error
-		path, err = imgload.ResolveValidatedPath(
-			r.Resource, b.allowedImageRoots)
-		if err != nil {
-			log.Printf("android: drawImage: %v",
-				err)
-			path = "-"
-		}
-		b.imagePathCache.Set(r.Resource, path)
-	}
+	path := b.ResolveImagePath(r.Resource, "android")
 	if path == "-" {
 		return
 	}
@@ -273,7 +261,7 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 		return
 	}
 
-	s := b.dpiScale
+	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s
 	w := r.W * s
@@ -281,12 +269,12 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 
 	// Fill background.
 	if r.Color.A > 0 {
-		b.setPipeline(pipeSolid)
+		b.SetPipeline(pipeSolid)
 		verts := gpu.BuildQuad(x, y, w, h, r.Color, 0, 0)
 		C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 	}
 
-	b.setPipeline(pipeImageClip)
+	b.SetPipeline(pipeImageClip)
 	C.glesBindTexture(C.int(tex.id))
 
 	z := gpu.PackParams(r.ClipRadius*s, 0)
@@ -307,7 +295,7 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	numVerts := len(r.Triangles) / 2
 	hasVCols := len(r.VertexColors) == numVerts
 	vAlpha := float32(1)
@@ -329,10 +317,10 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 		rcx, rcy = r.RotCX, r.RotCY
 	}
 
-	if cap(b.svgVerts) < numVerts {
-		b.svgVerts = make([]gpu.Vertex, numVerts)
+	if cap(b.SVGVerts) < numVerts {
+		b.SVGVerts = make([]gpu.Vertex, numVerts)
 	}
-	verts := b.svgVerts[:numVerts]
+	verts := b.SVGVerts[:numVerts]
 	var flatR, flatG, flatB, flatA float32
 	if !hasVCols {
 		flatR, flatG, flatB, flatA = gpu.NormColor(r.Color.R, r.Color.G,
@@ -375,7 +363,7 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 		}
 	}
 
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	C.glesDrawTriangles(
 		(*C.float)(unsafe.Pointer(&verts[0])),
 		C.int(numVerts))
@@ -409,17 +397,17 @@ func (b *Backend) drawText(r *gui.RenderCmd) {
 		cfg.Block.Width = r.W
 	}
 
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil {
 		log.Printf("android: DrawText: %v", err)
 	}
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawTextPath(r *gui.RenderCmd) {
 	layout, placements, err := gui.ComputeTextPathPlacements(
-		r, b.textSys, &b.textPathPlacements,
+		r, b.textSys, &b.TextPathPlacements,
 		guiStyleToGlyphConfig)
 	if err != nil {
 		log.Printf("android: drawTextPath: %v", err)
@@ -428,19 +416,19 @@ func (b *Backend) drawTextPath(r *gui.RenderCmd) {
 	if len(placements) == 0 {
 		return
 	}
-	b.textPathPlacements = placements
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.TextPathPlacements = placements
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	b.textSys.DrawLayoutPlaced(layout, placements)
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawLayout(r *gui.RenderCmd) {
 	if b.textSys == nil || r.LayoutPtr == nil {
 		return
 	}
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	if r.TextGradient != nil {
 		b.textSys.DrawLayoutWithGradient(
 			*r.LayoutPtr, r.X, r.Y, r.TextGradient,
@@ -448,7 +436,7 @@ func (b *Backend) drawLayout(r *gui.RenderCmd) {
 	} else {
 		b.textSys.DrawLayout(*r.LayoutPtr, r.X, r.Y)
 	}
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawLayoutTransformed(r *gui.RenderCmd) {
@@ -456,8 +444,8 @@ func (b *Backend) drawLayoutTransformed(r *gui.RenderCmd) {
 		r.LayoutTransform == nil {
 		return
 	}
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	if r.TextGradient != nil {
 		b.textSys.DrawLayoutTransformedWithGradient(
 			*r.LayoutPtr, r.X, r.Y,
@@ -468,7 +456,7 @@ func (b *Backend) drawLayoutTransformed(r *gui.RenderCmd) {
 			*r.LayoutPtr, r.X, r.Y, *r.LayoutTransform,
 		)
 	}
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawRtf(r *gui.RenderCmd) {
@@ -496,9 +484,9 @@ func (b *Backend) drawCustomShader(r *gui.RenderCmd) {
 		b.customCache.Set(h, idx)
 	}
 
-	s := b.dpiScale
+	s := b.DPIScale
 	C.glesSetCustomPipeline(idx)
-	C.glesSetMVP((*C.float)(&b.mvp[0]))
+	C.glesSetMVP((*C.float)(&b.MVP[0]))
 
 	var tm [16]float32
 	for i := range min(len(r.Shader.Params), 16) {
@@ -509,7 +497,7 @@ func (b *Backend) drawCustomShader(r *gui.RenderCmd) {
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		r.Color, r.Radius*s, 0)
 	C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func buildCustomGLES3Fragment(body string) string {
@@ -559,75 +547,63 @@ void main() {
 // --- Stencil clip ---
 
 func (b *Backend) beginStencilClip(r *gui.RenderCmd) {
-	s := b.dpiScale
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		gui.White, r.Radius*s, 0)
 	C.glesBeginStencilClip(
 		(*C.float)(unsafe.Pointer(&verts[0])),
 		C.int(r.StencilDepth))
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }
 
 func (b *Backend) endStencilClip(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		gui.White, r.Radius*s, 0)
 	C.glesEndStencilClip(
 		(*C.float)(unsafe.Pointer(&verts[0])),
 		C.int(r.StencilDepth))
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }
 
 // --- Rotation ---
 
 func (b *Backend) beginRotation(r *gui.RenderCmd) {
-	b.mvpStack = append(b.mvpStack, b.mvp)
-	s := b.dpiScale
-	cx := r.RotCX * s
-	cy := r.RotCY * s
-	gpu.ApplyRotation(&b.mvp, r.RotAngle, cx, cy)
-	b.mvpDirty = true
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.BeginRotation(r.RotAngle, r.RotCX*s, r.RotCY*s)
 }
 
 func (b *Backend) endRotation() {
-	n := len(b.mvpStack)
-	if n == 0 {
-		return
-	}
-	b.mvp = b.mvpStack[n-1]
-	b.mvpStack = b.mvpStack[:n-1]
-	b.mvpDirty = true
-	b.setPipeline(pipeSolid)
+	b.EndRotation()
 }
 
 // --- Filter (glow) ---
 
 func (b *Backend) beginFilter(r *gui.RenderCmd) {
-	b.filterBlur = r.BlurRadius * b.dpiScale
-	b.filterLayer = r.Layers
-	b.filterColorMatrix = r.ColorMatrix
+	b.FilterBlur = r.BlurRadius * b.DPIScale
+	b.FilterLayer = r.Layers
+	b.FilterColorMatrix = r.ColorMatrix
 
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 
-	rc := C.glesBeginFilter(C.int(b.physW), C.int(b.physH))
+	rc := C.glesBeginFilter(C.int(b.PhysW), C.int(b.PhysH))
 	if rc != 0 {
 		return
 	}
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }
 
 func (b *Backend) endFilter() {
 	var cmPtr *C.float
-	if b.filterColorMatrix != nil {
-		cmPtr = (*C.float)(&b.filterColorMatrix[0])
+	if b.FilterColorMatrix != nil {
+		cmPtr = (*C.float)(&b.FilterColorMatrix[0])
 	}
-	C.glesEndFilter(C.float(b.filterBlur),
-		C.int(b.filterLayer), cmPtr)
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	C.glesEndFilter(C.float(b.FilterBlur),
+		C.int(b.FilterLayer), cmPtr)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }

--- a/gui/backend/android/textures.go
+++ b/gui/backend/android/textures.go
@@ -48,7 +48,7 @@ func createGLESTexture(w, h int32,
 // image to a GLES texture.
 func (b *Backend) loadImageTexture(
 	path string) (glesTexture, error) {
-	f, err := imgload.OpenSafe(path, b.allowedImageRoots)
+	f, err := imgload.OpenSafe(path, b.AllowedImageRoots)
 	if err != nil {
 		return glesTexture{}, err
 	}

--- a/gui/backend/internal/framestate/framestate.go
+++ b/gui/backend/internal/framestate/framestate.go
@@ -1,0 +1,206 @@
+// Package framestate holds backend-neutral render-frame state
+// shared by the mobile GPU backends (Android GLES, iOS Metal).
+// It deliberately contains no C or platform code: the backends
+// inject their C bridges through the Bridge interface and keep
+// all platform-specific concerns (textures, shader sources,
+// event loops) in their own files.
+package framestate
+
+import (
+	"log"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/texcache"
+)
+
+// Bridge abstracts the platform C calls that mutate GPU state.
+// Implementations convert the plain int pipe IDs and the MVP
+// matrix into their C-facing calls (e.g. glesSetPipeline /
+// metalSetPipeline). Both calls are always issued together,
+// matching the pipeline-switch semantics of the backends.
+type Bridge interface {
+	// SetPipeline switches the active pipeline and uploads the
+	// current MVP matrix.
+	SetPipeline(pipe int, mvp *[16]float32)
+
+	// Resize notifies the GPU of new physical pixel dimensions.
+	Resize(physW, physH int32)
+}
+
+// FrameState is the platform-neutral render-frame state for a
+// single window: DPI/physical dimensions, the MVP matrix and its
+// rotation stack, reusable vertex/placement buffers, pipeline
+// dirty tracking, filter (glow) parameters, and the image path
+// cache. Backends embed a FrameState and promote its methods;
+// exported fields share names with the former Backend fields so
+// platform draw code reads the same way as before.
+type FrameState struct {
+	DPIScale float32
+	PhysW    int32
+	PhysH    int32
+	MVP      [16]float32
+
+	// MVPStack holds pushed MVP matrices for RenderRotateBegin /
+	// RenderRotateEnd nesting.
+	MVPStack [][16]float32
+
+	// Reusable scratch buffers kept across frames to avoid
+	// per-frame heap allocation.
+	SVGVerts           []gpu.Vertex
+	TextPathPlacements []glyph.GlyphPlacement
+	NormBuf            []gui.GradientStop
+	SampledBuf         []gui.GradientStop
+
+	// Filter (glow) parameters for RenderFilterBegin / End.
+	FilterBlur        float32
+	FilterLayer       int
+	FilterColorMatrix *[16]float32
+
+	// Pipeline state tracking to skip redundant C bridge calls.
+	LastPipe   int
+	MVPDirty   bool
+	TextQueued bool
+
+	// AllowedImageRoots and ImagePathCache back drawImage path
+	// resolution; see ResolveImagePath.
+	AllowedImageRoots []string
+	ImagePathCache    texcache.Cache[string, string]
+
+	// SolidPipe and GlyphTexPipe are the platform pipeline IDs
+	// (plain ints; the Bridge converts them) used after rotation,
+	// stencil, and text-flush state changes.
+	SolidPipe    int
+	GlyphTexPipe int
+
+	bridge Bridge
+}
+
+// New returns a FrameState ready for the first frame. LastPipe is
+// seeded with -1 so the first SetPipeline always issues the bridge
+// calls. The image path cache holds up to 1024 entries.
+func New(solidPipe, glyphTexPipe int, bridge Bridge) *FrameState {
+	fs := &FrameState{
+		SolidPipe:    solidPipe,
+		GlyphTexPipe: glyphTexPipe,
+		LastPipe:     -1,
+		bridge:       bridge,
+	}
+	fs.ImagePathCache = texcache.New[string, string](1024, nil)
+	return fs
+}
+
+// UpdateProjection rebuilds the orthographic MVP from the current
+// physical dimensions. The Y axis points down (top-left origin).
+func (fs *FrameState) UpdateProjection() {
+	gpu.Ortho(&fs.MVP,
+		0, float32(fs.PhysW),
+		float32(fs.PhysH), 0,
+		-1, 1)
+}
+
+// SetPipeline switches the pipeline and uploads the MVP, skipping
+// redundant bridge calls when nothing changed. An invalidation
+// (InvalidatePipelineState) or a pending rotation (MVPDirty) forces
+// the bridge calls on the next call.
+func (fs *FrameState) SetPipeline(pipe int) {
+	if pipe == fs.LastPipe && !fs.MVPDirty {
+		return
+	}
+	fs.bridge.SetPipeline(pipe, &fs.MVP)
+	fs.LastPipe = pipe
+	fs.MVPDirty = false
+}
+
+// InvalidatePipelineState forces the next SetPipeline to issue
+// bridge calls even for the same pipeline (used after direct C
+// state mutation such as stencil or filter begin/end).
+func (fs *FrameState) InvalidatePipelineState() {
+	fs.LastPipe = -1
+}
+
+// UseGlyphPipeline switches to the glyph-text pipeline.
+func (fs *FrameState) UseGlyphPipeline() {
+	fs.SetPipeline(fs.GlyphTexPipe)
+}
+
+// HandleResize updates DPI and physical dimensions, notifies the
+// GPU bridge, and rebuilds the projection. The logical size and
+// scale arrive from the platform's surface-change callback.
+func (fs *FrameState) HandleResize(w, h int32, scale float32) {
+	fs.DPIScale = scale
+	fs.PhysW = int32(float32(w) * scale)
+	fs.PhysH = int32(float32(h) * scale)
+	fs.bridge.Resize(fs.PhysW, fs.PhysH)
+	fs.UpdateProjection()
+}
+
+// FrameBg resolves the frame clear color: the window's configured
+// background, falling back to the current theme's background when
+// unset. Returns normalized 0..1 components ready for the C
+// begin-frame call.
+func (fs *FrameState) FrameBg(w *gui.Window) (r, g, b, a float32) {
+	bg := w.Config.BgColor
+	if bg == (gui.Color{}) {
+		t := gui.CurrentTheme()
+		bg = t.ColorBackground
+	}
+	return float32(bg.R) / 255.0,
+		float32(bg.G) / 255.0,
+		float32(bg.B) / 255.0,
+		float32(bg.A) / 255.0
+}
+
+// BeginRotation pushes the current MVP, applies a rotation about
+// (cx, cy) in physical pixels, and re-issues the solid pipeline so
+// subsequent draws use the rotated matrix.
+func (fs *FrameState) BeginRotation(angleDeg, cx, cy float32) {
+	fs.MVPStack = append(fs.MVPStack, fs.MVP)
+	gpu.ApplyRotation(&fs.MVP, angleDeg, cx, cy)
+	fs.MVPDirty = true
+	fs.SetPipeline(fs.SolidPipe)
+}
+
+// EndRotation pops the MVP stack, restoring the matrix in effect
+// before the matching BeginRotation. A no-op on an empty stack.
+func (fs *FrameState) EndRotation() {
+	n := len(fs.MVPStack)
+	if n == 0 {
+		return
+	}
+	fs.MVP = fs.MVPStack[n-1]
+	fs.MVPStack = fs.MVPStack[:n-1]
+	fs.MVPDirty = true
+	fs.SetPipeline(fs.SolidPipe)
+}
+
+// FlushText commits queued glyph text to the GPU when any text was
+// drawn this frame, and clears the queued flag.
+func (fs *FrameState) FlushText(textSys *glyph.TextSystem) {
+	if fs.TextQueued {
+		fs.UseGlyphPipeline()
+		textSys.Commit()
+		fs.TextQueued = false
+	}
+}
+
+// ResolveImagePath returns the validated filesystem path for a
+// render resource, caching the result (including the "-" failure
+// sentinel) so validation runs once per resource. Failures are
+// logged with the backend's log prefix.
+func (fs *FrameState) ResolveImagePath(resource, logPrefix string) string {
+	if path, ok := fs.ImagePathCache.Get(resource); ok {
+		return path
+	}
+	path, err := imgload.ResolveValidatedPath(
+		resource, fs.AllowedImageRoots)
+	if err != nil {
+		log.Printf("%s: drawImage: %v", logPrefix, err)
+		path = "-"
+	}
+	fs.ImagePathCache.Set(resource, path)
+	return path
+}

--- a/gui/backend/internal/framestate/framestate_test.go
+++ b/gui/backend/internal/framestate/framestate_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/go-gui-org/go-glyph"
@@ -311,6 +312,9 @@ func (s *stubGlyphBackend) DrawTexturedQuadTransformed(
 func (s *stubGlyphBackend) DPIScale() float32 { return 1 }
 
 func TestFlushText(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("glyph.NewTextSystem requires a DOM canvas; covered on native")
+	}
 	fs, br := newTestFS()
 
 	// No text queued: nothing happens, even with a nil system.

--- a/gui/backend/internal/framestate/framestate_test.go
+++ b/gui/backend/internal/framestate/framestate_test.go
@@ -1,0 +1,335 @@
+package framestate
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// stubBridge records bridge calls for assertions.
+type stubBridge struct {
+	pipes   []int
+	mvps    [][16]float32
+	resizes [][2]int32
+}
+
+func (s *stubBridge) SetPipeline(pipe int, mvp *[16]float32) {
+	s.pipes = append(s.pipes, pipe)
+	copy := *mvp
+	s.mvps = append(s.mvps, copy)
+}
+
+func (s *stubBridge) Resize(physW, physH int32) {
+	s.resizes = append(s.resizes, [2]int32{physW, physH})
+}
+
+func newTestFS() (*FrameState, *stubBridge) {
+	br := &stubBridge{}
+	return New(7, 9, br), br
+}
+
+func TestSetPipelineDedupe(t *testing.T) {
+	fs, br := newTestFS()
+
+	fs.SetPipeline(7)
+	fs.SetPipeline(7) // same pipe, no invalidation: skipped
+	fs.InvalidatePipelineState()
+	fs.SetPipeline(7) // invalidated: re-issued
+	fs.SetPipeline(8)
+	fs.SetPipeline(8) // same pipe, skipped
+
+	if len(br.pipes) != 3 {
+		t.Fatalf("expected 3 bridge calls, got %d: %v",
+			len(br.pipes), br.pipes)
+	}
+	want := []int{7, 7, 8}
+	for i, p := range want {
+		if br.pipes[i] != p {
+			t.Errorf("call %d: pipe = %d, want %d", i, br.pipes[i], p)
+		}
+		if br.mvps[i] != fs.MVP {
+			t.Errorf("call %d: mvp not passed through", i)
+		}
+	}
+	if fs.LastPipe != 8 {
+		t.Errorf("LastPipe = %d, want 8", fs.LastPipe)
+	}
+	if fs.MVPDirty {
+		t.Error("MVPDirty should be false after SetPipeline")
+	}
+}
+
+func TestSetPipelineMVPDirtyBypassesDedupe(t *testing.T) {
+	fs, br := newTestFS()
+	fs.SetPipeline(7)
+	fs.MVPDirty = true
+	fs.SetPipeline(7) // same pipe, but dirty: re-issued
+	if len(br.pipes) != 2 {
+		t.Fatalf("expected 2 bridge calls, got %d: %v",
+			len(br.pipes), br.pipes)
+	}
+	if fs.MVPDirty {
+		t.Error("MVPDirty not cleared after SetPipeline")
+	}
+}
+
+func TestUseGlyphPipeline(t *testing.T) {
+	fs, br := newTestFS()
+	fs.UseGlyphPipeline()
+	if len(br.pipes) != 1 || br.pipes[0] != 9 {
+		t.Fatalf("UseGlyphPipeline issued pipe %v, want 9", br.pipes)
+	}
+}
+
+func TestUpdateProjection(t *testing.T) {
+	fs, _ := newTestFS()
+	fs.PhysW = 800
+	fs.PhysH = 600
+	fs.UpdateProjection()
+
+	m := fs.MVP
+	if math.Abs(float64(m[0]-2.0/800)) > 1e-6 {
+		t.Errorf("m[0] = %v, want %v", m[0], 2.0/800)
+	}
+	if math.Abs(float64(m[5]+2.0/600)) > 1e-6 {
+		t.Errorf("m[5] = %v, want %v", m[5], -2.0/600)
+	}
+	if m[12] != -1 || m[13] != 1 || m[15] != 1 {
+		t.Errorf("translation/scale wrong: m[12..15] = %v", m[12:16])
+	}
+	if m[10] != -1 {
+		t.Errorf("m[10] = %v, want -1", m[10])
+	}
+}
+
+func TestUpdateProjectionDegenerateDims(t *testing.T) {
+	fs, _ := newTestFS()
+	// Zero-area viewport (e.g. surface not yet sized) must produce
+	// an identity matrix, never NaN/Inf.
+	fs.PhysW = 0
+	fs.PhysH = 0
+	fs.UpdateProjection()
+	if fs.MVP != [16]float32{0: 1, 5: 1, 10: 1, 15: 1} {
+		t.Errorf("degenerate MVP = %v, want identity", fs.MVP)
+	}
+}
+
+func TestRotationStackRestores(t *testing.T) {
+	fs, br := newTestFS()
+	fs.PhysW = 100
+	fs.PhysH = 100
+	fs.UpdateProjection()
+	before := fs.MVP
+
+	fs.BeginRotation(90, 50, 50)
+	if len(fs.MVPStack) != 1 {
+		t.Fatalf("stack depth = %d, want 1", len(fs.MVPStack))
+	}
+	if fs.MVP == before {
+		t.Error("MVP unchanged after rotation")
+	}
+	// The dirty flag is consumed by the immediate SetPipeline, so
+	// the bridge must have received the rotated MVP with the solid
+	// pipe.
+	if n := len(br.pipes); n != 1 || br.pipes[n-1] != 7 {
+		t.Errorf("BeginRotation issued pipes %v, want [7]", br.pipes)
+	}
+	if br.mvps[0] == before {
+		t.Error("bridge received the unrotated MVP")
+	}
+
+	fs.EndRotation()
+	if fs.MVP != before {
+		t.Error("EndRotation did not restore the original MVP")
+	}
+	if len(fs.MVPStack) != 0 {
+		t.Errorf("stack depth = %d, want 0", len(fs.MVPStack))
+	}
+
+	// Empty-stack EndRotation must be a no-op, not a panic.
+	fs.EndRotation()
+}
+
+func TestRotationStackNested(t *testing.T) {
+	fs, _ := newTestFS()
+	fs.PhysW = 100
+	fs.PhysH = 100
+	fs.UpdateProjection()
+	before := fs.MVP
+
+	// Nested rotations: inner End restores the outer's matrix, the
+	// outer End restores the base matrix (LIFO).
+	fs.BeginRotation(90, 50, 50)
+	outer := fs.MVP
+	fs.BeginRotation(45, 50, 50)
+	if len(fs.MVPStack) != 2 {
+		t.Fatalf("stack depth = %d, want 2", len(fs.MVPStack))
+	}
+
+	fs.EndRotation()
+	if fs.MVP != outer {
+		t.Error("inner EndRotation did not restore the outer matrix")
+	}
+	fs.EndRotation()
+	if fs.MVP != before {
+		t.Error("outer EndRotation did not restore the base matrix")
+	}
+	if len(fs.MVPStack) != 0 {
+		t.Errorf("stack depth = %d, want 0", len(fs.MVPStack))
+	}
+}
+
+func TestHandleResize(t *testing.T) {
+	fs, br := newTestFS()
+	fs.HandleResize(400, 300, 2)
+
+	if fs.DPIScale != 2 || fs.PhysW != 800 || fs.PhysH != 600 {
+		t.Errorf("dims = %v/%v@%v, want 800/600@2",
+			fs.PhysW, fs.PhysH, fs.DPIScale)
+	}
+	if len(br.resizes) != 1 || br.resizes[0] != [2]int32{800, 600} {
+		t.Errorf("bridge resizes = %v, want [[800 600]]", br.resizes)
+	}
+	if fs.MVP[0] != 2.0/800 || fs.MVP[5] != -2.0/600 {
+		t.Errorf("projection not rebuilt on resize: %v", fs.MVP)
+	}
+
+	// A later resize with a different scale recomputes dims,
+	// notifies the bridge, and rebuilds the projection.
+	fs.HandleResize(500, 400, 1)
+	if fs.DPIScale != 1 || fs.PhysW != 500 || fs.PhysH != 400 {
+		t.Errorf("dims after resize = %v/%v@%v, want 500/400@1",
+			fs.PhysW, fs.PhysH, fs.DPIScale)
+	}
+	if len(br.resizes) != 2 || br.resizes[1] != [2]int32{500, 400} {
+		t.Errorf("bridge resizes = %v, want second [[500 400]]", br.resizes)
+	}
+	if fs.MVP[0] != 2.0/500 || fs.MVP[5] != -2.0/400 {
+		t.Errorf("projection not rebuilt after second resize: %v", fs.MVP)
+	}
+}
+
+func TestFrameBgDefaultsToTheme(t *testing.T) {
+	fs, _ := newTestFS()
+	w := gui.NewWindow(gui.WindowCfg{})
+	w.Config.BgColor = gui.Color{} // explicit zero: unset
+	r, g, b, a := fs.FrameBg(w)
+	theme := gui.CurrentTheme()
+	if r != float32(theme.ColorBackground.R)/255.0 {
+		t.Errorf("red = %v, want %v", r, float32(theme.ColorBackground.R)/255.0)
+	}
+	if g != float32(theme.ColorBackground.G)/255.0 {
+		t.Errorf("green = %v, want %v", g, float32(theme.ColorBackground.G)/255.0)
+	}
+	if b != float32(theme.ColorBackground.B)/255.0 {
+		t.Errorf("blue = %v, want %v", b, float32(theme.ColorBackground.B)/255.0)
+	}
+	if a != float32(theme.ColorBackground.A)/255.0 {
+		t.Errorf("alpha = %v, want %v", a, float32(theme.ColorBackground.A)/255.0)
+	}
+}
+
+func TestFrameBgExplicitColor(t *testing.T) {
+	fs, _ := newTestFS()
+	w := gui.NewWindow(gui.WindowCfg{})
+	w.Config.BgColor = gui.RGB(255, 128, 64)
+	r, g, b, a := fs.FrameBg(w)
+	// 128/255 and 64/255 do not round-trip through float32
+	// exactly; compare with a tolerance.
+	if r != 1 || math.Abs(float64(g)-0.5) > 0.003 ||
+		math.Abs(float64(b)-0.25) > 0.003 || a != 1 {
+		t.Errorf("components = %v/%v/%v/%v, want 1/0.5/0.25/1", r, g, b, a)
+	}
+}
+
+func TestResolveImagePath(t *testing.T) {
+	fs, _ := newTestFS()
+	root := t.TempDir()
+	fs.AllowedImageRoots = []string{root}
+
+	good := filepath.Join(root, "a.png")
+	if err := os.WriteFile(good, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// ResolveValidatedPath canonicalizes symlinks, so resolve the
+	// expected path the same way.
+	want, err := filepath.EvalSymlinks(good)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p := fs.ResolveImagePath(good, "test:"); p != want {
+		t.Errorf("path = %q, want %q", p, want)
+	}
+
+	// A missing file inside a root resolves fine (path validation
+	// only); decode failure is handled at texture upload time.
+	// ResolveWithParentFallback canonicalizes the parent dir.
+	rootReal, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(root, "nope.png")
+	wantMissing := filepath.Join(rootReal, "nope.png")
+	if p := fs.ResolveImagePath(missing, "test:"); p != wantMissing {
+		t.Errorf("missing path = %q, want %q", p, wantMissing)
+	}
+
+	// Paths outside the allowed roots are rejected.
+	if p := fs.ResolveImagePath(filepath.Join(t.TempDir(), "x.png"), "test:"); p != "-" {
+		t.Errorf("outside-root path = %q, want %q", p, "-")
+	}
+
+	// A NUL byte is a validation failure.
+	if p := fs.ResolveImagePath("a\x00b.png", "test:"); p != "-" {
+		t.Errorf("NUL path = %q, want %q", p, "-")
+	}
+
+	// Cache: the sentinel is stored, so a second resolve of the
+	// same key must not re-validate (same result, no error).
+	if p := fs.ResolveImagePath(filepath.Join(t.TempDir(), "x.png"), "test:"); p != "-" {
+		t.Errorf("cached outside-root path = %q, want %q", p, "-")
+	}
+}
+
+// stubGlyphBackend implements glyph.DrawBackend without any GPU.
+type stubGlyphBackend struct{}
+
+func (s *stubGlyphBackend) NewTexture(width, height int) glyph.TextureID  { return 0 }
+func (s *stubGlyphBackend) UpdateTexture(id glyph.TextureID, data []byte) {}
+func (s *stubGlyphBackend) DeleteTexture(id glyph.TextureID)              {}
+func (s *stubGlyphBackend) DrawTexturedQuad(id glyph.TextureID, src, dst glyph.Rect, c glyph.Color) {
+}
+func (s *stubGlyphBackend) DrawFilledRect(dst glyph.Rect, c glyph.Color) {}
+func (s *stubGlyphBackend) DrawTexturedQuadTransformed(
+	id glyph.TextureID, src, dst glyph.Rect, c glyph.Color, t glyph.AffineTransform) {
+}
+func (s *stubGlyphBackend) DPIScale() float32 { return 1 }
+
+func TestFlushText(t *testing.T) {
+	fs, br := newTestFS()
+
+	// No text queued: nothing happens, even with a nil system.
+	fs.FlushText(nil)
+	if len(br.pipes) != 0 {
+		t.Fatalf("flush issued pipes with nothing queued: %v", br.pipes)
+	}
+
+	// Queued text: commits and clears the flag.
+	textSys, err := glyph.NewTextSystem(&stubGlyphBackend{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.TextQueued = true
+	fs.FlushText(textSys)
+	if len(br.pipes) != 1 || br.pipes[0] != 9 {
+		t.Errorf("flush issued pipes %v, want [9] (glyph tex)", br.pipes)
+	}
+	if fs.TextQueued {
+		t.Error("TextQueued still set after flush")
+	}
+}

--- a/gui/backend/ios/backend.go
+++ b/gui/backend/ios/backend.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-gui-org/go-glyph"
 
 	"github.com/go-gui-org/go-gui/gui"
-	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/framestate"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/imgpath"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/msl"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/tempfont"
@@ -50,39 +50,32 @@ var (
 	iosWindow  *gui.Window
 )
 
+// metalBridge implements framestate.Bridge with the Metal C calls.
+type metalBridge struct{}
+
+func (metalBridge) SetPipeline(pipe int, mvp *[16]float32) {
+	C.metalSetPipeline(C.int(pipe))
+	C.metalSetMVP((*C.float)(unsafe.Pointer(mvp)))
+}
+
+func (metalBridge) Resize(physW, physH int32) {
+	C.metalResize(C.int(physW), C.int(physH))
+}
+
 // Backend is the iOS Metal backend for go-gui.
+// Embeds framestate.FrameState for all shared render-frame
+// state; platform-specific resources stay on the Backend.
 type Backend struct {
-	textSys  *glyph.TextSystem
-	dpiScale float32
-	physW    int32
-	physH    int32
-	mvp      [16]float32
+	framestate.FrameState
 
-	mvpStack [][16]float32
+	textSys      *glyph.TextSystem
+	textures     texcache.Cache[string, metalTexture]
+	glyphBack    *metalGlyphBackend
+	customCache  texcache.Cache[uint64, C.int]
+	iconFontPath string
 
-	// Reusable buffers.
-	svgVerts           []gpu.Vertex
-	textPathPlacements []glyph.GlyphPlacement
-	normBuf            []gui.GradientStop
-	sampledBuf         []gui.GradientStop
-
-	textures          texcache.Cache[string, metalTexture]
-	glyphBack         *metalGlyphBackend
-	filterBlur        float32
-	filterLayer       int
-	filterColorMatrix *[16]float32
-	customCache       texcache.Cache[uint64, C.int]
-	iconFontPath      string
-
-	allowedImageRoots []string
-	imagePathCache    texcache.Cache[string, string]
-	maxImageBytes     int64
-	maxImagePixels    int64
-
-	// Pipeline state tracking to skip redundant CGo calls.
-	lastPipe   int
-	mvpDirty   bool
-	textQueued bool
+	maxImageBytes  int64
+	maxImagePixels int64
 }
 
 // --- Pattern A: Go-driven (backend.Run) ---
@@ -123,22 +116,19 @@ func initBackend(layerPtr unsafe.Pointer,
 
 	cfg := iosWindow.Config
 	b := &Backend{
-		dpiScale: scale,
-		physW:    physW,
-		physH:    physH,
+		FrameState: *framestate.New(
+			int(pipeSolid), int(pipeGlyphTex), metalBridge{}),
 		textures: newMetalTexCacheLRU(128),
 		customCache: texcache.New[uint64, C.int](
 			maxCustomPipelines,
 			func(idx C.int) { C.metalDeleteCustomPipeline(idx) },
 		),
-		imagePathCache: texcache.New[string, string](1024, nil),
 		maxImageBytes:  cfg.MaxImageBytes,
 		maxImagePixels: cfg.MaxImagePixels,
-		lastPipe:       -1,
 	}
-	b.allowedImageRoots = imgpath.NormalizeRoots(
+	b.AllowedImageRoots = imgpath.NormalizeRoots(
 		cfg.AllowedImageRoots)
-	b.updateProjection()
+	b.HandleResize(int32(w), int32(h), scale)
 
 	// Initialize glyph text system with Metal backend.
 	b.glyphBack = newMetalGlyphBackend(scale)
@@ -188,52 +178,30 @@ func initBackend(layerPtr unsafe.Pointer,
 // renderFrame clears the screen, draws the current layout, and
 // presents the Metal drawable.
 func (b *Backend) renderFrame(w *gui.Window) {
-	bg := w.Config.BgColor
-	if bg == (gui.Color{}) {
-		t := gui.CurrentTheme()
-		bg = t.ColorBackground
-	}
+	r, g, bl, a := b.FrameBg(w)
 
 	rc := C.metalBeginFrame(
-		C.float(float32(bg.R)/255.0),
-		C.float(float32(bg.G)/255.0),
-		C.float(float32(bg.B)/255.0),
-		C.float(float32(bg.A)/255.0),
+		C.float(r), C.float(g), C.float(bl), C.float(a),
 	)
 	if rc != 0 {
 		return
 	}
 
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(b.SolidPipe)
 
 	w.Lock()
 	b.renderersDraw(w)
 	w.Unlock()
 
 	// Flush queued text.
-	if b.textQueued {
-		b.useGlyphPipeline()
-		b.textSys.Commit()
-		b.textQueued = false
-	}
+	b.FlushText(b.textSys)
 
 	C.metalEndFrame()
 }
 
 func (b *Backend) handleResize(w, h int32, scale float32) {
-	b.dpiScale = scale
-	b.physW = int32(float32(w) * scale)
-	b.physH = int32(float32(h) * scale)
-	C.metalResize(C.int(b.physW), C.int(b.physH))
-	b.updateProjection()
-}
-
-func (b *Backend) updateProjection() {
-	gpu.Ortho(&b.mvp,
-		0, float32(b.physW),
-		float32(b.physH), 0,
-		-1, 1)
+	b.HandleResize(w, h, scale)
 }
 
 // Destroy releases all backend resources.
@@ -251,29 +219,6 @@ func (b *Backend) Destroy() {
 		b.iconFontPath = ""
 	}
 	C.metalDestroy()
-}
-
-// setPipeline sets Metal pipeline and MVP, skipping redundant
-// CGo calls when unchanged.
-func (b *Backend) setPipeline(pipe int) {
-	if pipe == b.lastPipe && !b.mvpDirty {
-		return
-	}
-	C.metalSetPipeline(C.int(pipe))
-	C.metalSetMVP((*C.float)(&b.mvp[0]))
-	b.lastPipe = pipe
-	b.mvpDirty = false
-}
-
-// invalidatePipelineState forces the next setPipeline to issue
-// CGo calls.
-func (b *Backend) invalidatePipelineState() {
-	b.lastPipe = -1
-}
-
-// useGlyphPipeline sets up Metal state for glyph text rendering.
-func (b *Backend) useGlyphPipeline() {
-	b.setPipeline(pipeGlyphTex)
 }
 
 // --- Exported callbacks for ios_app.m (Pattern A) ---

--- a/gui/backend/ios/draw.go
+++ b/gui/backend/ios/draw.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
-	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
 )
 
 // renderersDraw iterates render commands and draws them.
@@ -85,29 +84,29 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 // --- Individual draw commands ---
 
 func (b *Backend) drawClip(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	x := int32(r.X * s)
 	y := int32(r.Y * s)
 	w := int32(r.W * s)
 	h := int32(r.H * s)
 	C.metalSetScissor(C.int(x), C.int(y), C.int(w), C.int(h),
-		C.int(b.physH))
+		C.int(b.PhysH))
 }
 
 func (b *Backend) drawRect(r *gui.RenderCmd) {
 	if !r.Fill {
 		return
 	}
-	s := b.dpiScale
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		r.Color, r.Radius*s, 0)
 	C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
 func (b *Backend) drawStrokeRect(r *gui.RenderCmd) {
-	s := b.dpiScale
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		r.Color, r.Radius*s, r.Thickness*s)
 	C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
@@ -117,9 +116,9 @@ func (b *Backend) drawCircle(r *gui.RenderCmd) {
 	if !r.Fill || r.Radius <= 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	rad := r.Radius * s
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(
 		(r.X-r.Radius)*s,
 		(r.Y-r.Radius)*s,
@@ -129,7 +128,7 @@ func (b *Backend) drawCircle(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawLine(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	x0 := r.X * s
 	y0 := r.Y * s
 	x1 := r.OffsetX * s
@@ -154,12 +153,12 @@ func (b *Backend) drawLine(r *gui.RenderCmd) {
 		{X: x0 - nx, Y: y0 - ny, Z: 0, U: -1, V: 1, R: cr, G: cg, B: cb, A: ca},
 	}
 
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
 func (b *Backend) drawShadow(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	x := (r.X + r.OffsetX) * s
 	y := (r.Y + r.OffsetY) * s
 	w := r.W * s
@@ -173,7 +172,7 @@ func (b *Backend) drawShadow(r *gui.RenderCmd) {
 	qw := w + 2*expand
 	qh := h + 2*expand
 
-	b.setPipeline(pipeShadow)
+	b.SetPipeline(pipeShadow)
 
 	tm := gpu.IdentityTM()
 	tm[12] = r.OffsetX * s
@@ -185,12 +184,12 @@ func (b *Backend) drawShadow(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawBlur(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	blur := r.BlurRadius * s
 	rad := r.Radius * s
 	expand := blur * 1.5
 
-	b.setPipeline(pipeBlur)
+	b.SetPipeline(pipeBlur)
 	tm := gpu.IdentityTM()
 	C.metalSetTM((*C.float)(&tm[0]))
 
@@ -206,7 +205,7 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 		r.W <= 0 || r.H <= 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s
 	w := r.W * s
@@ -214,14 +213,14 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	rad := r.Radius * s
 
 	stops := gui.NormalizeGradientStopsInto(
-		r.Gradient.Stops, &b.normBuf, &b.sampledBuf)
+		r.Gradient.Stops, &b.NormBuf, &b.SampledBuf)
 	if len(stops) == 0 {
 		return
 	}
 
 	tm := gpu.PackGradientUniforms(r.Gradient, stops, w, h)
 
-	b.setPipeline(pipeGradient)
+	b.SetPipeline(pipeGradient)
 	C.metalSetTM((*C.float)(&tm[0]))
 
 	verts := gpu.BuildQuad(x, y, w, h, gui.White, rad, 0)
@@ -232,9 +231,9 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 	if r.Gradient == nil || len(r.Gradient.Stops) == 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	rects := gui.GradientBorderRects(r)
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	for i := range 4 {
 		rc := &rects[i]
 		verts := gpu.BuildQuad(rc.X*s, rc.Y*s, rc.W*s, rc.H*s,
@@ -244,18 +243,7 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	path, ok := b.imagePathCache.Get(r.Resource)
-	if !ok {
-		var err error
-		path, err = imgload.ResolveValidatedPath(
-			r.Resource, b.allowedImageRoots)
-		if err != nil {
-			log.Printf("ios: drawImage: %v",
-				err)
-			path = "-"
-		}
-		b.imagePathCache.Set(r.Resource, path)
-	}
+	path := b.ResolveImagePath(r.Resource, "ios")
 	if path == "-" {
 		return
 	}
@@ -273,7 +261,7 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 		return
 	}
 
-	s := b.dpiScale
+	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s
 	w := r.W * s
@@ -281,12 +269,12 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 
 	// Fill background.
 	if r.Color.A > 0 {
-		b.setPipeline(pipeSolid)
+		b.SetPipeline(pipeSolid)
 		verts := gpu.BuildQuad(x, y, w, h, r.Color, 0, 0)
 		C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 	}
 
-	b.setPipeline(pipeImageClip)
+	b.SetPipeline(pipeImageClip)
 	C.metalBindTexture(C.int(tex.id))
 
 	z := gpu.PackParams(r.ClipRadius*s, 0)
@@ -307,7 +295,7 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
 		return
 	}
-	s := b.dpiScale
+	s := b.DPIScale
 	numVerts := len(r.Triangles) / 2
 	hasVCols := len(r.VertexColors) == numVerts
 	vAlpha := float32(1)
@@ -329,10 +317,10 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 		rcx, rcy = r.RotCX, r.RotCY
 	}
 
-	if cap(b.svgVerts) < numVerts {
-		b.svgVerts = make([]gpu.Vertex, numVerts)
+	if cap(b.SVGVerts) < numVerts {
+		b.SVGVerts = make([]gpu.Vertex, numVerts)
 	}
-	verts := b.svgVerts[:numVerts]
+	verts := b.SVGVerts[:numVerts]
 	var flatR, flatG, flatB, flatA float32
 	if !hasVCols {
 		flatR, flatG, flatB, flatA = gpu.NormColor(r.Color.R, r.Color.G,
@@ -375,7 +363,7 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 		}
 	}
 
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 	C.metalDrawTriangles(
 		(*C.float)(unsafe.Pointer(&verts[0])),
 		C.int(numVerts))
@@ -409,17 +397,17 @@ func (b *Backend) drawText(r *gui.RenderCmd) {
 		cfg.Block.Width = r.W
 	}
 
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil {
 		log.Printf("ios: DrawText: %v", err)
 	}
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawTextPath(r *gui.RenderCmd) {
 	layout, placements, err := gui.ComputeTextPathPlacements(
-		r, b.textSys, &b.textPathPlacements,
+		r, b.textSys, &b.TextPathPlacements,
 		guiStyleToGlyphConfig)
 	if err != nil {
 		log.Printf("ios: drawTextPath: %v", err)
@@ -428,19 +416,19 @@ func (b *Backend) drawTextPath(r *gui.RenderCmd) {
 	if len(placements) == 0 {
 		return
 	}
-	b.textPathPlacements = placements
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.TextPathPlacements = placements
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	b.textSys.DrawLayoutPlaced(layout, placements)
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawLayout(r *gui.RenderCmd) {
 	if b.textSys == nil || r.LayoutPtr == nil {
 		return
 	}
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	if r.TextGradient != nil {
 		b.textSys.DrawLayoutWithGradient(
 			*r.LayoutPtr, r.X, r.Y, r.TextGradient,
@@ -448,7 +436,7 @@ func (b *Backend) drawLayout(r *gui.RenderCmd) {
 	} else {
 		b.textSys.DrawLayout(*r.LayoutPtr, r.X, r.Y)
 	}
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawLayoutTransformed(r *gui.RenderCmd) {
@@ -456,8 +444,8 @@ func (b *Backend) drawLayoutTransformed(r *gui.RenderCmd) {
 		r.LayoutTransform == nil {
 		return
 	}
-	b.useGlyphPipeline()
-	b.textQueued = true
+	b.UseGlyphPipeline()
+	b.TextQueued = true
 	if r.TextGradient != nil {
 		b.textSys.DrawLayoutTransformedWithGradient(
 			*r.LayoutPtr, r.X, r.Y,
@@ -468,7 +456,7 @@ func (b *Backend) drawLayoutTransformed(r *gui.RenderCmd) {
 			*r.LayoutPtr, r.X, r.Y, *r.LayoutTransform,
 		)
 	}
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func (b *Backend) drawRtf(r *gui.RenderCmd) {
@@ -496,9 +484,9 @@ func (b *Backend) drawCustomShader(r *gui.RenderCmd) {
 		b.customCache.Set(h, idx)
 	}
 
-	s := b.dpiScale
+	s := b.DPIScale
 	C.metalSetCustomPipeline(idx)
-	C.metalSetMVP((*C.float)(&b.mvp[0]))
+	C.metalSetMVP((*C.float)(&b.MVP[0]))
 
 	var tm [16]float32
 	for i := range min(len(r.Shader.Params), 16) {
@@ -509,7 +497,7 @@ func (b *Backend) drawCustomShader(r *gui.RenderCmd) {
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		r.Color, r.Radius*s, 0)
 	C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
-	b.invalidatePipelineState()
+	b.InvalidatePipelineState()
 }
 
 func buildCustomMSL(body string) string {
@@ -586,75 +574,63 @@ fragment float4 fs_main(
 // --- Stencil clip ---
 
 func (b *Backend) beginStencilClip(r *gui.RenderCmd) {
-	s := b.dpiScale
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.SetPipeline(pipeSolid)
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		gui.White, r.Radius*s, 0)
 	C.metalBeginStencilClip(
 		(*C.float)(unsafe.Pointer(&verts[0])),
 		C.int(r.StencilDepth))
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }
 
 func (b *Backend) endStencilClip(r *gui.RenderCmd) {
-	s := b.dpiScale
+	s := b.DPIScale
 	verts := gpu.BuildQuad(r.X*s, r.Y*s, r.W*s, r.H*s,
 		gui.White, r.Radius*s, 0)
 	C.metalEndStencilClip(
 		(*C.float)(unsafe.Pointer(&verts[0])),
 		C.int(r.StencilDepth))
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }
 
 // --- Rotation ---
 
 func (b *Backend) beginRotation(r *gui.RenderCmd) {
-	b.mvpStack = append(b.mvpStack, b.mvp)
-	s := b.dpiScale
-	cx := r.RotCX * s
-	cy := r.RotCY * s
-	gpu.ApplyRotation(&b.mvp, r.RotAngle, cx, cy)
-	b.mvpDirty = true
-	b.setPipeline(pipeSolid)
+	s := b.DPIScale
+	b.BeginRotation(r.RotAngle, r.RotCX*s, r.RotCY*s)
 }
 
 func (b *Backend) endRotation() {
-	n := len(b.mvpStack)
-	if n == 0 {
-		return
-	}
-	b.mvp = b.mvpStack[n-1]
-	b.mvpStack = b.mvpStack[:n-1]
-	b.mvpDirty = true
-	b.setPipeline(pipeSolid)
+	b.EndRotation()
 }
 
 // --- Filter (glow) ---
 
 func (b *Backend) beginFilter(r *gui.RenderCmd) {
-	b.filterBlur = r.BlurRadius * b.dpiScale
-	b.filterLayer = r.Layers
-	b.filterColorMatrix = r.ColorMatrix
+	b.FilterBlur = r.BlurRadius * b.DPIScale
+	b.FilterLayer = r.Layers
+	b.FilterColorMatrix = r.ColorMatrix
 
-	b.setPipeline(pipeSolid)
+	b.SetPipeline(pipeSolid)
 
-	rc := C.metalBeginFilter(C.int(b.physW), C.int(b.physH))
+	rc := C.metalBeginFilter(C.int(b.PhysW), C.int(b.PhysH))
 	if rc != 0 {
 		return
 	}
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }
 
 func (b *Backend) endFilter() {
 	var cmPtr *C.float
-	if b.filterColorMatrix != nil {
-		cmPtr = (*C.float)(&b.filterColorMatrix[0])
+	if b.FilterColorMatrix != nil {
+		cmPtr = (*C.float)(&b.FilterColorMatrix[0])
 	}
-	C.metalEndFilter(C.float(b.filterBlur),
-		C.int(b.filterLayer), cmPtr)
-	b.invalidatePipelineState()
-	b.setPipeline(pipeSolid)
+	C.metalEndFilter(C.float(b.FilterBlur),
+		C.int(b.FilterLayer), cmPtr)
+	b.InvalidatePipelineState()
+	b.SetPipeline(pipeSolid)
 }

--- a/gui/backend/ios/textures.go
+++ b/gui/backend/ios/textures.go
@@ -48,7 +48,7 @@ func createMetalTexture(w, h int32,
 // image to a Metal texture.
 func (b *Backend) loadImageTexture(
 	path string) (metalTexture, error) {
-	f, err := imgload.OpenSafe(path, b.allowedImageRoots)
+	f, err := imgload.OpenSafe(path, b.AllowedImageRoots)
 	if err != nil {
 		return metalTexture{}, err
 	}


### PR DESCRIPTION
## Summary

First slice of issue #287: extract backend-neutral render-frame state from the Android (GLES) and iOS (Metal) backends into a shared pure-Go package.

## Changes

- New `gui/backend/internal/framestate` package: `FrameState` struct + methods for DPI/physical dims, MVP + rotation stack, reusable buffers, pipeline dirty tracking, filter params, image-path cache, frame bg color. Platform C calls behind a 2-method `Bridge` interface; pipe IDs pass as plain ints.
- Android/iOS `Backend` now embeds `framestate.FrameState`; deleted 17 duplicated struct fields and the duplicated `updateProjection`/`setPipeline`/`invalidatePipelineState`/`useGlyphPipeline`/rotation/frame-bg/text-flush/drawImage path-resolution logic.
- Platform files keep: all C calls, custom-shader source builders, glyph backends, texture upload, events/bridges.
- 12 new unit tests (pipeline dedupe, projection incl. degenerate dims, rotation stack incl. nesting, resize, bg fallback, image path resolution).

Net: 370 lines deleted, 209 added across platform files.

## Verification

- `make check-all` green (test + lint + vet + gates)
- Android build + vet with NDK clean
- iOS `go vet -tags ios` (CI-equivalent) clean

Follow-up slices (not in this PR, per issue scope): draw-loop extraction behind the bridge, desktop Metal `windowState` adoption, glyph-backend unification.

Closes #287