### PR TITLE
chore: keep build artifacts out of repo root; drop cgo from desktop builds (#289)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,8 @@ jobs:
           repository: go-gui-org/go-glyph
           path: go-glyph
 
+      # msys2 is kept only for the `zip` tool the Package step uses; the
+      # showcase itself builds cgo-free (purego GL bindings, #155).
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -127,8 +129,6 @@ jobs:
           release: false
           path-type: inherit
           install: >-
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-pkg-config
             zip
 
       - uses: actions/setup-go@v6
@@ -143,7 +143,7 @@ jobs:
         working-directory: go-gui
         run: |
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=gcc \
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
             go build -ldflags \
               "-X github.com/go-gui-org/go-gui/gui.Version=${VERSION} \
                -X github.com/go-gui-org/go-gui/gui.Commit=$(git rev-parse --short HEAD)" \

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,23 @@
 !*/
 ### Above combination will ignore all files without extension
 
+# Build outputs belong in build/ or examples/bin/ — never the repo root.
+# The catch-all above already ignores extensionless binaries, but these
+# strays were built with a bare `go build` before -o conventions existed.
+# `make clean` removes them; do not recreate them. Add new tool/example
+# binaries here if one slips through.
+/showcase
+/fontviewer
+/listbox
+/get_started
+/command_demo
+/process_monitor
+/scroll_demo
+/depsdoc
+/exportaudit
+/ergonomics-audit
+/readme_check
+
 !Makefile
 !LICENSE
 !.githooks/pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,13 @@ For a tight edit → rebuild → relaunch loop while iterating on an example app
 see [docs/dev-loop.md](docs/dev-loop.md)
 (`./scripts/dev-loop.sh ./examples/get_started/`).
 
+Build artifacts never land in the repo root: `make build-examples` writes each
+example to `examples/bin/`, `make build-macos`/`build-windows`/etc. write to
+`build/`, and `scripts/dev-loop.sh` writes to `build/dev-loop/`. A bare
+`go build ./examples/<name>/` or `go build ./tools/<name>/` drops a binary in
+the repo root, so always pass `-o` with an explicit output path (e.g.
+`-o build/<name>`).
+
 `go vet` does not run the `requiredid` analyzer — it is a standalone
 framework-owned analyzer. CI runs it on every push, and `make vet` includes it.
 Adopter projects can invoke it the same way, standalone, without the Makefile:
@@ -78,27 +85,3 @@ package that demonstrates a specific feature or pattern.
 ## License
 
 Contributions are accepted under the [MIT License](LICENSE).
-
-## Troubleshooting
-
-### Windows: `undefined reference to __ms_vsscanf`
-
-`gui/compat_mingw.go` provides a compatibility shim so **this error should not
-appear** when building with current go-gui. If you see it on an older revision:
-
-**Why:** Bundled static libraries compiled against older MinGW GCC may reference
-`__ms_vsscanf`, which was removed in MinGW-w64 GCC ≥15. The
-`gui/compat_mingw.go` file provides a compatibility shim.
-
-**Solutions (pick one):**
-
-1. **Update go-gui** to a revision that includes `gui/compat_mingw.go`.
-
-2. **Use dynamic linking** (simplest for development):
-
-   ```bash
-   CGO_ENABLED=1 go build ./examples/showcase/
-   ```
-
-3. **Use the release zip's pre-built binary.** Download from the latest GitHub
-   release.

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,20 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS  = -X github.com/go-gui-org/go-gui/gui.Version=$(VERSION) \
            -X github.com/go-gui-org/go-gui/gui.Commit=$(COMMIT)
 
-CC_WINDOWS ?= x86_64-w64-mingw32-gcc
 LINT_VERSION = v2.12.2
 
 .PHONY: build-linux build-windows build-macos build-wasm build-ios build-android build-examples release clean test test-race vet lint check bench bench-gate deps-doc deps-doc-check security gosec govulncheck large-files deadcode generate-check tidy-check workflow-audit cov-report license-check ergonomics-audit ergonomics-audit-fix ergonomics-audit-fix-dry
 
+# Desktop builds are cgo-free since the purego GL bindings (#155): the
+# backend/gl uses X11/xgb + purego EGL on Linux and Win32 syscalls on
+# Windows. Only macOS (Metal) and the mobile backends need cgo.
 build-linux:
-	CGO_ENABLED=1 \
+	CGO_ENABLED=0 \
 	go build -ldflags "$(LDFLAGS)" \
 	  -o build/showcase-linux ./examples/showcase/
 
 build-windows:
-	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=$(CC_WINDOWS) \
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
 	go build -ldflags "$(LDFLAGS)" \
 	  -o build/showcase-windows.exe ./examples/showcase/
 
@@ -87,8 +89,16 @@ bench-gate:
 	  -bench='Benchmark(Layout|GenerateViewLayout|ViewFrame|ParseSvg|Tessellate|BuildDefsPathDataCache|RenderLayout|RenderSvg)' \
 	  -benchmem -count=5 -run='^$$' -timeout=15m ./gui/...
 
+# Remove all build artifacts: the two artifact directories plus the stray
+# root-level binaries produced by bare `go build ./examples/<name>/` or
+# `go build ./tools/<name>/` before -o conventions were documented. New
+# binaries belong in build/ or examples/bin/, never the repo root.
 clean:
 	rm -rf build/
+	rm -rf examples/bin/
+	rm -f showcase fontviewer listbox get_started command_demo \
+	  process_monitor scroll_demo depsdoc exportaudit \
+	  ergonomics-audit readme_check
 
 # Run all tests with explicit timeout.
 # The gl backend must run cgo-free on Linux with a display: cgo + the


### PR DESCRIPTION
Closes #289.

## Root-level build artifacts

The repo root had accumulated 11 stray ignored binaries (`showcase`, `fontviewer`, `listbox`, `get_started`, `command_demo`, `process_monitor`, `scroll_demo`, `depsdoc`, `exportaudit`, `ergonomics-audit`, orphan `readme_check`), produced by bare `go build ./examples/<name>/` runs. The `.gitignore` extensionless catch-all hid them silently.

- **CONTRIBUTING.md** — deleted the Windows `__ms_vsscanf` troubleshooting section (fix is in-tree via `gui/compat_mingw.go`; the release pipeline exercises the MinGW path every release). Its `go build ./examples/showcase/` was the only documented root-producing build. Added an artifact-layout note: binaries belong in `build/` or `examples/bin/`, never the repo root; always pass `-o`.
- **Makefile `clean`** — now also removes `examples/bin/` and the known stray root binaries.
- **.gitignore** — explicit `/name` entries for the strays with a comment explaining where binaries belong.
- All 11 strays deleted from the working tree.

## CGO_ENABLED=1 audit

Scanned all `CGO_ENABLED=1` sites. The Linux/Windows desktop builds were leftovers from the pre-purego (go-gl) era:

- **`make build-linux`** — `CGO_ENABLED=1` predates the purego GL bindings (#155); backend/gl has zero cgo files. Now `CGO_ENABLED=0`.
- **`make build-windows`** — was `CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc` (mingw static-build era, f282f91). Now `CGO_ENABLED=0`; removed the unused `CC_WINDOWS` variable.
- **release.yml Windows job** — dropped `CGO_ENABLED=1 CC=gcc`; msys2 install trimmed to `zip` only (the Package step's sole remaining need).
- iOS/Android sites kept — ObjC backend / purego `cgo.Dlopen` + C ES3 driver respectively.

Verified: `CGO_ENABLED=0` cross-builds of showcase for linux/amd64 and windows/amd64 succeed; CI independently smoke-tests the cgo-free Windows showcase.

No tracked source or release artifact workflow disrupted.