### PR TITLE
refactor(gui): unexport Theme.WithInspectorStyle, finish issue #288 API-surface review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,16 @@ and this project adheres to
   `MouseInvalid`. The event is still `Type: EventMouseMove` and is
   rebuilt field-by-field every frame.
 
+- **`Theme.WithInspectorStyle` is unexported (breaking; no known
+  consumers).** It was the only exported member of the `with*Style`
+  family and was carried on an `exportaudit:keep` claim of sibling-repo
+  use that does not exist. It is now `withInspectorStyle`, matching
+  `withDataGridStyle` and the rest of the family. This completes the
+  issue #288 API-surface review: with all sibling repos scanned, the
+  authoritative audit reports a clean surface — one `none` export
+  (`FillBorder`, intentionally public, showcase-documented) and every
+  self/selftest-only export carries a justified keep marker.
+
 ### Added
 
 - **Markdown interaction test suite expands to the nested-document and

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -200,7 +200,7 @@ func (c evClass) name() string {
 //
 // Named TestUnconsumedEvents before v0.55.0, when it measured the cost of
 // a collapse that has since happened.
-// exportaudit:keep — public testing API used by sibling repos
+// exportaudit:keep — public testing API in the documented Test* family
 func (w *Window) TestUnconsumedEvents() []string {
 	root := w.TestRender(nil)
 	if root == nil {

--- a/gui/theme_with.go
+++ b/gui/theme_with.go
@@ -180,9 +180,8 @@ func (t Theme) withDataGridStyle(s DataGridStyle) Theme {
 	return t
 }
 
-// WithInspectorStyle returns a Theme with the given style.
-// exportaudit:keep — public theme API used by sibling repos
-func (t Theme) WithInspectorStyle(s InspectorStyle) Theme {
+// withInspectorStyle returns a Theme with the given style.
+func (t Theme) withInspectorStyle(s InspectorStyle) Theme {
 	t.inspectorStyle = s
 	return t
 }

--- a/gui/theme_with_test.go
+++ b/gui/theme_with_test.go
@@ -65,12 +65,12 @@ func TestWithTextStyleUsesTextStyleDefField(t *testing.T) {
 func TestWithInspectorStyle(t *testing.T) {
 	var base Theme
 	s := InspectorStyle{ColorPanel: RGB(10, 20, 30)}
-	got := base.WithInspectorStyle(s)
+	got := base.withInspectorStyle(s)
 	if got.inspectorStyle.ColorPanel != s.ColorPanel {
-		t.Error("WithInspectorStyle should set the inspector style")
+		t.Error("withInspectorStyle should set the inspector style")
 	}
 	// Value semantics: the receiver stays untouched.
 	if base.inspectorStyle.ColorPanel != (Color{}) {
-		t.Error("WithInspectorStyle must not mutate the receiver")
+		t.Error("withInspectorStyle must not mutate the receiver")
 	}
 }


### PR DESCRIPTION
Closes #288

## Summary

The issue #288 API-surface review is complete. With all five sibling repos (go-charts, go-edit, go-kite, go-term, go-map) scanned, the authoritative exportaudit gate reports a clean surface. The review found exactly one export whose justification did not survive scrutiny, plus one stale keep comment.

## Changes

- **Unexport `Theme.WithInspectorStyle`** → `withInspectorStyle` (gui/theme_with.go, gui/theme_with_test.go). It was the only exported member of the `with*Style` family, carried on an `exportaudit:keep` claim of sibling-repo use that does not exist — zero consumer usage across all siblings. Consistent with `withDataGridStyle` and the rest of the family; breaks nothing.
- **Fix stale keep comment** on `TestUnconsumedEvents` (gui/debug_event.go): "used by sibling repos" → "public testing API in the documented Test* family" (the sibling `Test*` methods are consumer-used; this one is the newest member awaiting adoption).
- **Changelog**: [Unreleased] Changed entry documenting the unexport and the review outcome.

## Verification

- Authoritative gate: `go run ./tools/exportaudit/ -mode gate . ../go-charts ../go-edit ../go-kite ../go-term ../go-map` → surface clean (exit 0)
- `make export-audit` (CI advisory run) → clean
- `go build ./...`, `go test ./...`, `golangci-lint run ./...` → pass

## Issue #288 verdict

Acceptance criteria met:

1. Unreferenced list reduced to one: `FillBorder` (intentionally public, showcase-documented). The other five in-repo "unreferenced" exports (`EventScrollBegan`, `ModAltShift`, `ModCtrlAlt`, `ModCtrlAltShift`, `NewDrawContext`) are all genuinely consumed by sibling repos — the in-repo CI run cannot see siblings, so it reports them as advisory by design.
2. Every self/selftest-only export carries an `exportaudit:keep` with a concrete justification (reachable from exported signature, name collisions, json tags, interface methods, showcase docs).
3. `make export-audit` clean with sibling repos present.
4. API change (the unexport) called out in the changelog.
