### PR TITLE
feat(gui): per-window themes and scoped subtree theming (issue #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,110 +8,123 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Per-window themes (issue #296).** A `Window` now owns its theme.
+  `w.SetTheme(t)` themes that window alone and `w.Theme()` reads it back;
+  windows that never pin one follow the app default, which package-level
+  `gui.SetTheme` still sets. The frame pass installs the active window's theme
+  before the view function runs, so widget factories keep resolving their
+  defaults exactly as before — no factory signature changed, no allocation was
+  added, and existing single-window code behaves identically. See
+  `docs/specs/per-window-theme.md`.
+
+- **`gui.Themed(t, build)` scopes a theme to one subtree.** Views the builder
+  returns resolve their defaults from `t`; everything outside keeps the window's
+  theme, and `Themed` nests. The builder runs at layout-generation time, which
+  is what makes the scope work: factories resolve defaults when they are called,
+  so ready-made child views would already carry the enclosing theme.
+
 ### Fixed
 
-- **The datagrid column-resize handle now renders its active color
-  during a resize drag (issue #284).** A drag holds a mouse lock and
-  `layoutHover` bails under a lock, so the handle's pressed color —
-  painted only from `OnHover` — could not fire mid-drag and the handle
-  showed its resting color while resizing. The handle's color now comes
-  from the resize state read at generation time
-  (`dataGridActiveResizeColID`), live for the whole drag and reverting
-  on release or cancel.
+- **Theme-keyed text caches no longer serve stale layouts.** The per-window
+  markdown and rich-text layout caches invalidated on `Theme.Name`; two themes
+  can share a name and differ in text styles, as a derived or scoped theme does.
+  Both now key on a stamped theme identity.
 
-- **Pressed-while-hovered colors now render.** Seven `OnHover` handlers
-  paint a click color while the left button is held (button
-  `Colors.Click`, breadcrumb crumb, expand-panel header, switch pill,
-  toggle, radio, datagrid resize handle), but no frame could reach
-  those branches: `layoutHover` synthesized its event with
-  `MouseButton: MouseInvalid` no matter what the user was holding. The
-  window now reports the real held button in hover events (see Changed
-  below), so a press-and-hold renders the click color and release
+- **The datagrid column-resize handle now renders its active color during a
+  resize drag (issue #284).** A drag holds a mouse lock and `layoutHover` bails
+  under a lock, so the handle's pressed color — painted only from `OnHover` —
+  could not fire mid-drag and the handle showed its resting color while
+  resizing. The handle's color now comes from the resize state read at
+  generation time (`dataGridActiveResizeColID`), live for the whole drag and
+  reverting on release or cancel.
+
+- **Pressed-while-hovered colors now render.** Seven `OnHover` handlers paint a
+  click color while the left button is held (button `Colors.Click`, breadcrumb
+  crumb, expand-panel header, switch pill, toggle, radio, datagrid resize
+  handle), but no frame could reach those branches: `layoutHover` synthesized
+  its event with `MouseButton: MouseInvalid` no matter what the user was
+  holding. The window now reports the real held button in hover events (see
+  Changed below), so a press-and-hold renders the click color and release
   restores the hover color.
 
-- **Interrupted (capture-loss) selection drags no longer leave a stuck
-  selection (issue #281).** Input, Text and RTF selection drags hold a
-  mouse lock whose `Cancel` hook fired on capture loss — a mouse-up that
-  will never arrive (window-resize steal, alt-tab, the #237 class) —
-  but only removed the edge-scroll animation; the partial selection
-  survived as if committed. The three Cancel hooks now zero the dragged
-  widget's own `selectBeg`/`selectEnd` (scoped to its `nsInput` key,
-  never other widgets'), so an interrupted drag leaves nothing. A normal
-  release still commits even outside the widget — the lock delivers the
-  mouse-up anywhere; only capture loss goes through the Cancel hook.
+- **Interrupted (capture-loss) selection drags no longer leave a stuck selection
+  (issue #281).** Input, Text and RTF selection drags hold a mouse lock whose
+  `Cancel` hook fired on capture loss — a mouse-up that will never arrive
+  (window-resize steal, alt-tab, the #237 class) — but only removed the
+  edge-scroll animation; the partial selection survived as if committed. The
+  three Cancel hooks now zero the dragged widget's own `selectBeg`/`selectEnd`
+  (scoped to its `nsInput` key, never other widgets'), so an interrupted drag
+  leaves nothing. A normal release still commits even outside the widget — the
+  lock delivers the mouse-up anywhere; only capture loss goes through the Cancel
+  hook.
 
-- **Re-asserting focus no longer clears input selections (issue
-  #277).** `setFocusLocked` called `clearInputSelections()` on every
-  `SetFocus`, unconditionally, while the IME clear next to it was
-  already guarded by `id != prev` (#156). Because consumers
-  legitimately re-assert focus from inside their View function — which
-  runs on every layout rebuild — an unconditional clear wiped every
-  `nsInput` selection window-wide on each re-assert, silently dropping
-  selections in the focused input and every unrelated field. The clear
-  is now guarded exactly like the IME clear: only a real focus change
-  drops selections (window-wide, as before); a same-widget re-assert
-  leaves them alone. Clicking an already-focused input still collapses
-  its selection to a caret at the click — that path sets the selection
-  itself and never depended on the clear.
+- **Re-asserting focus no longer clears input selections (issue #277).**
+  `setFocusLocked` called `clearInputSelections()` on every `SetFocus`,
+  unconditionally, while the IME clear next to it was already guarded by
+  `id != prev` (#156). Because consumers legitimately re-assert focus from
+  inside their View function — which runs on every layout rebuild — an
+  unconditional clear wiped every `nsInput` selection window-wide on each
+  re-assert, silently dropping selections in the focused input and every
+  unrelated field. The clear is now guarded exactly like the IME clear: only a
+  real focus change drops selections (window-wide, as before); a same-widget
+  re-assert leaves them alone. Clicking an already-focused input still collapses
+  its selection to a caret at the click — that path sets the selection itself
+  and never depended on the clear.
 
-- **Markdown/RTF in-document anchor links (`#slug`) now scroll
-  (issue #278).** `rtfOnClick` scrolled the bare slug, but a heading's
-  ID is scoped to its document (`ScopeID(docID, "h", slug)` — e.g.
-  `md:h:slug`, or `panel:md:h:slug` nested), so `FindByID(slug)` missed
-  and the scroll silently no-opped — even at root. The `#` branch now
-  resolves through `rtfResolveAnchor`: for a markdown block (every
-  block carries the document's effective ID in `TC.markdownID`, now
-  stamped on non-focusable documents too), the document-scoped heading
-  spelling is tried first, then the bare slug — so arbitrary absolute
-  targets (`#view:bottom`) and standalone RTF links keep working. The
-  identity stamping and the selection machinery are separate flags now:
-  a non-focusable markdown document gains anchor resolution but keeps
-  its exact prior click behavior (no focus, no mouse lock, no
-  per-frame selection walk).
+- **Markdown/RTF in-document anchor links (`#slug`) now scroll (issue #278).**
+  `rtfOnClick` scrolled the bare slug, but a heading's ID is scoped to its
+  document (`ScopeID(docID, "h", slug)` — e.g. `md:h:slug`, or `panel:md:h:slug`
+  nested), so `FindByID(slug)` missed and the scroll silently no-opped — even at
+  root. The `#` branch now resolves through `rtfResolveAnchor`: for a markdown
+  block (every block carries the document's effective ID in `TC.markdownID`, now
+  stamped on non-focusable documents too), the document-scoped heading spelling
+  is tried first, then the bare slug — so arbitrary absolute targets
+  (`#view:bottom`) and standalone RTF links keep working. The identity stamping
+  and the selection machinery are separate flags now: a non-focusable markdown
+  document gains anchor resolution but keeps its exact prior click behavior (no
+  focus, no mouse lock, no per-frame selection walk).
 
-- **Markdown: cross-block selection works under ID-bearing ancestors
-  (issue #273).** The document's blocks were stamped with the raw
-  `cfg.ID` at generation time, while the container's amend and key
-  handlers keyed on the *effective* ID the resolve pass stamps — so a
-  markdown nested in a panel with an ID collected an empty block list
-  (`nsMdBlocks` was keyed `panel:md`, the blocks matched `md`), and
-  cross-block drag, Ctrl+A, Ctrl+C and click focus were dead, with the
-  click writing selection state under a key nothing read. `Markdown` is
-  now a struct view whose `GenerateLayout` resolves the effective ID
-  once (`w.EffID(cfg.ID)`, the same mechanism the splitter uses) and
-  stamps it into every block and inner ID, so the container, the
-  blocks, the state slots and `SetFocus` all agree on one identity.
-  Flat documents are unchanged; two documents sharing a leaf under
-  different panels now keep separate selections.
+- **Markdown: cross-block selection works under ID-bearing ancestors (issue
+  #273).** The document's blocks were stamped with the raw `cfg.ID` at
+  generation time, while the container's amend and key handlers keyed on the
+  _effective_ ID the resolve pass stamps — so a markdown nested in a panel with
+  an ID collected an empty block list (`nsMdBlocks` was keyed `panel:md`, the
+  blocks matched `md`), and cross-block drag, Ctrl+A, Ctrl+C and click focus
+  were dead, with the click writing selection state under a key nothing read.
+  `Markdown` is now a struct view whose `GenerateLayout` resolves the effective
+  ID once (`w.EffID(cfg.ID)`, the same mechanism the splitter uses) and stamps
+  it into every block and inner ID, so the container, the blocks, the state
+  slots and `SetFocus` all agree on one identity. Flat documents are unchanged;
+  two documents sharing a leaf under different panels now keep separate
+  selections.
 
-- **Markdown: a stale selection no longer survives a document content
-  change (issue #275).** `markdownContainerAmendLayout` now hashes the
-  block list (offsets, rune counts, flat text) each frame and resets
-  the per-widget selection when the hash changes: `SelBeg`/`SelEnd`
-  are rune offsets into the *previous* source, so a stale range would
-  highlight — and Ctrl+C would copy — the wrong runes of the new
-  text. A same-length rewrite of the document is caught too; a pure
-  layout change (resize, font) leaves the selection alone.
+- **Markdown: a stale selection no longer survives a document content change
+  (issue #275).** `markdownContainerAmendLayout` now hashes the block list
+  (offsets, rune counts, flat text) each frame and resets the per-widget
+  selection when the hash changes: `SelBeg`/`SelEnd` are rune offsets into the
+  _previous_ source, so a stale range would highlight — and Ctrl+C would copy —
+  the wrong runes of the new text. A same-length rewrite of the document is
+  caught too; a pure layout change (resize, font) leaves the selection alone.
 
 ### Changed
 
-- **`OnHover` receives the held mouse button.** The window tracks the
-  held button from its own event stream — set on `EventMouseDown`,
-  cleared on `EventMouseUp` and `MouseCancel` — and `layoutHover`
-  reports it in the synthesized hover event: `MouseLeft`/`MouseRight`/
-  `MouseMiddle` while held, `MouseInvalid` when none is held. A hover
-  handler can now distinguish a press-and-hold from a plain hover; it
-  could not before, because the event always arrived with
-  `MouseInvalid`. The event is still `Type: EventMouseMove` and is
-  rebuilt field-by-field every frame.
+- **`OnHover` receives the held mouse button.** The window tracks the held
+  button from its own event stream — set on `EventMouseDown`, cleared on
+  `EventMouseUp` and `MouseCancel` — and `layoutHover` reports it in the
+  synthesized hover event: `MouseLeft`/`MouseRight`/ `MouseMiddle` while held,
+  `MouseInvalid` when none is held. A hover handler can now distinguish a
+  press-and-hold from a plain hover; it could not before, because the event
+  always arrived with `MouseInvalid`. The event is still `Type: EventMouseMove`
+  and is rebuilt field-by-field every frame.
 
-- **`Theme.WithInspectorStyle` is unexported (breaking; no known
-  consumers).** It was the only exported member of the `with*Style`
-  family and was carried on an `exportaudit:keep` claim of sibling-repo
-  use that does not exist. It is now `withInspectorStyle`, matching
-  `withDataGridStyle` and the rest of the family. This completes the
-  issue #288 API-surface review: with all sibling repos scanned, the
-  authoritative audit reports a clean surface — one `none` export
+- **`Theme.WithInspectorStyle` is unexported (breaking; no known consumers).**
+  It was the only exported member of the `with*Style` family and was carried on
+  an `exportaudit:keep` claim of sibling-repo use that does not exist. It is now
+  `withInspectorStyle`, matching `withDataGridStyle` and the rest of the family.
+  This completes the issue #288 API-surface review: with all sibling repos
+  scanned, the authoritative audit reports a clean surface — one `none` export
   (`FillBorder`, intentionally public, showcase-documented) and every
   self/selftest-only export carries a justified keep marker.
 
@@ -119,62 +132,57 @@ and this project adheres to
 
 - **Markdown interaction test suite expands to the nested-document and
   source-change cases** (`gui/markdown_select_interaction_test.go`):
-  effective-ID block collection, click focus, Ctrl+A/C, cross-block
-  drag and per-panel isolation under ID-bearing ancestors; offset-block
-  click accuracy (the click handlers receive shape-relative coordinates
-  via `callRelative`, so a click maps to the rune under the cursor
-  wherever the block sits); and selection reset on content change with
-  an idle-frame positive control. Plus diagram-cache async tests
-  (`gui/markdown_diagram_fetch_test.go`) and block-renderer tests
-  (`gui/view_markdown_blocks_test.go`). Package `gui/` moves from
-  81.0% to 82.4%.
+  effective-ID block collection, click focus, Ctrl+A/C, cross-block drag and
+  per-panel isolation under ID-bearing ancestors; offset-block click accuracy
+  (the click handlers receive shape-relative coordinates via `callRelative`, so
+  a click maps to the rune under the cursor wherever the block sits); and
+  selection reset on content change with an idle-frame positive control. Plus
+  diagram-cache async tests (`gui/markdown_diagram_fetch_test.go`) and
+  block-renderer tests (`gui/view_markdown_blocks_test.go`). Package `gui/`
+  moves from 81.0% to 82.4%.
 
-- **FillFill roots on axis-less containers resolve to the window size
-  (issue #262).** `updateLayoutLocked` pins a Fill root to the window
-  dimensions via `Min = Max`, but the width/height sizing passes only
-  consulted the pin on axis-bearing containers — so a `Splitter` (built
-  on a `Canvas`) returned directly as the root view resolved to 0x0 and
-  was invisible, despite `Sizing` defaulting to `FillFill`. The
-  `axisNone` branch of both passes now honors explicit min/max pins, so
-  `FillFill` is honest on axis-less roots and tracks window resize. It
-  also makes an explicit `MinWidth`/`MaxWidth` on a `Fit`-sized `Canvas`
-  take effect, which is the documented intent of those fields (Fill
-  roots keep the window pin; the fill distribution clamps nested Fill
-  children). Children of axis-less containers keep their sizing
-  semantics unchanged.
+- **FillFill roots on axis-less containers resolve to the window size (issue
+  #262).** `updateLayoutLocked` pins a Fill root to the window dimensions via
+  `Min = Max`, but the width/height sizing passes only consulted the pin on
+  axis-bearing containers — so a `Splitter` (built on a `Canvas`) returned
+  directly as the root view resolved to 0x0 and was invisible, despite `Sizing`
+  defaulting to `FillFill`. The `axisNone` branch of both passes now honors
+  explicit min/max pins, so `FillFill` is honest on axis-less roots and tracks
+  window resize. It also makes an explicit `MinWidth`/`MaxWidth` on a
+  `Fit`-sized `Canvas` take effect, which is the documented intent of those
+  fields (Fill roots keep the window pin; the fill distribution clamps nested
+  Fill children). Children of axis-less containers keep their sizing semantics
+  unchanged.
 
-- **Splitter: a collapsed pane with content now reaches its collapsed
-  size (issue #263).** `splitterLayoutChild` pinned the pane to the size
-  `splitterCompute` decided, then re-ran the fit passes, which recomputed
-  the pane from its content's minimum and overwrote the pin — so a pane
-  holding real content kept a sliver that drew underneath the handle. The
-  pin is now re-applied after the fit passes, so collapse is exact
-  (zero-width with the default `collapsedSize`, or exactly
-  `collapsedSize` when set). Contract note: pane sizes come from
-  ratio/min/max only; content larger than the computed pane size is
-  clipped (panes have `Clip: true`), never stretches the pane.
-- **Splitter: the spacebar toggles collapse again.** `splitterOnKeydown`
-  tested `Event.CharCode`, which backends populate only on `EventChar` —
-  a space keydown arrives with `KeyCode == KeySpace` and `CharCode == 0`,
-  so the branch never fired. Now reads `KeyCode`, matching `DatePicker`,
-  `Tree`, `Menu` and `Select`.
-- **Breadcrumb and TabControl: the spacebar activates again.** Both had
-  the same defect — `bcOnKeydown` and `tabControlOnKeydown` tested
-  `Event.CharCode` from an `OnKeyDown` handler, so space never selected
-  the focused crumb or tab. Both now read `KeyCode == KeySpace`, grouped
-  with the identical `KeyEnter` branch. `Splitter`, `Breadcrumb` and
-  `TabControl` were the only three sites with this defect; every other
-  `CharCode` reader in `gui/` is an `OnChar` handler, where the field is
-  populated.
+- **Splitter: a collapsed pane with content now reaches its collapsed size
+  (issue #263).** `splitterLayoutChild` pinned the pane to the size
+  `splitterCompute` decided, then re-ran the fit passes, which recomputed the
+  pane from its content's minimum and overwrote the pin — so a pane holding real
+  content kept a sliver that drew underneath the handle. The pin is now
+  re-applied after the fit passes, so collapse is exact (zero-width with the
+  default `collapsedSize`, or exactly `collapsedSize` when set). Contract note:
+  pane sizes come from ratio/min/max only; content larger than the computed pane
+  size is clipped (panes have `Clip: true`), never stretches the pane.
+- **Splitter: the spacebar toggles collapse again.** `splitterOnKeydown` tested
+  `Event.CharCode`, which backends populate only on `EventChar` — a space
+  keydown arrives with `KeyCode == KeySpace` and `CharCode == 0`, so the branch
+  never fired. Now reads `KeyCode`, matching `DatePicker`, `Tree`, `Menu` and
+  `Select`.
+- **Breadcrumb and TabControl: the spacebar activates again.** Both had the same
+  defect — `bcOnKeydown` and `tabControlOnKeydown` tested `Event.CharCode` from
+  an `OnKeyDown` handler, so space never selected the focused crumb or tab. Both
+  now read `KeyCode == KeySpace`, grouped with the identical `KeyEnter` branch.
+  `Splitter`, `Breadcrumb` and `TabControl` were the only three sites with this
+  defect; every other `CharCode` reader in `gui/` is an `OnChar` handler, where
+  the field is populated.
 - **Splitter: `SplitterStyle`'s border and radius reach the handle.**
   `applySplitterDefaults` seeded every color from the style but skipped
-  `SizeBorder`, `Radius` and `radiusBorder`, so the handle and the
-  collapse buttons fell through to the generic container and button
-  defaults. Visible change under the stock theme: corner radius on both
-  goes from `radiusMedium` (5.5) to the splitter's `radiusSmall` (3.5) —
-  the border width was already `sizeBorderDef` either way. For a custom
-  theme the splitter's own three values were dead and now apply. An
-  explicit `SomeF(0)` still means "no border".
+  `SizeBorder`, `Radius` and `radiusBorder`, so the handle and the collapse
+  buttons fell through to the generic container and button defaults. Visible
+  change under the stock theme: corner radius on both goes from `radiusMedium`
+  (5.5) to the splitter's `radiusSmall` (3.5) — the border width was already
+  `sizeBorderDef` either way. For a custom theme the splitter's own three values
+  were dead and now apply. An explicit `SomeF(0)` still means "no border".
 - **Splitter: part IDs now scope with the root (issue #264).** `Splitter`
   composed its pane, handle and collapse-button IDs in the factory, where no
   `Window` exists, so under an ID-bearing ancestor the root resolved to
@@ -182,49 +190,47 @@ and this project adheres to
   splitters reusing one leaf ID collided on every part. The splitter is now a
   struct view whose `GenerateLayout` resolves the effective ID
   (`w.EffID(cfg.ID)`) and composes every part under that path. With no
-  ID-bearing ancestor the spellings are unchanged. API consequence: parts of
-  a nested splitter are addressed by scoped effective IDs (`outer:sp:handle`,
+  ID-bearing ancestor the spellings are unchanged. API consequence: parts of a
+  nested splitter are addressed by scoped effective IDs (`outer:sp:handle`,
   `outer:sp:pane:first`).
-- **Splitter: the handle's active (button-held) color now renders during a
-  drag (issue #265).** `splitterOnHandleHover` painted `colorHandleActive`
-  only while `Event.MouseButton == MouseLeft` — a branch no real frame could
-  reach, because `layoutHover` bails while the mouse is locked (and a
-  splitter drag runs under `MouseLock`) and always synthesizes hover events
-  with `MouseButton: MouseInvalid`. The active color is now driven from the
-  splitter's own drag state instead: the press paints the handle immediately
-  and records a pressed flag in window state, and `splitterAmendLayout`
-  re-paints the active color every frame while the lock is held, so the
-  pressed feedback survives the per-frame regeneration of the handle. The
-  flag is cleared on release and by the mouse lock's `Cancel` hook, and the
-  amend paint is additionally guarded by the window's actual lock state, so
-  capture lost without a release (issue #237) can never leave the handle
-  permanently active.
+- **Splitter: the handle's active (button-held) color now renders during a drag
+  (issue #265).** `splitterOnHandleHover` painted `colorHandleActive` only while
+  `Event.MouseButton == MouseLeft` — a branch no real frame could reach, because
+  `layoutHover` bails while the mouse is locked (and a splitter drag runs under
+  `MouseLock`) and always synthesizes hover events with
+  `MouseButton: MouseInvalid`. The active color is now driven from the
+  splitter's own drag state instead: the press paints the handle immediately and
+  records a pressed flag in window state, and `splitterAmendLayout` re-paints
+  the active color every frame while the lock is held, so the pressed feedback
+  survives the per-frame regeneration of the handle. The flag is cleared on
+  release and by the mouse lock's `Cancel` hook, and the amend paint is
+  additionally guarded by the window's actual lock state, so capture lost
+  without a release (issue #237) can never leave the handle permanently active.
 
 ### Added
 
-- **Splitter interaction test suite**
-  (`gui/view_splitter_interaction_test.go`): AmendLayout geometry, drag
-  resize through the mouse lock, hover, the keyboard map, and the
-  collapse buttons. Both splitter files reach 100% statement coverage;
-  package `gui/` moves from 79.8% to 81.0%.
+- **Splitter interaction test suite** (`gui/view_splitter_interaction_test.go`):
+  AmendLayout geometry, drag resize through the mouse lock, hover, the keyboard
+  map, and the collapse buttons. Both splitter files reach 100% statement
+  coverage; package `gui/` moves from 79.8% to 81.0%.
 
 ## [v0.59.2] - 2026-08-13
 
 ### Changed
 
-- **go-glyph bumped to v1.20.2** — the face LRU now idle-evicts and the
-  fallback cache evicts FIFO, so long sessions release font memory without
-  new face churn; single-codepoint emoji fallback is decided from cmap
-  coverage alone (PR #266).
+- **go-glyph bumped to v1.20.2** — the face LRU now idle-evicts and the fallback
+  cache evicts FIFO, so long sessions release font memory without new face
+  churn; single-codepoint emoji fallback is decided from cmap coverage alone (PR
+  #266).
 
 ## [v0.59.1] - 2026-08-12
 
 ### Fixed
 
-- **GL backend tests now run cgo-free** to dodge a runtime exit crash on
-  macOS (issue #162, PR #257).
-- **`make` gates match golangci-lint's version string** without assuming a
-  `v` prefix (PR #258), fixing local runs against newer linter releases.
+- **GL backend tests now run cgo-free** to dodge a runtime exit crash on macOS
+  (issue #162, PR #257).
+- **`make` gates match golangci-lint's version string** without assuming a `v`
+  prefix (PR #258), fixing local runs against newer linter releases.
 
 ### Changed
 
@@ -235,21 +241,20 @@ and this project adheres to
 
 ### Added
 
-- **`Sizing` self-flags like `Padding`/`Color` (#243, #254).** `Sizing`
-  carries a `set` field: the zero value (`FitFit`) is a real combination, so
-  the flag is what distinguishes "unset" from an explicit `Sizing{FitFit}`.
-  Predefined vars (`FitFit`…`FillFixed`) set it; read with `IsSet()`/`Or()`.
-  The raw `Sizing{...}` literal now reads as unset (ergoaudit literals mode
-  flags it). `DataGridCfg.Sizing` drops `Opt[gg.Sizing]` for plain
-  `gg.Sizing` (breaking). An explicit `FitFit` + wrap mode in text is no
-  longer clobbered to `FillFit`.
+- **`Sizing` self-flags like `Padding`/`Color` (#243, #254).** `Sizing` carries
+  a `set` field: the zero value (`FitFit`) is a real combination, so the flag is
+  what distinguishes "unset" from an explicit `Sizing{FitFit}`. Predefined vars
+  (`FitFit`…`FillFixed`) set it; read with `IsSet()`/`Or()`. The raw
+  `Sizing{...}` literal now reads as unset (ergoaudit literals mode flags it).
+  `DataGridCfg.Sizing` drops `Opt[gg.Sizing]` for plain `gg.Sizing` (breaking).
+  An explicit `FitFit` + wrap mode in text is no longer clobbered to `FillFit`.
 
 ### Changed
 
 - **Async present outside live resize on macOS Metal (#255).** During live
   window resize the Metal backend now presents asynchronously, decoupling
-  presentation from the resize hot path instead of blocking on the
-  drawable. Reduced jank and dropped frames while resizing.
+  presentation from the resize hot path instead of blocking on the drawable.
+  Reduced jank and dropped frames while resizing.
 
 ## [v0.58.0] - 2026-08-11
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ silent no-op — the widget renders and clicks but never joins the tab order. Th
 `FocusDisabled`, never with `Focusable: false`.** Fifteen Cfgs default on:
 `Button`, `ColorPicker`, `Combobox`, `DatePicker`, `Input`, `InputDate`,
 `ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`, `Slider`,
-`Switch`, `Toggle`, `Tree`. Everything else is opt-in via `Focusable: true`.
-See `docs/specs/focusable-default-input.md`; run `ergonomics-audit -mode focus`
-for the current inventory.
+`Switch`, `Toggle`, `Tree`. Everything else is opt-in via `Focusable: true`. See
+`docs/specs/focusable-default-input.md`; run `ergonomics-audit -mode focus` for
+the current inventory.
 
 **`Shape.ID` is a leaf; identity is the effective ID.** `resolveShapeIDs`
 (`gui/id_resolve.go`, run from `layoutArrange`) stamps `Shape.effID` = the leaf
@@ -94,8 +94,8 @@ without allocating for the number — use it for loop-derived identity. Both cos
 exactly one allocation; `gui/id_scope_test.go` asserts that. A **part** (a row
 key, a heading slug — a leaf value fed _into_ a composition) must not contain
 `:` and keeps its own spelling; rebuilding an ID at a lookup site is how
-producers and consumers drift. `make ergonomics-audit` (mode `ids`) fails on
-any hand-rolled composition; see `docs/specs/widget-id-scoping.md`.
+producers and consumers drift. `make ergonomics-audit` (mode `ids`) fails on any
+hand-rolled composition; see `docs/specs/widget-id-scoping.md`.
 
 Uniqueness is strict, including within one widget: a composite widget's inner
 shape that needs the owning widget's focus or spell-check state sets
@@ -105,23 +105,22 @@ asserts a rendered window is clean.
 
 #### `Opt[T]` vs plain fields
 
-**Rule: types the repo owns self-flag; only primitives get `Opt`.**
-`Opt[T]` is for when the zero value is a legitimate user choice that must be
-distinguishable from "unset" — and only when the type cannot carry that
-distinction itself. `SizeBorder` is the canonical case: `0` is a border width a
-caller means, so a plain `float32` cannot tell "no border" from "not
-specified". Where zero is not meaningful — most widths, heights, counts, and
-indices — `Opt` costs a wrapper call and buys nothing.
+**Rule: types the repo owns self-flag; only primitives get `Opt`.** `Opt[T]` is
+for when the zero value is a legitimate user choice that must be distinguishable
+from "unset" — and only when the type cannot carry that distinction itself.
+`SizeBorder` is the canonical case: `0` is a border width a caller means, so a
+plain `float32` cannot tell "no border" from "not specified". Where zero is not
+meaningful — most widths, heights, counts, and indices — `Opt` costs a wrapper
+call and buys nothing.
 
 Owned struct types self-flag instead of wrapping: `Color` (`gui/color.go`),
-`Padding` (`gui/padding.go`) and `Sizing` (`gui/sizing.go`) carry a `set`
-field, so they are plain fields with `IsSet()`/`Or()` rather than `Opt[T]`.
-`Sizing`'s zero value (FitFit) is a real combination, which is exactly why it
-flags: build sizings with the predefined vars (`FitFit`…`FillFixed`), never a
-raw `Sizing{...}` literal — that reads as unset (ergoaudit mode `literals`
-gates this). Build `Padding` values with
-`NewPadding`/`PadAll`/`PaddingNone`; a raw `Padding{...}` literal reads as
-unset (ergoaudit mode `literals` gates this).
+`Padding` (`gui/padding.go`) and `Sizing` (`gui/sizing.go`) carry a `set` field,
+so they are plain fields with `IsSet()`/`Or()` rather than `Opt[T]`. `Sizing`'s
+zero value (FitFit) is a real combination, which is exactly why it flags: build
+sizings with the predefined vars (`FitFit`…`FillFixed`), never a raw
+`Sizing{...}` literal — that reads as unset (ergoaudit mode `literals` gates
+this). Build `Padding` values with `NewPadding`/`PadAll`/`PaddingNone`; a raw
+`Padding{...}` literal reads as unset (ergoaudit mode `literals` gates this).
 
 Decide this when authoring the field, not by copying whichever neighbor was
 nearest.
@@ -131,9 +130,8 @@ nearest.
 Use plain `Color`, never `Opt[Color]`. `Color` carries its own `set` flag
 (`gui/color.go`), so `Color{}` is unset and `ColorTransparent` is an explicit
 fully-transparent choice — wrapping would give the field two notions of unset.
-Build colors with `RGBA`/`RGB`/`Hex`; a raw `Color{...}` literal reads as
-unset (ergoaudit mode `literals` gates this; the empty `Color{}` sentinel is
-exempt).
+Build colors with `RGBA`/`RGB`/`Hex`; a raw `Color{...}` literal reads as unset
+(ergoaudit mode `literals` gates this; the empty `Color{}` sentinel is exempt).
 
 `ColorSet` (`gui/color_set.go`) groups the per-state colors; `Flat(c)` is the
 "keep one appearance" case. **Precedence: an assigned flat `Color*` field wins
@@ -165,6 +163,16 @@ Backend injects at startup. Nil in tests:
 - `Children []Layout` = values. Parents = pointers. Avoids cycles
 - `StateMap` (keyed by namespace consts like `nsOverflow`, `nsSvgCache`) =
   per-window typed kv store for widget internal state
+- **Theme is window-owned; `guiTheme` and the `default*Style` mirrors are a
+  frame-scoped cache, not app state.** `FrameFn` calls `w.installTheme()` before
+  anything reads them, so a factory-time read resolves to the window being
+  generated — that works only because every window's frame pass runs on the one
+  main OS thread. `w.Theme()` reads, `w.SetTheme` pins that window, package
+  `SetTheme` sets the app default for windows that never pinned one.
+  `Themed(t, build)` scopes a theme to one subtree; its builder must run at
+  generation time because factories resolve defaults when called. Anything keyed
+  on a theme keys on `Theme.id`, never `Theme.Name` — names are not unique. See
+  `docs/specs/per-window-theme.md`.
 - `AmendLayout` hook on shapes runs after sizing to reposition overlays (color
   picker circles, splitter handles, etc.) or manage hover. Layout uses absolute
   coords. Moving parent in `AmendLayout` does NOT move children. Use float

--- a/docs/specs/per-window-theme.md
+++ b/docs/specs/per-window-theme.md
@@ -1,0 +1,127 @@
+# Per-window themes
+
+Status: implemented. Issue #296.
+
+## Problem
+
+`Window.SetTheme` looked like a per-window API but delegated to package globals,
+so every window in an `App` shared one theme. The global surface is large:
+`guiTheme` plus about 30 `default*Style` mirror variables that `SetTheme`
+rewrote in one pass.
+
+Widget factories resolve their defaults when they are called, not when the
+layout is generated. Roughly 220 read sites inside `gui/` and 200
+`CurrentTheme()` calls in `examples/` read theme state this way.
+
+## Rejected: resolve defaults during GenerateLayout
+
+Issue #296 proposed reading `w.Theme()` inside `GenerateLayout`. Factories build
+eagerly, so this needs each factory body wrapped in a `viewFunc` closure. That
+adds one closure and one `Cfg` heap escape per widget per frame, against a
+baseline of 5000 widgets in 4-5 ms, and rewrites about 220 call sites. The
+observable result is the same as the design below.
+
+## Design
+
+The window owns the theme. The frame pass installs that theme into the existing
+globals before anything reads them.
+
+```
+FrameFn
+  installTheme()      <- window theme becomes the installed theme
+  flushCommands()
+  Update()
+    view fn -> generateViewLayout -> layoutArrange -> renderLayout
+  (backend clear color reads CurrentTheme here)
+```
+
+The globals stop being app state. They are a frame-scoped cache of the theme
+belonging to the window currently being generated.
+
+### Why this is correct
+
+Every window's frame pass runs on the one main OS thread. Both desktop backends
+call `runtime.LockOSThread` in package `init` and drive all windows from a
+single sequential loop (`gui/backend/metal/backend.go`,
+`gui/backend/gl/runapp_x11.go`). Two windows can never generate layouts at the
+same time, and no layout is generated off that thread. A factory-time read
+therefore always resolves against the window being generated.
+
+### Layers
+
+| State                | Meaning                           | Written by                 |
+| -------------------- | --------------------------------- | -------------------------- |
+| `guiTheme` + mirrors | installed theme for this frame    | `applyTheme`, frame thread |
+| `Window.theme`       | the window's own theme, if pinned | `(*Window).SetTheme`       |
+| `defaultTheme`       | app default for unpinned windows  | `gui.SetTheme`             |
+
+`(*Window).Theme()` returns the pinned theme, or the app default.
+
+`gui.SetTheme` sets the app default and requests a rebuild on every window that
+has not pinned one, so existing code that calls it from `main` or from a handler
+keeps working. Both setters also install eagerly, so callers outside a frame
+pass (tests, `main` before `Run`) see the change at once; the next frame
+re-establishes the correct per-window theme regardless.
+
+### Theme identity
+
+`Theme.id` is stamped by `ThemeMaker` and re-stamped by every `with*Style`
+helper. `installTheme` compares ids and returns without writing when the theme
+is already installed, which is the steady state for a single-window app. Zero
+means "built outside `ThemeMaker`" and forces a re-install rather than a wrong
+fast-path hit.
+
+The per-window text-layout caches (`viewState.rtfLayoutTheme`,
+`viewState.markdownTheme`) key on `Theme.id` for the same reason: two themes can
+share a `Name` and differ in text styles.
+
+## Scoped subtree themes
+
+`Themed(t, build)` installs `t` for the duration of `build`'s subtree generation
+and restores the enclosing theme afterwards. It nests.
+
+```go
+gui.Themed(light, func(w *gui.Window) gui.View {
+    return gui.Column(gui.ContainerCfg{Content: []gui.View{
+        gui.Button(gui.ButtonCfg{ID: "ok", Text: "OK"}),
+    }})
+})
+```
+
+The builder callback is required, not sugar. A signature taking ready-made child
+views would receive children the caller already built under the enclosing theme,
+because factories resolve defaults when they are called.
+
+`Themed` scopes generation only. Reads that happen after generation stay
+window-scoped: scroll metrics on the event path, and the theme picker's report
+of the active theme.
+
+## Override precedence
+
+Unchanged. Factories fill only the fields a caller left unset, so an assigned
+`Cfg` field beats the theme at every level, inside a `Themed` subtree included.
+
+## Known drift, deliberately not fixed here
+
+`init` seeds `installedThemeID` instead of installing `ThemeDark`, so the first
+frame's `installTheme` is a no-op and the shipped default appearance is
+unchanged.
+
+This matters because the `default*Style` literals in `styles*.go` do not all
+match `ThemeDark`. Examples: `SizeBorder` is 1.5 in the literals and 0 in
+`ThemeDark` for button, input, container, dialog, toast and others; the
+`dataGrid` literal is an unstyled placeholder with zero colors; `badge.Color`,
+`input.Padding` and `listbox.Padding` differ. An app that never calls `SetTheme`
+runs on this mixture today, because some widgets read `guiTheme.xStyle` and
+others read the `default*Style` mirror.
+
+Installing `ThemeDark` at init would silently restyle every such app. The first
+`SetTheme` call already replaces the literals, today and before this change, so
+the mixture is short-lived in practice. Reconciling the literals with
+`ThemeDark` is a visible-appearance decision and belongs in its own change.
+
+## Follow-up
+
+Migrating factory-time reads to `w.Theme()` is optional and only pays where a
+window is already in hand and no closure is added: the event path
+(`gui/event_handlers.go`, `gui/scroll.go`), the backends, and new widgets.

--- a/examples/showcase/demo_theme.go
+++ b/examples/showcase/demo_theme.go
@@ -285,7 +285,55 @@ func demoThemeGen(w *gui.Window) gui.View {
 					}),
 				},
 			}),
+			themeContrastPreview(),
 		},
+	})
+}
+
+// themeContrastPreview renders the same widgets under the light preset
+// while the rest of the window keeps its own theme. gui.Themed scopes a
+// theme to one subtree; its builder runs at layout-generation time,
+// which is what lets the widgets inside resolve their defaults from the
+// scoped theme rather than the window's.
+func themeContrastPreview() gui.View {
+	light, ok := gui.ThemeGet("light")
+	if !ok {
+		return nil
+	}
+	return gui.Themed(light, func(w *gui.Window) gui.View {
+		lt := gui.CurrentTheme()
+		return gui.Column(gui.ContainerCfg{
+			ID:      "theme-preview",
+			Sizing:  gui.FillFit,
+			Spacing: gui.SomeF(8),
+			Padding: gui.PadAll(12),
+			Color:   lt.ColorPanel,
+			Radius:  gui.SomeF(8),
+			Content: []gui.View{
+				gui.Text(gui.TextCfg{
+					Text:      "Scoped theme (light) — window theme unchanged",
+					TextStyle: lt.N3,
+				}),
+				gui.Row(gui.ContainerCfg{
+					Sizing:  gui.FillFit,
+					Spacing: gui.SomeF(8),
+					Padding: gui.NoPadding,
+					Content: []gui.View{
+						gui.Button(gui.ButtonCfg{
+							ID:      "theme-preview-btn",
+							Content: []gui.View{gui.Text(gui.TextCfg{Text: "Button"})},
+						}),
+						gui.Switch(gui.SwitchCfg{ID: "theme-preview-switch"}),
+						gui.Slider(gui.SliderCfg{
+							ID:     "theme-preview-slider",
+							Value:  40,
+							Width:  120,
+							Sizing: gui.FixedFit,
+						}),
+					},
+				}),
+			},
+		})
 	})
 }
 

--- a/gui/a11y_tree.go
+++ b/gui/a11y_tree.go
@@ -316,5 +316,6 @@ func (w *Window) WindowCleanup() {
 		}
 		w.clearViewStateLocked()
 		w.renderGuardWarned = 0
+		unregisterWindow(w)
 	})
 }

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -223,10 +223,10 @@ func layoutWrapRTF(shape *Shape, tc *shapeTextConfig, w *Window) {
 	vs := &w.viewState
 
 	// Invalidate on theme change.
-	themeName := guiTheme.Name
-	if vs.rtfLayoutCache != nil && vs.rtfLayoutTheme != themeName {
+	themeID := guiTheme.id
+	if vs.rtfLayoutCache != nil && vs.rtfLayoutTheme != themeID {
 		vs.rtfLayoutCache.Clear()
-		vs.rtfLayoutTheme = themeName
+		vs.rtfLayoutTheme = themeID
 	}
 
 	// Check cross-frame cache.
@@ -285,7 +285,7 @@ func layoutWrapRTF(shape *Shape, tc *shapeTextConfig, w *Window) {
 	// Store in cross-frame cache.
 	if vs.rtfLayoutCache == nil {
 		vs.rtfLayoutCache = NewBoundedMap[uint64, rtfLayoutEntry](200)
-		vs.rtfLayoutTheme = themeName
+		vs.rtfLayoutTheme = themeID
 	}
 	vs.rtfLayoutCache.Set(cacheKey, rtfLayoutEntry{
 		Layout: l,

--- a/gui/theme.go
+++ b/gui/theme.go
@@ -1,12 +1,41 @@
 package gui
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
-// guiTheme is the package-level active theme.
+// Theme state comes in two layers.
+//
+// guiTheme (and the ~30 default*Style mirrors that applyTheme writes) is
+// the *installed* theme: a frame-scoped cache of the theme belonging to
+// the window currently being generated. Widget factories read it at
+// construction time, which is inside that window's frame pass, so the
+// value they see is that window's theme. Only the frame thread writes it,
+// through applyTheme.
+//
+// defaultTheme is *app* state: the theme a window follows until it sets
+// its own with (*Window).SetTheme. Package-level SetTheme writes this one.
 var (
 	guiTheme   Theme
 	guiThemeMu sync.RWMutex
+
+	defaultTheme   Theme
+	defaultThemeMu sync.RWMutex
+
+	// installedThemeID is the id of the theme currently written into
+	// guiTheme and the style mirrors. Frame-thread only.
+	installedThemeID uint64
+
+	// themeIDCounter hands out Theme.id values. Starts at 1 so a
+	// zero-valued Theme never collides with a real one.
+	themeIDCounter atomic.Uint64
 )
+
+// nextThemeID returns a fresh theme identity.
+func nextThemeID() uint64 {
+	return themeIDCounter.Add(1)
+}
 
 // Theme describes a complete GUI theme. Only styles for existing
 // Go views are populated (Button, Container, Rectangle, Text,
@@ -111,6 +140,12 @@ type Theme struct {
 	scrollDeltaLine  float32
 	scrollDeltaPage  float32
 	inspectorStyle   InspectorStyle
+
+	// id identifies this exact theme value. Stamped by ThemeMaker and
+	// re-stamped by every with*Style helper, so a derived theme never
+	// reuses its parent's id. Zero means "built outside ThemeMaker" and
+	// forces a re-install rather than a wrong fast-path hit.
+	id uint64
 
 	ColorBackground Color
 	ColorPanel      Color
@@ -233,8 +268,36 @@ func CurrentTheme() Theme {
 	return guiTheme
 }
 
-// SetTheme sets the active theme and updates all Default*Style vars.
+// SetTheme sets the app-default theme: the theme every window follows
+// until it pins its own with (*Window).SetTheme. Windows that never pin
+// one pick this up on their next frame, so calling SetTheme from main or
+// from an event handler rethemes the app as it always has.
 func SetTheme(t Theme) {
+	defaultThemeMu.Lock()
+	defaultTheme = t
+	defaultThemeMu.Unlock()
+	// Install eagerly as well, so callers outside a frame pass — main
+	// before Run, tests building views directly — see the change at
+	// once. Each window's frame start re-installs its own theme, so
+	// this cannot outlive the next frame of a window that pinned one.
+	applyTheme(t)
+	appUpdateWindows()
+}
+
+// currentDefaultTheme returns the app-default theme.
+func currentDefaultTheme() Theme {
+	defaultThemeMu.RLock()
+	defer defaultThemeMu.RUnlock()
+	return defaultTheme
+}
+
+// applyTheme installs t as the active theme: guiTheme plus every
+// default*Style mirror that widget factories read.
+//
+// Frame-thread only. Callers are (*Window).installTheme at frame start,
+// Themed's push/pop around a scoped subtree, and package init.
+func applyTheme(t Theme) {
+	installedThemeID = t.id
 	guiThemeMu.Lock()
 	defer guiThemeMu.Unlock()
 	guiTheme = t

--- a/gui/theme_defaults.go
+++ b/gui/theme_defaults.go
@@ -200,6 +200,18 @@ func init() {
 	themeRegister(themeBlue)
 	themeRegister(themeBlueBordered)
 
-	// Set default active theme to dark.
+	// Dark is both the app default and the initially installed theme.
+	//
+	// Deliberately NOT applyTheme: the ~30 default*Style literals in
+	// styles*.go do not all match ThemeDark (button/input/container
+	// borders are 1.5 there and 0 in ThemeDark, the dataGrid literal is
+	// an unstyled placeholder), and an app that never calls SetTheme
+	// runs on that mixture today. Installing ThemeDark here would
+	// silently restyle every such app. Seeding installedThemeID instead
+	// makes the first frame's installTheme a no-op, so the shipped
+	// default appearance is bit-identical to before per-window themes.
+	// Reconciling the literals with ThemeDark is a separate change.
+	defaultTheme = ThemeDark
 	guiTheme = ThemeDark
+	installedThemeID = ThemeDark.id
 }

--- a/gui/theme_install.go
+++ b/gui/theme_install.go
@@ -1,0 +1,135 @@
+package gui
+
+import "sync"
+
+// Window-scoped theme installation.
+//
+// A window owns its theme; the frame pass installs that theme into the
+// package-level style state (guiTheme + the default*Style mirrors) before
+// the view function runs. Widget factories resolve their defaults at
+// construction time, and construction happens inside the frame pass of the
+// window being generated, so a factory-time read always sees the right
+// window's theme.
+//
+// The invariant this rests on: every window's frame pass runs on the one
+// main OS thread. Both desktop backends lock the thread in package init
+// and drive all windows from a single sequential loop, so two windows can
+// never generate layouts concurrently.
+
+// liveWindows tracks windows that follow the app-default theme so
+// SetTheme can request a repaint for them. Registration happens in
+// NewWindow; removal in WindowCleanup.
+var (
+	liveWindowsMu sync.Mutex
+	liveWindows   []*Window
+)
+
+// registerWindow adds w to the live-window set.
+func registerWindow(w *Window) {
+	liveWindowsMu.Lock()
+	liveWindows = append(liveWindows, w)
+	liveWindowsMu.Unlock()
+}
+
+// unregisterWindow drops w from the live-window set.
+func unregisterWindow(w *Window) {
+	liveWindowsMu.Lock()
+	for i := range liveWindows {
+		if liveWindows[i] == w {
+			liveWindows = append(liveWindows[:i], liveWindows[i+1:]...)
+			break
+		}
+	}
+	liveWindowsMu.Unlock()
+}
+
+// appUpdateWindows requests a rebuild on every window that follows the
+// app-default theme. Called after the default changes. The refresh flag
+// is frame-thread state, so the request goes through the command queue
+// rather than being written from the caller's goroutine.
+func appUpdateWindows() {
+	liveWindowsMu.Lock()
+	ws := make([]*Window, len(liveWindows))
+	copy(ws, liveWindows)
+	liveWindowsMu.Unlock()
+
+	for _, w := range ws {
+		if w.themePinned() {
+			continue
+		}
+		w.QueueCommand(func(win *Window) { win.markLayoutRefresh() })
+	}
+}
+
+// themePinned reports whether the window set its own theme.
+func (w *Window) themePinned() bool {
+	w.themeMu.RLock()
+	defer w.themeMu.RUnlock()
+	return w.themeSet
+}
+
+// Theme returns the window's active theme: the one set with SetTheme, or
+// the app default when the window has not pinned one.
+func (w *Window) Theme() Theme {
+	if w == nil {
+		return currentDefaultTheme()
+	}
+	w.themeMu.RLock()
+	pinned, t := w.themeSet, w.theme
+	w.themeMu.RUnlock()
+	if pinned {
+		return t
+	}
+	return currentDefaultTheme()
+}
+
+// SetTheme pins t as this window's theme and requests a rebuild. Other
+// windows keep theirs. The install happens at the start of the next
+// frame, which the requested rebuild guarantees.
+func (w *Window) SetTheme(t Theme) {
+	w.themeMu.Lock()
+	w.theme = t
+	w.themeSet = true
+	w.themeMu.Unlock()
+	// Installed eagerly for the same reason package SetTheme does it:
+	// the common caller is an event handler on the frame thread, and
+	// code running after it in that frame should already see t.
+	applyTheme(t)
+	w.UpdateWindow()
+}
+
+// needsInstall reports whether t must be (re-)installed: its id is
+// unset (built outside ThemeMaker, so it can never match the fast
+// path) or it is not the theme currently installed.
+func needsInstall(t Theme) bool {
+	return t.id == 0 || t.id != installedThemeID
+}
+
+// installTheme makes this window's theme the active one for the frame.
+// Frame-thread only; a no-op when the same theme is already installed,
+// which is the steady state for a single-window app.
+func (w *Window) installTheme() {
+	t := w.Theme()
+	if !needsInstall(t) {
+		return
+	}
+	applyTheme(t)
+}
+
+// pushTheme installs t and returns the theme it displaced, for a later
+// popTheme. Frame-thread only; used to scope a theme to a subtree.
+func pushTheme(t Theme) Theme {
+	prev := CurrentTheme()
+	if needsInstall(t) {
+		applyTheme(t)
+	}
+	return prev
+}
+
+// popTheme restores the theme a matching pushTheme displaced.
+func popTheme(prev Theme) {
+	if !needsInstall(prev) {
+		return
+	}
+	applyTheme(prev)
+}

--- a/gui/theme_install_test.go
+++ b/gui/theme_install_test.go
@@ -1,0 +1,269 @@
+package gui
+
+import "testing"
+
+// Theme installation is package-global by design (the installed theme is
+// a frame-scoped cache), so these tests must not run in parallel with
+// each other or with anything else that installs a theme.
+
+// themeWithPanel returns a theme whose ColorPanel is c, so a rendered
+// container's color identifies which theme was installed.
+func themeWithPanel(t *testing.T, name string, c Color) Theme {
+	t.Helper()
+	cfg := themeDarkCfg
+	cfg.Name = name
+	cfg.ColorPanel = c
+	return ThemeMaker(cfg)
+}
+
+// panelView renders one container colored from the installed theme.
+func panelView(w *Window) View {
+	return Column(ContainerCfg{
+		ID:    "panel",
+		Color: CurrentTheme().ColorPanel,
+	})
+}
+
+func restoreTheme(t *testing.T) {
+	t.Helper()
+	prev := currentDefaultTheme()
+	t.Cleanup(func() { SetTheme(prev) })
+}
+
+func TestWindowThemeIsolated(t *testing.T) {
+	restoreTheme(t)
+	red := themeWithPanel(t, "red", RGB(200, 0, 0))
+	blue := themeWithPanel(t, "blue", RGB(0, 0, 200))
+
+	w1 := NewTestWindow(WindowCfg{})
+	w2 := NewTestWindow(WindowCfg{})
+	w1.SetTheme(red)
+	w2.SetTheme(blue)
+
+	// Frames run one window at a time, exactly as the backend loop does.
+	got1 := findByLeafIDTest(t, w1.TestRender(panelView), "panel").Shape.Color
+	got2 := findByLeafIDTest(t, w2.TestRender(panelView), "panel").Shape.Color
+	if got1 != red.ColorPanel {
+		t.Errorf("w1 panel = %v, want %v", got1, red.ColorPanel)
+	}
+	if got2 != blue.ColorPanel {
+		t.Errorf("w2 panel = %v, want %v", got2, blue.ColorPanel)
+	}
+
+	// And back again — the install must follow the window, not the
+	// most recent SetTheme call.
+	if got := findByLeafIDTest(t, w1.TestRender(nil), "panel").Shape.Color; got != red.ColorPanel {
+		t.Errorf("w1 panel after w2 frame = %v, want %v",
+			got, red.ColorPanel)
+	}
+}
+
+func TestWindowThemeFollowsDefault(t *testing.T) {
+	restoreTheme(t)
+	green := themeWithPanel(t, "green", RGB(0, 200, 0))
+	pinned := themeWithPanel(t, "pinned", RGB(200, 0, 200))
+
+	follower := NewTestWindow(WindowCfg{})
+	pinnedWin := NewTestWindow(WindowCfg{})
+	pinnedWin.SetTheme(pinned)
+
+	SetTheme(green)
+
+	if got := follower.Theme().id; got != green.id {
+		t.Errorf("follower theme id = %d, want %d", got, green.id)
+	}
+	if got := pinnedWin.Theme().id; got != pinned.id {
+		t.Errorf("pinned theme id = %d, want %d", got, pinned.id)
+	}
+	if got := findByLeafIDTest(t, follower.TestRender(panelView), "panel").Shape.Color; got != green.ColorPanel {
+		t.Errorf("follower panel = %v, want %v", got, green.ColorPanel)
+	}
+	if got := findByLeafIDTest(t, pinnedWin.TestRender(panelView), "panel").Shape.Color; got != pinned.ColorPanel {
+		t.Errorf("pinned panel = %v, want %v", got, pinned.ColorPanel)
+	}
+}
+
+func TestInstallThemeSkipsWhenUnchanged(t *testing.T) {
+	restoreTheme(t)
+	th := themeWithPanel(t, "steady", RGB(1, 2, 3))
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(th)
+	w.TestRender(panelView)
+
+	// Corrupt one mirror. installTheme must not rewrite it, proving the
+	// fast path took over once the theme was already installed.
+	saved := defaultButtonStyle.Color
+	defaultButtonStyle.Color = RGB(9, 9, 9)
+	w.installTheme()
+	got := defaultButtonStyle.Color
+	defaultButtonStyle.Color = saved
+	if got != RGB(9, 9, 9) {
+		t.Error("installTheme rewrote mirrors for an already-installed theme")
+	}
+}
+
+func TestThemedScopesSubtree(t *testing.T) {
+	restoreTheme(t)
+	outer := themeWithPanel(t, "outer", RGB(10, 0, 0))
+	inner := themeWithPanel(t, "inner", RGB(0, 10, 0))
+
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(outer)
+
+	root := w.TestRender(func(win *Window) View {
+		return Column(ContainerCfg{
+			ID: "root",
+			Content: []View{
+				Themed(inner, func(*Window) View {
+					return Column(ContainerCfg{
+						ID:    "scoped",
+						Color: CurrentTheme().ColorPanel,
+					})
+				}),
+				// Built after Themed's node, so it also proves the
+				// theme was restored on the way out.
+				viewFunc(func(*Window) View {
+					return Column(ContainerCfg{
+						ID:    "sibling",
+						Color: CurrentTheme().ColorPanel,
+					})
+				}),
+			},
+		})
+	})
+
+	scoped := findByLeafIDTest(t, root, "scoped")
+	sibling := findByLeafIDTest(t, root, "sibling")
+	if scoped.Shape.Color != inner.ColorPanel {
+		t.Errorf("scoped = %v, want %v",
+			scoped.Shape.Color, inner.ColorPanel)
+	}
+	if sibling.Shape.Color != outer.ColorPanel {
+		t.Errorf("sibling = %v, want %v",
+			sibling.Shape.Color, outer.ColorPanel)
+	}
+	if CurrentTheme().id != outer.id {
+		t.Error("Themed did not restore the window theme after the frame")
+	}
+}
+
+func TestThemedNests(t *testing.T) {
+	restoreTheme(t)
+	a := themeWithPanel(t, "a", RGB(1, 0, 0))
+	b := themeWithPanel(t, "b", RGB(0, 1, 0))
+	c := themeWithPanel(t, "c", RGB(0, 0, 1))
+
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(a)
+
+	root := w.TestRender(func(*Window) View {
+		return Themed(b, func(*Window) View {
+			return Column(ContainerCfg{
+				ID:    "b",
+				Color: CurrentTheme().ColorPanel,
+				Content: []View{
+					Themed(c, func(*Window) View {
+						return Column(ContainerCfg{
+							ID:    "c",
+							Color: CurrentTheme().ColorPanel,
+						})
+					}),
+					viewFunc(func(*Window) View {
+						return Column(ContainerCfg{
+							ID:    "after-c",
+							Color: CurrentTheme().ColorPanel,
+						})
+					}),
+				},
+			})
+		})
+	})
+
+	if got := findByLeafIDTest(t, root, "c").Shape.Color; got != c.ColorPanel {
+		t.Errorf("inner = %v, want %v", got, c.ColorPanel)
+	}
+	if got := findByLeafIDTest(t, root, "after-c").Shape.Color; got != b.ColorPanel {
+		t.Errorf("after inner = %v, want %v", got, b.ColorPanel)
+	}
+}
+
+func TestThemedKeepsExplicitOverride(t *testing.T) {
+	restoreTheme(t)
+	inner := themeWithPanel(t, "inner-ovr", RGB(0, 10, 0))
+	want := RGB(123, 45, 67)
+
+	w := NewTestWindow(WindowCfg{})
+	root := w.TestRender(func(*Window) View {
+		return Themed(inner, func(*Window) View {
+			return Column(ContainerCfg{ID: "explicit", Color: want})
+		})
+	})
+	if got := findByLeafIDTest(t, root, "explicit").Shape.Color; got != want {
+		t.Errorf("explicit color = %v, want %v", got, want)
+	}
+}
+
+func TestThemedNilBuild(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(*Window) View {
+		return Column(ContainerCfg{
+			ID:      "root",
+			Content: []View{Themed(ThemeLight, nil)},
+		})
+	})
+}
+
+func TestThemedZeroIDThemeInstalls(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(themeWithPanel(t, "base", RGB(0, 0, 10)))
+	// A hand-built Theme has id 0, which must bypass the install fast
+	// path rather than masquerade as the already-installed theme.
+	raw := Theme{ColorPanel: RGB(1, 2, 3)}
+
+	root := w.TestRender(func(*Window) View {
+		return Themed(raw, func(*Window) View {
+			return Column(ContainerCfg{
+				ID:    "raw",
+				Color: CurrentTheme().ColorPanel,
+			})
+		})
+	})
+	if got := findByLeafIDTest(t, root, "raw").Shape.Color; got != raw.ColorPanel {
+		t.Errorf("raw theme panel = %v, want %v", got, raw.ColorPanel)
+	}
+	if CurrentTheme().id != w.Theme().id {
+		t.Error("Themed did not restore the window theme after the frame")
+	}
+}
+
+// findByLeafIDTest locates a layout node by its leaf ID, ignoring the
+// effective-ID scope the resolve pass stamps. Deliberate: these tests
+// build one shape per known leaf and assert its rendered style, and
+// spelling the scoped key ("root:scoped") would bake ancestor-scoping
+// rules into the expectations. Layout.FindByID is the API for real
+// lookups, which key on the effective ID.
+func findByLeafIDTest(t *testing.T, root *Layout, id string) *Layout {
+	t.Helper()
+	var walk func(*Layout) *Layout
+	walk = func(l *Layout) *Layout {
+		if l == nil {
+			return nil
+		}
+		if l.Shape != nil && l.Shape.ID == id {
+			return l
+		}
+		for i := range l.Children {
+			if found := walk(&l.Children[i]); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+	found := walk(root)
+	if found == nil {
+		t.Fatalf("layout %q not found", id)
+	}
+	return found
+}

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -579,5 +579,10 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 	theme.icon5 = makeStyle(icon, theme.sizeTextXSmall)
 	theme.icon6 = makeStyle(icon, theme.SizeTextTiny)
 
+	// Every theme leaving this constructor carries a fresh identity.
+	// Install and cache-invalidation compare ids, never Name: two themes
+	// may legitimately share a name and differ in styles.
+	theme.id = nextThemeID()
+
 	return theme
 }

--- a/gui/theme_with.go
+++ b/gui/theme_with.go
@@ -3,185 +3,216 @@ package gui
 // WithButtonStyle returns a Theme with the given style.
 func (t Theme) withButtonStyle(s buttonStyle) Theme {
 	t.ButtonStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithContainerStyle returns a Theme with the given style.
 func (t Theme) withContainerStyle(s containerStyle) Theme {
 	t.ContainerStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithRectangleStyle returns a Theme with the given style.
 func (t Theme) withRectangleStyle(s RectangleStyle) Theme {
 	t.rectangleStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithTextStyle returns a Theme with the given style.
 func (t Theme) withTextStyle(s TextStyle) Theme {
 	t.TextStyleDef = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithInputStyle returns a Theme with the given style.
 func (t Theme) withInputStyle(s InputStyle) Theme {
 	t.InputStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithScrollbarStyle returns a Theme with the given style.
 func (t Theme) withScrollbarStyle(s ScrollbarStyle) Theme {
 	t.ScrollbarStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithRadioStyle returns a Theme with the given style.
 func (t Theme) withRadioStyle(s RadioStyle) Theme {
 	t.radioStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithSwitchStyle returns a Theme with the given style.
 func (t Theme) withSwitchStyle(s SwitchStyle) Theme {
 	t.switchStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithToggleStyle returns a Theme with the given style.
 func (t Theme) withToggleStyle(s ToggleStyle) Theme {
 	t.toggleStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithSelectStyle returns a Theme with the given style.
 func (t Theme) withSelectStyle(s SelectStyle) Theme {
 	t.selectStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithListBoxStyle returns a Theme with the given style.
 func (t Theme) withListBoxStyle(s ListBoxStyle) Theme {
 	t.listBoxStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithTreeStyle returns a Theme with the given style.
 func (t Theme) withTreeStyle(s TreeStyle) Theme {
 	t.treeStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithDialogStyle returns a Theme with the given style.
 func (t Theme) withDialogStyle(s DialogStyle) Theme {
 	t.dialogStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithToastStyle returns a Theme with the given style.
 func (t Theme) withToastStyle(s ToastStyle) Theme {
 	t.toastStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithTooltipStyle returns a Theme with the given style.
 func (t Theme) withTooltipStyle(s TooltipStyle) Theme {
 	t.tooltipStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithBadgeStyle returns a Theme with the given style.
 func (t Theme) withBadgeStyle(s BadgeStyle) Theme {
 	t.badgeStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithExpandPanelStyle returns a Theme with the given style.
 func (t Theme) withExpandPanelStyle(s ExpandPanelStyle) Theme {
 	t.expandPanelStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithProgressBarStyle returns a Theme with the given style.
 func (t Theme) withProgressBarStyle(s ProgressBarStyle) Theme {
 	t.progressBarStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithSliderStyle returns a Theme with the given style.
 func (t Theme) withSliderStyle(s SliderStyle) Theme {
 	t.sliderStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithTabControlStyle returns a Theme with the given style.
 func (t Theme) withTabControlStyle(s TabControlStyle) Theme {
 	t.tabControlStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithBreadcrumbStyle returns a Theme with the given style.
 func (t Theme) withBreadcrumbStyle(s BreadcrumbStyle) Theme {
 	t.breadcrumbStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithSplitterStyle returns a Theme with the given style.
 func (t Theme) withSplitterStyle(s SplitterStyle) Theme {
 	t.splitterStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithTableStyle returns a Theme with the given style.
 func (t Theme) withTableStyle(s TableStyle) Theme {
 	t.tableStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithComboboxStyle returns a Theme with the given style.
 func (t Theme) withComboboxStyle(s ComboboxStyle) Theme {
 	t.comboboxStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithCommandPaletteStyle returns a Theme with the given style.
 func (t Theme) withCommandPaletteStyle(s CommandPaletteStyle) Theme {
 	t.commandPaletteStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithMenubarStyle returns a Theme with the given style.
 func (t Theme) withMenubarStyle(s MenubarStyle) Theme {
 	t.MenubarStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithDatePickerStyle returns a Theme with the given style.
 func (t Theme) withDatePickerStyle(s DatePickerStyle) Theme {
 	t.datePickerStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithColorPickerStyle returns a Theme with the given style.
 func (t Theme) withColorPickerStyle(s ColorPickerStyle) Theme {
 	t.colorPickerStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithSkeletonStyle returns a Theme with the given style.
 func (t Theme) withSkeletonStyle(s SkeletonStyle) Theme {
 	t.skeletonStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // WithDataGridStyle returns a Theme with the given style.
 func (t Theme) withDataGridStyle(s DataGridStyle) Theme {
 	t.dataGridStyle = s
+	t.id = nextThemeID()
 	return t
 }
 
 // withInspectorStyle returns a Theme with the given style.
 func (t Theme) withInspectorStyle(s InspectorStyle) Theme {
 	t.inspectorStyle = s
+	t.id = nextThemeID()
 	return t
 }

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -298,12 +298,12 @@ func (mv *markdownView) GenerateLayout(w *Window) Layout {
 
 	// Cache lookup; invalidate on theme change.
 	hash := int64(markdown.MathHash(cfg.Source))
-	themeName := guiTheme.Name
+	themeID := guiTheme.id
 	if w.viewState.markdownCache == nil ||
-		w.viewState.markdownTheme != themeName {
+		w.viewState.markdownTheme != themeID {
 		w.viewState.markdownCache =
 			NewBoundedMap[int64, []markdownBlock](100)
-		w.viewState.markdownTheme = themeName
+		w.viewState.markdownTheme = themeID
 	}
 	blocks, ok := w.viewState.markdownCache.Get(hash)
 	if !ok {

--- a/gui/view_themed.go
+++ b/gui/view_themed.go
@@ -1,0 +1,50 @@
+package gui
+
+// themedView scopes a theme to the subtree its builder produces.
+type themedView struct {
+	build func(*Window) View
+	theme Theme
+}
+
+// Themed scopes t to one subtree: the views build returns resolve their
+// theme defaults from t, and everything outside keeps the window's theme.
+// Themed nests — an inner Themed restores the outer theme on the way out.
+//
+// build runs at layout-generation time, and that is not sugar. Widget
+// factories resolve defaults when they are called, so a signature taking
+// ready-made child views would receive children already built under the
+// enclosing theme. Deferring construction is what makes the scope work.
+//
+//	gui.Themed(gui.ThemeGet("light"), func(w *gui.Window) gui.View {
+//	    return gui.Column(gui.ContainerCfg{Content: []gui.View{
+//	        gui.Button(gui.ButtonCfg{ID: "ok", Text: "OK"}),
+//	    }})
+//	})
+//
+// The scope covers generation only. The few theme reads that happen after
+// generation — scroll metrics on the event path, the theme picker's
+// report of the active theme — stay window-scoped.
+func Themed(t Theme, build func(w *Window) View) View {
+	return themedView{theme: t, build: build}
+}
+
+// Content satisfies View. Themed generates its own subtree so it can
+// restore the enclosing theme afterwards, which a Content slice walked
+// by the parent recursion would give it no hook to do.
+func (v themedView) Content() []View { return nil }
+
+// GenerateLayout installs the scoped theme, builds and generates the
+// subtree under it, then restores the theme it displaced.
+func (v themedView) GenerateLayout(w *Window) Layout {
+	if v.build == nil {
+		return Layout{}
+	}
+	prev := pushTheme(v.theme)
+	defer popTheme(prev)
+
+	inner := v.build(w)
+	if inner == nil {
+		return Layout{}
+	}
+	return generateViewLayout(inner, w)
+}

--- a/gui/window.go
+++ b/gui/window.go
@@ -191,6 +191,14 @@ type Window struct {
 	// Cleanup guard.
 	cleanupOnce sync.Once
 
+	// Theme owned by this window. Unset until SetTheme pins one, in
+	// which case the window follows the app default. Read from any
+	// goroutine (Theme()), written by SetTheme — hence its own lock
+	// rather than piggybacking on mu, which the frame pass holds.
+	theme    Theme
+	themeSet bool
+	themeMu  sync.RWMutex
+
 	// Mutexes.
 	mu         sync.Mutex // guards layout/renderer state
 	commandsMu sync.Mutex // guards command queue
@@ -465,12 +473,6 @@ func (w *Window) Timings() FrameTimings { return w.frameTimings }
 // MouseCursorState returns the current mouse cursor shape.
 func (w *Window) MouseCursorState() MouseCursor {
 	return w.viewState.mouseCursor
-}
-
-// SetTheme sets the active theme and updates the window.
-func (w *Window) SetTheme(t Theme) {
-	SetTheme(t)
-	w.UpdateWindow()
 }
 
 // App returns the parent App, or nil for single-window mode.

--- a/gui/window_cfg.go
+++ b/gui/window_cfg.go
@@ -99,5 +99,8 @@ func NewWindow(cfg WindowCfg) *Window {
 	if cfg.DebugTimeTravel {
 		w.enableHistory(cfg.historyBytes)
 	}
+	// Tracked so a later package-level SetTheme can repaint the windows
+	// that follow the app default. Dropped again in WindowCleanup.
+	registerWindow(w)
 	return w
 }

--- a/gui/window_state.go
+++ b/gui/window_state.go
@@ -88,9 +88,12 @@ type ViewState struct {
 	rtfLayoutCache *BoundedMap[uint64, rtfLayoutEntry]
 	tooltip        tooltipState
 
-	// Markdown caches (lazy-init: nil until first use).
-	markdownTheme     string
-	rtfLayoutTheme    string
+	// Markdown caches (lazy-init: nil until first use). Keyed on
+	// Theme.id, not Theme.Name: a derived or scoped theme can carry the
+	// same name with different text styles, which a name key would serve
+	// stale layouts for.
+	markdownTheme     uint64
+	rtfLayoutTheme    uint64
 	diagramRequestSeq uint64
 	focusID           string
 

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -160,6 +160,10 @@ func (w *Window) UpdateView(gen func(*Window) View) {
 // should call renderFrame.
 func (w *Window) FrameFn() bool {
 	w.frameCount++
+	// Before anything reads theme state this frame: make this window's
+	// theme the installed one. Also covers the backend's clear-color
+	// read, which happens right after FrameFn on the same thread.
+	w.installTheme()
 	w.flushCommands()
 	var rebuilt bool
 	if w.refreshLayout {
@@ -208,6 +212,9 @@ func (w *Window) PumpFrame() bool {
 
 // Update performs a full layout rebuild and re-renders.
 func (w *Window) Update() {
+	// Repeated from FrameFn because tests drive Update directly.
+	// Idempotent: a no-op when this window's theme is already installed.
+	w.installTheme()
 	w.mu.Lock()
 	w.refreshLayout = false
 	w.refreshRenderOnly = false


### PR DESCRIPTION
Closes #296.

## What

- **`w.SetTheme(t)` / `w.Theme()`** — a `Window` now owns its theme. Pinning themes one window; unpinned windows follow the app default that package-level `gui.SetTheme` still sets. The frame pass installs the active window's theme before the view function runs (`installTheme` in `FrameFn`/`Update`), so widget factories keep resolving their defaults at construction time — no factory signature changed, no per-frame allocation added, single-window behavior unchanged.
- **`gui.Themed(t, build)`** — scopes a theme to one subtree; nests; the builder runs at layout-generation time so factories resolve defaults under the scoped theme.
- **`Theme.id`** — stamped by `ThemeMaker` and re-stamped by every `with*Style` helper. Install fast-path and the markdown/RTF layout caches key on id, not `Name` (two themes may share a name and differ in styles).
- Theme state is now two layers: installed (frame-scoped cache) vs app-default. `SetTheme` repaints unpinned windows via the command queue.

Design and the deliberate init drift (`default*Style` literals vs `ThemeDark`) are documented in `docs/specs/per-window-theme.md`.

## Tests

`gui/theme_install_test.go`: window isolation, default-following, install fast-path, Themed scoping/nesting/override, zero-id (non-ThemeMaker) themes, nil builder.

## Note

`Theme.WithColors`/`Theme.AdjustFontSize` (theme_colors.go) derive themes without re-stamping `id`; no in-repo callers today, follow-up suggested.