### PR TITLE
refactor(gui): make ThemeMaker the single source of default styling (issue #300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,43 @@ and this project adheres to
   is what makes the scope work: factories resolve defaults when they are called,
   so ready-made child views would already carry the enclosing theme.
 
+### Changed
+
+- **The default appearance changed: `ThemeMaker` is now the only source of
+  widget styling (issue #300).** Go-Gui carried two sets of defaults — about 30
+  `default*Style` literals in `styles*.go`, and `ThemeDark` — and they had
+  drifted apart. Because `init` never installed a theme, an app that never
+  called `SetTheme` ran on a mixture of the two, and switching themes once
+  restyled it. The literals are gone; `init` installs `ThemeDark`.
+
+  Every widget now looks the way it already did after any theme switch. The
+  visible differences from the old fresh-app look:
+
+  - Buttons, inputs, containers, dialogs, toasts, tooltips, expand panels,
+    selects, trees, switches, toggles, tab controls, date pickers, color
+    pickers, menubars, splitters, the command palette, comboboxes and listboxes
+    lose their 1.5px border. Sliders lose 1px, radios 2px. `ThemeDark` is
+    borderless by design; bordered is the separate `dark-bordered` preset.
+  - The **data grid gains its styling**. Its literal was an unstyled placeholder
+    with zero colors, so an unthemed datagrid rendered flat.
+  - Inputs and listboxes take the theme's medium padding (10 rather than 5/6),
+    so they are slightly taller.
+  - Badges turn grey with bold white text instead of blue with unstyled text.
+  - Dialogs gain 200/300 width bounds; toast titles are no longer bold; the
+    button click color, input/switch/toggle focus colors, toggle radius, submenu
+    spacing, command-palette detail color and input spell-error color all move
+    to their `ThemeDark` values.
+  - `NumericInput` and `RadioButtonGroup` follow the active theme. Both had a
+    private hard-coded 1.5px border that no theme could reach, light included.
+
+  To keep the previous look, install the bordered variant:
+
+  ```go
+  gui.SetTheme(gui.ThemeDark.WithBorders(true))
+  ```
+
+  See `docs/specs/theme-style-single-source.md`.
+
 ### Fixed
 
 - **Theme-keyed text caches no longer serve stale layouts.** The per-window

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,15 @@ Backend injects at startup. Nil in tests:
   generation time because factories resolve defaults when called. Anything keyed
   on a theme keys on `Theme.id`, never `Theme.Name` — names are not unique. See
   `docs/specs/per-window-theme.md`.
+- **`ThemeMaker` is the only source of default styling. The `default*Style`
+  package vars have no initializers — never add one.** They are mirrors: `init`
+  fills them with `applyTheme(ThemeDark)` and `installTheme` refills them per
+  theme change. A literal there is a second source of truth that silently drifts
+  (issue #300 removed ~30 of them; `ThemeDark` is borderless, bordered is the
+  `dark-bordered` preset or `Theme.WithBorders(true)`). The two exceptions are
+  `DefaultTextStyle` and `defaultInspectorStyle`, which are ThemeMaker _inputs_.
+  `TestDefaultStylesMirrorThemeDark` is the gate. See
+  `docs/specs/theme-style-single-source.md`.
 - `AmendLayout` hook on shapes runs after sizing to reposition overlays (color
   picker circles, splitter handles, etc.) or manage hover. Layout uses absolute
   coords. Moving parent in `AmendLayout` does NOT move children. Use float

--- a/docs/specs/per-window-theme.md
+++ b/docs/specs/per-window-theme.md
@@ -101,24 +101,20 @@ of the active theme.
 Unchanged. Factories fill only the fields a caller left unset, so an assigned
 `Cfg` field beats the theme at every level, inside a `Themed` subtree included.
 
-## Known drift, deliberately not fixed here
+## One source of truth
 
-`init` seeds `installedThemeID` instead of installing `ThemeDark`, so the first
-frame's `installTheme` is a no-op and the shipped default appearance is
-unchanged.
+`init` calls `applyTheme(ThemeDark)`, so the `default*Style` package vars in
+`styles*.go` are filled from `ThemeMaker` before the first frame. They carry no
+literals of their own.
 
-This matters because the `default*Style` literals in `styles*.go` do not all
-match `ThemeDark`. Examples: `SizeBorder` is 1.5 in the literals and 0 in
-`ThemeDark` for button, input, container, dialog, toast and others; the
-`dataGrid` literal is an unstyled placeholder with zero colors; `badge.Color`,
-`input.Padding` and `listbox.Padding` differ. An app that never calls `SetTheme`
-runs on this mixture today, because some widgets read `guiTheme.xStyle` and
-others read the `default*Style` mirror.
-
-Installing `ThemeDark` at init would silently restyle every such app. The first
-`SetTheme` call already replaces the literals, today and before this change, so
-the mixture is short-lived in practice. Reconciling the literals with
-`ThemeDark` is a visible-appearance decision and belongs in its own change.
+This was not true when per-window themes landed. `init` seeded
+`installedThemeID` instead, leaving the literals in place, so an app that never
+called `SetTheme` ran on a mixture: widgets reading `guiTheme.xStyle` got
+`ThemeDark` while widgets reading the mirror got the literals. Issue #300
+removed the literals and resolved every delta in `ThemeDark`'s favour — a
+visible change to the default appearance, chiefly the loss of the 1.5px border
+on buttons, inputs and containers. See
+`docs/specs/theme-style-single-source.md`.
 
 ## Follow-up
 

--- a/docs/specs/theme-style-single-source.md
+++ b/docs/specs/theme-style-single-source.md
@@ -1,0 +1,102 @@
+# Theme styling has one source: ThemeMaker
+
+Issue #300. Landed on top of per-window themes (#296), which found the problem
+and deliberately left it alone.
+
+## The problem
+
+Go-Gui had two sources of default widget styling, maintained by hand:
+
+- About 30 `default*Style` package-var literals in `gui/styles.go`,
+  `gui/styles_widget.go`, `gui/styles_widget_control.go` and
+  `gui/styles_widget_overlay.go`.
+- `ThemeDark`, built by `ThemeMaker(themeDarkCfg)`.
+
+Only `applyTheme` writes the literals, and `init` never called it — it seeded
+`installedThemeID` so the first frame's `installTheme` would be a no-op. An app
+that never called `SetTheme` therefore ran on a **mixture**: widgets that read
+`guiTheme.xStyle` directly (badge, expand panel, slider, progress bar,
+inspector) got `ThemeDark`, while widgets that read the `default*Style` mirror
+(button, input, container, listbox, tree, menubar, ...) got the literals. The
+first `SetTheme` call replaced every literal, so the shipped look and the
+after-one-theme-switch look already differed.
+
+Two further styles were unreachable by any theme, because `applyTheme` never
+touched them: `defaultNumericInputStyle` and `defaultRadioGroupStyle`. Both kept
+a 1.5px border under every theme, light included.
+
+## The rule
+
+`ThemeMaker` is the only source of default styling. The `default*Style` package
+vars are **mirrors**: declared with no initializer, filled by
+`applyTheme(ThemeDark)` from `init`, and refilled by `(*Window).installTheme`
+whenever the active theme changes.
+
+Never give a mirror an initializer. A package-var initializer is evaluated
+before `init` runs, so `applyTheme` overwrites it immediately — the literal is
+dead weight whose only effect is to drift from `ThemeMaker` and mislead the next
+reader. `TestDefaultStylesMirrorThemeDark`
+(`gui/styles_widget_defaults_test.go`) fails if one reappears.
+
+Two literals in `gui/styles.go` are **not** mirrors and keep their values:
+
+- `DefaultTextStyle` — `baseDarkCfg` reads it while building `ThemeDark`, which
+  happens during `init` before any theme exists.
+- `defaultInspectorStyle` — `ThemeMaker` copies it into every theme.
+
+Both are still re-assigned by `applyTheme`; for `ThemeDark` that assignment is a
+no-op, and for any other theme it is the correct behaviour.
+
+## Why `ThemeDark` won every delta
+
+The literals were effectively the `dark-bordered` preset, not `dark`. Three
+independent signals say borderless is the designed default and the 1.5 values
+were the drift:
+
+- `baseCfg` never sets `SizeBorder`. It is 0 by omission in `dark`, `light` and
+  `blue-dark` alike.
+- `dark-bordered`, `light-bordered` and `blue-dark-bordered` are each their base
+  config plus `SizeBorder = sizeBorderDef`. Folding 1.5 into `baseCfg` would
+  have made all three presets exact duplicates of their base.
+- `Theme.WithBorders(true)` exists so a caller can opt in.
+
+Every other delta was a literal that had simply fallen behind: an unstyled
+`dataGrid` placeholder, a dialog with no width bounds, a badge with no text
+style.
+
+## Appearance changes
+
+Borders. `SizeBorder` drops to 0 on button, input, container, dialog, toast,
+tooltip, expand panel, select, tree, switch, toggle, tab control, date picker,
+color picker, menubar, splitter, command palette, combobox and listbox (1.5), on
+slider (1) and on radio (2). The tab control's `sizeTabBorder` and the
+breadcrumb's `sizeContentBorder` follow.
+
+Everything else:
+
+| Widget          | Change                                         |
+| --------------- | ---------------------------------------------- |
+| button          | `colorClick` 104 → 94                          |
+| input           | `ColorFocus` 104 → 74; `Padding` 5 → 10        |
+| input           | spell-error color → the theme's error red      |
+| listbox         | `Padding` 6 → 10                               |
+| switch, toggle  | `ColorFocus` → 74; toggle `Radius` 3.5 → 5.5   |
+| badge           | `Color` blue → grey 104; gains bold white text |
+| toast           | `TitleStyle` bold → normal                     |
+| dialog          | gains `MinWidth` 200 / `MaxWidth` 300          |
+| menubar         | `spacingSubmenu` 0 → 1                         |
+| command palette | detail text → 225,225,225,140                  |
+| data grid       | unstyled placeholder → full dark styling       |
+| numeric input   | follows the active theme                       |
+| radio group     | follows the active theme                       |
+
+To keep the previous bordered look:
+
+```go
+gui.SetTheme(gui.ThemeDark.WithBorders(true))
+```
+
+## Related
+
+- `docs/specs/per-window-theme.md` — how a theme is installed per window and per
+  subtree.

--- a/gui/styles.go
+++ b/gui/styles.go
@@ -179,34 +179,28 @@ type RectangleStyle struct {
 	ColorBorder    Color
 }
 
-// Default styles (dark theme).
+// DefaultTextStyle is a ThemeMaker *input*, not a mirror: baseDarkCfg
+// reads it while building ThemeDark, which happens during init before
+// any theme is installed, so it needs a real literal. applyTheme
+// re-assigns it afterwards (a no-op for ThemeDark).
+var DefaultTextStyle = TextStyle{
+	Family: defaultFontFamily,
+	Color:  colorTextDark,
+	Size:   sizeTextMedium,
+}
+
+// Widget style mirrors (issue #300). ThemeMaker is the only source of
+// these values: init() fills them via applyTheme(ThemeDark) and
+// (*Window).installTheme refills them whenever the active theme changes.
+//
+// Never give one an initializer. A literal here is a second source of
+// truth that silently drifts from ThemeMaker — which is exactly the bug
+// this block used to carry (button/input/container borders were 1.5 here
+// and 0 in ThemeDark, and DefaultDataGridStyle stayed unstyled until an
+// app happened to call SetTheme).
 var (
-	DefaultTextStyle = TextStyle{
-		Family: defaultFontFamily,
-		Color:  colorTextDark,
-		Size:   sizeTextMedium,
-	}
-
-	defaultButtonStyle = buttonStyle{
-		Color:            colorInteriorDark,
-		ColorHover:       colorHoverDark,
-		ColorFocus:       colorActiveDark,
-		colorClick:       colorActiveDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		Padding:          paddingButton,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusMedium,
-	}
-
-	defaultContainerStyle = containerStyle{
-		Color:       ColorTransparent,
-		ColorBorder: ColorTransparent,
-		Padding:     paddingMedium,
-		Radius:      radiusMedium,
-		Spacing:     SpacingMedium,
-		SizeBorder:  sizeBorderDef,
-	}
+	defaultButtonStyle    buttonStyle
+	defaultContainerStyle containerStyle
 
 	DefaultDataGridStyle DataGridStyle
 )
@@ -246,7 +240,9 @@ type InspectorStyle struct {
 	colorPadding   Color
 }
 
-// DefaultInspectorStyle provides the default inspector color palette.
+// defaultInspectorStyle provides the default inspector color palette.
+// Like DefaultTextStyle it is a ThemeMaker input (ThemeMaker copies it
+// into every theme's inspectorStyle), so it keeps a real literal.
 var defaultInspectorStyle = InspectorStyle{
 	ColorPanel:     RGBA(64, 64, 64, 245),
 	colorTextHelp:  RGBA(225, 225, 225, 130),

--- a/gui/styles_widget.go
+++ b/gui/styles_widget.go
@@ -48,11 +48,6 @@ type RadioStyle struct {
 	colorUnselect    Color
 }
 
-// RadioGroupStyle defines radio button group visual properties.
-type radioGroupStyle struct {
-	SizeBorder float32
-}
-
 // SwitchStyle defines switch toggle visual properties.
 // exportaudit:keep — reachable from an exported signature
 type SwitchStyle struct {
@@ -114,103 +109,19 @@ type SelectStyle struct {
 	ColorSelect      Color
 }
 
-// Default widget styles (dark theme).
+// Widget style mirrors. See the note on the mirror block in styles.go:
+// ThemeMaker is the only source of these values — never add an
+// initializer here.
 var (
-	defaultInputStyle = InputStyle{
-		Color:            colorInteriorDark,
-		ColorHover:       colorHoverDark,
-		ColorFocus:       colorActiveDark,
-		colorClick:       colorActiveDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		colorSpellError:  RGBA(255, 80, 80, 220),
-		Padding:          PaddingSmall,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusMedium,
-		textStyleNormal:  DefaultTextStyle,
-		PlaceholderStyle: TextStyle{
-			Color: RGBA(colorTextDark.R, colorTextDark.G, colorTextDark.B, 100),
-			Size:  sizeTextMedium,
-		},
-	}
+	defaultInputStyle InputStyle
 
-	DefaultScrollbarStyle = ScrollbarStyle{
-		Size:            7,
-		minThumbSize:    20,
-		colorThumb:      colorActiveDark,
-		ColorBackground: ColorTransparent,
-		Radius:          radiusSmall,
-		radiusThumb:     radiusSmall,
-		GapEdge:         3,
-		GapEnd:          2,
-	}
+	DefaultScrollbarStyle ScrollbarStyle
 
-	defaultRadioStyle = RadioStyle{
-		Size:             sizeTextMedium,
-		Color:            colorPanelDark,
-		ColorHover:       colorHoverDark,
-		ColorFocus:       colorSelectDark,
-		colorClick:       colorActiveDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		ColorSelect:      colorSelectDark,
-		colorUnselect:    colorActiveDark,
-		Padding:          PadAll(4),
-		SizeBorder:       2.0,
-		textStyleNormal:  DefaultTextStyle,
-	}
+	defaultRadioStyle RadioStyle
 
-	defaultSwitchStyle = SwitchStyle{
-		sizeWidth:        36,
-		sizeHeight:       22,
-		Color:            colorPanelDark,
-		colorClick:       colorInteriorDark,
-		ColorFocus:       colorFocusDark,
-		ColorHover:       colorHoverDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		ColorSelect:      colorSelectDark,
-		colorUnselect:    colorActiveDark,
-		Padding:          paddingThree,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusLarge * 2,
-		textStyleNormal:  DefaultTextStyle,
-	}
+	defaultSwitchStyle SwitchStyle
 
-	defaultToggleStyle = ToggleStyle{
-		Color:            colorPanelDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		colorClick:       colorInteriorDark,
-		ColorFocus:       colorActiveDark,
-		ColorHover:       colorHoverDark,
-		ColorSelect:      colorInteriorDark,
-		Padding:          NewPadding(1, 1, 1, 2),
-		Size:             sizeTextMedium + 4,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusSmall,
-		textStyleNormal:  DefaultTextStyle,
-		textStyleLabel:   DefaultTextStyle,
-	}
+	defaultToggleStyle ToggleStyle
 
-	defaultSelectStyle = SelectStyle{
-		MinWidth:         75,
-		MaxWidth:         200,
-		Color:            colorInteriorDark,
-		ColorHover:       colorHoverDark,
-		ColorFocus:       colorFocusDark,
-		colorClick:       colorActiveDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		ColorSelect:      colorSelectDark,
-		Padding:          PaddingSmall,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusMedium,
-		textStyleNormal:  DefaultTextStyle,
-		subheadingStyle:  DefaultTextStyle,
-		PlaceholderStyle: TextStyle{
-			Color: RGBA(colorTextDark.R, colorTextDark.G, colorTextDark.B, 100),
-			Size:  sizeTextMedium,
-		},
-	}
+	defaultSelectStyle SelectStyle
 )

--- a/gui/styles_widget_control.go
+++ b/gui/styles_widget_control.go
@@ -1,7 +1,5 @@
 package gui
 
-import "github.com/go-gui-org/go-glyph"
-
 // ProgressBarStyle defines progress bar visual properties.
 // exportaudit:keep — reachable from an exported signature
 type ProgressBarStyle struct {
@@ -243,240 +241,31 @@ type SkeletonStyle struct {
 	Radius         float32
 }
 
-// Default widget styles (dark theme).
+// Widget style mirrors. See the note on the mirror block in styles.go:
+// ThemeMaker is the only source of these values — never add an
+// initializer here.
 var (
-	defaultProgressBarStyle = ProgressBarStyle{
-		Size:           20,
-		Color:          colorInteriorDark,
-		colorBar:       colorSelectDark,
-		ColorBorder:    colorBorderDark,
-		textBackground: ColorTransparent,
-		Padding:        PaddingNone,
-		textPadding:    NewPadding(1, 4, 1, 4),
-		SizeBorder:     0,
-		Radius:         radiusSmall,
-		TextShow:       true,
-		TextStyle:      DefaultTextStyle,
-	}
+	defaultProgressBarStyle ProgressBarStyle
 
-	defaultSliderStyle = SliderStyle{
-		Size:             6,
-		ThumbSize:        16,
-		Color:            colorInteriorDark,
-		colorClick:       colorActiveDark,
-		colorThumb:       colorPanelDark,
-		colorLeft:        colorSelectDark,
-		ColorFocus:       colorSelectDark,
-		ColorHover:       colorHoverDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		Padding:          PaddingNone,
-		SizeBorder:       1,
-		Radius:           3,
-	}
+	defaultSliderStyle SliderStyle
 
-	defaultTabControlStyle = TabControlStyle{
-		Color:               colorPanelDark,
-		ColorBorder:         colorBorderDark,
-		ColorHeader:         ColorTransparent,
-		colorHeaderBorder:   ColorTransparent,
-		colorContent:        colorPanelDark,
-		colorContentBorder:  colorBorderDark,
-		colorTab:            colorInteriorDark,
-		colorTabHover:       colorHoverDark,
-		colorTabFocus:       colorFocusDark,
-		colorTabClick:       colorActiveDark,
-		colorTabSelected:    colorSelectDark,
-		colorTabDisabled:    colorPanelDark,
-		colorTabBorder:      colorBorderDark,
-		colorTabBorderFocus: colorSelectDark,
-		Padding:             PaddingNone,
-		PaddingHeader:       PaddingNone,
-		paddingContent:      paddingMedium,
-		paddingTab:          PaddingSmall,
-		SizeBorder:          sizeBorderDef,
-		sizeTabBorder:       sizeBorderDef,
-		Radius:              radiusMedium,
-		radiusHeader:        radiusSmall,
-		radiusContent:       radiusMedium,
-		radiusTab:           radiusSmall,
-		spacingHeader:       2,
-		TextStyle:           DefaultTextStyle,
-		textStyleSelected: TextStyle{
-			Color: colorTextDark,
-			Size:  sizeTextMedium,
-		},
-		textStyleDisabled: TextStyle{
-			Color: RGBA(colorTextDark.R, colorTextDark.G, colorTextDark.B, 130),
-			Size:  sizeTextMedium,
-		},
-	}
+	defaultTabControlStyle TabControlStyle
 
-	defaultBreadcrumbStyle = BreadcrumbStyle{
-		Separator:          "/",
-		Color:              ColorTransparent,
-		ColorBorder:        ColorTransparent,
-		colorTrail:         ColorTransparent,
-		colorCrumb:         ColorTransparent,
-		colorCrumbHover:    colorHoverDark,
-		colorCrumbClick:    colorActiveDark,
-		colorCrumbSelected: ColorTransparent,
-		colorCrumbDisabled: ColorTransparent,
-		colorContent:       colorPanelDark,
-		colorContentBorder: colorBorderDark,
-		Padding:            PaddingNone,
-		paddingTrail:       PaddingSmall,
-		paddingCrumb:       NewPadding(2, 4, 2, 4),
-		paddingContent:     paddingMedium,
-		Radius:             radiusMedium,
-		radiusCrumb:        radiusSmall,
-		radiusContent:      radiusMedium,
-		Spacing:            SpacingSmall,
-		spacingTrail:       SpacingSmall,
-		sizeContentBorder:  sizeBorderDef,
-		TextStyle:          DefaultTextStyle,
-		textStyleSelected: TextStyle{
-			Color: colorTextDark,
-			Size:  sizeTextMedium,
-		},
-		textStyleDisabled: TextStyle{
-			Color: RGBA(colorTextDark.R, colorTextDark.G, colorTextDark.B, 130),
-			Size:  sizeTextMedium,
-		},
-		textStyleSeparator: TextStyle{
-			Color: RGBA(colorTextDark.R, colorTextDark.G, colorTextDark.B, 160),
-			Size:  sizeTextMedium,
-		},
-	}
+	defaultBreadcrumbStyle BreadcrumbStyle
 
-	defaultSplitterStyle = SplitterStyle{
-		HandleSize:        9,
-		dragStep:          0.02,
-		dragStepLarge:     0.10,
-		colorHandle:       colorInteriorDark,
-		colorHandleHover:  colorHoverDark,
-		colorHandleActive: colorActiveDark,
-		colorHandleBorder: colorBorderDark,
-		colorGrip:         colorSelectDark,
-		colorButton:       colorInteriorDark,
-		colorButtonHover:  colorHoverDark,
-		colorButtonActive: colorActiveDark,
-		colorButtonIcon:   colorTextDark,
-		SizeBorder:        sizeBorderDef,
-		Radius:            radiusSmall,
-		radiusBorder:      radiusSmall,
-	}
+	defaultSplitterStyle SplitterStyle
 
-	defaultTableStyle = TableStyle{
-		ColorBorder: colorBorderDark,
-		ColorSelect: colorSelectDark,
-		ColorHover:  colorHoverDark,
-		cellPadding: PaddingTwoFive,
-		TextStyle:   DefaultTextStyle,
-		TextStyleHead: TextStyle{
-			Color:    DefaultTextStyle.Color,
-			Size:     DefaultTextStyle.Size,
-			Typeface: glyph.TypefaceBold,
-		},
-		alignHead:          HAlignCenter,
-		columnWidthDefault: 50,
-		columnWidthMin:     20,
-	}
+	defaultTableStyle TableStyle
 
-	defaultComboboxStyle = ComboboxStyle{
-		Color:             colorInteriorDark,
-		ColorHover:        colorHoverDark,
-		ColorFocus:        colorInteriorDark,
-		ColorBorder:       colorBorderDark,
-		ColorBorderFocus:  colorSelectDark,
-		ColorHighlight:    colorSelectDark,
-		Padding:           PaddingSmall,
-		SizeBorder:        sizeBorderDef,
-		Radius:            radiusMedium,
-		MinWidth:          75,
-		MaxWidth:          200,
-		maxDropdownHeight: 200,
-		TextStyle:         DefaultTextStyle,
-		PlaceholderStyle: TextStyle{
-			Color: RGBA(colorTextDark.R, colorTextDark.G, colorTextDark.B, 100),
-			Size:  sizeTextMedium,
-		},
-	}
+	defaultComboboxStyle ComboboxStyle
 
-	defaultCommandPaletteStyle = CommandPaletteStyle{
-		Color:          colorPanelDark,
-		ColorBorder:    colorBorderDark,
-		ColorHighlight: colorSelectDark,
-		SizeBorder:     sizeBorderDef,
-		Radius:         radiusMedium,
-		Width:          500,
-		MaxHeight:      400,
-		TextStyle:      DefaultTextStyle,
-		detailStyle: TextStyle{
-			Color: RGBA(128, 128, 128, 200),
-			Size:  sizeTextMedium,
-		},
-		backdropColor: RGBA(0, 0, 0, 120),
-	}
+	defaultCommandPaletteStyle CommandPaletteStyle
 
-	defaultDatePickerStyle = DatePickerStyle{
-		cellSpacing:      2,
-		Color:            colorInteriorDark,
-		ColorHover:       colorHoverDark,
-		ColorFocus:       colorFocusDark,
-		colorClick:       colorActiveDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		ColorSelect:      colorSelectDark,
-		Padding:          PaddingSmall,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusMedium,
-		radiusBorder:     radiusMedium,
-		TextStyle:        DefaultTextStyle,
-	}
+	defaultDatePickerStyle DatePickerStyle
 
-	defaultColorPickerStyle = ColorPickerStyle{
-		Color:            colorInteriorDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusMedium,
-		sVSize:           200,
-		sliderHeight:     24,
-		indicatorSize:    16,
-		TextStyle:        DefaultTextStyle,
-	}
+	defaultColorPickerStyle ColorPickerStyle
 
-	defaultSkeletonStyle = SkeletonStyle{
-		Color:          colorInteriorDark,
-		ColorHighlight: colorInteriorDark.Add(RGBA(20, 20, 20, 0)),
-		Radius:         radiusSmall,
-	}
+	defaultSkeletonStyle SkeletonStyle
 
-	defaultMenubarStyle = MenubarStyle{
-		widthSubmenuMin:  50,
-		widthSubmenuMax:  200,
-		Color:            colorInteriorDark,
-		ColorHover:       colorHoverDark,
-		ColorFocus:       colorFocusDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		ColorSelect:      colorSelectDark,
-		Padding:          PaddingSmall,
-		paddingMenuItem:  PaddingTwoFive,
-		paddingSubmenu:   PaddingSmall,
-		paddingSubtitle:  NewPadding(0, PadSmall, 0, PadSmall),
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusSmall,
-		radiusBorder:     radiusMedium,
-		radiusSubmenu:    radiusSmall,
-		radiusMenuItem:   radiusSmall,
-		Spacing:          SpacingMedium,
-		spacingSubmenu:   0,
-		TextStyle:        DefaultTextStyle,
-		textStyleSubtitle: TextStyle{
-			Color: colorTextDark,
-			Size:  sizeTextSmall,
-		},
-	}
+	defaultMenubarStyle MenubarStyle
 )

--- a/gui/styles_widget_defaults_test.go
+++ b/gui/styles_widget_defaults_test.go
@@ -1,316 +1,113 @@
 package gui
 
-// Pins the Default*Style package vars declared in
-// styles_widget_control.go and styles_widget_overlay.go.
+// Guards the single-source rule for the default*Style package vars
+// (issue #300).
 //
-// Go-Gui has two sources of widget defaults: these package vars (used
-// when a widget renders without a theme-supplied style) and ThemeMaker
-// (which builds every style from a ThemeCfg). They are maintained by
-// hand and drift apart silently. The tests below pin the package-var
-// side and call out, in comments, each place the two disagree — so a
-// future edit to one has to be a deliberate decision about the other.
+// Go-Gui used to have two sources of widget defaults: hand-written
+// literals in styles*.go and ThemeMaker. They drifted silently — an app
+// that never called SetTheme ran on a mixture of the two. The literals
+// are gone; the vars are now mirrors that applyTheme fills from the
+// installed theme, and the test below fails the moment someone gives one
+// of them an initializer again.
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/go-gui-org/go-glyph"
 )
 
-// SetTheme (theme.go:236) overwrites every Default*Style global from
-// the active theme, and nothing restores them. Any earlier test that
-// switches themes therefore leaves the live vars holding theme values
-// rather than the declared literals, which makes naive assertions
-// order-dependent (and repeat-run dependent under -count=N).
-//
-// These snapshots are package-level vars, so Go initializes them from
-// the declared literals before any test runs. Assert against the
-// snapshot, never the live global.
+// Snapshots taken by a test-file init(), which the go tool runs after
+// the init() in theme_defaults.go — package-var initializers would be
+// too early, since they are evaluated before any init() runs.
 var (
-	pristineProgressBarStyle    = defaultProgressBarStyle
-	pristineSliderStyle         = defaultSliderStyle
-	pristineTabControlStyle     = defaultTabControlStyle
-	pristineBreadcrumbStyle     = defaultBreadcrumbStyle
-	pristineSplitterStyle       = defaultSplitterStyle
-	pristineTableStyle          = defaultTableStyle
-	pristineComboboxStyle       = defaultComboboxStyle
-	pristineCommandPaletteStyle = defaultCommandPaletteStyle
-	pristineDatePickerStyle     = defaultDatePickerStyle
-	pristineColorPickerStyle    = defaultColorPickerStyle
-	pristineSkeletonStyle       = defaultSkeletonStyle
-	pristineMenubarStyle        = defaultMenubarStyle
-	pristineBadgeStyle          = defaultBadgeStyle
-	pristineExpandPanelStyle    = defaultExpandPanelStyle
-	pristineDialogStyle         = DefaultDialogStyle
-	pristineToastStyle          = defaultToastStyle
-	pristineTreeStyle           = defaultTreeStyle
-	pristineDataGridStyle       = DefaultDataGridStyle
-	pristineTextStyle           = DefaultTextStyle
-	pristineListBoxStyle        = defaultListBoxStyle
-	pristineRadioStyle          = defaultRadioStyle
-	pristineSwitchStyle         = defaultSwitchStyle
-	pristineToggleStyle         = defaultToggleStyle
-	pristineSelectStyle         = defaultSelectStyle
-	pristineInputStyle          = defaultInputStyle
-	pristineScrollbarStyle      = DefaultScrollbarStyle
-	pristineTooltipStyle        = defaultTooltipStyle
+	pkgInitButtonStyle      buttonStyle
+	pkgInitDataGridStyle    DataGridStyle
+	pkgInitInstalledThemeID uint64
 )
 
-// --- styles_widget_control.go ----------------------------------------
+func init() {
+	pkgInitButtonStyle = defaultButtonStyle
+	pkgInitDataGridStyle = DefaultDataGridStyle
+	pkgInitInstalledThemeID = installedThemeID
+}
 
-func TestDefaultProgressBarStyle(t *testing.T) {
-	s := pristineProgressBarStyle
-	// ThemeMaker drives Size from cfg.SizeProgressBar and never sets
-	// SizeBorder at all; the package var hard-codes both.
-	if s.Size != 20 {
-		t.Errorf("size = %v, want 20", s.Size)
+// TestDefaultStylesMirrorThemeDark pins every mirror to its ThemeDark
+// field. Re-adding a literal to styles*.go breaks this immediately,
+// because a package-var initializer is evaluated before init() calls
+// applyTheme — but applyTheme overwrites it, so the literal would be
+// dead weight that only diverges.
+//
+// reflect.DeepEqual rather than ==: several style structs carry pointer
+// fields (*BoxShadow, *GradientDef, *glyph.FontFeatures) where value
+// equality is what the test means.
+func TestDefaultStylesMirrorThemeDark(t *testing.T) {
+	restoreTheme(t)
+	SetTheme(ThemeDark)
+
+	// One entry per assignment in applyTheme (gui/theme.go). Add a row
+	// whenever a mirror is added there.
+	mirrors := []struct {
+		got  any
+		want any
+		name string
+	}{
+		{DefaultTextStyle, ThemeDark.TextStyleDef, "DefaultTextStyle"},
+		{defaultButtonStyle, ThemeDark.ButtonStyle, "defaultButtonStyle"},
+		{defaultContainerStyle, ThemeDark.ContainerStyle, "defaultContainerStyle"},
+		{defaultInputStyle, ThemeDark.InputStyle, "defaultInputStyle"},
+		{DefaultScrollbarStyle, ThemeDark.ScrollbarStyle, "DefaultScrollbarStyle"},
+		{defaultRadioStyle, ThemeDark.radioStyle, "defaultRadioStyle"},
+		{defaultSwitchStyle, ThemeDark.switchStyle, "defaultSwitchStyle"},
+		{defaultToggleStyle, ThemeDark.toggleStyle, "defaultToggleStyle"},
+		{defaultSelectStyle, ThemeDark.selectStyle, "defaultSelectStyle"},
+		{defaultListBoxStyle, ThemeDark.listBoxStyle, "defaultListBoxStyle"},
+		{defaultTreeStyle, ThemeDark.treeStyle, "defaultTreeStyle"},
+		{DefaultDialogStyle, ThemeDark.dialogStyle, "DefaultDialogStyle"},
+		{defaultToastStyle, ThemeDark.toastStyle, "defaultToastStyle"},
+		{defaultTooltipStyle, ThemeDark.tooltipStyle, "defaultTooltipStyle"},
+		{defaultBadgeStyle, ThemeDark.badgeStyle, "defaultBadgeStyle"},
+		{defaultExpandPanelStyle, ThemeDark.expandPanelStyle, "defaultExpandPanelStyle"},
+		{defaultProgressBarStyle, ThemeDark.progressBarStyle, "defaultProgressBarStyle"},
+		{defaultSliderStyle, ThemeDark.sliderStyle, "defaultSliderStyle"},
+		{defaultTabControlStyle, ThemeDark.tabControlStyle, "defaultTabControlStyle"},
+		{defaultBreadcrumbStyle, ThemeDark.breadcrumbStyle, "defaultBreadcrumbStyle"},
+		{defaultSplitterStyle, ThemeDark.splitterStyle, "defaultSplitterStyle"},
+		{defaultTableStyle, ThemeDark.tableStyle, "defaultTableStyle"},
+		{defaultComboboxStyle, ThemeDark.comboboxStyle, "defaultComboboxStyle"},
+		{defaultCommandPaletteStyle, ThemeDark.commandPaletteStyle, "defaultCommandPaletteStyle"},
+		{defaultMenubarStyle, ThemeDark.MenubarStyle, "defaultMenubarStyle"},
+		{defaultDatePickerStyle, ThemeDark.datePickerStyle, "defaultDatePickerStyle"},
+		{defaultColorPickerStyle, ThemeDark.colorPickerStyle, "defaultColorPickerStyle"},
+		{DefaultDataGridStyle, ThemeDark.dataGridStyle, "DefaultDataGridStyle"},
+		{defaultSkeletonStyle, ThemeDark.skeletonStyle, "defaultSkeletonStyle"},
+		{defaultInspectorStyle, ThemeDark.inspectorStyle, "defaultInspectorStyle"},
 	}
-	if s.SizeBorder != 0 {
-		t.Errorf("size_border = %v, want 0 (progress bar is borderless)", s.SizeBorder)
-	}
-	if s.Radius != radiusSmall {
-		t.Errorf("radius = %v, want RadiusSmall %v", s.Radius, radiusSmall)
-	}
-	if !s.TextShow {
-		t.Error("text_show should default true")
-	}
-	if !s.textBackground.eq(ColorTransparent) {
-		t.Errorf("text_background = %v, want transparent", s.textBackground)
+
+	for _, m := range mirrors {
+		if !reflect.DeepEqual(m.got, m.want) {
+			t.Errorf("%s does not match ThemeDark:\n got  = %+v\n want = %+v",
+				m.name, m.got, m.want)
+		}
 	}
 }
 
-func TestDefaultSliderStyle(t *testing.T) {
-	s := pristineSliderStyle
-	// Both of these are bare literals, not the SizeBorderDef / Radius*
-	// constants — and ThemeMaker computes Radius as cfg.SizeSlider/2.
-	if s.SizeBorder != 1 {
-		t.Errorf("size_border = %v, want literal 1 (not SizeBorderDef %v)",
-			s.SizeBorder, sizeBorderDef)
+// TestDefaultStylesFilledAtInit is the half the table above cannot cover:
+// it asserts the mirrors are populated by package init alone, with no
+// SetTheme call anywhere. That is precisely the case issue #300 broke —
+// a fresh app used to run on the literals until it switched themes.
+func TestDefaultStylesFilledAtInit(t *testing.T) {
+	if pkgInitDataGridStyle == (DataGridStyle{}) {
+		t.Error("DefaultDataGridStyle was still the zero value after init; " +
+			"init must call applyTheme(ThemeDark)")
 	}
-	if s.Radius != 3 {
-		t.Errorf("radius = %v, want literal 3", s.Radius)
+	if pkgInitButtonStyle != ThemeDark.ButtonStyle {
+		t.Errorf("defaultButtonStyle after init = %+v, want ThemeDark.ButtonStyle %+v",
+			pkgInitButtonStyle, ThemeDark.ButtonStyle)
 	}
-	if s.Size != 6 {
-		t.Errorf("size = %v, want 6", s.Size)
-	}
-	if s.ThumbSize != 16 {
-		t.Errorf("thumb_size = %v, want 16", s.ThumbSize)
-	}
-}
-
-func TestDefaultTabControlStyle(t *testing.T) {
-	s := pristineTabControlStyle
-	if s.SizeBorder != sizeBorderDef || s.sizeTabBorder != sizeBorderDef {
-		t.Errorf("borders = %v/%v, want SizeBorderDef %v",
-			s.SizeBorder, s.sizeTabBorder, sizeBorderDef)
-	}
-	if s.Radius != radiusMedium || s.radiusTab != radiusSmall {
-		t.Errorf("radius/radius_tab = %v/%v, want %v/%v",
-			s.Radius, s.radiusTab, radiusMedium, radiusSmall)
-	}
-	if s.spacingHeader != 2 {
-		t.Errorf("spacing_header = %v, want 2", s.spacingHeader)
-	}
-	// Disabled text is the normal text color at alpha 130.
-	if s.textStyleDisabled.Color.A != 130 {
-		t.Errorf("disabled alpha = %d, want 130", s.textStyleDisabled.Color.A)
-	}
-}
-
-func TestDefaultBreadcrumbStyle(t *testing.T) {
-	s := pristineBreadcrumbStyle
-	if s.Separator != "/" {
-		t.Errorf("separator = %q, want %q", s.Separator, "/")
-	}
-	// Disabled crumbs sit at alpha 130, separators at the lighter 160.
-	if s.textStyleDisabled.Color.A != 130 {
-		t.Errorf("disabled alpha = %d, want 130", s.textStyleDisabled.Color.A)
-	}
-	if s.textStyleSeparator.Color.A != 160 {
-		t.Errorf("separator alpha = %d, want 160", s.textStyleSeparator.Color.A)
-	}
-	if s.sizeContentBorder != sizeBorderDef {
-		t.Errorf("content border = %v, want %v", s.sizeContentBorder, sizeBorderDef)
-	}
-}
-
-func TestDefaultSplitterStyle(t *testing.T) {
-	s := pristineSplitterStyle
-	if s.HandleSize != 9 {
-		t.Errorf("handle_size = %v, want 9", s.HandleSize)
-	}
-	// Keyboard drag increments: 2% normal, 10% with a modifier.
-	if s.dragStep != 0.02 {
-		t.Errorf("drag_step = %v, want 0.02", s.dragStep)
-	}
-	if s.dragStepLarge != 0.10 {
-		t.Errorf("drag_step_large = %v, want 0.10", s.dragStepLarge)
-	}
-}
-
-func TestDefaultTableStyle(t *testing.T) {
-	s := pristineTableStyle
-	if s.columnWidthDefault != 50 {
-		t.Errorf("column_width_default = %v, want 50", s.columnWidthDefault)
-	}
-	if s.columnWidthMin != 20 {
-		t.Errorf("column_width_min = %v, want 20", s.columnWidthMin)
-	}
-	if s.alignHead != HAlignCenter {
-		t.Errorf("align_head = %v, want center", s.alignHead)
-	}
-	// Header is bold at the normal text size. ThemeMaker instead
-	// overwrites TextStyleHead with theme.B3 after the struct literal.
-	if s.TextStyleHead.Typeface != glyph.TypefaceBold {
-		t.Errorf("head typeface = %v, want bold", s.TextStyleHead.Typeface)
-	}
-	if s.TextStyleHead.Size != pristineTextStyle.Size {
-		t.Errorf("head size = %v, want %v", s.TextStyleHead.Size, pristineTextStyle.Size)
-	}
-}
-
-func TestDefaultComboboxStyle(t *testing.T) {
-	s := pristineComboboxStyle
-	// Fixed RadiusMedium here; ThemeMaker uses cfg.Radius, so a
-	// square-cornered theme still gets a rounded unthemed combobox.
-	if s.Radius != radiusMedium {
-		t.Errorf("radius = %v, want RadiusMedium %v", s.Radius, radiusMedium)
-	}
-	if s.MinWidth != 75 || s.MaxWidth != 200 {
-		t.Errorf("width bounds = %v/%v, want 75/200", s.MinWidth, s.MaxWidth)
-	}
-	if s.maxDropdownHeight != 200 {
-		t.Errorf("max_dropdown_height = %v, want 200", s.maxDropdownHeight)
-	}
-	// Placeholder alpha 100 matches ThemeMaker's placeholderColor.
-	if s.PlaceholderStyle.Color.A != 100 {
-		t.Errorf("placeholder alpha = %d, want 100", s.PlaceholderStyle.Color.A)
-	}
-}
-
-func TestDefaultCommandPaletteStyle(t *testing.T) {
-	s := pristineCommandPaletteStyle
-	if s.Width != 500 || s.MaxHeight != 400 {
-		t.Errorf("size = %v x %v, want 500 x 400", s.Width, s.MaxHeight)
-	}
-	// Fixed grey; ThemeMaker derives the detail color from the theme
-	// text color at alpha 140 instead.
-	if !s.detailStyle.Color.eq(RGBA(128, 128, 128, 200)) {
-		t.Errorf("detail color = %v, want RGBA(128,128,128,200)", s.detailStyle.Color)
-	}
-	if !s.backdropColor.eq(RGBA(0, 0, 0, 120)) {
-		t.Errorf("backdrop = %v, want RGBA(0,0,0,120)", s.backdropColor)
-	}
-}
-
-func TestDefaultDatePickerStyle(t *testing.T) {
-	s := pristineDatePickerStyle
-	if s.cellSpacing != 2 {
-		t.Errorf("cell_spacing = %v, want 2", s.cellSpacing)
-	}
-	if s.SizeBorder != sizeBorderDef {
-		t.Errorf("size_border = %v, want %v", s.SizeBorder, sizeBorderDef)
-	}
-	if s.Radius != radiusMedium || s.radiusBorder != radiusMedium {
-		t.Errorf("radius/radius_border = %v/%v, want both %v",
-			s.Radius, s.radiusBorder, radiusMedium)
-	}
-}
-
-func TestDefaultColorPickerStyle(t *testing.T) {
-	s := pristineColorPickerStyle
-	if s.sVSize != 200 {
-		t.Errorf("sv_size = %v, want 200", s.sVSize)
-	}
-	if s.sliderHeight != 24 {
-		t.Errorf("slider_height = %v, want 24", s.sliderHeight)
-	}
-	if s.indicatorSize != 16 {
-		t.Errorf("indicator_size = %v, want 16", s.indicatorSize)
-	}
-}
-
-// ColorHighlight is the one computed value in the control defaults:
-// colorInteriorDark.Add(RGBA(20,20,20,0)). Assert the resolved color so
-// a change to either the base color or Color.Add saturation shows up.
-func TestDefaultSkeletonStyleHighlightResolved(t *testing.T) {
-	s := pristineSkeletonStyle
-	want := RGBA(94, 94, 94, 255) // 74+20 per channel, alpha unchanged
-	if !s.ColorHighlight.eq(want) {
-		t.Errorf("color_highlight = %v, want %v", s.ColorHighlight, want)
-	}
-	// The highlight must be lighter than the base or the shimmer is invisible.
-	if s.ColorHighlight.R <= s.Color.R {
-		t.Errorf("highlight R %d not lighter than base R %d",
-			s.ColorHighlight.R, s.Color.R)
-	}
-	if s.Radius != radiusSmall {
-		t.Errorf("radius = %v, want RadiusSmall %v", s.Radius, radiusSmall)
-	}
-}
-
-func TestDefaultMenubarStyle(t *testing.T) {
-	s := pristineMenubarStyle
-	if s.widthSubmenuMin != 50 || s.widthSubmenuMax != 200 {
-		t.Errorf("submenu width = %v/%v, want 50/200",
-			s.widthSubmenuMin, s.widthSubmenuMax)
-	}
-	if s.Spacing != SpacingMedium {
-		t.Errorf("spacing = %v, want SpacingMedium %v", s.Spacing, SpacingMedium)
-	}
-	// Submenu items are flush by default; ThemeMaker uses 1 instead.
-	if s.spacingSubmenu != 0 {
-		t.Errorf("spacing_submenu = %v, want 0", s.spacingSubmenu)
-	}
-	if s.Radius != radiusSmall || s.radiusBorder != radiusMedium {
-		t.Errorf("radius/radius_border = %v/%v, want %v/%v",
-			s.Radius, s.radiusBorder, radiusSmall, radiusMedium)
-	}
-}
-
-// --- styles_widget_overlay.go ----------------------------------------
-
-// DefaultBadgeStyle leaves TextStyle at its zero value, unlike
-// ThemeMaker which sets it to B5 with a White color. A badge rendered
-// without a theme therefore inherits size 0 and must be given a style
-// by the caller.
-func TestDefaultBadgeStyle(t *testing.T) {
-	s := pristineBadgeStyle
-	if s.TextStyle != (TextStyle{}) {
-		t.Errorf("text_style = %+v, want zero value", s.TextStyle)
-	}
-	if s.dotSize != 8 {
-		t.Errorf("dot_size = %v, want 8", s.dotSize)
-	}
-	// Semantic colors are hard-coded rather than theme-derived, and
-	// match the toast palette exactly.
-	if !s.ColorSuccess.eq(pristineToastStyle.ColorSuccess) {
-		t.Errorf("badge success %v != toast success %v",
-			s.ColorSuccess, pristineToastStyle.ColorSuccess)
-	}
-	if !s.ColorWarning.eq(pristineToastStyle.ColorWarning) {
-		t.Errorf("badge warning %v != toast warning %v",
-			s.ColorWarning, pristineToastStyle.ColorWarning)
-	}
-	if !s.ColorError.eq(pristineToastStyle.ColorError) {
-		t.Errorf("badge error %v != toast error %v",
-			s.ColorError, pristineToastStyle.ColorError)
-	}
-}
-
-func TestDefaultExpandPanelStyle(t *testing.T) {
-	s := pristineExpandPanelStyle
-	if s.SizeBorder != sizeBorderDef {
-		t.Errorf("size_border = %v, want %v", s.SizeBorder, sizeBorderDef)
-	}
-	if s.Radius != radiusMedium || s.radiusBorder != radiusMedium {
-		t.Errorf("radius/radius_border = %v/%v, want both %v",
-			s.Radius, s.radiusBorder, radiusMedium)
-	}
-	if s.Color.eq(Color{}) {
-		t.Error("color should not be the zero Color")
-	}
-	if s.ColorHover.eq(s.colorClick) {
-		t.Error("hover and click colors should differ")
+	if pkgInitInstalledThemeID != ThemeDark.id {
+		t.Errorf("installedThemeID after init = %d, want ThemeDark.id %d",
+			pkgInitInstalledThemeID, ThemeDark.id)
 	}
 }
 
@@ -331,41 +128,6 @@ func TestToastAnchorConstants(t *testing.T) {
 		if a.got != a.want {
 			t.Errorf("%s = %d, want %d", a.name, a.got, a.want)
 		}
-	}
-}
-
-// DefaultDialogStyle leaves the width bounds unset while ThemeMaker
-// sets 200/300 — an unthemed dialog is therefore unconstrained.
-func TestDefaultDialogStyleWidthBoundsUnset(t *testing.T) {
-	s := pristineDialogStyle
-	if s.MinWidth != 0 || s.MaxWidth != 0 {
-		t.Errorf("width bounds = %v/%v, want 0/0 (ThemeMaker sets 200/300)",
-			s.MinWidth, s.MaxWidth)
-	}
-}
-
-func TestDefaultTreeStyleIndentAndSpacing(t *testing.T) {
-	s := pristineTreeStyle
-	if s.indent != 25 {
-		t.Errorf("indent = %v, want 25", s.indent)
-	}
-	if s.Spacing != 0 {
-		t.Errorf("spacing = %v, want 0", s.Spacing)
-	}
-	// Tree chevrons come from the bundled icon font, not the text font.
-	if s.textStyleIcon.Family != IconFontName {
-		t.Errorf("icon family = %q, want %q", s.textStyleIcon.Family, IconFontName)
-	}
-}
-
-// --- styles.go --------------------------------------------------------
-
-// DefaultDataGridStyle is declared with no initializer. That is
-// intentional — the datagrid resolves its style from the theme — but it
-// means the package var is not a usable fallback like its siblings.
-func TestDefaultDataGridStyleIsZeroValue(t *testing.T) {
-	if pristineDataGridStyle != (DataGridStyle{}) {
-		t.Errorf("DefaultDataGridStyle = %+v, want the zero value", pristineDataGridStyle)
 	}
 }
 

--- a/gui/styles_widget_overlay.go
+++ b/gui/styles_widget_overlay.go
@@ -1,10 +1,6 @@
 package gui
 
-import (
-	"time"
-
-	"github.com/go-gui-org/go-glyph"
-)
+import "time"
 
 // ListBoxStyle defines list box visual properties.
 // exportaudit:keep — reachable from an exported signature
@@ -128,106 +124,21 @@ type ExpandPanelStyle struct {
 	radiusBorder float32
 }
 
-// Default widget styles (dark theme).
+// Widget style mirrors. See the note on the mirror block in styles.go:
+// ThemeMaker is the only source of these values — never add an
+// initializer here.
 var (
-	defaultListBoxStyle = ListBoxStyle{
-		Color:           colorInteriorDark,
-		ColorHover:      colorHoverDark,
-		ColorBorder:     colorBorderDark,
-		ColorSelect:     colorSelectDark,
-		Padding:         paddingButton,
-		SizeBorder:      sizeBorderDef,
-		Radius:          radiusMedium,
-		textStyleNormal: DefaultTextStyle,
-		subheadingStyle: DefaultTextStyle,
-	}
+	defaultListBoxStyle ListBoxStyle
 
-	defaultTreeStyle = TreeStyle{
-		Color:       ColorTransparent,
-		ColorHover:  colorHoverDark,
-		ColorFocus:  colorFocusDark,
-		ColorBorder: ColorTransparent,
-		Padding:     PaddingNone,
-		SizeBorder:  sizeBorderDef,
-		Radius:      radiusMedium,
-		TextStyle:   DefaultTextStyle,
-		textStyleIcon: TextStyle{
-			Color:  colorTextDark,
-			Size:   sizeTextSmall,
-			Family: IconFontName,
-		},
-		indent:  25,
-		Spacing: 0,
-	}
+	defaultTreeStyle TreeStyle
 
-	DefaultDialogStyle = DialogStyle{
-		Color:            colorPanelDark,
-		ColorBorder:      colorBorderDark,
-		ColorBorderFocus: colorSelectDark,
-		Padding:          PaddingLarge,
-		SizeBorder:       sizeBorderDef,
-		Radius:           radiusMedium,
-		radiusBorder:     radiusMedium,
-		AlignButtons:     HAlignCenter,
-		titleTextStyle: TextStyle{
-			Color: colorTextDark,
-			Size:  sizeTextLarge,
-		},
-		TextStyle: DefaultTextStyle,
-	}
+	DefaultDialogStyle DialogStyle
 
-	defaultToastStyle = ToastStyle{
-		maxVisible:   5,
-		Anchor:       toastBottomRight,
-		Width:        260,
-		margin:       16,
-		Spacing:      8,
-		accentWidth:  4,
-		Padding:      paddingMedium,
-		Radius:       radiusMedium,
-		SizeBorder:   sizeBorderDef,
-		Color:        colorPanelDark,
-		ColorBorder:  colorBorderDark,
-		colorInfo:    colorSelectDark,
-		ColorSuccess: RGBA(46, 160, 67, 255),
-		ColorWarning: RGBA(210, 153, 34, 255),
-		ColorError:   RGBA(218, 54, 51, 255),
-		TextStyle:    DefaultTextStyle,
-		TitleStyle: TextStyle{
-			Color:    colorTextDark,
-			Size:     sizeTextMedium,
-			Typeface: glyph.TypefaceBold,
-		},
-	}
+	defaultToastStyle ToastStyle
 
-	defaultTooltipStyle = TooltipStyle{
-		Delay:       500 * time.Millisecond,
-		Color:       colorInteriorDark,
-		ColorBorder: colorBorderDark,
-		Padding:     PaddingSmall,
-		SizeBorder:  sizeBorderDef,
-		Radius:      radiusSmall,
-		TextStyle:   DefaultTextStyle,
-	}
+	defaultTooltipStyle TooltipStyle
 
-	defaultBadgeStyle = BadgeStyle{
-		Color:        colorSelectDark,
-		colorInfo:    colorSelectDark,
-		ColorSuccess: RGBA(46, 160, 67, 255),
-		ColorWarning: RGBA(210, 153, 34, 255),
-		ColorError:   RGBA(218, 54, 51, 255),
-		Padding:      NewPadding(2, 6, 2, 6),
-		dotSize:      8,
-	}
+	defaultBadgeStyle BadgeStyle
 
-	defaultExpandPanelStyle = ExpandPanelStyle{
-		Color:        colorPanelDark,
-		ColorHover:   colorHoverDark,
-		colorClick:   colorActiveDark,
-		ColorBorder:  colorBorderDark,
-		Padding:      paddingMedium,
-		SizeBorder:   sizeBorderDef,
-		Radius:       radiusMedium,
-		radiusBorder: radiusMedium,
-	}
+	defaultExpandPanelStyle ExpandPanelStyle
 )

--- a/gui/styles_widget_test.go
+++ b/gui/styles_widget_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDefaultInputStyleColors(t *testing.T) {
-	s := pristineInputStyle
+	s := ThemeDark.InputStyle
 	if s.Color.eq(Color{}) {
 		t.Error("input color should not be zero")
 	}
@@ -17,7 +17,7 @@ func TestDefaultInputStyleColors(t *testing.T) {
 }
 
 func TestDefaultScrollbarStyle(t *testing.T) {
-	s := pristineScrollbarStyle
+	s := ThemeDark.ScrollbarStyle
 	if s.Size != 7 {
 		t.Errorf("scrollbar size = %f", s.Size)
 	}
@@ -26,28 +26,30 @@ func TestDefaultScrollbarStyle(t *testing.T) {
 	}
 }
 
-func TestDefaultWidgetStylesNonZero(t *testing.T) {
-	// Verify all widget default styles have non-zero radius
-	// (except scrollbar which uses RadiusSmall).
+// ThemeDark is borderless by design — bordered is the separate
+// dark-bordered preset, or Theme.WithBorders(true). What every widget
+// style must have is a real corner radius, so a widget never renders
+// with square corners just because a style went unpopulated.
+func TestDefaultWidgetStylesRadius(t *testing.T) {
 	styles := []struct {
 		name   string
 		radius float32
 	}{
-		{"radio", pristineRadioStyle.SizeBorder},
-		{"switch", pristineSwitchStyle.SizeBorder},
-		{"toggle", pristineToggleStyle.SizeBorder},
-		{"select", pristineSelectStyle.SizeBorder},
-		{"listbox", pristineListBoxStyle.SizeBorder},
+		{"button", ThemeDark.ButtonStyle.Radius},
+		{"input", ThemeDark.InputStyle.Radius},
+		{"toggle", ThemeDark.toggleStyle.Radius},
+		{"select", ThemeDark.selectStyle.Radius},
+		{"listbox", ThemeDark.listBoxStyle.Radius},
 	}
 	for _, s := range styles {
 		if s.radius == 0 {
-			t.Errorf("%s has zero size_border", s.name)
+			t.Errorf("%s has zero radius", s.name)
 		}
 	}
 }
 
 func TestDefaultDialogStyle(t *testing.T) {
-	s := pristineDialogStyle
+	s := ThemeDark.dialogStyle
 	if s.Color.eq(Color{}) {
 		t.Error("dialog color should not be zero")
 	}
@@ -60,7 +62,7 @@ func TestDefaultDialogStyle(t *testing.T) {
 }
 
 func TestDefaultToastStyle(t *testing.T) {
-	s := pristineToastStyle
+	s := ThemeDark.toastStyle
 	if s.maxVisible != 5 {
 		t.Errorf("max_visible = %d, want 5", s.maxVisible)
 	}
@@ -73,7 +75,7 @@ func TestDefaultToastStyle(t *testing.T) {
 }
 
 func TestDefaultTooltipStyle(t *testing.T) {
-	s := pristineTooltipStyle
+	s := ThemeDark.tooltipStyle
 	if s.Delay == 0 {
 		t.Error("delay should not be zero")
 	}
@@ -121,7 +123,7 @@ func TestEffectiveTextTransformDefault(t *testing.T) {
 }
 
 func TestDefaultTreeStyle(t *testing.T) {
-	s := pristineTreeStyle
+	s := ThemeDark.treeStyle
 	if !s.ColorHover.IsSet() {
 		t.Error("tree hover color should be set")
 	}

--- a/gui/theme_defaults.go
+++ b/gui/theme_defaults.go
@@ -201,17 +201,10 @@ func init() {
 	themeRegister(themeBlueBordered)
 
 	// Dark is both the app default and the initially installed theme.
-	//
-	// Deliberately NOT applyTheme: the ~30 default*Style literals in
-	// styles*.go do not all match ThemeDark (button/input/container
-	// borders are 1.5 there and 0 in ThemeDark, the dataGrid literal is
-	// an unstyled placeholder), and an app that never calls SetTheme
-	// runs on that mixture today. Installing ThemeDark here would
-	// silently restyle every such app. Seeding installedThemeID instead
-	// makes the first frame's installTheme a no-op, so the shipped
-	// default appearance is bit-identical to before per-window themes.
-	// Reconciling the literals with ThemeDark is a separate change.
+	// applyTheme is what fills the default*Style mirrors — they carry no
+	// literals of their own, so an app that never calls SetTheme still
+	// gets ThemeDark everywhere rather than a mixture (issue #300). It
+	// also sets guiTheme and installedThemeID.
 	defaultTheme = ThemeDark
-	guiTheme = ThemeDark
-	installedThemeID = ThemeDark.id
+	applyTheme(ThemeDark)
 }

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -61,21 +61,15 @@ type NumericInputCfg struct {
 	Invisible bool
 }
 
-// DefaultNumericInputStyle holds defaults for NumericInputCfg Opt fields.
-var defaultNumericInputStyle = struct {
-	SizeBorder float32
-	Radius     float32
-}{
-	SizeBorder: sizeBorderDef,
-	Radius:     radiusMedium,
-}
-
 // NumericInput creates a locale-aware numeric input.
 func NumericInput(cfg NumericInputCfg) View {
 	applyNumericInputDefaults(&cfg)
 	requireFocusID("NumericInput", cfg.FocusDisabled, cfg.ID)
 
-	dn := &defaultNumericInputStyle
+	// A numeric input is an Input with steppers, so it takes its border
+	// and radius from the theme's input style rather than a private copy
+	// that no theme could reach (issue #300).
+	dn := &defaultInputStyle
 	sizeBorder := cfg.SizeBorder.Get(dn.SizeBorder)
 	radius := cfg.Radius.Get(dn.Radius)
 	locale := numericLocaleNormalize(cfg.Locale)

--- a/gui/view_input_numeric_test.go
+++ b/gui/view_input_numeric_test.go
@@ -68,6 +68,39 @@ func TestNumericInputReadOnlyForwardsToInput(t *testing.T) {
 	}
 }
 
+// TestNumericInputBorderFollowsTheme covers issue #300: the numeric
+// input used to resolve its fallback border/radius against a private
+// literal that no theme could reach. It must take them from the
+// theme's input style, and an explicit cfg value must still win.
+func TestNumericInputBorderFollowsTheme(t *testing.T) {
+	restoreTheme(t)
+	th := ThemeDark.withInputStyle(InputStyle{SizeBorder: 7, Radius: 9})
+	SetTheme(th)
+
+	w := &Window{}
+	v := NumericInput(NumericInputCfg{
+		ID:      "ni-theme-border",
+		StepCfg: NumericStepCfg{ShowButtons: true, Step: 1},
+	})
+	layout := generateViewLayout(v, w)
+	if layout.Shape.SizeBorder != 7 {
+		t.Errorf("size_border = %v, want 7 (input style)", layout.Shape.SizeBorder)
+	}
+	if layout.Shape.Radius != 9 {
+		t.Errorf("radius = %v, want 9 (input style)", layout.Shape.Radius)
+	}
+
+	v = NumericInput(NumericInputCfg{
+		ID:         "ni-theme-border-override",
+		StepCfg:    NumericStepCfg{ShowButtons: true, Step: 1},
+		SizeBorder: SomeF(3),
+	})
+	layout = generateViewLayout(v, w)
+	if layout.Shape.SizeBorder != 3 {
+		t.Errorf("size_border = %v, want 3 (cfg wins)", layout.Shape.SizeBorder)
+	}
+}
+
 // TestNumericInputReadOnlyStepButtonsGated covers #82: a read-only
 // numeric input must not increment via its step buttons. The buttons
 // are visually disabled, and numericInputApplyStep (the choke point)

--- a/gui/view_radio_button_group.go
+++ b/gui/view_radio_button_group.go
@@ -41,11 +41,6 @@ type RadioButtonGroupCfg struct {
 	Disabled      bool
 }
 
-// DefaultRadioGroupStyle holds defaults for RadioButtonGroupCfg Opt fields.
-var defaultRadioGroupStyle = radioGroupStyle{
-	SizeBorder: 1.5,
-}
-
 // RadioButtonGroupColumn creates a vertically stacked radio
 // button group.
 func RadioButtonGroupColumn(cfg RadioButtonGroupCfg) View {
@@ -69,13 +64,16 @@ func radioGroup(cfg RadioButtonGroupCfg, axis func(ContainerCfg) View) View {
 				Label: cfg.Items[i], Value: cfg.Items[i]}
 		}
 	}
-	sizeBorder := cfg.SizeBorder.Get(defaultRadioGroupStyle.SizeBorder)
+	// The group's border is the group box's, so pass the Opt through
+	// unresolved and let Container fall back to the themed container
+	// style. Resolving it here against a private literal was how this
+	// widget stayed at a 1.5px border under every theme (issue #300).
 	return axis(ContainerCfg{
 		A11YRole:        AccessRoleRadioGroup,
 		A11YLabel:       cfg.A11YLabel,
 		A11YDescription: cfg.A11YDescription,
 		ColorBorder:     cfg.ColorBorder,
-		SizeBorder:      Some(sizeBorder),
+		SizeBorder:      cfg.SizeBorder,
 		Title:           cfg.Title,
 		TitleBG:         cfg.TitleBG,
 		Spacing:         cfg.Spacing,

--- a/gui/view_radio_button_group_test.go
+++ b/gui/view_radio_button_group_test.go
@@ -197,3 +197,39 @@ func TestNewRadioOption(t *testing.T) {
 		t.Errorf("got %+v", opt)
 	}
 }
+
+// TestRadioButtonGroupBorderFollowsTheme covers issue #300: the group
+// box border used to resolve against a private 1.5px literal that no
+// theme could reach. An unset cfg.SizeBorder must fall back to the
+// themed container style, and an explicit value must still win.
+func TestRadioButtonGroupBorderFollowsTheme(t *testing.T) {
+	restoreTheme(t)
+	th := ThemeDark.withContainerStyle(containerStyle{SizeBorder: 7})
+	SetTheme(th)
+
+	w := &Window{}
+	v := RadioButtonGroupColumn(RadioButtonGroupCfg{
+		ID: "radio-group-theme-border",
+		Options: []RadioOption{
+			{Label: "A", Value: "a"},
+		},
+		OnSelect: func(_ string, ctx EventCtx) {},
+	})
+	layout := generateViewLayout(v, w)
+	if layout.Shape.SizeBorder != 7 {
+		t.Errorf("size_border = %v, want 7 (container style)", layout.Shape.SizeBorder)
+	}
+
+	v = RadioButtonGroupColumn(RadioButtonGroupCfg{
+		ID:         "radio-group-theme-border-override",
+		SizeBorder: SomeF(3),
+		Options: []RadioOption{
+			{Label: "A", Value: "a"},
+		},
+		OnSelect: func(_ string, ctx EventCtx) {},
+	})
+	layout = generateViewLayout(v, w)
+	if layout.Shape.SizeBorder != 3 {
+		t.Errorf("size_border = %v, want 3 (cfg wins)", layout.Shape.SizeBorder)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #300. Removes the second source of widget defaults: the ~30 `default*Style` literals in `styles*.go` were maintained by hand alongside `ThemeDark` and had drifted apart. Because `init` never installed a theme, an app that never called `SetTheme` ran on a mixture of the two, and the first theme switch restyled it.

`ThemeMaker` is now the only source. The `default*Style` package vars are declared with no initializer; `init()` fills them via `applyTheme(ThemeDark)`, and `(*Window).installTheme` refills them per theme change. `TestDefaultStylesMirrorThemeDark` pins every mirror to its `ThemeDark` field (30 rows, 1:1 with `applyTheme`), so a literal can never silently reappear.

## Appearance changes (documented in CHANGELOG and `docs/specs/theme-style-single-source.md`)

- Widgets lose their 1.5px border (ThemeDark is borderless by design; bordered is the `dark-bordered` preset or `Theme.WithBorders(true)`).
- The data grid gains full dark styling (its literal was an unstyled zero-value placeholder).
- Inputs/listboxes take the theme's medium padding (10 vs 5/6).
- `NumericInput` and `RadioButtonGroup` follow the active theme — both had private hard-coded 1.5px borders no theme could reach, light included.

## Tests

- `TestDefaultStylesMirrorThemeDark` — every mirror equals its ThemeDark field.
- `TestDefaultStylesFilledAtInit` — mirrors populated by package init alone (the case #300 broke).
- `TestNumericInputBorderFollowsTheme`, `TestRadioButtonGroupBorderFollowsTheme` — new gap tests pinning the follow-the-theme contract.