### PR TITLE
fix(gui): post-generation code reads the window's theme (issue #301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,21 @@ and this project adheres to
 
 ### Fixed
 
+- **Post-generation code now reads the theme of the window it is acting on
+  (issue #301).** Event handlers, post-arrange work and the backends resolved
+  the theme from the frame-scoped cache, which holds whichever window generated
+  last — correct in a one-window app, wrong with two. Thirteen such sites now
+  call `w.Theme()`: the scroll and key-scroll paths, print export, the theme
+  picker's highlight sync (visibly wrong before), toast max-visible, the select
+  dropdown scroll, the inspector wireframe, and every backend's clear color.
+  Widget factories and `GenerateLayout` are unchanged and keep the bare read,
+  which is what makes `gui.Themed` subtree scoping work. The window and app
+  theme stores now hold a pointer to an immutable value, so the per-event reads
+  do not copy a struct holding ~40 style structs (the scroll benchmark stays at
+  ~39 ns/op, 0 allocs); `w.Theme()` still returns a value and is unchanged for
+  callers. A new `make ergonomics-audit` mode (`theme`) gates the
+  post-generation paths. See `docs/specs/per-window-theme.md`.
+
 - **Theme-keyed text caches no longer serve stale layouts.** The per-window
   markdown and rich-text layout caches invalidated on `Theme.Name`; two themes
   can share a name and differ in text styles, as a derived or scoped theme does.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,17 @@ Backend injects at startup. Nil in tests:
   generation time because factories resolve defaults when called. Anything keyed
   on a theme keys on `Theme.id`, never `Theme.Name` — names are not unique. See
   `docs/specs/per-window-theme.md`.
+- **Theme reads split by phase, not by reachability. Code running _outside_
+  generation with a `*Window` in hand calls `w.Theme()`; factories and
+  `GenerateLayout` keep the bare `guiTheme` / `default*Style` read.** Outside
+  generation the frame cache holds whichever window generated last — wrong as
+  soon as there are two windows (issue #301 migrated 13 such sites). Inside
+  generation the bare read is required, not tolerated: `Themed` scopes a theme
+  by push/pop of the _installed_ theme, so `w.Theme()` there would ignore the
+  scope. `make ergonomics-audit` mode `theme` gates the post-generation paths
+  (`gui/backend/**`, `gui/scroll*.go`, `gui/event*.go`, `gui/native_*.go`,
+  `gui/window_*.go`); mark a deliberate exception
+  `ergonomics-audit:theme-global`.
 - **`ThemeMaker` is the only source of default styling. The `default*Style`
   package vars have no initializers — never add one.** They are mirrors: `init`
   fills them with `applyTheme(ThemeDark)` and `installTheme` refills them per

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,14 @@ go mod edit -replace=github.com/go-gui-org/go-glyph=../go-glyph
 
 Code must pass `golangci-lint run ./...` and `gofmt`. No variable shadowing.
 
+Theme reads follow the generation boundary. Code that runs **outside**
+generation — event handlers, post-arrange work, backends — and has a `*Window`
+in hand calls `w.Theme()`. The bare `guiTheme` / `default*Style` read is for
+widget factories and `GenerateLayout`, which have no window at hand and where
+the bare read is also what makes `gui.Themed` subtree scoping work.
+`make ergonomics-audit` (mode `theme`) gates the post-generation paths; see
+[docs/specs/per-window-theme.md](docs/specs/per-window-theme.md).
+
 ## Submitting Changes
 
 1. Fork, create a feature branch, make focused commits.

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ ergonomics-audit:
 	go run ./tools/ergonomics-audit/ -mode opt .
 	go run ./tools/ergonomics-audit/ -mode ids .
 	go run ./tools/ergonomics-audit/ -mode literals .
+	go run ./tools/ergonomics-audit/ -mode theme .
 
 # Insert a generated ID into every broken literal in this repo's tests
 # and examples. Scoped away from gui/ deliberately: go-gui's own widget

--- a/docs/specs/per-window-theme.md
+++ b/docs/specs/per-window-theme.md
@@ -116,8 +116,88 @@ visible change to the default appearance, chiefly the loss of the 1.5px border
 on buttons, inputs and containers. See
 `docs/specs/theme-style-single-source.md`.
 
-## Follow-up
+## The generation boundary (issue #301)
 
-Migrating factory-time reads to `w.Theme()` is optional and only pays where a
-window is already in hand and no closure is added: the event path
-(`gui/event_handlers.go`, `gui/scroll.go`), the backends, and new widgets.
+Reads split by **phase**, not by whether a window happens to be reachable.
+
+**During generation** — widget factories and `GenerateLayout` — the bare
+`guiTheme` / `default*Style` read stays. It is not a compromise: `Themed` scopes
+a theme by push/pop of the _installed_ theme, so a generation-time read that
+called `w.Theme()` would silently ignore the scope. The ~420 sites are also the
+hot path; deferring one means a closure plus a `Cfg` heap escape per widget per
+frame.
+
+**Outside generation** — event handlers, post-arrange injection, public window
+methods reached from handlers, and the backends — the read names its window.
+Before #301 those resolved against whichever window generated last: right by
+timing in a one-window app, wrong with two. `themePickerSyncHighlight` was
+already wrong that way.
+
+Migrated in #301:
+
+| File                                    | Function                                       |
+| --------------------------------------- | ---------------------------------------------- |
+| `gui/event_handlers.go`                 | `keyDownScrollHandler`                         |
+| `gui/scroll.go`                         | `scrollHorizontal`, `scrollVertical`           |
+| `gui/scroll_smooth.go`                  | `scrollSmoothBy`                               |
+| `gui/native_print.go`                   | `ExportPrintJob`                               |
+| `gui/view_theme_picker.go`              | `themePickerSyncHighlight`                     |
+| `gui/view_toast.go`                     | `toastEnforceMaxVisible`                       |
+| `gui/view_select.go`                    | `selectScrollTo`                               |
+| `gui/inspector.go`                      | `inspectorInjectWireframe`                     |
+| `gui/backend/{metal,gl,web}/backend.go` | `renderFrame`                                  |
+| `gui/backend/internal/framestate`       | `FrameBg`                                      |
+| `gui/backend/web/custom_shader.go`      | `drawCustomShaderFallback` (via `Backend.win`) |
+
+### The copy, and why the store is a pointer
+
+`Theme` is a large value — ~40 style structs plus ~40 text styles — so
+`w.Theme()`, which returns it by value, is not free. The scroll path reads it
+per wheel or arrow event, and the first cut of #301 cost 36 ns → 1083 ns per
+event on `BenchmarkEventFnMouseScrollFocused`: a 30x regression, all of it
+memcpy.
+
+So both stores hold a pointer to an immutable value: `Window.theme` and the
+package `defaultTheme`. A setter publishes a new value instead of writing
+through the pointer, so a reader that took the pointer under `RLock` may keep
+using it after dropping the lock. `w.Theme()` is unchanged for callers — it
+dereferences — and internal hot reads call the unexported `w.themeRef()`
+(`gui/theme_install.go`), which returns the pointer and copies nothing. With
+that, the scroll benchmark is back at ~39 ns/op, 0 allocs.
+
+Per-frame readers (the backends' clear color) keep `w.Theme()`; the copy is
+irrelevant once per frame and the value form is the safer default.
+
+### Gate
+
+`make ergonomics-audit` runs mode `theme`, which flags a `guiTheme`,
+`CurrentTheme()` or `default*Style` read inside a function with a `*Window` /
+`*gui.Window` receiver or parameter — but only in paths that are post-generation
+by construction: `gui/backend/**`, `gui/scroll*.go`, `gui/event*.go`,
+`gui/native_*.go`, `gui/window_*.go`. The phase cannot be decided from one
+function's syntax, so the mode does not guess; handlers living in mixed-phase
+`view_*.go` files are covered by the convention only. A deliberate exception
+carries `ergonomics-audit:theme-global` on its line.
+
+### Rejected: `w.Button(...)` receiver sugar
+
+Raised as #296 proposal item 5 and declined again in #301:
+
+1. It does not fix the phase problem. `w.Button(cfg)` still runs eagerly and
+   still resolves the theme at factory time — the same error with a window name
+   attached.
+2. It breaks reusability. A package factory builds window-agnostic view intent;
+   a receiver binds a fragment to a window at construction, so every sub-tree
+   helper threads `w` and closing over the wrong window becomes easy — the bug
+   class per-window themes set out to close.
+3. It fights `Themed`, for the reason above: the subtree scope lives in the
+   installed theme, not in the window.
+4. It is all cost. ~60 factories, every example, and the sibling consumers
+   churn, with no perf win — the closure cost that ruled out the blanket
+   migration comes from deferring, not from the receiver.
+5. The access already exists where it is needed: `GenerateLayout(w)`,
+   `EventCtx.Window`, `viewFunc(func(w *Window) View)`, `w.EffID` / `ctx.EffID`.
+
+The pattern is not banned — the boundary is a receiver for window-level
+singletons (`(*Window).Sidebar`, `(*Window).Toast`) and a package factory for
+reusable view fragments.

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -192,8 +192,10 @@ func (b *Backend) renderFrame(w *gui.Window) {
 	b.plat.makeCurrent()
 	bg := w.Config.BgColor
 	if bg == (gui.Color{}) {
-		t := gui.CurrentTheme()
-		bg = t.ColorBackground
+		// Runs after FrameFn on the same thread, so the installed
+		// theme happens to be right; w.Theme() makes it right by
+		// construction instead of by timing.
+		bg = w.Theme().ColorBackground
 	}
 	gogl.ClearColor(
 		float32(bg.R)/255.0,

--- a/gui/backend/internal/framestate/framestate.go
+++ b/gui/backend/internal/framestate/framestate.go
@@ -139,14 +139,16 @@ func (fs *FrameState) HandleResize(w, h int32, scale float32) {
 }
 
 // FrameBg resolves the frame clear color: the window's configured
-// background, falling back to the current theme's background when
+// background, falling back to the window's theme background when
 // unset. Returns normalized 0..1 components ready for the C
 // begin-frame call.
 func (fs *FrameState) FrameBg(w *gui.Window) (r, g, b, a float32) {
 	bg := w.Config.BgColor
 	if bg == (gui.Color{}) {
-		t := gui.CurrentTheme()
-		bg = t.ColorBackground
+		// Runs after FrameFn on the same thread, so the installed
+		// theme happens to be right; w.Theme() makes it right by
+		// construction instead of by timing.
+		bg = w.Theme().ColorBackground
 	}
 	return float32(bg.R) / 255.0,
 		float32(bg.G) / 255.0,

--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -626,8 +626,10 @@ func (ws *windowState) destroy() {
 func (ws *windowState) renderFrame(w *gui.Window) {
 	bg := w.Config.BgColor
 	if bg == (gui.Color{}) {
-		t := gui.CurrentTheme()
-		bg = t.ColorBackground
+		// Runs after FrameFn on the same thread, so the installed
+		// theme happens to be right; w.Theme() makes it right by
+		// construction instead of by timing.
+		bg = w.Theme().ColorBackground
 	}
 	rc := C.metalBeginFrame(ws.ctx,
 		C.float(float32(bg.R)/255.0),

--- a/gui/backend/web/backend.go
+++ b/gui/backend/web/backend.go
@@ -19,6 +19,11 @@ import (
 
 // Backend is the Canvas2D/WASM backend for go-gui.
 type Backend struct {
+	// win is the one window this backend serves — the browser window
+	// IS the application window here. Held so draw paths that resolve
+	// a theme default (custom-shader fallback) can name the window
+	// instead of reading the frame-scoped theme cache.
+	win       *gui.Window
 	canvas    js.Value
 	ctx2d     js.Value
 	glyphBack *glyphweb.Backend
@@ -148,6 +153,7 @@ func newBackend(w *gui.Window) (*Backend, error) {
 	loadIconFont(gui.IconFontData)
 
 	b := &Backend{
+		win:          w,
 		canvas:       canvas,
 		ctx2d:        ctx2d,
 		glyphBack:    glyphBack,
@@ -250,8 +256,10 @@ func (b *Backend) renderFrame(w *gui.Window) {
 	// default — not distinguishable from unset.
 	bg := w.Config.BgColor
 	if bg == (gui.Color{}) {
-		t := gui.CurrentTheme()
-		bg = t.ColorBackground
+		// Runs after FrameFn on the same thread, so the installed
+		// theme happens to be right; w.Theme() makes it right by
+		// construction instead of by timing.
+		bg = w.Theme().ColorBackground
 	}
 	b.glyphBack.BeginFrame(
 		float32(bg.R)/255, float32(bg.G)/255,

--- a/gui/backend/web/custom_shader.go
+++ b/gui/backend/web/custom_shader.go
@@ -84,7 +84,9 @@ func (b *Backend) drawCustomShader(r *gui.RenderCmd) {
 func (b *Backend) drawCustomShaderFallback(r *gui.RenderCmd) {
 	fill := r.Color
 	if fill == (gui.Color{}) {
-		fill = gui.CurrentTheme().ColorActive
+		// Draw path, outside generation: name the window this backend
+		// serves rather than the frame-scoped theme cache.
+		fill = b.win.Theme().ColorActive
 	}
 	fallback := *r
 	fallback.Fill = true

--- a/gui/event_handlers.go
+++ b/gui/event_handlers.go
@@ -154,8 +154,11 @@ const (
 )
 
 func keyDownScrollHandler(layout *Layout, e *Event, w *Window) {
-	deltaLine := guiTheme.scrollDeltaLine
-	deltaPage := guiTheme.scrollDeltaPage
+	// Post-generation read: name the window rather than the installed
+	// frame cache, which belongs to whichever window generated last.
+	th := w.themeRef()
+	deltaLine := th.scrollDeltaLine
+	deltaPage := th.scrollDeltaPage
 
 	switch e.Modifiers {
 	case ModNone:

--- a/gui/event_handlers_test.go
+++ b/gui/event_handlers_test.go
@@ -158,7 +158,9 @@ func TestKeydownHandlerFallbackScroll(t *testing.T) {
 	}
 	w := &Window{}
 	w.SetFocus("f1")
-	guiTheme.scrollDeltaLine = 20
+	pinTheme(w, func(th *Theme) {
+		th.scrollDeltaLine = 20
+	})
 	e := &Event{KeyCode: KeyDown, Modifiers: ModNone}
 	keydownHandler(root, e, w)
 	if !e.IsHandled {
@@ -167,9 +169,6 @@ func TestKeydownHandlerFallbackScroll(t *testing.T) {
 }
 
 func TestKeyDownScrollHandlerArrows(t *testing.T) {
-	guiTheme.scrollDeltaLine = 20
-	guiTheme.scrollDeltaPage = 100
-	guiTheme.scrollMultiplier = 1
 
 	layout := &Layout{
 		Shape: &Shape{
@@ -183,6 +182,11 @@ func TestKeyDownScrollHandlerArrows(t *testing.T) {
 		},
 	}
 	w := &Window{}
+	pinTheme(w, func(th *Theme) {
+		th.scrollDeltaLine = 20
+		th.scrollDeltaPage = 100
+		th.scrollMultiplier = 1
+	})
 
 	tests := []struct {
 		name string
@@ -363,7 +367,6 @@ func TestMouseMoveHandlerSkipsOutOfWindow(t *testing.T) {
 }
 
 func TestMouseScrollHandlerVertical(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	root := &Layout{Shape: &Shape{
 		Scrollable: true,
 		ID:         "1",
@@ -375,6 +378,9 @@ func TestMouseScrollHandlerVertical(t *testing.T) {
 		{Shape: &Shape{shapeType: shapeRectangle, Height: 200}},
 	}}
 	w := &Window{windowWidth: 800, windowHeight: 600}
+	pinTheme(w, func(th *Theme) {
+		th.scrollMultiplier = 1
+	})
 	e := &Event{
 		MouseX:    50,
 		MouseY:    25,
@@ -388,7 +394,6 @@ func TestMouseScrollHandlerVertical(t *testing.T) {
 }
 
 func TestMouseScrollHandlerHorizontalShift(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	root := &Layout{Shape: &Shape{
 		Scrollable: true,
 		ID:         "1",
@@ -401,6 +406,9 @@ func TestMouseScrollHandlerHorizontalShift(t *testing.T) {
 		{Shape: &Shape{shapeType: shapeRectangle, Width: 200}},
 	}}
 	w := &Window{windowWidth: 800, windowHeight: 600}
+	pinTheme(w, func(th *Theme) {
+		th.scrollMultiplier = 1
+	})
 	e := &Event{
 		MouseX:    25,
 		MouseY:    50,
@@ -440,7 +448,6 @@ func TestMouseScrollHandlerFocusedOnMouseScroll(t *testing.T) {
 }
 
 func TestMouseScrollUnhandledCascadesToScrollContainer(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	// Focused handler does NOT set IsHandled — scroll should
 	// cascade to the scroll container fallback.
 	focusCalled := false
@@ -470,6 +477,9 @@ func TestMouseScrollUnhandledCascadesToScrollContainer(t *testing.T) {
 		},
 	}
 	w := &Window{windowWidth: 800, windowHeight: 600}
+	pinTheme(w, func(th *Theme) {
+		th.scrollMultiplier = 1
+	})
 	w.SetFocus("f7")
 	e := &Event{
 		MouseX: 50, MouseY: 25,
@@ -529,7 +539,6 @@ func TestMouseScrollFallbackRespectsIsHandled(t *testing.T) {
 }
 
 func TestMouseScrollFallbackUnhandledReachesContainer(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	// Layout callback does NOT set IsHandled — scroll should
 	// fall through to the parent scroll container.
 	root := &Layout{
@@ -557,6 +566,9 @@ func TestMouseScrollFallbackUnhandledReachesContainer(t *testing.T) {
 		},
 	}
 	w := &Window{windowWidth: 800, windowHeight: 600}
+	pinTheme(w, func(th *Theme) {
+		th.scrollMultiplier = 1
+	})
 	e := &Event{
 		MouseX: 50, MouseY: 25,
 		ScrollY: -10, Modifiers: ModNone,

--- a/gui/gesture_test.go
+++ b/gui/gesture_test.go
@@ -442,7 +442,7 @@ func TestPanFallbackScroll(t *testing.T) {
 	w.animations = make(map[string]Animation)
 	gs := &w.viewState.gesture
 	gs.nowFn = fixedClock(0)
-	guiTheme.scrollMultiplier = 1
+	pinScrollMultiplier(w, 1)
 
 	w.handleTouch(root, touchEvent(EventTouchesBegan, 1, 100, 100))
 	// Pan downward — first move crosses threshold (Began).

--- a/gui/inspector.go
+++ b/gui/inspector.go
@@ -177,6 +177,9 @@ func inspectorInjectWireframe(w *Window) {
 		return
 	}
 	shape := node.Shape
+	// Runs from updateLayout after arrange, outside generation: name
+	// the window rather than the installed frame cache.
+	insp := w.Theme().inspectorStyle
 	emitRenderer(RenderCmd{
 		Kind:      RenderStrokeRect,
 		X:         shape.X,
@@ -184,7 +187,7 @@ func inspectorInjectWireframe(w *Window) {
 		W:         shape.Width,
 		H:         shape.Height,
 		Radius:    shape.Radius,
-		Color:     guiTheme.inspectorStyle.colorWireframe,
+		Color:     insp.colorWireframe,
 		Thickness: 2,
 	}, w)
 
@@ -197,7 +200,7 @@ func inspectorInjectWireframe(w *Window) {
 		Y:         shape.Y + shape.Padding.Top,
 		W:         f32Max(0, shape.Width-shape.Padding.Left-shape.Padding.Right),
 		H:         f32Max(0, shape.Height-shape.Padding.Top-shape.Padding.Bottom),
-		Color:     guiTheme.inspectorStyle.colorPadding,
+		Color:     insp.colorPadding,
 		Thickness: 1,
 	}, w)
 }

--- a/gui/native_print.go
+++ b/gui/native_print.go
@@ -33,7 +33,8 @@ func (w *Window) ExportPrintJob(job PrintJob) PrintExportResult {
 		// background via Clear(), which is not in the renderers).
 		bg := w.Config.BgColor
 		if bg == (Color{}) {
-			bg = CurrentTheme().ColorBackground
+			// Export runs outside generation: this window's theme.
+			bg = w.Theme().ColorBackground
 		}
 		out := make([]RenderCmd, 0, len(w.renderers)+1)
 		out = append(out, RenderCmd{

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -198,8 +198,9 @@ func scrollHorizontal(layout *Layout, delta float32, w *Window) bool {
 	sx := w.scrollX()
 	// Default 0: unscrolled position when no offset recorded yet.
 	old := sx.GetOr(id, 0)
+	// Post-generation read: this window's theme, not the frame cache.
 	clamped := f32Clamp(
-		old+delta*guiTheme.scrollMultiplier, maxOffset, 0)
+		old+delta*w.themeRef().scrollMultiplier, maxOffset, 0)
 	if old == clamped {
 		return false
 	}
@@ -223,8 +224,9 @@ func scrollVertical(layout *Layout, delta float32, w *Window) bool {
 	sy := w.scrollY()
 	// Default 0: unscrolled position when no offset recorded yet.
 	old := sy.GetOr(id, 0)
+	// Post-generation read: this window's theme, not the frame cache.
 	clamped := f32Clamp(
-		old+delta*guiTheme.scrollMultiplier, maxOffset, 0)
+		old+delta*w.themeRef().scrollMultiplier, maxOffset, 0)
 	if old == clamped {
 		return false
 	}

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -143,7 +143,8 @@ func scrollSmoothBy(w *Window, layout *Layout, axis scrollAxis, delta float32) b
 	if !ok {
 		return false
 	}
-	increment := delta * guiTheme.scrollMultiplier
+	// Post-generation read: this window's theme, not the frame cache.
+	increment := delta * w.themeRef().scrollMultiplier
 	return scrollSmoothArm(w, layout.Shape.idKey(), axis, displayed, maxOffset, increment, true)
 }
 

--- a/gui/scroll_smooth_live_test.go
+++ b/gui/scroll_smooth_live_test.go
@@ -13,11 +13,13 @@ import (
 // interactions — regression cover for the command scratch buffer
 // being handed back to writers while the flush loop still read it.
 func TestScrollVerticalToSmoothLiveLoop(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 
 	// NewWindow, not a bare Window: the animation goroutine only
 	// starts when the lifecycle channels exist.
 	w := NewWindow(WindowCfg{Width: 100, Height: 100})
+	pinTheme(w, func(th *Theme) {
+		th.scrollMultiplier = 1
+	})
 	t.Cleanup(func() {
 		w.stopAnimationLoop()
 	})

--- a/gui/scroll_smooth_test.go
+++ b/gui/scroll_smooth_test.go
@@ -29,7 +29,6 @@ func driveScrollSmooth(w *Window, maxTicks int) int {
 }
 
 func TestScrollSmoothTargetSetDisplayUnchangedFrame0(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("1", 100, 100, 100, 300)
 
 	ok := scrollSmoothBy(w, layout, scrollAxisY, -50)
@@ -56,7 +55,6 @@ func TestScrollSmoothTargetSetDisplayUnchangedFrame0(t *testing.T) {
 }
 
 func TestScrollSmoothConvergesAndStops(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("2", 100, 100, 100, 300)
 	scrollSmoothBy(w, layout, scrollAxisY, -50)
 
@@ -105,7 +103,6 @@ func TestScrollSmoothConvergesAndStops(t *testing.T) {
 }
 
 func TestScrollSmoothClampsAtBounds(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("3", 100, 100, 100, 300) // maxOffset -200
 
 	// Huge delta clamps target to the max offset.
@@ -132,7 +129,6 @@ func TestScrollSmoothClampsAtBounds(t *testing.T) {
 }
 
 func TestScrollSmoothAccumulatesTarget(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("4", 100, 100, 100, 300)
 
 	// Two rapid notches before any tick: targets accumulate.
@@ -149,7 +145,6 @@ func TestScrollSmoothAccumulatesTarget(t *testing.T) {
 }
 
 func TestScrollSmoothCanceledByInstantScroll(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("5", 100, 100, 100, 300)
 
 	scrollSmoothBy(w, layout, scrollAxisY, -50)
@@ -170,8 +165,8 @@ func TestScrollSmoothCanceledByInstantScroll(t *testing.T) {
 }
 
 func TestScrollSmoothHorizontalAxis(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	w := &Window{}
+	pinScrollMultiplier(w, 1)
 	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 50}}
 	layout := Layout{
 		Shape: &Shape{
@@ -198,7 +193,6 @@ func TestScrollSmoothHorizontalAxis(t *testing.T) {
 }
 
 func TestScrollSmoothFiresOnScroll(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("7", 100, 100, 100, 300)
 	w.layout.Children[0].Parent = &w.layout
 	fired := 0
@@ -213,7 +207,6 @@ func TestScrollSmoothFiresOnScroll(t *testing.T) {
 }
 
 func TestScrollSmoothResetClearsEntries(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("8", 100, 100, 100, 300)
 	scrollSmoothBy(w, layout, scrollAxisY, -50)
 	w.scrollSmoothReset()
@@ -228,7 +221,6 @@ func TestScrollSmoothResetClearsEntries(t *testing.T) {
 // TestScrollSmoothNoAllocSteadyState guards the per-event allocation
 // budget: once an entry exists, accumulating deltas must not allocate.
 func TestScrollSmoothNoAllocSteadyState(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("9", 100, 100, 100, 900) // maxOffset -800
 	// Warm up: create the entry and animations map.
 	scrollSmoothBy(w, layout, scrollAxisY, -5)
@@ -252,7 +244,6 @@ func TestScrollSmoothNoAllocSteadyState(t *testing.T) {
 // deltas poisoning the ease target into a never-settling animation
 // (60fps layout-refresh DoS).
 func TestScrollSmoothRejectsNonFiniteDelta(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	nan := float32(math.NaN())
 	layout, w := makeScrollLayout("10", 100, 100, 100, 300)
 
@@ -277,7 +268,6 @@ func TestScrollSmoothRejectsNonFiniteDelta(t *testing.T) {
 // TestScrollSmoothRetiresPoisonedEntry verifies Update deactivates an
 // entry whose target became non-finite instead of ticking forever.
 func TestScrollSmoothRetiresPoisonedEntry(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("11", 100, 100, 100, 300)
 	scrollSmoothBy(w, layout, scrollAxisY, -50)
 	e := w.scrollSmooth.findEntry("11", scrollAxisY)
@@ -296,7 +286,6 @@ func TestScrollSmoothRetiresPoisonedEntry(t *testing.T) {
 }
 
 func TestScrollSmoothByNoScrollID(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("0", 100, 100, 100, 300)
 	layout.Shape.Scrollable = false
 	layout.Shape.ID = ""
@@ -306,7 +295,6 @@ func TestScrollSmoothByNoScrollID(t *testing.T) {
 }
 
 func TestScrollSmoothByRespectsScrollMode(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("12", 100, 100, 100, 300)
 
 	layout.Shape.ScrollMode = ScrollHorizontalOnly
@@ -320,7 +308,6 @@ func TestScrollSmoothByRespectsScrollMode(t *testing.T) {
 }
 
 func TestScrollSmoothCanceledByScrollToPct(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	layout, w := makeScrollLayout("13", 100, 100, 100, 300)
 	scrollSmoothBy(w, layout, scrollAxisY, -50)
 
@@ -341,7 +328,6 @@ func TestCommandApplyScrollSmoothNilSafe(t *testing.T) {
 }
 
 func TestScrollVerticalToSmoothEasesToAbsoluteTarget(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	_, w := makeScrollLayout("14", 100, 100, 100, 300)
 	w.scrollY().Set("14", -100)
 
@@ -369,7 +355,6 @@ func TestScrollVerticalToSmoothEasesToAbsoluteTarget(t *testing.T) {
 }
 
 func TestScrollVerticalToSmoothClampsAtBounds(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	_, w := makeScrollLayout("15", 100, 100, 100, 300) // maxOffset -200
 
 	w.scrollVerticalToSmooth("15", -9999)
@@ -384,7 +369,6 @@ func TestScrollVerticalToSmoothClampsAtBounds(t *testing.T) {
 }
 
 func TestScrollVerticalToSmoothNoOpAtTarget(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	_, w := makeScrollLayout("16", 100, 100, 100, 300)
 
 	// Already at offset 0: nothing to ease, no entry armed.
@@ -397,7 +381,6 @@ func TestScrollVerticalToSmoothNoOpAtTarget(t *testing.T) {
 }
 
 func TestScrollVerticalToSmoothUnknownID(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	_, w := makeScrollLayout("17", 100, 100, 100, 300)
 
 	w.scrollVerticalToSmooth("nope", -50) // must not panic or arm
@@ -407,8 +390,8 @@ func TestScrollVerticalToSmoothUnknownID(t *testing.T) {
 }
 
 func TestScrollHorizontalToSmoothEases(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	w := &Window{}
+	pinScrollMultiplier(w, 1)
 	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 50}}
 	layout := Layout{
 		Shape: &Shape{
@@ -434,7 +417,6 @@ func TestScrollHorizontalToSmoothEases(t *testing.T) {
 }
 
 func TestScrollVerticalToSmoothCanceledByInstantScroll(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	_, w := makeScrollLayout("19", 100, 100, 100, 300)
 	w.scrollY().Set("19", -100)
 
@@ -454,8 +436,8 @@ func TestScrollVerticalToSmoothCanceledByInstantScroll(t *testing.T) {
 }
 
 func TestScrollHorizontalToSmoothCanceledByInstantScroll(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	w := &Window{}
+	pinScrollMultiplier(w, 1)
 	child := Layout{Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 50}}
 	layout := Layout{
 		Shape: &Shape{
@@ -490,7 +472,6 @@ func TestScrollHorizontalToSmoothCanceledByInstantScroll(t *testing.T) {
 }
 
 func TestScrollVerticalToSmoothRejectsNaN(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	_, w := makeScrollLayout("21", 100, 100, 100, 300)
 
 	w.scrollVerticalToSmooth("21", float32(math.NaN()))

--- a/gui/scroll_test.go
+++ b/gui/scroll_test.go
@@ -5,8 +5,12 @@ import (
 	"testing"
 )
 
+// makeScrollLayout builds a one-child scrollable layout and the window
+// that owns it. The window is pinned to a theme whose scroll multiplier
+// is 1, so a delta maps 1:1 to an offset in every scroll test.
 func makeScrollLayout(idScroll string, width, height float32, contentW, contentH float32) (*Layout, *Window) {
 	w := &Window{}
+	pinScrollMultiplier(w, 1)
 	child := Layout{
 		Shape: &Shape{
 			shapeType: shapeRectangle,
@@ -34,7 +38,6 @@ func makeScrollLayout(idScroll string, width, height float32, contentW, contentH
 
 func TestScrollVerticalClampsWithinBounds(t *testing.T) {
 	layout, w := makeScrollLayout("1", 100, 100, 100, 300)
-	guiTheme.scrollMultiplier = 1
 
 	ok := scrollVertical(layout, -50, w)
 	if !ok {
@@ -55,7 +58,7 @@ func TestScrollVerticalClampsWithinBounds(t *testing.T) {
 
 func TestScrollHorizontalClampsWithinBounds(t *testing.T) {
 	w := &Window{}
-	guiTheme.scrollMultiplier = 1
+	pinScrollMultiplier(w, 1)
 	child := Layout{
 		Shape: &Shape{shapeType: shapeRectangle, Width: 400, Height: 50},
 	}
@@ -262,7 +265,6 @@ func TestScrollPctNoScrollNeeded(t *testing.T) {
 }
 
 func TestScrollVerticalFiresOnScroll(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	fired := false
 	layout, w := makeScrollLayout("7", 100, 100, 100, 300)
 	layout.Shape.events = &eventHandlers{
@@ -275,7 +277,6 @@ func TestScrollVerticalFiresOnScroll(t *testing.T) {
 }
 
 func TestScrollReturnsFalseAtBoundary(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	t.Run("vertical", func(t *testing.T) {
 		layout, w := makeScrollLayout("10", 100, 100, 100, 300)
 		scrollVertical(layout, -500, w)
@@ -340,9 +341,9 @@ func TestScrollReturnsFalseAtBoundary(t *testing.T) {
 }
 
 func TestScrollMode(t *testing.T) {
-	guiTheme.scrollMultiplier = 1
 	t.Run("vertical_only_blocks_horizontal", func(t *testing.T) {
 		w := &Window{}
+		pinScrollMultiplier(w, 1)
 		child := Layout{
 			Shape: &Shape{shapeType: shapeRectangle,
 				Width: 400, Height: 50},

--- a/gui/theme.go
+++ b/gui/theme.go
@@ -20,7 +20,11 @@ var (
 	guiTheme   Theme
 	guiThemeMu sync.RWMutex
 
-	defaultTheme   Theme
+	// Held as a pointer to an immutable value for the same reason
+	// Window.theme is: readers take the pointer and skip copying a
+	// large struct. SetTheme publishes a new value; nothing writes
+	// through the pointer.
+	defaultTheme   *Theme
 	defaultThemeMu sync.RWMutex
 
 	// installedThemeID is the id of the theme currently written into
@@ -273,8 +277,9 @@ func CurrentTheme() Theme {
 // one pick this up on their next frame, so calling SetTheme from main or
 // from an event handler rethemes the app as it always has.
 func SetTheme(t Theme) {
+	published := t
 	defaultThemeMu.Lock()
-	defaultTheme = t
+	defaultTheme = &published
 	defaultThemeMu.Unlock()
 	// Install eagerly as well, so callers outside a frame pass — main
 	// before Run, tests building views directly — see the change at
@@ -286,9 +291,22 @@ func SetTheme(t Theme) {
 
 // currentDefaultTheme returns the app-default theme.
 func currentDefaultTheme() Theme {
+	return *currentDefaultThemeRef()
+}
+
+// currentDefaultThemeRef is currentDefaultTheme without the copy. The
+// value it points at is never written through, so the pointer stays
+// valid after the lock is dropped. Callers must not mutate it.
+func currentDefaultThemeRef() *Theme {
 	defaultThemeMu.RLock()
-	defer defaultThemeMu.RUnlock()
-	return defaultTheme
+	t := defaultTheme
+	defaultThemeMu.RUnlock()
+	if t == nil {
+		// Before init's SetTheme-equivalent runs (a test constructing
+		// a Window in an init of its own).
+		return &ThemeDark
+	}
+	return t
 }
 
 // applyTheme installs t as the active theme: guiTheme plus every

--- a/gui/theme_defaults.go
+++ b/gui/theme_defaults.go
@@ -205,6 +205,6 @@ func init() {
 	// literals of their own, so an app that never calls SetTheme still
 	// gets ThemeDark everywhere rather than a mixture (issue #300). It
 	// also sets guiTheme and installedThemeID.
-	defaultTheme = ThemeDark
+	defaultTheme = &ThemeDark
 	applyTheme(ThemeDark)
 }

--- a/gui/theme_install.go
+++ b/gui/theme_install.go
@@ -71,24 +71,36 @@ func (w *Window) themePinned() bool {
 // Theme returns the window's active theme: the one set with SetTheme, or
 // the app default when the window has not pinned one.
 func (w *Window) Theme() Theme {
+	return *w.themeRef()
+}
+
+// themeRef is Theme without the copy. Theme is a large value (~40 style
+// structs plus ~40 text styles), so the per-event reads on the scroll
+// path must not copy it. The pointed-to value is published once and
+// never written through, so the pointer stays valid after the lock is
+// dropped. Callers must not mutate it.
+func (w *Window) themeRef() *Theme {
 	if w == nil {
-		return currentDefaultTheme()
+		return currentDefaultThemeRef()
 	}
 	w.themeMu.RLock()
 	pinned, t := w.themeSet, w.theme
 	w.themeMu.RUnlock()
-	if pinned {
+	if pinned && t != nil {
 		return t
 	}
-	return currentDefaultTheme()
+	return currentDefaultThemeRef()
 }
 
 // SetTheme pins t as this window's theme and requests a rebuild. Other
 // windows keep theirs. The install happens at the start of the next
 // frame, which the requested rebuild guarantees.
 func (w *Window) SetTheme(t Theme) {
+	// Publish a fresh value rather than writing through the pointer:
+	// a reader may still hold the previous one.
+	pinned := t
 	w.themeMu.Lock()
-	w.theme = t
+	w.theme = &pinned
 	w.themeSet = true
 	w.themeMu.Unlock()
 	// Installed eagerly for the same reason package SetTheme does it:

--- a/gui/theme_install_test.go
+++ b/gui/theme_install_test.go
@@ -58,6 +58,50 @@ func TestWindowThemeIsolated(t *testing.T) {
 	}
 }
 
+// TestThemeNilWindowReturnsDefault guards the nil-receiver branch of
+// themeRef: Theme() on a nil window must resolve to the app default
+// rather than dereferencing nil (issue #301 moved the branch into
+// themeRef).
+func TestThemeNilWindowReturnsDefault(t *testing.T) {
+	var w *Window
+	if got, want := w.Theme().id, currentDefaultTheme().id; got != want {
+		t.Errorf("nil-window theme id = %d, want %d (app default)",
+			got, want)
+	}
+}
+
+// TestWindowThemeScrollIsPerWindow covers the post-generation half of
+// per-window theming (issue #301): the scroll paths run after
+// generation, so before they read w.Theme() they resolved against the
+// installed frame cache — whichever window generated last. Two windows
+// with different scroll multipliers must scroll by their own.
+func TestWindowThemeScrollIsPerWindow(t *testing.T) {
+	restoreTheme(t)
+	slowCfg := themeDarkCfg
+	slowCfg.Name = "slow"
+	slowCfg.scrollMultiplier = 1
+	fastCfg := themeDarkCfg
+	fastCfg.Name = "fast"
+	fastCfg.scrollMultiplier = 4
+
+	l1, w1 := makeScrollLayout("s1", 100, 100, 100, 300)
+	l2, w2 := makeScrollLayout("s2", 100, 100, 100, 300)
+	w1.SetTheme(ThemeMaker(slowCfg))
+	w2.SetTheme(ThemeMaker(fastCfg))
+
+	// w2 pinned last, so the installed cache holds "fast": w1 must
+	// still scroll at 1x.
+	scrollVertical(l1, -10, w1)
+	scrollVertical(l2, -10, w2)
+
+	if v, _ := w1.scrollY().Get("s1"); v != -10 {
+		t.Errorf("w1 offset = %v, want -10 (multiplier 1)", v)
+	}
+	if v, _ := w2.scrollY().Get("s2"); v != -40 {
+		t.Errorf("w2 offset = %v, want -40 (multiplier 4)", v)
+	}
+}
+
 func TestWindowThemeFollowsDefault(t *testing.T) {
 	restoreTheme(t)
 	green := themeWithPanel(t, "green", RGB(0, 200, 0))

--- a/gui/theme_pin_test.go
+++ b/gui/theme_pin_test.go
@@ -1,0 +1,31 @@
+package gui
+
+// Test helpers for driving the theme values that post-generation code
+// reads through w.Theme() (issue #301). Before that migration these
+// tests wrote guiTheme directly; that no longer reaches the code under
+// test, and it leaked across tests because guiTheme is process-wide.
+
+// pinTheme pins a mutated copy of w's active theme on w. Window-scoped,
+// so no restore is needed. Deliberately does not go through
+// (*Window).SetTheme: that also calls applyTheme and UpdateWindow, which
+// a bare test Window does not need.
+//
+// The copy keeps its Theme.id, so needsInstall treats it as already
+// installed and the default*Style mirrors are NOT refreshed from it. That
+// is correct for code reading w.Theme(); do not use this helper to drive
+// a test that asserts on a default*Style var.
+func pinTheme(w *Window, mutate func(*Theme)) {
+	th := w.Theme()
+	mutate(&th)
+	w.themeMu.Lock()
+	w.theme = &th
+	w.themeSet = true
+	w.themeMu.Unlock()
+}
+
+// pinScrollMultiplier pins mult as w's scroll multiplier, the knob the
+// scroll paths read per event. Tests use 1 so a delta maps 1:1 to an
+// offset.
+func pinScrollMultiplier(w *Window, mult float32) {
+	pinTheme(w, func(th *Theme) { th.scrollMultiplier = mult })
+}

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -447,8 +447,10 @@ func selectNextSelectable(options []string, start, dir int) int {
 
 func selectScrollTo(cfg *SelectCfg, scrollID string, idx int, w *Window) {
 	rowH := cfg.TextStyle.Size + 4
+	// Called from the key handler, after generation: read the window's
+	// theme rather than the frame-scoped style mirror.
 	listH := selectDropdownMaxH - 2*cfg.SizeBorder.Get(
-		defaultSelectStyle.SizeBorder)
+		w.Theme().selectStyle.SizeBorder)
 	scrollEnsureVisible(scrollID, idx, rowH, listH, w)
 }
 

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -191,7 +191,9 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 // theme name.
 func themePickerSyncHighlight(lbID string, w *Window) {
 	names := themeRegisteredNames()
-	current := guiTheme.Name
+	// Runs from the listbox handlers, after generation: the frame cache
+	// holds whichever window generated last, so name this one.
+	current := w.Theme().Name
 	idx := 0
 	for i, n := range names {
 		if n == current {

--- a/gui/view_theme_picker_test.go
+++ b/gui/view_theme_picker_test.go
@@ -34,9 +34,7 @@ func TestThemePickerOpen(t *testing.T) {
 }
 
 func TestThemePickerSyncHighlight(t *testing.T) {
-	savedName := guiTheme.Name
 	defer func() {
-		guiTheme.Name = savedName
 		themeRegistryMu.Lock()
 		delete(themeRegistry, "alpha")
 		delete(themeRegistry, "beta")
@@ -44,9 +42,11 @@ func TestThemePickerSyncHighlight(t *testing.T) {
 	}()
 	themeRegister(Theme{Name: "alpha"})
 	themeRegister(Theme{Name: "beta"})
-	guiTheme.Name = "beta"
 
+	// The sync runs post-generation and reads the window's theme, so
+	// pin the name on the window rather than on the frame cache.
 	w := &Window{}
+	pinTheme(w, func(th *Theme) { th.Name = "beta" })
 	themePickerSyncHighlight("test-lb", w)
 	idx := StateReadOr(w, nsListBoxFocus, "test-lb", -1)
 	// "alpha"=0, "beta"=1 (sorted).

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -374,7 +374,9 @@ func toastRemove(w *Window, id uint64) {
 // toastEnforceMaxVisible starts exit on oldest non-exiting toasts
 // when count exceeds max.
 func toastEnforceMaxVisible(w *Window) {
-	maxVisible := defaultToastStyle.maxVisible
+	// Reached from (*Window).Toast, outside generation: read the
+	// window's theme rather than the frame-scoped style mirror.
+	maxVisible := w.Theme().toastStyle.maxVisible
 	if maxVisible <= 0 {
 		return
 	}

--- a/gui/window.go
+++ b/gui/window.go
@@ -195,7 +195,11 @@ type Window struct {
 	// which case the window follows the app default. Read from any
 	// goroutine (Theme()), written by SetTheme — hence its own lock
 	// rather than piggybacking on mu, which the frame pass holds.
-	theme    Theme
+	// Stored as a pointer to an immutable value: SetTheme publishes a
+	// new one rather than writing through, so a hot read (themeRef, on
+	// the scroll path) can take the pointer and skip copying a struct
+	// that holds ~40 style structs and ~40 text styles.
+	theme    *Theme
 	themeSet bool
 	themeMu  sync.RWMutex
 

--- a/gui/window_event_test.go
+++ b/gui/window_event_test.go
@@ -300,7 +300,7 @@ func TestEventFnMouseScrollFocusedHandlerPrecedence(t *testing.T) {
 		},
 	}
 	w.SetFocus("f11")
-	guiTheme.scrollMultiplier = 1
+	pinScrollMultiplier(w, 1)
 	e := &Event{
 		Type:      EventMouseScroll,
 		MouseX:    25,

--- a/tools/ergonomics-audit/main.go
+++ b/tools/ergonomics-audit/main.go
@@ -9,6 +9,7 @@
 //	go run ./tools/ergonomics-audit/ -mode ids [repo...]
 //	go run ./tools/ergonomics-audit/ -mode opt [repo...]
 //	go run ./tools/ergonomics-audit/ -mode literals [repo...]
+//	go run ./tools/ergonomics-audit/ -mode theme [repo...]
 //
 // With no repo arguments both modes audit the current directory.
 //
@@ -69,7 +70,7 @@ import (
 var listShape *string
 
 func main() {
-	mode := flag.String("mode", "focus", "audit to run: focus | callbacks | ids | opt | literals")
+	mode := flag.String("mode", "focus", "audit to run: focus | callbacks | ids | opt | literals | theme")
 	guiRoot := flag.String("gui", ".", "path to the go-gui repo (source of truth for mode=focus)")
 	listShape = flag.String("list", "", "mode=callbacks: also list distinct signatures of this shape, or \"all\"")
 	fix := flag.Bool("fix", false, "mode=focus: rewrite broken literals in place, adding a generated ID")
@@ -107,8 +108,10 @@ func main() {
 		err = runOpt(repos)
 	case "literals":
 		err = runLiterals(repos)
+	case "theme":
+		err = runTheme(repos)
 	default:
-		err = fmt.Errorf("unknown -mode %q (want focus, callbacks, ids, opt or literals)", *mode)
+		err = fmt.Errorf("unknown -mode %q (want focus, callbacks, ids, opt, literals or theme)", *mode)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "ergonomics-audit:", err)

--- a/tools/ergonomics-audit/theme.go
+++ b/tools/ergonomics-audit/theme.go
@@ -1,0 +1,262 @@
+package main
+
+// Mode theme answers: does post-generation code still read the theme
+// from the frame-scoped cache instead of naming its window?
+//
+// The theme is window-owned (docs/specs/per-window-theme.md). guiTheme
+// and the ~30 default*Style package vars are a frame-scoped cache that
+// FrameFn installs before the view function runs, so the ~420
+// factory-time reads resolve to the right window without naming it.
+// That is by design and must stay: Themed(t, build) scopes a theme to a
+// subtree by push/pop of the *installed* theme, so a generation-time
+// read that called w.Theme() would silently ignore the scope.
+//
+// Code that runs OUTSIDE generation has no such excuse. An event
+// handler, a post-arrange injection, or a backend's clear-color read
+// resolves against whichever window generated last — right by timing in
+// a one-window app, wrong as soon as there are two. Issue #301 migrated
+// those sites to w.Theme(); this mode keeps them migrated.
+//
+// Distinguishing "runs during generation" from "runs after it" is not
+// decidable from one function's syntax, so the mode does not try. It
+// scans only paths that are post-generation by construction:
+//
+//   - gui/backend/**    — runs after FrameFn, on the same thread
+//   - gui/scroll*.go    — scroll math, driven by input events
+//   - gui/event*.go     — dispatch and handlers
+//   - gui/native_*.go   — native dialogs, print, export
+//   - gui/window_*.go   — window lifecycle and update
+//
+// Within those, a finding is a read of guiTheme, CurrentTheme(), or a
+// default*Style var from a function that has a *Window (or *gui.Window)
+// receiver or parameter — that is, one that could name its window and
+// did not.
+//
+// Known gap: handlers that live in a mixed-phase file (view_*.go holds
+// both the factory and its handlers) are not scanned, because the same
+// file's generation-time reads must stay bare. themePickerSyncHighlight,
+// selectScrollTo and toastEnforceMaxVisible are migrated but ungated;
+// the rule in CLAUDE.md covers them.
+//
+// A deliberate exception carries a same-line marker and prints as
+// deferred rather than gating:
+//
+//	bg = gui.CurrentTheme().ColorBackground // ergonomics-audit:theme-global
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// themeGlobalMarker exempts one line: the read of the installed theme is
+// deliberate, because the code genuinely wants whatever is installed
+// rather than one window's theme.
+const themeGlobalMarker = "ergonomics-audit:theme-global"
+
+// themeStylePattern matches the default*Style / Default*Style mirrors
+// that applyTheme writes. They are the same frame-scoped cache as
+// guiTheme, one style struct at a time.
+var themeStylePattern = regexp.MustCompile(`^[Dd]efault[A-Za-z]*Style$`)
+
+// themeScannedPaths are the repo-relative paths that are
+// post-generation by construction. A path outside this set is not
+// scanned at all — see the mode comment for why the boundary cannot be
+// computed from syntax.
+func themeScanned(rel string) bool {
+	rel = filepath.ToSlash(rel)
+	if !strings.HasPrefix(rel, "gui/") {
+		return false
+	}
+	if strings.HasPrefix(rel, "gui/backend/") {
+		return true
+	}
+	base := filepath.Base(rel)
+	if filepath.Dir(rel) != "gui" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(base, "scroll"),
+		strings.HasPrefix(base, "event"),
+		strings.HasPrefix(base, "native_"),
+		strings.HasPrefix(base, "window_"):
+		return true
+	}
+	return false
+}
+
+// themeFinding is one frame-cache read from a function that had a
+// window to name.
+type themeFinding struct {
+	path     string
+	line     int
+	fn       string
+	read     string
+	deferred bool // carried the marker: advisory, does not gate
+}
+
+// runTheme reports frame-cache theme reads in post-generation code. It
+// returns an error when any unmarked finding survives, so the audit
+// gates like modes ids, opt and literals.
+func runTheme(repos []string) error {
+	var all []themeFinding
+	for _, repo := range repos {
+		found, err := scanTheme(repo)
+		if err != nil {
+			return err
+		}
+		all = append(all, found...)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].path != all[j].path {
+			return all[i].path < all[j].path
+		}
+		return all[i].line < all[j].line
+	})
+
+	var gating int
+	for _, f := range all {
+		if !f.deferred {
+			gating++
+		}
+	}
+
+	fmt.Printf("Window-theme read audit (%d finding(s), %d deferred)\n",
+		gating, len(all)-gating)
+	for _, f := range all {
+		tag := ""
+		if f.deferred {
+			tag = " [deferred]"
+		}
+		fmt.Printf("  %s:%d: %s reads %s with a window in hand%s\n",
+			f.path, f.line, f.fn, f.read, tag)
+	}
+	if gating > 0 {
+		fmt.Println()
+		fmt.Println("Post-generation code with a *Window in hand reads w.Theme().")
+		fmt.Printf("If the installed theme is genuinely what is wanted, mark the line %q.\n",
+			themeGlobalMarker)
+		return fmt.Errorf("%d frame-cache theme read(s)", gating)
+	}
+	return nil
+}
+
+func scanTheme(repo string) ([]themeFinding, error) {
+	var out []themeFinding
+	err := walkGo(filepath.Join(repo, "gui"), func(path string, fset *token.FileSet, f *ast.File) {
+		if strings.HasSuffix(path, "_test.go") {
+			return
+		}
+		rel := relPath(repo, path)
+		if !themeScanned(rel) {
+			return
+		}
+		marked := markedLines(fset, f, themeGlobalMarker)
+		inspectTheme(fset, f, func(fn string, line int, read string) {
+			out = append(out, themeFinding{
+				path: rel, line: line, fn: fn, read: read,
+				deferred: marked[line],
+			})
+		})
+	})
+	return out, err
+}
+
+// hasWindowParam reports whether fn could name a window: a receiver or
+// parameter typed *Window or *gui.Window.
+func hasWindowParam(fn *ast.FuncDecl) bool {
+	if fn.Recv != nil {
+		for _, fld := range fn.Recv.List {
+			if isWindowPtr(fld.Type) {
+				return true
+			}
+		}
+	}
+	if fn.Type != nil && fn.Type.Params != nil {
+		for _, fld := range fn.Type.Params.List {
+			if isWindowPtr(fld.Type) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isWindowPtr reports whether a type expression is *Window (in package
+// gui) or *gui.Window (in a backend package).
+func isWindowPtr(typ ast.Expr) bool {
+	star, ok := typ.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	switch t := star.X.(type) {
+	case *ast.Ident:
+		return t.Name == "Window"
+	case *ast.SelectorExpr:
+		pkg, ok := t.X.(*ast.Ident)
+		return ok && pkg.Name == "gui" && t.Sel.Name == "Window"
+	}
+	return false
+}
+
+// themeRead names the frame-scoped cache an expression reads, or "" if
+// it reads none.
+func themeRead(n ast.Node) string {
+	switch e := n.(type) {
+	case *ast.Ident:
+		if e.Name == "guiTheme" {
+			return "guiTheme"
+		}
+		if themeStylePattern.MatchString(e.Name) {
+			return e.Name
+		}
+	case *ast.CallExpr:
+		switch fn := e.Fun.(type) {
+		case *ast.Ident:
+			if fn.Name == "CurrentTheme" {
+				return "CurrentTheme()"
+			}
+		case *ast.SelectorExpr:
+			pkg, ok := fn.X.(*ast.Ident)
+			if ok && pkg.Name == "gui" && fn.Sel.Name == "CurrentTheme" {
+				return "gui.CurrentTheme()"
+			}
+		}
+	}
+	return ""
+}
+
+// inspectTheme walks one parsed file and calls report for each
+// frame-cache read inside a function that has a window in hand. Split
+// out from scanTheme so the rules can be exercised against in-memory
+// source in tests.
+func inspectTheme(
+	fset *token.FileSet, f *ast.File, report func(fn string, line int, read string),
+) {
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || !hasWindowParam(fn) {
+			continue
+		}
+		name := fn.Name.Name
+		seen := map[int]bool{}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			read := themeRead(n)
+			if read == "" {
+				return true
+			}
+			line := fset.Position(n.Pos()).Line
+			// One line can hold a call and its ident; report once.
+			if seen[line] {
+				return true
+			}
+			seen[line] = true
+			report(name, line, read)
+			return true
+		})
+	}
+}

--- a/tools/ergonomics-audit/theme_test.go
+++ b/tools/ergonomics-audit/theme_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunThemeGatesOnFrameCacheReads covers runTheme end-to-end: the
+// gating contract that make check-all relies on. Unmarked reads fail
+// the audit; the marker defers them; clean code passes.
+func TestRunThemeGatesOnFrameCacheReads(t *testing.T) {
+	repo := t.TempDir()
+	guiDir := filepath.Join(repo, "gui")
+	if err := os.MkdirAll(guiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scrollPath := filepath.Join(guiDir, "scroll.go")
+
+	write := func(src string) {
+		t.Helper()
+		if err := os.WriteFile(scrollPath, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Unmarked frame-cache read in a scanned path: gates.
+	write(`package gui
+
+var guiTheme struct{ scrollMultiplier float32 }
+
+func scrollVertical(w *Window, d float32) float32 {
+	return d * guiTheme.scrollMultiplier
+}
+`)
+	if err := runTheme([]string{repo}); err == nil {
+		t.Fatal("runTheme passed with an unmarked frame-cache read")
+	}
+
+	// Same line marked: advisory only, passes.
+	write(`package gui
+
+var guiTheme struct{ scrollMultiplier float32 }
+
+func scrollVertical(w *Window, d float32) float32 {
+	return d * guiTheme.scrollMultiplier // ergonomics-audit:theme-global
+}
+`)
+	if err := runTheme([]string{repo}); err != nil {
+		t.Fatalf("runTheme failed with a marked read: %v", err)
+	}
+
+	// Window named: passes.
+	write(`package gui
+
+type Theme struct{ scrollMultiplier float32 }
+
+func scrollVertical(w *Window, d float32) float32 {
+	return d * w.Theme().scrollMultiplier
+}
+`)
+	if err := runTheme([]string{repo}); err != nil {
+		t.Fatalf("runTheme failed on clean code: %v", err)
+	}
+}
+
+// scanThemeSrc runs the theme-mode rules over one in-memory file and
+// returns the reported findings as "fn:line:read", with a "[deferred]"
+// suffix when the line carried the marker.
+func scanThemeSrc(t *testing.T, src string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	marked := markedLines(fset, f, themeGlobalMarker)
+	var out []string
+	inspectTheme(fset, f, func(fn string, line int, read string) {
+		s := fn + ":" + read
+		if marked[line] {
+			s += " [deferred]"
+		}
+		out = append(out, s)
+	})
+	return out
+}
+
+func TestThemeFlagsFrameCacheReadsWithWindowInHand(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+
+type Window struct{}
+type Theme struct{ ColorBackground int }
+
+func CurrentTheme() Theme { return Theme{} }
+
+var guiTheme Theme
+var defaultToastStyle struct{ maxVisible int }
+var DefaultScrollbarStyle struct{ Size int }
+
+// Parameter form.
+func handler(w *Window, delta float32) {
+	_ = guiTheme.ColorBackground
+}
+
+// Receiver form.
+func (w *Window) export() {
+	_ = CurrentTheme().ColorBackground
+}
+
+// Qualified call, backend style.
+func render(w *gui.Window) {
+	_ = gui.CurrentTheme().ColorBackground
+}
+
+// Style mirrors, both spellings.
+func enforce(w *Window) {
+	_ = defaultToastStyle.maxVisible
+	_ = DefaultScrollbarStyle.Size
+}
+`
+	got := scanThemeSrc(t, src)
+	want := []string{
+		"handler:guiTheme",
+		"export:CurrentTheme()",
+		"render:gui.CurrentTheme()",
+		"enforce:defaultToastStyle",
+		"enforce:DefaultScrollbarStyle",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("findings = %v, want %v", got, want)
+	}
+}
+
+func TestThemeIgnoresFunctionsWithoutAWindow(t *testing.T) {
+	t.Parallel()
+	// A factory has no window to name — the bare read is the design,
+	// and it is what makes Themed() scoping work.
+	const src = `package p
+
+type Theme struct{ ColorBackground int }
+
+var guiTheme Theme
+var defaultButtonStyle struct{ Radius int }
+
+func Button(cfg int) int {
+	_ = guiTheme.ColorBackground
+	return defaultButtonStyle.Radius
+}
+
+func (b *Backend) draw(r int) {
+	_ = guiTheme.ColorBackground
+}
+`
+	if got := scanThemeSrc(t, src); len(got) != 0 {
+		t.Errorf("findings = %v, want none", got)
+	}
+}
+
+func TestThemeMarkerDefersFinding(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+
+type Window struct{}
+type Theme struct{ ColorBackground int }
+
+var guiTheme Theme
+
+func handler(w *Window) {
+	_ = guiTheme.ColorBackground // ergonomics-audit:theme-global
+}
+`
+	got := scanThemeSrc(t, src)
+	want := []string{"handler:guiTheme [deferred]"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("findings = %v, want %v", got, want)
+	}
+}
+
+func TestThemeScannedPaths(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"gui/scroll.go":                        true,
+		"gui/scroll_smooth.go":                 true,
+		"gui/event_handlers.go":                true,
+		"gui/native_print.go":                  true,
+		"gui/window_update.go":                 true,
+		"gui/backend/metal/backend.go":         true,
+		"gui/backend/internal/framestate/f.go": true,
+		// Mixed-phase and generation-time files stay out: their bare
+		// reads are correct, and Themed() depends on them.
+		"gui/view_toast.go":     false,
+		"gui/theme.go":          false,
+		"gui/layout_arrange.go": false,
+		"examples/x/main.go":    false,
+	}
+	for path, want := range cases {
+		if got := themeScanned(path); got != want {
+			t.Errorf("themeScanned(%q) = %v, want %v", path, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #301.

## What

Post-generation code — event handlers, post-arrange work, and the
backends — now reads the theme of the window it is acting on instead of
the frame-scoped cache, which holds whichever window generated last:
correct in a one-window app, wrong with two.

Thirteen sites migrated to `w.Theme()`:

- scroll paths: `keyDownScrollHandler`, `scrollHorizontal`/`scrollVertical`, `scrollSmoothBy`
- print export: `ExportPrintJob`
- theme picker highlight sync (visibly wrong before)
- toast max-visible, select dropdown scroll
- inspector wireframe
- every backend's clear color + the web custom-shader fallback

Widget factories and `GenerateLayout` are unchanged and keep the bare
`guiTheme`/`default*Style` read — required for `gui.Themed` subtree
scoping.

## The copy

`Theme` is ~40 style structs plus ~40 text styles; `w.Theme()` returns
by value, and the first cut cost 36 ns → 1083 ns/event on the scroll
benchmark. Both stores (`Window.theme`, package `defaultTheme`) now hold
a pointer to an immutable value: setters publish a new value, never
write through, so a reader that took the pointer under `RLock` may keep
it after the lock drops. Internal hot reads use `w.themeRef()`; the
public `w.Theme()` is unchanged. Scroll benchmark back at ~39 ns/op,
0 allocs.

## Gate

New `make ergonomics-audit` mode `theme`: flags a `guiTheme` /
`CurrentTheme()` / `default*Style` read in a function with a `*Window`
receiver or parameter, but only in paths that are post-generation by
construction (`gui/backend/**`, `gui/scroll*.go`, `gui/event*.go`,
`gui/native_*.go`, `gui/window_*.go`). Deliberate exceptions carry
`ergonomics-audit:theme-global` and print as deferred, not gating.

Docs: spec expanded with the generation boundary, the copy, and the
rejected `w.Button(...)` receiver sugar (per-window-theme.md); CLAUDE.md
and CONTRIBUTING.md carry the phase rule.

## Tests

- `TestWindowThemeScrollIsPerWindow` — two windows with different scroll
  multipliers scroll by their own.
- `TestThemeNilWindowReturnsDefault` — nil-receiver branch of `themeRef`.
- Audit unit tests: findings, window-less exemption, marker deferral,
  scanned-path table; `TestRunThemeGatesOnFrameCacheReads` end-to-end.

`make check-all` green (build, test, lint, vet, ergonomics-audit).