### PR TITLE
changelog: add v0.60.0 (single-method View, per-window themes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.60.0] - 2026-08-14
 
 ### Added
 
@@ -26,6 +26,18 @@ and this project adheres to
   so ready-made child views would already carry the enclosing theme.
 
 ### Changed
+
+- **`View` is now a single method — `GenerateLayout(*Window) Layout` (breaking).**
+  `View.Content() []View` is gone. The 24 container and composite widgets that
+  built child trees in `Content()` now build them in `GenerateLayout` and hand
+  them to `appendChildViews`, which owns the child walk, the event-children cap,
+  the scratch-arena reservation and the ID-scope push/restore — one mechanism
+  instead of two, with identical behavior and allocations (flat_100 100,
+  nested_3x10 100, deep_12x1 1). `*Layout` does not implement `View`;
+  `ContainerCfg.Content` remains a plain field. Sibling consumers migrate in
+  lockstep: go-charts records its gallery charts at build time (go-charts#41),
+  go-map and go-term drop their `Content()` implementations. See
+  `docs/specs/view-single-method.md`.
 
 - **The default appearance changed: `ThemeMaker` is now the only source of
   widget styling (issue #300).** Go-Gui carried two sets of defaults — about 30


### PR DESCRIPTION
Release changelog for v0.60.0: breaking single-method View, per-window themes, and the splitter/markdown fixes shipped since v0.59.2.