### PR TITLE
refactor(gui): scope Form children under form:<id> (issue #306)

### DIFF
--- a/docs/specs/view-single-method.md
+++ b/docs/specs/view-single-method.md
@@ -4,7 +4,7 @@
 - Area: `gui/` core pipeline
 - Blocked on: go-gui-org/go-charts#41 (before the release tag, not before
   step 1)
-- Related: #306 (form child scoping, deliberately deferred)
+- Related: #306 (resolved — Form scopes its children; see §5)
 
 ## Summary
 
@@ -533,9 +533,19 @@ Tag go-gui, then propagate. `go-map` (18 call sites) and `go-term` (1) migrate
 **with** the bump rather than ahead of it. `go-edit` and `go-kite` have neither
 implementations nor call sites.
 
-### 5. Issue #306
+### 5. Issue #306 — resolved: Form scopes its children
 
-Form child scoping, decided on its own merits once the above has settled.
+Landed 2026-08-14, after the refactor settled. `Form` now routes through
+the single `appendChildViews` path like every other container;
+`appendChildViewsFlat` is deleted. Form children's effective IDs changed
+from the flat leaf to `form:<id>:<leaf>` (absolute prefix — a form inside
+an ID-bearing panel still scopes under `form:<id>`, never the panel's
+scope). That is a breaking change for `SetFocus` / `FindByID` callers
+that used the flat name; the field registry never participated
+(`FieldID` is a separate namespace) and is unaffected. What it fixes:
+two forms in one window may each hold an `Input{ID: "email"}` without
+colliding on one effective ID — the flat behavior made such a window
+fail `TestDuplicateIDs`.
 
 ## Verification
 
@@ -631,12 +641,12 @@ A large API break across six repos, in exchange for a saving that measures zero.
    in this spec — that field registration would break — was wrong; field IDs are
    a separate namespace. See "The scope suppression is accidental" above.
 
-   **Decided (2026-08-14): keep flat.** This change is behavior-preserving —
-   `appendChildViewsFlat` reproduces today's effective IDs exactly, and `Form`
-   remains the one container whose children do not take its scope, with that
-   exception now written down rather than accidental. Whether `Form` _should_
-   scope its children is tracked separately as issue #306; doing both at once
-   would make any resulting focus bug ambiguous between the two causes.
+   **Decided (2026-08-14): keep flat, superseded by #306 the same day.**
+   This change was behavior-preserving — `appendChildViewsFlat` reproduced
+   today's effective IDs exactly, keeping any resulting focus bug
+   unambiguous between the two causes. Issue #306 then resolved the question
+   on its own merits: `Form` scopes its children like every other container,
+   and `appendChildViewsFlat` is gone. See §5.
 
 3. ~~Is the per-frame `View` interface box actually measurable?~~ **Resolved: it
    is exactly zero.** Measured on an Apple M5, `go test -benchmem`:

--- a/examples/get_started/main.go
+++ b/examples/get_started/main.go
@@ -42,7 +42,7 @@ func mainView(w *gui.Window) gui.View {
 		Content: []gui.View{
 			gui.Text(gui.TextCfg{
 				Text:      "Hello GUI! 😀🚀🎉👍",
-				TextStyle: gui.CurrentTheme().B1,
+				TextStyle: w.Theme().B1,
 			}),
 			gui.Button(gui.ButtonCfg{
 				ID: "gs_counter",

--- a/gui/view.go
+++ b/gui/view.go
@@ -69,29 +69,6 @@ func generateViewLayout(view View, w *Window) Layout {
 // its children resolve under it. Children the parent injected directly
 // (addGroupBoxTitle's eraser + label) keep their position ahead of these.
 func appendChildViews(w *Window, parent *Layout, children []View) {
-	appendChildViewsScoped(w, parent, children, true)
-}
-
-// appendChildViewsFlat appends children WITHOUT pushing the parent's ID
-// scope, so they resolve in the parent's enclosing scope.
-//
-// Exactly one caller: Form, and only to preserve today's observable
-// effective IDs. Form's own field registry is NOT affected either way —
-// FormFieldAdapterCfg.FieldID never passes through ID resolution. What
-// scoping would change is the effective ID of every widget the caller
-// put inside the form, and therefore SetFocus/FindByID against it.
-//
-// Form is therefore the one container whose children do not take its
-// scope. That is deliberate here only in the sense that this refactor
-// preserves it; whether it should hold at all is issue #306. This helper
-// is the single place that decision would change.
-func appendChildViewsFlat(w *Window, parent *Layout, children []View) {
-	appendChildViewsScoped(w, parent, children, false)
-}
-
-func appendChildViewsScoped(
-	w *Window, parent *Layout, children []View, scope bool,
-) {
 	// Callers build parent.Shape before calling: childScopeID reads its
 	// ID to derive the child scope, and a shape built late (or a nil
 	// shape — childScopeID's nil branch) silently generates the
@@ -119,12 +96,8 @@ func appendChildViewsScoped(
 	}
 	// Saved and restored rather than recomputed on the way out: a sibling
 	// must not inherit a child's scope.
-	saved := ""
-	pushed := scope && w != nil
-	if pushed {
-		saved = w.viewState.idScope
-		w.viewState.idScope = childScopeID(w, saved, parent.Shape)
-	}
+	saved := w.viewState.idScope
+	w.viewState.idScope = childScopeID(w, saved, parent.Shape)
 	for _, child := range children {
 		if child == nil {
 			continue
@@ -134,7 +107,5 @@ func appendChildViewsScoped(
 			generateViewLayout(child, w),
 		)
 	}
-	if pushed {
-		w.viewState.idScope = saved
-	}
+	w.viewState.idScope = saved
 }

--- a/gui/view_form.go
+++ b/gui/view_form.go
@@ -246,11 +246,10 @@ func (fv *formView) GenerateLayout(w *Window) Layout {
 	// carries no Content, so its own appendChildViews call is a no-op
 	// and no scope is pushed for it.
 	layout := generateViewLayout(inner, w)
-	// Form children append flat — they resolve in the form's enclosing
-	// scope, never under "form:<id>" (appendChildViewsFlat). The field
-	// registry is unaffected either way: FieldID never passes through ID
-	// resolution. See issue #306.
-	appendChildViewsFlat(w, &layout, children)
+	// Children resolve under the absolute "form:<id>" scope (issue #306);
+	// the field registry is unaffected — FieldID never passes through ID
+	// resolution.
+	appendChildViews(w, &layout, children)
 	return layout
 }
 

--- a/gui/view_form_test.go
+++ b/gui/view_form_test.go
@@ -797,68 +797,122 @@ func TestFormFieldErrorsAliasesRuntimeSlice(t *testing.T) {
 
 // --- Form child ID scoping ---
 //
-// Form children generate under the form's *enclosing* scope, not under
-// "form:<id>". The form's inner container carries an absolute ID
-// ("form:myform", formLayoutID), so a scope push there would resolve
-// children as form:myform:email and change every SetFocus/FindByID
-// caller that uses the flat name. The tests below pin the flat behavior
-// (see docs/specs/view-single-method.md, issue #306).
+// Form children generate under the form's own scope: the inner
+// container carries an absolute ID ("form:myform", formLayoutID), so a
+// child resolves as form:myform:<leaf> — the same rule every other
+// container applies. Because formLayoutID is absolute, a form nested in
+// an ID-bearing panel still scopes its children under "form:<id>",
+// never the panel's scope (issue #306).
+//
+// The form field registry is a separate namespace and is unaffected
+// either way: FieldID never passes through ID resolution.
 
-// TestFormChildrenStayFlat documents that w.EffID resolves a form
-// child's leaf against the enclosing scope (empty here), never against
-// "form:<id>". The generation-time scope is the seam the form's child
-// append path controls.
-func TestFormChildrenStayFlat(t *testing.T) {
-	w := newTestWindow()
-	formID := "flat-form"
-	captured := ""
-	v := Form(FormCfg{
-		ID: formID,
-		Content: []View{
-			viewFunc(func(w *Window) View {
-				captured = w.EffID("email")
-				return Input(InputCfg{ID: "email"})
-			}),
-		},
+// renderScopedFormChild renders a form holding one leaf-named child —
+// wrapped in wrap when given — and returns the effective ID the child
+// resolved to at generation time plus the composed root layout.
+func renderScopedFormChild(
+	t *testing.T, w *Window, formID, leaf string, wrap func(v View) View,
+) (captured string, root *Layout) {
+	t.Helper()
+	root = w.TestRender(func(_ *Window) View {
+		form := Form(FormCfg{
+			ID: formID,
+			Content: []View{
+				viewFunc(func(w *Window) View {
+					captured = w.EffID(leaf)
+					return Input(InputCfg{ID: leaf})
+				}),
+			},
+		})
+		if wrap != nil {
+			return wrap(form)
+		}
+		return form
 	})
-	layout := generateViewLayout(v, w)
-	if layout.Shape.ID != formLayoutID(formID) {
-		t.Fatalf("form root ID = %q, want %q",
-			layout.Shape.ID, formLayoutID(formID))
-	}
-	if captured != "email" {
+	return captured, root
+}
+
+// TestFormChildrenScoped documents that w.EffID resolves a form child's
+// leaf against "form:<id>", that the resolve pass stamps the same
+// identity (so FindByID finds it), and that SetFocus accepts the
+// scoped name end to end.
+func TestFormChildrenScoped(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	const formID = "scoped-form"
+	captured, root := renderScopedFormChild(t, w, formID, "email", nil)
+	want := ScopeID(formLayoutID(formID), "email")
+	if captured != want {
 		t.Errorf("w.EffID(\"email\") inside form = %q, want %q",
-			captured, "email")
+			captured, want)
 	}
-	if len(layout.Children) != 1 {
-		t.Fatalf("form children = %d, want 1", len(layout.Children))
+	if _, ok := root.FindByID(want); !ok {
+		t.Fatalf("FindByID(%q) = false, want the scoped input", want)
+	}
+	if err := w.testFocus(want); err != nil {
+		t.Fatalf("TestFocus(%s) = %v, want nil", want, err)
+	}
+	if got := w.FocusID(); got != want {
+		t.Fatalf("FocusID() = %q, want %q", got, want)
 	}
 }
 
-// TestFormChildrenFlatInsideIDPanel pins the same flatness when the
-// form sits inside an ID-bearing panel: "flat" means the form's
-// enclosing scope — the panel's, here — not window-global, because
-// formLayoutID is absolute.
-func TestFormChildrenFlatInsideIDPanel(t *testing.T) {
-	w := newTestWindow()
-	captured := ""
-	form := Form(FormCfg{
-		ID: "nested-form",
-		Content: []View{
-			viewFunc(func(w *Window) View {
-				captured = w.EffID("email")
-				return Input(InputCfg{ID: "email"})
-			}),
-		},
-	})
-	v := Column(ContainerCfg{
-		ID:      "panel",
-		Content: []View{form},
-	})
-	generateViewLayout(v, w)
-	if captured != "panel:email" {
+// TestFormChildrenScopedInsideIDPanel pins the absolute-prefix rule: a
+// form inside an ID-bearing panel still scopes its children under
+// "form:<id>", never "panel:form:<id>". This is the same absolute-ID
+// pattern as gui/datagrid and is what formDecodeLayoutID's
+// reverse-parse relies on.
+func TestFormChildrenScopedInsideIDPanel(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	const formID = "nested-form"
+	captured, root := renderScopedFormChild(t, w, formID, "email",
+		func(v View) View {
+			return Column(ContainerCfg{ID: "panel", Content: []View{v}})
+		})
+	want := ScopeID(formLayoutID(formID), "email")
+	if captured != want {
 		t.Errorf("w.EffID(\"email\") inside panel-nested form = %q, want %q",
-			captured, "panel:email")
+			captured, want)
+	}
+	if _, ok := root.FindByID(want); !ok {
+		t.Fatalf("FindByID(%q) = false, want the scoped input", want)
+	}
+}
+
+// TestFormChildrenDistinctPerForm pins the reason the form scopes its
+// children at all: two forms in one window may each hold an
+// Input{ID: "email"} without colliding on one effective ID. The flat
+// behavior Form had before made such a window fail TestDuplicateIDs.
+func TestFormChildrenDistinctPerForm(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	root := w.TestRender(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				Form(FormCfg{
+					ID: "login",
+					Content: []View{
+						Input(InputCfg{ID: "email"}),
+					},
+				}),
+				Form(FormCfg{
+					ID: "signup",
+					Content: []View{
+						Input(InputCfg{ID: "email"}),
+					},
+				}),
+			},
+		})
+	})
+	for _, id := range []string{
+		ScopeID(formLayoutID("login"), "email"),
+		ScopeID(formLayoutID("signup"), "email"),
+	} {
+		if _, ok := root.FindByID(id); !ok {
+			t.Fatalf("FindByID(%q) = false, want the scoped input", id)
+		}
+	}
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("want no duplicate findings, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Resolves #306: Form children now scope under `form:<id>` like every other container. `appendChildViewsFlat` / `appendChildViewsScoped` are deleted; Form routes through the single `appendChildViews` path.

## Behavior change

- Form children's effective IDs change from the flat leaf to `form:<id>:<leaf>` (absolute prefix — a form in an ID-bearing panel still scopes under `form:<id>`, never the panel's scope).
- Breaking for `SetFocus` / `FindByID` callers that used the flat name; the field registry (`FieldID`) is a separate namespace and is unaffected.
- Fixes: two forms in one window may each hold an `Input{ID: "email"}` without failing `TestDuplicateIDs` (previously impossible).

## Simplify pass

- `gui/view.go`: collapse the dead `w != nil` guard left over from the `scope` bool parameter (no caller passes nil).
- `gui/view_form_test.go`: extract the shared form-child capture helper (`renderScopedFormChild`), compose expected IDs with `ScopeID`, drop unreachable `root == nil` guards, standardize on `root.FindByID`.
- `gui/view_form.go` / docs: trim comments that re-explained general scoping mechanics.

## Tests

Rewrite of the Form child scoping tests (`TestFormChildrenScoped`, `TestFormChildrenScopedInsideIDPanel`, `TestFormChildrenDistinctPerForm`) asserting the new scoped identities end to end (EffID → resolve pass → FindByID → SetFocus).