### PR TITLE
fix(gui): centre single glyphs on their ink, not the advance box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The check mark now sits in the middle of the checkbox.** `Toggle` (and its
+  `Checkbox` alias) centred the check on the font's advance box, which spans the
+  descent the glyph never paints into and each side bearing, so the check
+  floated above centre — barely at the default size, glaringly on a large one.
+  It is now centred on its ink: the backend measures the glyph's painted box
+  (new go-glyph `InkBounds`) and `AmendLayout` moves the arranged glyph, so
+  nothing about sizing, draw order, or the widget tree changes. Backends without
+  the capability, and tests with no measurer, keep the previous advance-box
+  centring. The toggle theme style's padding is symmetric again, its left-heavy
+  value having been a partial nudge for the same defect. The same correction now
+  applies wherever a single glyph is centred inside a drawn frame: the markdown
+  task-list checkbox and the splitter's collapse buttons.
+
 ## [v0.60.0] - 2026-08-14
 
 ### Added
@@ -27,17 +44,17 @@ and this project adheres to
 
 ### Changed
 
-- **`View` is now a single method — `GenerateLayout(*Window) Layout` (breaking).**
-  `View.Content() []View` is gone. The 24 container and composite widgets that
-  built child trees in `Content()` now build them in `GenerateLayout` and hand
-  them to `appendChildViews`, which owns the child walk, the event-children cap,
-  the scratch-arena reservation and the ID-scope push/restore — one mechanism
-  instead of two, with identical behavior and allocations (flat_100 100,
-  nested_3x10 100, deep_12x1 1). `*Layout` does not implement `View`;
-  `ContainerCfg.Content` remains a plain field. Sibling consumers migrate in
-  lockstep: go-charts records its gallery charts at build time (go-charts#41),
-  go-map and go-term drop their `Content()` implementations. See
-  `docs/specs/view-single-method.md`.
+- **`View` is now a single method — `GenerateLayout(*Window) Layout`
+  (breaking).** `View.Content() []View` is gone. The 24 container and composite
+  widgets that built child trees in `Content()` now build them in
+  `GenerateLayout` and hand them to `appendChildViews`, which owns the child
+  walk, the event-children cap, the scratch-arena reservation and the ID-scope
+  push/restore — one mechanism instead of two, with identical behavior and
+  allocations (flat_100 100, nested_3x10 100, deep_12x1 1). `*Layout` does not
+  implement `View`; `ContainerCfg.Content` remains a plain field. Sibling
+  consumers migrate in lockstep: go-charts records its gallery charts at build
+  time (go-charts#41), go-map and go-term drop their `Content()`
+  implementations. See `docs/specs/view-single-method.md`.
 
 - **The default appearance changed: `ThemeMaker` is now the only source of
   widget styling (issue #300).** Go-Gui carried two sets of defaults — about 30

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Go toolchain pin: `go 1.26.0`.
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.26.1 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.1 | cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends. |
-| `github.com/go-gui-org/go-glyph` | v1.20.2 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.21.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio decode + mixing (sound effects, music, mixer, fade) for `gui/audio`. |

--- a/examples/get_started/main.go
+++ b/examples/get_started/main.go
@@ -42,7 +42,7 @@ func mainView(w *gui.Window) gui.View {
 		Content: []gui.View{
 			gui.Text(gui.TextCfg{
 				Text:      "Hello GUI! 😀🚀🎉👍",
-				TextStyle: w.Theme().B1,
+				TextStyle: gui.CurrentTheme().B1,
 			}),
 			gui.Button(gui.ButtonCfg{
 				ID: "gs_counter",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/ebitengine/purego v0.10.1
-	github.com/go-gui-org/go-glyph v1.20.2
+	github.com/go-gui-org/go-glyph v1.21.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/go-gui-org/go-glyph v1.20.2 h1:6Xsf1QUd9UeiSpJzJ9c9gVGBg1tReU8KV5uBtuhVMVI=
 github.com/go-gui-org/go-glyph v1.20.2/go.mod h1:1Nta2shuXtETUdEXJJn0oFRisUXPxi1ToSVb0Sfi7kU=
+github.com/go-gui-org/go-glyph v1.21.0 h1:wdcELsxVOFl7uzbQ1SI3MvbMW5ddgqwlWnEsmeW3YMs=
+github.com/go-gui-org/go-glyph v1.21.0/go.mod h1:1Nta2shuXtETUdEXJJn0oFRisUXPxi1ToSVb0Sfi7kU=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/ebitengine/oto/v3 v3.3.2 h1:VTWBsKX9eb+dXzaF4jEwQbs4yWIdXukJ0K40KgkpY
 github.com/ebitengine/oto/v3 v3.3.2/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/go-gui-org/go-glyph v1.20.2 h1:6Xsf1QUd9UeiSpJzJ9c9gVGBg1tReU8KV5uBtuhVMVI=
-github.com/go-gui-org/go-glyph v1.20.2/go.mod h1:1Nta2shuXtETUdEXJJn0oFRisUXPxi1ToSVb0Sfi7kU=
 github.com/go-gui-org/go-glyph v1.21.0 h1:wdcELsxVOFl7uzbQ1SI3MvbMW5ddgqwlWnEsmeW3YMs=
 github.com/go-gui-org/go-glyph v1.21.0/go.mod h1:1Nta2shuXtETUdEXJJn0oFRisUXPxi1ToSVb0Sfi7kU=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=

--- a/gui/backend/android/text.go
+++ b/gui/backend/android/text.go
@@ -231,6 +231,22 @@ func (tm *textMeasurer) FontAscent(
 	return m.Ascender
 }
 
+// TextInkBounds returns the painted box of text, relative to the
+// top-left of its advance box. Backs gui's optional ink-measuring
+// capability, which widgets use to centre a single glyph on its ink
+// instead of on the font's advance box.
+func (tm *textMeasurer) TextInkBounds(
+	text string, style gui.TextStyle) (gui.InkBounds, bool) {
+	cfg := guiStyleToGlyphConfig(style)
+	r, ok := tm.textSys.InkBounds(text, cfg)
+	if !ok {
+		return gui.InkBounds{}, false
+	}
+	return gui.InkBounds{
+		X: r.X, Y: r.Y, Width: r.Width, Height: r.Height,
+	}, true
+}
+
 func (tm *textMeasurer) LayoutText(
 	text string, style gui.TextStyle, wrapWidth float32,
 ) (glyph.Layout, error) {

--- a/gui/backend/gl/text.go
+++ b/gui/backend/gl/text.go
@@ -267,6 +267,22 @@ func (tm *textMeasurer) FontAscent(style gui.TextStyle) float32 {
 	return m.Ascender
 }
 
+// TextInkBounds returns the painted box of text, relative to the
+// top-left of its advance box. Backs gui's optional ink-measuring
+// capability, which widgets use to centre a single glyph on its ink
+// instead of on the font's advance box.
+func (tm *textMeasurer) TextInkBounds(
+	text string, style gui.TextStyle) (gui.InkBounds, bool) {
+	cfg := guiStyleToGlyphConfig(style)
+	r, ok := tm.textSys.InkBounds(text, cfg)
+	if !ok {
+		return gui.InkBounds{}, false
+	}
+	return gui.InkBounds{
+		X: r.X, Y: r.Y, Width: r.Width, Height: r.Height,
+	}, true
+}
+
 func (tm *textMeasurer) LayoutText(
 	text string, style gui.TextStyle, wrapWidth float32,
 ) (glyph.Layout, error) {

--- a/gui/backend/ios/text.go
+++ b/gui/backend/ios/text.go
@@ -231,6 +231,22 @@ func (tm *textMeasurer) FontAscent(
 	return m.Ascender
 }
 
+// TextInkBounds returns the painted box of text, relative to the
+// top-left of its advance box. Backs gui's optional ink-measuring
+// capability, which widgets use to centre a single glyph on its ink
+// instead of on the font's advance box.
+func (tm *textMeasurer) TextInkBounds(
+	text string, style gui.TextStyle) (gui.InkBounds, bool) {
+	cfg := guiStyleToGlyphConfig(style)
+	r, ok := tm.textSys.InkBounds(text, cfg)
+	if !ok {
+		return gui.InkBounds{}, false
+	}
+	return gui.InkBounds{
+		X: r.X, Y: r.Y, Width: r.Width, Height: r.Height,
+	}, true
+}
+
 func (tm *textMeasurer) LayoutText(
 	text string, style gui.TextStyle, wrapWidth float32,
 ) (glyph.Layout, error) {

--- a/gui/backend/metal/text.go
+++ b/gui/backend/metal/text.go
@@ -234,6 +234,22 @@ func (tm *textMeasurer) FontAscent(
 	return m.Ascender
 }
 
+// TextInkBounds returns the painted box of text, relative to the
+// top-left of its advance box. Backs gui's optional ink-measuring
+// capability, which widgets use to centre a single glyph on its ink
+// instead of on the font's advance box.
+func (tm *textMeasurer) TextInkBounds(
+	text string, style gui.TextStyle) (gui.InkBounds, bool) {
+	cfg := guiStyleToGlyphConfig(style)
+	r, ok := tm.textSys.InkBounds(text, cfg)
+	if !ok {
+		return gui.InkBounds{}, false
+	}
+	return gui.InkBounds{
+		X: r.X, Y: r.Y, Width: r.Width, Height: r.Height,
+	}, true
+}
+
 func (tm *textMeasurer) LayoutText(
 	text string, style gui.TextStyle, wrapWidth float32,
 ) (glyph.Layout, error) {

--- a/gui/backend/web/text.go
+++ b/gui/backend/web/text.go
@@ -53,6 +53,22 @@ func (tm *textMeasurer) FontAscent(
 	return m.Ascender
 }
 
+// TextInkBounds returns the painted box of text, relative to the
+// top-left of its advance box. Backs gui's optional ink-measuring
+// capability, which widgets use to centre a single glyph on its ink
+// instead of on the font's advance box.
+func (tm *textMeasurer) TextInkBounds(
+	text string, style gui.TextStyle) (gui.InkBounds, bool) {
+	cfg := glyphconv.GuiStyleToGlyphConfig(style)
+	r, ok := tm.textSys.InkBounds(text, cfg)
+	if !ok {
+		return gui.InkBounds{}, false
+	}
+	return gui.InkBounds{
+		X: r.X, Y: r.Y, Width: r.Width, Height: r.Height,
+	}, true
+}
+
 func (tm *textMeasurer) LayoutText(
 	text string, style gui.TextStyle, wrapWidth float32,
 ) (glyph.Layout, error) {

--- a/gui/text_ink.go
+++ b/gui/text_ink.go
@@ -1,0 +1,114 @@
+package gui
+
+import "math"
+
+// InkBounds is the painted (ink) box of a text run, in logical pixels
+// relative to the top-left of the run's advance box — the box a text
+// shape is sized to (TextWidth × FontHeight).
+//
+// The two differ by the font's unpainted margins: the advance box spans
+// ascent and descent plus every glyph's side bearings, whether or not
+// the glyph paints there. Centring a single glyph on the advance box
+// therefore leaves it visibly off-centre — a check mark, which has no
+// descender, floats above the middle of its box by roughly half the
+// descent. Widgets that centre one glyph inside a drawn frame centre on
+// this box instead.
+type InkBounds struct {
+	X      float32
+	Y      float32
+	Width  float32
+	Height float32
+}
+
+// textInkMeasurer is an optional capability on TextMeasurer backends.
+// Backends wrapping a *glyph.TextSystem opt in; others need no change
+// and their callers fall back to the advance box.
+type textInkMeasurer interface {
+	TextInkBounds(text string, style TextStyle) (InkBounds, bool)
+}
+
+// textInkBounds measures the ink box of text in style. ok is false when
+// the backend cannot measure it — no measurer (tests), a backend without
+// the capability, or a glyph whose outline cannot be read — and callers
+// must then fall back to advance-box centring.
+func (w *Window) textInkBounds(text string, style TextStyle) (
+	InkBounds, bool,
+) {
+	if w == nil || text == "" {
+		return InkBounds{}, false
+	}
+	tm, ok := w.textMeasurer.(textInkMeasurer)
+	if !ok {
+		return InkBounds{}, false
+	}
+	return tm.TextInkBounds(text, style)
+}
+
+// centerGlyphOnInk returns an AmendLayout hook that re-centres a
+// container's text child on the glyph's ink rather than on the font's
+// advance box. Use it wherever a single glyph is centred inside a drawn
+// frame — a check inside a checkbox, an arrow inside a square button.
+// The advance box spans the descent the glyph never paints into, and its
+// side bearings are not symmetric, so an advance-centred glyph sits
+// visibly high and off to one side; the taller the frame, the more
+// obvious.
+//
+// The correction runs in AmendLayout, after sizing, for two reasons: it
+// needs a measurer (so it cannot happen in the factory) and it must not
+// feed back into sizing (so it moves the arranged shape rather than
+// padding it into place — padding large enough to centre a big glyph
+// would overflow a fixed frame and stop centring at all). The glyph is a
+// leaf, so moving it moves nothing else. Without a measurer (tests) or
+// without the ink capability the glyph stays where advance-box centring
+// put it.
+func centerGlyphOnInk(txt string, style TextStyle) func(EventCtx) {
+	return func(ctx EventCtx) {
+		if ctx.Layout == nil || ctx.Window == nil {
+			return
+		}
+		glyph := firstTextChild(ctx.Layout)
+		if glyph == nil {
+			return
+		}
+		ink, ok := ctx.Window.textInkBounds(txt, style)
+		if !ok {
+			return
+		}
+		box := ctx.Layout.Shape
+		// Place the ink box, not the shape: solve for the shape origin
+		// that puts the ink's centre on the frame's centre. Positioning
+		// from the frame rather than nudging the arranged position also
+		// drops whatever rounding flow centring left behind.
+		glyph.X = box.X + (box.Width-ink.Width)/2 - ink.X
+		glyph.Y = box.Y + (box.Height-ink.Height)/2 - ink.Y
+		// The text backend rounds each glyph's baseline to a whole
+		// physical pixel, so a fractional Y is resolved in a direction
+		// this code did not choose — at a default 17px checkbox that is a
+		// visible half-pixel of the check's ~7px ink. Land the baseline
+		// on the grid deliberately instead. X needs no such snap: the
+		// backend places glyphs on quarter-pixel subpixel bins. A
+		// non-finite scale (unset window, NaN from a corrupted backend)
+		// skips the snap, like render's own scale guard.
+		if s := ctx.Window.BackingScale; s > 0 && !math.IsInf(float64(s), 0) {
+			baseline := glyph.Y + ctx.Window.textMeasurer.FontAscent(style)
+			snapped := float32(math.Round(float64(baseline*s))) / s
+			glyph.Y += snapped - baseline
+		}
+	}
+}
+
+// firstTextChild returns the shape of the container's first direct text
+// child, or nil. Direct children only: the hook centres the glyph a
+// factory put in the frame, not text nested in some sub-container that
+// owns its own layout.
+func firstTextChild(l *Layout) *Shape {
+	for i := range l.Children {
+		if l.Children[i].Shape == nil {
+			continue
+		}
+		if l.Children[i].Shape.shapeType == shapeText {
+			return l.Children[i].Shape
+		}
+	}
+	return nil
+}

--- a/gui/text_ink_test.go
+++ b/gui/text_ink_test.go
@@ -1,0 +1,244 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+// inkStubMeasurer is a stubTextMeasurer that also reports an ink box, so
+// the ink-centring path can be exercised without a real font backend.
+// The ink box is inset from the advance box by the given margins.
+type inkStubMeasurer struct {
+	stubTextMeasurer
+	left, top, right, bottom float32
+	unavailable              bool
+}
+
+func (m *inkStubMeasurer) TextInkBounds(text string, style TextStyle) (
+	InkBounds, bool,
+) {
+	if m.unavailable {
+		return InkBounds{}, false
+	}
+	return InkBounds{
+		X:      m.left,
+		Y:      m.top,
+		Width:  m.TextWidth(text, style) - m.left - m.right,
+		Height: m.FontHeight(style) - m.top - m.bottom,
+	}, true
+}
+
+// inkTestFrame builds a 40x40 frame holding one 10x20 text child placed
+// where advance-box centring would put it, so a hook run can be compared
+// against the uncorrected position.
+func inkTestFrame() Layout {
+	frame := Layout{Shape: &Shape{X: 100, Y: 200, Width: 40, Height: 40}}
+	frame.Children = []Layout{{Shape: &Shape{
+		shapeType: shapeText,
+		X:         115, Y: 210, Width: 10, Height: 20,
+	}}}
+	return frame
+}
+
+// TestCenterGlyphOnInk asserts the hook lands the ink centre — not the
+// advance-box centre — on the frame's centre, which is the whole point of
+// the correction.
+func TestCenterGlyphOnInk(t *testing.T) {
+	w := newTestWindow()
+	// 10px per char, 20px line box: "x" occupies 10x20. Ink insets of
+	// 2 left / 6 top / 4 right / 2 bottom put the ink centre 1px left
+	// of and 2px above the advance-box centre.
+	w.SetTextMeasurer(&inkStubMeasurer{
+		stubTextMeasurer: stubTextMeasurer{charWidth: 10, fontHeight: 20},
+		left:             2, top: 6, right: 4, bottom: 2,
+	})
+
+	frame := inkTestFrame()
+	centerGlyphOnInk("x", TextStyle{Size: 12})(EventCtx{&frame, nil, w})
+
+	glyph := frame.Children[0].Shape
+	inkCX := glyph.X + 2 + (10-2-4)/2
+	inkCY := glyph.Y + 6 + (20-6-2)/2
+	if !floatNear(inkCX, 120, 0.01) || !floatNear(inkCY, 220, 0.01) {
+		t.Errorf("ink centre (%v, %v), want frame centre (120, 220)",
+			inkCX, inkCY)
+	}
+}
+
+// TestCenterGlyphOnInkUnavailable covers every path that must leave the
+// glyph on advance-box centring: no measurer, a measurer without the ink
+// capability, and a measurer that cannot read the glyph.
+func TestCenterGlyphOnInkUnavailable(t *testing.T) {
+	cases := []struct {
+		name string
+		tm   TextMeasurer
+	}{
+		{"no measurer", nil},
+		{"no ink capability",
+			&stubTextMeasurer{charWidth: 10, fontHeight: 20}},
+		{"unmeasurable glyph", &inkStubMeasurer{
+			stubTextMeasurer: stubTextMeasurer{charWidth: 10, fontHeight: 20},
+			unavailable:      true,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newTestWindow()
+			if tc.tm != nil {
+				w.SetTextMeasurer(tc.tm)
+			}
+			frame := inkTestFrame()
+			centerGlyphOnInk("x", TextStyle{Size: 12})(
+				EventCtx{&frame, nil, w})
+
+			glyph := frame.Children[0].Shape
+			if !floatNear(glyph.X, 115, 0.01) ||
+				!floatNear(glyph.Y, 210, 0.01) {
+				t.Errorf("glyph moved to (%v, %v), want (115, 210)",
+					glyph.X, glyph.Y)
+			}
+		})
+	}
+}
+
+// TestCenterGlyphOnInkNoText asserts a frame with no text child is a
+// no-op rather than a panic — mdTaskCheckbox builds an empty frame for an
+// unchecked item.
+func TestCenterGlyphOnInkNoText(t *testing.T) {
+	w := newTestWindow()
+	w.SetTextMeasurer(&inkStubMeasurer{
+		stubTextMeasurer: stubTextMeasurer{charWidth: 10, fontHeight: 20},
+	})
+	frame := Layout{Shape: &Shape{Width: 40, Height: 40}}
+	centerGlyphOnInk("x", TextStyle{Size: 12})(EventCtx{&frame, nil, w})
+}
+
+// TestCenterGlyphOnInkSnapToPixelGrid asserts the baseline snap lands
+// the glyph's baseline on a whole physical pixel at a fractional scale,
+// so the backend's own whole-pixel baseline rounding cannot fight the
+// ink centring.
+func TestCenterGlyphOnInkSnapToPixelGrid(t *testing.T) {
+	w := newTestWindow()
+	w.SetTextMeasurer(&inkStubMeasurer{
+		stubTextMeasurer: stubTextMeasurer{charWidth: 10, fontHeight: 20},
+		left:             2, top: 6, right: 4, bottom: 2,
+	})
+	// Retina 2x. The ink-centring math lands the baseline at an
+	// odd quarter-pixel (…217.6 at 1x in TestCenterGlyphOnInk);
+	// the snap must pull it onto the grid.
+	w.BackingScale = 2
+
+	frame := inkTestFrame()
+	centerGlyphOnInk("x", TextStyle{Size: 12})(EventCtx{&frame, nil, w})
+
+	glyph := frame.Children[0].Shape
+	baseline := glyph.Y + 12*0.8
+	snapped := baseline * 2
+	if !floatNear(snapped, float32(math.Round(float64(snapped))), 0.001) {
+		t.Errorf("baseline %v is off the 2x pixel grid (snapped: %v)",
+			baseline, snapped)
+	}
+}
+
+// TestCenterGlyphOnInkNonFiniteScale asserts a non-finite BackingScale
+// skips the snap entirely, leaving the ink-centred position alone — the
+// scale comes from the backend each frame and render defends against a
+// corrupted value, so the snap must not poison the glyph with NaN.
+func TestCenterGlyphOnInkNonFiniteScale(t *testing.T) {
+	for _, scale := range []float32{
+		float32(math.NaN()), float32(math.Inf(1)),
+	} {
+		w := newTestWindow()
+		w.SetTextMeasurer(&inkStubMeasurer{
+			stubTextMeasurer: stubTextMeasurer{charWidth: 10, fontHeight: 20},
+			left:             2, top: 6, right: 4, bottom: 2,
+		})
+		w.BackingScale = scale
+
+		frame := inkTestFrame()
+		centerGlyphOnInk("x", TextStyle{Size: 12})(EventCtx{&frame, nil, w})
+
+		glyph := frame.Children[0].Shape
+		if math.IsNaN(float64(glyph.Y)) || math.IsInf(float64(glyph.Y), 0) {
+			t.Errorf("scale %v: glyph.Y = %v, must stay finite",
+				scale, glyph.Y)
+		}
+	}
+}
+
+// TestToggleCheckCentersOnInk asserts the rendered check ends up centred
+// on its ink inside the box, which is the whole point of the correction:
+// the glyph's own centre, not its advance box's centre, lands on the box
+// centre.
+func TestToggleCheckCentersOnInk(t *testing.T) {
+	w := &Window{windowWidth: 200, windowHeight: 100}
+	w.SetTextMeasurer(&inkStubMeasurer{
+		stubTextMeasurer: stubTextMeasurer{charWidth: 10, fontHeight: 20},
+		left:             2, top: 6, right: 4, bottom: 2,
+	})
+
+	root := Toggle(ToggleCfg{
+		ID: "t", Selected: true, Size: SomeF(40),
+	}).GenerateLayout(w)
+	layoutArrange(&root, w)
+
+	box := root.Children[0]
+	text := findShapeType(&box, shapeText)
+	if text == nil {
+		t.Fatal("no text shape under the toggle box")
+	}
+
+	// Ink centre of the text shape, and the centre of the box it sits in.
+	inkCX := text.Shape.X + 2 + (text.Shape.Width-2-4)/2
+	inkCY := text.Shape.Y + 6 + (text.Shape.Height-6-2)/2
+	boxCX := box.Shape.X + box.Shape.Width/2
+	boxCY := box.Shape.Y + box.Shape.Height/2
+
+	if !floatNear(inkCX, boxCX, 0.01) || !floatNear(inkCY, boxCY, 0.01) {
+		t.Errorf("ink centre (%v, %v), box centre (%v, %v)",
+			inkCX, inkCY, boxCX, boxCY)
+	}
+}
+
+// TestToggleCheckFallsBackWithoutInk asserts the no-capability path
+// leaves the check exactly where advance-box centring put it.
+func TestToggleCheckFallsBackWithoutInk(t *testing.T) {
+	w := &Window{windowWidth: 200, windowHeight: 100}
+	w.SetTextMeasurer(&stubTextMeasurer{charWidth: 10, fontHeight: 20})
+
+	root := Toggle(ToggleCfg{
+		ID: "t", Selected: true, Size: SomeF(40),
+	}).GenerateLayout(w)
+	layoutArrange(&root, w)
+
+	box := root.Children[0]
+	text := box.Children[0]
+	// Advance box centred: 30x20 text in a 40x40 box.
+	if !floatNear(text.Shape.X, box.Shape.X+5, 0.01) ||
+		!floatNear(text.Shape.Y, box.Shape.Y+10, 0.01) {
+		t.Errorf("text at (%v, %v), want advance-centred (%v, %v)",
+			text.Shape.X, text.Shape.Y, box.Shape.X+5, box.Shape.Y+10)
+	}
+}
+
+func floatNear(a, b, tol float32) bool {
+	d := a - b
+	return d <= tol && d >= -tol
+}
+
+// findShapeType returns the first descendant (depth-first) with the given
+// shape type, or nil.
+func findShapeType(l *Layout, st shapeType) *Layout {
+	if l == nil || l.Shape == nil {
+		return nil
+	}
+	if l.Shape.shapeType == st {
+		return l
+	}
+	for i := range l.Children {
+		if found := findShapeType(&l.Children[i], st); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -138,12 +138,15 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			ColorFocus:       cfg.ColorInterior,
 			ColorHover:       cfg.ColorHover,
 			ColorSelect:      cfg.ColorInterior,
-			Padding:          NewPadding(1, 1, 1, 2),
-			Size:             ts.Size + 4,
-			SizeBorder:       cfg.SizeBorder,
-			Radius:           cfg.Radius,
-			textStyleNormal:  ts,
-			textStyleLabel:   ts,
+			// Symmetric: the check is centred on its ink (see
+			// centerGlyphOnInk), so any padding asymmetry here is a
+			// pure off-centre error, not a nudge that helps.
+			Padding:         PadAll(1),
+			Size:            ts.Size + 4,
+			SizeBorder:      cfg.SizeBorder,
+			Radius:          cfg.Radius,
+			textStyleNormal: ts,
+			textStyleLabel:  ts,
 		},
 		selectStyle: SelectStyle{
 			MinWidth:         75,

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -480,6 +480,7 @@ func mdRenderListItem(
 func mdTaskCheckbox(checked bool, boxSize float32, cfg MarkdownCfg) View {
 	boxColor := ColorTransparent
 	var content []View
+	var amend func(EventCtx)
 	if checked {
 		boxColor = cfg.Style.linkColor
 		checkStyle := guiTheme.icon5
@@ -488,6 +489,10 @@ func mdTaskCheckbox(checked bool, boxSize float32, cfg MarkdownCfg) View {
 		content = []View{
 			Text(TextCfg{Text: iconCheck, TextStyle: checkStyle}),
 		}
+		// Same defect as Toggle's check: the icon font's advance box is
+		// taller and wider than the mark, so flow centring leaves it high
+		// and off to one side inside this small fixed box.
+		amend = centerGlyphOnInk(iconCheck, checkStyle)
 	}
 
 	return Column(ContainerCfg{
@@ -504,6 +509,7 @@ func mdTaskCheckbox(checked bool, boxSize float32, cfg MarkdownCfg) View {
 		Padding:     NoPadding,
 		HAlign:      HAlignCenter,
 		VAlign:      VAlignMiddle,
+		AmendLayout: amend,
 		Content:     content,
 	})
 }

--- a/gui/view_splitter_handle.go
+++ b/gui/view_splitter_handle.go
@@ -95,21 +95,29 @@ func splitterButton(cfg *SplitterCfg, core *splitterCore,
 		Color: cfg.colorButtonIcon,
 		Size:  size,
 	}
+	icon := splitterButtonIcon(core, target)
 	return Button(ButtonCfg{
 		ID:      id + splitterButtonSuffix[target],
 		Width:   size,
 		Height:  size,
 		Sizing:  FixedFixed,
 		Padding: NoPadding,
-		Color:   cfg.colorButton,
-		Colors:  ColorSet{Hover: cfg.colorButtonHover, Click: cfg.colorButtonActive, Focus: cfg.colorButtonHover},
-		Radius:  cfg.radiusBorder,
+		// A triangle sits well above the baseline and its side bearings
+		// are lopsided, so advance-box centring puts it high and off to
+		// one side of this small square button. Note Button's own amend
+		// hook skips a disabled button, so a disabled one keeps the
+		// uncorrected position — cosmetic, and disabled splitter buttons
+		// are not a state the widget produces today.
+		AmendLayout: centerGlyphOnInk(icon, ts),
+		Color:       cfg.colorButton,
+		Colors:      ColorSet{Hover: cfg.colorButtonHover, Click: cfg.colorButtonActive, Focus: cfg.colorButtonHover},
+		Radius:      cfg.radiusBorder,
 		OnClick: func(ctx EventCtx) {
 			splitterOnButtonClick(core, target, ctx.Event, ctx.Window)
 		},
 		Content: []View{
 			Text(TextCfg{
-				Text:      splitterButtonIcon(core, target),
+				Text:      icon,
 				TextStyle: ts,
 			}),
 		},

--- a/gui/view_toggle.go
+++ b/gui/view_toggle.go
@@ -78,6 +78,7 @@ func Toggle(cfg ToggleCfg) View {
 		Sizing:      FixedFixed,
 		HAlign:      HAlignCenter,
 		VAlign:      VAlignMiddle,
+		AmendLayout: centerGlyphOnInk(txt, txtStyle),
 		Content: []View{
 			Text(TextCfg{Text: txt, TextStyle: txtStyle}),
 		},


### PR DESCRIPTION
## Summary

Toggle's check mark, the markdown task-list checkbox and the splitter's collapse buttons centred their glyph on the font's advance box — which spans the descent the glyph never paints into and each glyph's side bearings — so the mark floated visibly high and off to one side, glaringly at large sizes.

## What changed

- Backends expose an optional ink-measuring capability: `TextInkBounds` on the text measurer (glyph's new `TextSystem.InkBounds`). Backends without it, and tests with no measurer, keep the previous advance-box centring.
- `centerGlyphOnInk` AmendLayout hook re-centres a container's single text glyph on its painted box after sizing — nothing about sizing, draw order, or the widget tree changes.
- The baseline is snapped to the physical-pixel grid so the backend's own whole-pixel baseline rounding cannot fight the correction; non-finite `BackingScale` skips the snap.
- Applied to `Toggle`, markdown task-list checkboxes, and splitter collapse buttons.
- The toggle theme style's padding is symmetric again (`PadAll(1)`); its left-heavy value had been a partial nudge for the same defect.

## Tests

- `TestCenterGlyphOnInk` — ink centre (not advance-box centre) lands on frame centre
- Fallback paths: no measurer / no capability / unmeasurable glyph / empty frame
- Baseline pixel-grid snap + non-finite scale guards
- `TestToggleCheckCentersOnInk` / `TestToggleCheckFallsBackWithoutInk` — full-layout rendering assertions

New go-glyph dependency feature (`InkBounds`); requires the working copy already wired via `go.work`.