### PR TITLE
Align local validation targets with CI (issue #292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,45 +50,10 @@ jobs:
       - name: Test with coverage
         run: go test -count=1 -coverprofile=coverage.out ./gui/...
 
-      - name: Check coverage threshold
-        run: |
-          go tool cover -func=coverage.out | awk 'END {
-            gsub(/%/, "", $3);
-            if ($3 + 0 < 70) {
-              printf "::error::Coverage %.1f%% below 70%% threshold\n", $3;
-              exit 1
-            } else {
-              printf "Coverage %.1f%% >= 70%% threshold\n", $3
-            }
-          }'
-
-      - name: Check per-package coverage floors
-        run: |
-          failures=0
-          while IFS='|' read -r pkg floor; do
-            pct=$(go tool cover -func=coverage.out | \
-              awk -v pkg="$pkg" '
-                $1 ~ "^"pkg"/" { stmts += $2; if ($3 > 0) cov += $2 }
-                END { if (stmts > 0) printf "%.1f", 100 * cov / stmts;
-                      else print "0.0" }')
-            if [ -n "$pct" ] && awk "BEGIN { exit ($pct < $floor) ? 0 : 1 }"; then
-              echo "::error::$pkg coverage ${pct}% below ${floor}% floor"
-              failures=$((failures + 1))
-            fi
-          done << 'EOF'
-          github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv|0
-          github.com/go-gui-org/go-gui/gui/backend/internal/imgpath|0
-          github.com/go-gui-org/go-gui/gui/backend/internal/texcache|0
-          github.com/go-gui-org/go-gui/gui/backend/internal/imgload|0
-          github.com/go-gui-org/go-gui/gui/backend/internal/tempfont|0
-          github.com/go-gui-org/go-gui/gui/backend/internal/nativehost|0
-          github.com/go-gui-org/go-gui/gui/backend/filedialog|0
-          EOF
-          if [ "$failures" -gt 0 ]; then
-            echo "::error::$failures package(s) below coverage floor"
-            exit 1
-          fi
-          echo "All per-package coverage floors met."
+      # Thresholds and floors live in scripts/coverage-gate.sh, shared
+      # with `make coverage-gate` (issue #292).
+      - name: Check coverage gates
+        run: scripts/coverage-gate.sh coverage.out
 
       - name: Save baseline coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,25 @@
 
 ## Build and Test
 
+Run the full local validation gate before pushing a branch:
+
 ```bash
-go test ./... && go vet ./... && golangci-lint run ./...
-go run ./tools/requiredid/cmd/requiredid ./...
+make prepush
 ```
+
+`make prepush` approximates the CI matrix from one host: race-enabled
+tests, vet, lint (linux + the cross-GOOS `//go:build` files via
+`make lint-cross`), cgo-free cross-compiles of the whole module
+(`make cross-compile`), the coverage gate (`make coverage-gate`: 70%
+total + per-package floors), and the export audit. CI and the Makefile
+share the coverage thresholds via `scripts/coverage-gate.sh`.
+
+When only the fast gate checks are wanted, `make check` (vet,
+deps-doc, large-files, generate-check, tidy-check) is the quick subset.
+The tracked `.githooks/pre-push` hook runs `make check-all` (test +
+lint + check) on every push — enable it with
+`git config core.hooksPath .githooks`. Tools like golangci-lint and
+gosec must be installed; `make lint` pins the golangci-lint version.
 
 For a tight edit → rebuild → relaunch loop while iterating on an example app,
 see [docs/dev-loop.md](docs/dev-loop.md)
@@ -35,8 +50,24 @@ harmless duplicate-library warnings with
 `export CGO_LDFLAGS="-Wl,-no_warn_duplicate_libraries"` (or use the repo's
 `.envrc` with [direnv](https://direnv.net/)).
 
-CI enforces 70% coverage, race detector, and benchmark regression gates. Run
-`go test ./...` locally before pushing.
+CI also enforces race detector and benchmark regression gates. Run
+`make test-race` locally before pushing (prepush includes it).
+
+### CI-only validation
+
+These CI checks have no local Makefile equivalent — they either need a
+different OS runner or a baseline from `main` that only CI can supply:
+
+- OS-matrix test runs (Windows, macOS runners; Windows also runs the
+  showcase smoke test with Mesa's software GL)
+- Coverage diff on PRs and the benchmark regression gate — both compare
+  against a baseline cached from `main` (`scripts/cov-diff.sh` can run
+  them locally if you supply two profiles)
+- WASM build/vet/test (`GOOS=js` needs a node `wasm_exec` wrapper);
+  `make build-wasm` covers the build half
+- iOS and Android vet+lint — need an Xcode iphoneos sysroot / Android
+  NDK; `make build-ios` and `make build-android` cover the build half
+- Release packaging (`release.yml`)
 
 ### Local development with sibling repos
 
@@ -75,7 +106,7 @@ the bare read is also what makes `gui.Themed` subtree scoping work.
 
 1. Fork, create a feature branch, make focused commits.
 2. Add or update tests.
-3. Run `go test ./... && go vet ./... && golangci-lint run ./...`.
+3. Run `make prepush` (fast subset: `make check`).
 4. Open a pull request against `main`.
 
 ## Claude Code hooks

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LDFLAGS  = -X github.com/go-gui-org/go-gui/gui.Version=$(VERSION) \
 
 LINT_VERSION = v2.12.2
 
-.PHONY: build-linux build-windows build-macos build-wasm build-ios build-android build-examples release clean test test-race vet lint check bench bench-gate deps-doc deps-doc-check security gosec govulncheck large-files deadcode generate-check tidy-check workflow-audit cov-report license-check ergonomics-audit ergonomics-audit-fix ergonomics-audit-fix-dry
+.PHONY: build-linux build-windows build-macos build-wasm build-ios build-android build-examples release clean test test-race vet lint lint-pin lint-cross cross-compile coverage-gate prepush check bench bench-gate deps-doc deps-doc-check security gosec govulncheck large-files deadcode generate-check tidy-check workflow-audit cov-report license-check ergonomics-audit ergonomics-audit-fix ergonomics-audit-fix-dry
 
 # Desktop builds are cgo-free since the purego GL bindings (#155): the
 # backend/gl uses X11/xgb + purego EGL on Linux and Win32 syscalls on
@@ -119,11 +119,48 @@ vet:
 	go vet ./...
 	go run ./tools/requiredid/cmd/requiredid ./...
 
-# Run golangci-lint (requires golangci-lint installed, pinned to LINT_VERSION).
-lint:
+# Verify golangci-lint is installed at the pinned version. Shared by
+# lint and lint-cross so the pin lives in one place.
+lint-pin:
 	@golangci-lint --version | grep -q "$(LINT_VERSION:v%=%)" || \
 	  { echo "::error::golangci-lint $(LINT_VERSION) required. Run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(LINT_VERSION)"; exit 1; }
+
+# Run golangci-lint (requires golangci-lint installed, pinned to LINT_VERSION).
+lint: lint-pin
 	golangci-lint run ./...
+
+# Lint the GOOS-conditional files the default (GOOS=linux or darwin)
+# build cannot see: every //go:build windows/js file was unlinted before
+# CI added these steps. Linting is a type-check, not an execution, so
+# each target analyses fine from any host. On macOS the darwin run is a
+# strict superset of CI's: it also covers the cgo metal files, which CI
+# cannot compile from a Linux runner. Mirror of the CI vet job's lint
+# steps (issue #292).
+lint-cross: lint-pin
+	GOOS=windows golangci-lint run ./...
+	GOOS=js GOARCH=wasm golangci-lint run ./...
+	GOOS=darwin golangci-lint run ./...
+
+# Cross-compile the whole module with no C toolchain on the host, for
+# every desktop target CI guards (issue #292). A new cgo import anywhere
+# fails this; gui/audio's default Linux output is the pure-Go PulseAudio
+# sink, so the oto/ALSA sink (-tags otoaudio) is built explicitly to
+# keep it from bit-rotting. Mirror of the CI vet job's build steps.
+cross-compile:
+	for target in linux/amd64 linux/arm64 windows/amd64 windows/arm64; do \
+		echo "==> $$target"; \
+		CGO_ENABLED=0 GOOS=$${target%/*} GOARCH=$${target#*/} \
+		  go build ./...; \
+	done
+	go build -tags otoaudio ./gui/audio/...
+
+# Enforce CI's coverage gates locally: 70% total over gui/ plus the
+# per-package floors. The thresholds live in scripts/coverage-gate.sh,
+# shared with the CI coverage job (issue #292). Scope matches CI's
+# ./gui/..., unlike cov-report's ./... report.
+coverage-gate:
+	go test -count=1 -coverprofile=/tmp/go-gui-coverage-gate.out ./gui/...
+	scripts/coverage-gate.sh /tmp/go-gui-coverage-gate.out
 
 # Run non-duplicated validation steps for CI gate.
 # test and lint run as separate CI jobs with OS matrices.
@@ -131,6 +168,17 @@ check: vet deps-doc-check large-files generate-check tidy-check
 
 # Run all validation steps: test, vet, lint, and gate checks.
 check-all: test lint check
+
+# Recommended full local validation before pushing (issue #292):
+# approximates the CI matrix from one host — race tests, linux + cross-
+# GOOS lint, cgo-free cross-compiles, coverage gate, export audit. The
+# .githooks/pre-push hook runs make check-all; run prepush once per
+# branch to cover the rest. Omissions vs CI, by design: OS-matrix runs,
+# coverage diff and benchmark gates (need a main baseline), WASM node
+# tests, iOS/Android vet+lint (Xcode/NDK), Windows smoke test, release
+# packaging. `make check` is the fast gate when only gate checks are
+# wanted.
+prepush: test-race lint check lint-cross cross-compile coverage-gate export-audit
 
 # Regenerate docs/dependencies.md from go.mod.
 deps-doc:

--- a/examples/fontviewer/main_test.go
+++ b/examples/fontviewer/main_test.go
@@ -6,8 +6,10 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
+// Not t.Parallel: SetTheme mutates process-global theme state
+// (applyTheme writes the default*Style mirrors), which is documented
+// frame-thread-only and races any other test touching theme state.
 func TestMainViewNoPanic(t *testing.T) {
-	t.Parallel()
 	gui.SetTheme(gui.ThemeLight.WithPadding(false))
 	w := gui.NewWindow(gui.WindowCfg{
 		State:  &FontViewerState{FontSize: initialFontSize, Sample: "The quick brown fox"},
@@ -129,8 +131,8 @@ func TestRandomPangramExcludes(t *testing.T) {
 	}
 }
 
+// Not t.Parallel: see TestMainViewNoPanic (SetTheme is not race-safe).
 func TestMainViewEmptyCatalog(t *testing.T) {
-	t.Parallel()
 	gui.SetTheme(gui.ThemeLight.WithBorders(true))
 	// Families is nil, Loaded is false → empty state shows "No system fonts".
 	w := gui.NewWindow(gui.WindowCfg{

--- a/examples/time_travel/main_test.go
+++ b/examples/time_travel/main_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
+// Not t.Parallel: SetTheme mutates process-global theme state
+// (applyTheme writes the default*Style mirrors), which is documented
+// frame-thread-only and races any other test touching theme state.
 func TestMainViewNoPanic(t *testing.T) {
-	t.Parallel()
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
 	w := gui.NewWindow(gui.WindowCfg{
 		State:  &appState{},
@@ -67,8 +69,8 @@ func TestSnapshotSize(t *testing.T) {
 
 // TestMainViewWithDebugTimeTravel verifies the example view renders
 // when DebugTimeTravel is enabled (the normal example path).
+// Not t.Parallel: see TestMainViewNoPanic (SetTheme is not race-safe).
 func TestMainViewWithDebugTimeTravel(t *testing.T) {
-	t.Parallel()
 	gui.SetTheme(gui.ThemeLight.WithPadding(false))
 	w := gui.NewWindow(gui.WindowCfg{
 		State:           &appState{Count: 7},
@@ -87,8 +89,8 @@ func TestMainViewWithDebugTimeTravel(t *testing.T) {
 
 // TestStateMutations verifies the Increment and Reset click handlers
 // mutate state as expected.
+// Not t.Parallel: see TestMainViewNoPanic (SetTheme is not race-safe).
 func TestStateMutations(t *testing.T) {
-	t.Parallel()
 	gui.SetTheme(gui.ThemeLight.WithPadding(false))
 	w := gui.NewWindow(gui.WindowCfg{
 		State:           &appState{Count: 0},

--- a/examples/todo/main_test.go
+++ b/examples/todo/main_test.go
@@ -10,8 +10,10 @@ import (
 // grew. This is the whole point of the app-testing API: the previous
 // version of this test only proved mainView did not panic, which would
 // still have held if the button were wired to nothing.
+// Not t.Parallel: SetTheme mutates process-global theme state
+// (applyTheme writes the default*Style mirrors), which is documented
+// frame-thread-only and races any other test touching theme state.
 func TestAddTodoAppendsItem(t *testing.T) {
-	t.Parallel()
 	gui.SetTheme(gui.ThemeLight.WithPadding(false))
 
 	app := newAppState()
@@ -44,8 +46,8 @@ func TestAddTodoAppendsItem(t *testing.T) {
 // The delete button is generated per item, so its ID is only correct if
 // the list rendered the item at all — a click that lands proves both the
 // ID scheme and the callback.
+// Not t.Parallel: see TestAddTodoAppendsItem (SetTheme is not race-safe).
 func TestDeleteTodoRemovesItem(t *testing.T) {
-	t.Parallel()
 	gui.SetTheme(gui.ThemeLight.WithPadding(false))
 
 	app := newAppState()

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# coverage-gate.sh — enforce total and per-package coverage floors on a
+# coverage.out profile. Shared by CI (`.github/workflows/ci.yml` coverage
+# job) and `make coverage-gate`, so the thresholds live in exactly one
+# place. Emits ::error:: annotations, exits non-zero on any failure.
+
+set -euo pipefail
+
+PROFILE="${1:?usage: coverage-gate.sh <coverage.out>}"
+
+# Total coverage threshold: the sum over every package in the profile
+# (CI generates the profile with `go test ./gui/...`).
+go tool cover -func="$PROFILE" | awk 'END {
+  gsub(/%/, "", $3);
+  if ($3 + 0 < 70) {
+    printf "::error::Coverage %.1f%% below 70%% threshold\n", $3;
+    exit 1
+  } else {
+    printf "Coverage %.1f%% >= 70%% threshold\n", $3
+  }
+}'
+
+# Per-package floors: packages listed below must not drop under their
+# floor. Floors are advisory for backend internals that CI runs but the
+# host display rarely exercises.
+failures=0
+while IFS='|' read -r pkg floor; do
+  pct=$(go tool cover -func="$PROFILE" | \
+    awk -v pkg="$pkg" '
+      $1 ~ "^"pkg"/" { stmts += $2; if ($3 > 0) cov += $2 }
+      END { if (stmts > 0) printf "%.1f", 100 * cov / stmts;
+            else print "0.0" }')
+  if [ -n "$pct" ] && awk "BEGIN { exit ($pct < $floor) ? 0 : 1 }"; then
+    echo "::error::$pkg coverage ${pct}% below ${floor}% floor"
+    failures=$((failures + 1))
+  fi
+done << 'EOF'
+github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv|0
+github.com/go-gui-org/go-gui/gui/backend/internal/imgpath|0
+github.com/go-gui-org/go-gui/gui/backend/internal/texcache|0
+github.com/go-gui-org/go-gui/gui/backend/internal/imgload|0
+github.com/go-gui-org/go-gui/gui/backend/internal/tempfont|0
+github.com/go-gui-org/go-gui/gui/backend/internal/nativehost|0
+github.com/go-gui-org/go-gui/gui/backend/filedialog|0
+EOF
+if [ "$failures" -gt 0 ]; then
+  echo "::error::$failures package(s) below coverage floor"
+  exit 1
+fi
+echo "All per-package coverage floors met."


### PR DESCRIPTION
Closes #292.

## Summary

Add `make prepush` as the recommended local pre-push gate, closing the gap between local validation and the CI matrix:

- **`make prepush`** — race tests, lint, gate checks, cross-GOOS lint (`lint-cross`), cgo-free cross-compiles (`cross-compile`), coverage gate, export audit.
- **`scripts/coverage-gate.sh`** (new) — CI's 70% total + per-package coverage floors extracted verbatim; the CI coverage job now calls it so thresholds live in one place (CI behavior unchanged).
- **Makefile** — new targets `prepush`, `lint-cross`, `cross-compile`, `coverage-gate`, `lint-pin` (pin check factored out of `lint`). Existing targets untouched.
- **CONTRIBUTING.md** — documents `make prepush` as the pre-push path and lists what stays CI-only (OS-matrix runs, baseline-dependent gates, WASM/iOS/Android, Windows smoke, release packaging).

## Race fix (found by the new gate)

`make test-race` was red on main: 7 example tests called `t.Parallel()` while mutating process-global theme state via `gui.SetTheme` — `applyTheme` writes the `default*Style` mirrors, documented frame-thread-only. CI never caught it because CI race-tests only `./gui/...`, never `./examples/...`. Dropped `t.Parallel()` (with an explanatory comment) in fontviewer/time_travel/todo.

## Verification

- `make prepush` exits 0 end-to-end on macOS.
- Full CI matrix runs on this PR; the only ci.yml change is the coverage steps collapsing into the shared script (logic identical).