### PR TITLE
feat(gui): per-shape AnimSnap mask and FLIP subtree shifts for transitions (issue #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **Layout and hero transitions left ID-less descendants behind.**
+  `AnimateLayout` only moved shapes that had a snapshot of their own, and layout
+  coordinates are absolute, so a sliding container's `Text` (no `ID`, so no
+  snapshot) jumped straight to its final position while the container eased
+  under it. The walk now carries the nearest interpolated ancestor's position
+  delta and applies it to descendants that have no snapshot — the standard FLIP
+  subtree shift. A shape with its own snapshot replaces the carried delta rather
+  than adding to it, since the snapshot is absolute and already accounts for its
+  ancestors. `AnimSnapPos` zeroes the delta for the subtree, so a snapped
+  container still holds everything under it still. `HeroTransition` had the
+  identical defect — a morphing card travelled without its label — and
+  `applyHeroRecursive` now carries the shift by the same rule.
+
+- **`examples/animations`: the seven toolbar buttons all shared one `ID`.** A
+  duplicate effective ID is a single identity, and the layout transition
+  snapshots by effective ID, so pressing **Layout** made every button lerp from
+  whichever button wrote the snapshot last — the toolbar borders visibly slid.
+  Each button now keys on its label under a scoping `animations_toolbar` row,
+  and `TestMainViewNoDuplicateIDs` asserts the window is clean.
+
+### Added
+
+- **Per-shape snap mask for layout transitions (issue #310).** `AnimateLayout`
+  used to be all-or-nothing over the whole window: every ID-bearing shape got X,
+  Y, Width and Height lerped, with no way to exclude a channel, a shape or a
+  subtree. `Shape.AnimSnap` (and its `ContainerCfg.AnimSnap` write-through, the
+  same seam `Hero` uses) now marks channels that snap instead of easing —
+  `AnimSnapPos`, `AnimSnapSize`, `AnimSnapAll`. This covers "slide, don't
+  stretch" card and grid reflow, and holding a scroll viewport, datagrid body or
+  virtualised list still while the surrounding chrome animates. The mask is an
+  **opt-out**: the zero value animates every channel the active transition
+  covers, so no existing caller changes behaviour. It is OR-inherited down the
+  layout walk, so a snapped container snaps its whole subtree and a child cannot
+  escape it. The hero transition is unaffected — `Shape.Hero` is already an
+  explicit per-shape opt-in. Cost is a `uint8` that lands in existing struct
+  padding (`Shape` stays 304 bytes) plus two branches inside a walk that already
+  runs.
+
 ### Changed
 
 - **BREAKING: `A11YLabel` and `A11YDescription` moved to an embedded `A11YCfg`

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -88,6 +88,25 @@ behind the label.
 Column{Title: "Account", TitleBG: RGB(255, 255, 255), ...}
 ```
 
+## Layout transitions: snap a channel or a subtree
+
+`AnimateLayout` eases X, Y, Width and Height on every ID-bearing shape.
+`AnimSnap` removes a channel from that, and the zero value keeps today's
+behavior, so it is an opt-out:
+
+```go
+// Slides to its new position, jumps to its new size.
+Column(ContainerCfg{ID: "card", AnimSnap: gui.AnimSnapSize, ...})
+
+// Holds a scroll viewport or grid body still while the chrome animates.
+Column(ContainerCfg{ID: "grid", AnimSnap: gui.AnimSnapAll, ...})
+```
+
+The mask inherits down the tree, and only down: a snapped container snaps
+everything inside it, and a child cannot escape the container's mask. The hero
+transition (`Shape.Hero`) ignores `AnimSnap` — it is already an explicit
+per-shape opt-in.
+
 ## The one-event rule
 
 Nothing is marked handled for you. A callback that acts on an event calls

--- a/examples/animations/main.go
+++ b/examples/animations/main.go
@@ -60,6 +60,10 @@ func mainView(w *gui.Window) gui.View {
 		Content: []gui.View{
 			// Control buttons
 			gui.Row(gui.ContainerCfg{
+				// The toolbar scopes the buttons: each button's leaf is
+				// its label, so the effective IDs are
+				// "animations_toolbar:Tween" and friends.
+				ID:      "animations_toolbar",
 				Spacing: gui.Some[float32](10),
 				Content: []gui.View{
 					animButton("Tween", tweenBox),
@@ -85,6 +89,22 @@ func mainView(w *gui.Window) gui.View {
 						Padding: gui.NewPadding(10, 10, 10, 10),
 						Content: []gui.View{
 							gui.Text(gui.TextCfg{Text: "Sidebar"}),
+						},
+					}),
+					// Same width change as the sidebar, driven by the
+					// same layout transition — but AnimSnapSize holds
+					// the size channel still, so this pane jumps to its
+					// new width while the purple one eases into it.
+					gui.Column(gui.ContainerCfg{
+						ID:       "snap-pane",
+						AnimSnap: gui.AnimSnapSize,
+						Width:    s.SidebarWidth,
+						Sizing:   gui.FixedFill,
+						Color:    gui.CornflowerBlue,
+						Radius:   gui.Some[float32](8),
+						Padding:  gui.NewPadding(10, 10, 10, 10),
+						Content: []gui.View{
+							gui.Text(gui.TextCfg{Text: "Snap size"}),
 						},
 					}),
 					// Canvas for absolute positioning
@@ -200,9 +220,13 @@ func detailView(w *gui.Window) gui.View {
 	})
 }
 
+// animButton keys each button on its own label. One shared ID across all
+// seven made them a single identity: the layout transition snapshots by
+// effective ID, so every button lerped from whichever button wrote the
+// entry last, and the toolbar visibly slid on any AnimateLayout.
 func animButton(label string, action func(w *gui.Window)) gui.View {
 	return gui.Button(gui.ButtonCfg{
-		ID:      "animations_anim_button",
+		ID:      label,
 		Content: []gui.View{gui.Text(gui.TextCfg{Text: label})},
 		OnClick: func(ctx gui.EventCtx) {
 			action(ctx.Window)

--- a/examples/animations/main_test.go
+++ b/examples/animations/main_test.go
@@ -21,3 +21,23 @@ func TestMainViewNoPanic(t *testing.T) {
 	_ = mainView(w).GenerateLayout(w)
 
 }
+
+func TestMainViewNoDuplicateIDs(t *testing.T) {
+	// Duplicate IDs are not cosmetic here: the layout transition
+	// snapshots by effective ID, so two shapes sharing one make each
+	// other's geometry the start of the lerp.
+	gui.SetTheme(gui.ThemeDark.WithBorders(true))
+	w := gui.NewWindow(gui.WindowCfg{
+		State: &State{
+			SidebarWidth: 200,
+			BoxX:         50,
+			SpringValue:  100,
+		},
+		Width:  800,
+		Height: 600,
+	})
+	w.UpdateView(mainView)
+	if dups := w.TestDuplicateIDs(); len(dups) > 0 {
+		t.Errorf("duplicate IDs: %v", dups)
+	}
+}

--- a/gui/animation_hero.go
+++ b/gui/animation_hero.go
@@ -71,7 +71,7 @@ func applyHeroTransition(layout *Layout, w *Window) {
 	if !ok || ht.stopped {
 		return
 	}
-	applyHeroRecursive(layout, ht.progress, ht.outgoing, ht.incoming)
+	applyHeroRecursive(layout, ht.progress, ht.outgoing, ht.incoming, 0, 0)
 }
 
 func propagateOpacity(layout *Layout, opacity float32) {
@@ -81,7 +81,15 @@ func propagateOpacity(layout *Layout, opacity float32) {
 	}
 }
 
-func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map[string]posSnapshot) {
+// applyHeroRecursive morphs each matched hero toward its incoming
+// geometry. dx/dy carry the nearest morphed ancestor's position shift,
+// the same rule applyTransitionRecursive follows: layout coordinates are
+// absolute, so a morphing card's label — no ID, so no snapshot — would
+// otherwise stay at its final position while the card travelled. A hero
+// with its own snapshot replaces the carried shift instead of adding to
+// it, because the snapshot is an absolute position.
+func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map[string]posSnapshot, dx, dy float32) {
+	shifted := false
 	if layout.Shape.Hero && layout.Shape.ID != "" {
 		// Hero matching is identity-keyed: the same leaf under two
 		// different ID-bearing ancestors is two widgets and does not
@@ -93,16 +101,23 @@ func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map
 
 		if out, hasOut := outgoing[id]; hasOut {
 			if _, hasIn := incoming[id]; hasIn {
-				layout.Shape.X = lerp(out.x, layout.Shape.X, morphProgress)
-				layout.Shape.Y = lerp(out.y, layout.Shape.Y, morphProgress)
+				finalX, finalY := layout.Shape.X, layout.Shape.Y
+				layout.Shape.X = lerp(out.x, finalX, morphProgress)
+				layout.Shape.Y = lerp(out.y, finalY, morphProgress)
 				layout.Shape.Width = lerp(out.width, layout.Shape.Width, morphProgress)
 				layout.Shape.Height = lerp(out.height, layout.Shape.Height, morphProgress)
+				dx, dy = layout.Shape.X-finalX, layout.Shape.Y-finalY
+				shifted = true
 			}
 		} else {
 			propagateOpacity(layout, fadeProgress)
 		}
 	}
+	if !shifted {
+		layout.Shape.X += dx
+		layout.Shape.Y += dy
+	}
 	for i := range layout.Children {
-		applyHeroRecursive(&layout.Children[i], progress, outgoing, incoming)
+		applyHeroRecursive(&layout.Children[i], progress, outgoing, incoming, dx, dy)
 	}
 }

--- a/gui/animation_hero_test.go
+++ b/gui/animation_hero_test.go
@@ -51,10 +51,64 @@ func TestApplyHeroRecursive(t *testing.T) {
 		"h": {x: 100, y: 100, width: 200, height: 200},
 	}
 	// progress=0 → morphProgress=0 → should be at outgoing position
-	applyHeroRecursive(&layout, 0, outgoing, incoming)
+	applyHeroRecursive(&layout, 0, outgoing, incoming, 0, 0)
 	if layout.Shape.X != 0 {
 		t.Errorf("X = %f, want 0", layout.Shape.X)
 	}
+}
+
+// heroShiftTree is a hero card that morphs from (0,0,100x100) to
+// (100,100,200x200) with an ID-less label inset 10pt from the card's
+// final corner. At progress 0.5 morphProgress is 1, so build the tree
+// per test and drive progress explicitly.
+func heroShiftTree() (*Layout, map[string]posSnapshot, map[string]posSnapshot) {
+	layout := &Layout{
+		Shape: &Shape{ID: "card", Hero: true, X: 100, Y: 100, Width: 200, Height: 200, Opacity: 1},
+		Children: []Layout{{
+			Shape: &Shape{X: 110, Y: 110, Width: 50, Height: 20, Opacity: 1},
+			Children: []Layout{{
+				Shape: &Shape{X: 120, Y: 120, Width: 10, Height: 10, Opacity: 1},
+			}},
+		}},
+	}
+	outgoing := map[string]posSnapshot{"card": {x: 0, y: 0, width: 100, height: 100}}
+	incoming := map[string]posSnapshot{"card": {x: 100, y: 100, width: 200, height: 200}}
+	return layout, outgoing, incoming
+}
+
+func TestApplyHeroShiftsIDLessChildren(t *testing.T) {
+	// progress 0.25 → morphProgress 0.5 → the card is halfway, so its
+	// contents must be halfway too, keeping their inset.
+	layout, outgoing, incoming := heroShiftTree()
+	applyHeroRecursive(layout, 0.25, outgoing, incoming, 0, 0)
+	checkShape(t, "card", layout.Shape, 50, 50, 150, 150)
+	checkShape(t, "label", layout.Children[0].Shape, 60, 60, 50, 20)
+	checkShape(t, "label child", layout.Children[0].Children[0].Shape, 70, 70, 10, 10)
+}
+
+func TestApplyHeroNoShiftWhenUnmatched(t *testing.T) {
+	// No incoming entry: the card only fades, so nothing moves.
+	layout, outgoing, _ := heroShiftTree()
+	applyHeroRecursive(layout, 0.25, outgoing, map[string]posSnapshot{}, 0, 0)
+	checkShape(t, "card", layout.Shape, 100, 100, 200, 200)
+	checkShape(t, "label", layout.Children[0].Shape, 110, 110, 50, 20)
+}
+
+func TestApplyHeroOwnSnapshotReplacesShift(t *testing.T) {
+	// A hero child with its own snapshot must not double-count the
+	// parent's morph — the snapshot is absolute and already accounts
+	// for the ancestor.
+	layout, outgoing, incoming := heroShiftTree()
+	layout.Children[0].Shape.ID = "label"
+	layout.Children[0].Shape.Hero = true
+	outgoing["label"] = posSnapshot{x: 10, y: 10, width: 50, height: 20}
+	incoming["label"] = posSnapshot{x: 110, y: 110, width: 50, height: 20}
+	applyHeroRecursive(layout, 0.25, outgoing, incoming, 0, 0)
+	// lerp(10, 110, 0.5) = 60 — the same place the carried shift would
+	// have put it, but derived from the label's own snapshot.
+	checkShape(t, "card", layout.Shape, 50, 50, 150, 150)
+	checkShape(t, "label", layout.Children[0].Shape, 60, 60, 50, 20)
+	checkShape(t, "label child", layout.Children[0].Children[0].Shape, 70, 70, 10, 10)
 }
 
 func TestHeroTransitionID(t *testing.T) {

--- a/gui/animation_layout.go
+++ b/gui/animation_layout.go
@@ -11,6 +11,38 @@ type LayoutTransitionCfg struct {
 
 const layoutTransitionID = "__layout_transition__"
 
+// AnimFlags marks the layout-transition channels that SNAP instead of
+// easing. It is an opt-out mask: the zero value animates every channel
+// the active transition covers, so a caller that never sets it sees the
+// behaviour it always had.
+//
+// go-gui animates only when AnimateLayout / AnimationAdd is called, so
+// "don't animate this" is already spelled "don't start the animation".
+// The mask exists for the narrower case — a transition that must run,
+// with one channel or one subtree held still.
+//
+// exportaudit:keep — reachable from an exported field (ContainerCfg.AnimSnap)
+type AnimFlags uint8
+
+const (
+	// AnimSnapPos skips the X/Y lerp: the shape jumps to its new
+	// position while its size still eases.
+	//
+	// exportaudit:keep — one member of a public mask; the set ships whole
+	AnimSnapPos AnimFlags = 1 << iota
+
+	// AnimSnapSize skips the Width/Height lerp: the shape jumps to its
+	// new size while its position still eases. This is the "slide, don't
+	// stretch" case for card and grid reflow.
+	AnimSnapSize
+
+	// AnimSnapAll holds a shape (and, by inheritance, its subtree)
+	// completely still for the duration of a transition.
+	//
+	// exportaudit:keep — one member of a public mask; the set ships whole
+	AnimSnapAll = AnimSnapPos | AnimSnapSize
+)
+
 // LayoutTransition animates layout changes (resize, reorder, add,
 // remove) using FLIP-style animation.
 type layoutTransition struct {
@@ -98,20 +130,60 @@ func applyLayoutTransition(layout *Layout, w *Window) {
 	if lt == nil || lt.stopped {
 		return
 	}
-	applyTransitionRecursive(layout, lt)
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
 }
 
-func applyTransitionRecursive(layout *Layout, lt *layoutTransition) {
-	if layout.Shape.ID != "" {
+// applyTransitionRecursive lerps each covered channel toward the shape's
+// current (post-layout) value. snap is the mask inherited from the
+// ancestors; the walk already carries state, so inheritance is a
+// parameter rather than a separate cascade pass.
+//
+// dx/dy carry the nearest interpolated ancestor's position shift. Layout
+// coordinates are absolute, so moving a container does not move its
+// children — a Text has no ID, so it has no snapshot of its own, and
+// without the carried shift it would sit at its final position while its
+// container slid underneath it. A shape that has its own snapshot
+// replaces the shift rather than adding to it: the snapshot recorded an
+// absolute position, so it already accounts for wherever its ancestors
+// were.
+func applyTransitionRecursive(layout *Layout, lt *layoutTransition, snap AnimFlags, dx, dy float32) {
+	// OR-inherit: a snapped parent snaps its whole subtree. With
+	// opt-out semantics there is deliberately no way for a child to
+	// escape an ancestor's mask — that escape hatch is where the
+	// prior art (go-shirei) spends most of its complexity.
+	snap |= layout.Shape.AnimSnap
+
+	// A shape whose position snaps sits at its final coordinates, and so
+	// does everything under it.
+	if snap&AnimSnapPos != 0 {
+		dx, dy = 0, 0
+	}
+
+	shifted := false
+	if layout.Shape.ID != "" && snap != AnimSnapAll {
 		if old, ok := lt.snapshots[layout.Shape.idKey()]; ok {
 			t := lt.progress
-			layout.Shape.X = lerp(old.x, layout.Shape.X, t)
-			layout.Shape.Y = lerp(old.y, layout.Shape.Y, t)
-			layout.Shape.Width = lerp(old.width, layout.Shape.Width, t)
-			layout.Shape.Height = lerp(old.height, layout.Shape.Height, t)
+			if snap&AnimSnapPos == 0 {
+				finalX, finalY := layout.Shape.X, layout.Shape.Y
+				layout.Shape.X = lerp(old.x, finalX, t)
+				layout.Shape.Y = lerp(old.y, finalY, t)
+				dx, dy = layout.Shape.X-finalX, layout.Shape.Y-finalY
+				shifted = true
+			}
+			if snap&AnimSnapSize == 0 {
+				layout.Shape.Width = lerp(old.width, layout.Shape.Width, t)
+				layout.Shape.Height = lerp(old.height, layout.Shape.Height, t)
+			}
 		}
 	}
+	if !shifted {
+		// No snapshot of its own (an ID-less child, or one that first
+		// appeared this frame): ride the ancestor's shift.
+		layout.Shape.X += dx
+		layout.Shape.Y += dy
+	}
+
 	for i := range layout.Children {
-		applyTransitionRecursive(&layout.Children[i], lt)
+		applyTransitionRecursive(&layout.Children[i], lt, snap, dx, dy)
 	}
 }

--- a/gui/animation_layout_test.go
+++ b/gui/animation_layout_test.go
@@ -52,11 +52,162 @@ func TestApplyTransitionRecursive(t *testing.T) {
 			"box": {x: 0, y: 0, width: 100, height: 100},
 		},
 	}
-	applyTransitionRecursive(&layout, lt)
+	applyTransitionRecursive(&layout, lt, 0, 0, 0)
 	// At progress=0.5: Lerp(0, 100, 0.5) = 50
 	if layout.Shape.X != 50 {
 		t.Errorf("X = %f, want 50", layout.Shape.X)
 	}
+}
+
+// snapTestTree builds a two-level tree whose every shape moves from
+// (0,0,100x100) to (100,100,200x200), so a lerped channel reads 50 at
+// progress 0.5 and a snapped one keeps its final value.
+func snapTestTree(rootSnap, childSnap AnimFlags) (*Layout, *layoutTransition) {
+	layout := &Layout{
+		Shape: &Shape{ID: "root", X: 100, Y: 100, Width: 200, Height: 200, AnimSnap: rootSnap},
+		Children: []Layout{
+			{Shape: &Shape{ID: "child", X: 100, Y: 100, Width: 200, Height: 200, AnimSnap: childSnap}},
+			{Shape: &Shape{ID: "sibling", X: 100, Y: 100, Width: 200, Height: 200}},
+		},
+	}
+	snap := posSnapshot{x: 0, y: 0, width: 100, height: 100}
+	lt := &layoutTransition{
+		transitionBase: transitionBase{progress: 0.5},
+		snapshots: map[string]posSnapshot{
+			"root":    snap,
+			"child":   snap,
+			"sibling": snap,
+		},
+	}
+	return layout, lt
+}
+
+func checkShape(t *testing.T, name string, s *Shape, x, y, w, h float32) {
+	t.Helper()
+	if s.X != x || s.Y != y || s.Width != w || s.Height != h {
+		t.Errorf("%s = (%g,%g,%gx%g), want (%g,%g,%gx%g)",
+			name, s.X, s.Y, s.Width, s.Height, x, y, w, h)
+	}
+}
+
+func TestApplyTransitionSnapChannels(t *testing.T) {
+	tests := []struct {
+		name       string
+		snap       AnimFlags
+		x, y, w, h float32
+	}{
+		// Zero value must reproduce pre-mask behaviour exactly.
+		{"zero animates everything", 0, 50, 50, 150, 150},
+		{"snap pos", AnimSnapPos, 100, 100, 150, 150},
+		{"snap size", AnimSnapSize, 50, 50, 200, 200},
+		{"snap all", AnimSnapAll, 100, 100, 200, 200},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			layout, lt := snapTestTree(0, tc.snap)
+			applyTransitionRecursive(layout, lt, 0, 0, 0)
+			checkShape(t, "child", layout.Children[0].Shape, tc.x, tc.y, tc.w, tc.h)
+			// The mask is per-shape: an unflagged sibling is untouched.
+			checkShape(t, "sibling", layout.Children[1].Shape, 50, 50, 150, 150)
+		})
+	}
+}
+
+func TestApplyTransitionSnapInherits(t *testing.T) {
+	// A snapped parent snaps its whole subtree even though no child
+	// sets the flag.
+	layout, lt := snapTestTree(AnimSnapAll, 0)
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	checkShape(t, "root", layout.Shape, 100, 100, 200, 200)
+	checkShape(t, "child", layout.Children[0].Shape, 100, 100, 200, 200)
+	checkShape(t, "sibling", layout.Children[1].Shape, 100, 100, 200, 200)
+}
+
+func TestApplyTransitionSnapDoesNotInheritUpward(t *testing.T) {
+	// A snapped child leaves its parent and its siblings animating.
+	layout, lt := snapTestTree(0, AnimSnapAll)
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	checkShape(t, "root", layout.Shape, 50, 50, 150, 150)
+	checkShape(t, "child", layout.Children[0].Shape, 100, 100, 200, 200)
+	checkShape(t, "sibling", layout.Children[1].Shape, 50, 50, 150, 150)
+}
+
+func TestApplyTransitionSnapPartialInheritCombines(t *testing.T) {
+	// Inheritance is a union: parent snaps position, child snaps size,
+	// so the child ends up fully still while the parent still resizes.
+	layout, lt := snapTestTree(AnimSnapPos, AnimSnapSize)
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	checkShape(t, "root", layout.Shape, 100, 100, 150, 150)
+	checkShape(t, "child", layout.Children[0].Shape, 100, 100, 200, 200)
+	checkShape(t, "sibling", layout.Children[1].Shape, 100, 100, 150, 150)
+}
+
+// shiftTestTree is a snapshotted container that slides 0→100 with an
+// ID-less label inside it, positioned 10pt in from the container's final
+// corner. The label must ride the container, not jump ahead of it.
+func shiftTestTree(containerSnap AnimFlags) (*Layout, *layoutTransition) {
+	layout := &Layout{
+		Shape: &Shape{ID: "panel", X: 100, Y: 100, Width: 200, Height: 200, AnimSnap: containerSnap},
+		Children: []Layout{{
+			Shape: &Shape{X: 110, Y: 110, Width: 50, Height: 20},
+			Children: []Layout{{
+				Shape: &Shape{X: 120, Y: 120, Width: 10, Height: 10},
+			}},
+		}},
+	}
+	lt := &layoutTransition{
+		transitionBase: transitionBase{progress: 0.5},
+		snapshots: map[string]posSnapshot{
+			"panel": {x: 0, y: 0, width: 100, height: 100},
+		},
+	}
+	return layout, lt
+}
+
+func TestApplyTransitionShiftsIDLessChildren(t *testing.T) {
+	// Layout coords are absolute, so without the carried shift the
+	// label would sit at its final position while the panel slid.
+	layout, lt := shiftTestTree(0)
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	checkShape(t, "panel", layout.Shape, 50, 50, 150, 150)
+	// Panel moved -50; the label and its own child follow by -50 and
+	// keep their offsets inside the panel (10 and 20).
+	checkShape(t, "label", layout.Children[0].Shape, 60, 60, 50, 20)
+	checkShape(t, "label child", layout.Children[0].Children[0].Shape, 70, 70, 10, 10)
+}
+
+func TestApplyTransitionSnapPosDoesNotShiftChildren(t *testing.T) {
+	// The panel holds its final position, so nothing under it moves.
+	layout, lt := shiftTestTree(AnimSnapPos)
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	checkShape(t, "panel", layout.Shape, 100, 100, 150, 150)
+	checkShape(t, "label", layout.Children[0].Shape, 110, 110, 50, 20)
+}
+
+func TestApplyTransitionOwnSnapshotReplacesShift(t *testing.T) {
+	// A child with its own snapshot must not double-count: the
+	// snapshot is an absolute position and already accounts for where
+	// the ancestor was.
+	layout, lt := shiftTestTree(0)
+	layout.Children[0].Shape.ID = "label"
+	lt.snapshots["label"] = posSnapshot{x: 10, y: 10, width: 50, height: 20}
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	// lerp(10, 110, 0.5) = 60 — the same place the carried shift would
+	// have put it, but derived from the label's own snapshot.
+	checkShape(t, "label", layout.Children[0].Shape, 60, 60, 50, 20)
+	checkShape(t, "label child", layout.Children[0].Children[0].Shape, 70, 70, 10, 10)
+}
+
+func TestApplyTransitionNewShapeRidesAncestorShift(t *testing.T) {
+	// A shape that first appeared this frame has an ID but no
+	// snapshot, so it must still ride the nearest interpolated
+	// ancestor — it appears attached to the panel, not stranded at
+	// its final coordinates.
+	layout, lt := shiftTestTree(0)
+	layout.Children[0].Shape.ID = "new-label"
+	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	checkShape(t, "panel", layout.Shape, 50, 50, 150, 150)
+	checkShape(t, "new label", layout.Children[0].Shape, 60, 60, 50, 20)
 }
 
 func TestLayoutTransitionID(t *testing.T) {

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -187,6 +187,13 @@ type Shape struct {
 	// center.
 	QuarterTurns uint8
 
+	// AnimSnap marks the layout-transition channels this shape snaps
+	// instead of easing. It inherits: applyTransitionRecursive ORs the
+	// mask down the walk, so a snapped shape snaps its whole subtree.
+	// Zero animates everything the active transition covers, which is
+	// why it is safe on every shape that never sets it.
+	AnimSnap AnimFlags
+
 	// fillGen matches scratchPools.fillGen when contentW and
 	// contentH are valid for the current frame. Set during the
 	// fill-height pass; read during position and scroll-offset

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -133,6 +133,13 @@ type ContainerCfg struct {
 	OverDraw     bool
 	Hero         bool
 
+	// AnimSnap holds layout-transition channels still for this
+	// container and everything under it — AnimSnapSize to slide
+	// without stretching, AnimSnapAll to exclude a scroll viewport or
+	// grid body from a transition running elsewhere on screen. Zero
+	// animates normally.
+	AnimSnap AnimFlags
+
 	// Floating
 	Float         bool
 	floatAutoFlip bool
@@ -384,6 +391,7 @@ func buildContainerShape(cfg *ContainerCfg, w *Window) Shape {
 		OverDraw:             cfg.OverDraw,
 		ScrollMode:           cfg.ScrollMode,
 		Hero:                 cfg.Hero,
+		AnimSnap:             cfg.AnimSnap,
 		Wrap:                 cfg.Wrap,
 		Overflow:             cfg.Overflow,
 		Opacity:              cfg.Opacity.Get(1.0),

--- a/gui/view_container_test.go
+++ b/gui/view_container_test.go
@@ -54,6 +54,16 @@ func TestContainerNoIDScrollNoScrollbars(t *testing.T) {
 	}
 }
 
+func TestContainerAnimSnapReachesShape(t *testing.T) {
+	// The mask is only useful if app code can set it; ContainerCfg is
+	// the write-through seam (the same one Hero uses).
+	v := Column(ContainerCfg{ID: "snap", AnimSnap: AnimSnapSize})
+	got := v.GenerateLayout(&Window{}).Shape.AnimSnap
+	if got != AnimSnapSize {
+		t.Errorf("AnimSnap = %d, want %d", got, AnimSnapSize)
+	}
+}
+
 func TestContainerGenerateLayoutShapeIsolation(t *testing.T) {
 	v := Row(ContainerCfg{
 		Content: []View{Text(TextCfg{Text: "a"})},


### PR DESCRIPTION
## Summary

Issue #310 — per-shape snap mask for layout transitions, plus the FLIP subtree shift both transition walks were missing.

### Layout transitions snap channels or subtrees (opt-out)

- New `AnimFlags` mask (`AnimSnapPos` / `AnimSnapSize` / `AnimSnapAll`) on `Shape` and `ContainerCfg` (the same write-through seam `Hero` uses). Zero value animates everything, so no existing caller changes behavior. The mask OR-inherits down the layout walk — a snapped container snaps its whole subtree. `Shape` stays 304 bytes (lands in existing padding).
- Covers "slide, don't stretch" card/grid reflow and holding a scroll viewport or grid body still while chrome animates.

### FLIP subtree shifts (fix)

- `AnimateLayout` only moved shapes with their own snapshot, and layout coordinates are absolute — a sliding container's ID-less `Text` jumped straight to its final position while the container eased under it. The walk now carries the nearest interpolated ancestor's delta and applies it to snapshot-less descendants; a shape with its own snapshot replaces the carried delta (its snapshot is absolute). `AnimSnapPos` zeroes the delta so a snapped container holds its subtree still.
- `HeroTransition` had the identical defect (a morphing card travelled without its label); `applyHeroRecursive` now carries the shift by the same rule.

### Example fix

- `examples/animations`: the seven toolbar buttons all shared one `ID` — a duplicate effective ID made the layout transition lerp every button from whichever wrote the snapshot last. Each button now keys on its label under a scoping `animations_toolbar` row; `TestMainViewNoDuplicateIDs` asserts a clean window. A `snap-pane` demonstrates `AnimSnapSize` beside the easing sidebar.

### Tests

13 new/updated tests across `animation_layout_test.go`, `animation_hero_test.go`, `view_container_test.go`, `examples/animations/main_test.go`: per-channel snap, inheritance (down only), union combination, ID-less child shifts, own-snapshot replacement, new-shape riding, hero mirrors, write-through, duplicate-ID guard.

`make check-all` green locally.
