### PR TITLE
fix(gui): ten widgets forward A11YDescription, ergoaudit a11y gate; docs: prepush gate (issues #316, #319)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,14 @@ Guidance for Claude Code (claude.ai/code) in this repo.
 
 ```
 go run ./examples/get_started/  # run the example app
-make check-all                  # test + lint + vet gates (pre-push)
+make prepush                    # full pre-push gate (race, cross-lint, cross-compile, coverage, export audit)
+make check-all                  # test + lint + vet gates (what .githooks/pre-push runs)
+make check                      # fast subset (vet, deps-doc, large-files, generate-check, tidy-check)
 git config core.hooksPath .githooks  # enable tracked pre-commit/pre-push hooks
 make test                       # tests only
 make lint                       # golangci-lint (pinned version)
 make vet                        # go vet + requiredid analyzer
-make ergonomics-audit                 # focus/callbacks inventory + ID composition
+make ergonomics-audit                 # focus/callbacks inventory + ID/a11y composition
 make export-audit               # exported surface (advisory in-repo)
 ./scripts/large-files.sh        # report Go files >800 lines in gui/
 ```

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,7 @@ ergonomics-audit:
 	go run ./tools/ergonomics-audit/ -mode ids .
 	go run ./tools/ergonomics-audit/ -mode literals .
 	go run ./tools/ergonomics-audit/ -mode theme .
+	go run ./tools/ergonomics-audit/ -mode a11y .
 
 # Insert a generated ID into every broken literal in this repo's tests
 # and examples. Scoped away from gui/ deliberately: go-gui's own widget

--- a/gui/a11y_description_test.go
+++ b/gui/a11y_description_test.go
@@ -1,0 +1,109 @@
+package gui
+
+import "testing"
+
+// TestA11YDescriptionForwarded guards issue #316: every widget whose
+// root shape carries the a11y node must forward A11YDescription from
+// its Cfg into Shape.a11Y. Before the fix these ten widgets accepted
+// the field and silently discarded it — the label travelled, the
+// description never reached the accessibility tree.
+//
+// The widget list is the root-container set: the widgets that delegate
+// to a ContainerCfg carrying their a11y info. Widgets whose a11y node
+// lands on an inner shape (Input, Radio, ...) or is built directly
+// (Skeleton, ProgressBar) forward the pair elsewhere and are covered by
+// their own tests plus the ergonomics-audit a11y mode.
+func TestA11YDescriptionForwarded(t *testing.T) {
+	tests := []struct {
+		name string
+		view func(desc string) View
+	}{
+		{"button", func(d string) View {
+			return Button(ButtonCfg{ID: "b", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		{"toggle", func(d string) View {
+			return Toggle(ToggleCfg{ID: "t", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		{"color picker", func(d string) View {
+			return ColorPicker(ColorPickerCfg{ID: "cp", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		{"combobox", func(d string) View {
+			return Combobox(ComboboxCfg{ID: "cb", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		{"date picker", func(d string) View {
+			return DatePicker(DatePickerCfg{ID: "dp", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		{"date picker roller", func(d string) View {
+			return DatePickerRoller(DatePickerRollerCfg{
+				ID: "dpr", A11YCfg: A11YCfg{A11YDescription: d},
+			})
+		}},
+		{"input date", func(d string) View {
+			return InputDate(InputDateCfg{ID: "id", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		{"numeric input", func(d string) View {
+			return NumericInput(NumericInputCfg{
+				ID: "ni", A11YCfg: A11YCfg{A11YDescription: d},
+			})
+		}},
+		// The stepper path is a second forwarding site: NumericInput
+		// with buttons wraps the field in a Row carrying its own a11y
+		// info, while the default path forwards into the inner Input.
+		{"numeric input steppers", func(d string) View {
+			return NumericInput(NumericInputCfg{
+				ID:      "nis",
+				StepCfg: NumericStepCfg{ShowButtons: true},
+				A11YCfg: A11YCfg{A11YDescription: d},
+			})
+		}},
+		{"listbox", func(d string) View {
+			return ListBox(ListBoxCfg{ID: "lb", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		// The non-virtualized factory path is a second forwarding
+		// site: a focus-disabled ListBox builds its items inline
+		// instead of delegating to listBoxView.
+		{"listbox non-virtualized", func(d string) View {
+			return ListBox(ListBoxCfg{
+				ID: "lbn", FocusDisabled: true,
+				A11YCfg: A11YCfg{A11YDescription: d},
+			})
+		}},
+		{"select", func(d string) View {
+			return Select(SelectCfg{ID: "se", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+		{"table", func(d string) View {
+			return Table(TableCfg{
+				ID:      "tb",
+				Data:    []TableRowCfg{{Cells: []TableCellCfg{{Value: "x"}}}},
+				A11YCfg: A11YCfg{A11YDescription: d},
+			})
+		}},
+		{"theme picker", func(d string) View {
+			return ThemePicker(ThemePickerCfg{
+				ID: "tp", A11YCfg: A11YCfg{A11YDescription: d},
+			})
+		}},
+		// Tree carries its a11y on the root via the explicit a11Y
+		// field (cfg.a11yInfo) rather than a forwarding literal; the
+		// description must travel that path too.
+		{"tree", func(d string) View {
+			return Tree(TreeCfg{ID: "tr", A11YCfg: A11YCfg{A11YDescription: d}})
+		}},
+	}
+
+	const desc = "known description"
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewTestWindow(WindowCfg{})
+			layout := generateViewLayout(tc.view(desc), w)
+			info := layout.Shape.a11Y
+			if info == nil {
+				t.Fatal("root shape has no a11y node")
+			}
+			if info.Description != desc {
+				t.Errorf("Shape.a11Y.Description = %q, want %q",
+					info.Description, desc)
+			}
+		})
+	}
+}

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -84,10 +84,13 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 	}
 
 	ccfg := ContainerCfg{
-		ID:          cfg.ID,
-		Focusable:   !cfg.FocusDisabled,
-		A11YRole:    AccessRoleColorWell,
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, "Color Picker")},
+		ID:        cfg.ID,
+		Focusable: !cfg.FocusDisabled,
+		A11YRole:  AccessRoleColorWell,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, "Color Picker"),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Color:       style.Color,
 		ColorBorder: style.ColorBorder,
 		SizeBorder:  Some(style.SizeBorder),

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -255,10 +255,13 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 	colorBorderFocus := cfg.ColorBorderFocus
 
 	ccfg := ContainerCfg{
-		ID:          cfg.ID,
-		Focusable:   !cfg.FocusDisabled,
-		A11YRole:    AccessRoleComboBox,
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, cfg.Placeholder)},
+		ID:        cfg.ID,
+		Focusable: !cfg.FocusDisabled,
+		A11YRole:  AccessRoleComboBox,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.Placeholder),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Color:       cfg.Color,
 		ColorBorder: cfg.ColorBorder,
 		SizeBorder:  Some(sizeBorder),

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -147,10 +147,13 @@ func (dv *datePickerView) GenerateLayout(w *Window) Layout {
 
 	cfgID := cfg.ID
 	col := Column(ContainerCfg{
-		ID:          cfg.ID,
-		Focusable:   !cfg.FocusDisabled,
-		A11YRole:    AccessRoleGrid,
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, "Date Picker")},
+		ID:        cfg.ID,
+		Focusable: !cfg.FocusDisabled,
+		A11YRole:  AccessRoleGrid,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, "Date Picker"),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Color:       cfg.Colors.Base,
 		ColorBorder: cfg.Colors.Border,
 		SizeBorder:  cfg.SizeBorder,

--- a/gui/view_date_picker_roller.go
+++ b/gui/view_date_picker_roller.go
@@ -75,10 +75,13 @@ func (rv *datePickerRollerView) GenerateLayout(w *Window) Layout {
 	wrapYear := cfg.wrapYear
 
 	return generateViewLayout(container(ContainerCfg{
-		ID:          cfg.ID,
-		Focusable:   cfg.Focusable,
-		A11YRole:    AccessRoleDateField,
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, "Date Roller")},
+		ID:        cfg.ID,
+		Focusable: cfg.Focusable,
+		A11YRole:  AccessRoleDateField,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, "Date Roller"),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Color:       cfg.Color,
 		ColorBorder: cfg.ColorBorder,
 		SizeBorder:  cfg.SizeBorder,

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -189,11 +189,14 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 	}
 
 	col := Column(ContainerCfg{
-		ID:          cfg.ID,
-		Focusable:   !cfg.FocusDisabled,
-		A11YRole:    AccessRoleDateField,
-		A11YState:   a11yReadOnlyState(cfg.ReadOnly),
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, "Date Input")},
+		ID:        cfg.ID,
+		Focusable: !cfg.FocusDisabled,
+		A11YRole:  AccessRoleDateField,
+		A11YState: a11yReadOnlyState(cfg.ReadOnly),
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, "Date Input"),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Color:       cfg.Colors.Base,
 		ColorBorder: cfg.Colors.Border,
 		SizeBorder:  cfg.SizeBorder,

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -89,11 +89,14 @@ func NumericInput(cfg NumericInputCfg) View {
 	}
 
 	return Row(ContainerCfg{
-		ID:          cfg.ID,
-		Focusable:   !cfg.FocusDisabled,
-		A11YRole:    AccessRoleTextField,
-		A11YState:   a11yReadOnlyState(cfg.ReadOnly),
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, cfg.Placeholder)},
+		ID:        cfg.ID,
+		Focusable: !cfg.FocusDisabled,
+		A11YRole:  AccessRoleTextField,
+		A11YState: a11yReadOnlyState(cfg.ReadOnly),
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.Placeholder),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Width:       cfg.Width,
 		Height:      cfg.Height,
 		MinWidth:    cfg.MinWidth,
@@ -177,6 +180,7 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 		ReadOnly:         cfg.ReadOnly,
 		Text:             cfg.Text,
 		Placeholder:      cfg.Placeholder,
+		A11YCfg:          cfg.A11YCfg,
 		Sizing:           sizing,
 		Width:            width,
 		Height:           height,

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -133,9 +133,12 @@ func ListBox(cfg ListBoxCfg) View {
 	}
 
 	return Column(ContainerCfg{
-		ID:         cfg.ID,
-		A11YRole:   AccessRoleList,
-		A11YCfg:    A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, cfg.ID)},
+		ID:       cfg.ID,
+		A11YRole: AccessRoleList,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.ID),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Focusable:  !cfg.FocusDisabled,
 		Scrollable: cfg.Scrollable,
 		OnKeyDown: func(ctx EventCtx) {
@@ -235,9 +238,12 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 	}
 
 	return generateViewLayout(Column(ContainerCfg{
-		ID:          cfg.ID,
-		A11YRole:    AccessRoleList,
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, cfg.ID)},
+		ID:       cfg.ID,
+		A11YRole: AccessRoleList,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.ID),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Focusable:   !cfg.FocusDisabled,
 		Scrollable:  cfg.Scrollable,
 		AmendLayout: listBoxAmendLayout(cache),

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -159,11 +159,14 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 
 	// Build the outer row layout directly.
 	ccfg := ContainerCfg{
-		ID:          cfg.ID,
-		Focusable:   !cfg.FocusDisabled,
-		Clip:        clip,
-		A11YRole:    AccessRoleComboBox,
-		A11YCfg:     A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, cfg.Placeholder)},
+		ID:        cfg.ID,
+		Focusable: !cfg.FocusDisabled,
+		Clip:      clip,
+		A11YRole:  AccessRoleComboBox,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.Placeholder),
+			A11YDescription: cfg.A11YDescription,
+		},
 		Color:       cfg.Color,
 		ColorBorder: cfg.ColorBorder,
 		SizeBorder:  Some(sizeBorder),

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -95,9 +95,12 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 		ID:        cfg.ID,
 		Focusable: cfg.Focusable,
 		A11YRole:  AccessRoleButton,
-		A11YCfg:   A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, "Theme Picker")},
-		Sizing:    cfg.Sizing,
-		Padding:   PaddingSmall,
+		A11YCfg: A11YCfg{
+			A11YLabel:       a11yLabel(cfg.A11YLabel, "Theme Picker"),
+			A11YDescription: cfg.A11YDescription,
+		},
+		Sizing:  cfg.Sizing,
+		Padding: PaddingSmall,
 		OnClick: func(ctx EventCtx) {
 			ss := StateMap[string, bool](ctx.Window, nsSelect, capModerate)
 			ss.Clear()

--- a/gui/view_tree.go
+++ b/gui/view_tree.go
@@ -235,9 +235,11 @@ func (tv *treeView) GenerateLayout(w *Window) Layout {
 	radius := cfg.Radius.Get(defaultTreeStyle.Radius)
 
 	return generateViewLayout(Column(ContainerCfg{
-		ID:         cfg.ID,
-		A11YRole:   AccessRoleTree,
-		A11YCfg:    A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, cfg.ID)},
+		ID:       cfg.ID,
+		A11YRole: AccessRoleTree,
+		// a11y comes from the explicit field: makeContainerA11Y honors
+		// it over the A11YCfg literal, and a11yInfo carries the
+		// caller's description with the label.
 		a11Y:       cfg.a11yInfo(cfg.ID),
 		Focusable:  !cfg.FocusDisabled,
 		Scrollable: cfg.Scrollable,

--- a/tools/ergonomics-audit/a11y.go
+++ b/tools/ergonomics-audit/a11y.go
@@ -1,0 +1,206 @@
+package main
+
+// Mode a11y answers: does any code build an A11YCfg composite literal
+// that forwards the label but drops the description?
+//
+// A11YCfg (gui/a11y_cfg.go) is the embed that every widget Cfg carries
+// its accessible name and description in. Widgets that reach the
+// accessibility tree forward the pair into an inner shape's ContainerCfg
+// — the issue #316 class of bug was ten widgets whose forwarding site
+// spelled A11YCfg{A11YLabel: a11yLabel(...)} and silently omitted
+// A11YDescription. The compiler accepts it, nothing warns, and the
+// description never reaches the accessibility tree: a screen-reader
+// user hears the label and nothing else.
+//
+// A keyed A11YCfg literal is a *forwarding* site when its label comes
+// from the caller — spelled as a selector into the widget's own cfg
+// (cfg.A11YLabel, itemCfg.A11YLabel, a11yLabel(cfg.A11YLabel, ...)).
+// Dropping A11YDescription there is never legitimate: the caller's
+// description either has a value to carry or is empty and costs
+// nothing. (An unkeyed A11YCfg{} is a different thing — the explicit
+// "no a11y fields" embed — and a literal whose label is content-derived
+// — row.Text, col.Title, toastA11YLabel(toast) — has no caller-supplied
+// description to forward, so neither flags.) This mode makes the
+// forwarding class of bug a compile-time gate.
+//
+// Findings exit non-zero, so the audit gates like modes ids and opt.
+// The whole tree is scanned — examples and tests build the same
+// literals as gui/ — except the definition file gui/a11y_cfg.go.
+//
+// Spelling notes: A11YCfg: cfg.A11YCfg is a value copy, not a
+// composite literal, so it never flags (that is the correct spelling
+// where no label fallback exists). At a forwarding site a deliberately
+// description-less literal is still a bug by the rule above — write
+// the key explicitly with the empty string if one must be sentinel.
+// Known gap: a positional A11YCfg{label} literal drops the description
+// with no key to inspect; the repo's keyed-literal convention keeps
+// this out of the code, so the mode does not chase it.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"sort"
+)
+
+// a11yCfgDefFile is the definition of the type; its own literals (in
+// doc comments) are the type's canonical spelling, never forwarding
+// sites.
+const a11yCfgDefFile = "gui/a11y_cfg.go"
+
+// a11yFinding is one A11YCfg literal that forwards a label but drops
+// the description.
+type a11yFinding struct {
+	path string
+	line int
+	text string
+}
+
+// runA11Y reports every forwarding A11YCfg literal — one whose label
+// is sourced from a caller's .A11YLabel — that omits the
+// A11YDescription key, in each repo's tree. Any finding exits non-zero.
+func runA11Y(repos []string) error {
+	var findings []a11yFinding
+	for _, repo := range repos {
+		found, err := scanA11YCfgLiterals(repo)
+		if err != nil {
+			return err
+		}
+		findings = append(findings, found...)
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].path != findings[j].path {
+			return findings[i].path < findings[j].path
+		}
+		return findings[i].line < findings[j].line
+	})
+
+	fmt.Printf("A11YCfg forwarding audit (%d finding(s))\n", len(findings))
+	for _, f := range findings {
+		fmt.Printf("%s:%d: %s forwards the label but drops A11YDescription —\n",
+			f.path, f.line, f.text)
+		fmt.Println("    the description never reaches the accessibility tree.")
+	}
+	if len(findings) > 0 {
+		fmt.Println()
+		return fmt.Errorf("%d A11YCfg literal(s) drop the description", len(findings))
+	}
+	return nil
+}
+
+// scanA11YCfgLiterals walks one repo's whole tree for forwarding
+// A11YCfg literals missing the A11YDescription key.
+func scanA11YCfgLiterals(repo string) ([]a11yFinding, error) {
+	var findings []a11yFinding
+	err := walkGo(repo, func(path string, fset *token.FileSet, f *ast.File) {
+		inspectA11YCfgLiterals(fset, f, relPath(repo, path), &findings)
+	})
+	return findings, err
+}
+
+// inspectA11YCfgLiterals walks one parsed file and appends findings.
+// Split out from scanA11YCfgLiterals so the rules can be exercised
+// against in-memory source in tests.
+func inspectA11YCfgLiterals(
+	fset *token.FileSet, f *ast.File, rel string, findings *[]a11yFinding,
+) {
+	if rel == a11yCfgDefFile {
+		return
+	}
+	ast.Inspect(f, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if !isA11YCfgLiteral(lit) {
+			return true
+		}
+		// A11YCfg{} with no elements is the explicit "no a11y fields"
+		// embed — nothing is forwarded, so nothing can be dropped.
+		if len(lit.Elts) == 0 {
+			return true
+		}
+		if hasA11YDescriptionKey(lit) {
+			return true
+		}
+		// Only forwarding literals flag: the label must come from a
+		// caller's .A11YLabel selector (cfg.A11YLabel, itemCfg.A11YLabel,
+		// a11yLabel(cfg.A11YLabel, ...)). A content-derived label —
+		// row.Text, col.Title, toastA11YLabel(toast) — has no caller
+		// description to forward, so it never flags.
+		if !forwardsCallerLabel(lit) {
+			return true
+		}
+		*findings = append(*findings, a11yFinding{
+			path: rel,
+			line: fset.Position(lit.Pos()).Line,
+			text: renderLit(lit),
+		})
+		return true
+	})
+}
+
+// isA11YCfgLiteral reports whether a composite literal names A11YCfg.
+// Bare idents match (in-package gui code); qualified forms match only
+// when the package part is gui or its gg alias — a foreign type of
+// the same name is a different type and never flags.
+func isA11YCfgLiteral(lit *ast.CompositeLit) bool {
+	switch t := lit.Type.(type) {
+	case *ast.Ident:
+		return t.Name == "A11YCfg"
+	case *ast.SelectorExpr:
+		id, ok := t.X.(*ast.Ident)
+		if !ok || (id.Name != "gui" && id.Name != "gg") {
+			return false
+		}
+		return t.Sel.Name == "A11YCfg"
+	}
+	return false
+}
+
+// hasA11YDescriptionKey reports whether the literal names the
+// A11YDescription field, whether or not it is empty.
+func hasA11YDescriptionKey(lit *ast.CompositeLit) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if id, ok := kv.Key.(*ast.Ident); ok &&
+			id.Name == "A11YDescription" {
+			return true
+		}
+	}
+	return false
+}
+
+// forwardsCallerLabel reports whether any label expression in the
+// literal references a caller's A11YLabel — a selector whose Sel is
+// exactly A11YLabel (cfg.A11YLabel, itemCfg.A11YLabel), including
+// inside a fallback call like a11yLabel(cfg.A11YLabel, ...). Such a
+// literal forwards caller identity, so it must forward the caller's
+// description too.
+func forwardsCallerLabel(lit *ast.CompositeLit) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if id, ok := kv.Key.(*ast.Ident); !ok || id.Name != "A11YLabel" {
+			continue
+		}
+		found := false
+		ast.Inspect(kv.Value, func(n ast.Node) bool {
+			if sel, ok := n.(*ast.SelectorExpr); ok &&
+				sel.Sel.Name == "A11YLabel" {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/ergonomics-audit/a11y_test.go
+++ b/tools/ergonomics-audit/a11y_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// scanA11ySrc runs the a11y-mode rules over one in-memory file and
+// returns the finding texts in source order, so a case can be written
+// as source.
+func scanA11ySrc(t *testing.T, rel, src string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, rel, src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var found []a11yFinding
+	inspectA11YCfgLiterals(fset, f, rel, &found)
+	out := make([]string, len(found))
+	for i, x := range found {
+		out[i] = x.text
+	}
+	return out
+}
+
+func TestA11YFlagsLabelOnlyForwardingLiteral(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+
+var a = A11YCfg{A11YLabel: cfg.A11YLabel}
+var b = gui.A11YCfg{A11YLabel: cfg.A11YLabel}
+var c = gg.A11YCfg{A11YLabel: a11yLabel(cfg.A11YLabel, "x")}
+var d = A11YCfg{A11YLabel: cfg.A11YLabel, A11YDescription: "y"}
+var e = A11YCfg{}
+var f = A11YCfg{A11YLabel: "literal string"}
+var g = A11YCfg{A11YLabel: row.Text}
+var h = A11YCfg{A11YLabel: toastA11YLabel(toast)}
+`
+	findings := scanA11ySrc(t, "x.go", src)
+	want := "A11YCfg{...} gui.A11YCfg{...} gg.A11YCfg{...}"
+	if len(findings) != 3 || (findings[0]+" "+findings[1]+" "+findings[2]) != want {
+		t.Fatalf("findings = %q, want %q", findings, want)
+	}
+}
+
+func TestA11YFlagsForeignTypeNever(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+
+var a = glyph.A11YCfg{A11YLabel: cfg.A11YLabel}
+var b = Widget{A11YCfg: gui.A11YCfg{A11YLabel: cfg.A11YLabel}}
+`
+	findings := scanA11ySrc(t, "x.go", src)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %q, want the nested gui literal only", findings)
+	}
+	if findings[0] != "gui.A11YCfg{...}" {
+		t.Fatalf("finding = %q, want gui.A11YCfg{...}", findings[0])
+	}
+}
+
+func TestA11YSkipsDefinitionFile(t *testing.T) {
+	t.Parallel()
+	const src = `package gui
+
+// doc example: A11YCfg{A11YLabel: "Save"}
+var d = A11YCfg{A11YLabel: "Save"}
+`
+	findings := scanA11ySrc(t, a11yCfgDefFile, src)
+	if len(findings) != 0 {
+		t.Fatalf("findings = %q, want none (definition file is exempt)", findings)
+	}
+}
+
+func TestA11YFindingsCarryLineNumbers(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+
+func f() {
+	var x = A11YCfg{A11YLabel: cfg.A11YLabel}
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var found []a11yFinding
+	inspectA11YCfgLiterals(fset, f, "x.go", &found)
+	if len(found) != 1 || found[0].line != 4 {
+		t.Fatalf("findings = %+v, want one finding at line 4", found)
+	}
+}

--- a/tools/ergonomics-audit/main.go
+++ b/tools/ergonomics-audit/main.go
@@ -10,6 +10,7 @@
 //	go run ./tools/ergonomics-audit/ -mode opt [repo...]
 //	go run ./tools/ergonomics-audit/ -mode literals [repo...]
 //	go run ./tools/ergonomics-audit/ -mode theme [repo...]
+//	go run ./tools/ergonomics-audit/ -mode a11y [repo...]
 //
 // With no repo arguments both modes audit the current directory.
 //
@@ -51,6 +52,11 @@
 // raw composite literal instead of a constructor, silently reading as
 // unset? It exits non-zero on any finding, so it gates. See literals.go.
 //
+// Mode a11y answers: does any code build a keyed A11YCfg literal that
+// forwards the label but drops the description, so a description never
+// reaches the accessibility tree? It exits non-zero on any finding, so
+// it gates. See a11y.go.
+//
 // All modes parse with go/ast: composite literals and func literals
 // span lines, and regex cannot bracket-match them.
 package main
@@ -70,7 +76,7 @@ import (
 var listShape *string
 
 func main() {
-	mode := flag.String("mode", "focus", "audit to run: focus | callbacks | ids | opt | literals | theme")
+	mode := flag.String("mode", "focus", "audit to run: focus | callbacks | ids | opt | literals | theme | a11y")
 	guiRoot := flag.String("gui", ".", "path to the go-gui repo (source of truth for mode=focus)")
 	listShape = flag.String("list", "", "mode=callbacks: also list distinct signatures of this shape, or \"all\"")
 	fix := flag.Bool("fix", false, "mode=focus: rewrite broken literals in place, adding a generated ID")
@@ -110,8 +116,10 @@ func main() {
 		err = runLiterals(repos)
 	case "theme":
 		err = runTheme(repos)
+	case "a11y":
+		err = runA11Y(repos)
 	default:
-		err = fmt.Errorf("unknown -mode %q (want focus, callbacks, ids, opt, literals or theme)", *mode)
+		err = fmt.Errorf("unknown -mode %q (want focus, callbacks, ids, opt, literals, theme or a11y)", *mode)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "ergonomics-audit:", err)


### PR DESCRIPTION
## issue #316 — A11YDescription silently discarded by ten widgets

Ten widgets accepted `A11YDescription` and dropped it: the label travelled into the a11y tree, the description never did. All ten delegating sites now forward the pair. Two sites beyond the issue's probe (which read only root shapes) were also broken:

- `NumericInput`'s default path (no steppers) returns the inner `Input` directly and never forwarded `A11YCfg` at all — label *and* description dropped.
- `Tree` carried a dead `A11YCfg` literal overridden by its explicit `a11Y: cfg.a11yInfo(cfg.ID)` field; removed.

**Guards:**
- `gui/a11y_description_test.go` — table test over the root-container widgets (incl. both ListBox paths, both NumericInput paths, Tree's explicit-field path) asserting the description survives into `Shape.a11Y.Description`.
- `tools/ergonomics-audit` `-mode a11y` (new, wired into `make ergonomics-audit`) — flags keyed `A11YCfg` literals that forward a caller's `.A11YLabel` but omit `A11YDescription`. Content-derived labels (`row.Text`, `col.Title`) are exempt: no caller description exists to forward.

## issue #319 — CLAUDE.md mislabeled the pre-push gate

`make check-all` was annotated as the pre-push gate; `make prepush` (the full gate: race, cross-lint, cross-compile, coverage, export audit) was never mentioned. Commands block now names `prepush` as the gate and `check-all` as what `.githooks/pre-push` runs.

Verified: `make prepush` green, `make ergonomics-audit` green.