### PR TITLE
fix(buildapp): -sign flag so rebuilds keep TCC grants (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`buildapp` ad-hoc signing silently revoked every TCC grant on each
+  rebuild.** The tool hard-coded `codesign -s -`, and an ad-hoc signature
+  carries no certificate and no team identifier, so TCC keys its grant on the
+  cdhash — which changes every build. Screen recording, microphone, camera,
+  accessibility, input monitoring and full disk access were all dropped on every
+  `make app`, while the System Settings row survived (that list is keyed by
+  bundle id, the authorization check by cdhash), so the permission looked
+  granted and the API returned denied. New `-sign <identity>` flag, defaulting
+  to `$BUILDAPP_SIGN_IDENTITY` and then to `-`, so existing callers are
+  unchanged and anyone with a self-signed code-signing certificate keeps grants
+  across rebuilds. The `-bundle-deps` re-sign now reports `codesign`'s own
+  output instead of a bare exit status. See `cmd/buildapp/README.md` § Signing
+  (issue #303).
+
 ## [v0.61.0] - 2026-08-15
 
 ### Changed
 
-- **go-glyph bumped v1.21.0 → v1.22.0.** Brings `backend/ebitengine` out of
-  the root module into its own module (same import path), so ebiten and the
-  `oto/v3` audio stack drop out of the dependency graph for every go-gui
-  consumer. Also adds a `make prepush` gate on the glyph side.
+- **go-glyph bumped v1.21.0 → v1.22.0.** Brings `backend/ebitengine` out of the
+  root module into its own module (same import path), so ebiten and the `oto/v3`
+  audio stack drop out of the dependency graph for every go-gui consumer. Also
+  adds a `make prepush` gate on the glyph side.
 
 ### Fixed
 

--- a/cmd/buildapp/README.md
+++ b/cmd/buildapp/README.md
@@ -19,19 +19,95 @@ go run ./cmd/buildapp [flags] <binary>
 ## Usage
 
 ```
-buildapp [-o outdir] [-name Name] [-id bundle.id] [-icon icon.png|.icns] [-version 1.0] <binary>
+buildapp [-o outdir] [-name Name] [-id bundle.id] [-icon icon.png|.icns] [-version 1.0] [-sign identity] <binary>
 ```
 
 Positional arg: path to a compiled Mach-O executable.
 
-| Flag           | Default                 | Purpose                                             |
-| -------------- | ----------------------- | --------------------------------------------------- |
-| `-o`           | `.`                     | Output directory                                    |
-| `-name`        | binary basename, capped | Bundle display name                                 |
-| `-id`          | `local.gogui.<name>`    | `CFBundleIdentifier`                                |
-| `-icon`        | none                    | `.png` (auto-converted) or `.icns`                  |
-| `-version`     | `1.0`                   | `CFBundleVersion` / short version                   |
-| `-bundle-deps` | `false`                 | Bundle non-system dylibs into `Contents/Frameworks` |
+| Flag           | Default                        | Purpose                                             |
+| -------------- | ------------------------------ | --------------------------------------------------- |
+| `-o`           | `.`                            | Output directory                                    |
+| `-name`        | binary basename, capped        | Bundle display name                                 |
+| `-id`          | `local.gogui.<name>`           | `CFBundleIdentifier`                                |
+| `-icon`        | none                           | `.png` (auto-converted) or `.icns`                  |
+| `-version`     | `1.0`                          | `CFBundleVersion` / short version                   |
+| `-bundle-deps` | `false`                        | Bundle non-system dylibs into `Contents/Frameworks` |
+| `-sign`        | `$BUILDAPP_SIGN_IDENTITY`, `-` | `codesign` identity; `-` is ad-hoc                  |
+
+### Signing
+
+`buildapp` always signs the bundle. An unsigned bundle makes Gatekeeper report
+the app as "damaged", even when every binary inside is individually signed, and
+an unsigned Mach-O does not load at all on Apple Silicon.
+
+The default identity is `-`, which is **ad-hoc**: no certificate, no team
+identifier.
+
+```
+Signature=adhoc
+TeamIdentifier=not set
+CDHash=6ec1c5c95e15276640294221cfd868ab6e073487
+```
+
+An ad-hoc signature gives TCC (the macOS privacy database) no designated
+requirement to key a grant against, so TCC falls back to the **cdhash**. Every
+rebuild produces a new cdhash, so **every rebuild silently revokes every
+TCC-gated permission the app holds** — screen recording, microphone, camera,
+accessibility, input monitoring, full disk access.
+
+The failure is actively misleading: the System Settings row survives, because
+that list is keyed by bundle id for display, while the authorization check is
+keyed by cdhash. The permission looks granted and the API returns denied, with
+nothing in any log connecting the two. Recovery is
+`tccutil reset <service> <bundle-id>`, a relaunch, and a re-grant — after every
+build.
+
+Pass a stable identity to key the grant on the certificate instead of the hash:
+
+```
+buildapp -sign "My Dev Cert" ...
+```
+
+or set it once per machine (fish):
+
+```fish
+set -Ux BUILDAPP_SIGN_IDENTITY "My Dev Cert"
+```
+
+`-sign` wins over the environment variable. A **self-signed** code-signing
+certificate is enough; no Apple Developer account is needed. Create one in
+Keychain Access → Certificate Assistant → Create a Certificate, with type "Code
+Signing", then confirm it is visible to `codesign`:
+
+```
+security find-identity -v -p codesigning
+```
+
+Verify what a bundle actually carries:
+
+```
+codesign -dv --verbose=4 Foo.app
+```
+
+Ad-hoc prints `Signature=adhoc`; a real identity prints an `Authority=` line. To
+confirm the TCC fix end to end, grant the app a permission, rebuild, and check
+the permission still works without a re-grant.
+
+This was verified on macOS 26 with a self-signed certificate: Falcon
+(`github.com.go-gui-org.go-term`) kept its Screen Recording grant across a
+rebuild that moved the cdhash from `573a437d…` to `bfa13ddf…`, with
+`TeamIdentifier=not set` throughout. A certificate is enough; an Apple-issued
+one is not required.
+
+Release builds in CI have no certificate and stay ad-hoc. That is fine — freshly
+downloaded apps have no grants to lose.
+
+The bundle-level signature uses `codesign --force --deep`. Apple deprecates
+`--deep` for distribution signing; it is kept here because the bundle carries no
+entitlements and no nested code beyond `Contents/Frameworks` (already signed
+inside-out by `-bundle-deps`), so re-signing those with the same identity costs
+nothing. Entitlements and hardened runtime are not supported — run `codesign`
+and `notarytool` separately for distribution.
 
 ### `-bundle-deps`
 
@@ -44,8 +120,9 @@ copies every non-system dylib (anything outside `/usr/lib`, `/System/Library`,
   `@rpath/<basename>`
 - add `@executable_path/../Frameworks` as an rpath on the executable
 
-Transitive dependencies are followed. Every modified Mach-O file is ad-hoc
-re-signed with `codesign -s -` (required on Apple Silicon). Requires `otool`,
+Transitive dependencies are followed. `install_name_tool` invalidates each
+signature it touches, so every modified Mach-O file is re-signed with the
+`-sign` identity (required on Apple Silicon). Requires `otool`,
 `install_name_tool`, and `codesign` (Xcode Command Line Tools).
 
 Verify a clean bundle:
@@ -82,6 +159,7 @@ GetStarted.app/
 
 - macOS only.
 - Existing `.app` at the destination is overwritten without prompting.
-- No code signing is performed. For Gatekeeper-friendly distribution, run
-  `codesign` and `notarytool` separately.
-- Shared libraries are not bundled; the target machine must have them installed.
+- The bundle is always signed — ad-hoc by default, see [Signing](#signing).
+  Notarization is not performed; run `notarytool` separately for distribution.
+- Shared libraries are bundled only with `-bundle-deps`. Without it the target
+  machine must have them installed.

--- a/cmd/buildapp/main.go
+++ b/cmd/buildapp/main.go
@@ -2,7 +2,8 @@
 //
 // Usage:
 //
-//	buildapp [-o outdir] [-name Name] [-id bundle.id] [-icon icon.png] <binary>
+//	buildapp [-o outdir] [-name Name] [-id bundle.id] [-icon icon.png]
+//	         [-sign identity] <binary>
 package main
 
 import (
@@ -27,7 +28,17 @@ type bundleOpts struct {
 	Icon       string
 	Version    string
 	BundleDeps bool
+	// SignID is the codesign identity ("-" = ad-hoc).  Empty is treated
+	// as "-" so a zero-valued bundleOpts keeps the historical behaviour.
+	SignID string
 }
+
+// envSignIdentity supplies the -sign default, so a developer with a
+// certificate can set it once per machine instead of per Makefile.
+const envSignIdentity = "BUILDAPP_SIGN_IDENTITY"
+
+// adHocIdentity is codesign's spelling of "sign with no certificate".
+const adHocIdentity = "-"
 
 const infoPlistTmpl = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -64,6 +75,8 @@ func run() error {
 	flag.StringVar(&o.Version, "version", "1.0", "bundle version")
 	flag.BoolVar(&o.BundleDeps, "bundle-deps", false,
 		"copy non-system dylibs into Contents/Frameworks and rewrite paths")
+	flag.StringVar(&o.SignID, "sign", defaultSignIdentity(),
+		"codesign identity; \"-\" is ad-hoc, which drops TCC grants on every rebuild (see README)")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: buildapp [flags] <binary>\n")
 		flag.PrintDefaults()
@@ -75,6 +88,22 @@ func run() error {
 	}
 	o.Binary = flag.Arg(0)
 	return build(o)
+}
+
+// defaultSignIdentity resolves the -sign default from the environment,
+// falling back to ad-hoc.  An explicit -sign wins because flag.Parse
+// overwrites the default.
+func defaultSignIdentity() string {
+	return signIdentityOr(os.Getenv(envSignIdentity))
+}
+
+// signIdentityOr maps an unset identity onto ad-hoc.  Used for both the
+// env default and for programmatic callers that leave SignID empty.
+func signIdentityOr(id string) string {
+	if id == "" {
+		return adHocIdentity
+	}
+	return id
 }
 
 // #nosec G301 — standard macOS .app bundle permissions
@@ -89,6 +118,7 @@ func build(o bundleOpts) error {
 	if o.ID == "" {
 		o.ID = "local.gogui." + strings.ToLower(o.Name)
 	}
+	o.SignID = signIdentityOr(o.SignID)
 
 	stage, err := os.MkdirTemp("", "buildapp-*")
 	if err != nil {
@@ -125,15 +155,15 @@ func build(o bundleOpts) error {
 	}
 
 	if o.BundleDeps {
-		if err = bundleDeps(stagedBin, contents); err != nil {
+		if err = bundleDeps(stagedBin, contents, o.SignID); err != nil {
 			return fmt.Errorf("bundle deps: %w", err)
 		}
 	}
 
-	// Sign the entire .app bundle (ad-hoc).  Without a bundle-level
-	// signature macOS Gatekeeper reports the app as damaged even when
-	// individual binaries inside are signed.
-	if err = signBundle(appDir); err != nil {
+	// Sign the entire .app bundle.  Without a bundle-level signature
+	// macOS Gatekeeper reports the app as damaged even when individual
+	// binaries inside are signed.
+	if err = signBundle(appDir, o.SignID); err != nil {
 		return fmt.Errorf("sign bundle: %w", err)
 	}
 
@@ -278,10 +308,10 @@ func moveDir(src, dst string) error {
 
 // bundleDeps copies non-system dylibs referenced by binary into
 // Contents/Frameworks, rewrites all install names to @rpath form, adds
-// an rpath of @executable_path/../Frameworks, and ad-hoc re-signs every
-// modified file. Recurses through transitive dependencies.
+// an rpath of @executable_path/../Frameworks, and re-signs every
+// modified file with signID. Recurses through transitive dependencies.
 // #nosec G204,G301 — build tool, args from otool output on own binaries
-func bundleDeps(binary, contents string) error {
+func bundleDeps(binary, contents, signID string) error {
 	for _, tool := range []string{"otool", "install_name_tool", "codesign"} {
 		if _, err := exec.LookPath(tool); err != nil {
 			return fmt.Errorf("%s not found", tool)
@@ -335,14 +365,19 @@ func bundleDeps(binary, contents string) error {
 		return fmt.Errorf("add_rpath: %w", err)
 	}
 
-	// ad-hoc re-sign everything we touched
+	// re-sign everything we touched: install_name_tool invalidates the
+	// existing signature, and an unsigned Mach-O will not load on Apple
+	// Silicon.  Capture codesign's output — with a caller-supplied
+	// identity the usual failure is "identity not found", which is
+	// unreadable from the exit status alone.
 	signTargets := []string{binary}
 	for _, base := range copied {
 		signTargets = append(signTargets, filepath.Join(fw, base))
 	}
 	for _, t := range signTargets {
-		if err := exec.Command("codesign", "-s", "-", "--force", t).Run(); err != nil {
-			return fmt.Errorf("codesign %s: %w", t, err)
+		cmd := exec.Command("codesign", "-s", signID, "--force", t)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("codesign %s: %v: %s", t, err, out)
 		}
 	}
 	return nil
@@ -384,15 +419,28 @@ func otoolDeps(path string) ([]string, error) {
 	return deps, nil
 }
 
-// signBundle ad-hoc signs the entire .app bundle.  A missing
+// signBundle signs the entire .app bundle with signID.  A missing
 // bundle-level signature causes Gatekeeper to report the app as
 // "damaged" even when every binary inside is individually signed.
+//
+// signID "-" is ad-hoc: no certificate, no team identifier, so TCC has
+// no designated requirement to key a grant against and falls back to the
+// cdhash.  The cdhash changes on every rebuild, so every ad-hoc rebuild
+// silently revokes screen recording, microphone, camera, accessibility
+// and friends — see README, "Signing".  Pass a real identity to keep
+// grants across rebuilds.
+//
+// --deep re-signs the nested code under Contents/Frameworks that
+// bundleDeps already signed.  Apple deprecates it for distribution
+// signing; it is kept here because the bundle carries no entitlements
+// and no nested code beyond those dylibs, so a same-identity re-sign
+// costs nothing.
 // #nosec G204 — build tool, appDir from temp dir
-func signBundle(appDir string) error {
+func signBundle(appDir, signID string) error {
 	if _, err := exec.LookPath("codesign"); err != nil {
 		return errors.New("codesign not found")
 	}
-	cmd := exec.Command("codesign", "-s", "-", "--force", "--deep", appDir)
+	cmd := exec.Command("codesign", "-s", signID, "--force", "--deep", appDir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%v: %s", err, out)
 	}

--- a/cmd/buildapp/main_test.go
+++ b/cmd/buildapp/main_test.go
@@ -303,6 +303,70 @@ func TestBundleDepsOnStub(t *testing.T) {
 	}
 }
 
+func TestSignIdentityOr(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"", "-"},
+		{"-", "-"},
+		{"My Dev Cert", "My Dev Cert"},
+	} {
+		if got := signIdentityOr(tc.in); got != tc.want {
+			t.Errorf("signIdentityOr(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDefaultSignIdentityFromEnv(t *testing.T) {
+	t.Setenv(envSignIdentity, "")
+	if got := defaultSignIdentity(); got != "-" {
+		t.Errorf("unset env: got %q, want %q", got, "-")
+	}
+	t.Setenv(envSignIdentity, "Env Cert")
+	if got := defaultSignIdentity(); got != "Env Cert" {
+		t.Errorf("env set: got %q, want %q", got, "Env Cert")
+	}
+}
+
+// A zero-valued bundleOpts must keep signing ad-hoc, the behaviour every
+// caller had before -sign existed.
+func TestBuildDefaultsToAdHoc(t *testing.T) {
+	bin := buildStubBinary(t)
+	if _, err := exec.LookPath("codesign"); err != nil {
+		t.Skip("codesign not available")
+	}
+	outDir := t.TempDir()
+	if err := build(bundleOpts{Binary: bin, OutDir: outDir, Version: "1.0"}); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	// codesign -dv writes its report to stderr.
+	out, err := exec.Command("codesign", "-dv",
+		filepath.Join(outDir, "Stub.app")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("codesign -dv: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), "Signature=adhoc") {
+		t.Errorf("expected an ad-hoc signature, got:\n%s", out)
+	}
+}
+
+// An unknown identity must fail loudly and carry codesign's own message,
+// which is the only readable diagnosis of a mistyped certificate name.
+func TestBuildUnknownIdentityErrors(t *testing.T) {
+	bin := buildStubBinary(t)
+	if _, err := exec.LookPath("codesign"); err != nil {
+		t.Skip("codesign not available")
+	}
+	err := build(bundleOpts{
+		Binary: bin, OutDir: t.TempDir(), Version: "1.0",
+		SignID: "buildapp-no-such-identity",
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown signing identity")
+	}
+	if !strings.Contains(err.Error(), "buildapp-no-such-identity") {
+		t.Errorf("error should quote codesign's output, got: %v", err)
+	}
+}
+
 func TestWritePlistOmitsEmptyIcon(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "Info.plist")
 	if err := writePlist(p, "stub", "id", "Stub", "1.0", ""); err != nil {


### PR DESCRIPTION
Fixes #303.

## The bug

`buildapp` hard-coded `codesign -s -`. An ad-hoc signature carries no certificate and no team identifier, so TCC has no designated requirement to key a grant against and falls back to the **cdhash** — which changes on every build.

Every `make app` therefore silently revoked screen recording, microphone, camera, accessibility, input monitoring and full disk access. The failure is actively misleading: the System Settings row survives (that list is keyed by bundle id for display) while the authorization check is keyed by cdhash, so the permission looks granted and the API returns denied, with nothing in any log connecting the two. Recovery was `tccutil reset` plus a relaunch and re-grant — after every build.

## The fix

`-sign <identity>`, defaulting to `$BUILDAPP_SIGN_IDENTITY` and then to `-`. Existing callers are unchanged; anyone with a certificate opts in:

```
buildapp -sign "My Dev Cert" ...
```

Threaded to both call sites through `bundleOpts`. An empty `SignID` maps to ad-hoc, so programmatic callers and existing tests keep working.

Also in scope:

- The `-bundle-deps` re-sign loop used `.Run()`, discarding codesign's stderr. With a caller-supplied identity the usual failure is "identity not found", which was invisible from the exit status alone — now `CombinedOutput()`.
- Two stale README notes claimed no signing is performed and no libraries are bundled. Both contradicted the code (`signBundle` is unconditional; `-bundle-deps` exists).
- New `### Signing` section explaining the cdhash-vs-bundle-id split, self-signed certificate setup, and verification commands.

`--deep` is kept. Apple deprecates it for distribution signing, but the bundle carries no entitlements and no nested code beyond `Contents/Frameworks` (already signed inside-out by `-bundle-deps`), so a same-identity re-sign costs nothing. Entitlements and hardened runtime stay out of scope.

## Verification

`make lint` clean, `go test ./cmd/buildapp/...` passes. Four new tests: identity resolution table, env-default resolution, zero-valued `bundleOpts` still produces `Signature=adhoc`, and an unknown identity errors with codesign's own message.

End to end on macOS 26 with a **self-signed** certificate — Falcon (`github.com.go-gui-org.go-term`) kept its Screen Recording grant across a rebuild:

| | cdhash | Authority | TeamIdentifier |
|---|---|---|---|
| before rebuild | `573a437de4c756…` | `Go-Gui Dev` | not set |
| after rebuild | `bfa13ddf49ccc9…` | `Go-Gui Dev` | not set |

`screencapture` succeeded in the rebuilt app with no re-prompt. This settles the open question on the issue: a self-signed certificate is enough, no Apple Developer account required.

CI cannot test the signed path — no certificate exists there — so the identity tests assert failure modes only.

## Consumers

Sibling Makefiles get an overridable `SIGN_IDENTITY` (empty by default) in separate PRs: go-term, go-edit, go-kite. go-edit and go-kite build `buildapp` from `../go-gui` and work as soon as this merges; go-term resolves it through `go.work` locally but through its `go.mod` pin in CI, so that one needs a go-gui release first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)