### PR TITLE
feat(gui): shared disclosureArrow for ExpandPanel, Combobox, Select

### DIFF
--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -188,14 +188,7 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		}),
 	)
 
-	arrowText := "▼"
-	if isOpen {
-		arrowText = "▲"
-	}
-	content = append(content, Text(TextCfg{
-		Text:      arrowText,
-		TextStyle: cfg.TextStyle,
-	}))
+	content = append(content, disclosureArrow(isOpen, cfg.TextStyle))
 
 	if isOpen {
 		viewKey := comboboxViewKey{
@@ -272,6 +265,7 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		MaxWidth:    cfg.MaxWidth,
 		Disabled:    cfg.Disabled,
 		axis:        axisLeftToRight,
+		VAlign:      VAlignMiddle,
 		AmendLayout: func(ctx EventCtx) {
 			if ctx.Layout.Shape.Disabled {
 				return

--- a/gui/view_disclosure_arrow.go
+++ b/gui/view_disclosure_arrow.go
@@ -1,0 +1,57 @@
+package gui
+
+// disclosureArrowScale shrinks the disclosure triangle relative to the
+// widget's body text. U+25BC/U+25B2 are full-width geometric glyphs that
+// fill nearly the whole em box, so drawn at the label's size the wedge
+// reads as an oversized graphic rather than an affordance. Roughly
+// three-fifths of the body size matches the optical weight of the arrow
+// native controls draw.
+const disclosureArrowScale float32 = 0.6
+
+// disclosureArrowNudge corrects the triangle's optical center, as a
+// fraction of the arrow's own font size. Centering aligns line boxes,
+// not ink: the box runs from the ascent down to the descent, while the
+// triangle's ink stops at the baseline, so the wedge sits about a half
+// descent above the true middle. The padding goes on the top only; the
+// middle alignment then re-centers the taller box, which moves the ink
+// down by half this fraction.
+const disclosureArrowNudge float32 = 0.2
+
+// disclosureArrow builds the open/closed triangle shared by ExpandPanel,
+// Combobox and Select. style is the widget's body text style; only the
+// size is altered, so the arrow keeps the label's color, family and
+// typeface.
+//
+// The shrunken glyph's line box is shorter than the label's, so the
+// container holding both must set VAlign: VAlignMiddle — with the
+// default top alignment the arrow rides against the top of the row.
+func disclosureArrow(open bool, style TextStyle) View {
+	text := "▼"
+	if open {
+		text = "▲"
+	}
+	// Resolve the default here rather than leaving it to Text(): Text
+	// substitutes the full medium size when Size is zero, which would
+	// land after the scale had already been applied to a zero. Mirror
+	// Text()'s substitution exactly: a fully zero style gets the whole
+	// DefaultTextStyle (family and color too), a style with fields but
+	// zero Size only gets the size.
+	if style == (TextStyle{}) {
+		style = DefaultTextStyle
+	}
+	if style.Size == 0 {
+		style.Size = sizeTextMedium
+	}
+	style.Size *= disclosureArrowScale
+	// The wrapper exists only to carry the optical-center padding; Text
+	// has no vertical offset of its own.
+	return Row(ContainerCfg{
+		Padding: NewPadding(style.Size*disclosureArrowNudge, 0, 0, 0),
+		Content: []View{
+			Text(TextCfg{
+				Text:      text,
+				TextStyle: style,
+			}),
+		},
+	})
+}

--- a/gui/view_disclosure_arrow_test.go
+++ b/gui/view_disclosure_arrow_test.go
@@ -1,0 +1,63 @@
+package gui
+
+import "testing"
+
+// disclosureArrowLayout generates the helper's view tree and returns
+// the root Row plus its Text child, which the arrow glyph lives in.
+func disclosureArrowLayout(open bool, style TextStyle) (Layout, *Shape) {
+	root := generateViewLayout(disclosureArrow(open, style), &Window{})
+	if len(root.Children) != 1 {
+		return root, nil
+	}
+	return root, root.Children[0].Shape
+}
+
+// TestDisclosureArrowGlyph pins the open/closed glyph selection shared
+// by ExpandPanel, Combobox and Select.
+func TestDisclosureArrowGlyph(t *testing.T) {
+	_, closed := disclosureArrowLayout(false, DefaultTextStyle)
+	if closed.TC.Text != "▼" {
+		t.Errorf("closed: glyph %q, want ▼", closed.TC.Text)
+	}
+	_, open := disclosureArrowLayout(true, DefaultTextStyle)
+	if open.TC.Text != "▲" {
+		t.Errorf("open: glyph %q, want ▲", open.TC.Text)
+	}
+}
+
+// TestDisclosureArrowScale pins the size reduction and the optical
+// nudge padding: the glyph renders at 0.6x the body size and the
+// wrapper carries nudge*scaledSize of top padding.
+func TestDisclosureArrowScale(t *testing.T) {
+	root, glyph := disclosureArrowLayout(false, DefaultTextStyle)
+	wantSize := DefaultTextStyle.Size * disclosureArrowScale
+	if got := glyph.TC.TextStyle.Size; got != wantSize {
+		t.Errorf("size: got %v, want %v", got, wantSize)
+	}
+	wantPad := wantSize * disclosureArrowNudge
+	if got := root.Shape.Padding.Top; got != wantPad {
+		t.Errorf("top padding: got %v, want %v", got, wantPad)
+	}
+}
+
+// TestDisclosureArrowZeroStyle pins that a fully zero style inherits
+// DefaultTextStyle (family, color and size) and a style with fields but
+// zero Size only gets the size, both before the scale applies.
+func TestDisclosureArrowZeroStyle(t *testing.T) {
+	_, zero := disclosureArrowLayout(false, TextStyle{})
+	if zero.TC.TextStyle.Family != DefaultTextStyle.Family {
+		t.Error("zero style: family not inherited from DefaultTextStyle")
+	}
+	if zero.TC.TextStyle.Color != DefaultTextStyle.Color {
+		t.Error("zero style: color not inherited from DefaultTextStyle")
+	}
+
+	c := RGBA(10, 20, 30, 255)
+	_, partial := disclosureArrowLayout(false, TextStyle{Color: c})
+	if partial.TC.TextStyle.Color != c {
+		t.Error("partial style: color not preserved")
+	}
+	if got := partial.TC.TextStyle.Size; got != sizeTextMedium*disclosureArrowScale {
+		t.Errorf("partial style: size = %v, want %v", got, sizeTextMedium*disclosureArrowScale)
+	}
+}

--- a/gui/view_expand_panel.go
+++ b/gui/view_expand_panel.go
@@ -55,11 +55,6 @@ func ExpandPanel(cfg ExpandPanelCfg) View {
 		a11yState = AccessStateExpanded
 	}
 
-	arrowText := "▼"
-	if cfg.Open {
-		arrowText = "▲"
-	}
-
 	return Column(ContainerCfg{
 		ID:          cfg.ID,
 		A11YRole:    AccessRoleDisclosure,
@@ -86,10 +81,7 @@ func ExpandPanel(cfg ExpandPanelCfg) View {
 					Row(ContainerCfg{
 						Padding: NewPadding(0, PadMedium, 0, 0),
 						Content: []View{
-							Text(TextCfg{
-								Text:      arrowText,
-								TextStyle: guiTheme.N3,
-							}),
+							disclosureArrow(cfg.Open, guiTheme.N3),
 						},
 					}),
 				},

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -89,11 +89,6 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 		wrapMode = TextModeWrap
 	}
 
-	arrowText := "▼"
-	if isOpen {
-		arrowText = "▲"
-	}
-
 	spacerSizing := FillFill
 	if wrapMode != TextModeSingleLine {
 		spacerSizing = FitFill
@@ -110,10 +105,7 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 			Sizing:  spacerSizing,
 			Padding: NoPadding,
 		}),
-		Text(TextCfg{
-			Text:      arrowText,
-			TextStyle: cfg.TextStyle,
-		}),
+		disclosureArrow(isOpen, cfg.TextStyle),
 	)
 
 	if isOpen {
@@ -178,6 +170,7 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 		Disabled:    cfg.Disabled,
 		Invisible:   cfg.Invisible,
 		axis:        axisLeftToRight,
+		VAlign:      VAlignMiddle,
 		AmendLayout: func(ctx EventCtx) {
 			if ctx.Layout.Shape.Disabled {
 				return


### PR DESCRIPTION
Extract the duplicated open/closed disclosure triangle (▼/▲) into one shared helper.

- Glyph scaled to 0.6x body size — U+25BC/U+25B2 are full-width geometric glyphs that read as oversized graphics at label size
- Top-padding optical nudge, halved by the row's middle alignment, lands the wedge ink ~centered
- All three widgets now `VAlign: VAlignMiddle` the arrow instead of hanging it from the top
- ExpandPanel's wrapper VAlign removed: it cancelled the nudge inside the wrapper, making the offset inconsistent with Combobox/Select
- New tests pin glyph selection, scale + nudge geometry, and zero/partial style substitution