### PR TITLE
feat(gui): composable color components over an in-memory image registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Composable color components.** `ColorPlane` (saturation × lightness),
+  `ColorWheel` (hue × saturation), `ColorChannelSlider` (one HSLA channel, with
+  a track showing the colors it can pick, horizontal or `Vertical`),
+  `ColorSwatch` (a color over a transparency checkerboard) and `ColorFields`
+  (hex and channel inputs) are now public widgets. They are stateless: each
+  takes a `gui.HSLA` and reports changes, so an app holding one value can drive
+  any arrangement of them and they stay in sync. See
+  `docs/specs/color-picker-components.md`.
+- **`gui.HSLA`**, the color model those components speak, plus `ColorToHSLA`,
+  `HSLA.Color`, `HSLA.String` (CSS `hsla()` notation), `Color.Hex` and
+  `ColorFromHex`. An app holds an `HSLA` rather than a `Color` because RGBA
+  cannot carry hue through a gray or through black.
+- **In-memory image registry** — `gui.UseImage`, `HasImage`, `DropImage`,
+  `SetMemImageBudget`. Register an NRGBA8 pixel buffer under a content key and
+  get a `Src` string usable anywhere `ImageCfg.Src` or `DrawContext.Image` is
+  accepted; every backend uploads it as a texture. This is what makes imagery no
+  gradient can express — a hue wheel, an HSL plane, an alpha checkerboard —
+  drawable at all.
+
+### Changed
+
+- **`gui.ColorPicker` is now a composition of the components above.** Its
+  `ColorPickerCfg` is unchanged and existing callers compile untouched. Five
+  visible changes: the square is the HSL saturation × lightness plane rather
+  than the HSV square, the hue and alpha sliders stand vertically to the right
+  of the plane instead of stacking beneath it (so the picker is squarer), the
+  preview swatch moves next to the hex field it previews, the alpha slider gains
+  a real transparency checkerboard, and the hue strip is exact instead of being
+  silently resampled to five gradient stops. `ShowHSV` still works and is
+  deprecated in favour of `ShowHSL`.
+
 ### Fixed
 
 - **`buildapp` ad-hoc signing silently revoked every TCC grant on each

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -19,12 +19,13 @@ Button{Label: "Save", OnClick: save}
 Input{ID: "name", FocusDisabled: true} // not in the tab order
 ```
 
-Most input controls are focusable by default: `Button`, `ColorPicker`,
-`Combobox`, `DatePicker`, `Input`, `InputDate`, `ListBox`, `NumericInput`,
-`RadioButtonGroup`, `Radio`, `Select`, `Slider`, `Switch`, `Toggle`, `Tree`.
-Everything else opts in with `Focusable: true`. If a control never answers the
-keyboard, the usual cause is a missing `ID`. The `requiredid` analyzer and the
-`DebugMissingIDs` gate report it. See `docs/specs/focusable-default-input.md`.
+Most input controls are focusable by default: `Button`, `ColorChannelSlider`,
+`ColorPicker`, `ColorPlane`, `ColorWheel`, `Combobox`, `DatePicker`, `Input`,
+`InputDate`, `ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`,
+`Slider`, `Switch`, `Toggle`, `Tree`. Everything else opts in with
+`Focusable: true`. If a control never answers the keyboard, the usual cause is a
+missing `ID`. The `requiredid` analyzer and the `DebugMissingIDs` gate report
+it. See `docs/specs/focusable-default-input.md`.
 
 ## ID scoping
 
@@ -39,49 +40,48 @@ per window.
 Input{ID: "name", ...}
 ```
 
-Two panels can contain the same leaf ID. Each is a different widget. Compose
-IDs with `ScopeID` or `ScopeIDN`, never by hand. Public APIs — `SetFocus`,
+Two panels can contain the same leaf ID. Each is a different widget. Compose IDs
+with `ScopeID` or `ScopeIDN`, never by hand. Public APIs — `SetFocus`,
 `FindByID`, `IsFocus`, `ScrollVerticalTo`, `Test*` — take the effective ID.
 
 A part (a row key, a heading slug) must not contain `:`. A composite widget's
-inner shape sets `Shape.focusOwner` to the owner's leaf instead of repeating
-its `ID`. Duplicates are loud: `gui.Debug` reports them, and
+inner shape sets `Shape.focusOwner` to the owner's leaf instead of repeating its
+`ID`. Duplicates are loud: `gui.Debug` reports them, and
 `(*Window).TestDuplicateIDs` asserts a clean window. See
 `docs/specs/widget-id-scoping.md` and
 `docs/specs/widget-id-per-scope-uniqueness.md`.
 
 ## `Opt[T]` vs plain fields
 
-`Opt[T]` distinguishes "zero" from "not set". Use it for primitives where
-zero is a real choice:
+`Opt[T]` distinguishes "zero" from "not set". Use it for primitives where zero
+is a real choice:
 
 - Zero is a real choice (a border width of 0): `Opt[float32]`.
 - Zero is not meaningful (widths, heights, counts): plain field.
 - The type knows whether it was set (`Color`, `Padding`): plain field.
 
-`SizeBorder` is the example: `0` means "no border", so a plain `float32`
-cannot tell that from "not specified". `Color` and `Padding` carry their own
-set flag and stay plain.
+`SizeBorder` is the example: `0` means "no border", so a plain `float32` cannot
+tell that from "not specified". `Color` and `Padding` carry their own set flag
+and stay plain.
 
 ## Colors
 
 Use plain `Color`, never `Opt[Color]`. Build values with `RGBA`, `RGB`, or
-`Hex`. `Color{}` is unset, and `ColorTransparent` is explicitly transparent.
-A `ColorSet` groups the per-state colors, and an assigned flat `Color` field
-wins over it.
+`Hex`. `Color{}` is unset, and `ColorTransparent` is explicitly transparent. A
+`ColorSet` groups the per-state colors, and an assigned flat `Color` field wins
+over it.
 
 ## `AmendLayout` and floats
 
-`AmendLayout` runs after sizing with absolute coordinates. Moving a parent
-there does not move its children. To move an element with its children, use
-the float fields: `FloatAnchor`, `FloatTieOff`, `FloatOffsetX`,
-`FloatOffsetY`.
+`AmendLayout` runs after sizing with absolute coordinates. Moving a parent there
+does not move its children. To move an element with its children, use the float
+fields: `FloatAnchor`, `FloatTieOff`, `FloatOffsetX`, `FloatOffsetY`.
 
 ## Group-box titles
 
-`ContainerCfg.Title` draws a label in the top border, like an HTML fieldset.
-Set `TitleBG` to the parent's background color, so the border line disappears
-behind the label.
+`ContainerCfg.Title` draws a label in the top border, like an HTML fieldset. Set
+`TitleBG` to the parent's background color, so the border line disappears behind
+the label.
 
 ```go
 // The label sits on a patch of the mismatched color.
@@ -110,20 +110,20 @@ per-shape opt-in.
 ## The one-event rule
 
 Nothing is marked handled for you. A callback that acts on an event calls
-`ctx.Consume()`. One that declines lets the event travel on. `ctx.Event` is
-nil in `AmendLayout` and `OnScroll`, and both `EventCtx` methods are nil-safe.
-See `docs/specs/eventctx-callback-refactor.md`.
+`ctx.Consume()`. One that declines lets the event travel on. `ctx.Event` is nil
+in `AmendLayout` and `OnScroll`, and both `EventCtx` methods are nil-safe. See
+`docs/specs/eventctx-callback-refactor.md`.
 
 ## Find it early
 
-`gui.Debug(true)`, or `GOGUI_DEBUG=1`, checks the layout every frame. It
-reports duplicate IDs, focusable shapes without IDs, and handlers that act
-without consuming. Findings print once per window. In tests, use
+`gui.Debug(true)`, or `GOGUI_DEBUG=1`, checks the layout every frame. It reports
+duplicate IDs, focusable shapes without IDs, and handlers that act without
+consuming. Findings print once per window. In tests, use
 `(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.
 
 `DebugUnscopedIDs` is separate and opt-in: it is not part of `DebugAll`. It
-reports an ID with no ID-bearing ancestor — the widget cannot move into a
-second panel as it stands. Ask for it when you plan to reuse a screen:
+reports an ID with no ID-bearing ancestor — the widget cannot move into a second
+panel as it stands. Ask for it when you plan to reuse a screen:
 
 ```go
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)

--- a/docs/specs/color-picker-components.md
+++ b/docs/specs/color-picker-components.md
@@ -1,0 +1,158 @@
+# Color picker components
+
+Status: implemented. Supersedes the monolithic `ColorPicker` internals.
+
+## Problem
+
+`gui.ColorPicker` was one welded widget. An app that wanted only a hue wheel, or
+a saturation plane beside its own controls, had to copy the file. Three things
+blocked splitting it up:
+
+1. **No conic gradient, and no gradient can express an HSL plane.** The old
+   saturation/value square worked only because HSV factorizes into `white → hue`
+   across and `transparent → black` down. HSL's saturation × lightness plane is
+   a bilinear blend, and a hue wheel is conic. Neither is reachable with the
+   linear and radial gradients the renderer has.
+2. **No pixel-buffer path.** Images were `Src string` only — a path, an http(s)
+   URL, or a `data:` URL. There was no way to hand the renderer bytes.
+3. **Hue is not recoverable from RGBA.** At `S=0`, `L=0` or `L=1` the hue is
+   gone. The old widget hid an `H` in window state to paper over this. Four
+   independent components each hiding their own copy would drift apart.
+
+`gradientShaderStopLimit = 5` compounded (1): the old hue strip declared seven
+stops and was silently resampled to five on every GPU backend.
+
+## Design
+
+### One value, owned by the app
+
+`HSLA` (`gui/color_hsl.go`) is a plain value the caller holds. Every component
+takes `Value HSLA` and reports `OnChange(HSLA, EventCtx)`; none keeps state. Two
+controls stay in sync because they read the same variable, not because they talk
+to each other.
+
+This is what makes (3) a non-issue: hue lives in the value, so it survives a
+drag through black. `ColorPicker` keeps a single `nsColorPicker` entry only
+because its own public API is still RGBA in and RGBA out — a lossy-conversion
+guard for the back-compat surface, not a second color model.
+
+### The in-memory image registry
+
+`gui/image_mem.go` is the primitive the components stand on, and it is useful
+well beyond them:
+
+```go
+src := gui.UseImage(key, w, h, pix) // "mem:"+key; NRGBA8, straight alpha
+ok := gui.HasImage(key)             // skip generating a buffer that exists
+gui.DropImage(key)
+gui.SetMemImageBudget(bytes)        // default 32 MiB
+```
+
+`Src` strings starting `mem:` are resolved by every backend through
+`gui.LookupImage` before any path handling (`drawImage` in `metal`, `gl`, `ios`,
+`android`; an offscreen canvas in `web`; a PNG-encoded embed in the PDF export).
+The registry is a byte-budgeted LRU, process-global because backends resolve a
+`Src` string with no `*Window` in hand.
+
+**Content keying is the contract.** The key names the inputs the buffer was
+generated from, so a buffer that must change is registered under a _new_ key and
+the stale variant ages out on its own. There is deliberately no invalidation
+call: backends cache uploaded textures under the same string, so an app that
+mutated a buffer in place would have no way to tell them.
+
+Keys quantize — hue to whole degrees, S/L/A to whole percent. A key tracking a
+float exactly would miss on every frame of a drag and rebuild the buffer each
+time, which is the failure the cache exists to prevent. A steady frame costs one
+map lookup and zero allocations: the key is built into a stack scratch buffer,
+and `memImageSrc` returns the string stored at registration.
+
+Buffers are generated at `imgScale = 2` and displayed at logical size — sharp on
+HiDPI, cheaply downscaled on 1×, and the scale never enters a key.
+
+**Security.** A `mem:` buffer bypasses `AllowedImageRoots`, `MaxImageBytes` and
+`MaxImagePixels`. Those bound _untrusted_ input — a path or URL an attacker
+might steer. An in-process pixel buffer is trusted by construction; the
+registry's byte budget is its bound.
+
+### What each control depends on
+
+| Control              | Buffer keyed on            | Rebuilt when          |
+| -------------------- | -------------------------- | --------------------- |
+| `ColorChannelSlider` | channel, size, other H/S/L | another channel moves |
+| `ColorPlane`         | hue, size                  | hue moves             |
+| `ColorWheel`         | lightness, size            | lightness moves       |
+| `ColorSwatch`        | size                       | never (one checker)   |
+
+A channel is never in its own strip's key — the strip sweeps it — so dragging
+hue repaints the saturation and lightness tracks but not the hue track. Alpha is
+in no strip's key at all: H/S/L tracks are drawn opaque, and the alpha track is
+the one sweeping it.
+
+### Shared internals
+
+- `colorDragTrack` (`gui/view_color_drag.go`) — the whole pointer-capture
+  sequence in one place. `OnClick` arrives shape-relative while `MouseLock`
+  delivers window-absolute, and the dragged shape must be re-found by ID each
+  move because the tree is rebuilt every frame.
+- `colorMarker` (`gui/view_color_marker.go`) — the ring. It floats above the
+  imagery: a channel slider floats its track to centre it in a control the thumb
+  makes taller, and a marker under that track is invisible.
+- Arrow keys move every control (`colorKeyDelta`); Shift takes the 10× step. A
+  key a control does not handle is not consumed, so Tab still escapes.
+
+## API
+
+```go
+gui.ColorPlane(gui.ColorPlaneCfg{ID, Value, Size, OnChange})
+gui.ColorWheel(gui.ColorWheelCfg{ID, Value, Size, OnChange})
+gui.ColorChannelSlider(gui.ColorChannelSliderCfg{ID, Channel, Value, Vertical, Width, Height, OnChange})
+gui.ColorSwatch(gui.ColorSwatchCfg{ID, Color, Width, Height})
+gui.ColorFields(gui.ColorFieldsCfg{ID, Value, ShowHSL, ShowSwatch, OnChange})
+```
+
+All are fixed-size (`FixedFixed`): their size is tied to the buffer generated
+for them, so they must not stretch to fill a parent.
+
+A channel slider set `Vertical` sweeps bottom (minimum) to top (maximum) and
+takes its length from `Height`. Orientation is part of the strip's content key,
+so the two orientations are separate buffers rather than one rotated at draw
+time — the strip must be generated along the axis it is displayed on or the
+end-cap insets land on the wrong sides.
+
+`ColorFields` set `ShowSwatch` puts a `ColorSwatch` to the right of the hex
+field, under the fields' own ID scope. Both are readouts of the same color — one
+exact, one legible — so they belong on one line; a caller that wants the swatch
+anywhere else leaves the flag off and places a plain `ColorSwatch`.
+
+`gui.ColorPicker` is now a composition of `ColorPlane`, two vertical
+`ColorChannelSlider`s standing to the right of the plane, and `ColorFields`
+carrying the swatch. Its `Cfg` is unchanged and every existing caller compiles
+untouched. `ShowHSV` still works and is deprecated in favour of `ShowHSL`, which
+names what the row contains.
+
+## What callers see change
+
+The square is the HSL saturation × lightness plane rather than the HSV square;
+the hue and alpha sliders stand vertically to the right of it instead of
+stacking beneath it, which makes the picker squarer; the preview swatch sits
+beside the hex field rather than left of the whole numeric column; the alpha
+slider gains a real transparency checkerboard; the hue strip is exact instead of
+resampled to five stops. No API break.
+
+## Rejected
+
+- **Keeping the HSV square as a mode.** It is free — two gradients, no buffer —
+  but it would have forced `ColorPicker` to carry a permanent RGBA↔HSV↔HSLA
+  adapter and two plane implementations. That is the second-source-of-truth
+  pattern this repo rejects elsewhere (`ThemeMaker` vs `default*Style`).
+- **Per-vertex colored triangle meshes** instead of buffers. Would have reached
+  the wheel without a texture upload, but touches every backend's shader and is
+  far less reusable than an image source.
+- **PNG-encoded `data:` URLs** to avoid backend work. Re-encoding a 400×400 PNG
+  on every hue change is a visible hitch on drag.
+
+## Follow-up
+
+`gradientShaderStopLimit = 5` (`gui/render_gradient.go:11`) still silently
+resamples any gradient with more than five stops. This work no longer depends on
+it, but it degrades every such gradient in the repo.

--- a/docs/specs/color-picker-components.md
+++ b/docs/specs/color-picker-components.md
@@ -125,7 +125,9 @@ exact, one legible — so they belong on one line; a caller that wants the swatc
 anywhere else leaves the flag off and places a plain `ColorSwatch`. It is drawn
 twice as wide as `SwatchSize`, which stays its height: a square beside a text
 field reads as a button, where a wide bar reads as a sample of the value next to
-it.
+it. A flexible spacer sits between the two, so the swatch tracks the block's
+right edge — set by the wider channel row beneath it — instead of leaving dead
+space past a short hex value.
 
 `gui.ColorPicker` is now a composition of `ColorPlane`, two vertical
 `ColorChannelSlider`s standing to the right of the plane, and `ColorFields`

--- a/docs/specs/color-picker-components.md
+++ b/docs/specs/color-picker-components.md
@@ -122,13 +122,24 @@ end-cap insets land on the wrong sides.
 `ColorFields` set `ShowSwatch` puts a `ColorSwatch` to the right of the hex
 field, under the fields' own ID scope. Both are readouts of the same color — one
 exact, one legible — so they belong on one line; a caller that wants the swatch
-anywhere else leaves the flag off and places a plain `ColorSwatch`.
+anywhere else leaves the flag off and places a plain `ColorSwatch`. It is drawn
+twice as wide as `SwatchSize`, which stays its height: a square beside a text
+field reads as a button, where a wide bar reads as a sample of the value next to
+it.
 
 `gui.ColorPicker` is now a composition of `ColorPlane`, two vertical
 `ColorChannelSlider`s standing to the right of the plane, and `ColorFields`
 carrying the swatch. Its `Cfg` is unchanged and every existing caller compiles
-untouched. `ShowHSV` still works and is deprecated in favour of `ShowHSL`, which
-names what the row contains.
+untouched.
+
+The plane's size is derived rather than taken from the theme's `sVSize`, which
+becomes an upper bound. The picker is as wide as its widest row — the four RGBA
+fields — so the plane is that width less what the two sliders and the gaps
+beside them occupy, and the two rows come out flush. Widening the gap therefore
+narrows the plane instead of widening the picker.
+
+`ShowHSV` still works and is deprecated in favour of `ShowHSL`, which names what
+the row contains.
 
 ## What callers see change
 

--- a/examples/color_picker/main.go
+++ b/examples/color_picker/main.go
@@ -1,16 +1,28 @@
-// This example demonstrates color editing with runtime theme switching.
-// The color picker example combines color editing with runtime
-// theme switching.
+// The color picker example shows the composable color components:
+// one HSLA value in app state, edited four ways — channel sliders, a
+// saturation × lightness plane, a hue wheel, and text fields. Every
+// control reads and writes the same value, so they all stay in sync
+// without any of them holding state of its own.
+//
+// gui.ColorPicker packages the same components into the one
+// arrangement most apps want; the last panel shows it for comparison.
 package main
 
 import (
+	"strconv"
+
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend"
 )
 
 type App struct {
-	Color      gui.Color
-	ShowHSV    bool
+	// Color is the one value every control below edits. It is an
+	// HSLA, not a Color, because RGBA cannot carry hue through a gray
+	// or through black — drag lightness to the bottom and back and an
+	// RGBA-held value would come back red.
+	Color gui.HSLA
+
+	ShowPacked bool
 	LightTheme bool
 }
 
@@ -18,10 +30,12 @@ func main() {
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
 
 	w := gui.NewWindow(gui.WindowCfg{
-		State:  &App{Color: gui.RGBA(0x3D, 0x81, 0x7C, 255), ShowHSV: true},
+		State: &App{
+			Color: gui.HSLA{H: 210, S: 0.7, L: 0.55, A: 0.85},
+		},
 		Title:  "Color Picker",
-		Width:  300,
-		Height: 490,
+		Width:  900,
+		Height: 620,
 		OnInit: func(w *gui.Window) {
 			w.UpdateView(mainView)
 		},
@@ -34,10 +48,22 @@ func mainView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
 	t := gui.CurrentTheme()
 
+	panels := []gui.View{
+		card("Channel sliders", "Tracks show what each slider picks.",
+			slidersPanel(app)),
+		card("Saturation × Lightness", "The S/L plane at the current hue.",
+			planePanel(app)),
+		card("Hue wheel", "Angle = hue, radius = saturation.",
+			wheelPanel(app)),
+	}
+	if app.ShowPacked {
+		panels = append(panels, card("gui.ColorPicker",
+			"The same components, pre-arranged.", packedPanel(app)))
+	}
+
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFill,
 		Padding: t.PaddingMedium,
-
 		Spacing: gui.Some(t.SpacingMedium),
 		Content: []gui.View{
 			gui.Row(gui.ContainerCfg{
@@ -47,30 +73,213 @@ func mainView(w *gui.Window) gui.View {
 				Spacing: gui.Some(t.SpacingMedium),
 				Content: []gui.View{
 					toggleTheme(app),
-					toggleHSV(app),
+					togglePacked(app),
 				},
 			}),
-			gui.ColorPicker(gui.ColorPickerCfg{
-				ID:      "picker",
-				Color:   app.Color,
-				ShowHSV: app.ShowHSV,
-				OnColorChange: func(c gui.Color, ctx gui.EventCtx) {
-					// Keep the picker controlled by the window state.
-					gui.State[App](ctx.Window).Color = c
+			gui.Row(gui.ContainerCfg{
+				Sizing:  gui.FitFit,
+				Padding: gui.NoPadding,
+				Spacing: gui.Some(t.SpacingMedium),
+				Content: panels,
+			}),
+			previewBar(app),
+		},
+	})
+}
+
+// setColor is the one writer every control shares. Because the value
+// is an HSLA, a control that drives saturation to zero does not lose
+// the hue the others are showing.
+func setColor(ctx gui.EventCtx, v gui.HSLA) {
+	gui.State[App](ctx.Window).Color = v
+}
+
+// card wraps a panel in a titled box.
+func card(title, sub string, body gui.View) gui.View {
+	t := gui.CurrentTheme()
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FitFit,
+		Padding: t.PaddingMedium,
+		Spacing: gui.Some(t.SpacingMedium),
+		Content: []gui.View{
+			gui.Column(gui.ContainerCfg{
+				Padding: gui.NoPadding,
+				Spacing: gui.SomeF(2),
+				Content: []gui.View{
+					gui.Text(gui.TextCfg{Text: title, TextStyle: t.N2}),
+					gui.Text(gui.TextCfg{Text: sub, TextStyle: t.N4}),
+				},
+			}),
+			body,
+		},
+	})
+}
+
+const sliderWidth = 240
+
+func slidersPanel(app *App) gui.View {
+	return gui.Column(gui.ContainerCfg{
+		Padding: gui.NoPadding,
+		Spacing: gui.SomeF(10),
+		Content: []gui.View{
+			channelRow(app, "hue", "Hue", gui.ChannelHue),
+			channelRow(app, "sat", "Saturation", gui.ChannelSaturation),
+			channelRow(app, "light", "Lightness", gui.ChannelLightness),
+			channelRow(app, "alpha", "Alpha", gui.ChannelAlpha),
+		},
+	})
+}
+
+// channelRow pairs a slider with its name and current value. The
+// component draws only the control — a caller that wants a label
+// places it, which is what keeps the same slider usable in a compact
+// toolbar and in a labeled panel like this one.
+func channelRow(
+	app *App, id, label string, ch gui.ColorChannel,
+) gui.View {
+	t := gui.CurrentTheme()
+	return gui.Column(gui.ContainerCfg{
+		Padding: gui.NoPadding,
+		Spacing: gui.SomeF(3),
+		Content: []gui.View{
+			gui.Row(gui.ContainerCfg{
+				Sizing:  gui.FillFit,
+				Width:   sliderWidth,
+				Padding: gui.NoPadding,
+				Content: []gui.View{
+					gui.Text(gui.TextCfg{
+						Text: label, TextStyle: t.N3,
+					}),
+					// Fill pushes the value to the right edge.
+					gui.Text(gui.TextCfg{
+						Text:      channelText(app.Color, ch),
+						TextStyle: valueStyle(t),
+						Sizing:    gui.FillFit,
+					}),
+				},
+			}),
+			gui.ColorChannelSlider(gui.ColorChannelSliderCfg{
+				ID:      gui.ScopeID("channels", id),
+				Channel: ch,
+				Value:   app.Color,
+				Width:   sliderWidth,
+				OnChange: func(v gui.HSLA, ctx gui.EventCtx) {
+					setColor(ctx, v)
 				},
 			}),
 		},
 	})
 }
 
-func toggleHSV(app *App) gui.View {
+// valueStyle right-aligns the readout so the numbers line up down the
+// column as they change width.
+func valueStyle(t gui.Theme) gui.TextStyle {
+	s := t.N3
+	s.Align = gui.TextAlignRight
+	return s
+}
+
+// channelText formats one channel the way its units read: degrees for
+// hue, percent for saturation and lightness, a fraction for alpha.
+func channelText(v gui.HSLA, ch gui.ColorChannel) string {
+	switch ch {
+	case gui.ChannelHue:
+		return strconv.Itoa(int(v.H + 0.5))
+	case gui.ChannelSaturation:
+		return strconv.Itoa(int(v.S*100 + 0.5))
+	case gui.ChannelLightness:
+		return strconv.Itoa(int(v.L*100 + 0.5))
+	default:
+		return strconv.FormatFloat(float64(v.A), 'f', 2, 32)
+	}
+}
+
+func planePanel(app *App) gui.View {
+	return gui.ColorPlane(gui.ColorPlaneCfg{
+		ID:    "plane",
+		Value: app.Color,
+		Size:  200,
+		OnChange: func(v gui.HSLA, ctx gui.EventCtx) {
+			setColor(ctx, v)
+		},
+	})
+}
+
+func wheelPanel(app *App) gui.View {
+	return gui.ColorWheel(gui.ColorWheelCfg{
+		ID:    "wheel",
+		Value: app.Color,
+		Size:  200,
+		OnChange: func(v gui.HSLA, ctx gui.EventCtx) {
+			setColor(ctx, v)
+		},
+	})
+}
+
+// packedPanel shows gui.ColorPicker driven by the same value. Its API
+// is RGBA in and RGBA out, so the conversion happens here — and the
+// hue it holds internally is what keeps that conversion honest.
+func packedPanel(app *App) gui.View {
+	return gui.ColorPicker(gui.ColorPickerCfg{
+		ID:      "packed",
+		Color:   app.Color.Color(),
+		ShowHSL: true,
+		OnColorChange: func(c gui.Color, ctx gui.EventCtx) {
+			setColor(ctx, gui.ColorToHSLA(c))
+		},
+	})
+}
+
+// previewBar shows the value as a swatch and as text, the two ways a
+// user checks that the controls agree.
+func previewBar(app *App) gui.View {
+	t := gui.CurrentTheme()
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FitFit,
+		VAlign:  gui.VAlignMiddle,
+		Padding: t.PaddingMedium,
+		Spacing: gui.Some(t.SpacingMedium),
+		Content: []gui.View{
+			gui.ColorSwatch(gui.ColorSwatchCfg{
+				ID:     "preview",
+				Color:  app.Color.Color(),
+				Width:  96,
+				Height: 56,
+			}),
+			gui.Column(gui.ContainerCfg{
+				Padding: gui.NoPadding,
+				Spacing: gui.SomeF(4),
+				Content: []gui.View{
+					gui.Text(gui.TextCfg{
+						Text:      app.Color.String(),
+						TextStyle: t.N2,
+					}),
+					gui.Text(gui.TextCfg{
+						Text:      app.Color.Color().Hex(),
+						TextStyle: t.N4,
+					}),
+				},
+			}),
+			gui.ColorFields(gui.ColorFieldsCfg{
+				ID:      "fields",
+				Value:   app.Color,
+				ShowHSL: true,
+				OnChange: func(v gui.HSLA, ctx gui.EventCtx) {
+					setColor(ctx, v)
+				},
+			}),
+		},
+	})
+}
+
+func togglePacked(app *App) gui.View {
 	return gui.Switch(gui.SwitchCfg{
-		ID:       "color_picker_toggle_hsv",
-		Label:    "HSV",
-		Selected: app.ShowHSV,
+		ID:       "color_picker_toggle_packed",
+		Label:    "gui.ColorPicker",
+		Selected: app.ShowPacked,
 		OnClick: func(ctx gui.EventCtx) {
 			a := gui.State[App](ctx.Window)
-			a.ShowHSV = !a.ShowHSV
+			a.ShowPacked = !a.ShowPacked
 		},
 	})
 }
@@ -88,7 +297,7 @@ func toggleTheme(app *App) gui.View {
 		OnClick: func(ctx gui.EventCtx) {
 			a := gui.State[App](ctx.Window)
 			a.LightTheme = !a.LightTheme
-			// Switching the theme is enough; the next frame re-renders the picker.
+			// Switching the theme is enough; the next frame re-renders.
 			if a.LightTheme {
 				ctx.Window.SetTheme(gui.ThemeLight.WithBorders(true))
 			} else {

--- a/examples/color_picker/main_test.go
+++ b/examples/color_picker/main_test.go
@@ -10,10 +10,12 @@ func TestMainViewNoPanic(t *testing.T) {
 	t.Parallel()
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
 	w := gui.NewWindow(gui.WindowCfg{
-		State:  &App{Color: gui.RGBA(0x3D, 0x81, 0x7C, 255), ShowHSV: true},
-		Width:  300,
-		Height: 490,
+		State: &App{
+			Color:      gui.HSLA{H: 210, S: 0.7, L: 0.55, A: 0.85},
+			ShowPacked: true,
+		},
+		Width:  920,
+		Height: 760,
 	})
 	_ = mainView(w).GenerateLayout(w)
-
 }

--- a/examples/showcase/demo_input.go
+++ b/examples/showcase/demo_input.go
@@ -240,6 +240,10 @@ func demoColorPicker(w *gui.Window) gui.View {
 				Text:      fmt.Sprintf("RGBA(%d, %d, %d, %d)", c.R, c.G, c.B, c.A),
 				TextStyle: gui.CurrentTheme().N3,
 			}),
+			// The composite control above and the loose components
+			// below edit different values, so a rule between them says
+			// where one demo ends and the next begins.
+			line(),
 			demoColorComponents(app),
 		},
 	})

--- a/examples/showcase/demo_input.go
+++ b/examples/showcase/demo_input.go
@@ -220,23 +220,88 @@ func demoColorPicker(w *gui.Window) gui.View {
 		Padding: gui.NoPadding,
 		Content: []gui.View{
 			gui.Switch(gui.SwitchCfg{
-				ID:       "color-picker-hsv",
-				Label:    "Show HSV",
-				Selected: app.ColorPickerHSV,
+				ID:       "color-picker-hsl",
+				Label:    "Show HSL",
+				Selected: app.ColorPickerHSL,
 				OnClick: func(ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).ColorPickerHSV = !gui.State[ShowcaseApp](ctx.Window).ColorPickerHSV
+					a := gui.State[ShowcaseApp](ctx.Window)
+					a.ColorPickerHSL = !a.ColorPickerHSL
 				},
 			}),
 			gui.ColorPicker(gui.ColorPickerCfg{
 				ID:      "color-picker",
 				Color:   c,
-				ShowHSV: app.ColorPickerHSV,
+				ShowHSL: app.ColorPickerHSL,
 				OnColorChange: func(color gui.Color, ctx gui.EventCtx) {
 					gui.State[ShowcaseApp](ctx.Window).ColorPickerColor = color
 				},
 			}),
 			gui.Text(gui.TextCfg{
 				Text:      fmt.Sprintf("RGBA(%d, %d, %d, %d)", c.R, c.G, c.B, c.A),
+				TextStyle: gui.CurrentTheme().N3,
+			}),
+			demoColorComponents(app),
+		},
+	})
+}
+
+// demoColorComponents shows the pieces gui.ColorPicker is built from,
+// driven by one HSLA in app state. Each control writes the whole value
+// and reads it back, so they stay in sync with no state of their own.
+func demoColorComponents(app *ShowcaseApp) gui.View {
+	set := func(v gui.HSLA, ctx gui.EventCtx) {
+		gui.State[ShowcaseApp](ctx.Window).ColorHSLA = v
+	}
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Spacing: gui.SomeF(8),
+		Padding: gui.NoPadding,
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{
+				Text:      "Composable components",
+				TextStyle: gui.CurrentTheme().N2,
+			}),
+			gui.Row(gui.ContainerCfg{
+				Sizing:  gui.FitFit,
+				Padding: gui.NoPadding,
+				Spacing: gui.SomeF(12),
+				Content: []gui.View{
+					gui.ColorPlane(gui.ColorPlaneCfg{
+						ID:       "color-parts-plane",
+						Value:    app.ColorHSLA,
+						Size:     120,
+						OnChange: set,
+					}),
+					gui.ColorWheel(gui.ColorWheelCfg{
+						ID:       "color-parts-wheel",
+						Value:    app.ColorHSLA,
+						Size:     120,
+						OnChange: set,
+					}),
+					gui.ColorSwatch(gui.ColorSwatchCfg{
+						ID:     "color-parts-swatch",
+						Color:  app.ColorHSLA.Color(),
+						Width:  64,
+						Height: 120,
+					}),
+				},
+			}),
+			gui.ColorChannelSlider(gui.ColorChannelSliderCfg{
+				ID:       "color-parts-hue",
+				Channel:  gui.ChannelHue,
+				Value:    app.ColorHSLA,
+				Width:    320,
+				OnChange: set,
+			}),
+			gui.ColorChannelSlider(gui.ColorChannelSliderCfg{
+				ID:       "color-parts-alpha",
+				Channel:  gui.ChannelAlpha,
+				Value:    app.ColorHSLA,
+				Width:    320,
+				OnChange: set,
+			}),
+			gui.Text(gui.TextCfg{
+				Text:      app.ColorHSLA.String(),
 				TextStyle: gui.CurrentTheme().N3,
 			}),
 		},

--- a/examples/showcase/showcase_test.go
+++ b/examples/showcase/showcase_test.go
@@ -438,3 +438,24 @@ func TestDemoPagesHaveNoIDDefects(t *testing.T) {
 		app.ShowDocs = false
 	}
 }
+
+// The color picker demo shows both the packed widget and the
+// components it is built from. Generating it is what proves the
+// composable controls survive a real app's state wiring.
+func TestDemoColorPickerBuildsComponents(t *testing.T) {
+	w := gui.NewWindow(gui.WindowCfg{State: newShowcaseApp()})
+	layout := gui.GenerateViewLayout(demoColorPicker(w), w)
+
+	for _, id := range []string{
+		"color-picker",
+		"color-parts-plane",
+		"color-parts-wheel",
+		"color-parts-swatch",
+		"color-parts-hue",
+		"color-parts-alpha",
+	} {
+		if _, ok := layout.FindByID(id); !ok {
+			t.Errorf("color picker demo is missing %q", id)
+		}
+	}
+}

--- a/examples/showcase/state.go
+++ b/examples/showcase/state.go
@@ -156,6 +156,10 @@ type ShowcaseApp struct {
 
 	ColorPickerColor gui.Color
 
+	// ColorHSLA drives the composable color components. It is an HSLA
+	// rather than a Color so hue survives a drag through gray or black.
+	ColorHSLA gui.HSLA
+
 	ThemeGenSeed gui.Color
 	ThemeGenText gui.Color
 	ShowDocs     bool
@@ -165,7 +169,7 @@ type ShowcaseApp struct {
 	ToggleA        bool
 	CheckboxA      bool
 	SwitchA        bool
-	ColorPickerHSV bool
+	ColorPickerHSL bool
 
 	SidebarOpen bool
 	ExpandOpen  bool
@@ -201,6 +205,7 @@ func newShowcaseApp() *ShowcaseApp {
 		InputDate:            time.Now(),
 		RollerDate:           time.Now(),
 		ColorPickerColor:     gui.RGBA(51, 79, 103, 255),
+		ColorHSLA:            gui.HSLA{H: 205, S: 0.34, L: 0.3, A: 1},
 		BCSelected:           "page",
 		BCPath:               append([]gui.BreadcrumbItemCfg(nil), showcaseBreadcrumbPath...),
 		TabSelected:          "overview",

--- a/gui/backend/android/draw.go
+++ b/gui/backend/android/draw.go
@@ -243,40 +243,31 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	tex, ok := b.resolveMemTexture(r.Resource)
-	if !ok {
-		tex, ok = b.resolvePathTexture(r.Resource)
-	}
+	tex, ok := b.resolveImageTexture(r.Resource)
 	if !ok || tex.id == 0 {
 		return
 	}
 	b.drawImageTex(r, tex)
 }
 
-// resolveMemTexture returns the texture for a mem: source — a buffer
-// in gui's in-memory registry. It has no path, so it skips path
-// resolution and the AllowedImageRoots sandbox (see gui.LookupImage on
-// why that is safe). Cached under the Resource string itself, which
-// callers content-key, so a changed buffer arrives as a new key and
-// never reuses a stale upload.
-func (b *Backend) resolveMemTexture(
-	res string,
-) (glesTexture, bool) {
-	iw, ih, pix, ok := gui.LookupImage(res)
-	if !ok {
-		return glesTexture{}, false
+// resolveImageTexture returns the uploaded texture for a render
+// command's Resource, uploading on first use.
+//
+// A mem: source names a buffer in gui's in-memory registry: it has no
+// path, so it skips path resolution and the AllowedImageRoots sandbox
+// (see gui.LookupImage on why that is safe). The texture is cached
+// under the Resource string itself, which callers content-key, so a
+// changed buffer arrives as a new key and never reuses a stale upload.
+func (b *Backend) resolveImageTexture(res string) (glesTexture, bool) {
+	if iw, ih, pix, ok := gui.LookupImage(res); ok {
+		tex, hit := b.textures.Get(res)
+		if !hit {
+			tex = createGLESTexture(int32(iw), int32(ih), pix)
+			b.textures.Set(res, tex)
+		}
+		return tex, true
 	}
-	tex, hit := b.textures.Get(res)
-	if !hit {
-		tex = createGLESTexture(int32(iw), int32(ih), pix)
-		b.textures.Set(res, tex)
-	}
-	return tex, true
-}
 
-func (b *Backend) resolvePathTexture(
-	res string,
-) (glesTexture, bool) {
 	path := b.ResolveImagePath(res, "android")
 	if path == "-" {
 		return glesTexture{}, false

--- a/gui/backend/android/draw.go
+++ b/gui/backend/android/draw.go
@@ -243,9 +243,43 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	path := b.ResolveImagePath(r.Resource, "android")
-	if path == "-" {
+	tex, ok := b.resolveMemTexture(r.Resource)
+	if !ok {
+		tex, ok = b.resolvePathTexture(r.Resource)
+	}
+	if !ok || tex.id == 0 {
 		return
+	}
+	b.drawImageTex(r, tex)
+}
+
+// resolveMemTexture returns the texture for a mem: source — a buffer
+// in gui's in-memory registry. It has no path, so it skips path
+// resolution and the AllowedImageRoots sandbox (see gui.LookupImage on
+// why that is safe). Cached under the Resource string itself, which
+// callers content-key, so a changed buffer arrives as a new key and
+// never reuses a stale upload.
+func (b *Backend) resolveMemTexture(
+	res string,
+) (glesTexture, bool) {
+	iw, ih, pix, ok := gui.LookupImage(res)
+	if !ok {
+		return glesTexture{}, false
+	}
+	tex, hit := b.textures.Get(res)
+	if !hit {
+		tex = createGLESTexture(int32(iw), int32(ih), pix)
+		b.textures.Set(res, tex)
+	}
+	return tex, true
+}
+
+func (b *Backend) resolvePathTexture(
+	res string,
+) (glesTexture, bool) {
+	path := b.ResolveImagePath(res, "android")
+	if path == "-" {
+		return glesTexture{}, false
 	}
 
 	tex, ok := b.textures.Get(path)
@@ -257,10 +291,14 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 		}
 		b.textures.Set(path, tex)
 	}
-	if tex.id == 0 {
-		return
-	}
+	return tex, true
+}
 
+// drawImageTex paints an already-resolved texture into the command's
+// rect, filling BgColor behind it first.
+func (b *Backend) drawImageTex(
+	r *gui.RenderCmd, tex glesTexture,
+) {
 	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -248,32 +248,8 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	path, ok := b.imagePathCache.Get(r.Resource)
-	if !ok {
-		var err error
-		path, err = imgload.ResolveValidatedPath(
-			r.Resource, b.allowedImageRoots)
-		if err != nil {
-			log.Printf("gl: drawImage: %v",
-				err)
-			path = "-"
-		}
-		b.imagePathCache.Set(r.Resource, path)
-	}
-	if path == "-" {
-		return
-	}
-
-	tex, ok := b.textures.Get(path)
-	if !ok {
-		var err error
-		tex, err = b.loadImageTexture(path)
-		if err != nil {
-			log.Printf("gl: drawImage: %v", err)
-		}
-		b.textures.Set(path, tex)
-	}
-	if tex.id == 0 {
+	tex, ok := b.resolveImageTexture(r.Resource)
+	if !ok || tex.id == 0 {
 		return
 	}
 
@@ -298,6 +274,51 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 	}
 	b.drawQuadUV(x, y, w, h, gui.White, r.ClipRadius*s)
 	gogl.BindTexture(gogl.TEXTURE_2D, 0)
+}
+
+// resolveImageTexture returns the uploaded texture for a render
+// command's Resource, uploading on first use.
+//
+// A mem: source names a buffer in gui's in-memory registry: it has no
+// path, so it skips path resolution and the AllowedImageRoots sandbox
+// (see gui.LookupImage on why that is safe). The texture is cached
+// under the Resource string itself, which callers content-key, so a
+// changed buffer arrives as a new key and never reuses a stale upload.
+func (b *Backend) resolveImageTexture(res string) (glTexture, bool) {
+	if iw, ih, pix, ok := gui.LookupImage(res); ok {
+		tex, hit := b.textures.Get(res)
+		if !hit {
+			tex = createTexture(int32(iw), int32(ih), pix)
+			b.textures.Set(res, tex)
+		}
+		return tex, true
+	}
+
+	path, ok := b.imagePathCache.Get(res)
+	if !ok {
+		var err error
+		path, err = imgload.ResolveValidatedPath(
+			res, b.allowedImageRoots)
+		if err != nil {
+			log.Printf("gl: drawImage: %v", err)
+			path = "-"
+		}
+		b.imagePathCache.Set(res, path)
+	}
+	if path == "-" {
+		return glTexture{}, false
+	}
+
+	tex, ok := b.textures.Get(path)
+	if !ok {
+		var err error
+		tex, err = b.loadImageTexture(path)
+		if err != nil {
+			log.Printf("gl: drawImage: %v", err)
+		}
+		b.textures.Set(path, tex)
+	}
+	return tex, true
 }
 
 func (b *Backend) drawSvg(r *gui.RenderCmd) {

--- a/gui/backend/ios/draw.go
+++ b/gui/backend/ios/draw.go
@@ -243,9 +243,43 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	path := b.ResolveImagePath(r.Resource, "ios")
-	if path == "-" {
+	tex, ok := b.resolveMemTexture(r.Resource)
+	if !ok {
+		tex, ok = b.resolvePathTexture(r.Resource)
+	}
+	if !ok || tex.id == 0 {
 		return
+	}
+	b.drawImageTex(r, tex)
+}
+
+// resolveMemTexture returns the texture for a mem: source — a buffer
+// in gui's in-memory registry. It has no path, so it skips path
+// resolution and the AllowedImageRoots sandbox (see gui.LookupImage on
+// why that is safe). Cached under the Resource string itself, which
+// callers content-key, so a changed buffer arrives as a new key and
+// never reuses a stale upload.
+func (b *Backend) resolveMemTexture(
+	res string,
+) (metalTexture, bool) {
+	iw, ih, pix, ok := gui.LookupImage(res)
+	if !ok {
+		return metalTexture{}, false
+	}
+	tex, hit := b.textures.Get(res)
+	if !hit {
+		tex = createMetalTexture(int32(iw), int32(ih), pix)
+		b.textures.Set(res, tex)
+	}
+	return tex, true
+}
+
+func (b *Backend) resolvePathTexture(
+	res string,
+) (metalTexture, bool) {
+	path := b.ResolveImagePath(res, "ios")
+	if path == "-" {
+		return metalTexture{}, false
 	}
 
 	tex, ok := b.textures.Get(path)
@@ -257,10 +291,14 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 		}
 		b.textures.Set(path, tex)
 	}
-	if tex.id == 0 {
-		return
-	}
+	return tex, true
+}
 
+// drawImageTex paints an already-resolved texture into the command's
+// rect, filling BgColor behind it first.
+func (b *Backend) drawImageTex(
+	r *gui.RenderCmd, tex metalTexture,
+) {
 	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s

--- a/gui/backend/ios/draw.go
+++ b/gui/backend/ios/draw.go
@@ -243,40 +243,31 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	tex, ok := b.resolveMemTexture(r.Resource)
-	if !ok {
-		tex, ok = b.resolvePathTexture(r.Resource)
-	}
+	tex, ok := b.resolveImageTexture(r.Resource)
 	if !ok || tex.id == 0 {
 		return
 	}
 	b.drawImageTex(r, tex)
 }
 
-// resolveMemTexture returns the texture for a mem: source — a buffer
-// in gui's in-memory registry. It has no path, so it skips path
-// resolution and the AllowedImageRoots sandbox (see gui.LookupImage on
-// why that is safe). Cached under the Resource string itself, which
-// callers content-key, so a changed buffer arrives as a new key and
-// never reuses a stale upload.
-func (b *Backend) resolveMemTexture(
-	res string,
-) (metalTexture, bool) {
-	iw, ih, pix, ok := gui.LookupImage(res)
-	if !ok {
-		return metalTexture{}, false
+// resolveImageTexture returns the uploaded texture for a render
+// command's Resource, uploading on first use.
+//
+// A mem: source names a buffer in gui's in-memory registry: it has no
+// path, so it skips path resolution and the AllowedImageRoots sandbox
+// (see gui.LookupImage on why that is safe). The texture is cached
+// under the Resource string itself, which callers content-key, so a
+// changed buffer arrives as a new key and never reuses a stale upload.
+func (b *Backend) resolveImageTexture(res string) (metalTexture, bool) {
+	if iw, ih, pix, ok := gui.LookupImage(res); ok {
+		tex, hit := b.textures.Get(res)
+		if !hit {
+			tex = createMetalTexture(int32(iw), int32(ih), pix)
+			b.textures.Set(res, tex)
+		}
+		return tex, true
 	}
-	tex, hit := b.textures.Get(res)
-	if !hit {
-		tex = createMetalTexture(int32(iw), int32(ih), pix)
-		b.textures.Set(res, tex)
-	}
-	return tex, true
-}
 
-func (b *Backend) resolvePathTexture(
-	res string,
-) (metalTexture, bool) {
 	path := b.ResolveImagePath(res, "ios")
 	if path == "-" {
 		return metalTexture{}, false

--- a/gui/backend/metal/draw.go
+++ b/gui/backend/metal/draw.go
@@ -254,32 +254,8 @@ func (b *windowState) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *windowState) drawImage(r *gui.RenderCmd) {
-	path, ok := b.imagePathCache.Get(r.Resource)
-	if !ok {
-		var err error
-		path, err = imgload.ResolveValidatedPath(
-			r.Resource, b.allowedImageRoots)
-		if err != nil {
-			log.Printf("metal: drawImage: %v",
-				err)
-			path = "-"
-		}
-		b.imagePathCache.Set(r.Resource, path)
-	}
-	if path == "-" {
-		return
-	}
-
-	tex, ok := b.textures.Get(path)
-	if !ok {
-		var err error
-		tex, err = b.loadImageTexture(path)
-		if err != nil {
-			log.Printf("metal: drawImage: %v", err)
-		}
-		b.textures.Set(path, tex)
-	}
-	if tex.id == 0 {
+	tex, ok := b.resolveImageTexture(r.Resource)
+	if !ok || tex.id == 0 {
 		return
 	}
 
@@ -310,6 +286,54 @@ func (b *windowState) drawImage(r *gui.RenderCmd) {
 		{X: x, Y: y + h, Z: z, U: -1, V: 1, R: cr, G: cg, B: cb, A: ca},
 	}
 	C.metalDrawQuad(b.ctx, (*C.float)(unsafe.Pointer(&verts[0])))
+}
+
+// resolveImageTexture returns the uploaded texture for a render
+// command's Resource, uploading on first use.
+//
+// A mem: source names a buffer in gui's in-memory registry: it has no
+// path, so it skips path resolution and the AllowedImageRoots sandbox
+// (see gui.LookupImage on why that is safe). The texture is cached
+// under the Resource string itself, which callers content-key, so a
+// changed buffer arrives as a new key and never reuses a stale upload.
+func (b *windowState) resolveImageTexture(
+	res string,
+) (metalTexture, bool) {
+	if iw, ih, pix, ok := gui.LookupImage(res); ok {
+		tex, hit := b.textures.Get(res)
+		if !hit {
+			tex = createMetalTexture(
+				b.ctx, int32(iw), int32(ih), pix)
+			b.textures.Set(res, tex)
+		}
+		return tex, true
+	}
+
+	path, ok := b.imagePathCache.Get(res)
+	if !ok {
+		var err error
+		path, err = imgload.ResolveValidatedPath(
+			res, b.allowedImageRoots)
+		if err != nil {
+			log.Printf("metal: drawImage: %v", err)
+			path = "-"
+		}
+		b.imagePathCache.Set(res, path)
+	}
+	if path == "-" {
+		return metalTexture{}, false
+	}
+
+	tex, ok := b.textures.Get(path)
+	if !ok {
+		var err error
+		tex, err = b.loadImageTexture(path)
+		if err != nil {
+			log.Printf("metal: drawImage: %v", err)
+		}
+		b.textures.Set(path, tex)
+	}
+	return tex, true
 }
 
 func (b *windowState) drawSvg(r *gui.RenderCmd) {

--- a/gui/backend/web/draw.go
+++ b/gui/backend/web/draw.go
@@ -385,57 +385,8 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 }
 
 func (b *Backend) drawImage(r *gui.RenderCmd) {
-	if _, failed := b.failedImages[r.Resource]; failed {
-		return
-	}
-	img, ok := b.imgCache[r.Resource]
+	img, ok := b.resolveImageSource(r.Resource)
 	if !ok {
-		if !isAllowedImageSrc(r.Resource) {
-			scheme := r.Resource
-			if idx := strings.IndexByte(r.Resource, ':'); idx >= 0 {
-				scheme = r.Resource[:idx]
-			}
-			log.Printf("web: blocked image src scheme: %q",
-				scheme)
-			return
-		}
-		// Evict a batch of random entries when cache is full.
-		// Random eviction is O(1) with no bookkeeping. Batch
-		// eviction amortizes overhead for image-heavy UIs.
-		if len(b.imgCache) >= maxImageCacheSize {
-			n := 0
-			for k := range b.imgCache {
-				delete(b.imgCache, k)
-				n++
-				if n >= imageCacheEvictN {
-					break
-				}
-			}
-		}
-		img = js.Global().Get("Image").New()
-		img.Set("src", r.Resource)
-		b.imgCache[r.Resource] = img
-	}
-	if !img.Get("complete").Bool() {
-		return
-	}
-	// Loaded but broken (e.g. 404) — track in failedImages
-	// to prevent eternal retry. Keep the negative cache bounded
-	// so a stream of unique bad URLs cannot grow session memory
-	// without limit.
-	if img.Get("naturalWidth").Int() == 0 {
-		if len(b.failedImages) >= maxFailedImageCacheSize {
-			n := 0
-			for k := range b.failedImages {
-				delete(b.failedImages, k)
-				n++
-				if n >= failedImageCacheEvictN {
-					break
-				}
-			}
-		}
-		b.failedImages[r.Resource] = struct{}{}
-		delete(b.imgCache, r.Resource)
 		return
 	}
 	// Fill background.
@@ -460,6 +411,108 @@ func (b *Backend) drawImage(r *gui.RenderCmd) {
 	if r.ClipRadius > 0 {
 		b.ctx2d.Call("restore")
 	}
+}
+
+// resolveImageSource returns a canvas drawImage source for a render
+// command's Resource: an offscreen canvas for a mem: buffer, an Image
+// element for a path, URL, or data URL. ok=false means nothing is
+// drawable this frame — blocked scheme, download in flight, or a
+// permanently broken source.
+func (b *Backend) resolveImageSource(res string) (js.Value, bool) {
+	// A mem: source names a buffer in gui's in-memory registry. It has
+	// no URL to load, so it is painted into an offscreen canvas once
+	// and cached alongside the Image elements; a canvas is a valid
+	// drawImage source. Callers content-key, so a changed buffer
+	// arrives as a new key and never reuses this canvas.
+	if iw, ih, pix, ok := gui.LookupImage(res); ok {
+		if c, hit := b.imgCache[res]; hit {
+			return c, true
+		}
+		b.evictImageCache()
+		c := b.memImageCanvas(iw, ih, pix)
+		b.imgCache[res] = c
+		return c, true
+	}
+
+	if _, failed := b.failedImages[res]; failed {
+		return js.Value{}, false
+	}
+	img, ok := b.imgCache[res]
+	if !ok {
+		if !isAllowedImageSrc(res) {
+			scheme := res
+			if s, _, ok := strings.Cut(res, ":"); ok {
+				scheme = s
+			}
+			log.Printf("web: blocked image src scheme: %q",
+				scheme)
+			return js.Value{}, false
+		}
+		b.evictImageCache()
+		img = js.Global().Get("Image").New()
+		img.Set("src", res)
+		b.imgCache[res] = img
+	}
+	if !img.Get("complete").Bool() {
+		return js.Value{}, false
+	}
+	// Loaded but broken (e.g. 404) — track in failedImages
+	// to prevent eternal retry. Keep the negative cache bounded
+	// so a stream of unique bad URLs cannot grow session memory
+	// without limit.
+	if img.Get("naturalWidth").Int() == 0 {
+		if len(b.failedImages) >= maxFailedImageCacheSize {
+			n := 0
+			for k := range b.failedImages {
+				delete(b.failedImages, k)
+				n++
+				if n >= failedImageCacheEvictN {
+					break
+				}
+			}
+		}
+		b.failedImages[res] = struct{}{}
+		delete(b.imgCache, res)
+		return js.Value{}, false
+	}
+	return img, true
+}
+
+// evictImageCache drops a batch of random entries when the cache is
+// full. Random eviction is O(1) with no bookkeeping; batch eviction
+// amortizes the overhead for image-heavy UIs.
+func (b *Backend) evictImageCache() {
+	if len(b.imgCache) < maxImageCacheSize {
+		return
+	}
+	n := 0
+	for k := range b.imgCache {
+		delete(b.imgCache, k)
+		n++
+		if n >= imageCacheEvictN {
+			break
+		}
+	}
+}
+
+// memImageCanvas paints an NRGBA8 buffer into an offscreen canvas.
+// ImageData is non-premultiplied RGBA, the same layout the registry
+// stores, so the bytes transfer with no conversion.
+func (b *Backend) memImageCanvas(
+	w, h int, pix []byte,
+) js.Value {
+	canvas := js.Global().Get("document").
+		Call("createElement", "canvas")
+	canvas.Set("width", w)
+	canvas.Set("height", h)
+	ctx := canvas.Call("getContext", "2d")
+
+	buf := js.Global().Get("Uint8Array").New(len(pix))
+	js.CopyBytesToJS(buf, pix)
+	data := ctx.Call("createImageData", w, h)
+	data.Get("data").Call("set", buf)
+	ctx.Call("putImageData", data, 0, 0)
+	return canvas
 }
 
 func (b *Backend) drawSvg(r *gui.RenderCmd) {

--- a/gui/color_buffers.go
+++ b/gui/color_buffers.go
@@ -1,0 +1,348 @@
+package gui
+
+import "strconv"
+
+// Pixel generators for the color components.
+//
+// Every generator follows one shape: build a *content key* naming the
+// inputs the buffer depends on, hand it to memImageSrc, and only on a miss
+// allocate a buffer and fill it. The key is built into a stack scratch
+// buffer and the hit path returns the string stored at registration, so a
+// steady frame — the common case, since one drag moves one channel —
+// costs a map lookup and nothing else.
+//
+// Keys quantize: hue to whole degrees, saturation/lightness/alpha to whole
+// percent. A key that tracked a float exactly would miss on every frame of
+// a drag and rebuild the buffer each time, which is the failure this design
+// exists to avoid.
+
+// imgScale is how many pixels of generated imagery back one logical point.
+// Buffers are built at 2× and displayed at logical size: sharp on HiDPI,
+// cheaply downscaled on 1×. Fixed rather than read from BackingScale so the
+// scale stays out of every content key.
+const imgScale = 2
+
+// colorKeyBuf is the scratch a content key is built into. 64 bytes holds
+// the longest key any generator below produces.
+type colorKeyBuf [64]byte
+
+// appendQ appends a channel value quantized to an integer, plus a
+// separator. Channels the buffer does not depend on pass -1, which keeps
+// the key's shape fixed while marking the axis as "swept".
+func appendQ(b []byte, v int) []byte {
+	b = strconv.AppendInt(b, int64(v), 10)
+	return append(b, '-')
+}
+
+// quantHSLA renders an HSLA to the integers its keys are built from:
+// hue in degrees, the rest in percent.
+func quantHSLA(v HSLA) (h, s, l, a int) {
+	n := v.Normalized()
+	return int(n.H + 0.5), int(n.S*100 + 0.5),
+		int(n.L*100 + 0.5), int(n.A*100 + 0.5)
+}
+
+// ColorChannel names the HSLA component a color control edits.
+type ColorChannel uint8
+
+// Channel constants for ColorChannelSliderCfg.Channel.
+const (
+	ChannelHue ColorChannel = iota
+	ChannelSaturation
+	ChannelLightness
+	ChannelAlpha
+)
+
+// channelSpan is the value range each channel sweeps, in the units the
+// caller sees: degrees for hue, percent for saturation and lightness, and
+// 0–1 for alpha.
+func (ch ColorChannel) span() float32 {
+	switch ch {
+	case ChannelHue:
+		return 360
+	case ChannelAlpha:
+		return 1
+	default:
+		return 100
+	}
+}
+
+// value reads this channel out of an HSLA in the units span() describes.
+func (ch ColorChannel) value(v HSLA) float32 {
+	switch ch {
+	case ChannelHue:
+		return v.H
+	case ChannelSaturation:
+		return v.S * 100
+	case ChannelLightness:
+		return v.L * 100
+	default:
+		return v.A
+	}
+}
+
+// with returns v with this channel set to t (again in span() units).
+func (ch ColorChannel) with(v HSLA, t float32) HSLA {
+	switch ch {
+	case ChannelHue:
+		v.H = t
+	case ChannelSaturation:
+		v.S = t / 100
+	case ChannelLightness:
+		v.L = t / 100
+	default:
+		v.A = t
+	}
+	return v
+}
+
+// channelStripSrc returns the track image for one channel: the color the
+// slider would pick at each step along it, holding the other channels where
+// they are. A vertical strip sweeps bottom to top, so its low end is at the
+// bottom of the screen where a vertical slider's low end belongs.
+//
+// The gradient is inset by half the thumb at each end so the thumb's centre
+// always sits on the exact color it selects; the end caps pin to the
+// extreme values. Hue, saturation and lightness tracks are drawn opaque —
+// alpha is irrelevant to what they pick — while the alpha track composites
+// over the checkerboard, which is the only honest way to show it.
+func channelStripSrc(
+	ch ColorChannel, v HSLA, w, h, inset int, vertical bool,
+) string {
+	var kb colorKeyBuf
+	key := kb[:0]
+	key = append(key, "gui/cstrip/"...)
+	key = appendQ(key, int(ch))
+	key = appendQ(key, w)
+	key = appendQ(key, h)
+	key = appendQ(key, inset)
+	key = appendQ(key, boolInt(vertical))
+
+	qh, qs, ql, _ := quantHSLA(v)
+	// A channel does not affect its own strip: the strip sweeps it.
+	// Excluding it is what keeps a hue drag from rebuilding the hue
+	// strip on every frame.
+	switch ch {
+	case ChannelHue:
+		qh = -1
+	case ChannelSaturation:
+		qs = -1
+	case ChannelLightness:
+		ql = -1
+	}
+	key = appendQ(key, qh)
+	key = appendQ(key, qs)
+	key = appendQ(key, ql)
+	// Alpha is in no strip's key: the H/S/L tracks are drawn opaque, and
+	// the alpha track is the one sweeping it.
+
+	if src, ok := memImageSrc(key); ok {
+		return src
+	}
+	return UseImage(string(key), w, h,
+		channelStripPixels(ch, v, w, h, inset, vertical))
+}
+
+func channelStripPixels(
+	ch ColorChannel, v HSLA, w, h, inset int, vertical bool,
+) []byte {
+	pix := make([]byte, w*h*4)
+	// The swept axis is x when horizontal and y when vertical; the other
+	// axis just repeats the column (or row) of colors.
+	steps, cross := w, h
+	if vertical {
+		steps, cross = h, w
+	}
+	track := float32(steps - 2*inset)
+	if track <= 0 {
+		track = float32(steps)
+	}
+	span := ch.span()
+
+	for n := range steps {
+		t := (float32(n) + 0.5 - float32(inset)) / track
+		if vertical {
+			// Screen y grows downward; a vertical slider's maximum is
+			// at the top, so the sweep runs the other way.
+			t = 1 - t
+		}
+		c := ch.with(v, f32Clamp(t, 0, 1)*span)
+		if ch != ChannelAlpha {
+			c.A = 1
+		}
+		col := c.Color()
+		for m := range cross {
+			x, y := n, m
+			if vertical {
+				x, y = m, n
+			}
+			r, g, b := col.R, col.G, col.B
+			if ch == ChannelAlpha {
+				// Composite onto the checker here rather than layering
+				// two views: the strip is one texture, so the checker
+				// must not slide independently of it.
+				bg := checkerShade(x, y)
+				a := float32(col.A) / 255
+				r = mix8(bg, r, a)
+				g = mix8(bg, g, a)
+				b = mix8(bg, b, a)
+			}
+			i := (y*w + x) * 4
+			pix[i+0] = r
+			pix[i+1] = g
+			pix[i+2] = b
+			pix[i+3] = 0xff
+		}
+	}
+	return pix
+}
+
+// boolInt renders a flag as a key segment.
+func boolInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// planeSrc returns the saturation(→) × lightness(↑) plane at v's hue.
+// Keyed on hue alone: moving saturation or lightness moves the marker
+// across a plane that has not changed.
+func planeSrc(v HSLA, size int) string {
+	var kb colorKeyBuf
+	key := kb[:0]
+	key = append(key, "gui/cplane/"...)
+	key = appendQ(key, size)
+	qh, _, _, _ := quantHSLA(v)
+	key = appendQ(key, qh)
+
+	if src, ok := memImageSrc(key); ok {
+		return src
+	}
+	return UseImage(string(key), size, size, planePixels(v.H, size))
+}
+
+func planePixels(hue float32, size int) []byte {
+	pix := make([]byte, size*size*4)
+	d := float32(size)
+	for y := range size {
+		l := 1 - (float32(y)+0.5)/d
+		for x := range size {
+			s := (float32(x) + 0.5) / d
+			col := HSLA{H: hue, S: s, L: l, A: 1}.Color()
+			i := (y*size + x) * 4
+			pix[i+0] = col.R
+			pix[i+1] = col.G
+			pix[i+2] = col.B
+			pix[i+3] = 0xff
+		}
+	}
+	return pix
+}
+
+// wheelSrc returns the hue(angle) × saturation(radius) disc at v's
+// lightness. Keyed on lightness alone, quantized to whole percent, which
+// caps the disc at 101 distinct buffers however long a drag runs.
+func wheelSrc(v HSLA, size int) string {
+	var kb colorKeyBuf
+	key := kb[:0]
+	key = append(key, "gui/cwheel/"...)
+	key = appendQ(key, size)
+	_, _, ql, _ := quantHSLA(v)
+	key = appendQ(key, ql)
+
+	if src, ok := memImageSrc(key); ok {
+		return src
+	}
+	return UseImage(string(key), size, size,
+		wheelPixels(float32(ql)/100, size))
+}
+
+func wheelPixels(light float32, size int) []byte {
+	pix := make([]byte, size*size*4)
+	radius := float32(size) / 2
+	for y := range size {
+		dy := float32(y) + 0.5 - radius
+		for x := range size {
+			dx := float32(x) + 0.5 - radius
+			r := f32Sqrt(dx*dx + dy*dy)
+			// One device pixel of edge coverage, so the rim fades into
+			// transparency instead of showing a staircase.
+			cov := f32Clamp(radius-r+0.5, 0, 1)
+			if cov == 0 {
+				continue // leaves the pixel fully transparent
+			}
+			col := HSLA{
+				H: hueOf(dx, dy),
+				S: f32Clamp(r/radius, 0, 1),
+				L: light,
+				A: 1,
+			}.Color()
+			i := (y*size + x) * 4
+			pix[i+0] = col.R
+			pix[i+1] = col.G
+			pix[i+2] = col.B
+			pix[i+3] = uint8(255*cov + 0.5)
+		}
+	}
+	return pix
+}
+
+// hueOf maps a vector from the wheel centre to a hue angle in degrees:
+// 0° points right (+x) and hue increases counterclockwise. Y grows
+// downward on screen, hence the negated dy.
+func hueOf(dx, dy float32) float32 {
+	h := f32Atan2(-dy, dx) * 180 / f32Pi
+	if h < 0 {
+		h += 360
+	}
+	return h
+}
+
+// checkerSrc returns the transparency checkerboard drawn behind a swatch.
+// One buffer serves every swatch on screen, so it is keyed on size alone.
+func checkerSrc(w, h int) string {
+	var kb colorKeyBuf
+	key := kb[:0]
+	key = append(key, "gui/checker/"...)
+	key = appendQ(key, w)
+	key = appendQ(key, h)
+
+	if src, ok := memImageSrc(key); ok {
+		return src
+	}
+	return UseImage(string(key), w, h, checkerPixels(w, h))
+}
+
+func checkerPixels(w, h int) []byte {
+	pix := make([]byte, w*h*4)
+	for y := range h {
+		for x := range w {
+			s := checkerShade(x, y)
+			i := (y*w + x) * 4
+			pix[i+0] = s
+			pix[i+1] = s
+			pix[i+2] = s
+			pix[i+3] = 0xff
+		}
+	}
+	return pix
+}
+
+// checkerCell is the checkerboard square size in generated pixels — 8
+// logical points at imgScale 2.
+const checkerCell = 8 * imgScale
+
+// checkerShade returns the light or dark shade of the checkerboard cell
+// covering a generated pixel.
+func checkerShade(x, y int) uint8 {
+	if (x/checkerCell+y/checkerCell)%2 == 0 {
+		return 0xff
+	}
+	return 0xcc
+}
+
+// mix8 blends fg over bg at alpha a (0–1).
+func mix8(bg, fg uint8, a float32) uint8 {
+	return uint8(float32(bg)*(1-a) + float32(fg)*a + 0.5)
+}

--- a/gui/color_buffers_test.go
+++ b/gui/color_buffers_test.go
@@ -1,0 +1,274 @@
+package gui
+
+import "testing"
+
+// pixAt returns the RGBA bytes of one pixel in a w-wide buffer.
+func pixAt(pix []byte, w, x, y int) (r, g, b, a uint8) {
+	i := (y*w + x) * 4
+	return pix[i], pix[i+1], pix[i+2], pix[i+3]
+}
+
+// nearGray reports whether the channels are within tol of each other.
+// Generators sample pixel *centres*, so the leftmost column of a plane
+// is S≈0.008 rather than exactly 0 — near-gray, never bit-identical.
+func nearGray(r, g, b uint8, tol int) bool {
+	mx := max(int(r), max(int(g), int(b)))
+	mn := min(int(r), min(int(g), int(b)))
+	return mx-mn <= tol
+}
+
+// The plane's corners are what tell a user what the control does:
+// saturation right, lightness up.
+func TestPlanePixelsCorners(t *testing.T) {
+	const size = 64
+	pix := planePixels(0, size) // red hue
+
+	// Top-left: S=0, L=1 → white. Top-right: S=1, L=1 → white too,
+	// since full lightness washes out any hue.
+	if r, g, b, _ := pixAt(pix, size, 0, 0); r < 250 || g < 250 || b < 250 {
+		t.Errorf("top-left = %d,%d,%d, want ~white", r, g, b)
+	}
+	// Bottom row is L≈0 → black regardless of saturation.
+	if r, g, b, _ := pixAt(pix, size, size-1, size-1); r > 8 || g > 8 || b > 8 {
+		t.Errorf("bottom-right = %d,%d,%d, want ~black", r, g, b)
+	}
+	// Middle-left is unsaturated mid-lightness → gray.
+	r, g, b, _ := pixAt(pix, size, 0, size/2)
+	if !nearGray(r, g, b, 4) {
+		t.Errorf("middle-left = %d,%d,%d, want ~gray", r, g, b)
+	}
+	// Middle-right is fully saturated red at mid lightness.
+	r, g, b, _ = pixAt(pix, size, size-1, size/2)
+	if r < 240 || g > 20 || b > 20 {
+		t.Errorf("middle-right = %d,%d,%d, want ~red", r, g, b)
+	}
+}
+
+// The wheel must be a disc: opaque at the centre, transparent at the
+// corners, with hue following the angle.
+func TestWheelPixelsDiscAndAngle(t *testing.T) {
+	const size = 64
+	pix := wheelPixels(0.5, size)
+
+	if _, _, _, a := pixAt(pix, size, 0, 0); a != 0 {
+		t.Errorf("corner alpha = %d, want 0 (outside the disc)", a)
+	}
+	if _, _, _, a := pixAt(pix, size, size/2, size/2); a != 255 {
+		t.Errorf("centre alpha = %d, want 255", a)
+	}
+	// Centre is radius 0 → saturation 0 → gray at L=0.5.
+	if r, g, b, _ := pixAt(pix, size, size/2, size/2); !nearGray(r, g, b, 8) {
+		t.Errorf("centre = %d,%d,%d, want ~gray", r, g, b)
+	}
+	// Hue 0 (red) sits at +x, i.e. the right edge of the middle row.
+	if r, g, b, _ := pixAt(pix, size, size-2, size/2); r < 200 || b > 80 {
+		t.Errorf("right edge = %d,%d,%d, want ~red", r, g, b)
+	}
+	// Hue 180 (cyan) is opposite it.
+	if r, g, b, _ := pixAt(pix, size, 1, size/2); r > 80 || b < 200 {
+		t.Errorf("left edge = %d,%d,%d, want ~cyan", r, g, b)
+	}
+}
+
+func TestHueOfQuadrants(t *testing.T) {
+	cases := []struct {
+		name   string
+		dx, dy float32
+		want   float32
+	}{
+		{"right", 1, 0, 0},
+		{"up", 0, -1, 90},    // y grows downward on screen
+		{"left", -1, 0, 180}, //
+		{"down", 0, 1, 270},  //
+		{"up-right", 1, -1, 45},
+	}
+	for _, tc := range cases {
+		if got := hueOf(tc.dx, tc.dy); f32Abs(got-tc.want) > 0.5 {
+			t.Errorf("%s: hueOf = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The thumb must sit on the color it picks, which is why the strip
+// insets its gradient by half a thumb and pins the end caps.
+func TestChannelStripInsetPinsEndCaps(t *testing.T) {
+	const w, h, inset = 64, 4, 8
+	v := HSLA{H: 0, S: 1, L: 0.5, A: 1}
+	pix := channelStripPixels(ChannelHue, v, w, h, inset, false)
+
+	// Everything inside the left inset pins to hue 0 (red).
+	for x := range inset {
+		r, g, b, _ := pixAt(pix, w, x, 0)
+		if r < 250 || g > 5 || b > 5 {
+			t.Fatalf("x=%d = %d,%d,%d, want pinned red", x, r, g, b)
+		}
+	}
+	// The right cap pins to hue 360, which is red again.
+	r, g, b, _ := pixAt(pix, w, w-1, 0)
+	if r < 250 || g > 5 || b > 5 {
+		t.Errorf("right cap = %d,%d,%d, want pinned red", r, g, b)
+	}
+	// A third of the way along the track is around hue 120 (green).
+	x := inset + (w-2*inset)/3
+	r, g, b, _ = pixAt(pix, w, x, 0)
+	if g < 200 || r > 60 {
+		t.Errorf("x=%d = %d,%d,%d, want ~green", x, r, g, b)
+	}
+}
+
+// The H/S/L tracks are drawn opaque; only the alpha track composites
+// over the checkerboard, and it must actually reach transparency at the
+// low end and the color at the high end.
+func TestChannelStripAlphaCompositesOverChecker(t *testing.T) {
+	const w, h, inset = 64, checkerCell * 2, 8
+	v := HSLA{H: 0, S: 1, L: 0.5, A: 1} // red
+
+	opaque := channelStripPixels(ChannelHue, v, w, h, inset, false)
+	for y := range h {
+		if _, _, _, a := pixAt(opaque, w, w/2, y); a != 255 {
+			t.Fatalf("hue strip alpha = %d, want opaque", a)
+		}
+	}
+
+	alpha := channelStripPixels(ChannelAlpha, v, w, h, inset, false)
+	// Left cap is alpha 0 → pure checkerboard, so the two checker rows
+	// must differ from each other.
+	r0, g0, b0, _ := pixAt(alpha, w, 0, 0)
+	r1, _, _, _ := pixAt(alpha, w, 0, checkerCell)
+	if r0 != g0 || g0 != b0 {
+		t.Errorf("alpha=0 pixel = %d,%d,%d, want neutral checker",
+			r0, g0, b0)
+	}
+	if r0 == r1 {
+		t.Error("checkerboard rows identical; pattern not visible")
+	}
+	// Right cap is alpha 1 → the color itself.
+	r, g, b, _ := pixAt(alpha, w, w-1, 0)
+	if r < 240 || g > 20 || b > 20 {
+		t.Errorf("alpha=1 pixel = %d,%d,%d, want ~red", r, g, b)
+	}
+}
+
+// Content keying is the whole caching design: a channel must not
+// rebuild its own strip, and must rebuild the strips that depend on it.
+func TestChannelStripKeyingIgnoresOwnChannel(t *testing.T) {
+	resetMemImages(t)
+	const w, h, inset = 32, 8, 4
+
+	base := HSLA{H: 10, S: 0.5, L: 0.5, A: 1}
+	hueSrc := channelStripSrc(ChannelHue, base, w, h, inset, false)
+	satSrc := channelStripSrc(ChannelSaturation, base, w, h, inset, false)
+
+	moved := base
+	moved.H = 200
+	if got := channelStripSrc(ChannelHue, moved, w, h, inset, false); got != hueSrc {
+		t.Error("hue strip rebuilt when only hue moved")
+	}
+	if got := channelStripSrc(
+		ChannelSaturation, moved, w, h, inset, false); got == satSrc {
+		t.Error("saturation strip did not rebuild when hue moved")
+	}
+
+	// Alpha is in no strip's key at all.
+	faded := base
+	faded.A = 0.25
+	if got := channelStripSrc(
+		ChannelSaturation, faded, w, h, inset, false); got != satSrc {
+		t.Error("saturation strip rebuilt when only alpha moved")
+	}
+}
+
+func TestPlaneAndWheelKeying(t *testing.T) {
+	resetMemImages(t)
+	base := HSLA{H: 10, S: 0.5, L: 0.5, A: 1}
+
+	plane := planeSrc(base, 16)
+	wheel := wheelSrc(base, 16)
+
+	// Saturation moves the markers, not the imagery.
+	sat := base
+	sat.S = 0.9
+	if planeSrc(sat, 16) != plane {
+		t.Error("plane rebuilt when only saturation moved")
+	}
+	if wheelSrc(sat, 16) != wheel {
+		t.Error("wheel rebuilt when only saturation moved")
+	}
+
+	// Hue repaints the plane; lightness repaints the wheel.
+	hue := base
+	hue.H = 200
+	if planeSrc(hue, 16) == plane {
+		t.Error("plane did not rebuild when hue moved")
+	}
+	if wheelSrc(hue, 16) != wheel {
+		t.Error("wheel rebuilt when only hue moved")
+	}
+	light := base
+	light.L = 0.9
+	if wheelSrc(light, 16) == wheel {
+		t.Error("wheel did not rebuild when lightness moved")
+	}
+}
+
+// Sub-quantum jitter must land on the same key, or a drag rebuilds
+// every buffer every frame — the failure the quantization prevents.
+func TestKeysQuantize(t *testing.T) {
+	resetMemImages(t)
+	a := HSLA{H: 200.1, S: 0.5001, L: 0.5, A: 1}
+	b := HSLA{H: 200.2, S: 0.5002, L: 0.5, A: 1}
+	if planeSrc(a, 16) != planeSrc(b, 16) {
+		t.Error("plane key not quantized")
+	}
+	if wheelSrc(a, 16) != wheelSrc(b, 16) {
+		t.Error("wheel key not quantized")
+	}
+}
+
+// A steady frame must cost nothing: the key is built into a stack
+// buffer and the hit returns the string stored at registration.
+func TestBufferSrcCacheHitDoesNotAllocate(t *testing.T) {
+	resetMemImages(t)
+	v := HSLA{H: 210, S: 0.7, L: 0.55, A: 0.85}
+	planeSrc(v, 16)
+	wheelSrc(v, 16)
+	channelStripSrc(ChannelHue, v, 32, 8, 4, false)
+	checkerSrc(16, 16)
+
+	if got := testing.AllocsPerRun(100, func() {
+		planeSrc(v, 16)
+		wheelSrc(v, 16)
+		channelStripSrc(ChannelHue, v, 32, 8, 4, false)
+		checkerSrc(16, 16)
+	}); got != 0 {
+		t.Errorf("allocs per frame = %v, want 0", got)
+	}
+}
+
+func TestColorChannelAccessors(t *testing.T) {
+	v := HSLA{H: 180, S: 0.25, L: 0.75, A: 0.5}
+	cases := []struct {
+		ch   ColorChannel
+		want float32
+		span float32
+	}{
+		{ChannelHue, 180, 360},
+		{ChannelSaturation, 25, 100},
+		{ChannelLightness, 75, 100},
+		{ChannelAlpha, 0.5, 1},
+	}
+	for _, tc := range cases {
+		if got := tc.ch.value(v); f32Abs(got-tc.want) > 0.001 {
+			t.Errorf("ch %d value = %v, want %v", tc.ch, got, tc.want)
+		}
+		if got := tc.ch.span(); got != tc.span {
+			t.Errorf("ch %d span = %v, want %v", tc.ch, got, tc.span)
+		}
+		// with/value must round-trip, since a drag writes through with
+		// and the next frame reads back through value.
+		got := tc.ch.value(tc.ch.with(v, tc.want))
+		if f32Abs(got-tc.want) > 0.001 {
+			t.Errorf("ch %d round-trip = %v, want %v", tc.ch, got, tc.want)
+		}
+	}
+}

--- a/gui/color_hsl.go
+++ b/gui/color_hsl.go
@@ -1,0 +1,144 @@
+package gui
+
+import "strconv"
+
+// HSLA is a color in hue/saturation/lightness form with alpha. It is
+// the value the color components (ColorPlane, ColorWheel,
+// ColorChannelSlider, ColorSwatch) read and write.
+//
+// Why a value the *app* owns rather than a Color: RGBA cannot
+// represent hue at S=0 (grays) or at L=0/L=1 (black and white), so a
+// picker that round-trips through Color loses the hue as soon as the
+// pointer touches an edge. The old monolithic ColorPicker hid an H in
+// window state to paper over that; components that each hid their own
+// copy would drift apart instead. Holding one HSLA in app state makes
+// every control read the same value, which is the whole point of
+// splitting them up.
+//
+// Ranges: H in degrees 0–360 (wrapping), S, L and A in 0–1. Nothing
+// clamps on construction — Normalized does, at the point of use.
+type HSLA struct {
+	H float32 // hue, degrees
+	S float32 // saturation, 0–1
+	L float32 // lightness, 0–1
+	A float32 // alpha, 0–1
+}
+
+// Normalized returns v with H wrapped into [0, 360) and S, L, A
+// clamped to [0, 1]. Conversions call it, so callers may hand over raw
+// pointer-derived values.
+func (v HSLA) Normalized() HSLA {
+	h := f32Mod(v.H, 360)
+	if h < 0 {
+		h += 360
+	}
+	return HSLA{
+		H: h,
+		S: f32Clamp(v.S, 0, 1),
+		L: f32Clamp(v.L, 0, 1),
+		A: f32Clamp(v.A, 0, 1),
+	}
+}
+
+// Color converts to an RGBA Color. The conversion is lossy in the one
+// direction that matters — hue and saturation collapse at the
+// lightness extremes — which is why the HSLA value, not the Color, is
+// what a picker keeps.
+func (v HSLA) Color() Color {
+	n := v.Normalized()
+	a := uint8(n.A*255 + 0.5)
+
+	// c is the chroma the lightness leaves room for; m re-centers the
+	// result on that lightness. Standard HSL→RGB.
+	c := (1 - f32Abs(2*n.L-1)) * n.S
+	hh := f32Mod(n.H/60, 6)
+	x := c * (1 - f32Abs(f32Mod(hh, 2)-1))
+	m := n.L - c/2
+
+	var r, g, b float32
+	switch {
+	case hh < 1:
+		r, g = c, x
+	case hh < 2:
+		r, g = x, c
+	case hh < 3:
+		g, b = c, x
+	case hh < 4:
+		g, b = x, c
+	case hh < 5:
+		r, b = x, c
+	default:
+		r, b = c, x
+	}
+	return RGBA(
+		uint8((r+m)*255+0.5),
+		uint8((g+m)*255+0.5),
+		uint8((b+m)*255+0.5),
+		a)
+}
+
+// ColorToHSLA converts an RGBA Color to HSLA. Hue is 0 for grays,
+// where it is genuinely undefined — a caller tracking a live HSLA
+// value should keep its own H rather than round-tripping through this.
+func ColorToHSLA(c Color) HSLA {
+	r := float32(c.R) / 255
+	g := float32(c.G) / 255
+	b := float32(c.B) / 255
+
+	mx := f32Max(r, f32Max(g, b))
+	mn := f32Min(r, f32Min(g, b))
+	delta := mx - mn
+
+	v := HSLA{L: (mx + mn) / 2, A: float32(c.A) / 255}
+	if delta == 0 {
+		return v // gray: hue undefined, saturation zero
+	}
+
+	den := 1 - f32Abs(2*v.L-1)
+	if den > 0 {
+		v.S = f32Clamp(delta/den, 0, 1)
+	}
+	switch mx {
+	case r:
+		v.H = 60 * f32Mod((g-b)/delta, 6)
+	case g:
+		v.H = 60 * (((b - r) / delta) + 2)
+	default:
+		v.H = 60 * (((r - g) / delta) + 4)
+	}
+	if v.H < 0 {
+		v.H += 360
+	}
+	return v
+}
+
+// String formats the value as CSS hsla(), the notation the readout
+// shows: hsla(210, 70%, 55%, 0.85).
+func (v HSLA) String() string {
+	n := v.Normalized()
+	b := make([]byte, 0, 32)
+	b = append(b, "hsla("...)
+	b = strconv.AppendInt(b, int64(n.H+0.5), 10)
+	b = append(b, ", "...)
+	b = strconv.AppendInt(b, int64(n.S*100+0.5), 10)
+	b = append(b, "%, "...)
+	b = strconv.AppendInt(b, int64(n.L*100+0.5), 10)
+	b = append(b, "%, "...)
+	b = strconv.AppendFloat(b, float64(n.A), 'f', 2, 32)
+	b = append(b, ')')
+	return string(b)
+}
+
+// Hex returns "#RRGGBB", or "#RRGGBBAA" when alpha is not opaque.
+func (c Color) Hex() string { return c.toHexString() }
+
+// ColorFromHex parses "#RRGGBB" or "#RRGGBBAA"; the leading "#" is
+// optional. It returns ok=false on malformed input, leaving the
+// caller's current color untouched — which is what a hex field wants
+// while the user is still typing.
+//
+// exportaudit:keep — public counterpart of Color.Hex, for app code
+// reading colors from config or user input.
+func ColorFromHex(s string) (Color, bool) {
+	return colorFromHexString(s)
+}

--- a/gui/color_hsl.go
+++ b/gui/color_hsl.go
@@ -27,7 +27,23 @@ type HSLA struct {
 // Normalized returns v with H wrapped into [0, 360) and S, L, A
 // clamped to [0, 1]. Conversions call it, so callers may hand over raw
 // pointer-derived values.
+//
+// Non-finite components become zero rather than surviving into color
+// math: f32Clamp lets NaN through (both comparisons are false), and a
+// NaN hue or saturation would corrupt every pixel it reaches.
 func (v HSLA) Normalized() HSLA {
+	if !f32IsFinite(v.H) {
+		v.H = 0
+	}
+	if !f32IsFinite(v.S) {
+		v.S = 0
+	}
+	if !f32IsFinite(v.L) {
+		v.L = 0
+	}
+	if !f32IsFinite(v.A) {
+		v.A = 0
+	}
 	h := f32Mod(v.H, 360)
 	if h < 0 {
 		h += 360
@@ -55,21 +71,8 @@ func (v HSLA) Color() Color {
 	x := c * (1 - f32Abs(f32Mod(hh, 2)-1))
 	m := n.L - c/2
 
-	var r, g, b float32
-	switch {
-	case hh < 1:
-		r, g = c, x
-	case hh < 2:
-		r, g = x, c
-	case hh < 3:
-		g, b = c, x
-	case hh < 4:
-		g, b = x, c
-	case hh < 5:
-		r, b = x, c
-	default:
-		r, b = c, x
-	}
+	// Same sector geometry as the HSV conversion; see sectorRGB.
+	r, g, b := sectorRGB(hh, c, x)
 	return RGBA(
 		uint8((r+m)*255+0.5),
 		uint8((g+m)*255+0.5),

--- a/gui/color_hsl_test.go
+++ b/gui/color_hsl_test.go
@@ -1,0 +1,128 @@
+package gui
+
+import "testing"
+
+func TestHSLAColorPrimaries(t *testing.T) {
+	cases := []struct {
+		name string
+		in   HSLA
+		want Color
+	}{
+		{"red", HSLA{0, 1, 0.5, 1}, RGBA(255, 0, 0, 255)},
+		{"yellow", HSLA{60, 1, 0.5, 1}, RGBA(255, 255, 0, 255)},
+		{"green", HSLA{120, 1, 0.5, 1}, RGBA(0, 255, 0, 255)},
+		{"cyan", HSLA{180, 1, 0.5, 1}, RGBA(0, 255, 255, 255)},
+		{"blue", HSLA{240, 1, 0.5, 1}, RGBA(0, 0, 255, 255)},
+		{"magenta", HSLA{300, 1, 0.5, 1}, RGBA(255, 0, 255, 255)},
+		{"black", HSLA{0, 1, 0, 1}, RGBA(0, 0, 0, 255)},
+		{"white", HSLA{0, 1, 1, 1}, RGBA(255, 255, 255, 255)},
+		{"mid gray", HSLA{0, 0, 0.5, 1}, RGBA(128, 128, 128, 255)},
+		{"half alpha", HSLA{0, 1, 0.5, 0.5}, RGBA(255, 0, 0, 128)},
+	}
+	for _, tc := range cases {
+		got := tc.in.Color()
+		if got != tc.want {
+			t.Errorf("%s: Color() = %v, want %v",
+				tc.name, got, tc.want)
+		}
+	}
+}
+
+// Hue must wrap and S/L/A must clamp, because pointer-derived values
+// arrive raw from a drag that ran past the edge of the control.
+func TestHSLANormalized(t *testing.T) {
+	got := HSLA{H: -30, S: 1.4, L: -0.2, A: 2}.Normalized()
+	want := HSLA{H: 330, S: 1, L: 0, A: 1}
+	if got != want {
+		t.Errorf("Normalized() = %+v, want %+v", got, want)
+	}
+	if got := (HSLA{H: 720}).Normalized().H; got != 0 {
+		t.Errorf("720° wrapped to %v, want 0", got)
+	}
+}
+
+func TestColorToHSLARoundTrip(t *testing.T) {
+	cases := []HSLA{
+		{0, 1, 0.5, 1},
+		{210, 0.7, 0.55, 0.85},
+		{45, 0.3, 0.2, 1},
+		{300, 1, 0.75, 0.5},
+	}
+	for _, want := range cases {
+		got := ColorToHSLA(want.Color())
+		// 8-bit RGB quantization bounds the achievable precision;
+		// a degree of hue and a percent of S/L is well inside it.
+		if f32Abs(got.H-want.H) > 1 {
+			t.Errorf("%v: H = %v", want, got.H)
+		}
+		if f32Abs(got.S-want.S) > 0.01 {
+			t.Errorf("%v: S = %v", want, got.S)
+		}
+		if f32Abs(got.L-want.L) > 0.01 {
+			t.Errorf("%v: L = %v", want, got.L)
+		}
+		if f32Abs(got.A-want.A) > 0.01 {
+			t.Errorf("%v: A = %v", want, got.A)
+		}
+	}
+}
+
+// The degenerate points are exactly where a picker that round-trips
+// through Color loses its hue — assert the conversion is at least
+// well defined there.
+func TestColorToHSLADegenerate(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      Color
+		wantS   float32
+		wantL   float32
+		wantHue float32
+	}{
+		{"black", RGBA(0, 0, 0, 255), 0, 0, 0},
+		{"white", RGBA(255, 255, 255, 255), 0, 1, 0},
+		{"gray", RGBA(128, 128, 128, 255), 0, 0.502, 0},
+	}
+	for _, tc := range cases {
+		got := ColorToHSLA(tc.in)
+		if f32Abs(got.S-tc.wantS) > 0.001 ||
+			f32Abs(got.L-tc.wantL) > 0.005 ||
+			got.H != tc.wantHue {
+			t.Errorf("%s: got %+v", tc.name, got)
+		}
+	}
+}
+
+func TestHSLAString(t *testing.T) {
+	got := HSLA{210, 0.7, 0.55, 0.85}.String()
+	want := "hsla(210, 70%, 55%, 0.85)"
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestColorHexExports(t *testing.T) {
+	if got := RGBA(0x3b, 0x8c, 0xdc, 255).Hex(); got != "#3B8CDC" {
+		t.Errorf("Hex() = %q", got)
+	}
+	if got := RGBA(0x3b, 0x8c, 0xdc, 128).Hex(); got != "#3B8CDC80" {
+		t.Errorf("Hex() with alpha = %q", got)
+	}
+	c, ok := ColorFromHex("#3b8cdc")
+	if !ok || c != RGBA(0x3b, 0x8c, 0xdc, 255) {
+		t.Errorf("ColorFromHex = %v, %v", c, ok)
+	}
+	if _, ok := ColorFromHex("#nothex"); ok {
+		t.Error("ColorFromHex accepted malformed input")
+	}
+}
+
+// The components convert on every frame of a drag, so the hot
+// conversions must stay off the heap.
+func TestHSLAConversionsDoNotAllocate(t *testing.T) {
+	v := HSLA{210, 0.7, 0.55, 0.85}
+	if got := testing.AllocsPerRun(100, func() {
+		_ = ColorToHSLA(v.Color())
+	}); got != 0 {
+		t.Errorf("allocs = %v, want 0", got)
+	}
+}

--- a/gui/color_hsl_test.go
+++ b/gui/color_hsl_test.go
@@ -1,6 +1,9 @@
 package gui
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestHSLAColorPrimaries(t *testing.T) {
 	cases := []struct {
@@ -38,6 +41,25 @@ func TestHSLANormalized(t *testing.T) {
 	}
 	if got := (HSLA{H: 720}).Normalized().H; got != 0 {
 		t.Errorf("720° wrapped to %v, want 0", got)
+	}
+}
+
+// Non-finite components must normalize to zero, not survive into the
+// color math: f32Clamp lets NaN through, and a NaN hue would corrupt
+// every pixel a buffer generator draws.
+func TestHSLANormalizedNonFinite(t *testing.T) {
+	got := HSLA{
+		H: float32(math.NaN()),
+		S: float32(math.Inf(1)),
+		L: float32(math.NaN()),
+		A: float32(math.Inf(-1)),
+	}.Normalized()
+	want := HSLA{0, 0, 0, 0}
+	if got != want {
+		t.Errorf("Normalized() = %+v, want %+v", got, want)
+	}
+	if c := (HSLA{S: float32(math.NaN())}).Normalized().Color(); !c.IsSet() {
+		t.Error("a NaN saturation must not poison Color()")
 	}
 }
 

--- a/gui/color_hsv.go
+++ b/gui/color_hsv.go
@@ -53,8 +53,15 @@ func colorFromHSVA(h, s, v float32, a uint8) Color {
 	hh := f32Mod(h/60.0, 6)
 	x := c * (1.0 - f32Abs(f32Mod(hh, 2)-1.0))
 	m := v - c
+	r, g, b := sectorRGB(hh, c, x)
+	return RGBA(uint8((r+m)*255.0+0.5), uint8((g+m)*255.0+0.5), uint8((b+m)*255.0+0.5), a)
+}
 
-	var r, g, b float32
+// sectorRGB maps the hue sector hh (in units of 60°, 0–6) to RGB
+// components from chroma c and its intermediate x. The HSV and HSL
+// conversions share this geometry; only the chroma and the offset m
+// differ between them, so the sector mapping lives here once.
+func sectorRGB(hh, c, x float32) (r, g, b float32) {
 	switch {
 	case hh < 1:
 		r, g = c, x
@@ -69,8 +76,7 @@ func colorFromHSVA(h, s, v float32, a uint8) Color {
 	default:
 		r, b = c, x
 	}
-
-	return RGBA(uint8((r+m)*255.0+0.5), uint8((g+m)*255.0+0.5), uint8((b+m)*255.0+0.5), a)
+	return r, g, b
 }
 
 // HueColor returns the pure color for a given hue (s=1, v=1).

--- a/gui/image_download.go
+++ b/gui/image_download.go
@@ -171,7 +171,7 @@ func resolveImageSrcWithFetcher(
 	if src == "" {
 		return ""
 	}
-	if isDataURL(src) {
+	if isDataURL(src) || isMemImage(src) {
 		return src
 	}
 	if !isHTTPURL(src) {

--- a/gui/image_mem.go
+++ b/gui/image_mem.go
@@ -36,6 +36,11 @@ const memImagePrefix = "mem:"
 // drag from growing memory without limit.
 const defaultMemImageBudget = 32 << 20 // 32 MiB
 
+// maxMemImageDim caps one registered buffer's edge, in pixels. 4096 is
+// beyond any generated control imagery and keeps the dimension × 4 byte
+// count far below int overflow on every platform.
+const maxMemImageDim = 4096
+
 // memImage is one registered buffer. Pix is NRGBA8, straight (non-
 // premultiplied) alpha, W*H*4 bytes, matching imgload.DecodeNRGBA so
 // backends upload it with no conversion.
@@ -84,6 +89,15 @@ var memImages = memImageRegistry{budget: defaultMemImageBudget}
 // can draw imagery gradients cannot express.
 func UseImage(key string, w, h int, pix []byte) string {
 	if key == "" || w <= 0 || h <= 0 || len(pix) != w*h*4 {
+		return ""
+	}
+	// w*h*4 above is int arithmetic: for dimensions past a few thousand
+	// pixels it can wrap, passing the length check with a corrupt
+	// stride. The cap bounds the wrapped product below int64 range on
+	// every platform, and the int64 comparison then rejects any buffer
+	// whose true byte count does not match its dimensions.
+	if w > maxMemImageDim || h > maxMemImageDim ||
+		int64(w)*int64(h)*4 != int64(len(pix)) {
 		return ""
 	}
 	memImages.mu.Lock()

--- a/gui/image_mem.go
+++ b/gui/image_mem.go
@@ -1,0 +1,224 @@
+package gui
+
+import (
+	"container/list"
+	"strings"
+	"sync"
+)
+
+// In-memory image registry.
+//
+// Widgets that must draw imagery no gradient can express — a hue wheel, an
+// HSL saturation/lightness plane, an alpha checkerboard — generate a pixel
+// buffer and register it here. UseImage returns a Src string usable anywhere
+// ImageCfg.Src or DrawContext.Image accepts one, and every GPU backend
+// resolves that string through LookupImage instead of touching the disk.
+//
+// Callers are expected to *content-key*: the key names the inputs the buffer
+// was generated from ("colorpicker/wheel/l55"), so a buffer that must change
+// is registered under a new key and the stale variant ages out on its own.
+// There is deliberately no invalidation API — an app that mutates a buffer
+// in place has no way to tell the backends their uploaded texture is stale,
+// because the backend texture caches key on the same string.
+//
+// SECURITY: a mem: buffer bypasses WindowCfg.AllowedImageRoots,
+// MaxImageBytes and MaxImagePixels. Those bound *untrusted* input — a file
+// path or a URL an attacker might steer. An in-process pixel buffer is
+// trusted by construction; the registry's own byte budget is its bound.
+
+// memImagePrefix marks a Src string as naming a registered buffer rather
+// than a path, URL, or data URL.
+const memImagePrefix = "mem:"
+
+// defaultMemImageBudget caps the registry's total pixel bytes. Content-keyed
+// callers register a new key per distinct appearance (one per hue, one per
+// lightness), so the budget — not a call to DropImage — is what keeps a long
+// drag from growing memory without limit.
+const defaultMemImageBudget = 32 << 20 // 32 MiB
+
+// memImage is one registered buffer. Pix is NRGBA8, straight (non-
+// premultiplied) alpha, W*H*4 bytes, matching imgload.DecodeNRGBA so
+// backends upload it with no conversion.
+//
+// src is the prefixed Src string, built once at registration. Holding it
+// here is what lets a generator hand the same string back every frame
+// without allocating (see memImageSrc).
+type memImage struct {
+	src  string
+	pix  []byte
+	elem *list.Element // position in the LRU order; value is the key
+	w    int
+	h    int
+}
+
+// memImageRegistry is a byte-budgeted LRU. It is process-global rather than
+// per-window because backends resolve a Src string with no *Window in hand.
+//
+// data is keyed by the bare key, not the prefixed Src string, so a lookup
+// can be spelled data[string(keyBytes)] — which the compiler performs
+// without allocating.
+type memImageRegistry struct {
+	data   map[string]*memImage
+	order  list.List // front = least recently used
+	bytes  int
+	budget int
+	mu     sync.Mutex
+}
+
+var memImages = memImageRegistry{budget: defaultMemImageBudget}
+
+// UseImage registers pix under key and returns the Src string naming it.
+// Passing a key that is already registered with the same dimensions is a
+// no-op that refreshes the entry's recency, so callers may call it
+// unconditionally each frame; use HasImage to skip generating the buffer at
+// all.
+//
+// The registry takes ownership of pix. Callers must not mutate it
+// afterwards: backends cache an uploaded texture under the same key and
+// would never observe the change.
+//
+// pix must be W*H*4 bytes of NRGBA8. A mismatched length, or a
+// non-positive dimension, registers nothing and returns "".
+//
+// exportaudit:keep — the registry is app-facing: it exists so callers
+// can draw imagery gradients cannot express.
+func UseImage(key string, w, h int, pix []byte) string {
+	if key == "" || w <= 0 || h <= 0 || len(pix) != w*h*4 {
+		return ""
+	}
+	memImages.mu.Lock()
+	defer memImages.mu.Unlock()
+
+	if mi, ok := memImages.data[key]; ok {
+		// Same key, same size: keep the uploaded texture valid by
+		// leaving the stored buffer alone. Only recency changes.
+		if mi.w == w && mi.h == h {
+			memImages.order.MoveToBack(mi.elem)
+			return mi.src
+		}
+		memImages.removeLocked(key)
+	}
+
+	if memImages.data == nil {
+		memImages.data = make(map[string]*memImage)
+	}
+	src := memImagePrefix + key
+	elem := memImages.order.PushBack(key)
+	memImages.data[key] = &memImage{
+		src: src, pix: pix, elem: elem, w: w, h: h,
+	}
+	memImages.bytes += len(pix)
+	memImages.evictLocked()
+	return src
+}
+
+// memImageSrc returns the registered Src string for a key held as bytes,
+// marking it most recently used. Generators build their content key into a
+// scratch buffer each frame and call this: the map lookup on a []byte-to-
+// string conversion does not allocate, and the returned string is the one
+// stored at registration, so a cache hit costs no allocation at all.
+func memImageSrc(key []byte) (string, bool) {
+	memImages.mu.Lock()
+	defer memImages.mu.Unlock()
+	mi, ok := memImages.data[string(key)]
+	if !ok {
+		return "", false
+	}
+	memImages.order.MoveToBack(mi.elem)
+	return mi.src, true
+}
+
+// HasImage reports whether key is registered, and marks it most recently
+// used. Generators gate on it so a repeat frame costs a map lookup rather
+// than a buffer allocation and a pixel loop.
+//
+// exportaudit:keep — half of the app-facing generate-once idiom with
+// UseImage.
+func HasImage(key string) bool {
+	memImages.mu.Lock()
+	defer memImages.mu.Unlock()
+	mi, ok := memImages.data[key]
+	if ok {
+		memImages.order.MoveToBack(mi.elem)
+	}
+	return ok
+}
+
+// DropImage unregisters key. Content-keyed callers do not need this — the
+// budget evicts stale variants — but an app that registers one large buffer
+// for a screen it has left can reclaim the bytes immediately.
+//
+// exportaudit:keep — app-facing reclaim for the registry.
+func DropImage(key string) {
+	memImages.mu.Lock()
+	defer memImages.mu.Unlock()
+	memImages.removeLocked(key)
+}
+
+// SetMemImageBudget caps the registry's total pixel bytes, evicting the
+// least recently used entries until the new budget is met. A non-positive
+// budget restores the default.
+//
+// exportaudit:keep — app-facing tuning for the registry.
+func SetMemImageBudget(bytes int) {
+	memImages.mu.Lock()
+	defer memImages.mu.Unlock()
+	if bytes <= 0 {
+		bytes = defaultMemImageBudget
+	}
+	memImages.budget = bytes
+	memImages.evictLocked()
+}
+
+// LookupImage resolves a Src string to a registered buffer, marking it most
+// recently used. It returns ok=false for any string that is not a mem:
+// source, so backends can call it first and fall through to their path and
+// URL handling unchanged.
+//
+// The returned slice aliases registry storage and must be treated as
+// read-only.
+//
+// exportaudit:keep — consumed by gui/backend/* to resolve mem: sources.
+func LookupImage(src string) (w, h int, pix []byte, ok bool) {
+	if !isMemImage(src) {
+		return 0, 0, nil, false
+	}
+	key := src[len(memImagePrefix):] // substring; no allocation
+	memImages.mu.Lock()
+	defer memImages.mu.Unlock()
+	mi, found := memImages.data[key]
+	if !found {
+		return 0, 0, nil, false
+	}
+	memImages.order.MoveToBack(mi.elem)
+	return mi.w, mi.h, mi.pix, true
+}
+
+// isMemImage reports whether src names a registered in-memory buffer. It
+// sits beside isDataURL and isHTTPURL (gui/image_download.go) as the third
+// non-filesystem source form.
+func isMemImage(src string) bool {
+	return strings.HasPrefix(src, memImagePrefix)
+}
+
+// removeLocked deletes one entry and its bytes. Caller holds mu.
+func (r *memImageRegistry) removeLocked(src string) {
+	mi, ok := r.data[src]
+	if !ok {
+		return
+	}
+	r.order.Remove(mi.elem)
+	delete(r.data, src)
+	r.bytes -= len(mi.pix)
+}
+
+// evictLocked drops least-recently-used entries until the registry fits its
+// budget. The most recent entry is never evicted: a single buffer larger
+// than the whole budget is still the one the caller is about to draw.
+// Caller holds mu.
+func (r *memImageRegistry) evictLocked() {
+	for r.bytes > r.budget && r.order.Len() > 1 {
+		front := r.order.Front()
+		r.removeLocked(front.Value.(string))
+	}
+}

--- a/gui/image_mem_test.go
+++ b/gui/image_mem_test.go
@@ -1,0 +1,197 @@
+package gui
+
+import "testing"
+
+// resetMemImages clears the process-global registry so tests do not
+// observe each other's entries or budget changes.
+func resetMemImages(t *testing.T) {
+	t.Helper()
+	memImages.mu.Lock()
+	memImages.data = nil
+	memImages.order.Init()
+	memImages.bytes = 0
+	memImages.budget = defaultMemImageBudget
+	memImages.mu.Unlock()
+}
+
+// pixels returns a w*h NRGBA8 buffer filled with fill.
+func pixels(w, h int, fill byte) []byte {
+	p := make([]byte, w*h*4)
+	for i := range p {
+		p[i] = fill
+	}
+	return p
+}
+
+func TestUseImageRoundTrip(t *testing.T) {
+	resetMemImages(t)
+	src := UseImage("round/trip", 2, 3, pixels(2, 3, 0x7f))
+	if src != "mem:round/trip" {
+		t.Fatalf("src = %q, want mem:round/trip", src)
+	}
+	w, h, pix, ok := LookupImage(src)
+	if !ok {
+		t.Fatal("LookupImage: not found")
+	}
+	if w != 2 || h != 3 {
+		t.Errorf("dims = %dx%d, want 2x3", w, h)
+	}
+	if len(pix) != 2*3*4 || pix[0] != 0x7f {
+		t.Errorf("pix len=%d [0]=%#x", len(pix), pix[0])
+	}
+	if !HasImage("round/trip") {
+		t.Error("HasImage = false for a registered key")
+	}
+}
+
+// LookupImage must reject anything that is not a mem: source so
+// backends can call it first and fall through to path/URL handling.
+func TestLookupImageRejectsNonMemSources(t *testing.T) {
+	resetMemImages(t)
+	UseImage("real", 1, 1, pixels(1, 1, 0xff))
+	for _, src := range []string{
+		"", "real", "/tmp/real.png", "https://example.com/a.png",
+		"data:image/png;base64,AAAA", "mem:missing",
+	} {
+		if _, _, _, ok := LookupImage(src); ok {
+			t.Errorf("LookupImage(%q) = ok, want not ok", src)
+		}
+	}
+}
+
+// A malformed buffer must register nothing rather than hand a
+// backend a slice it will read past the end of.
+func TestUseImageRejectsBadBuffers(t *testing.T) {
+	resetMemImages(t)
+	cases := []struct {
+		name string
+		key  string
+		w, h int
+		pix  []byte
+	}{
+		{"empty key", "", 1, 1, pixels(1, 1, 0)},
+		{"zero width", "k", 0, 1, nil},
+		{"negative height", "k", 1, -1, nil},
+		{"short buffer", "k", 4, 4, pixels(2, 2, 0)},
+		{"long buffer", "k", 2, 2, pixels(4, 4, 0)},
+	}
+	for _, tc := range cases {
+		if got := UseImage(tc.key, tc.w, tc.h, tc.pix); got != "" {
+			t.Errorf("%s: UseImage = %q, want \"\"", tc.name, got)
+		}
+	}
+	if HasImage("k") {
+		t.Error("a rejected buffer was registered")
+	}
+}
+
+// Re-registering a key at the same size must not swap the stored
+// buffer: backends cache an uploaded texture under that key and would
+// never observe the change. Callers content-key instead.
+func TestUseImageSameKeyKeepsFirstBuffer(t *testing.T) {
+	resetMemImages(t)
+	UseImage("stable", 1, 1, pixels(1, 1, 0x11))
+	UseImage("stable", 1, 1, pixels(1, 1, 0x22))
+	_, _, pix, ok := LookupImage("mem:stable")
+	if !ok {
+		t.Fatal("LookupImage: not found")
+	}
+	if pix[0] != 0x11 {
+		t.Errorf("pix[0] = %#x, want 0x11 (first buffer)", pix[0])
+	}
+}
+
+// A key re-registered at a different size is a different image, so
+// the new buffer must replace the old one.
+func TestUseImageSizeChangeReplaces(t *testing.T) {
+	resetMemImages(t)
+	UseImage("resize", 1, 1, pixels(1, 1, 0x11))
+	UseImage("resize", 2, 2, pixels(2, 2, 0x22))
+	w, h, pix, ok := LookupImage("mem:resize")
+	if !ok {
+		t.Fatal("LookupImage: not found")
+	}
+	if w != 2 || h != 2 || pix[0] != 0x22 {
+		t.Errorf("dims = %dx%d pix[0] = %#x, want 2x2 0x22",
+			w, h, pix[0])
+	}
+}
+
+func TestDropImage(t *testing.T) {
+	resetMemImages(t)
+	UseImage("drop/me", 1, 1, pixels(1, 1, 0))
+	DropImage("drop/me")
+	if HasImage("drop/me") {
+		t.Error("HasImage = true after DropImage")
+	}
+	if _, _, _, ok := LookupImage("mem:drop/me"); ok {
+		t.Error("LookupImage found a dropped key")
+	}
+}
+
+// The budget, not an explicit Drop, is what stops a content-keyed
+// drag from growing memory without limit.
+func TestMemImageBudgetEvictsLeastRecentlyUsed(t *testing.T) {
+	resetMemImages(t)
+	defer SetMemImageBudget(0)
+
+	const px = 16 // 2x2 NRGBA
+	SetMemImageBudget(2 * px)
+
+	UseImage("a", 2, 2, pixels(2, 2, 0xaa))
+	UseImage("b", 2, 2, pixels(2, 2, 0xbb))
+	// Touch "a" so "b" becomes the least recently used.
+	if !HasImage("a") {
+		t.Fatal("a evicted early")
+	}
+	UseImage("c", 2, 2, pixels(2, 2, 0xcc))
+
+	if HasImage("b") {
+		t.Error("b survived; want the least-recently-used evicted")
+	}
+	if !HasImage("a") || !HasImage("c") {
+		t.Error("a and c should both still be registered")
+	}
+	if _, _, _, ok := LookupImage("mem:b"); ok {
+		t.Error("LookupImage still resolves an evicted key")
+	}
+}
+
+// A single buffer larger than the whole budget is still the one the
+// caller is about to draw, so it must survive its own registration.
+func TestMemImageOversizedEntrySurvives(t *testing.T) {
+	resetMemImages(t)
+	defer SetMemImageBudget(0)
+
+	SetMemImageBudget(4)
+	UseImage("huge", 8, 8, pixels(8, 8, 0xff))
+	if !HasImage("huge") {
+		t.Error("an over-budget entry evicted itself")
+	}
+}
+
+// The HasImage gate is the reason a repeat frame is cheap: it must
+// not allocate.
+func TestHasImageDoesNotAllocate(t *testing.T) {
+	resetMemImages(t)
+	UseImage("noalloc", 4, 4, pixels(4, 4, 0))
+	got := testing.AllocsPerRun(100, func() {
+		if !HasImage("noalloc") {
+			t.Fatal("key missing")
+		}
+	})
+	if got != 0 {
+		t.Errorf("HasImage allocs = %v, want 0", got)
+	}
+}
+
+func TestIsMemImage(t *testing.T) {
+	if !isMemImage("mem:x") {
+		t.Error("mem:x not recognized")
+	}
+	for _, s := range []string{"", "memx", "/mem:x", "data:mem:"} {
+		if isMemImage(s) {
+			t.Errorf("isMemImage(%q) = true", s)
+		}
+	}
+}

--- a/gui/image_mem_test.go
+++ b/gui/image_mem_test.go
@@ -74,6 +74,8 @@ func TestUseImageRejectsBadBuffers(t *testing.T) {
 		{"negative height", "k", 1, -1, nil},
 		{"short buffer", "k", 4, 4, pixels(2, 2, 0)},
 		{"long buffer", "k", 2, 2, pixels(4, 4, 0)},
+		{"oversized dimension", "k", maxMemImageDim + 1, 1, pixels(1, 1, 0)},
+		{"wrapping dimension", "k", 1 << 30, 1 << 30, pixels(1, 1, 0)},
 	}
 	for _, tc := range cases {
 		if got := UseImage(tc.key, tc.w, tc.h, tc.pix); got != "" {

--- a/gui/locale.go
+++ b/gui/locale.go
@@ -140,6 +140,10 @@ type Locale struct {
 	strHue   string
 	strSat   string
 	strValue string
+	// strLightness is HSL's L. Distinct from strValue, which is
+	// HSV's V — the two are different quantities, not translations
+	// of one another.
+	strLightness string
 
 	// Data grid
 	StrColumns  string
@@ -209,6 +213,8 @@ func localeDefaults() Locale {
 		strHue:   "Hue",
 		strSat:   "Sat",
 		strValue: "Value",
+
+		strLightness: "Lightness",
 
 		StrColumns:  "Columns",
 		StrSelected: "Selected",

--- a/gui/locale_bundle.go
+++ b/gui/locale_bundle.go
@@ -168,6 +168,8 @@ func (b *localeBundle) toLocale() Locale {
 		strHue:   bundleStr(b.Strings, "hue", d.strHue),
 		strSat:   bundleStr(b.Strings, "sat", d.strSat),
 		strValue: bundleStr(b.Strings, "value", d.strValue),
+		strLightness: bundleStr(
+			b.Strings, "lightness", d.strLightness),
 
 		WeekdaysShort: toFixed7(b.WeekdaysShort, d.WeekdaysShort),
 		WeekdaysMed:   toFixed7(b.WeekdaysMed, d.WeekdaysMed),

--- a/gui/math.go
+++ b/gui/math.go
@@ -75,6 +75,30 @@ func f32Max(a, b float32) float32 {
 	return b
 }
 
+// f32Pi is math.Pi in float32 precision.
+const f32Pi = float32(math.Pi)
+
+// f32Sqrt returns the square root of x.
+func f32Sqrt(x float32) float32 {
+	return float32(math.Sqrt(float64(x)))
+}
+
+// f32Sin returns the sine of x, in radians.
+func f32Sin(x float32) float32 {
+	return float32(math.Sin(float64(x)))
+}
+
+// f32Cos returns the cosine of x, in radians.
+func f32Cos(x float32) float32 {
+	return float32(math.Cos(float64(x)))
+}
+
+// f32Atan2 returns the arc tangent of y/x, using the signs of both to
+// place the result in the correct quadrant.
+func f32Atan2(y, x float32) float32 {
+	return float32(math.Atan2(float64(y), float64(x)))
+}
+
 // f32IsFinite returns true if value is not NaN or Inf.
 func f32IsFinite(f float32) bool {
 	return math.Float32bits(f)&0x7F800000 != 0x7F800000

--- a/gui/print_pdf.go
+++ b/gui/print_pdf.go
@@ -1,8 +1,11 @@
 package gui
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"image"
+	"image/png"
 	"math"
 	"os"
 	"strings"
@@ -288,11 +291,43 @@ func pdfRenderImage(ctx *pdfCtx, cmd RenderCmd) {
 	if path == "" {
 		return
 	}
+	if isMemImage(path) {
+		pdfRenderMemImage(ctx, cmd)
+		return
+	}
 	if _, err := os.Stat(path); err != nil {
 		return
 	}
 	opts := fpdf.ImageOptions{ReadDpi: true}
 	ctx.pdf.ImageOptions(path, ctx.px(cmd.X), ctx.py(cmd.Y),
+		ctx.pw(cmd.W), ctx.ph(cmd.H), false, opts, 0, "")
+}
+
+// pdfRenderMemImage embeds a registered in-memory buffer. fpdf reads
+// encoded image files, not raw pixels, so the buffer is PNG-encoded
+// once and registered under its Resource name — repeat draws of the
+// same key reuse the embedded image rather than re-encoding.
+func pdfRenderMemImage(ctx *pdfCtx, cmd RenderCmd) {
+	w, h, pix, ok := LookupImage(cmd.Resource)
+	if !ok {
+		return
+	}
+	if info := ctx.pdf.GetImageInfo(cmd.Resource); info == nil {
+		img := &image.NRGBA{
+			Pix:    pix,
+			Stride: w * 4,
+			Rect:   image.Rect(0, 0, w, h),
+		}
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, img); err != nil {
+			return
+		}
+		opts := fpdf.ImageOptions{ImageType: "PNG"}
+		ctx.pdf.RegisterImageOptionsReader(
+			cmd.Resource, opts, &buf)
+	}
+	opts := fpdf.ImageOptions{ImageType: "PNG"}
+	ctx.pdf.ImageOptions(cmd.Resource, ctx.px(cmd.X), ctx.py(cmd.Y),
 		ctx.pw(cmd.W), ctx.ph(cmd.H), false, opts, 0, "")
 }
 

--- a/gui/print_pdf_test.go
+++ b/gui/print_pdf_test.go
@@ -124,6 +124,36 @@ func TestRenderToPDF_ImageMissing(t *testing.T) {
 	assertPDFExists(t, j.OutputPath)
 }
 
+// A mem: source embeds a registered buffer as PNG rather than reading
+// a file. It must render without a path, and the same resource drawn
+// twice must not re-encode it (the GetImageInfo dedup branch).
+func TestRenderToPDF_MemImage(t *testing.T) {
+	j := testPrintJob(t)
+	resetMemImages(t)
+	src := UseImage("pdf/checker", 8, 8, pixels(8, 8, 0x7f))
+	cmds := []RenderCmd{
+		{Kind: RenderImage, X: 0, Y: 0, W: 100, H: 100, Resource: src},
+		{Kind: RenderImage, X: 150, Y: 0, W: 50, H: 50, Resource: src},
+	}
+	if err := renderToPDF(cmds, j, 800, 600); err != nil {
+		t.Fatal(err)
+	}
+	assertPDFExists(t, j.OutputPath)
+}
+
+// An unregistered mem: key must skip the draw, not panic the render.
+func TestRenderToPDF_MemImageMissing(t *testing.T) {
+	j := testPrintJob(t)
+	cmds := []RenderCmd{{
+		Kind: RenderImage, X: 0, Y: 0, W: 100, H: 100,
+		Resource: "mem:pdf/nope",
+	}}
+	if err := renderToPDF(cmds, j, 800, 600); err != nil {
+		t.Fatal(err)
+	}
+	assertPDFExists(t, j.OutputPath)
+}
+
 func TestRenderToPDF_ClipBeginEnd(t *testing.T) {
 	j := testPrintJob(t)
 	cmds := []RenderCmd{

--- a/gui/view_color_channel_slider.go
+++ b/gui/view_color_channel_slider.go
@@ -220,22 +220,18 @@ func (ch ColorChannel) name() string {
 func colorChannelKeys(
 	ch ColorChannel, v HSLA, onChange func(HSLA, EventCtx),
 ) func(EventCtx) {
-	return func(ctx EventCtx) {
-		dx, dy, ok := colorKeyDelta(ctx.Event)
-		if !ok || onChange == nil {
-			return // not ours: let it travel on
-		}
-		d := dx - dy // up/right increase, down/left decrease
-		span := ch.span()
-		next := ch.value(v) + d*span
-		if ch == ChannelHue {
-			// Hue wraps: stepping past 360 lands back at 0 rather
-			// than sticking at the end of the strip.
-			next = f32Mod(next+360, 360)
-		} else {
-			next = f32Clamp(next, 0, span)
-		}
-		onChange(ch.with(v, next), ctx)
-		ctx.Consume()
-	}
+	return colorArrowKeys(v, onChange,
+		func(v HSLA, dx, dy float32) HSLA {
+			d := dx - dy // up/right increase, down/left decrease
+			span := ch.span()
+			next := ch.value(v) + d*span
+			if ch == ChannelHue {
+				// Hue wraps: stepping past 360 lands back at 0 rather
+				// than sticking at the end of the strip.
+				next = f32Mod(next+360, 360)
+			} else {
+				next = f32Clamp(next, 0, span)
+			}
+			return ch.with(v, next)
+		})
 }

--- a/gui/view_color_channel_slider.go
+++ b/gui/view_color_channel_slider.go
@@ -1,0 +1,241 @@
+package gui
+
+// ColorChannelSliderCfg configures one HSLA channel slider.
+//
+// The track is not a theme fill: it shows the colors this slider can
+// pick, holding the other channels where they are. Drag the hue slider
+// and the saturation and lightness tracks repaint under it; the alpha
+// track composites over a checkerboard so transparency is visible
+// rather than implied.
+//
+// It is not built on SliderCfg. That widget's track fill and thumb
+// color are unexported and it has no gradient or image track, so a
+// channel slider built on it could not show what it picks — which is
+// the entire point of this control.
+type ColorChannelSliderCfg struct {
+	OnChange func(HSLA, EventCtx)
+	ID       string `gui:"required"`
+
+	A11YCfg
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled bool
+
+	// Channel selects which component of Value this slider edits:
+	// ChannelHue, ChannelSaturation, ChannelLightness or ChannelAlpha.
+	Channel ColorChannel
+	Value   HSLA
+
+	// Vertical lays the track out bottom (minimum) to top (maximum)
+	// instead of left to right. Height then gives its length, and Width
+	// is ignored.
+	//
+	// exportaudit:keep — caller-facing orientation; ColorPicker is the
+	// only in-repo user.
+	Vertical bool
+
+	// Width is the control's length in points, or its thickness when
+	// Vertical. Zero takes defaultColorSliderWidth.
+	Width float32
+	// Height is the control's length in points when Vertical. Zero takes
+	// defaultColorSliderWidth. Ignored when horizontal, where the
+	// thickness follows the thumb and track.
+	Height float32
+	// TrackHeight is the colored track's thickness. Zero takes the
+	// theme default.
+	// exportaudit:keep — caller-facing sizing
+	TrackHeight float32
+	// ThumbSize is the diameter of the ring handle. Zero takes the
+	// theme default. The control's height is the larger of this and
+	// TrackHeight.
+	ThumbSize float32
+}
+
+type colorChannelSliderView struct {
+	cfg ColorChannelSliderCfg
+}
+
+// ColorChannelSlider creates a slider for one HSLA channel, with a
+// track showing the colors it can pick.
+func ColorChannelSlider(cfg ColorChannelSliderCfg) View {
+	requireFocusID("ColorChannelSlider", cfg.FocusDisabled, cfg.ID)
+	applyColorChannelSliderDefaults(&cfg)
+	return &colorChannelSliderView{cfg: cfg}
+}
+
+func applyColorChannelSliderDefaults(cfg *ColorChannelSliderCfg) {
+	d := &defaultColorPickerStyle
+	if cfg.TrackHeight <= 0 {
+		cfg.TrackHeight = d.sliderHeight
+	}
+	if cfg.ThumbSize <= 0 {
+		cfg.ThumbSize = d.indicatorSize
+	}
+}
+
+func (sv *colorChannelSliderView) GenerateLayout(w *Window) Layout {
+	cfg := &sv.cfg
+	id := w.EffID(cfg.ID)
+	v := cfg.Value.Normalized()
+	ch := cfg.Channel
+	onChange := cfg.OnChange
+
+	vert := cfg.Vertical
+	// length is the swept axis; thick is the other one, which is only
+	// as wide as the larger of the thumb and the track.
+	length := cfg.Width
+	if vert {
+		length = cfg.Height
+	}
+	if length <= 0 {
+		length = defaultColorSliderWidth
+	}
+	thick := f32Max(cfg.ThumbSize, cfg.TrackHeight)
+	inset := cfg.ThumbSize / 2
+
+	ctlW, ctlH := length, thick
+	trackW, trackH := length, cfg.TrackHeight
+	if vert {
+		ctlW, ctlH = thick, length
+		trackW, trackH = cfg.TrackHeight, length
+	}
+
+	// The track's gradient is inset by half a thumb at each end, so
+	// the thumb's centre — not its edge — sits on the color it picks.
+	// The drag maps the same way, or clicking a color would select a
+	// different one.
+	apply := func(nx, ny float32, ctx EventCtx) {
+		if onChange == nil {
+			return
+		}
+		n := nx
+		if vert {
+			n = 1 - ny // bottom is the minimum
+		}
+		onChange(ch.with(v, trackFraction(n, length, inset)*ch.span()),
+			ctx)
+	}
+
+	frac := ch.value(v) / ch.span()
+	if vert {
+		frac = 1 - frac
+	}
+	along := inset + frac*(length-2*inset)
+	thumbX, thumbY := along, thick/2
+	if vert {
+		thumbX, thumbY = thick/2, along
+	}
+
+	// The track is thinner than the control when the thumb is the wider
+	// of the two, so it is centred on the cross axis.
+	trackOffX, trackOffY := float32(0), (thick-cfg.TrackHeight)/2
+	if vert {
+		trackOffX, trackOffY = (thick-cfg.TrackHeight)/2, 0
+	}
+
+	return generateViewLayout(&containerView{
+		cfg: ContainerCfg{
+			ID:        id,
+			Focusable: !cfg.FocusDisabled,
+			A11YRole:  AccessRoleSlider,
+			A11YCfg: A11YCfg{
+				A11YLabel:       a11yLabel(cfg.A11YLabel, ch.name()),
+				A11YDescription: cfg.A11YDescription,
+			},
+			Width:  ctlW,
+			Height: ctlH,
+			// Fixed: the track image is generated at this size.
+			Sizing:     FixedFixed,
+			Padding:    NoPadding,
+			SizeBorder: NoBorder,
+			axis:       axisTopToBottom,
+			OnClick:    colorDragTrack(id, apply),
+			OnKeyDown:  colorChannelKeys(ch, v, onChange),
+		},
+		content: []View{
+			container(ContainerCfg{
+				Float:        true,
+				FloatOffsetX: trackOffX,
+				FloatOffsetY: trackOffY,
+				Width:        trackW,
+				Height:       trackH,
+				Padding:      NoPadding,
+				SizeBorder:   NoBorder,
+				Radius:       SomeF(cfg.TrackHeight / 2),
+				Clip:         true,
+				Content: []View{
+					Image(ImageCfg{
+						Src: channelStripSrc(ch, v,
+							int(trackW)*imgScale,
+							int(trackH)*imgScale,
+							int(inset)*imgScale, vert),
+						Width:  trackW,
+						Height: trackH,
+					}),
+				},
+			}),
+			colorMarker(cfg.ThumbSize, v.Color(), func(ctx EventCtx) {
+				colorAmendMarker(ctx.Layout,
+					thumbX, thumbY, cfg.ThumbSize)
+			}),
+		},
+	}, w)
+}
+
+// defaultColorSliderWidth is the track length used when Width is
+// unset. A slider whose length came from the parent would have to know
+// its pixel width at buffer-generation time, which happens before
+// arrange — so the width is explicit here rather than Fill.
+const defaultColorSliderWidth = 200
+
+// trackFraction converts a pointer position normalized to the whole
+// control into a fraction of the inset track, so the value under the
+// thumb's centre is the value the thumb picks.
+func trackFraction(nx, width, inset float32) float32 {
+	track := width - 2*inset
+	if track <= 0 {
+		return f32Clamp(nx, 0, 1)
+	}
+	return f32Clamp((nx*width-inset)/track, 0, 1)
+}
+
+// name is the channel's accessible label.
+func (ch ColorChannel) name() string {
+	switch ch {
+	case ChannelHue:
+		return ActiveLocale.strHue
+	case ChannelSaturation:
+		return ActiveLocale.strSat
+	case ChannelLightness:
+		return ActiveLocale.strLightness
+	default:
+		return ActiveLocale.strAlpha
+	}
+}
+
+// colorChannelKeys steps the channel with the left and right arrows.
+// Up and down move it too: on a one-axis control both pairs mean "more"
+// and "less", and requiring the horizontal pair would be a needless
+// trap for keyboard users.
+func colorChannelKeys(
+	ch ColorChannel, v HSLA, onChange func(HSLA, EventCtx),
+) func(EventCtx) {
+	return func(ctx EventCtx) {
+		dx, dy, ok := colorKeyDelta(ctx.Event)
+		if !ok || onChange == nil {
+			return // not ours: let it travel on
+		}
+		d := dx - dy // up/right increase, down/left decrease
+		span := ch.span()
+		next := ch.value(v) + d*span
+		if ch == ChannelHue {
+			// Hue wraps: stepping past 360 lands back at 0 rather
+			// than sticking at the end of the strip.
+			next = f32Mod(next+360, 360)
+		} else {
+			next = f32Clamp(next, 0, span)
+		}
+		onChange(ch.with(v, next), ctx)
+		ctx.Consume()
+	}
+}

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -1,0 +1,404 @@
+package gui
+
+import (
+	"slices"
+	"testing"
+)
+
+// shapeIDs collects every ID in a generated tree, so a component's
+// composed identities can be asserted without reaching into layout
+// internals at each call site.
+func shapeIDs(l *Layout) []string {
+	var out []string
+	var walk func(*Layout)
+	walk = func(n *Layout) {
+		if n.Shape != nil && n.Shape.ID != "" {
+			out = append(out, n.Shape.ID)
+		}
+		for i := range n.Children {
+			walk(&n.Children[i])
+		}
+	}
+	walk(l)
+	return out
+}
+
+func hasID(ids []string, want string) bool {
+	return slices.Contains(ids, want)
+}
+
+func TestColorPlaneLayout(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorPlane(ColorPlaneCfg{
+		ID:    "plane",
+		Value: HSLA{H: 210, S: 0.7, L: 0.55, A: 1},
+		Size:  100,
+	}), w)
+
+	if l.Shape.ID != "plane" {
+		t.Errorf("ID = %q", l.Shape.ID)
+	}
+	if !l.Shape.Focusable {
+		t.Error("plane should be focusable by default")
+	}
+	if l.Shape.Width != 100 || l.Shape.Height != 100 {
+		t.Errorf("size = %vx%v, want 100x100",
+			l.Shape.Width, l.Shape.Height)
+	}
+	// The plane's imagery must be a registered buffer, not a file.
+	var img *Shape
+	var walk func(*Layout)
+	walk = func(n *Layout) {
+		if n.Shape != nil && n.Shape.shapeType == shapeImage {
+			img = n.Shape
+		}
+		for i := range n.Children {
+			walk(&n.Children[i])
+		}
+	}
+	walk(&l)
+	if img == nil {
+		t.Fatal("no image shape in the plane")
+	}
+	if !isMemImage(img.Resource) {
+		t.Errorf("Resource = %q, want a mem: source", img.Resource)
+	}
+}
+
+func TestColorPlaneFocusDisabled(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorPlane(ColorPlaneCfg{
+		ID: "plane-nf", Size: 50, FocusDisabled: true,
+	}), w)
+	if l.Shape.Focusable {
+		t.Error("FocusDisabled should opt out of focus")
+	}
+}
+
+func TestColorWheelLayout(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorWheel(ColorWheelCfg{
+		ID:    "wheel",
+		Value: HSLA{H: 90, S: 0.5, L: 0.5, A: 1},
+		Size:  120,
+	}), w)
+	if l.Shape.ID != "wheel" {
+		t.Errorf("ID = %q", l.Shape.ID)
+	}
+	if l.Shape.Width != 120 {
+		t.Errorf("width = %v, want 120", l.Shape.Width)
+	}
+}
+
+func TestColorChannelSliderLayout(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(
+		ColorChannelSlider(ColorChannelSliderCfg{
+			ID:      "hue",
+			Channel: ChannelHue,
+			Value:   HSLA{H: 10, S: 1, L: 0.5, A: 1},
+			Width:   200,
+		}), w)
+	if l.Shape.ID != "hue" {
+		t.Errorf("ID = %q", l.Shape.ID)
+	}
+	if l.Shape.Width != 200 {
+		t.Errorf("width = %v, want 200", l.Shape.Width)
+	}
+	if l.Shape.A11YRole != AccessRoleSlider {
+		t.Errorf("role = %v, want slider", l.Shape.A11YRole)
+	}
+}
+
+// A vertical slider swaps its axes: Height is the length, and the
+// control is only as wide as its thumb.
+func TestColorChannelSliderVerticalLayout(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(
+		ColorChannelSlider(ColorChannelSliderCfg{
+			ID:          "hue",
+			Channel:     ChannelHue,
+			Value:       HSLA{H: 10, S: 1, L: 0.5, A: 1},
+			Vertical:    true,
+			Height:      200,
+			ThumbSize:   16,
+			TrackHeight: 10,
+		}), w)
+	if l.Shape.Height != 200 {
+		t.Errorf("height = %v, want 200", l.Shape.Height)
+	}
+	// Thickness is the larger of thumb and track, as it is horizontally.
+	if l.Shape.Width != 16 {
+		t.Errorf("width = %v, want 16 (thumb)", l.Shape.Width)
+	}
+}
+
+// The vertical strip runs bottom to top: the minimum belongs at the
+// bottom of the screen, where the thumb sits at value 0.
+func TestVerticalStripSweepsUpward(t *testing.T) {
+	const w, h, inset = 8, 64, 4
+	v := HSLA{H: 0, S: 1, L: 0.5, A: 1}
+	pix := channelStripPixels(ChannelLightness, v, w, h, inset, true)
+	at := func(y int) uint8 { return pix[(y*w)*4] } // red of column 0
+
+	if top, bot := at(0), at(h-1); top <= bot {
+		t.Errorf("top=%d bottom=%d: lightness must increase upward",
+			top, bot)
+	}
+}
+
+// A vertical strip is a different buffer from a horizontal one of the
+// same dimensions, or one orientation would draw the other's pixels.
+func TestStripKeyIncludesOrientation(t *testing.T) {
+	resetMemImages(t)
+	v := HSLA{H: 120, S: 0.5, L: 0.5, A: 1}
+	horiz := channelStripSrc(ChannelHue, v, 32, 32, 4, false)
+	vert := channelStripSrc(ChannelHue, v, 32, 32, 4, true)
+	if horiz == vert {
+		t.Error("orientation missing from the strip's content key")
+	}
+}
+
+func TestColorSwatchLayout(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorSwatch(ColorSwatchCfg{
+		ID:     "swatch",
+		Color:  RGBA(255, 0, 0, 128),
+		Width:  40,
+		Height: 20,
+	}), w)
+	if l.Shape.ID != "swatch" {
+		t.Errorf("ID = %q", l.Shape.ID)
+	}
+	// The checkerboard is the point: a half-transparent color must
+	// sit over a generated pattern, not over the theme background.
+	found := false
+	var walk func(*Layout)
+	walk = func(n *Layout) {
+		if n.Shape != nil && n.Shape.shapeType == shapeImage &&
+			isMemImage(n.Shape.Resource) {
+			found = true
+		}
+		for i := range n.Children {
+			walk(&n.Children[i])
+		}
+	}
+	walk(&l)
+	if !found {
+		t.Error("swatch has no checkerboard buffer")
+	}
+}
+
+// Inner IDs must be composed under the component's own ID, or two
+// pickers on one screen collide.
+func TestColorFieldsComposesInnerIDs(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorFields(ColorFieldsCfg{
+		ID:      "fields",
+		Value:   HSLA{H: 0, S: 1, L: 0.5, A: 1},
+		ShowHSL: true,
+	}), w)
+	ids := shapeIDs(&l)
+	for _, want := range []string{
+		"fields", "fields:hex", "fields:rgb:0", "fields:hsl:2",
+	} {
+		if !hasID(ids, want) {
+			t.Errorf("missing composed ID %q; got %v", want, ids)
+		}
+	}
+}
+
+// The swatch rides beside the hex value, so it must appear under the
+// fields' own scope rather than the caller's.
+func TestColorFieldsShowSwatch(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorFields(ColorFieldsCfg{
+		ID:         "fields",
+		Value:      HSLA{H: 0, S: 1, L: 0.5, A: 1},
+		ShowSwatch: true,
+	}), w)
+	if ids := shapeIDs(&l); !hasID(ids, "fields:swatch") {
+		t.Errorf("ShowSwatch rendered no swatch; got %v", ids)
+	}
+}
+
+func TestColorFieldsHideHexAndHSL(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorFields(ColorFieldsCfg{
+		ID:      "f2",
+		Value:   HSLA{H: 0, S: 1, L: 0.5, A: 1},
+		HideHex: true,
+	}), w)
+	ids := shapeIDs(&l)
+	if hasID(ids, "f2:hex") {
+		t.Error("HideHex still rendered the hex field")
+	}
+	if hasID(ids, "f2:hsl:0") {
+		t.Error("HSL row rendered without ShowHSL")
+	}
+}
+
+// The composed picker must produce unique effective IDs — the whole
+// reason inner IDs are scoped.
+func TestColorPickerNoDuplicateIDs(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorPicker(ColorPickerCfg{
+		ID: "cp-dup", Color: RGB(0, 128, 255), ShowHSL: true,
+	}), w)
+	seen := map[string]bool{}
+	for _, id := range shapeIDs(&l) {
+		if seen[id] {
+			t.Errorf("duplicate ID %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+// The thumb must select the color under its centre, which is what the
+// inset mapping buys.
+func TestTrackFraction(t *testing.T) {
+	const width, inset = 100, 10
+	cases := []struct {
+		nx   float32
+		want float32
+	}{
+		{0, 0},     // left edge pins to the minimum
+		{0.1, 0},   // start of the track
+		{0.5, 0.5}, // centre
+		{0.9, 1},   // end of the track
+		{1, 1},     // right edge pins to the maximum
+	}
+	for _, tc := range cases {
+		got := trackFraction(tc.nx, width, inset)
+		if f32Abs(got-tc.want) > 0.001 {
+			t.Errorf("trackFraction(%v) = %v, want %v",
+				tc.nx, got, tc.want)
+		}
+	}
+	// A control narrower than its thumb must not divide by zero.
+	if got := trackFraction(0.5, 10, 20); got != 0.5 {
+		t.Errorf("degenerate track = %v, want the raw fraction", got)
+	}
+}
+
+func TestColorKeyDelta(t *testing.T) {
+	cases := []struct {
+		key          KeyCode
+		mods         Modifier
+		wantX, wantY float32
+		wantOK       bool
+	}{
+		{KeyLeft, 0, -colorKeyStep, 0, true},
+		{KeyRight, 0, colorKeyStep, 0, true},
+		{KeyUp, 0, 0, -colorKeyStep, true},
+		{KeyDown, 0, 0, colorKeyStep, true},
+		{KeyRight, ModShift, colorKeyStep * 10, 0, true},
+		{KeyTab, 0, 0, 0, false},
+	}
+	for _, tc := range cases {
+		dx, dy, ok := colorKeyDelta(
+			&Event{KeyCode: tc.key, Modifiers: tc.mods})
+		if ok != tc.wantOK {
+			t.Errorf("key %v: ok = %v, want %v", tc.key, ok, tc.wantOK)
+			continue
+		}
+		if f32Abs(dx-tc.wantX) > 1e-6 || f32Abs(dy-tc.wantY) > 1e-6 {
+			t.Errorf("key %v: delta = %v,%v want %v,%v",
+				tc.key, dx, dy, tc.wantX, tc.wantY)
+		}
+	}
+	if _, _, ok := colorKeyDelta(nil); ok {
+		t.Error("nil event should not produce a delta")
+	}
+}
+
+// A key the control does not handle must travel on: consuming it would
+// swallow Tab and trap focus inside the control.
+func TestColorKeysIgnoreUnrelatedKeys(t *testing.T) {
+	v := HSLA{H: 100, S: 0.5, L: 0.5, A: 1}
+	called := false
+	onChange := func(HSLA, EventCtx) { called = true }
+
+	handlers := []func(EventCtx){
+		colorPlaneKeys(v, onChange),
+		colorWheelKeys(v, onChange),
+		colorChannelKeys(ChannelHue, v, onChange),
+	}
+	for i, h := range handlers {
+		e := &Event{KeyCode: KeyTab}
+		h(EventCtx{nil, e, nil})
+		if called {
+			t.Errorf("handler %d acted on Tab", i)
+		}
+		if e.IsHandled {
+			t.Errorf("handler %d consumed Tab", i)
+		}
+	}
+}
+
+func TestColorPlaneKeysMoveSaturationAndLightness(t *testing.T) {
+	v := HSLA{H: 100, S: 0.5, L: 0.5, A: 1}
+	var got HSLA
+	h := colorPlaneKeys(v, func(next HSLA, _ EventCtx) { got = next })
+
+	e := &Event{KeyCode: KeyRight}
+	h(EventCtx{nil, e, nil})
+	if got.S <= v.S {
+		t.Errorf("right arrow: S = %v, want > %v", got.S, v.S)
+	}
+	if !e.IsHandled {
+		t.Error("a handler that acted must consume")
+	}
+
+	// Up increases lightness: the plane paints light at the top.
+	h(EventCtx{nil, &Event{KeyCode: KeyUp}, nil})
+	if got.L <= v.L {
+		t.Errorf("up arrow: L = %v, want > %v", got.L, v.L)
+	}
+}
+
+func TestColorChannelKeysHueWraps(t *testing.T) {
+	v := HSLA{H: 359, S: 1, L: 0.5, A: 1}
+	var got HSLA
+	h := colorChannelKeys(ChannelHue, v,
+		func(next HSLA, _ EventCtx) { got = next })
+	// Shift steps 10% of 360 = 36°, past the end of the strip.
+	h(EventCtx{nil, &Event{
+		KeyCode: KeyRight, Modifiers: ModShift,
+	}, nil})
+	if got.H > 359 {
+		t.Errorf("H = %v, want wrapped below 359", got.H)
+	}
+}
+
+func TestColorChannelKeysClampNonHue(t *testing.T) {
+	v := HSLA{H: 0, S: 0.99, L: 0.5, A: 1}
+	var got HSLA
+	h := colorChannelKeys(ChannelSaturation, v,
+		func(next HSLA, _ EventCtx) { got = next })
+	h(EventCtx{nil, &Event{
+		KeyCode: KeyRight, Modifiers: ModShift,
+	}, nil})
+	if got.S != 1 {
+		t.Errorf("S = %v, want clamped to 1", got.S)
+	}
+}
+
+// A nil OnChange must be inert rather than panic: a read-only display
+// of a color is a legitimate use.
+func TestColorComponentsNilOnChange(t *testing.T) {
+	w := &Window{}
+	generateViewLayout(ColorPlane(ColorPlaneCfg{ID: "p", Size: 20}), w)
+	generateViewLayout(ColorWheel(ColorWheelCfg{ID: "w", Size: 20}), w)
+	generateViewLayout(ColorChannelSlider(ColorChannelSliderCfg{
+		ID: "s", Width: 40,
+	}), w)
+
+	for _, h := range []func(EventCtx){
+		colorPlaneKeys(HSLA{}, nil),
+		colorWheelKeys(HSLA{}, nil),
+		colorChannelKeys(ChannelHue, HSLA{}, nil),
+	} {
+		h(EventCtx{nil, &Event{KeyCode: KeyRight}, nil})
+	}
+}

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -284,6 +284,42 @@ func TestColorPickerNoDuplicateIDs(t *testing.T) {
 	}
 }
 
+// The marker must sit on the color it names: its centre lands at the
+// value's point on the plane, in the plane's own coordinates. AmendLayout
+// positions it in absolute space, and a mis-mapped control drifts the
+// thumb off the color it reports — the failure mode the inset-mapping
+// tests exist to catch on the slider.
+func TestColorPlaneMarkerTracksValue(t *testing.T) {
+	w := &Window{}
+	const size float32 = 100
+	v := HSLA{H: 210, S: 0.7, L: 0.55, A: 1}
+	l := w.TestRender(func(*Window) View {
+		return ColorPlane(ColorPlaneCfg{ID: "p", Value: v, Size: size})
+	})
+
+	var marker *Shape
+	var walk func(*Layout)
+	walk = func(n *Layout) {
+		if s := n.Shape; s != nil && s.Float {
+			marker = s
+		}
+		for i := range n.Children {
+			walk(&n.Children[i])
+		}
+	}
+	walk(l)
+	if marker == nil {
+		t.Fatal("no marker shape")
+	}
+	r := marker.Width / 2
+	wantX := v.S*size - r
+	wantY := (1-v.L)*size - r
+	if f32Abs(marker.X-wantX) > 0.1 || f32Abs(marker.Y-wantY) > 0.1 {
+		t.Errorf("marker at %v,%v, want %v,%v",
+			marker.X, marker.Y, wantX, wantY)
+	}
+}
+
 // The thumb must select the color under its centre, which is what the
 // inset mapping buys.
 func TestTrackFraction(t *testing.T) {

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -222,6 +222,36 @@ func TestColorFieldsShowSwatch(t *testing.T) {
 	}
 }
 
+// The hex row is narrower than the RGBA row below it, so the swatch
+// must ride out to the block's right edge on a flexible spacer rather
+// than sit against the hex field with dead space beyond it.
+func TestColorFieldsSwatchIsRightAligned(t *testing.T) {
+	for _, borders := range []bool{false, true} {
+		w := &Window{}
+		w.SetTheme(ThemeDark.WithBorders(borders))
+		// A real measurer: without one the labels are zero-width and
+		// the rows' widths do not differ enough to show the defect.
+		w.textMeasurer = &stubTextMeasurer{charWidth: 7, fontHeight: 16}
+		l := w.TestRender(func(*Window) View {
+			return ColorFields(ColorFieldsCfg{
+				ID:         "cf",
+				Value:      HSLA{H: 200, S: 0.5, L: 0.5, A: 1},
+				ShowSwatch: true,
+			})
+		})
+		fields := findShapeByID(l, "cf")
+		swatch := findShapeByID(l, "cf:swatch")
+		if fields == nil || swatch == nil {
+			t.Fatalf("borders=%v: missing shapes", borders)
+		}
+		want := fields.Shape.X + fields.Shape.Width
+		if got := swatch.Shape.X + swatch.Shape.Width; got != want {
+			t.Errorf("borders=%v: swatch right = %v, block right = %v",
+				borders, got, want)
+		}
+	}
+}
+
 func TestColorFieldsHideHexAndHSL(t *testing.T) {
 	w := &Window{}
 	l := generateViewLayout(ColorFields(ColorFieldsCfg{

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -484,3 +484,37 @@ func TestColorSwatchColorLayerHasOutline(t *testing.T) {
 		t.Fatal("no floating color layer in the swatch")
 	}
 }
+
+// The fields correct for optical centring: an Input centres the text's
+// line box, and the descent space under a digit is empty, so metric
+// centring leaves the ink visibly high. This asserts the predicted ink
+// centre lands on the box centre, and that a window with no measurer
+// falls back to even padding rather than to a guess.
+func TestColorFieldPaddingCentersInkOptically(t *testing.T) {
+	style := TextStyle{Size: 16}
+
+	if got := colorFieldPadding(nil, style); got.Top != got.Bottom {
+		t.Errorf("no measurer: padding %v, want symmetric", got)
+	}
+
+	w := &Window{}
+	w.textMeasurer = &stubTextMeasurer{charWidth: 8, fontHeight: 19}
+	pad := colorFieldPadding(w, style)
+	if pad.Top <= pad.Bottom {
+		t.Fatalf("padding %v: top must exceed bottom to lower the ink",
+			pad)
+	}
+
+	// Where the ink lands, relative to the field's own centre: the
+	// line box starts below the top padding, the glyphs start one
+	// ascent-minus-cap below that, and the box spans both paddings
+	// plus the line.
+	ascent := w.textMeasurer.FontAscent(style)
+	line := w.textMeasurer.FontHeight(style)
+	capH := style.Size * colorFieldCapRatio
+	inkMid := pad.Top + (ascent - capH) + capH/2
+	boxMid := (pad.Top + line + pad.Bottom) / 2
+	if off := inkMid - boxMid; off < -0.75 || off > 0.75 {
+		t.Errorf("ink centre off by %.2fpt, want within 0.75", off)
+	}
+}

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -403,10 +403,10 @@ func TestColorComponentsNilOnChange(t *testing.T) {
 	}
 }
 
-// The hex field is Fit-sized, so without a floor it would track its
-// own text and the swatch beside it would shift as the value changed
-// length.
-func TestColorFieldsHexMinWidth(t *testing.T) {
+// Every field is Fit-sized, so without a floor each would track its
+// own text: the swatch beside the hex value and the numeric columns
+// would shift as the value changed length.
+func TestColorFieldsMinWidths(t *testing.T) {
 	w := &Window{}
 	for _, v := range []HSLA{
 		{H: 0, S: 0, L: 1, A: 1},           // "#FFFFFF", short form
@@ -415,6 +415,7 @@ func TestColorFieldsHexMinWidth(t *testing.T) {
 		l := generateViewLayout(ColorFields(ColorFieldsCfg{
 			ID:         "hexw",
 			Value:      v,
+			ShowHSL:    true,
 			ShowSwatch: true,
 		}), w)
 		found := findShapeByID(&l, "hexw:hex")
@@ -425,6 +426,21 @@ func TestColorFieldsHexMinWidth(t *testing.T) {
 		if s.MinWidth != defaultHexFieldWidth {
 			t.Errorf("hex MinWidth = %v, want %v",
 				s.MinWidth, defaultHexFieldWidth)
+		}
+
+		// The numeric fields have the same problem: "0" and "255"
+		// would resolve to different widths and shift the column.
+		for _, leaf := range []string{
+			"hexw:rgb:0", "hexw:rgb:3", "hexw:hsl:0", "hexw:hsl:2",
+		} {
+			f := findShapeByID(&l, leaf)
+			if f == nil {
+				t.Fatalf("no field %q for %v", leaf, v)
+			}
+			if f.Shape.MinWidth != defaultColorFieldWidth {
+				t.Errorf("%s MinWidth = %v, want %v", leaf,
+					f.Shape.MinWidth, defaultColorFieldWidth)
+			}
 		}
 	}
 }

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -423,9 +423,11 @@ func TestColorFieldsMinWidths(t *testing.T) {
 			t.Fatalf("no hex field for %v", v)
 		}
 		s := found.Shape
-		if s.MinWidth != defaultHexFieldWidth {
-			t.Errorf("hex MinWidth = %v, want %v",
-				s.MinWidth, defaultHexFieldWidth)
+		if s.MinWidth != defaultHexFieldWidth ||
+			s.MaxWidth != defaultHexFieldWidth {
+			t.Errorf("hex width bounds = [%v,%v], want [%v,%v]",
+				s.MinWidth, s.MaxWidth,
+				defaultHexFieldWidth, defaultHexFieldWidth)
 		}
 
 		// The numeric fields have the same problem: "0" and "255"
@@ -437,9 +439,11 @@ func TestColorFieldsMinWidths(t *testing.T) {
 			if f == nil {
 				t.Fatalf("no field %q for %v", leaf, v)
 			}
-			if f.Shape.MinWidth != defaultColorFieldWidth {
-				t.Errorf("%s MinWidth = %v, want %v", leaf,
-					f.Shape.MinWidth, defaultColorFieldWidth)
+			if f.Shape.MinWidth != defaultColorFieldWidth ||
+				f.Shape.MaxWidth != defaultColorFieldWidth {
+				t.Errorf("%s width bounds = [%v,%v], want [%v,%v]",
+					leaf, f.Shape.MinWidth, f.Shape.MaxWidth,
+					defaultColorFieldWidth, defaultColorFieldWidth)
 			}
 		}
 	}

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -448,3 +448,39 @@ func TestColorFieldsMinWidths(t *testing.T) {
 		}
 	}
 }
+
+// A white swatch on a light theme is an invisible rectangle without an
+// outline, and the outline has to sit on the color overlay: that float
+// covers the whole widget, so a border on the box beneath would be
+// drawn under it.
+func TestColorSwatchColorLayerHasOutline(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorSwatch(ColorSwatchCfg{
+		ID:     "sw",
+		Color:  White,
+		Width:  40,
+		Height: 20,
+	}), w)
+
+	var found bool
+	var walk func(*Layout)
+	walk = func(n *Layout) {
+		if s := n.Shape; s != nil && s.Float && s.Color.eq(White) {
+			found = true
+			if s.SizeBorder <= 0 {
+				t.Errorf("color layer border = %v, want > 0",
+					s.SizeBorder)
+			}
+			if s.ColorBorder.A == 0 {
+				t.Error("color layer outline is fully transparent")
+			}
+		}
+		for i := range n.Children {
+			walk(&n.Children[i])
+		}
+	}
+	walk(&l)
+	if !found {
+		t.Fatal("no floating color layer in the swatch")
+	}
+}

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -402,3 +402,29 @@ func TestColorComponentsNilOnChange(t *testing.T) {
 		h(EventCtx{nil, &Event{KeyCode: KeyRight}, nil})
 	}
 }
+
+// The hex field is Fit-sized, so without a floor it would track its
+// own text and the swatch beside it would shift as the value changed
+// length.
+func TestColorFieldsHexMinWidth(t *testing.T) {
+	w := &Window{}
+	for _, v := range []HSLA{
+		{H: 0, S: 0, L: 1, A: 1},           // "#FFFFFF", short form
+		{H: 210, S: 0.7, L: 0.55, A: 0.85}, // "#3C8CDDD9", long form
+	} {
+		l := generateViewLayout(ColorFields(ColorFieldsCfg{
+			ID:         "hexw",
+			Value:      v,
+			ShowSwatch: true,
+		}), w)
+		found := findShapeByID(&l, "hexw:hex")
+		if found == nil {
+			t.Fatalf("no hex field for %v", v)
+		}
+		s := found.Shape
+		if s.MinWidth != defaultHexFieldWidth {
+			t.Errorf("hex MinWidth = %v, want %v",
+				s.MinWidth, defaultHexFieldWidth)
+		}
+	}
+}

--- a/gui/view_color_drag.go
+++ b/gui/view_color_drag.go
@@ -100,3 +100,22 @@ func colorKeyDelta(e *Event) (dx, dy float32, ok bool) {
 	}
 	return 0, 0, false
 }
+
+// colorArrowKeys is the key-handling skeleton every color control
+// shares: read the arrow delta, decline anything that is not an arrow
+// (it must travel on — consuming would swallow Tab and trap focus),
+// and consume the event it acted on. apply maps the step to the
+// control's own axes.
+func colorArrowKeys(
+	v HSLA, onChange func(HSLA, EventCtx),
+	apply func(cur HSLA, dx, dy float32) HSLA,
+) func(EventCtx) {
+	return func(ctx EventCtx) {
+		dx, dy, ok := colorKeyDelta(ctx.Event)
+		if !ok || onChange == nil {
+			return // not ours: let it travel on
+		}
+		onChange(apply(v, dx, dy), ctx)
+		ctx.Consume()
+	}
+}

--- a/gui/view_color_drag.go
+++ b/gui/view_color_drag.go
@@ -1,0 +1,102 @@
+package gui
+
+// colorDragTrack returns an OnClick handler that reports the pointer
+// position normalized to the clicked shape's own box — (0,0) at its
+// top-left corner, (1,1) at its bottom-right, clamped — and keeps
+// reporting while the button is held.
+//
+// The three draggable color components (plane, wheel, channel slider)
+// need exactly this and nothing else, and the sequence is easy to get
+// subtly wrong: OnClick arrives with shape-relative coordinates while
+// MouseLock delivers window-absolute ones, so the first report has to
+// be converted up before it can share a code path with the drag, and
+// the dragged shape has to be re-found by ID each move because the
+// layout tree is rebuilt every frame.
+//
+// id must be the *effective* ID of the shape the handler is installed
+// on — FindByID takes effective IDs.
+func colorDragTrack(
+	id string, onPoint func(nx, ny float32, ctx EventCtx),
+) func(EventCtx) {
+	report := func(shape *Shape, ctx EventCtx) {
+		if shape.Width <= 0 || shape.Height <= 0 || ctx.Event == nil {
+			return
+		}
+		nx := f32Clamp(
+			(ctx.Event.MouseX-shape.X)/shape.Width, 0, 1)
+		ny := f32Clamp(
+			(ctx.Event.MouseY-shape.Y)/shape.Height, 0, 1)
+		onPoint(nx, ny, ctx)
+	}
+
+	return func(ctx EventCtx) {
+		if ctx.Event == nil || ctx.Layout == nil {
+			return
+		}
+		// Lift the click into window-absolute space so it means the
+		// same thing as every MouseMove that follows it.
+		ev := *ctx.Event
+		ev.MouseX += ctx.Layout.Shape.X
+		ev.MouseY += ctx.Layout.Shape.Y
+		report(ctx.Layout.Shape,
+			EventCtx{ctx.Layout, &ev, ctx.Window})
+
+		ctx.Window.MouseLock(MouseLockCfg{
+			MouseMove: func(mc EventCtx) {
+				// The layout is rebuilt every frame, so the shape
+				// captured at press time is stale by now.
+				l, ok := mc.Layout.FindByID(id)
+				if !ok {
+					return
+				}
+				report(l.Shape, mc)
+			},
+			MouseUp: func(mc EventCtx) {
+				mc.Window.MouseUnlock()
+			},
+			Cancel: func(w *Window) {
+				// Capture revoked with no MouseUp coming. Nothing to
+				// commit — the value was written on every move — so
+				// just let go.
+				w.MouseUnlock()
+			},
+		})
+		// These controls sit inside a focusable container in the
+		// composed picker; without consuming, the click would travel
+		// on and move focus off the control being dragged.
+		ctx.Consume()
+	}
+}
+
+// colorKeyStep is the fraction of a channel's full span one arrow key
+// moves. 1/100 gives a percent per press on saturation, lightness and
+// alpha, and a little under 4° on hue — fine enough to be useful,
+// coarse enough to cross the range without holding the key forever.
+const colorKeyStep = 0.01
+
+// colorKeyDelta maps an arrow key to a step along one axis, as a
+// fraction of the axis span. ok=false for any other key, which the
+// caller must let travel on rather than consume.
+//
+// Shift takes the larger step: the same 10× convention the slider and
+// numeric input use for a coarse adjustment.
+func colorKeyDelta(e *Event) (dx, dy float32, ok bool) {
+	if e == nil {
+		return 0, 0, false
+	}
+	step := float32(colorKeyStep)
+	if e.Modifiers&ModShift != 0 {
+		step *= 10
+	}
+	switch e.KeyCode {
+	case KeyLeft:
+		return -step, 0, true
+	case KeyRight:
+		return step, 0, true
+	case KeyUp:
+		return 0, -step, true
+	case KeyDown:
+		return 0, step, true
+	}
+	return 0, 0, false
+}

--- a/gui/view_color_drag_test.go
+++ b/gui/view_color_drag_test.go
@@ -1,0 +1,156 @@
+package gui
+
+import "testing"
+
+// clickShape dispatches a left-click at window coordinates (x, y) into
+// a one-shape tree covering box, and returns the event so the caller
+// can check whether the handler consumed it.
+//
+// The shape is placed at box's origin: dispatch hit-tests against
+// shapeClip while the handler reads Shape.X/Y, and a control that
+// works only at the window origin is exactly the bug this catches.
+func clickShape(
+	t *testing.T, s *Shape, x, y float32,
+) *Event {
+	t.Helper()
+	root := &Layout{
+		Shape:    &Shape{shapeClip: drawClip{Width: 1000, Height: 1000}},
+		Children: []Layout{{Shape: s}},
+	}
+	layoutParents(root, nil)
+	e := &Event{MouseX: x, MouseY: y}
+	mouseDownHandler(root, false, e, &Window{})
+	return e
+}
+
+// dragShape builds a shape carrying a colorDragTrack handler over the
+// given box.
+func dragShape(
+	id string, x, y, w, h float32,
+	onPoint func(nx, ny float32, ctx EventCtx),
+) *Shape {
+	return &Shape{
+		ID:     id,
+		X:      x,
+		Y:      y,
+		Width:  w,
+		Height: h,
+		events: &eventHandlers{
+			OnClick: colorDragTrack(id, onPoint),
+		},
+		shapeClip: drawClip{X: x, Y: y, Width: w, Height: h},
+	}
+}
+
+// A click must report where in the control it landed, as a fraction of
+// the control's own box.
+func TestColorDragTrackReportsNormalizedPoint(t *testing.T) {
+	var gotX, gotY float32
+	got := false
+	s := dragShape("d", 0, 0, 100, 200,
+		func(nx, ny float32, _ EventCtx) {
+			gotX, gotY, got = nx, ny, true
+		})
+
+	clickShape(t, s, 25, 150)
+	if !got {
+		t.Fatal("handler never fired")
+	}
+	if f32Abs(gotX-0.25) > 0.001 || f32Abs(gotY-0.75) > 0.001 {
+		t.Errorf("point = %v,%v want 0.25,0.75", gotX, gotY)
+	}
+}
+
+// The coordinate conversion is the subtle part: OnClick arrives
+// shape-relative, so a control away from the window origin must still
+// report the same fraction.
+func TestColorDragTrackHandlesOffsetShape(t *testing.T) {
+	var gotX, gotY float32
+	s := dragShape("d", 300, 400, 100, 100,
+		func(nx, ny float32, _ EventCtx) { gotX, gotY = nx, ny })
+
+	// Window (350, 450) is the centre of a control at (300, 400).
+	clickShape(t, s, 350, 450)
+	if f32Abs(gotX-0.5) > 0.001 || f32Abs(gotY-0.5) > 0.001 {
+		t.Errorf("point = %v,%v want 0.5,0.5", gotX, gotY)
+	}
+}
+
+// A drag that runs past the edge must pin to the edge rather than
+// report a fraction outside the box.
+func TestColorDragTrackClamps(t *testing.T) {
+	var gotX, gotY float32
+	s := dragShape("d", 0, 0, 100, 100,
+		func(nx, ny float32, _ EventCtx) { gotX, gotY = nx, ny })
+	s.shapeClip = drawClip{Width: 1000, Height: 1000} // let the click land
+
+	clickShape(t, s, 500, 500)
+	if gotX != 1 || gotY != 1 {
+		t.Errorf("point = %v,%v want clamped to 1,1", gotX, gotY)
+	}
+}
+
+// The control sits inside a focusable container in the composed
+// picker; not consuming would move focus off it mid-drag.
+func TestColorDragTrackConsumes(t *testing.T) {
+	s := dragShape("d", 0, 0, 100, 100, func(float32, float32, EventCtx) {})
+	e := clickShape(t, s, 50, 50)
+	if !e.IsHandled {
+		t.Error("drag handler did not consume the click")
+	}
+}
+
+// A zero-sized shape would divide by zero; it must report nothing.
+func TestColorDragTrackIgnoresZeroSize(t *testing.T) {
+	called := false
+	s := dragShape("d", 0, 0, 0, 0,
+		func(float32, float32, EventCtx) { called = true })
+	s.shapeClip = drawClip{Width: 100, Height: 100}
+	clickShape(t, s, 5, 5)
+	if called {
+		t.Error("handler fired for a zero-sized control")
+	}
+}
+
+// End to end through the real component: a click in the plane's
+// lower-right quadrant must raise saturation and lower lightness.
+func TestColorPlaneClickSetsValue(t *testing.T) {
+	w := &Window{}
+	var got HSLA
+	fired := false
+	l := generateViewLayout(ColorPlane(ColorPlaneCfg{
+		ID:    "plane",
+		Value: HSLA{H: 210, S: 0.5, L: 0.5, A: 1},
+		Size:  100,
+		OnChange: func(v HSLA, _ EventCtx) {
+			got, fired = v, true
+		},
+	}), w)
+
+	// Give the shape a box; layout normally does this in arrange.
+	l.Shape.X, l.Shape.Y = 0, 0
+	l.Shape.Width, l.Shape.Height = 100, 100
+	l.Shape.shapeClip = drawClip{Width: 100, Height: 100}
+
+	root := &Layout{
+		Shape:    &Shape{shapeClip: drawClip{Width: 500, Height: 500}},
+		Children: []Layout{l},
+	}
+	layoutParents(root, nil)
+	mouseDownHandler(root, false,
+		&Event{MouseX: 75, MouseY: 80}, w)
+
+	if !fired {
+		t.Fatal("plane did not report a change")
+	}
+	if f32Abs(got.S-0.75) > 0.01 {
+		t.Errorf("S = %v, want 0.75", got.S)
+	}
+	if f32Abs(got.L-0.2) > 0.01 {
+		t.Errorf("L = %v, want 0.2", got.L)
+	}
+	// Hue and alpha are not this control's business.
+	if got.H != 210 || got.A != 1 {
+		t.Errorf("H/A = %v/%v, want 210/1 passed through", got.H, got.A)
+	}
+}

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -151,7 +151,13 @@ func colorHexField(cfg *ColorFieldsCfg, id string, v HSLA) View {
 		Text:      v.Color().Hex(),
 		TextStyle: cfg.TextStyle,
 		Width:     defaultHexFieldWidth,
-		A11YCfg:   A11YCfg{A11YLabel: "Hex color"},
+		// An Input is Fit-sized, so Width alone is only a starting
+		// point and the field tracks its text: "#FFF" and "#3C8CDDD9"
+		// give different widths, and the swatch beside it slides
+		// around as the user types. MinWidth pins the floor so the
+		// row only ever grows, never twitches.
+		MinWidth: defaultHexFieldWidth,
+		A11YCfg:  A11YCfg{A11YLabel: "Hex color"},
 		OnTextChanged: func(text string, ctx EventCtx) {
 			apply(text, ctx)
 		},

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -310,6 +310,13 @@ func colorHSLRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 	})
 }
 
+// centeredText centres a copy of a style, leaving the caller's
+// unchanged.
+func centeredText(s TextStyle) TextStyle {
+	s.Align = TextAlignCenter
+	return s
+}
+
 // colorFieldColumn builds one labeled numeric input.
 func colorFieldColumn(
 	cfg *ColorFieldsCfg, label string, val int,
@@ -335,9 +342,12 @@ func colorFieldColumn(
 				},
 			}),
 			Input(InputCfg{
-				ID:        inputID,
-				Text:      strconv.Itoa(val),
-				TextStyle: cfg.TextStyle,
+				ID:   inputID,
+				Text: strconv.Itoa(val),
+				// Centred under a centred label, so the pair reads
+				// as one unit -- and so "60" and "140" do not sit
+				// ragged against each other down the row.
+				TextStyle: centeredText(cfg.TextStyle),
 				Width:     cfg.FieldWidth,
 				// Pinned both ways like the hex field: an Input is
 				// Fit-sized, so "0" and "255" would resolve to

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -1,0 +1,281 @@
+package gui
+
+import "strconv"
+
+// ColorFieldsCfg configures the numeric side of a color editor: a hex
+// field, the R/G/B/A channels, and optionally the H/S/L channels.
+//
+// Text entry is where a color is named exactly rather than aimed at, so
+// the fields commit on every keystroke that parses and ignore the ones
+// that do not — a half-typed "#3b8" leaves the current color alone
+// instead of jumping to black.
+type ColorFieldsCfg struct {
+	OnChange func(HSLA, EventCtx)
+	ID       string `gui:"required"`
+
+	A11YCfg
+
+	Value HSLA
+
+	// ShowHSL adds the hue/saturation/lightness row under the RGBA
+	// one.
+	ShowHSL bool
+	// HideHex drops the hex field, for a caller that shows the hex
+	// value elsewhere.
+	// exportaudit:keep — caller-facing layout choice
+	HideHex bool
+	// ShowSwatch puts a ColorSwatch of Value to the right of the hex
+	// field, where the hex string it previews is. Ignored with HideHex —
+	// a swatch with nothing to sit beside belongs in the caller's own
+	// layout, as a plain ColorSwatch.
+	//
+	// exportaudit:keep — caller-facing layout choice; ColorPicker is the
+	// only in-repo user.
+	ShowSwatch bool
+	// SwatchSize is the swatch's edge length. Zero takes the default.
+	//
+	// exportaudit:keep — caller-facing sizing
+	SwatchSize float32
+
+	TextStyle TextStyle
+	// FieldWidth is the width of one channel input. Zero takes the
+	// default.
+	// exportaudit:keep — caller-facing sizing
+	FieldWidth float32
+}
+
+type colorFieldsView struct {
+	cfg ColorFieldsCfg
+}
+
+// ColorFields creates the hex and channel inputs for a color.
+func ColorFields(cfg ColorFieldsCfg) View {
+	RequireID("ColorFields", cfg.ID)
+	if cfg.FieldWidth <= 0 {
+		cfg.FieldWidth = defaultColorFieldWidth
+	}
+	if cfg.TextStyle == (TextStyle{}) {
+		cfg.TextStyle = defaultColorPickerStyle.TextStyle
+	}
+	if cfg.SwatchSize <= 0 {
+		cfg.SwatchSize = defaultColorFieldsSwatch
+	}
+	return &colorFieldsView{cfg: cfg}
+}
+
+const (
+	defaultColorFieldWidth = 50
+	defaultHexFieldWidth   = 100
+	// defaultColorFieldsSwatch matches the hex input's height closely
+	// enough that the two read as one row.
+	defaultColorFieldsSwatch = 28
+)
+
+func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
+	cfg := &fv.cfg
+	id := w.EffID(cfg.ID)
+	v := cfg.Value.Normalized()
+
+	rows := make([]View, 0, 3)
+	if !cfg.HideHex {
+		rows = append(rows, colorHexRow(cfg, id, v))
+	}
+	rows = append(rows, colorRGBARow(cfg, id, v))
+	if cfg.ShowHSL {
+		rows = append(rows, colorHSLRow(cfg, id, v))
+	}
+
+	return generateViewLayout(&containerView{
+		cfg: ContainerCfg{
+			ID:      id,
+			Padding: NoPadding,
+			Spacing: Some(SpacingSmall),
+			axis:    axisTopToBottom,
+			A11YCfg: cfg.A11YCfg,
+		},
+		content: rows,
+	}, w)
+}
+
+// colorHexRow builds the hex text field, and — with ShowSwatch — the
+// preview swatch beside it. The swatch belongs next to the hex value:
+// both are readouts of the same color, one exact and one legible.
+func colorHexRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
+	hex := colorHexField(cfg, id, v)
+	if !cfg.ShowSwatch {
+		return hex
+	}
+	return Row(ContainerCfg{
+		Padding: NoPadding,
+		Spacing: Some(SpacingSmall),
+		VAlign:  VAlignMiddle,
+		Content: []View{
+			hex,
+			ColorSwatch(ColorSwatchCfg{
+				ID:     ScopeID(id, "swatch"),
+				Color:  v.Color(),
+				Width:  cfg.SwatchSize,
+				Height: cfg.SwatchSize,
+			}),
+		},
+	})
+}
+
+func colorHexField(cfg *ColorFieldsCfg, id string, v HSLA) View {
+	onChange := cfg.OnChange
+	apply := func(text string, ctx EventCtx) {
+		c, ok := ColorFromHex(text)
+		if !ok || onChange == nil {
+			return // still typing, or malformed: keep the current color
+		}
+		out := ColorToHSLA(c)
+		// Hex carries no hue for a gray, so keep the hue the user was
+		// already on rather than snapping the other controls to red.
+		if out.S == 0 {
+			out.H = v.H
+		}
+		onChange(out, ctx)
+	}
+	return Input(InputCfg{
+		ID:        ScopeID(id, "hex"),
+		Text:      v.Color().Hex(),
+		TextStyle: cfg.TextStyle,
+		Width:     defaultHexFieldWidth,
+		A11YCfg:   A11YCfg{A11YLabel: "Hex color"},
+		OnTextChanged: func(text string, ctx EventCtx) {
+			apply(text, ctx)
+		},
+		OnTextCommit: func(
+			text string, _ InputCommitReason, ctx EventCtx,
+		) {
+			apply(text, ctx)
+		},
+	})
+}
+
+// colorRGBARow builds the R/G/B/A inputs. They edit the Color the HSLA
+// converts to, then convert back — the one place in these components
+// where a value round-trips through RGBA, because that is exactly what
+// the user asked to edit.
+func colorRGBARow(cfg *ColorFieldsCfg, id string, v HSLA) View {
+	c := v.Color()
+	l := ActiveLocale
+	vals := [4]uint8{c.R, c.G, c.B, c.A}
+	labels := [4]string{l.strRed, l.strGreen, l.strBlue, l.strAlpha}
+
+	fields := make([]View, 0, 4)
+	for i := range 4 {
+		fields = append(fields, colorFieldColumn(cfg,
+			labels[i], int(vals[i]), ScopeIDN(id, "rgb", i),
+			func(text string, ctx EventCtx) {
+				n, err := strconv.ParseUint(text, 10, 8)
+				if err != nil || cfg.OnChange == nil {
+					return
+				}
+				out := c
+				switch i {
+				case 0:
+					out.R = uint8(n)
+				case 1:
+					out.G = uint8(n)
+				case 2:
+					out.B = uint8(n)
+				case 3:
+					out.A = uint8(n)
+				}
+				next := ColorToHSLA(out)
+				// Same gray caveat as hex: RGB cannot carry the hue
+				// of a color it has just desaturated.
+				if next.S == 0 {
+					next.H = v.H
+				}
+				cfg.OnChange(next, ctx)
+			}))
+	}
+	return Row(ContainerCfg{
+		Padding: NoPadding,
+		Spacing: Some(SpacingSmall),
+		Content: fields,
+	})
+}
+
+// colorHSLRow builds the H/S/L inputs, which edit the value directly
+// with no RGBA round-trip and so cannot lose the hue.
+func colorHSLRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
+	l := ActiveLocale
+	type field struct {
+		label string
+		val   int
+		maxV  int
+	}
+	fs := [3]field{
+		{l.strHue, int(v.H + 0.5), 360},
+		{l.strSat, int(v.S*100 + 0.5), 100},
+		{l.strLightness, int(v.L*100 + 0.5), 100},
+	}
+
+	fields := make([]View, 0, 3)
+	for i := range 3 {
+		f := fs[i]
+		fields = append(fields, colorFieldColumn(cfg,
+			f.label, f.val, ScopeIDN(id, "hsl", i),
+			func(text string, ctx EventCtx) {
+				n, err := strconv.Atoi(text)
+				if err != nil || cfg.OnChange == nil {
+					return
+				}
+				n = intClamp(n, 0, f.maxV)
+				out := v
+				switch i {
+				case 0:
+					out.H = float32(n)
+				case 1:
+					out.S = float32(n) / 100
+				default:
+					out.L = float32(n) / 100
+				}
+				cfg.OnChange(out, ctx)
+			}))
+	}
+	return Row(ContainerCfg{
+		Padding: NoPadding,
+		Spacing: Some(SpacingSmall),
+		Content: fields,
+	})
+}
+
+// colorFieldColumn builds one labeled numeric input.
+func colorFieldColumn(
+	cfg *ColorFieldsCfg, label string, val int,
+	inputID string, apply func(string, EventCtx),
+) View {
+	return Column(ContainerCfg{
+		Padding: NoPadding,
+		Spacing: SomeF(2),
+		Content: []View{
+			Text(TextCfg{
+				Text: label,
+				TextStyle: TextStyle{
+					Color: cfg.TextStyle.Color,
+					Size:  cfg.TextStyle.Size,
+					Align: TextAlignCenter,
+				},
+			}),
+			Input(InputCfg{
+				ID:        inputID,
+				Text:      strconv.Itoa(val),
+				TextStyle: cfg.TextStyle,
+				Width:     cfg.FieldWidth,
+				A11YCfg:   A11YCfg{A11YLabel: label},
+				OnTextChanged: func(text string, ctx EventCtx) {
+					apply(text, ctx)
+				},
+				OnTextCommit: func(
+					text string, _ InputCommitReason, ctx EventCtx,
+				) {
+					apply(text, ctx)
+				},
+			}),
+		},
+	})
+}

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -65,7 +65,12 @@ func ColorFields(cfg ColorFieldsCfg) View {
 }
 
 const (
-	defaultColorFieldWidth = 50
+	// defaultColorFieldWidth holds three digits with room for the caret,
+	// and stays just above the widest RGBA label ("Green") so the label
+	// never widens the column. It sets the whole picker's width — four
+	// of these is its widest row — so the slack here is what shows up as
+	// empty space beside the shorter rows.
+	defaultColorFieldWidth = 46
 	// defaultHexFieldWidth holds the widest value the field ever shows
 	// — "#RRGGBBAA", which Hex() emits whenever alpha is not full — so
 	// pinning the field to it never clips.

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -102,9 +102,14 @@ func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
 		cfg: ContainerCfg{
 			ID:      id,
 			Padding: NoPadding,
-			Spacing: Some(SpacingSmall),
-			axis:    axisTopToBottom,
-			A11YCfg: cfg.A11YCfg,
+			// Structural: these containers group fields, they are not
+			// boxes. Without opting out they inherit the theme border
+			// under a bordered theme, and every nesting level then adds
+			// its width to the row and shifts its children.
+			SizeBorder: NoBorder,
+			Spacing:    Some(SpacingSmall),
+			axis:       axisTopToBottom,
+			A11YCfg:    cfg.A11YCfg,
 		},
 		content: rows,
 	}, w)
@@ -119,9 +124,10 @@ func colorHexRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 		return hex
 	}
 	return Row(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: Some(SpacingSmall),
-		VAlign:  VAlignMiddle,
+		Padding:    NoPadding,
+		SizeBorder: NoBorder, // structural; see colorFieldsView
+		Spacing:    Some(SpacingSmall),
+		VAlign:     VAlignMiddle,
 		Content: []View{
 			hex,
 			ColorSwatch(ColorSwatchCfg{
@@ -219,9 +225,10 @@ func colorRGBARow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 			}))
 	}
 	return Row(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: Some(SpacingSmall),
-		Content: fields,
+		Padding:    NoPadding,
+		SizeBorder: NoBorder, // structural; see colorFieldsView
+		Spacing:    Some(SpacingSmall),
+		Content:    fields,
 	})
 }
 
@@ -264,9 +271,10 @@ func colorHSLRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 			}))
 	}
 	return Row(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: Some(SpacingSmall),
-		Content: fields,
+		Padding:    NoPadding,
+		SizeBorder: NoBorder, // structural; see colorFieldsView
+		Spacing:    Some(SpacingSmall),
+		Content:    fields,
 	})
 }
 
@@ -276,8 +284,9 @@ func colorFieldColumn(
 	inputID string, apply func(string, EventCtx),
 ) View {
 	return Column(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: SomeF(2),
+		Padding:    NoPadding,
+		SizeBorder: NoBorder, // structural; see colorFieldsView
+		Spacing:    SomeF(2),
 		Content: []View{
 			Text(TextCfg{
 				Text: label,

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -130,7 +130,7 @@ func colorFieldLabelSize(valueSize float32) float32 {
 // flat gray chosen against one background is wrong against the other.
 // The same trick sets placeholder text in ThemeMaker.
 func colorFieldLabelColor(c Color) Color {
-	return RGBA(c.R, c.G, c.B, uint8(float32(c.A)*colorFieldLabelAlpha))
+	return c.WithOpacity(colorFieldLabelAlpha)
 }
 
 func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
@@ -256,6 +256,33 @@ func colorHexField(
 	})
 }
 
+// colorFieldSpec is one labeled channel input: the label, the current
+// value to show, the scoped ID, and the parse-and-commit closure.
+type colorFieldSpec struct {
+	label string
+	val   int
+	id    string
+	apply func(string, EventCtx)
+}
+
+// colorFieldRow lays out a row of labeled channel inputs. The RGBA and
+// HSL rows share everything except what each column edits, so the
+// difference lives in the specs, not in a second copy of the row.
+func colorFieldRow(cfg *ColorFieldsCfg, pad Padding, specs []colorFieldSpec) View {
+	fields := make([]View, 0, len(specs))
+	for i := range specs {
+		s := &specs[i]
+		fields = append(fields, colorFieldColumn(cfg, pad,
+			s.label, s.val, s.id, s.apply))
+	}
+	return Row(ContainerCfg{
+		Padding:    NoPadding,
+		SizeBorder: NoBorder, // structural; see colorFieldsView
+		Spacing:    Some(SpacingSmall),
+		Content:    fields,
+	})
+}
+
 // colorRGBARow builds the R/G/B/A inputs. They edit the Color the HSLA
 // converts to, then convert back — the one place in these components
 // where a value round-trips through RGBA, because that is exactly what
@@ -268,11 +295,13 @@ func colorRGBARow(
 	vals := [4]uint8{c.R, c.G, c.B, c.A}
 	labels := [4]string{l.strRed, l.strGreen, l.strBlue, l.strAlpha}
 
-	fields := make([]View, 0, 4)
+	specs := make([]colorFieldSpec, 0, 4)
 	for i := range 4 {
-		fields = append(fields, colorFieldColumn(cfg, pad,
-			labels[i], int(vals[i]), ScopeIDN(id, "rgb", i),
-			func(text string, ctx EventCtx) {
+		specs = append(specs, colorFieldSpec{
+			label: labels[i],
+			val:   int(vals[i]),
+			id:    ScopeIDN(id, "rgb", i),
+			apply: func(text string, ctx EventCtx) {
 				n, err := strconv.ParseUint(text, 10, 8)
 				if err != nil || cfg.OnChange == nil {
 					return
@@ -295,14 +324,10 @@ func colorRGBARow(
 					next.H = v.H
 				}
 				cfg.OnChange(next, ctx)
-			}))
+			},
+		})
 	}
-	return Row(ContainerCfg{
-		Padding:    NoPadding,
-		SizeBorder: NoBorder, // structural; see colorFieldsView
-		Spacing:    Some(SpacingSmall),
-		Content:    fields,
-	})
+	return colorFieldRow(cfg, pad, specs)
 }
 
 // colorHSLRow builds the H/S/L inputs, which edit the value directly
@@ -322,12 +347,14 @@ func colorHSLRow(
 		{l.strLightness, int(v.L*100 + 0.5), 100},
 	}
 
-	fields := make([]View, 0, 3)
+	specs := make([]colorFieldSpec, 0, 3)
 	for i := range 3 {
 		f := fs[i]
-		fields = append(fields, colorFieldColumn(cfg, pad,
-			f.label, f.val, ScopeIDN(id, "hsl", i),
-			func(text string, ctx EventCtx) {
+		specs = append(specs, colorFieldSpec{
+			label: f.label,
+			val:   f.val,
+			id:    ScopeIDN(id, "hsl", i),
+			apply: func(text string, ctx EventCtx) {
 				n, err := strconv.Atoi(text)
 				if err != nil || cfg.OnChange == nil {
 					return
@@ -343,14 +370,10 @@ func colorHSLRow(
 					out.L = float32(n) / 100
 				}
 				cfg.OnChange(out, ctx)
-			}))
+			},
+		})
 	}
-	return Row(ContainerCfg{
-		Padding:    NoPadding,
-		SizeBorder: NoBorder, // structural; see colorFieldsView
-		Spacing:    Some(SpacingSmall),
-		Content:    fields,
-	})
+	return colorFieldRow(cfg, pad, specs)
 }
 
 // centeredText centres a copy of a style, leaving the caller's
@@ -391,6 +414,15 @@ func colorFieldPadding(w *Window, style TextStyle) Padding {
 	// the bottom padding cannot cover.
 	bottom := f32Max(colorFieldPadY-shift, 0)
 	return NewPadding(bottom+shift, colorFieldPadX, bottom, colorFieldPadX)
+}
+
+// colorFieldsBlockWidth is the width of a default-configured fields
+// block: four channel inputs at the default width with small spacing
+// between them. The picker's plane-size math mirrors it so the two
+// rows of a composed picker come out the same width, and both sides
+// read one name instead of one hard-coded formula each.
+func colorFieldsBlockWidth() float32 {
+	return 4*defaultColorFieldWidth + 3*SpacingSmall
 }
 
 // colorFieldColumn builds one labeled numeric input.

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -70,7 +70,7 @@ const (
 	// never widens the column. It sets the whole picker's width — four
 	// of these is its widest row — so the slack here is what shows up as
 	// empty space beside the shorter rows.
-	defaultColorFieldWidth = 46
+	defaultColorFieldWidth = 44
 	// defaultHexFieldWidth holds the widest value the field ever shows
 	// — "#RRGGBBAA", which Hex() emits whenever alpha is not full — so
 	// pinning the field to it never clips.
@@ -82,7 +82,22 @@ const (
 	// which stays the height so the swatch keeps matching the hex
 	// input's line.
 	colorFieldsSwatchAspect = 2
+	// colorFieldLabelDrop takes the channel labels one step down from
+	// the value text, the theme's N3-to-N4 step. The label names the
+	// field; the value is what gets read, so the value keeps the larger
+	// size. It also stops a long label ("Lightness") from setting the
+	// column width, which is what the whole picker's width follows.
+	colorFieldLabelDrop = 2
+	// colorFieldLabelMin floors the drop so a caller already using a
+	// tiny TextStyle does not end up with an unreadable label.
+	colorFieldLabelMin = 10
 )
+
+// colorFieldLabelSize derives a channel label's size from the value
+// text's, never going below the floor.
+func colorFieldLabelSize(valueSize float32) float32 {
+	return f32Max(valueSize-colorFieldLabelDrop, colorFieldLabelMin)
+}
 
 func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
 	cfg := &fv.cfg
@@ -292,7 +307,7 @@ func colorFieldColumn(
 				Text: label,
 				TextStyle: TextStyle{
 					Color: cfg.TextStyle.Color,
-					Size:  cfg.TextStyle.Size,
+					Size:  colorFieldLabelSize(cfg.TextStyle.Size),
 					Align: TextAlignCenter,
 				},
 			}),

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -91,6 +91,23 @@ const (
 	// colorFieldLabelMin floors the drop so a caller already using a
 	// tiny TextStyle does not end up with an unreadable label.
 	colorFieldLabelMin = 10
+	// colorFieldCapRatio is a digit's cap height as a fraction of the
+	// font size. It is the one metric TextMeasurer does not expose, and
+	// it varies little across text faces; every other term in the
+	// optical-centring correction is measured.
+	colorFieldCapRatio = 0.72
+	// colorFieldLeadRatio covers half-leading: FontHeight includes line
+	// spacing beyond ascent+descent, split above and below the glyphs,
+	// and the metrics do not separate it out. Measured from the
+	// rendered field — the cap-height term alone left the ink 1.5
+	// device pixels high at size 16.
+	colorFieldLeadRatio = 0.047
+	// colorFieldPadX is the fields' horizontal padding, matching the
+	// input default (paddingTwoFour).
+	colorFieldPadX = 4
+	// colorFieldPadY is its vertical half, the baseline the optical
+	// correction adjusts around.
+	colorFieldPadY = 2
 	// colorFieldLabelAlpha dims the label against its value. Size alone
 	// separates them only while both are read in isolation; dropping
 	// contrast as well is what makes the column scan as "value, with a
@@ -121,13 +138,17 @@ func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
 	id := w.EffID(cfg.ID)
 	v := cfg.Value.Normalized()
 
+	// One measurement for every field in the block; see
+	// colorFieldPadding.
+	pad := colorFieldPadding(w, cfg.TextStyle)
+
 	rows := make([]View, 0, 3)
 	if !cfg.HideHex {
-		rows = append(rows, colorHexRow(cfg, id, v))
+		rows = append(rows, colorHexRow(cfg, id, v, pad))
 	}
-	rows = append(rows, colorRGBARow(cfg, id, v))
+	rows = append(rows, colorRGBARow(cfg, id, v, pad))
 	if cfg.ShowHSL {
-		rows = append(rows, colorHSLRow(cfg, id, v))
+		rows = append(rows, colorHSLRow(cfg, id, v, pad))
 	}
 
 	return generateViewLayout(&containerView{
@@ -150,8 +171,10 @@ func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
 // colorHexRow builds the hex text field, and — with ShowSwatch — the
 // preview swatch beside it. The swatch belongs next to the hex value:
 // both are readouts of the same color, one exact and one legible.
-func colorHexRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
-	hex := colorHexField(cfg, id, v)
+func colorHexRow(
+	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding,
+) View {
+	hex := colorHexField(cfg, id, v, pad)
 	if !cfg.ShowSwatch {
 		return hex
 	}
@@ -177,7 +200,9 @@ func colorHexRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 	})
 }
 
-func colorHexField(cfg *ColorFieldsCfg, id string, v HSLA) View {
+func colorHexField(
+	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding,
+) View {
 	onChange := cfg.OnChange
 	apply := func(text string, ctx EventCtx) {
 		c, ok := ColorFromHex(text)
@@ -205,6 +230,7 @@ func colorHexField(cfg *ColorFieldsCfg, id string, v HSLA) View {
 		// bounds pin it: a floor alone still lets a long value grow.
 		MinWidth: defaultHexFieldWidth,
 		MaxWidth: defaultHexFieldWidth,
+		Padding:  pad,
 		A11YCfg:  A11YCfg{A11YLabel: "Hex color"},
 		OnTextChanged: func(text string, ctx EventCtx) {
 			apply(text, ctx)
@@ -221,7 +247,9 @@ func colorHexField(cfg *ColorFieldsCfg, id string, v HSLA) View {
 // converts to, then convert back — the one place in these components
 // where a value round-trips through RGBA, because that is exactly what
 // the user asked to edit.
-func colorRGBARow(cfg *ColorFieldsCfg, id string, v HSLA) View {
+func colorRGBARow(
+	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding,
+) View {
 	c := v.Color()
 	l := ActiveLocale
 	vals := [4]uint8{c.R, c.G, c.B, c.A}
@@ -229,7 +257,7 @@ func colorRGBARow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 
 	fields := make([]View, 0, 4)
 	for i := range 4 {
-		fields = append(fields, colorFieldColumn(cfg,
+		fields = append(fields, colorFieldColumn(cfg, pad,
 			labels[i], int(vals[i]), ScopeIDN(id, "rgb", i),
 			func(text string, ctx EventCtx) {
 				n, err := strconv.ParseUint(text, 10, 8)
@@ -266,7 +294,9 @@ func colorRGBARow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 
 // colorHSLRow builds the H/S/L inputs, which edit the value directly
 // with no RGBA round-trip and so cannot lose the hue.
-func colorHSLRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
+func colorHSLRow(
+	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding,
+) View {
 	l := ActiveLocale
 	type field struct {
 		label string
@@ -282,7 +312,7 @@ func colorHSLRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 	fields := make([]View, 0, 3)
 	for i := range 3 {
 		f := fs[i]
-		fields = append(fields, colorFieldColumn(cfg,
+		fields = append(fields, colorFieldColumn(cfg, pad,
 			f.label, f.val, ScopeIDN(id, "hsl", i),
 			func(text string, ctx EventCtx) {
 				n, err := strconv.Atoi(text)
@@ -317,9 +347,42 @@ func centeredText(s TextStyle) TextStyle {
 	return s
 }
 
+// colorFieldPadding centres a digit string optically rather than
+// metrically inside its field.
+//
+// An Input centres the text's *line box*, which is correct and still
+// looks wrong here: the line box reserves descent space, and digits and
+// hex have no descenders, so the ink hangs above the box's middle by
+// half the descent. Measured on the RGBA row, the gap below the digits
+// was twice the gap above.
+//
+// The correction moves the line box down by shifting padding from the
+// bottom to the top. Working from the box's own centre, the ink sits
+// off by (ascent - cap - descent)/2, so top-minus-bottom must make up
+// twice that. Ascent and descent are measured; only cap height is a
+// ratio, and it is the smallest term.
+func colorFieldPadding(w *Window, style TextStyle) Padding {
+	even := NewPadding(
+		colorFieldPadY, colorFieldPadX, colorFieldPadY, colorFieldPadX)
+	if w == nil || w.textMeasurer == nil {
+		return even // no metrics: metric centring is the best available
+	}
+	ascent := w.textMeasurer.FontAscent(style)
+	descent := w.textMeasurer.FontHeight(style) - ascent
+	shift := descent - ascent +
+		style.Size*(colorFieldCapRatio+colorFieldLeadRatio)
+	if shift <= 0 {
+		return even // a face whose ink already sits centred
+	}
+	// Take from the bottom first so the field grows only by whatever
+	// the bottom padding cannot cover.
+	bottom := f32Max(colorFieldPadY-shift, 0)
+	return NewPadding(bottom+shift, colorFieldPadX, bottom, colorFieldPadX)
+}
+
 // colorFieldColumn builds one labeled numeric input.
 func colorFieldColumn(
-	cfg *ColorFieldsCfg, label string, val int,
+	cfg *ColorFieldsCfg, pad Padding, label string, val int,
 	inputID string, apply func(string, EventCtx),
 ) View {
 	return Column(ContainerCfg{
@@ -348,6 +411,7 @@ func colorFieldColumn(
 				// as one unit -- and so "60" and "140" do not sit
 				// ragged against each other down the row.
 				TextStyle: centeredText(cfg.TextStyle),
+				Padding:   pad,
 				Width:     cfg.FieldWidth,
 				// Pinned both ways like the hex field: an Input is
 				// Fit-sized, so "0" and "255" would resolve to

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -183,8 +183,21 @@ func colorHexRow(
 		SizeBorder: NoBorder, // structural; see colorFieldsView
 		Spacing:    Some(SpacingSmall),
 		VAlign:     VAlignMiddle,
+		// Fill so the row spans the block's full width — set by the
+		// wider RGBA row below — giving the spacer something to take
+		// up. A Fit row would shrink to hex + swatch and the spacer
+		// would collapse to nothing.
+		Sizing: FillFit,
 		Content: []View{
 			hex,
+			// Flexible gap: it absorbs the whole surplus, pinning the
+			// swatch to the block's right edge so it lines up with the
+			// last channel field under it rather than floating mid-row.
+			Row(ContainerCfg{
+				Sizing:     FillFit,
+				Padding:    NoPadding,
+				SizeBorder: NoBorder,
+			}),
 			ColorSwatch(ColorSwatchCfg{
 				ID:    ScopeID(id, "swatch"),
 				Color: v.Color(),

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -282,7 +282,12 @@ func colorFieldColumn(
 				Text:      strconv.Itoa(val),
 				TextStyle: cfg.TextStyle,
 				Width:     cfg.FieldWidth,
-				A11YCfg:   A11YCfg{A11YLabel: label},
+				// Same floor as the hex field: an Input is
+				// Fit-sized, so "0" and "255" would resolve to
+				// different widths and the whole column of fields
+				// would shift as the user drags a control.
+				MinWidth: cfg.FieldWidth,
+				A11YCfg:  A11YCfg{A11YLabel: label},
 				OnTextChanged: func(text string, ctx EventCtx) {
 					apply(text, ctx)
 				},

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -66,7 +66,10 @@ func ColorFields(cfg ColorFieldsCfg) View {
 
 const (
 	defaultColorFieldWidth = 50
-	defaultHexFieldWidth   = 100
+	// defaultHexFieldWidth holds the widest value the field ever shows
+	// — "#RRGGBBAA", which Hex() emits whenever alpha is not full — so
+	// pinning the field to it never clips.
+	defaultHexFieldWidth = 115
 	// defaultColorFieldsSwatch matches the hex input's height closely
 	// enough that the two read as one row.
 	defaultColorFieldsSwatch = 28
@@ -152,11 +155,13 @@ func colorHexField(cfg *ColorFieldsCfg, id string, v HSLA) View {
 		TextStyle: cfg.TextStyle,
 		Width:     defaultHexFieldWidth,
 		// An Input is Fit-sized, so Width alone is only a starting
-		// point and the field tracks its text: "#FFF" and "#3C8CDDD9"
-		// give different widths, and the swatch beside it slides
-		// around as the user types. MinWidth pins the floor so the
-		// row only ever grows, never twitches.
+		// point and the field tracks its text. Hex() emits "#RRGGBB"
+		// at full alpha and "#RRGGBBAA" otherwise, and even at one
+		// length the glyphs differ in width, so the field — and the
+		// swatch beside it — would move on nearly every edit. Both
+		// bounds pin it: a floor alone still lets a long value grow.
 		MinWidth: defaultHexFieldWidth,
+		MaxWidth: defaultHexFieldWidth,
 		A11YCfg:  A11YCfg{A11YLabel: "Hex color"},
 		OnTextChanged: func(text string, ctx EventCtx) {
 			apply(text, ctx)
@@ -282,11 +287,12 @@ func colorFieldColumn(
 				Text:      strconv.Itoa(val),
 				TextStyle: cfg.TextStyle,
 				Width:     cfg.FieldWidth,
-				// Same floor as the hex field: an Input is
+				// Pinned both ways like the hex field: an Input is
 				// Fit-sized, so "0" and "255" would resolve to
 				// different widths and the whole column of fields
 				// would shift as the user drags a control.
 				MinWidth: cfg.FieldWidth,
+				MaxWidth: cfg.FieldWidth,
 				A11YCfg:  A11YCfg{A11YLabel: label},
 				OnTextChanged: func(text string, ctx EventCtx) {
 					apply(text, ctx)

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -82,21 +82,38 @@ const (
 	// which stays the height so the swatch keeps matching the hex
 	// input's line.
 	colorFieldsSwatchAspect = 2
-	// colorFieldLabelDrop takes the channel labels one step down from
-	// the value text, the theme's N3-to-N4 step. The label names the
+	// colorFieldLabelDrop takes the channel labels two steps down from
+	// the value text — the theme's N3-to-N5 step. The label names the
 	// field; the value is what gets read, so the value keeps the larger
 	// size. It also stops a long label ("Lightness") from setting the
 	// column width, which is what the whole picker's width follows.
-	colorFieldLabelDrop = 2
+	colorFieldLabelDrop = 4
 	// colorFieldLabelMin floors the drop so a caller already using a
 	// tiny TextStyle does not end up with an unreadable label.
 	colorFieldLabelMin = 10
+	// colorFieldLabelAlpha dims the label against its value. Size alone
+	// separates them only while both are read in isolation; dropping
+	// contrast as well is what makes the column scan as "value, with a
+	// name over it" rather than as two competing lines. Kept well above
+	// placeholder dimness (~0.4), which reads as disabled.
+	colorFieldLabelAlpha = 0.7
 )
 
 // colorFieldLabelSize derives a channel label's size from the value
 // text's, never going below the floor.
 func colorFieldLabelSize(valueSize float32) float32 {
 	return f32Max(valueSize-colorFieldLabelDrop, colorFieldLabelMin)
+}
+
+// colorFieldLabelColor dims a channel label relative to its value.
+//
+// Scaling the text color's alpha rather than picking a gray keeps one
+// source of truth: the label tracks whatever color the caller or theme
+// set, and it stays legible on a light theme and a dark one alike. A
+// flat gray chosen against one background is wrong against the other.
+// The same trick sets placeholder text in ThemeMaker.
+func colorFieldLabelColor(c Color) Color {
+	return RGBA(c.R, c.G, c.B, uint8(float32(c.A)*colorFieldLabelAlpha))
 }
 
 func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
@@ -301,12 +318,18 @@ func colorFieldColumn(
 	return Column(ContainerCfg{
 		Padding:    NoPadding,
 		SizeBorder: NoBorder, // structural; see colorFieldsView
-		Spacing:    SomeF(2),
+		// Centered: the label is narrower than its field, and left
+		// alignment hangs it off the field's left edge instead of
+		// reading as a heading over it. TextAlignCenter alone cannot
+		// do this — a Fit text shape is only as wide as its glyphs, so
+		// there is nothing to center within.
+		HAlign:  HAlignCenter,
+		Spacing: SomeF(2),
 		Content: []View{
 			Text(TextCfg{
 				Text: label,
 				TextStyle: TextStyle{
-					Color: cfg.TextStyle.Color,
+					Color: colorFieldLabelColor(cfg.TextStyle.Color),
 					Size:  colorFieldLabelSize(cfg.TextStyle.Size),
 					Align: TextAlignCenter,
 				},

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -32,7 +32,8 @@ type ColorFieldsCfg struct {
 	// exportaudit:keep — caller-facing layout choice; ColorPicker is the
 	// only in-repo user.
 	ShowSwatch bool
-	// SwatchSize is the swatch's edge length. Zero takes the default.
+	// SwatchSize is the swatch's height; it is drawn twice as wide.
+	// Zero takes the default.
 	//
 	// exportaudit:keep — caller-facing sizing
 	SwatchSize float32
@@ -69,6 +70,10 @@ const (
 	// defaultColorFieldsSwatch matches the hex input's height closely
 	// enough that the two read as one row.
 	defaultColorFieldsSwatch = 28
+	// colorFieldsSwatchAspect widens the swatch relative to SwatchSize,
+	// which stays the height so the swatch keeps matching the hex
+	// input's line.
+	colorFieldsSwatchAspect = 2
 )
 
 func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
@@ -112,9 +117,14 @@ func colorHexRow(cfg *ColorFieldsCfg, id string, v HSLA) View {
 		Content: []View{
 			hex,
 			ColorSwatch(ColorSwatchCfg{
-				ID:     ScopeID(id, "swatch"),
-				Color:  v.Color(),
-				Width:  cfg.SwatchSize,
+				ID:    ScopeID(id, "swatch"),
+				Color: v.Color(),
+				// Twice as wide as it is tall. A square beside a
+				// text field reads as a button; a wide bar reads
+				// as a sample of the value next to it, and gives
+				// the checkerboard room to show under a
+				// translucent color.
+				Width:  cfg.SwatchSize * colorFieldsSwatchAspect,
 				Height: cfg.SwatchSize,
 			}),
 		},

--- a/gui/view_color_marker.go
+++ b/gui/view_color_marker.go
@@ -1,0 +1,54 @@
+package gui
+
+// colorMarker builds the ring that shows where a color control's
+// current value sits. It is a circle filled with that color and ringed
+// in white, so it reads against both ends of the imagery underneath —
+// the same treatment on the plane, the wheel, and the slider thumbs.
+//
+// amend positions it: the marker is a child of the control, and layout
+// alone cannot express "at this fraction across the parent", so every
+// caller repositions it in AmendLayout against absolute coordinates.
+func colorMarker(
+	size float32, fill Color, amend func(EventCtx),
+) View {
+	return Circle(ContainerCfg{
+		Width:  size,
+		Height: size,
+		// Fixed on both axes: a marker is a circle, not a box that may
+		// be resolved per axis. Left Fit, the shrink pass squeezes it
+		// against the imagery it floats over — the control's content is
+		// taller than the control — and the circle renders as an
+		// ellipse.
+		Sizing:      FixedFixed,
+		Color:       fill,
+		ColorBorder: White,
+		SizeBorder:  SomeF(colorMarkerRing),
+		Padding:     NoPadding,
+		// Float with a z-index above the imagery: a channel slider
+		// floats its track to centre it in a control the thumb makes
+		// taller, and a marker drawn under that track is invisible.
+		Float:       true,
+		FloatZIndex: colorMarkerZ,
+		AmendLayout: amend,
+	})
+}
+
+// colorMarkerZ keeps markers above the generated imagery they sit on.
+const colorMarkerZ = 1
+
+// colorMarkerRing is the marker's white outline width in points.
+const colorMarkerRing = 2
+
+// colorAmendMarker centres a marker on (x, y), given relative to the
+// parent's top-left corner. AmendLayout works in absolute coordinates,
+// so the parent's origin is added here rather than by every caller.
+func colorAmendMarker(
+	layout *Layout, x, y, size float32,
+) {
+	if layout == nil || layout.Parent == nil {
+		return
+	}
+	r := size / 2
+	layout.Shape.X = layout.Parent.Shape.X + x - r
+	layout.Shape.Y = layout.Parent.Shape.Y + y - r
+}

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -103,26 +103,29 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 			Spacing:    Some(colorPickerPlaneGap),
 			Content: []View{
 				ColorPlane(ColorPlaneCfg{
-					ID:       ScopeID(cfg.ID, "plane"),
-					Value:    v,
-					Size:     planeSize,
-					OnChange: onChange,
+					ID:            ScopeID(cfg.ID, "plane"),
+					Value:         v,
+					Size:          planeSize,
+					FocusDisabled: cfg.FocusDisabled,
+					OnChange:      onChange,
 				}),
 				ColorChannelSlider(ColorChannelSliderCfg{
-					ID:       ScopeID(cfg.ID, "hue"),
-					Channel:  ChannelHue,
-					Value:    v,
-					Vertical: true,
-					Height:   planeSize,
-					OnChange: onChange,
+					ID:            ScopeID(cfg.ID, "hue"),
+					Channel:       ChannelHue,
+					Value:         v,
+					Vertical:      true,
+					Height:        planeSize,
+					FocusDisabled: cfg.FocusDisabled,
+					OnChange:      onChange,
 				}),
 				ColorChannelSlider(ColorChannelSliderCfg{
-					ID:       ScopeID(cfg.ID, "alpha"),
-					Channel:  ChannelAlpha,
-					Value:    v,
-					Vertical: true,
-					Height:   planeSize,
-					OnChange: onChange,
+					ID:            ScopeID(cfg.ID, "alpha"),
+					Channel:       ChannelAlpha,
+					Value:         v,
+					Vertical:      true,
+					Height:        planeSize,
+					FocusDisabled: cfg.FocusDisabled,
+					OnChange:      onChange,
 				}),
 			},
 		}),
@@ -194,10 +197,8 @@ const colorPickerMinPlane = 120
 // asking for a small plane is never grown to fill the row.
 func colorPickerPlaneSize(style ColorPickerStyle) float32 {
 	sliderThick := f32Max(style.sliderHeight, style.indicatorSize)
-	// The fields block's own width, mirroring colorRGBARow: four
-	// inputs at the default width with small spacing between them.
-	fieldsW := 4*defaultColorFieldWidth + 3*SpacingSmall
-	size := fieldsW - 2*(sliderThick+colorPickerPlaneGap)
+	// The fields block's own width; see colorFieldsBlockWidth.
+	size := colorFieldsBlockWidth() - 2*(sliderThick+colorPickerPlaneGap)
 	if size > style.sVSize {
 		size = style.sVSize
 	}

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -97,7 +97,7 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 		// squarer than a stack of full-width tracks would make it.
 		Row(ContainerCfg{
 			Padding: NoPadding,
-			Spacing: Some(SpacingSmall),
+			Spacing: Some(colorPickerPlaneGap),
 			Content: []View{
 				ColorPlane(ColorPlaneCfg{
 					ID:       ScopeID(cfg.ID, "plane"),
@@ -163,6 +163,15 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 // colorPickerSwatchSize is the preview swatch's edge length.
 const colorPickerSwatchSize = 32
 
+// colorPickerPlaneGap separates the plane from the two vertical
+// sliders beside it. Wider than the picker's usual small spacing: the
+// sliders carry their own imagery, so at small spacing they read as
+// part of the plane's edge rather than as separate controls.
+//
+// colorPickerPlaneSize subtracts it, so widening the gap narrows the
+// plane and the row's total width does not move.
+const colorPickerPlaneGap = SpacingMedium
+
 // colorPickerMinPlane floors the derived plane size. A theme with wide
 // sliders and narrow fields could otherwise drive the plane down to
 // something unusable; below this the picker stops shrinking and simply
@@ -185,7 +194,7 @@ func colorPickerPlaneSize(style ColorPickerStyle) float32 {
 	// The fields block's own width, mirroring colorRGBARow: four
 	// inputs at the default width with small spacing between them.
 	fieldsW := 4*defaultColorFieldWidth + 3*SpacingSmall
-	size := fieldsW - 2*(sliderThick+SpacingSmall)
+	size := fieldsW - 2*(sliderThick+colorPickerPlaneGap)
 	if size > style.sVSize {
 		size = style.sVSize
 	}

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -1,15 +1,20 @@
 package gui
 
-import (
-	"strconv"
-)
-
-// colorPickerState stores persistent HSV to preserve hue when
-// saturation or value goes to zero.
+// colorPickerState holds the picker's live HSLA across frames.
+//
+// The public API is RGBA in and RGBA out, and RGBA cannot represent
+// hue at S=0 or at the lightness extremes. Without this, dragging
+// lightness to the bottom would discard the hue and the control would
+// come back red on the way up. It is a lossy-conversion guard for the
+// back-compat surface, not a second color model: the components below
+// all speak HSLA directly.
 type colorPickerState struct {
-	H float32
-	S float32
-	V float32
+	hsla HSLA
+	// color is the Color the stored hsla was derived from, so a
+	// caller changing Color out from under the picker is detected and
+	// wins, while a round-trip of the picker's own output does not
+	// clobber the hue it is holding.
+	color Color
 }
 
 // ColorPickerCfg configures a color picker view.
@@ -25,21 +30,47 @@ type ColorPickerCfg struct {
 	Width         float32
 	Height        float32
 
-	Color   Color
-	Sizing  Sizing
+	Color  Color
+	Sizing Sizing
+
+	// ShowHSV shows the hue/saturation/lightness input row.
+	//
+	// Deprecated: the picker edits HSL, not HSV. Use ShowHSL, which
+	// names what the row actually contains. Both set the same flag.
+	//
+	// exportaudit:keep — back-compat for callers outside this repo; the
+	// in-repo examples all moved to ShowHSL.
 	ShowHSV bool
+	// ShowHSL shows the hue/saturation/lightness input row.
+	ShowHSL bool
 }
 
 type colorPickerView struct {
 	cfg ColorPickerCfg
 }
 
-// ColorPicker creates a color picker view with SV area, hue slider,
-// alpha slider, hex input, and RGBA/HSV channel inputs.
+// ColorPicker creates a color picker with a saturation × lightness
+// plane, hue and alpha sliders, a preview swatch and channel inputs.
+//
+// It is a composition of the color components — ColorPlane,
+// ColorChannelSlider, ColorSwatch, ColorFields — assembled into the
+// arrangement most callers want. Reach for those directly to lay the
+// same controls out differently, add a ColorWheel, or drive several
+// controls from one HSLA value in app state.
 func ColorPicker(cfg ColorPickerCfg) View {
 	RequireID("ColorPicker", cfg.ID)
 	applyColorPickerDefaults(&cfg)
 	return &colorPickerView{cfg: cfg}
+}
+
+func applyColorPickerDefaults(cfg *ColorPickerCfg) {
+	d := &defaultColorPickerStyle
+	if cfg.Style == (ColorPickerStyle{}) {
+		cfg.Style = *d
+	}
+	if !cfg.Color.IsSet() {
+		cfg.Color = Red
+	}
 }
 
 func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
@@ -48,45 +79,67 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 	// One resolved identity for every key below; see (*Window).EffID.
 	cfg.ID = w.EffID(cfg.ID)
 	style := cfg.Style
+	v := cpValue(w, cfg.ID, cfg.Color)
 
-	// Get or init HSV state.
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	hsv, ok := sm.Get(cfg.ID)
-	if !ok {
-		h, s, v := cfg.Color.ToHSV()
-		hsv = colorPickerState{H: h, S: s, V: v}
-		sm.Set(cfg.ID, hsv)
+	// Every child reports an HSLA; the picker stores it, converts it
+	// once, and hands the caller the Color its API promises.
+	onChange := func(next HSLA, ctx EventCtx) {
+		cpStore(ctx.Window, cfg.ID, next)
+		if cfg.OnColorChange != nil {
+			cfg.OnColorChange(next.Color(), ctx)
+		}
 	}
 
-	svSize := style.sVSize
-	sliderH := style.sliderHeight
-	indicatorSize := style.indicatorSize
-
-	content := make([]View, 0, 5)
-
-	// SV area + hue slider side by side.
-	content = append(content, cpSVAndHueRow(cfg, hsv,
-		svSize, sliderH, indicatorSize))
-
-	// Alpha slider.
-	content = append(content, cpAlphaSlider(cfg))
-
-	// Preview + hex row.
-	content = append(content, cpPreviewRow(cfg))
-
-	// RGBA inputs.
-	content = append(content, cpRGBAInputs(cfg))
-
-	// Optional HSV inputs.
-	if cfg.ShowHSV {
-		content = append(content, cpHSVInputs(cfg, hsv))
+	planeSize := colorPickerPlaneSize(style)
+	content := []View{
+		// Plane first, then the two channel sliders stood on end beside
+		// it: the sliders are as tall as the plane, so the picker is
+		// squarer than a stack of full-width tracks would make it.
+		Row(ContainerCfg{
+			Padding: NoPadding,
+			Spacing: Some(SpacingSmall),
+			Content: []View{
+				ColorPlane(ColorPlaneCfg{
+					ID:       ScopeID(cfg.ID, "plane"),
+					Value:    v,
+					Size:     planeSize,
+					OnChange: onChange,
+				}),
+				ColorChannelSlider(ColorChannelSliderCfg{
+					ID:       ScopeID(cfg.ID, "hue"),
+					Channel:  ChannelHue,
+					Value:    v,
+					Vertical: true,
+					Height:   planeSize,
+					OnChange: onChange,
+				}),
+				ColorChannelSlider(ColorChannelSliderCfg{
+					ID:       ScopeID(cfg.ID, "alpha"),
+					Channel:  ChannelAlpha,
+					Value:    v,
+					Vertical: true,
+					Height:   planeSize,
+					OnChange: onChange,
+				}),
+			},
+		}),
+		// The swatch rides in the fields block, beside the hex value it
+		// previews, rather than standing to the left of the whole
+		// numeric column.
+		ColorFields(ColorFieldsCfg{
+			ID:         ScopeID(cfg.ID, "fields"),
+			Value:      v,
+			ShowHSL:    cfg.ShowHSL || cfg.ShowHSV,
+			ShowSwatch: true,
+			SwatchSize: colorPickerSwatchSize,
+			TextStyle:  style.TextStyle,
+			OnChange:   onChange,
+		}),
 	}
 
 	ccfg := ContainerCfg{
-		ID:        cfg.ID,
-		Focusable: !cfg.FocusDisabled,
-		A11YRole:  AccessRoleColorWell,
+		ID:       cfg.ID,
+		A11YRole: AccessRoleColorWell,
 		A11YCfg: A11YCfg{
 			A11YLabel:       a11yLabel(cfg.A11YLabel, "Color Picker"),
 			A11YDescription: cfg.A11YDescription,
@@ -100,11 +153,6 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 		Width:       cfg.Width,
 		Height:      cfg.Height,
 		axis:        axisTopToBottom,
-		AmendLayout: func(ctx EventCtx) {
-			if ctx.Window.IsFocus(cfg.ID) {
-				ctx.Layout.Shape.ColorBorder = style.ColorBorderFocus
-			}
-		},
 	}
 	return generateViewLayout(&containerView{
 		cfg:     ccfg,
@@ -112,506 +160,60 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 	}, w)
 }
 
-// cpSVAndHueRow builds the SV area and hue slider row.
-func cpSVAndHueRow(
-	cfg *ColorPickerCfg, hsv colorPickerState,
-	svSize, sliderH, indicatorSize float32,
-) View {
-	return Row(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: Some(SpacingSmall),
-		Content: []View{
-			cpSVArea(cfg, hsv, svSize, indicatorSize),
-			cpHueSlider(cfg, hsv, sliderH, svSize,
-				indicatorSize),
-		},
-	})
-}
+// colorPickerSwatchSize is the preview swatch's edge length.
+const colorPickerSwatchSize = 32
 
-// cpSVArea builds the saturation/value area with gradients.
-func cpSVArea(
-	cfg *ColorPickerCfg, hsv colorPickerState,
-	size, indicatorSize float32,
-) View {
-	pureHue := hueColor(hsv.H)
-	cfgID := cfg.ID
-	cfgColor := cfg.Color
-	onChange := cfg.OnColorChange
+// colorPickerMinPlane floors the derived plane size. A theme with wide
+// sliders and narrow fields could otherwise drive the plane down to
+// something unusable; below this the picker stops shrinking and simply
+// runs wider than its fields.
+const colorPickerMinPlane = 120
 
-	return container(ContainerCfg{
-		ID:     ScopeID(cfg.ID, "sv"),
-		Width:  size,
-		Height: size,
-		axis:   axisTopToBottom,
-		Gradient: &GradientDef{
-			Direction: GradientToRight,
-			Stops: []GradientStop{
-				{Color: White, Pos: 0},
-				{Color: pureHue, Pos: 1},
-			},
-		},
-		Padding:    NoPadding,
-		SizeBorder: NoBorder,
-		Radius:     Some(cfg.Style.Radius),
-		Content: []View{
-			container(ContainerCfg{
-				Sizing: FillFill,
-				Gradient: &GradientDef{
-					Direction: GradientToBottom,
-					Stops: []GradientStop{
-						{Color: ColorTransparent, Pos: 0},
-						{Color: Black, Pos: 1},
-					},
-				},
-				Padding: NoPadding,
-				Content: []View{
-					Circle(ContainerCfg{
-						Width:       indicatorSize,
-						Height:      indicatorSize,
-						Color:       cfgColor,
-						ColorBorder: White,
-						SizeBorder:  SomeF(2),
-						Padding:     NoPadding,
-						AmendLayout: func(ctx EventCtx) {
-							cpAmendSVIndicator(ctx.Layout, hsv,
-								size, indicatorSize)
-						},
-					}),
-				},
-				OnClick: func(ctx EventCtx) {
-					// Convert local mouse coords to absolute.
-					ev := *ctx.Event
-					ev.MouseX += ctx.Layout.Shape.X
-					ev.MouseY += ctx.Layout.Shape.Y
-					cpSVMouseAction(cfgID, cfgColor,
-						onChange, ctx.Layout.Shape, &ev, ctx.Window)
-					ctx.Window.MouseLock(MouseLockCfg{
-						MouseMove: func(ctx EventCtx) {
-							sv, ok := ctx.Layout.FindByID(
-								ScopeID(cfgID, "sv"))
-							if !ok {
-								return
-							}
-							cpSVMouseAction(cfgID, cfgColor,
-								onChange, sv.Shape, ctx.Event, ctx.Window)
-						},
-						MouseUp: func(ctx EventCtx) {
-							ctx.Window.MouseUnlock()
-							ctx.Window.SetMouseCursorArrow()
-						},
-						Cancel: func(w *Window) {
-							// Restore the cursor the drag hid.
-							w.SetMouseCursorArrow()
-						},
-					})
-					// Same as the hue strip: nested in the focusable
-					// picker root, so consume to keep the focus where
-					// it is once spec §4.3b removes the pre-mark.
-					ctx.Consume()
-				},
-			}),
-		},
-	})
-}
-
-// cpHueSlider builds the vertical hue slider.
-func cpHueSlider(
-	cfg *ColorPickerCfg, hsv colorPickerState,
-	sliderWidth, sliderHeight, indicatorSize float32,
-) View {
-	cfgID := cfg.ID
-	cfgColor := cfg.Color
-	onChange := cfg.OnColorChange
-
-	return container(ContainerCfg{
-		ID:     ScopeID(cfg.ID, "hue"),
-		Width:  sliderWidth,
-		Height: sliderHeight,
-		Gradient: &GradientDef{
-			Direction: GradientToBottom,
-			Stops: []GradientStop{
-				{Color: RGB(255, 0, 0), Pos: 0.0},
-				{Color: RGB(255, 255, 0), Pos: 1.0 / 6},
-				{Color: RGB(0, 255, 0), Pos: 2.0 / 6},
-				{Color: RGB(0, 255, 255), Pos: 3.0 / 6},
-				{Color: RGB(0, 0, 255), Pos: 4.0 / 6},
-				{Color: RGB(255, 0, 255), Pos: 5.0 / 6},
-				{Color: RGB(255, 0, 0), Pos: 1.0},
-			},
-		},
-		Padding: NoPadding,
-		Radius:  Some(cfg.Style.Radius),
-		Content: []View{
-			Circle(ContainerCfg{
-				Width:       indicatorSize,
-				Height:      indicatorSize,
-				Color:       hueColor(hsv.H),
-				ColorBorder: White,
-				SizeBorder:  SomeF(2),
-				Padding:     NoPadding,
-				AmendLayout: func(ctx EventCtx) {
-					cpAmendHueIndicator(ctx.Layout, hsv,
-						sliderHeight, indicatorSize)
-				},
-			}),
-		},
-		OnClick: func(ctx EventCtx) {
-			// Convert local mouse coords to absolute.
-			ev := *ctx.Event
-			ev.MouseX += ctx.Layout.Shape.X
-			ev.MouseY += ctx.Layout.Shape.Y
-			cpHueMouseAction(cfgID, cfgColor, onChange,
-				ctx.Layout.Shape, &ev, ctx.Window)
-			ctx.Window.MouseLock(MouseLockCfg{
-				MouseMove: func(ctx EventCtx) {
-					hue, ok := ctx.Layout.FindByID(
-						ScopeID(cfgID, "hue"))
-					if !ok {
-						return
-					}
-					cpHueMouseAction(cfgID, cfgColor,
-						onChange, hue.Shape, ctx.Event, ctx.Window)
-				},
-				MouseUp: func(ctx EventCtx) {
-					ctx.Window.MouseUnlock()
-				},
-			})
-			// The hue strip is inside the focusable picker root, which
-			// would take focus off this click once spec §4.3b removes
-			// the consume-class pre-mark.
-			ctx.Consume()
-		},
-	})
-}
-
-// cpAlphaSlider builds the alpha channel slider.
-func cpAlphaSlider(cfg *ColorPickerCfg) View {
-	onChange := cfg.OnColorChange
-	c := cfg.Color
-	thumbSize := cfg.Style.indicatorSize
-	trackSize := float32(6)
-	return Slider(SliderCfg{
-		ID:           ScopeID(cfg.ID, "alpha"),
-		Value:        float32(c.A),
-		Min:          0,
-		Max:          255,
-		Step:         1,
-		Sizing:       FillFit,
-		Size:         trackSize,
-		SizeBorder:   SomeF(1),
-		ThumbSize:    thumbSize,
-		Height:       thumbSize,
-		radiusBorder: SomeF(trackSize / 2),
-		OnChange: func(v float32, ctx EventCtx) {
-			if onChange != nil {
-				nc := c
-				nc.A = uint8(f32Clamp(v, 0, 255))
-				onChange(nc, EventCtx{nil, ctx.Event, ctx.Window})
-			}
-		},
-		roundValue: true,
-	})
-}
-
-// cpPreviewRow builds the color swatch + hex input row.
-func cpPreviewRow(cfg *ColorPickerCfg) View {
-	c := cfg.Color
-	onChange := cfg.OnColorChange
-	cfgID := cfg.ID
-
-	return Row(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: Some(SpacingSmall),
-		VAlign:  VAlignMiddle,
-		Content: []View{
-			Rectangle(RectangleCfg{
-				Width:  32,
-				Height: 32,
-				Color:  c,
-				Radius: cfg.Style.Radius,
-			}),
-			Input(InputCfg{
-				ID:        ScopeID(cfgID, "hex"),
-				Text:      c.toHexString(),
-				TextStyle: cfg.Style.TextStyle,
-				Width:     100,
-				OnTextChanged: func(text string, ctx EventCtx) {
-					cpApplyHex(text, cfgID, onChange, ctx.Window)
-				},
-				OnTextCommit: func(text string, _ InputCommitReason, ctx EventCtx) {
-					cpApplyHex(text, cfgID, onChange, ctx.Window)
-				},
-			}),
-		},
-	})
-}
-
-// cpRGBAInputs builds the R/G/B/A channel inputs row.
-func cpRGBAInputs(cfg *ColorPickerCfg) View {
-	c := cfg.Color
-	l := ActiveLocale
-	return Row(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: Some(SpacingSmall),
-		Content: []View{
-			cpChannelInput(cfg, l.strRed, c.R, 0),
-			cpChannelInput(cfg, l.strGreen, c.G, 1),
-			cpChannelInput(cfg, l.strBlue, c.B, 2),
-			cpChannelInput(cfg, l.strAlpha, c.A, 3),
-		},
-	})
-}
-
-// cpHSVInputs builds the H/S/V channel inputs row.
-func cpHSVInputs(
-	cfg *ColorPickerCfg, hsv colorPickerState,
-) View {
-	l := ActiveLocale
-	return Row(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: Some(SpacingSmall),
-		Content: []View{
-			cpHSVChannelInput(cfg, l.strHue,
-				int(hsv.H+0.5), 360, 0),
-			cpHSVChannelInput(cfg, l.strSat,
-				int(hsv.S*100+0.5), 100, 1),
-			cpHSVChannelInput(cfg, l.strValue,
-				int(hsv.V*100+0.5), 100, 2),
-		},
-	})
-}
-
-// cpChannelInput builds a labeled RGB channel input.
-func cpChannelInput(
-	cfg *ColorPickerCfg, ch string, val uint8, idx int,
-) View {
-	onChange := cfg.OnColorChange
-	cfgID := cfg.ID
-	c := cfg.Color
-	applyFn := func(text string, w *Window) {
-		cpApplyRGB(text, idx, c, cfgID, onChange, w)
+// colorPickerPlaneSize derives the plane's edge length instead of
+// taking the theme's sVSize directly.
+//
+// The picker is as wide as its widest row, and that row is the four
+// RGBA fields. A plane at the full sVSize makes the top row — plane
+// plus the two vertical sliders — wider than the fields, which shows
+// up as dead space to the right of the alpha input. Subtract exactly
+// what the sliders occupy so the two rows come out the same width.
+//
+// It is only ever a shrink: sVSize stays the upper bound, so a theme
+// asking for a small plane is never grown to fill the row.
+func colorPickerPlaneSize(style ColorPickerStyle) float32 {
+	sliderThick := f32Max(style.sliderHeight, style.indicatorSize)
+	// The fields block's own width, mirroring colorRGBARow: four
+	// inputs at the default width with small spacing between them.
+	fieldsW := 4*defaultColorFieldWidth + 3*SpacingSmall
+	size := fieldsW - 2*(sliderThick+SpacingSmall)
+	if size > style.sVSize {
+		size = style.sVSize
 	}
-	inputID := ScopeIDN(cfgID, "rgb", idx)
-	return cpInputColumn(cfg, ch, int(val), inputID, applyFn)
+	return f32Max(size, colorPickerMinPlane)
 }
 
-// cpHSVChannelInput builds a labeled HSV channel input.
-func cpHSVChannelInput(
-	cfg *ColorPickerCfg, ch string,
-	val, maxVal int, idx int,
-) View {
-	onChange := cfg.OnColorChange
-	cfgID := cfg.ID
-	alpha := cfg.Color.A
-	applyFn := func(text string, w *Window) {
-		cpApplyHSV(text, idx, maxVal, cfgID, alpha, onChange, w)
-	}
-	inputID := ScopeIDN(cfgID, "hsv", idx)
-	return cpInputColumn(cfg, ch, val, inputID, applyFn)
-}
-
-// cpInputColumn builds a labeled channel input column shared by
-// RGB and HSV inputs.
-func cpInputColumn(
-	cfg *ColorPickerCfg, label string, val int,
-	inputID string, applyFn func(string, *Window),
-) View {
-	return Column(ContainerCfg{
-		Padding: NoPadding,
-		Spacing: SomeF(2),
-		Content: []View{
-			Text(TextCfg{
-				Text: label,
-				TextStyle: TextStyle{
-					Color: cfg.Style.TextStyle.Color,
-					Size:  cfg.Style.TextStyle.Size,
-					Align: TextAlignCenter,
-				},
-			}),
-			Input(InputCfg{
-				ID:        inputID,
-				Text:      strconv.Itoa(val),
-				TextStyle: cfg.Style.TextStyle,
-				Width:     50,
-				OnTextChanged: func(text string, ctx EventCtx) {
-					applyFn(text, ctx.Window)
-				},
-				OnTextCommit: func(text string, _ InputCommitReason, ctx EventCtx) {
-					applyFn(text, ctx.Window)
-				},
-			}),
-		},
-	})
-}
-
-// cpSVMouseAction handles mouse interaction in the SV area.
-func cpSVMouseAction(
-	id string, color Color,
-	onChange func(Color, EventCtx),
-	shape *Shape, e *Event, w *Window,
-) {
-	if onChange == nil ||
-		shape.Width <= 0 || shape.Height <= 0 {
-		return
-	}
-	s := f32Clamp((e.MouseX-shape.X)/shape.Width, 0, 1)
-	v := 1 - f32Clamp((e.MouseY-shape.Y)/shape.Height, 0, 1)
-
+// cpValue returns the picker's live HSLA for this frame.
+//
+// The stored value wins while the caller keeps handing back the Color
+// the picker produced — that is a round trip, and re-deriving from it
+// would drop the hue at the extremes. A Color the picker did not
+// produce is a caller setting the value, and it wins instead.
+func cpValue(w *Window, id string, c Color) HSLA {
 	sm := StateMap[string, colorPickerState](
 		w, nsColorPicker, capModerate)
-	// Default zero: HSV(0,0,0) is black; state seeded before callbacks
-	// fire so this default is never reached in practice.
-	hsv := sm.GetOr(id, colorPickerState{})
-	hsv.S = s
-	hsv.V = v
-	sm.Set(id, hsv)
-
-	nc := colorFromHSVA(hsv.H, s, v, color.A)
-	onChange(nc, EventCtx{nil, e, w})
+	if st, ok := sm.Get(id); ok && st.color == c {
+		return st.hsla
+	}
+	v := ColorToHSLA(c)
+	sm.Set(id, colorPickerState{hsla: v, color: c})
+	return v
 }
 
-// cpHueMouseAction handles mouse interaction on the hue slider.
-func cpHueMouseAction(
-	id string, color Color,
-	onChange func(Color, EventCtx),
-	shape *Shape, e *Event, w *Window,
-) {
-	if onChange == nil || shape.Height <= 0 {
-		return
-	}
-	h := f32Clamp(
-		(e.MouseY-shape.Y)/shape.Height, 0, 1) * 360
-
+// cpStore records the value a child just produced, along with the
+// Color the caller will see, so the next frame recognizes the round
+// trip.
+func cpStore(w *Window, id string, v HSLA) {
 	sm := StateMap[string, colorPickerState](
 		w, nsColorPicker, capModerate)
-	// Default zero: HSV(0,0,0) is black; state seeded before callbacks
-	// fire so this default is never reached in practice.
-	hsv := sm.GetOr(id, colorPickerState{})
-	hsv.H = h
-	sm.Set(id, hsv)
-
-	nc := colorFromHSVA(h, hsv.S, hsv.V, color.A)
-	onChange(nc, EventCtx{nil, e, w})
-}
-
-// cpAmendSVIndicator positions the SV indicator circle.
-func cpAmendSVIndicator(
-	layout *Layout, hsv colorPickerState,
-	svSize, indicatorSize float32,
-) {
-	if layout.Parent == nil {
-		return
-	}
-	parent := layout.Parent
-	radius := indicatorSize / 2
-	layout.Shape.X = parent.Shape.X +
-		hsv.S*svSize - radius
-	layout.Shape.Y = parent.Shape.Y +
-		(1-hsv.V)*svSize - radius
-}
-
-// cpAmendHueIndicator positions the hue slider indicator.
-func cpAmendHueIndicator(
-	layout *Layout, hsv colorPickerState,
-	sliderHeight, indicatorSize float32,
-) {
-	if layout.Parent == nil {
-		return
-	}
-	parent := layout.Parent
-	radius := indicatorSize / 2
-	y := (hsv.H / 360) * sliderHeight
-	layout.Shape.X = parent.Shape.X +
-		parent.Shape.Width/2 - radius
-	layout.Shape.Y = parent.Shape.Y + y - radius
-}
-
-func applyColorPickerDefaults(cfg *ColorPickerCfg) {
-	d := &defaultColorPickerStyle
-	if cfg.Style == (ColorPickerStyle{}) {
-		cfg.Style = *d
-	}
-	if !cfg.Color.IsSet() {
-		cfg.Color = Red
-	}
-}
-
-// cpApplyRGB applies an RGB channel change from text input.
-func cpApplyRGB(
-	text string, idx int, c Color, cfgID string,
-	onChange func(Color, EventCtx), w *Window,
-) {
-	parsed, err := strconv.ParseUint(text, 10, 8)
-	if err != nil || onChange == nil {
-		return
-	}
-	v := uint8(parsed)
-	nc := c
-	switch idx {
-	case 0:
-		nc.R = v
-	case 1:
-		nc.G = v
-	case 2:
-		nc.B = v
-	case 3:
-		nc.A = v
-	}
-	h, s, vv := nc.ToHSV()
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	sm.Set(cfgID, colorPickerState{H: h, S: s, V: vv})
-	onChange(nc, EventCtx{nil, nil, w})
-}
-
-func cpApplyHSV(
-	text string, idx, maxVal int, cfgID string,
-	alpha uint8, onChange func(Color, EventCtx),
-	w *Window,
-) {
-	n, err := strconv.Atoi(text)
-	if err != nil || onChange == nil {
-		return
-	}
-	n = intClamp(n, 0, maxVal)
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	// Default zero: HSV(0,0,0) is black; state seeded before callbacks
-	// fire so this default is never reached in practice.
-	hsv := sm.GetOr(cfgID, colorPickerState{})
-	switch idx {
-	case 0:
-		hsv.H = float32(n)
-	case 1:
-		hsv.S = float32(n) / 100
-	case 2:
-		hsv.V = float32(n) / 100
-	}
-	sm.Set(cfgID, hsv)
-	nc := colorFromHSVA(hsv.H, hsv.S, hsv.V, alpha)
-	onChange(nc, EventCtx{nil, nil, w})
-}
-
-func cpApplyHex(
-	text, cfgID string,
-	onChange func(Color, EventCtx), w *Window,
-) {
-	nc, ok := colorFromHexString(text)
-	if !ok || onChange == nil {
-		return
-	}
-	h, s, v := nc.ToHSV()
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	sm.Set(cfgID, colorPickerState{H: h, S: s, V: v})
-	onChange(nc, EventCtx{nil, nil, w})
-}
-
-// cpParseUint8 parses a string as a uint8 (0–255).
-func cpParseUint8(s string) (uint8, bool) {
-	n, err := strconv.Atoi(s)
-	if err != nil || n < 0 || n > 255 {
-		return 0, false
-	}
-	return uint8(n), true
+	sm.Set(id, colorPickerState{hsla: v, color: v.Color()})
 }

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -97,7 +97,10 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 		// squarer than a stack of full-width tracks would make it.
 		Row(ContainerCfg{
 			Padding: NoPadding,
-			Spacing: Some(colorPickerPlaneGap),
+			// Structural: a bordered theme would otherwise give this
+			// row a border of its own, widening it past the fields.
+			SizeBorder: NoBorder,
+			Spacing:    Some(colorPickerPlaneGap),
 			Content: []View{
 				ColorPlane(ColorPlaneCfg{
 					ID:       ScopeID(cfg.ID, "plane"),

--- a/gui/view_color_picker_test.go
+++ b/gui/view_color_picker_test.go
@@ -167,7 +167,7 @@ func TestColorPickerPlaneFitsFields(t *testing.T) {
 	}
 
 	thick := f32Max(style.sliderHeight, style.indicatorSize)
-	top := size + 2*(thick+SpacingSmall)
+	top := size + 2*(thick+colorPickerPlaneGap)
 	fields := float32(4*defaultColorFieldWidth + 3*SpacingSmall)
 	if top != fields {
 		t.Errorf("top row = %v, fields row = %v; want equal",

--- a/gui/view_color_picker_test.go
+++ b/gui/view_color_picker_test.go
@@ -174,3 +174,37 @@ func TestColorPickerPlaneFitsFields(t *testing.T) {
 			top, fields)
 	}
 }
+
+// A bordered theme gives every container a border unless it opts out.
+// The picker's rows are structural, so a border there would widen the
+// fields block past the plane row and offset it — the two must stay the
+// same width and start at the same x under either theme.
+func TestColorPickerRowsAlignUnderBorders(t *testing.T) {
+	for _, borders := range []bool{false, true} {
+		w := &Window{}
+		w.SetTheme(ThemeDark.WithBorders(borders))
+		// A real measurer is needed: the labels above each field are
+		// zero-width without one, so the defect would not show.
+		w.textMeasurer = &stubTextMeasurer{charWidth: 7, fontHeight: 16}
+		l := w.TestRender(func(*Window) View {
+			return ColorPicker(ColorPickerCfg{ID: "p", ShowHSL: true})
+		})
+
+		fields := findShapeByID(l, "p:fields")
+		plane := findShapeByID(l, "p:plane")
+		alpha := findShapeByID(l, "p:alpha")
+		if fields == nil || plane == nil || alpha == nil {
+			t.Fatalf("borders=%v: missing shapes", borders)
+		}
+		if fields.Shape.X != plane.Shape.X {
+			t.Errorf("borders=%v: fields x = %v, plane x = %v",
+				borders, fields.Shape.X, plane.Shape.X)
+		}
+		// The plane row ends at the alpha slider's right edge.
+		rowEnd := alpha.Shape.X + alpha.Shape.Width
+		if got := fields.Shape.X + fields.Shape.Width; got != rowEnd {
+			t.Errorf("borders=%v: fields right = %v, plane row = %v",
+				borders, got, rowEnd)
+		}
+	}
+}

--- a/gui/view_color_picker_test.go
+++ b/gui/view_color_picker_test.go
@@ -17,16 +17,40 @@ func TestColorPickerLayout(t *testing.T) {
 	}
 }
 
-func TestColorPickerLayoutWithHSV(t *testing.T) {
-	w := &Window{}
-	v := ColorPicker(ColorPickerCfg{
-		ID:      "cp-hsv",
-		Color:   RGB(0, 128, 255),
-		ShowHSV: true,
+// ShowHSV is the deprecated spelling of ShowHSL and must keep working:
+// callers in other repos still set it.
+func TestColorPickerShowHSVStillAddsRow(t *testing.T) {
+	countInputs := func(cfg ColorPickerCfg) int {
+		w := &Window{}
+		layout := generateViewLayout(ColorPicker(cfg), w)
+		n := 0
+		var walk func(*Layout)
+		walk = func(l *Layout) {
+			if l.Shape != nil && l.Shape.shapeType == shapeText {
+				n++
+			}
+			for i := range l.Children {
+				walk(&l.Children[i])
+			}
+		}
+		walk(&layout)
+		return n
+	}
+	base := countInputs(ColorPickerCfg{
+		ID: "cp-plain", Color: RGB(0, 128, 255),
 	})
-	layout := generateViewLayout(v, w)
-	if layout.Shape.ID != "cp-hsv" {
-		t.Errorf("ID = %q", layout.Shape.ID)
+	hsv := countInputs(ColorPickerCfg{
+		ID: "cp-hsv", Color: RGB(0, 128, 255), ShowHSV: true,
+	})
+	hsl := countInputs(ColorPickerCfg{
+		ID: "cp-hsl", Color: RGB(0, 128, 255), ShowHSL: true,
+	})
+	if hsv <= base {
+		t.Errorf("ShowHSV added no row: %d vs %d", hsv, base)
+	}
+	if hsl != hsv {
+		t.Errorf("ShowHSL = %d, ShowHSV = %d; want the same row",
+			hsl, hsv)
 	}
 }
 
@@ -58,302 +82,51 @@ func TestColorPickerDefaultColor(t *testing.T) {
 func TestColorPickerStateInit(t *testing.T) {
 	w := &Window{}
 	c := RGB(255, 0, 0) // pure red
-	v := ColorPicker(ColorPickerCfg{ID: "cp-state", Color: c})
-	generateViewLayout(v, w)
+	generateViewLayout(
+		ColorPicker(ColorPickerCfg{ID: "cp-state", Color: c}), w)
 
 	sm := StateMap[string, colorPickerState](
 		w, nsColorPicker, capModerate)
-	hsv, ok := sm.Get("cp-state")
+	st, ok := sm.Get("cp-state")
 	if !ok {
 		t.Fatal("state should be initialized")
 	}
-	// Pure red → H≈0, S≈1, V≈1.
-	if hsv.S < 0.99 || hsv.V < 0.99 {
-		t.Errorf("HSV = %v %v %v", hsv.H, hsv.S, hsv.V)
+	// Pure red → H≈0, S≈1, L≈0.5 in HSL.
+	if st.hsla.S < 0.99 || f32Abs(st.hsla.L-0.5) > 0.01 {
+		t.Errorf("HSLA = %+v", st.hsla)
 	}
 }
 
-func TestCpParseUint8(t *testing.T) {
-	tests := []struct {
-		input string
-		want  uint8
-		ok    bool
-	}{
-		{"0", 0, true},
-		{"255", 255, true},
-		{"128", 128, true},
-		{"-1", 0, false},
-		{"256", 0, false},
-		{"abc", 0, false},
-		{"", 0, false},
-	}
-	for _, tt := range tests {
-		got, ok := cpParseUint8(tt.input)
-		if ok != tt.ok || (ok && got != tt.want) {
-			t.Errorf("cpParseUint8(%q) = %d, %v; want %d, %v",
-				tt.input, got, ok, tt.want, tt.ok)
-		}
-	}
-}
-
-func TestCpAmendSVIndicator(t *testing.T) {
-	parent := &Layout{
-		Shape: &Shape{X: 10, Y: 20, Width: 200, Height: 200},
-	}
-	child := &Layout{Shape: &Shape{}, Parent: parent}
-	hsv := colorPickerState{H: 0, S: 0.5, V: 0.75}
-	cpAmendSVIndicator(child, hsv, 200, 12)
-
-	wantX := float32(10 + 0.5*200 - 6)
-	wantY := float32(20 + (1-0.75)*200 - 6)
-	if child.Shape.X != wantX {
-		t.Errorf("X = %f, want %f", child.Shape.X, wantX)
-	}
-	if child.Shape.Y != wantY {
-		t.Errorf("Y = %f, want %f", child.Shape.Y, wantY)
-	}
-}
-
-func TestCpAmendSVIndicatorNoParent(t *testing.T) {
-	child := &Layout{Shape: &Shape{X: 5, Y: 5}}
-	hsv := colorPickerState{H: 0, S: 0.5, V: 0.5}
-	cpAmendSVIndicator(child, hsv, 200, 12)
-	// Should not modify when no parent.
-	if child.Shape.X != 5 || child.Shape.Y != 5 {
-		t.Error("should not modify layout without parent")
-	}
-}
-
-func TestCpAmendHueIndicator(t *testing.T) {
-	parent := &Layout{
-		Shape: &Shape{X: 10, Y: 20, Width: 30, Height: 200},
-	}
-	child := &Layout{Shape: &Shape{}, Parent: parent}
-	hsv := colorPickerState{H: 180, S: 1, V: 1}
-	cpAmendHueIndicator(child, hsv, 200, 12)
-
-	wantX := float32(10 + 30.0/2 - 6)
-	wantY := float32(20 + (180.0/360)*200 - 6)
-	if child.Shape.X != wantX {
-		t.Errorf("X = %f, want %f", child.Shape.X, wantX)
-	}
-	if child.Shape.Y != wantY {
-		t.Errorf("Y = %f, want %f", child.Shape.Y, wantY)
-	}
-}
-
-func TestCpAmendHueIndicatorNoParent(t *testing.T) {
-	child := &Layout{Shape: &Shape{X: 5, Y: 5}}
-	hsv := colorPickerState{H: 90, S: 1, V: 1}
-	cpAmendHueIndicator(child, hsv, 200, 12)
-	if child.Shape.X != 5 || child.Shape.Y != 5 {
-		t.Error("should not modify layout without parent")
-	}
-}
-
-func TestCpSVMouseAction(t *testing.T) {
+// The picker's whole reason for holding state: a value the user drove
+// to a gray or to black must not lose the hue it was on, even though
+// the caller only ever sees a Color.
+func TestCpValuePreservesHueThroughRoundTrip(t *testing.T) {
 	w := &Window{}
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	sm.Set("sv-test", colorPickerState{H: 120, S: 0, V: 0})
+	const id = "cp-hue"
 
-	var gotColor Color
-	onChange := func(c Color, ctx EventCtx) { gotColor = c }
+	// Start on cyan, then drag lightness to zero.
+	cpStore(w, id, HSLA{H: 180, S: 1, L: 0.5, A: 1})
+	black := HSLA{H: 180, S: 1, L: 0, A: 1}
+	cpStore(w, id, black)
 
-	layout := &Layout{
-		Shape: &Shape{X: 0, Y: 0, Width: 100, Height: 100},
-	}
-	e := &Event{MouseX: 50, MouseY: 25}
-	cpSVMouseAction("sv-test", RGB(0, 0, 0), onChange, layout.Shape, e, w)
-
-	hsv, _ := sm.Get("sv-test")
-	if hsv.S < 0.49 || hsv.S > 0.51 {
-		t.Errorf("S = %f, want ~0.5", hsv.S)
-	}
-	if hsv.V < 0.74 || hsv.V > 0.76 {
-		t.Errorf("V = %f, want ~0.75", hsv.V)
-	}
-	if !gotColor.IsSet() {
-		t.Error("onChange should be called")
+	// The caller hands back exactly the Color the picker produced —
+	// a round trip, so the stored hue must survive.
+	got := cpValue(w, id, black.Color())
+	if got.H != 180 {
+		t.Errorf("H = %v after round trip, want 180 preserved", got.H)
 	}
 }
 
-func TestCpSVMouseActionWithOffset(t *testing.T) {
+// A Color the picker did not produce is the caller setting the value,
+// and it must win over the stored one.
+func TestCpValueCallerSetColorWins(t *testing.T) {
 	w := &Window{}
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	sm.Set("sv-off", colorPickerState{H: 120, S: 0, V: 0})
+	const id = "cp-set"
 
-	var gotColor Color
-	onChange := func(c Color, ctx EventCtx) { gotColor = c }
-
-	shape := &Shape{X: 100, Y: 200, Width: 100, Height: 100}
-	e := &Event{MouseX: 150, MouseY: 225}
-	cpSVMouseAction("sv-off", RGB(0, 0, 0), onChange, shape, e, w)
-
-	hsv, _ := sm.Get("sv-off")
-	if hsv.S < 0.49 || hsv.S > 0.51 {
-		t.Errorf("S = %f, want ~0.5", hsv.S)
-	}
-	if hsv.V < 0.74 || hsv.V > 0.76 {
-		t.Errorf("V = %f, want ~0.75", hsv.V)
-	}
-	if !gotColor.IsSet() {
-		t.Error("onChange should be called")
-	}
-}
-
-func TestCpSVMouseActionNilOnChange(_ *testing.T) {
-	w := &Window{}
-	layout := &Layout{
-		Shape: &Shape{X: 0, Y: 0, Width: 100, Height: 100},
-	}
-	e := &Event{MouseX: 50, MouseY: 50}
-	// Should not panic.
-	cpSVMouseAction("nil-test", RGB(0, 0, 0), nil, layout.Shape, e, w)
-}
-
-func TestCpHueMouseAction(t *testing.T) {
-	w := &Window{}
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	sm.Set("hue-test", colorPickerState{H: 0, S: 1, V: 1})
-
-	var gotColor Color
-	onChange := func(c Color, ctx EventCtx) { gotColor = c }
-
-	layout := &Layout{
-		Shape: &Shape{X: 0, Y: 0, Width: 30, Height: 360},
-	}
-	e := &Event{MouseX: 15, MouseY: 180}
-	cpHueMouseAction("hue-test", RGB(255, 0, 0), onChange, layout.Shape, e, w)
-
-	hsv, _ := sm.Get("hue-test")
-	if hsv.H < 179 || hsv.H > 181 {
-		t.Errorf("H = %f, want ~180", hsv.H)
-	}
-	if !gotColor.IsSet() {
-		t.Error("onChange should be called")
-	}
-}
-
-func TestCpHueMouseActionNilOnChange(_ *testing.T) {
-	w := &Window{}
-	layout := &Layout{
-		Shape: &Shape{X: 0, Y: 0, Width: 30, Height: 360},
-	}
-	e := &Event{MouseX: 15, MouseY: 180}
-	cpHueMouseAction("nil-test", RGB(255, 0, 0), nil, layout.Shape, e, w)
-}
-
-func TestCpSVMouseActionZeroSize(t *testing.T) {
-	w := &Window{}
-	called := false
-	onChange := func(_ Color, ctx EventCtx) { called = true }
-	shape := &Shape{X: 0, Y: 0, Width: 0, Height: 0}
-	e := &Event{MouseX: 50, MouseY: 50}
-	cpSVMouseAction("zero", RGB(0, 0, 0), onChange, shape, e, w)
-	if called {
-		t.Error("onChange should not be called with zero-size shape")
-	}
-}
-
-func TestCpHueMouseActionZeroHeight(t *testing.T) {
-	w := &Window{}
-	called := false
-	onChange := func(_ Color, ctx EventCtx) { called = true }
-	shape := &Shape{X: 0, Y: 0, Width: 30, Height: 0}
-	e := &Event{MouseX: 15, MouseY: 50}
-	cpHueMouseAction("zero", RGB(255, 0, 0), onChange, shape, e, w)
-	if called {
-		t.Error("onChange should not be called with zero-height shape")
-	}
-}
-
-func TestCpApplyRGB(t *testing.T) {
-	w := &Window{}
-	var got Color
-	onChange := func(c Color, ctx EventCtx) { got = c }
-	cpApplyRGB("128", 0, RGB(0, 50, 100), "rgb-test", onChange, w)
-	if got.R != 128 || got.G != 50 || got.B != 100 {
-		t.Errorf("color = %v, want R=128 G=50 B=100", got)
-	}
-	// Verify HSV state updated.
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	if _, ok := sm.Get("rgb-test"); !ok {
-		t.Error("HSV state should be set")
-	}
-}
-
-func TestCpApplyRGBInvalid(t *testing.T) {
-	w := &Window{}
-	called := false
-	onChange := func(_ Color, ctx EventCtx) { called = true }
-	cpApplyRGB("abc", 0, RGB(0, 0, 0), "inv", onChange, w)
-	if called {
-		t.Error("onChange should not be called for invalid input")
-	}
-}
-
-func TestCpApplyHSV(t *testing.T) {
-	w := &Window{}
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	sm.Set("hsv-test", colorPickerState{H: 0, S: 1, V: 1})
-
-	var got Color
-	onChange := func(c Color, ctx EventCtx) { got = c }
-	cpApplyHSV("180", 0, 360, "hsv-test", 255, onChange, w)
-	hsv, _ := sm.Get("hsv-test")
-	if hsv.H != 180 {
-		t.Errorf("H = %f, want 180", hsv.H)
-	}
-	if !got.IsSet() {
-		t.Error("onChange should be called")
-	}
-}
-
-func TestCpApplyHSVClamp(t *testing.T) {
-	w := &Window{}
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	sm.Set("hsv-clamp", colorPickerState{H: 0, S: 1, V: 1})
-
-	var got Color
-	onChange := func(c Color, ctx EventCtx) { got = c }
-	cpApplyHSV("-10", 0, 360, "hsv-clamp", 255, onChange, w)
-	hsv, _ := sm.Get("hsv-clamp")
-	if hsv.H != 0 {
-		t.Errorf("H = %f, want 0 (clamped)", hsv.H)
-	}
-	if !got.IsSet() {
-		t.Error("onChange should be called")
-	}
-}
-
-func TestCpApplyHex(t *testing.T) {
-	w := &Window{}
-	var got Color
-	onChange := func(c Color, ctx EventCtx) { got = c }
-	cpApplyHex("#FF8000", "hex-test", onChange, w)
-	if got.R != 255 || got.G != 128 || got.B != 0 {
-		t.Errorf("color = %v, want R=255 G=128 B=0", got)
-	}
-	sm := StateMap[string, colorPickerState](
-		w, nsColorPicker, capModerate)
-	if _, ok := sm.Get("hex-test"); !ok {
-		t.Error("HSV state should be set")
-	}
-}
-
-func TestCpApplyHexInvalid(t *testing.T) {
-	w := &Window{}
-	called := false
-	onChange := func(_ Color, ctx EventCtx) { called = true }
-	cpApplyHex("not-hex", "inv", onChange, w)
-	if called {
-		t.Error("onChange should not be called for invalid hex")
+	cpStore(w, id, HSLA{H: 180, S: 1, L: 0.5, A: 1})
+	got := cpValue(w, id, RGB(255, 0, 0)) // caller assigns red
+	if got.H != 0 || got.S < 0.99 {
+		t.Errorf("got %+v, want the caller's red", got)
 	}
 }
 
@@ -376,5 +149,28 @@ func TestHSVRoundTrip(t *testing.T) {
 			t.Errorf("round-trip %v: HSV(%f,%f,%f) → %v",
 				c, h, s, v, got)
 		}
+	}
+}
+
+// TestColorPickerPlaneFitsFields asserts the derived plane size makes
+// the plane-plus-sliders row exactly as wide as the RGBA fields row.
+// Any surplus renders as empty space to the right of the alpha input.
+func TestColorPickerPlaneFitsFields(t *testing.T) {
+	cfg := ColorPickerCfg{}
+	applyColorPickerDefaults(&cfg)
+	style := cfg.Style
+
+	size := colorPickerPlaneSize(style)
+	if size > style.sVSize {
+		t.Errorf("plane = %v, must not exceed sVSize %v",
+			size, style.sVSize)
+	}
+
+	thick := f32Max(style.sliderHeight, style.indicatorSize)
+	top := size + 2*(thick+SpacingSmall)
+	fields := float32(4*defaultColorFieldWidth + 3*SpacingSmall)
+	if top != fields {
+		t.Errorf("top row = %v, fields row = %v; want equal",
+			top, fields)
 	}
 }

--- a/gui/view_color_picker_test.go
+++ b/gui/view_color_picker_test.go
@@ -54,6 +54,25 @@ func TestColorPickerShowHSVStillAddsRow(t *testing.T) {
 	}
 }
 
+// FocusDisabled must reach the focusable parts of the composition — the
+// plane and the two sliders — or a picker opted out of focus still joins
+// the tab order three times over. The text fields' inputs stay focusable:
+// they always were, under the old picker too.
+func TestColorPickerFocusDisabledPropagates(t *testing.T) {
+	w := &Window{}
+	l := generateViewLayout(ColorPicker(ColorPickerCfg{
+		ID: "cp-fd", Color: RGB(0, 128, 255), FocusDisabled: true,
+	}), w)
+
+	for _, id := range []string{"cp-fd:plane", "cp-fd:hue", "cp-fd:alpha"} {
+		if s := findShapeByID(&l, id); s == nil {
+			t.Fatalf("missing shape %q", id)
+		} else if s.Shape.Focusable {
+			t.Errorf("%q still focusable under FocusDisabled", id)
+		}
+	}
+}
+
 func TestColorPickerDefaults(t *testing.T) {
 	cfg := ColorPickerCfg{}
 	applyColorPickerDefaults(&cfg)
@@ -168,7 +187,7 @@ func TestColorPickerPlaneFitsFields(t *testing.T) {
 
 	thick := f32Max(style.sliderHeight, style.indicatorSize)
 	top := size + 2*(thick+colorPickerPlaneGap)
-	fields := float32(4*defaultColorFieldWidth + 3*SpacingSmall)
+	fields := colorFieldsBlockWidth()
 	if top != fields {
 		t.Errorf("top row = %v, fields row = %v; want equal",
 			top, fields)

--- a/gui/view_color_plane.go
+++ b/gui/view_color_plane.go
@@ -1,0 +1,130 @@
+package gui
+
+// ColorPlaneCfg configures a saturation × lightness plane.
+//
+// The plane paints every color available at the current hue —
+// saturation left to right, lightness bottom to top — and a marker at
+// the current value. Dragging anywhere in it sets saturation and
+// lightness together; hue and alpha pass through untouched.
+//
+// It is stateless: Value in, OnChange out. Hold the HSLA in app state
+// and every other color control reading that same value stays in sync
+// with this one.
+type ColorPlaneCfg struct {
+	OnChange func(HSLA, EventCtx)
+	ID       string `gui:"required"`
+
+	A11YCfg
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled bool
+
+	Value HSLA
+	// Size is the plane's width and height in points. Zero takes the
+	// theme default.
+	Size   float32 // ergonomics-audit:opt-plain — a zero-sized plane is meaningless; 0 falls back to the theme
+	Radius Opt[float32]
+	// MarkerSize is the diameter of the position marker. Zero takes
+	// the theme default.
+	MarkerSize float32
+}
+
+type colorPlaneView struct {
+	cfg ColorPlaneCfg
+}
+
+// ColorPlane creates a saturation × lightness plane at Value's hue.
+func ColorPlane(cfg ColorPlaneCfg) View {
+	requireFocusID("ColorPlane", cfg.FocusDisabled, cfg.ID)
+	applyColorPlaneDefaults(&cfg)
+	return &colorPlaneView{cfg: cfg}
+}
+
+func applyColorPlaneDefaults(cfg *ColorPlaneCfg) {
+	d := &defaultColorPickerStyle
+	if cfg.Size <= 0 {
+		cfg.Size = d.sVSize
+	}
+	if cfg.MarkerSize <= 0 {
+		cfg.MarkerSize = d.indicatorSize
+	}
+	if !cfg.Radius.IsSet() {
+		cfg.Radius = Some(d.Radius)
+	}
+}
+
+func (pv *colorPlaneView) GenerateLayout(w *Window) Layout {
+	cfg := &pv.cfg
+	// One resolved identity for the drag lookup and the shape alike.
+	id := w.EffID(cfg.ID)
+	size := cfg.Size
+	v := cfg.Value.Normalized()
+	onChange := cfg.OnChange
+
+	// Saturation runs left to right, lightness bottom to top — the
+	// same mapping the generated buffer paints, so the marker lands on
+	// the color under it.
+	apply := func(nx, ny float32, ctx EventCtx) {
+		if onChange == nil {
+			return
+		}
+		out := v
+		out.S = nx
+		out.L = 1 - ny
+		onChange(out, ctx)
+	}
+
+	px := int(size) * imgScale
+	return generateViewLayout(&containerView{
+		cfg: ContainerCfg{
+			ID:        id,
+			Focusable: !cfg.FocusDisabled,
+			A11YRole:  AccessRoleColorWell,
+			A11YCfg: A11YCfg{
+				A11YLabel: a11yLabel(cfg.A11YLabel,
+					"Saturation and lightness"),
+				A11YDescription: cfg.A11YDescription,
+			},
+			Width:  size,
+			Height: size,
+			// Fixed: the plane's size is tied to the buffer generated
+			// for it, so it must not stretch to fill a parent.
+			Sizing:     FixedFixed,
+			Padding:    NoPadding,
+			SizeBorder: NoBorder,
+			Radius:     cfg.Radius,
+			axis:       axisTopToBottom,
+			OnClick:    colorDragTrack(id, apply),
+			OnKeyDown:  colorPlaneKeys(v, onChange),
+		},
+		content: []View{
+			Image(ImageCfg{
+				Src:    planeSrc(v, px),
+				Width:  size,
+				Height: size,
+			}),
+			colorMarker(cfg.MarkerSize, v.Color(), func(ctx EventCtx) {
+				colorAmendMarker(ctx.Layout,
+					v.S*size, (1-v.L)*size, cfg.MarkerSize)
+			}),
+		},
+	}, w)
+}
+
+// colorPlaneKeys moves saturation with the horizontal arrows and
+// lightness with the vertical ones, matching the axes on screen.
+func colorPlaneKeys(
+	v HSLA, onChange func(HSLA, EventCtx),
+) func(EventCtx) {
+	return func(ctx EventCtx) {
+		dx, dy, ok := colorKeyDelta(ctx.Event)
+		if !ok || onChange == nil {
+			return // not ours: let it travel on
+		}
+		out := v
+		out.S = f32Clamp(v.S+dx, 0, 1)
+		out.L = f32Clamp(v.L-dy, 0, 1)
+		onChange(out, ctx)
+		ctx.Consume()
+	}
+}

--- a/gui/view_color_plane.go
+++ b/gui/view_color_plane.go
@@ -116,15 +116,10 @@ func (pv *colorPlaneView) GenerateLayout(w *Window) Layout {
 func colorPlaneKeys(
 	v HSLA, onChange func(HSLA, EventCtx),
 ) func(EventCtx) {
-	return func(ctx EventCtx) {
-		dx, dy, ok := colorKeyDelta(ctx.Event)
-		if !ok || onChange == nil {
-			return // not ours: let it travel on
-		}
-		out := v
-		out.S = f32Clamp(v.S+dx, 0, 1)
-		out.L = f32Clamp(v.L-dy, 0, 1)
-		onChange(out, ctx)
-		ctx.Consume()
-	}
+	return colorArrowKeys(v, onChange,
+		func(v HSLA, dx, dy float32) HSLA {
+			v.S = f32Clamp(v.S+dx, 0, 1)
+			v.L = f32Clamp(v.L-dy, 0, 1)
+			return v
+		})
 }

--- a/gui/view_color_swatch.go
+++ b/gui/view_color_swatch.go
@@ -1,0 +1,97 @@
+package gui
+
+// ColorSwatchCfg configures a color preview swatch.
+//
+// The color is drawn over a checkerboard, so a half-transparent value
+// reads as half-transparent instead of as a muted opaque one. That is
+// the whole reason this is a widget rather than a Rectangle: the
+// checkerboard is a generated buffer, and compositing over it is not
+// something a caller should have to assemble.
+type ColorSwatchCfg struct {
+	ID string
+
+	A11YCfg
+
+	// Color is the value shown. Its alpha is honored.
+	Color Color
+
+	Width  float32
+	Height float32
+	Radius Opt[float32]
+}
+
+type colorSwatchView struct {
+	cfg ColorSwatchCfg
+}
+
+// ColorSwatch creates a color preview over a transparency
+// checkerboard.
+func ColorSwatch(cfg ColorSwatchCfg) View {
+	applyColorSwatchDefaults(&cfg)
+	return &colorSwatchView{cfg: cfg}
+}
+
+func applyColorSwatchDefaults(cfg *ColorSwatchCfg) {
+	d := &defaultColorPickerStyle
+	if cfg.Width <= 0 {
+		cfg.Width = defaultSwatchWidth
+	}
+	if cfg.Height <= 0 {
+		cfg.Height = defaultSwatchHeight
+	}
+	if !cfg.Radius.IsSet() {
+		cfg.Radius = Some(d.Radius)
+	}
+}
+
+const (
+	defaultSwatchWidth  = 48
+	defaultSwatchHeight = 32
+)
+
+func (sv *colorSwatchView) GenerateLayout(w *Window) Layout {
+	cfg := &sv.cfg
+
+	return generateViewLayout(&containerView{
+		cfg: ContainerCfg{
+			ID:       cfg.ID,
+			A11YRole: AccessRoleColorWell,
+			A11YCfg: A11YCfg{
+				A11YLabel: a11yLabel(cfg.A11YLabel,
+					// Naming the value, not "swatch": the color is
+					// the information, and hex is how it is written.
+					cfg.Color.Hex()),
+				A11YDescription: cfg.A11YDescription,
+			},
+			Width:  cfg.Width,
+			Height: cfg.Height,
+			// Fixed: the checkerboard is generated at this size.
+			Sizing:     FixedFixed,
+			Padding:    NoPadding,
+			SizeBorder: NoBorder,
+			Radius:     cfg.Radius,
+			Clip:       true,
+			axis:       axisTopToBottom,
+		},
+		content: []View{
+			Image(ImageCfg{
+				Src: checkerSrc(
+					int(cfg.Width)*imgScale,
+					int(cfg.Height)*imgScale),
+				Width:  cfg.Width,
+				Height: cfg.Height,
+			}),
+			// The color rides over the checker as a float so it
+			// covers it exactly rather than being laid out after it.
+			container(ContainerCfg{
+				Float:      true,
+				Width:      cfg.Width,
+				Height:     cfg.Height,
+				Color:      cfg.Color,
+				Radius:     cfg.Radius,
+				Padding:    NoPadding,
+				SizeBorder: NoBorder,
+			}),
+		},
+	}, w)
+}

--- a/gui/view_color_swatch.go
+++ b/gui/view_color_swatch.go
@@ -47,7 +47,23 @@ func applyColorSwatchDefaults(cfg *ColorSwatchCfg) {
 const (
 	defaultSwatchWidth  = 48
 	defaultSwatchHeight = 32
+	// colorSwatchBorder is a hairline: enough to separate the color
+	// from the surface behind it, not enough to read as a frame around
+	// it or to eat into a small swatch.
+	colorSwatchBorder = 1
+	// colorSwatchEdgeAlpha keeps the outline a contour rather than a
+	// stroke. Derived from the theme's border color, so it darkens on
+	// a light theme and lightens on a dark one instead of being one
+	// gray that is wrong against one of them.
+	colorSwatchEdgeAlpha = 0.5
 )
+
+// colorSwatchEdge is the swatch's outline color, dimmed from the
+// theme's own border color.
+func colorSwatchEdge() Color {
+	c := defaultColorPickerStyle.ColorBorder
+	return RGBA(c.R, c.G, c.B, uint8(float32(c.A)*colorSwatchEdgeAlpha))
+}
 
 func (sv *colorSwatchView) GenerateLayout(w *Window) Layout {
 	cfg := &sv.cfg
@@ -84,13 +100,21 @@ func (sv *colorSwatchView) GenerateLayout(w *Window) Layout {
 			// The color rides over the checker as a float so it
 			// covers it exactly rather than being laid out after it.
 			container(ContainerCfg{
-				Float:      true,
-				Width:      cfg.Width,
-				Height:     cfg.Height,
-				Color:      cfg.Color,
-				Radius:     cfg.Radius,
-				Padding:    NoPadding,
-				SizeBorder: NoBorder,
+				Float:  true,
+				Width:  cfg.Width,
+				Height: cfg.Height,
+				Color:  cfg.Color,
+				Radius: cfg.Radius,
+				// The outline goes on the color, not on the box
+				// beneath it: this container covers the whole
+				// swatch, so a border on the parent would be drawn
+				// under it. Without one a white value on a light
+				// theme is an invisible rectangle -- the swatch
+				// vanishes exactly when the color is hardest to
+				// read off the hex string.
+				ColorBorder: colorSwatchEdge(),
+				SizeBorder:  SomeF(colorSwatchBorder),
+				Padding:     NoPadding,
 			}),
 		},
 	}, w)

--- a/gui/view_color_swatch.go
+++ b/gui/view_color_swatch.go
@@ -61,8 +61,7 @@ const (
 // colorSwatchEdge is the swatch's outline color, dimmed from the
 // theme's own border color.
 func colorSwatchEdge() Color {
-	c := defaultColorPickerStyle.ColorBorder
-	return RGBA(c.R, c.G, c.B, uint8(float32(c.A)*colorSwatchEdgeAlpha))
+	return defaultColorPickerStyle.ColorBorder.WithOpacity(colorSwatchEdgeAlpha)
 }
 
 func (sv *colorSwatchView) GenerateLayout(w *Window) Layout {

--- a/gui/view_color_wheel.go
+++ b/gui/view_color_wheel.go
@@ -1,0 +1,136 @@
+package gui
+
+// ColorWheelCfg configures a hue × saturation wheel.
+//
+// Angle is hue — 0° at the right, increasing counterclockwise — and
+// radius is saturation, drawn at the current lightness. Dragging sets
+// hue and saturation together; lightness and alpha pass through
+// untouched.
+//
+// The disc cannot be drawn with gradients (there is no conic gradient),
+// so it is a generated buffer keyed on lightness. That is the reason
+// the in-memory image registry exists; see gui/color_buffers.go.
+type ColorWheelCfg struct {
+	OnChange func(HSLA, EventCtx)
+	ID       string `gui:"required"`
+
+	A11YCfg
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled bool
+
+	Value HSLA
+	// Size is the wheel's diameter in points. Zero takes the theme
+	// default.
+	Size float32 // ergonomics-audit:opt-plain — a zero-diameter wheel is meaningless; 0 falls back to the theme
+	// MarkerSize is the diameter of the position marker. Zero takes
+	// the theme default.
+	MarkerSize float32
+}
+
+type colorWheelView struct {
+	cfg ColorWheelCfg
+}
+
+// ColorWheel creates a hue × saturation wheel at Value's lightness.
+func ColorWheel(cfg ColorWheelCfg) View {
+	requireFocusID("ColorWheel", cfg.FocusDisabled, cfg.ID)
+	applyColorWheelDefaults(&cfg)
+	return &colorWheelView{cfg: cfg}
+}
+
+func applyColorWheelDefaults(cfg *ColorWheelCfg) {
+	d := &defaultColorPickerStyle
+	if cfg.Size <= 0 {
+		cfg.Size = d.sVSize
+	}
+	if cfg.MarkerSize <= 0 {
+		cfg.MarkerSize = d.indicatorSize
+	}
+}
+
+func (wv *colorWheelView) GenerateLayout(w *Window) Layout {
+	cfg := &wv.cfg
+	id := w.EffID(cfg.ID)
+	size := cfg.Size
+	radius := size / 2
+	v := cfg.Value.Normalized()
+	onChange := cfg.OnChange
+
+	apply := func(nx, ny float32, ctx EventCtx) {
+		if onChange == nil {
+			return
+		}
+		// Back from the unit box the drag helper reports to a vector
+		// out of the wheel's centre.
+		dx := nx*size - radius
+		dy := ny*size - radius
+		out := v
+		out.H = hueOf(dx, dy)
+		// A drag past the rim pins to full saturation rather than
+		// snapping the hue back, which is what makes the edge of the
+		// disc feel like a wall instead of a cliff.
+		out.S = f32Clamp(f32Sqrt(dx*dx+dy*dy)/radius, 0, 1)
+		onChange(out, ctx)
+	}
+
+	// Marker position: hue is the angle, saturation the distance out.
+	// Screen y grows downward, so the sine term is subtracted.
+	rad := v.H * f32Pi / 180
+	mr := v.S * radius
+	mx := radius + f32Cos(rad)*mr
+	my := radius - f32Sin(rad)*mr
+
+	px := int(size) * imgScale
+	return generateViewLayout(&containerView{
+		cfg: ContainerCfg{
+			ID:        id,
+			Focusable: !cfg.FocusDisabled,
+			A11YRole:  AccessRoleColorWell,
+			A11YCfg: A11YCfg{
+				A11YLabel: a11yLabel(cfg.A11YLabel,
+					"Hue and saturation wheel"),
+				A11YDescription: cfg.A11YDescription,
+			},
+			Width:  size,
+			Height: size,
+			// Fixed: the disc's size is tied to the buffer generated
+			// for it, so it must not stretch to fill a parent.
+			Sizing:     FixedFixed,
+			Padding:    NoPadding,
+			SizeBorder: NoBorder,
+			axis:       axisTopToBottom,
+			OnClick:    colorDragTrack(id, apply),
+			OnKeyDown:  colorWheelKeys(v, onChange),
+		},
+		content: []View{
+			Image(ImageCfg{
+				Src:    wheelSrc(v, px),
+				Width:  size,
+				Height: size,
+			}),
+			colorMarker(cfg.MarkerSize, v.Color(), func(ctx EventCtx) {
+				colorAmendMarker(ctx.Layout, mx, my, cfg.MarkerSize)
+			}),
+		},
+	}, w)
+}
+
+// colorWheelKeys steps hue with the horizontal arrows and saturation
+// with the vertical ones — the two axes the wheel edits, mapped to the
+// arrows a user can reach without a pointer.
+func colorWheelKeys(
+	v HSLA, onChange func(HSLA, EventCtx),
+) func(EventCtx) {
+	return func(ctx EventCtx) {
+		dx, dy, ok := colorKeyDelta(ctx.Event)
+		if !ok || onChange == nil {
+			return // not ours: let it travel on
+		}
+		out := v
+		out.H = v.H + dx*360
+		out.S = f32Clamp(v.S-dy, 0, 1)
+		onChange(out.Normalized(), ctx)
+		ctx.Consume()
+	}
+}

--- a/gui/view_color_wheel.go
+++ b/gui/view_color_wheel.go
@@ -122,15 +122,10 @@ func (wv *colorWheelView) GenerateLayout(w *Window) Layout {
 func colorWheelKeys(
 	v HSLA, onChange func(HSLA, EventCtx),
 ) func(EventCtx) {
-	return func(ctx EventCtx) {
-		dx, dy, ok := colorKeyDelta(ctx.Event)
-		if !ok || onChange == nil {
-			return // not ours: let it travel on
-		}
-		out := v
-		out.H = v.H + dx*360
-		out.S = f32Clamp(v.S-dy, 0, 1)
-		onChange(out.Normalized(), ctx)
-		ctx.Consume()
-	}
+	return colorArrowKeys(v, onChange,
+		func(v HSLA, dx, dy float32) HSLA {
+			v.H += dx * 360
+			v.S = f32Clamp(v.S-dy, 0, 1)
+			return v.Normalized()
+		})
 }

--- a/gui/view_image.go
+++ b/gui/view_image.go
@@ -64,8 +64,9 @@ func (iv *imageView) GenerateLayout(w *Window) Layout {
 	}
 
 	// Data URLs are passed directly to the backend renderer
-	// (used by WASM for embedded image assets).
-	if !isDataURL(c.Src) {
+	// (used by WASM for embedded image assets). mem: sources name a
+	// buffer in the in-memory registry, so there is no path to stat.
+	if !isDataURL(c.Src) && !isMemImage(c.Src) {
 		if err := validateImagePath(imagePath); err != nil {
 			log.Printf("image: %v", err)
 			return errorTextLayout(c.Src, w)


### PR DESCRIPTION
Splits the monolithic ColorPicker into composable, stateless widgets over one HSLA value, backed by a content-keyed in-memory image registry.

## New widgets
- **ColorPlane** — saturation × lightness at a fixed hue
- **ColorWheel** — hue × saturation disc (generated buffer; no conic gradient exists)
- **ColorChannelSlider** — one HSLA channel, track shows the colors it picks, horizontal or vertical, with a real transparency checkerboard under the alpha track
- **ColorSwatch** — color over a checkerboard
- **ColorFields** — hex + RGBA/HSL inputs with optical centring and pinned widths
- **gui.HSLA** + `ColorToHSLA` / `HSLA.Color` / `HSLA.String` / `Color.Hex` / `ColorFromHex` — RGBA cannot carry hue through a gray or through black, so apps hold HSLA

## In-memory image registry
`UseImage` / `HasImage` / `DropImage` / `SetMemImageBudget` / `LookupImage` — register an NRGBA8 buffer under a content key; every backend (gl, metal, web, android, ios) uploads it as a texture. Backends resolve `mem:` sources through `LookupImage`; the PDF renderer embeds them as PNG. Generators quantize keys (hue to degrees, S/L/A to percent) so a steady frame costs a map lookup and zero allocations.

## ColorPicker becomes a composition
Cfg unchanged; existing callers compile untouched. Plane + vertical hue/alpha sliders + swatch-by-hex + HSL fields. `ShowHSV` retained as a deprecated alias of `ShowHSL`.

## Docs
`docs/specs/color-picker-components.md`, updated example and showcase demos.

Tests: pixel-level buffer tests, keying/quantization, registry budget/eviction, drag/key interaction, composed-ID and border-alignment layout tests.