### PR TITLE
feat(gui): convenience constructors for common call sites (issue #325)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,8 +209,10 @@ Backend injects at startup. Nil in tests:
   package vars have no initializers — never add one.** They are mirrors: `init`
   fills them with `applyTheme(ThemeDark)` and `installTheme` refills them per
   theme change. A literal there is a second source of truth that silently drifts
-  (issue #300 removed ~30 of them; `ThemeDark` is borderless, bordered is the
-  `dark-bordered` preset or `Theme.WithBorders(true)`). The two exceptions are
+  (issue #300 removed ~30 of them; `ThemeDark` is bordered since 2026-08
+  — 90 of 104 examples call `WithBorders(true)` explicitly — use
+  `Theme.WithBorders(false)` or the `dark-no-padding` preset for the old
+  borderless look). The two exceptions are
   `DefaultTextStyle` and `defaultInspectorStyle`, which are ThemeMaker _inputs_.
   `TestDefaultStylesMirrorThemeDark` is the gate. See
   `docs/specs/theme-style-single-source.md`.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,8 @@ import (
 type App struct{ Clicks int }
 
 func main() {
-    w := gui.NewWindow(gui.WindowCfg{
-        State:  &App{},
-        Title:  "Counter",
-        Width:  300,
-        Height: 150,
-        OnInit: func(w *gui.Window) { w.UpdateView(mainView) },
+    w := gui.SimpleWindow("Counter", 300, 150, &App{}, func(w *gui.Window) {
+        w.UpdateView(mainView)
     })
 
     backend.Run(w)
@@ -38,19 +34,42 @@ func mainView(w *gui.Window) gui.View {
 
     return gui.Column(gui.ContainerCfg{
         Content: []gui.View{
-            gui.Text(gui.TextCfg{Text: fmt.Sprintf("%d Clicks", app.Clicks)}),
-            gui.Button(gui.ButtonCfg{
-                ID: "counter",
-                Content: []gui.View{
-                    gui.Text(gui.TextCfg{Text: "Click Me"}),
-                },
-                OnClick: func(ctx gui.EventCtx) {
-                    gui.State[App](ctx.Window).Clicks++
-                },
+            gui.Label(fmt.Sprintf("%d Clicks", app.Clicks), gui.TextStyle{}),
+            gui.TextButton("counter", "Click Me", func(ctx gui.EventCtx) {
+                gui.State[App](ctx.Window).Clicks++
             }),
         },
     })
 }
+```
+
+`gui.Label(text, style)` — pass the zero `TextStyle{}` for the default theme
+style. `gui.TextButton(id, label, onClick)` and `gui.SimpleWindow` are the
+same thin forwards; the `ID` argument stays explicit because identity is
+caller-owned.
+
+### Full control
+
+Every convenience form forwards to the matching `Cfg` struct. Use it when you
+need the knobs — fonts, colors, sizing, padding, events:
+
+```go
+w := gui.NewWindow(gui.WindowCfg{
+    State:  &App{},
+    Title:  "Counter",
+    Width:  300,
+    Height: 150,
+    OnInit: func(w *gui.Window) { w.UpdateView(mainView) },
+})
+
+gui.Button(gui.ButtonCfg{
+    ID:      "counter",
+    Content: []gui.View{gui.Text(gui.TextCfg{Text: "Click Me"})},
+    Padding: gui.NewPadding(8, 16, 8, 16),
+    OnClick: func(ctx gui.EventCtx) {
+        gui.State[App](ctx.Window).Clicks++
+    },
+})
 ```
 
 See [`examples/get_started/`](examples/get_started/) for the full runnable

--- a/docs/specs/theme-style-single-source.md
+++ b/docs/specs/theme-style-single-source.md
@@ -47,18 +47,17 @@ Two literals in `gui/styles.go` are **not** mirrors and keep their values:
 Both are still re-assigned by `applyTheme`; for `ThemeDark` that assignment is a
 no-op, and for any other theme it is the correct behaviour.
 
-## Why `ThemeDark` won every delta
+## Why `ThemeDark` carries the 1.5 border
 
-The literals were effectively the `dark-bordered` preset, not `dark`. Three
-independent signals say borderless is the designed default and the 1.5 values
-were the drift:
-
-- `baseCfg` never sets `SizeBorder`. It is 0 by omission in `dark`, `light` and
-  `blue-dark` alike.
-- `dark-bordered`, `light-bordered` and `blue-dark-bordered` are each their base
-  config plus `SizeBorder = sizeBorderDef`. Folding 1.5 into `baseCfg` would
-  have made all three presets exact duplicates of their base.
-- `Theme.WithBorders(true)` exists so a caller can opt in.
+Folding `SizeBorder = sizeBorderDef` into `baseCfg` makes `dark-bordered`
+an exact duplicate of `dark`. That is accepted, not an accident: the
+call-site count behind issue #325 found 90 of 104 example files calling
+`SetTheme(ThemeDark.WithBorders(true))` explicitly, so bordered is what
+applications actually use, and `ThemeDark` is the implicit default for
+apps that never call `SetTheme`. The `dark-bordered` preset stays
+registered for name-based theme selection, and `Theme.WithBorders(false)`
+restores the old borderless look. `light` and `blue-dark` remain
+borderless by omission.
 
 Every other delta was a literal that had simply fallen behind: an unstyled
 `dataGrid` placeholder, a dialog with no width bounds, a badge with no text
@@ -66,11 +65,14 @@ style.
 
 ## Appearance changes
 
-Borders. `SizeBorder` drops to 0 on button, input, container, dialog, toast,
-tooltip, expand panel, select, tree, switch, toggle, tab control, date picker,
-color picker, menubar, splitter, command palette, combobox and listbox (1.5), on
-slider (1) and on radio (2). The tab control's `sizeTabBorder` and the
-breadcrumb's `sizeContentBorder` follow.
+Borders, revisited 2026-08: issue #300 removed the literal borders and
+left `ThemeDark` borderless (`SizeBorder` 0 on every widget). The
+call-site count behind issue #325 then showed the borderless default
+missed the audience — 90 of 104 example files re-opted in with
+`Theme.WithBorders(true)` — so `baseDarkCfg` carries `sizeBorderDef`
+again. Widgets render with their 1.5 (slider 1, radio 2) borders under
+`ThemeDark` and the app default; `Theme.WithBorders(false)` restores the
+borderless look, and `light`/`blue-dark` remain borderless.
 
 Everything else:
 
@@ -90,10 +92,10 @@ Everything else:
 | numeric input   | follows the active theme                       |
 | radio group     | follows the active theme                       |
 
-To keep the previous bordered look:
+To get the old borderless look:
 
 ```go
-gui.SetTheme(gui.ThemeDark.WithBorders(true))
+gui.SetTheme(gui.ThemeDark.WithBorders(false))
 ```
 
 ## Related

--- a/examples/animations/main.go
+++ b/examples/animations/main.go
@@ -22,18 +22,25 @@ import (
 // 6. LAYOUT  - automatic position/size interpolation between frames
 // 7. HERO    - morph elements between different views
 
-type State struct {
+type AppState struct {
 	SidebarWidth float32
 	BoxX         float32
 	SpringValue  float32
 	ShowDetail   bool
 }
 
+// state is the typed state accessor for this window. Callbacks
+// reach the app state through it instead of repeating
+// gui.State[AppState](...) at every site.
+func state(w *gui.Window) *AppState {
+	return gui.State[AppState](w)
+}
+
 func main() {
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
 
 	w := gui.NewWindow(gui.WindowCfg{
-		State: &State{
+		State: &AppState{
 			SidebarWidth: 200,
 			BoxX:         50,
 			SpringValue:  100,
@@ -51,7 +58,7 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	s := gui.State[State](w)
+	s := state(w)
 
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFill,
@@ -236,14 +243,14 @@ func animButton(label string, action func(w *gui.Window)) gui.View {
 
 // Tween: interpolate box_x over fixed duration with easing.
 func tweenBox(w *gui.Window) {
-	s := gui.State[State](w)
+	s := state(w)
 	target := float32(400)
 	if s.BoxX >= 300 {
 		target = 50
 	}
 	a := gui.NewTweenAnimation("box_move", s.BoxX, target,
 		func(v float32, w *gui.Window) {
-			gui.State[State](w).BoxX = v
+			state(w).BoxX = v
 		})
 	a.Duration = 500 * time.Millisecond
 	a.Easing = gui.EaseOutCubic
@@ -252,14 +259,14 @@ func tweenBox(w *gui.Window) {
 
 // Spring: physics-based sidebar resize.
 func springSidebar(w *gui.Window) {
-	s := gui.State[State](w)
+	s := state(w)
 	target := float32(60)
 	if s.SidebarWidth <= 100 {
 		target = 200
 	}
 	a := gui.NewSpringAnimation("sidebar",
 		func(v float32, w *gui.Window) {
-			gui.State[State](w).SidebarWidth = v
+			state(w).SidebarWidth = v
 		})
 	a.Config = gui.SpringBouncy
 	a.SpringTo(s.SidebarWidth, target)
@@ -268,17 +275,17 @@ func springSidebar(w *gui.Window) {
 
 // Bounce: chained tween with bounce easing, then return.
 func bounceAnim(w *gui.Window) {
-	s := gui.State[State](w)
+	s := state(w)
 	a := gui.NewTweenAnimation("bounce", s.SpringValue, 300,
 		func(v float32, w *gui.Window) {
-			gui.State[State](w).SpringValue = v
+			state(w).SpringValue = v
 		})
 	a.Duration = 800 * time.Millisecond
 	a.Easing = gui.EaseOutBounce
 	a.OnDone = func(w *gui.Window) {
 		ret := gui.NewTweenAnimation("bounce_return", 300, 100,
 			func(v float32, w *gui.Window) {
-				gui.State[State](w).SpringValue = v
+				state(w).SpringValue = v
 			})
 		ret.Duration = 300 * time.Millisecond
 		ret.Easing = gui.EaseOutQuad
@@ -289,14 +296,14 @@ func bounceAnim(w *gui.Window) {
 
 // Elastic: tween with elastic overshoot easing.
 func elasticAnim(w *gui.Window) {
-	s := gui.State[State](w)
+	s := state(w)
 	target := float32(500)
 	if s.BoxX >= 300 {
 		target = 50
 	}
 	a := gui.NewTweenAnimation("elastic", s.BoxX, target,
 		func(v float32, w *gui.Window) {
-			gui.State[State](w).BoxX = v
+			state(w).BoxX = v
 		})
 	a.Duration = 1000 * time.Millisecond
 	a.Easing = gui.EaseOutElastic
@@ -308,7 +315,7 @@ func layoutAnim(w *gui.Window) {
 	w.AnimateLayout(gui.LayoutTransitionCfg{
 		Duration: 300 * time.Millisecond,
 	})
-	s := gui.State[State](w)
+	s := state(w)
 	if s.SidebarWidth > 100 {
 		s.SidebarWidth = 60
 	} else {
@@ -333,7 +340,7 @@ func heroBack(w *gui.Window) {
 
 // Keyframe: multi-waypoint shake effect.
 func keyframeAnim(w *gui.Window) {
-	s := gui.State[State](w)
+	s := state(w)
 	center := s.BoxX
 	a := gui.NewKeyframeAnimation("shake", []gui.Keyframe{
 		{At: 0.0, Value: center},
@@ -343,7 +350,7 @@ func keyframeAnim(w *gui.Window) {
 		{At: 0.8, Value: center + 8, Easing: gui.EaseOutQuad},
 		{At: 1.0, Value: center, Easing: gui.EaseOutQuad},
 	}, func(v float32, w *gui.Window) {
-		gui.State[State](w).BoxX = v
+		state(w).BoxX = v
 	})
 	a.Duration = 500 * time.Millisecond
 	w.AnimationAdd(a)

--- a/examples/animations/main_test.go
+++ b/examples/animations/main_test.go
@@ -10,7 +10,7 @@ func TestMainViewNoPanic(t *testing.T) {
 	t.Parallel()
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
 	w := gui.NewWindow(gui.WindowCfg{
-		State: &State{
+		State: &AppState{
 			SidebarWidth: 200,
 			BoxX:         50,
 			SpringValue:  100,
@@ -28,7 +28,7 @@ func TestMainViewNoDuplicateIDs(t *testing.T) {
 	// other's geometry the start of the lerp.
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
 	w := gui.NewWindow(gui.WindowCfg{
-		State: &State{
+		State: &AppState{
 			SidebarWidth: 200,
 			BoxX:         50,
 			SpringValue:  100,

--- a/examples/custom_shader/main.go
+++ b/examples/custom_shader/main.go
@@ -17,7 +17,7 @@ type App struct {
 }
 
 func main() {
-	gui.SetTheme(gui.ThemeDark)
+	gui.SetTheme(gui.ThemeDark.WithBorders(false))
 
 	w := gui.NewWindow(gui.WindowCfg{
 		State:  &App{StartTime: time.Now()},

--- a/examples/date_picker_options/main.go
+++ b/examples/date_picker_options/main.go
@@ -51,6 +51,13 @@ type App struct {
 	LightTheme bool
 }
 
+// state is the typed state accessor for this window. Callbacks
+// reach the app state through it instead of repeating
+// gui.State[App](...) at every site.
+func state(w *gui.Window) *App {
+	return gui.State[App](w)
+}
+
 func main() {
 	gui.SetTheme(gui.ThemeDark.WithBorders(true))
 
@@ -68,7 +75,7 @@ func main() {
 }
 
 func mainView(w *gui.Window) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFill,
@@ -200,7 +207,7 @@ func datePicker(app *App, _ *gui.Window) gui.View {
 		AllowedYears:         allowedYears,
 		AllowedDates:         allowedDates,
 		OnSelect: func(times []time.Time, ctx gui.EventCtx) {
-			gui.State[App](ctx.Window).Dates = times
+			state(ctx.Window).Dates = times
 			ctx.Consume()
 		},
 	})
@@ -216,8 +223,8 @@ func optionsGroup(app *App) gui.View {
 					Label:    "Monday first day of week",
 					Selected: app.MondayFirst,
 					OnClick: func(ctx gui.EventCtx) {
-						gui.State[App](ctx.Window).MondayFirst =
-							!gui.State[App](ctx.Window).MondayFirst
+						state(ctx.Window).MondayFirst =
+							!state(ctx.Window).MondayFirst
 					},
 				}),
 				gui.Toggle(gui.ToggleCfg{
@@ -225,8 +232,8 @@ func optionsGroup(app *App) gui.View {
 					Label:    "Show adjacent months",
 					Selected: app.ShowAdjacentMonths,
 					OnClick: func(ctx gui.EventCtx) {
-						gui.State[App](ctx.Window).ShowAdjacentMonths =
-							!gui.State[App](ctx.Window).ShowAdjacentMonths
+						state(ctx.Window).ShowAdjacentMonths =
+							!state(ctx.Window).ShowAdjacentMonths
 					},
 				}),
 				gui.Toggle(gui.ToggleCfg{
@@ -234,8 +241,8 @@ func optionsGroup(app *App) gui.View {
 					Label:    "Hide today indicator",
 					Selected: app.HideTodayIndicator,
 					OnClick: func(ctx gui.EventCtx) {
-						gui.State[App](ctx.Window).HideTodayIndicator =
-							!gui.State[App](ctx.Window).HideTodayIndicator
+						state(ctx.Window).HideTodayIndicator =
+							!state(ctx.Window).HideTodayIndicator
 					},
 				}),
 				gui.Toggle(gui.ToggleCfg{
@@ -243,8 +250,8 @@ func optionsGroup(app *App) gui.View {
 					Label:    "Multiple select",
 					Selected: app.SelectMultiple,
 					OnClick: func(ctx gui.EventCtx) {
-						gui.State[App](ctx.Window).SelectMultiple =
-							!gui.State[App](ctx.Window).SelectMultiple
+						state(ctx.Window).SelectMultiple =
+							!state(ctx.Window).SelectMultiple
 					},
 				}),
 			}),
@@ -276,7 +283,7 @@ func weekdaysLenGroup(app *App) gui.View {
 				gui.NewRadioOption("Full", "full"),
 			},
 			OnSelect: func(value string, ctx gui.EventCtx) {
-				gui.State[App](ctx.Window).WeekdaysLen = value
+				state(ctx.Window).WeekdaysLen = value
 			},
 		}),
 	})
@@ -312,7 +319,7 @@ func allowedWeekdaysGroup(app *App) gui.View {
 }
 
 func clickAllowWeekday(ctx gui.EventCtx) {
-	app := gui.State[App](ctx.Window)
+	app := state(ctx.Window)
 	switch ctx.Layout.Shape.ID {
 	case "mon":
 		app.AllowMonday = !app.AllowMonday
@@ -367,7 +374,7 @@ func monthsGroup(app *App) gui.View {
 }
 
 func clickAllowMonth(ctx gui.EventCtx) {
-	app := gui.State[App](ctx.Window)
+	app := state(ctx.Window)
 	switch ctx.Layout.Shape.ID {
 	case "jan":
 		app.AllowJanuary = !app.AllowJanuary
@@ -419,7 +426,7 @@ func yearsDatesGroup(app *App, _ *gui.Window) gui.View {
 						},
 						OnClick: func(ctx gui.EventCtx) {
 							ctx.Window.DatePickerReset("example")
-							app := gui.State[App](ctx.Window)
+							app := state(ctx.Window)
 							app.Dates = []time.Time{time.Now()}
 							app.WeekdaysLen = "one"
 							app.MondayFirst = false
@@ -485,7 +492,7 @@ func allowedYearsGroup(app *App) gui.View {
 }
 
 func clickAllowYear(ctx gui.EventCtx) {
-	app := gui.State[App](ctx.Window)
+	app := state(ctx.Window)
 	switch ctx.Layout.Shape.ID {
 	case "year_now":
 		app.AllowYearNow = !app.AllowYearNow
@@ -522,7 +529,7 @@ func allowedDatesGroup(app *App) gui.View {
 }
 
 func clickAllowDate(ctx gui.EventCtx) {
-	app := gui.State[App](ctx.Window)
+	app := state(ctx.Window)
 	switch ctx.Layout.Shape.ID {
 	case "tdy":
 		app.AllowToday = !app.AllowToday
@@ -544,7 +551,7 @@ func toggleTheme(app *App) gui.View {
 
 		Selected: app.LightTheme,
 		OnClick: func(ctx gui.EventCtx) {
-			app := gui.State[App](ctx.Window)
+			app := state(ctx.Window)
 			app.LightTheme = !app.LightTheme
 			if app.LightTheme {
 				ctx.Window.SetTheme(gui.ThemeLight.WithBorders(true))

--- a/examples/fontviewer/main.go
+++ b/examples/fontviewer/main.go
@@ -3,8 +3,7 @@
 //
 // Virtualized card grid with filter, sample text, size slider,
 // and click-to-copy. Follows the get_started pattern: state is
-// retrieved via gui.State[T](w) in every callback — no closure
-// captures.
+// retrieved via state(w) in every callback — no closure captures.
 //
 // Behavioral constraints (see docs/specs/font-viewer.md):
 //   - Grid is virtualized (P0) via gui.ListVisibleRange.
@@ -39,6 +38,13 @@ type FontViewerState struct {
 	CopiedFam   string  // family whose "Copied" badge is showing ("" = none)
 	CopyOpacity float32 // 1→0, written by the fade tween
 	HoveredFam  string  // family under the pointer ("" = none); cleared on eviction
+}
+
+// state is the typed state accessor for the font-viewer window.
+// Every callback repeats gui.State[FontViewerState](...); one
+// accessor keeps the type mention and the call site short.
+func state(w *gui.Window) *FontViewerState {
+	return gui.State[FontViewerState](w)
 }
 
 // --- Constants ---
@@ -188,7 +194,7 @@ func main() {
 // --- View tree ---
 
 func mainView(w *gui.Window) gui.View {
-	s := gui.State[FontViewerState](w)
+	s := state(w)
 
 	// Lazy one-time enumeration. ListSystemFonts reads a pre-built set
 	// (cheap, no shaping); nil until the backend is ready → retry next
@@ -250,7 +256,7 @@ func flexGap() gui.View {
 }
 
 func toolbar(w *gui.Window, matchCount int) gui.View {
-	s := gui.State[FontViewerState](w)
+	s := state(w)
 	t := gui.CurrentTheme()
 
 	row1 := toolbarRow(toolbarEdgePad, toolbarSeamPad, []gui.View{
@@ -261,7 +267,7 @@ func toolbar(w *gui.Window, matchCount int) gui.View {
 			TextStyle: t.B3,
 			Sizing:    gui.FillFit,
 			OnTextChanged: func(text string, ctx gui.EventCtx) {
-				gui.State[FontViewerState](ctx.Window).Sample = text
+				state(ctx.Window).Sample = text
 			},
 		}),
 		gui.Button(gui.ButtonCfg{
@@ -297,7 +303,7 @@ func toolbarRow2(s *FontViewerState, t gui.Theme, matchCount int) []gui.View {
 			Width:     filterInputW,
 			Sizing:    gui.FixedFit,
 			OnTextChanged: func(text string, ctx gui.EventCtx) {
-				gui.State[FontViewerState](ctx.Window).Filter = text
+				state(ctx.Window).Filter = text
 				ctx.Window.ScrollVerticalTo(gridID, 0)
 			},
 		}),
@@ -307,7 +313,7 @@ func toolbarRow2(s *FontViewerState, t gui.Theme, matchCount int) []gui.View {
 			ID:      "fontviewer_toolbar_row2",
 			Content: []gui.View{gui.Text(gui.TextCfg{Text: "×", TextStyle: t.B3})},
 			OnClick: func(ctx gui.EventCtx) {
-				gui.State[FontViewerState](ctx.Window).Filter = ""
+				state(ctx.Window).Filter = ""
 				ctx.Window.ScrollVerticalTo(gridID, 0)
 			},
 		}))
@@ -325,7 +331,7 @@ func toolbarRow2(s *FontViewerState, t gui.Theme, matchCount int) []gui.View {
 			Width:  sliderW,
 			Sizing: gui.FixedFit,
 			OnChange: func(v float32, ctx gui.EventCtx) {
-				gui.State[FontViewerState](ctx.Window).FontSize = v
+				state(ctx.Window).FontSize = v
 				ctx.Window.ScrollVerticalTo(gridID, 0) // rowH changed → reset offset
 				ctx.Event.IsHandled = true
 			},
@@ -347,7 +353,7 @@ func toolbarRow2(s *FontViewerState, t gui.Theme, matchCount int) []gui.View {
 
 // shuffleSample replaces the sample text with a fresh pangram.
 func shuffleSample(ctx gui.EventCtx) {
-	s := gui.State[FontViewerState](ctx.Window)
+	s := state(ctx.Window)
 	s.Sample = randomPangram(s.Sample)
 	ctx.Consume()
 }
@@ -366,7 +372,7 @@ func randomPangram(exclude string) string {
 // --- FontGrid (virtualized) ---
 
 func fontGrid(w *gui.Window, matches []string) gui.View {
-	s := gui.State[FontViewerState](w)
+	s := state(w)
 
 	if len(matches) == 0 {
 		return emptyState(len(s.Families) == 0)
@@ -460,7 +466,7 @@ func gridRow(w *gui.Window, matches []string, rowIdx, cols int, cardW, cardH, ro
 // --- FontCard ---
 
 func fontCard(w *gui.Window, name string, cardW, cardH float32) gui.View {
-	s := gui.State[FontViewerState](w)
+	s := state(w)
 	t := gui.CurrentTheme()
 
 	bg := colorCardBG
@@ -540,7 +546,7 @@ func cardPreview(sample, name string, fontSize float32) gui.View {
 // copyFamily copies the family name and starts the "Copied" fade.
 func copyFamily(name string) func(gui.EventCtx) {
 	return func(ctx gui.EventCtx) {
-		s := gui.State[FontViewerState](ctx.Window)
+		s := state(ctx.Window)
 		s.CopiedFam = name
 		s.CopyOpacity = 1
 		ctx.Window.SetClipboard(name)
@@ -550,8 +556,8 @@ func copyFamily(name string) func(gui.EventCtx) {
 			Easing:   gui.EaseOutCubic,
 			From:     1,
 			To:       0,
-			OnValue:  func(v float32, w *gui.Window) { gui.State[FontViewerState](w).CopyOpacity = v },
-			OnDone:   func(w *gui.Window) { gui.State[FontViewerState](w).CopiedFam = "" },
+			OnValue:  func(v float32, w *gui.Window) { state(w).CopyOpacity = v },
+			OnDone:   func(w *gui.Window) { state(w).CopiedFam = "" },
 		})
 		// let event bubble up to column to change focus
 	}
@@ -560,7 +566,7 @@ func copyFamily(name string) func(gui.EventCtx) {
 // hoverFamily tracks the hovered card for the "Copy" affordance and bg.
 func hoverFamily(name string) func(gui.EventCtx) {
 	return func(ctx gui.EventCtx) {
-		s := gui.State[FontViewerState](ctx.Window)
+		s := state(ctx.Window)
 		switch ctx.Event.Type {
 		case gui.EventMouseEnter:
 			s.HoveredFam = name

--- a/examples/get_started/main.go
+++ b/examples/get_started/main.go
@@ -1,6 +1,4 @@
 // This example demonstrates the smallest stateful go-gui app: one button and one counter.
-// Get_started is the smallest stateful go-gui app: one button
-// and one counter.
 package main
 
 import (
@@ -15,16 +13,8 @@ type App struct {
 }
 
 func main() {
-	gui.SetTheme(gui.ThemeDark.WithBorders(true))
-
-	w := gui.NewWindow(gui.WindowCfg{
-		State:  &App{},
-		Title:  "Get Started",
-		Width:  300,
-		Height: 300,
-		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
-		},
+	w := gui.SimpleWindow("Get Started", 300, 300, &App{}, func(w *gui.Window) {
+		w.UpdateView(mainView)
 	})
 
 	backend.Run(w)
@@ -33,28 +23,15 @@ func main() {
 func mainView(w *gui.Window) gui.View {
 	app := gui.State[App](w)
 
-	// FillFill fills the window and tracks resize automatically — no
-	// need to fetch WindowSize() or set an explicit Width/Height.
 	return gui.Column(gui.ContainerCfg{
 		Sizing: gui.FillFill,
 		HAlign: gui.HAlignCenter,
 		VAlign: gui.VAlignMiddle,
 		Content: []gui.View{
-			gui.Text(gui.TextCfg{
-				Text:      "Hello GUI! 😀🚀🎉👍",
-				TextStyle: gui.CurrentTheme().B1,
-			}),
-			gui.Button(gui.ButtonCfg{
-				ID: "gs_counter",
-				Content: []gui.View{
-					gui.Text(gui.TextCfg{
-						Text: fmt.Sprintf("%d Clicks", app.Clicks),
-					}),
-				},
-				OnClick: func(ctx gui.EventCtx) {
-					// Update the typed window state; the next frame reads it back.
-					gui.State[App](ctx.Window).Clicks++
-				},
+			gui.Label("Hello GUI! 😀🚀🎉👍", gui.CurrentTheme().B1),
+			gui.TextButton("gs_counter", fmt.Sprintf("%d Clicks", app.Clicks), func(ctx gui.EventCtx) {
+				// Update the typed window state; the next frame reads it back.
+				gui.State[App](ctx.Window).Clicks++
 			}),
 		},
 	})

--- a/examples/minesweeper/main.go
+++ b/examples/minesweeper/main.go
@@ -43,6 +43,13 @@ type App struct {
 	LogoBoom     bool // true = bomb hit, showing all bombs
 }
 
+// state is the typed state accessor for this window. Callbacks
+// reach the app state through it instead of repeating
+// gui.State[App](...) at every site.
+func state(w *gui.Window) *App {
+	return gui.State[App](w)
+}
+
 // logoDot tracks a single pixel in the title animation.
 type logoDot struct {
 	Mine     bool
@@ -71,7 +78,7 @@ func main() {
 				Delay:  time.Second,
 				Repeat: true,
 				Callback: func(_ *gui.Animate, w *gui.Window) {
-					app := gui.State[App](w)
+					app := state(w)
 					app.LandingFrame++
 					if app.Screen == ScreenLanding {
 						logoTick(app)
@@ -96,7 +103,7 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 	if e.Type != gui.EventKeyDown {
 		return
 	}
-	app := gui.State[App](w)
+	app := state(w)
 	if app.Screen == ScreenLanding {
 		return
 	}
@@ -146,7 +153,7 @@ func startNewGame(app *App, diff Difficulty) {
 // --- View routing ---
 
 func mainView(w *gui.Window) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	if app.Screen == ScreenPlaying {
 		return gameView(w)
 	}
@@ -182,7 +189,7 @@ var numberColors = [9]gui.Color{
 // --- Landing page ---
 
 func landingView(w *gui.Window) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	theme := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFill,
@@ -225,8 +232,8 @@ func landingContent(w *gui.Window, app *App, theme gui.Theme) []gui.View {
 					Label:     "No-Guess",
 					TextStyle: ts(theme.M4, 14, colorDimText),
 					OnClick: func(ctx gui.EventCtx) {
-						gui.State[App](ctx.Window).NoGuessMode =
-							!gui.State[App](ctx.Window).NoGuessMode
+						state(ctx.Window).NoGuessMode =
+							!state(ctx.Window).NoGuessMode
 					},
 				}),
 				gui.Switch(gui.SwitchCfg{
@@ -235,8 +242,8 @@ func landingContent(w *gui.Window, app *App, theme gui.Theme) []gui.View {
 					Label:     "Training",
 					TextStyle: ts(theme.M4, 14, colorDimText),
 					OnClick: func(ctx gui.EventCtx) {
-						gui.State[App](ctx.Window).TrainingMode =
-							!gui.State[App](ctx.Window).TrainingMode
+						state(ctx.Window).TrainingMode =
+							!state(ctx.Window).TrainingMode
 					},
 				}),
 				gui.Switch(gui.SwitchCfg{
@@ -245,8 +252,8 @@ func landingContent(w *gui.Window, app *App, theme gui.Theme) []gui.View {
 					Label:     "Garden",
 					TextStyle: ts(theme.M4, 14, colorDimText),
 					OnClick: func(ctx gui.EventCtx) {
-						gui.State[App](ctx.Window).GardenTheme =
-							!gui.State[App](ctx.Window).GardenTheme
+						state(ctx.Window).GardenTheme =
+							!state(ctx.Window).GardenTheme
 					},
 				}),
 			},
@@ -285,7 +292,7 @@ func diffButton(w *gui.Window, title, subtitle string, diff Difficulty, color gu
 			}),
 		},
 		OnClick: func(ctx gui.EventCtx) {
-			startNewGame(gui.State[App](ctx.Window), diff)
+			startNewGame(state(ctx.Window), diff)
 		},
 	})
 }
@@ -487,7 +494,7 @@ func cellPxSize(d Difficulty) float32 {
 }
 
 func gameView(w *gui.Window) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	g := app.Game
 	theme := gui.CurrentTheme()
 	cellPx := cellPxSize(app.Difficulty)
@@ -559,7 +566,7 @@ func headerView(app *App, theme gui.Theme, boardW float32) gui.View {
 							}),
 						},
 						OnClick: func(ctx gui.EventCtx) {
-							resetGame(gui.State[App](ctx.Window))
+							resetGame(state(ctx.Window))
 						},
 					}),
 				},
@@ -791,7 +798,7 @@ func numContent(adj int, cellPx float32, theme gui.Theme) []gui.View {
 
 func cellClickHandler(row, col int) func(gui.EventCtx) {
 	return func(ctx gui.EventCtx) {
-		app := gui.State[App](ctx.Window)
+		app := state(ctx.Window)
 		g := app.Game
 		if g.State != GamePlaying {
 			return
@@ -862,14 +869,14 @@ func footerView(app *App, g *Game, theme gui.Theme) gui.View {
 	if g.State == GamePlaying {
 		buttons = []gui.View{
 			smallButton("Hint (H)", func(w *gui.Window) {
-				showHint(gui.State[App](w))
+				showHint(state(w))
 			}),
 			smallButton("Check (C)", func(w *gui.Window) {
-				a := gui.State[App](w)
+				a := state(w)
 				a.BadChecks = a.Game.CheckBoard()
 			}),
 			smallButton("Menu (Esc)", func(w *gui.Window) {
-				a := gui.State[App](w)
+				a := state(w)
 				a.Screen = ScreenLanding
 				a.TimerActive = false
 			}),
@@ -877,10 +884,10 @@ func footerView(app *App, g *Game, theme gui.Theme) gui.View {
 	} else {
 		buttons = []gui.View{
 			smallButton("New Game (R)", func(w *gui.Window) {
-				resetGame(gui.State[App](w))
+				resetGame(state(w))
 			}),
 			smallButton("Menu (Esc)", func(w *gui.Window) {
-				a := gui.State[App](w)
+				a := state(w)
 				a.Screen = ScreenLanding
 				a.TimerActive = false
 			}),

--- a/examples/particles/main.go
+++ b/examples/particles/main.go
@@ -71,6 +71,13 @@ type App struct {
 	EmitterType EmitterType
 }
 
+// state is the typed state accessor for this window. Callbacks
+// reach the app state through it instead of repeating
+// gui.State[App](...) at every site.
+func state(w *gui.Window) *App {
+	return gui.State[App](w)
+}
+
 const (
 	maxParticles = 5000
 	windowW      = 1100
@@ -115,7 +122,7 @@ func main() {
 				Delay:  tickDelay,
 				Repeat: true,
 				Callback: func(_ *gui.Animate, w *gui.Window) {
-					a := gui.State[App](w)
+					a := state(w)
 					a.LandingFrame++
 					if a.Screen == ScreenPlaying {
 						spawnParticles(&a.Particles, a, a.EmitterX, a.EmitterY)
@@ -137,7 +144,7 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 	if e.Type != gui.EventKeyDown {
 		return
 	}
-	app := gui.State[App](w)
+	app := state(w)
 	switch e.KeyCode {
 	case gui.KeyEscape:
 		if app.Screen == ScreenPlaying {
@@ -171,7 +178,7 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 // --- View routing ---
 
 func mainView(w *gui.Window) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	// Allowlisted viewport use: the particle field is simulated in pixel
 	// space and the play screen splits it against a fixed sidebar.
 	ww, wh := w.WindowSize()
@@ -184,7 +191,7 @@ func mainView(w *gui.Window) gui.View {
 // --- Landing page ---
 
 func landingView(w *gui.Window, ww, wh float32) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	theme := gui.CurrentTheme()
 	blink := app.LandingFrame%60 < 30
 
@@ -230,7 +237,7 @@ func landingView(w *gui.Window, ww, wh float32) gui.View {
 				SizeBorder: gui.SomeF(2),
 				Padding:    gui.NewPadding(14, 28, 14, 28),
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[App](ctx.Window)
+					a := state(ctx.Window)
 					a.Screen = ScreenPlaying
 				},
 				Content: []gui.View{
@@ -261,7 +268,7 @@ func landingView(w *gui.Window, ww, wh float32) gui.View {
 // --- Play view ---
 
 func playView(w *gui.Window, ww, wh float32) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	cw := ww - sidebarW
 	return gui.Row(gui.ContainerCfg{
 		Width:      ww,
@@ -285,14 +292,14 @@ func playView(w *gui.Window, ww, wh float32) gui.View {
 					dc.Line(ex, ey-8, ex, ey+8, xh, 1)
 				},
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[App](ctx.Window)
+					a := state(ctx.Window)
 					ox := ctx.Layout.Shape.X
 					oy := ctx.Layout.Shape.Y
 					a.EmitterX = ctx.Event.MouseX
 					a.EmitterY = ctx.Event.MouseY
 					ctx.Window.MouseLock(gui.MouseLockCfg{
 						MouseMove: func(ctx gui.EventCtx) {
-							a := gui.State[App](ctx.Window)
+							a := state(ctx.Window)
 							a.EmitterX = ctx.Event.MouseX - ox
 							a.EmitterY = ctx.Event.MouseY - oy
 						},
@@ -309,7 +316,7 @@ func playView(w *gui.Window, ww, wh float32) gui.View {
 // --- Sidebar ---
 
 func sidebarView(w *gui.Window, wh float32) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	theme := gui.CurrentTheme()
 	sectionSpacing := gui.SomeF(8)
 	sectionPadding := gui.NewPadding(10, 12, 10, 12)
@@ -339,7 +346,7 @@ func sidebarView(w *gui.Window, wh float32) gui.View {
 						Options:     []string{"Point", "Ring", "Line"},
 						FloatZIndex: 10,
 						OnSelect: func(sel []string, ctx gui.EventCtx) {
-							a := gui.State[App](ctx.Window)
+							a := state(ctx.Window)
 							switch sel[0] {
 							case "Ring":
 								a.EmitterType = EmitterRing
@@ -352,11 +359,11 @@ func sidebarView(w *gui.Window, wh float32) gui.View {
 					}),
 					sliderRow("Rate", "spawn-rate", app.SpawnRate, 1, 30, 1,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).SpawnRate = v
+							state(ctx.Window).SpawnRate = v
 						}),
 					sliderRow("Spread", "spread", app.SpreadAngle, 0, math.Pi, 0.1,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).SpreadAngle = v
+							state(ctx.Window).SpreadAngle = v
 						}),
 				},
 			}),
@@ -371,15 +378,15 @@ func sidebarView(w *gui.Window, wh float32) gui.View {
 				Content: []gui.View{
 					sliderRow("Gravity", "gravity", app.GravityY, -300, 300, 5,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).GravityY = v
+							state(ctx.Window).GravityY = v
 						}),
 					sliderRow("Wind", "wind", app.WindX, -200, 200, 5,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).WindX = v
+							state(ctx.Window).WindX = v
 						}),
 					sliderRow("Friction", "friction", app.Friction, 0.80, 1.00, 0.005,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).Friction = v
+							state(ctx.Window).Friction = v
 						}),
 				},
 			}),
@@ -397,20 +404,20 @@ func sidebarView(w *gui.Window, wh float32) gui.View {
 						ID:    "base-color",
 						Color: app.BaseColor,
 						OnColorChange: func(c gui.Color, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).BaseColor = c
+							state(ctx.Window).BaseColor = c
 						},
 					}),
 					sliderRow("Min Size", "size-min", app.SizeMin, 1, 10, 0.5,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).SizeMin = v
+							state(ctx.Window).SizeMin = v
 						}),
 					sliderRow("Max Size", "size-max", app.SizeMax, 1, 15, 0.5,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).SizeMax = v
+							state(ctx.Window).SizeMax = v
 						}),
 					sliderRow("Lifetime", "lifetime", app.Lifetime, 0.3, 8, 0.1,
 						func(v float32, ctx gui.EventCtx) {
-							gui.State[App](ctx.Window).Lifetime = v
+							state(ctx.Window).Lifetime = v
 						}),
 				},
 			}),
@@ -672,7 +679,7 @@ func presetBtn(_ *gui.Window, label string, color gui.Color,
 		Padding:    gui.NewPadding(6, 10, 6, 10),
 		Radius:     gui.SomeF(4),
 		OnClick: func(ctx gui.EventCtx) {
-			a := gui.State[App](ctx.Window)
+			a := state(ctx.Window)
 			apply(a)
 		},
 		Content: []gui.View{

--- a/examples/process_monitor/main.go
+++ b/examples/process_monitor/main.go
@@ -30,6 +30,13 @@ type App struct {
 	TreeMode    bool
 }
 
+// state is the typed state accessor for this window. Callbacks
+// reach the app state through it instead of repeating
+// state(...) at every site.
+func state(w *gui.Window) *App {
+	return gui.State[App](w)
+}
+
 // Sample interval presets shown by the toolbar radio group.
 var intervalLabels = []string{"0.5s", "1s", "2s", "5s"}
 
@@ -79,7 +86,7 @@ func startSampler(w *gui.Window) {
 			snap, err := Collect()
 
 			w.Lock()
-			app := gui.State[App](w)
+			app := state(w)
 			app.Snapshot = snap
 			app.Err = err
 			if snap != nil {

--- a/examples/process_monitor/view.go
+++ b/examples/process_monitor/view.go
@@ -134,7 +134,7 @@ func lessRSS(a, b *Process) bool {
 // rootView is registered once in OnInit; the sampler goroutine re-runs it each
 // refresh via Window.UpdateWindow.
 func rootView(w *gui.Window) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	theme := gui.CurrentTheme()
 
 	return gui.Column(gui.ContainerCfg{
@@ -257,7 +257,7 @@ func toolbarView(app *App) gui.View {
 				Text:        app.Filter,
 				Placeholder: "name, command, user, or PID",
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
-					gui.State[App](ctx.Window).Filter = text
+					state(ctx.Window).Filter = text
 				},
 			}),
 			spacer(),
@@ -279,7 +279,7 @@ func viewModeRadio(app *App) gui.View {
 		Items: []string{"Flat", "Tree"},
 		Value: value,
 		OnSelect: func(v string, ctx gui.EventCtx) {
-			gui.State[App](ctx.Window).TreeMode = v == "Tree"
+			state(ctx.Window).TreeMode = v == "Tree"
 		},
 	})
 }
@@ -290,7 +290,7 @@ func intervalRadio(app *App) gui.View {
 		Items: intervalLabels,
 		Value: intervalLabel(app.Interval),
 		OnSelect: func(v string, ctx gui.EventCtx) {
-			gui.State[App](ctx.Window).Interval = intervalFromLabel(v)
+			state(ctx.Window).Interval = intervalFromLabel(v)
 		},
 	})
 }
@@ -365,7 +365,7 @@ func headerCell(col column, idx int, app *App) gui.View {
 		Padding: gui.NewPadding(0, 6, 0, 6),
 		Content: []gui.View{gui.Text(gui.TextCfg{Text: label, TextStyle: theme.B6, Clip: true})},
 		OnClick: func(ctx gui.EventCtx) {
-			a := gui.State[App](ctx.Window)
+			a := state(ctx.Window)
 			if a.Sort.Column == idx {
 				a.Sort.Desc = !a.Sort.Desc
 			} else {
@@ -406,7 +406,7 @@ func processRow(p *Process, app *App, i int) gui.View {
 		VAlign:  gui.VAlignMiddle,
 		Content: cells,
 		OnClick: func(ctx gui.EventCtx) {
-			gui.State[App](ctx.Window).Selected = p
+			state(ctx.Window).Selected = p
 		},
 	})
 }

--- a/examples/showcase/catalog.go
+++ b/examples/showcase/catalog.go
@@ -8,7 +8,7 @@ import (
 
 func catalogPanel(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	entries := filteredEntries(app)
 
 	switch {
@@ -62,7 +62,7 @@ func catalogPanel(w *gui.Window) gui.View {
 							if !ok {
 								return
 							}
-							syncThemeGenFromCfg(gui.State[ShowcaseApp](ctx.Window), theme.Cfg)
+							syncThemeGenFromCfg(appState(ctx.Window), theme.Cfg)
 						},
 					}),
 				},
@@ -78,7 +78,7 @@ func searchInput(app *ShowcaseApp) gui.View {
 		Text:        app.NavQuery,
 		Placeholder: "Search controls...",
 		OnTextChanged: func(text string, ctx gui.EventCtx) {
-			gui.State[ShowcaseApp](ctx.Window).NavQuery = text
+			appState(ctx.Window).NavQuery = text
 		},
 	})
 }
@@ -123,7 +123,7 @@ func groupPickerItem(label, key string, app *ShowcaseApp) gui.View {
 			gui.Text(gui.TextCfg{Text: label, TextStyle: t.N5}),
 		},
 		OnClick: func(ctx gui.EventCtx) {
-			showcaseApp := gui.State[ShowcaseApp](ctx.Window)
+			showcaseApp := appState(ctx.Window)
 			showcaseApp.SelectedGroup = key
 			showcaseApp.ShowDocs = false
 			showcaseApp.NavQuery = ""
@@ -197,7 +197,7 @@ func catalogRow(entry DemoEntry, app *ShowcaseApp) gui.View {
 			gui.Text(gui.TextCfg{Text: entry.Label, TextStyle: t.N4}),
 		},
 		OnClick: func(ctx gui.EventCtx) {
-			showcaseApp := gui.State[ShowcaseApp](ctx.Window)
+			showcaseApp := appState(ctx.Window)
 			showcaseApp.SelectedComponent = entry.ID
 			showcaseApp.ShowDocs = false
 			ctx.Window.ScrollVerticalTo(scrollDetail, 0)
@@ -220,7 +220,7 @@ func toggleLocale(app *ShowcaseApp) gui.View {
 			}),
 		},
 		OnClick: func(ctx gui.EventCtx) {
-			showcaseApp := gui.State[ShowcaseApp](ctx.Window)
+			showcaseApp := appState(ctx.Window)
 			showcaseApp.LocaleIndex = (showcaseApp.LocaleIndex + 1) % localeCount()
 			if locale, ok := showcaseLocaleAt(showcaseApp.LocaleIndex); ok {
 				ctx.Window.SetLocale(locale)

--- a/examples/showcase/demo_animations.go
+++ b/examples/showcase/demo_animations.go
@@ -8,7 +8,7 @@ import (
 
 func demoAnimations(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -63,14 +63,14 @@ func animTweenDemo(t gui.Theme, app *ShowcaseApp) gui.View {
 						Padding: gui.NewPadding(6, 16, 6, 16),
 						Content: []gui.View{gui.Text(gui.TextCfg{Text: "Animate", TextStyle: t.N3})},
 						OnClick: func(ctx gui.EventCtx) {
-							app := gui.State[ShowcaseApp](ctx.Window)
+							app := appState(ctx.Window)
 							target := float32(300)
 							if app.AnimTweenX > 100 {
 								target = 0
 							}
 							a := gui.NewTweenAnimation("showcase-tween", app.AnimTweenX, target,
 								func(v float32, w *gui.Window) {
-									gui.State[ShowcaseApp](w).AnimTweenX = v
+									appState(w).AnimTweenX = v
 								})
 							ctx.Window.AnimationAdd(a)
 						},
@@ -120,14 +120,14 @@ func animSpringDemo(t gui.Theme, app *ShowcaseApp) gui.View {
 						Padding: gui.NewPadding(6, 16, 6, 16),
 						Content: []gui.View{gui.Text(gui.TextCfg{Text: "Spring", TextStyle: t.N3})},
 						OnClick: func(ctx gui.EventCtx) {
-							app := gui.State[ShowcaseApp](ctx.Window)
+							app := appState(ctx.Window)
 							target := float32(300)
 							if app.AnimSpringX > 100 {
 								target = 0
 							}
 							a := gui.NewSpringAnimation("showcase-spring",
 								func(v float32, w *gui.Window) {
-									gui.State[ShowcaseApp](w).AnimSpringX = v
+									appState(w).AnimSpringX = v
 								})
 							a.SpringTo(app.AnimSpringX, target)
 							ctx.Window.AnimationAdd(a)
@@ -187,7 +187,7 @@ func animKeyframeDemo(t gui.Theme, app *ShowcaseApp) gui.View {
 									{At: 1.0, Value: 0, Easing: gui.EaseOutCubic},
 								},
 								func(v float32, w *gui.Window) {
-									gui.State[ShowcaseApp](w).AnimKeyframeX = v
+									appState(w).AnimKeyframeX = v
 								})
 							ctx.Window.AnimationAdd(a)
 						},

--- a/examples/showcase/demo_audio.go
+++ b/examples/showcase/demo_audio.go
@@ -21,7 +21,7 @@ var (
 
 func demoAudio(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -143,7 +143,7 @@ func demoAudio(w *gui.Window) gui.View {
 						},
 						OnClick: func(ctx gui.EventCtx) {
 							audio.HaltChannel(0)
-							app := gui.State[ShowcaseApp](ctx.Window)
+							app := appState(ctx.Window)
 							app.AudioStatus = "Ch 0 halted"
 						},
 					}),
@@ -241,7 +241,7 @@ func demoAudio(w *gui.Window) gui.View {
 						Max:    100,
 						Sizing: gui.FillFit,
 						OnChange: func(v float32, ctx gui.EventCtx) {
-							a := gui.State[ShowcaseApp](ctx.Window)
+							a := appState(ctx.Window)
 							a.AudioVolume = float64(v) / 100
 							audio.SetMasterVolume(a.AudioVolume)
 						},
@@ -265,7 +265,7 @@ func demoAudio(w *gui.Window) gui.View {
 }
 
 func ensureAudioInit(w *gui.Window) bool {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if app.AudioReady {
 		return true
 	}
@@ -285,7 +285,7 @@ func playBeep(w *gui.Window) {
 	if !ensureAudioInit(w) {
 		return
 	}
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if beepSound == nil {
 		wav := generateWAV(440, 0.25, 44100)
 		snd, err := audio.LoadSoundBytes(wav)
@@ -306,7 +306,7 @@ func playHighTone(w *gui.Window) {
 	if !ensureAudioInit(w) {
 		return
 	}
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if highSound == nil {
 		wav := generateWAV(880, 0.25, 44100)
 		snd, err := audio.LoadSoundBytes(wav)
@@ -327,7 +327,7 @@ func fadeInBeep(w *gui.Window) {
 	if !ensureAudioInit(w) {
 		return
 	}
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if beepSound == nil {
 		wav := generateWAV(440, 0.25, 44100)
 		snd, err := audio.LoadSoundBytes(wav)
@@ -348,7 +348,7 @@ func playOnChannel(w *gui.Window, channel int) {
 	if !ensureAudioInit(w) {
 		return
 	}
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if highSound == nil {
 		wav := generateWAV(880, 0.5, 44100)
 		snd, err := audio.LoadSoundBytes(wav)
@@ -372,7 +372,7 @@ func loadMusicDemo(w *gui.Window) {
 	if !ensureAudioInit(w) {
 		return
 	}
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	cleanupMusic(w)
 	wav := generateWAV(660, 3, 44100)
 	tmp, err := os.CreateTemp("", "showcase-audio-*.wav")
@@ -398,7 +398,7 @@ func loadMusicDemo(w *gui.Window) {
 }
 
 func playMusic(w *gui.Window) {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if musicTrack == nil {
 		app.AudioStatus = "Load music first"
 		return
@@ -413,7 +413,7 @@ func playMusic(w *gui.Window) {
 }
 
 func fadeOutMusic(w *gui.Window) {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if !app.AudioMusicPlaying {
 		app.AudioStatus = "No music to fade out"
 		return
@@ -425,7 +425,7 @@ func fadeOutMusic(w *gui.Window) {
 
 func stopMusic(w *gui.Window) {
 	audio.HaltMusic()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	app.AudioMusicPlaying = false
 	app.AudioMusicPaused = false
 	app.AudioStatus = "Music stopped"
@@ -441,7 +441,7 @@ func cleanupMusic(w *gui.Window) {
 		_ = os.Remove(musicPath)
 		musicPath = ""
 	}
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	app.AudioMusicLoaded = false
 	app.AudioMusicPlaying = false
 }

--- a/examples/showcase/demo_data.go
+++ b/examples/showcase/demo_data.go
@@ -26,7 +26,7 @@ const showcaseDataGridFeaturesSource = `# Data Grid Features
 - Clipboard and export helpers`
 
 func demoTable(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	rows := showcaseTableRowsSorted(app.TableSortBy)
 	cfg := gui.TableCfgFromData(rows)
 	cfg.ID = "catalog-table"
@@ -42,7 +42,7 @@ func demoTable(w *gui.Window) gui.View {
 	cfg.FreezeHeader = app.TableFreezeHeader
 	cfg.Selected = app.TableSelected
 	cfg.OnSelect = func(sel map[int]bool, _ int, ctx gui.EventCtx) {
-		gui.State[ShowcaseApp](ctx.Window).TableSelected = sel
+		appState(ctx.Window).TableSelected = sel
 	}
 
 	if cfg.BorderStyle == gui.TableBorderNone {
@@ -64,7 +64,7 @@ func demoTable(w *gui.Window) gui.View {
 			Value:    label,
 			HeadCell: true,
 			OnClick: func(ctx gui.EventCtx) {
-				app := gui.State[ShowcaseApp](ctx.Window)
+				app := appState(ctx.Window)
 				switch app.TableSortBy {
 				case col:
 					app.TableSortBy = -col
@@ -111,7 +111,7 @@ func demoTable(w *gui.Window) gui.View {
 							gui.NewRadioOption("None", "none"),
 						},
 						OnSelect: func(value string, ctx gui.EventCtx) {
-							gui.State[ShowcaseApp](ctx.Window).TableBorderStyle = value
+							appState(ctx.Window).TableBorderStyle = value
 						},
 					}),
 					gui.Column(gui.ContainerCfg{
@@ -124,7 +124,7 @@ func demoTable(w *gui.Window) gui.View {
 								Label:    "Multi-select",
 								Selected: app.TableMultiSelect,
 								OnClick: func(ctx gui.EventCtx) {
-									a := gui.State[ShowcaseApp](ctx.Window)
+									a := appState(ctx.Window)
 									a.TableMultiSelect = !a.TableMultiSelect
 									a.TableSelected = nil
 								},
@@ -134,7 +134,7 @@ func demoTable(w *gui.Window) gui.View {
 								Label:    "Freeze header",
 								Selected: app.TableFreezeHeader,
 								OnClick: func(ctx gui.EventCtx) {
-									gui.State[ShowcaseApp](ctx.Window).TableFreezeHeader = !app.TableFreezeHeader
+									appState(ctx.Window).TableFreezeHeader = !app.TableFreezeHeader
 								},
 							}),
 						},
@@ -154,7 +154,7 @@ func demoTable(w *gui.Window) gui.View {
 }
 
 func demoDataGrid(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	rows := showcaseDataGridApplyQuery(showcaseDataGridRows(), app.DataGridQuery)
 	gridFeaturesStyle := gui.DefaultMarkdownStyle()
 	gridFeaturesStyle.CodeHighlighter = highlight.Default()
@@ -183,10 +183,10 @@ func demoDataGrid(w *gui.Window) gui.View {
 				ShowFilterRow:     true,
 				ShowColumnChooser: true,
 				OnQueryChange: func(query datagrid.GridQueryState, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).DataGridQuery = query
+					appState(ctx.Window).DataGridQuery = query
 				},
 				OnSelectionChange: func(selection datagrid.GridSelection, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).DataGridSelection = selection
+					appState(ctx.Window).DataGridSelection = selection
 				},
 			}),
 			w.Markdown(gui.MarkdownCfg{
@@ -199,7 +199,7 @@ func demoDataGrid(w *gui.Window) gui.View {
 }
 
 func demoDataSource(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if app.DataSource == nil {
 		app.DataSource = datagrid.NewInMemoryDataSource(showcaseDataSourceRows())
 	}
@@ -230,10 +230,10 @@ func demoDataSource(w *gui.Window) gui.View {
 				Selection:       app.DataSourceSelection,
 				MaxHeight:       260,
 				OnQueryChange: func(query datagrid.GridQueryState, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).DataSourceQuery = query
+					appState(ctx.Window).DataSourceQuery = query
 				},
 				OnSelectionChange: func(selection datagrid.GridSelection, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).DataSourceSelection = selection
+					appState(ctx.Window).DataSourceSelection = selection
 				},
 			}),
 			gui.Text(gui.TextCfg{Text: "- DataGridDataSource interface for async backends"}),
@@ -244,7 +244,7 @@ func demoDataSource(w *gui.Window) gui.View {
 }
 
 func demoTree(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -492,13 +492,13 @@ func showcaseBigTreeNodes() []gui.TreeNodeCfg {
 }
 
 func showcaseTreeOnSelect(id string, ctx gui.EventCtx) {
-	gui.State[ShowcaseApp](ctx.Window).TreeSelected = id
+	appState(ctx.Window).TreeSelected = id
 }
 
 func showcaseTreeOnLazyLoad(_ string, nodeID string, w *gui.Window) {
 	// Capture abort counter now (under w.mu) so the goroutine can
 	// detect navigation-away before applying its result.
-	abortAt := gui.State[ShowcaseApp](w).TreeLazyLoadAbort
+	abortAt := appState(w).TreeLazyLoadAbort
 	go func() {
 		time.Sleep(800 * time.Millisecond)
 
@@ -520,7 +520,7 @@ func showcaseTreeOnLazyLoad(_ string, nodeID string, w *gui.Window) {
 		}
 
 		w.QueueCommand(func(w *gui.Window) {
-			app := gui.State[ShowcaseApp](w)
+			app := appState(w)
 			if app.TreeLazyLoadAbort != abortAt {
 				return // navigated away; discard stale result
 			}

--- a/examples/showcase/demo_dock_layout.go
+++ b/examples/showcase/demo_dock_layout.go
@@ -13,7 +13,7 @@ func dockInitialLayout() *gui.DockNode {
 }
 
 func demoDockLayout(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	if app.DockRoot == nil {
 		app.DockRoot = dockInitialLayout()
 	}
@@ -31,14 +31,14 @@ func demoDockLayout(w *gui.Window) gui.View {
 				Root:   app.DockRoot,
 				Panels: dockPanels(),
 				OnLayoutChange: func(root *gui.DockNode, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).DockRoot = root
+					appState(ctx.Window).DockRoot = root
 				},
 				OnPanelSelect: func(groupID string, panelID string, ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.DockRoot = gui.DockTreeSelectPanel(a.DockRoot, groupID, panelID)
 				},
 				OnPanelClose: func(panelID string, ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.DockRoot = gui.DockTreeRemovePanel(a.DockRoot, panelID)
 				},
 			}),
@@ -57,14 +57,14 @@ func dockToolbar(_ *ShowcaseApp) gui.View {
 				ID:      "demo_dock_layout_reset",
 				Content: []gui.View{gui.Text(gui.TextCfg{Text: "Reset"})},
 				OnClick: func(ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).DockRoot = dockInitialLayout()
+					appState(ctx.Window).DockRoot = dockInitialLayout()
 				},
 			}),
 			gui.Button(gui.ButtonCfg{
 				ID:      "demo_dock_layout_add_properties",
 				Content: []gui.View{gui.Text(gui.TextCfg{Text: "Add Properties"})},
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					if _, ok := gui.DockTreeFindGroupByPanel(a.DockRoot, "properties"); ok {
 						ctx.Consume()
 						return

--- a/examples/showcase/demo_feedback.go
+++ b/examples/showcase/demo_feedback.go
@@ -10,7 +10,7 @@ import (
 )
 
 func demoButton(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(8),
@@ -31,7 +31,7 @@ func demoButton(w *gui.Window) gui.View {
 }
 
 func buttonFeatureRows(w *gui.Window) []gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	buttonText := fmt.Sprintf("%d Clicks Given", app.ButtonClicks)
 	buttonWidth := float32(160)
 	progress := float32(math.Mod(float64(app.ButtonClicks)/25.0, 1.0))
@@ -94,7 +94,7 @@ func buttonFeatureRows(w *gui.Window) []gui.View {
 			Content:  []gui.View{gui.Text(gui.TextCfg{Text: copyLabel})},
 			OnClick: func(ctx gui.EventCtx) {
 				incrementButtonClicks(ctx.Window)
-				gui.State[ShowcaseApp](ctx.Window).ButtonCopyUntil = time.Now().Add(2 * time.Second)
+				appState(ctx.Window).ButtonCopyUntil = time.Now().Add(2 * time.Second)
 			},
 		})),
 	}
@@ -114,7 +114,7 @@ func buttonFeatureRow(label string, button gui.View) gui.View {
 }
 
 func incrementButtonClicks(w *gui.Window) {
-	gui.State[ShowcaseApp](w).ButtonClicks++
+	appState(w).ButtonClicks++
 }
 
 func showcaseButtonClick(ctx gui.EventCtx) {
@@ -198,7 +198,7 @@ func demoBadge(_ *gui.Window) gui.View {
 }
 
 func demoCommandButton(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -226,7 +226,7 @@ func demoCommandButton(w *gui.Window) gui.View {
 }
 
 func demoThemePicker(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	result := app.ThemePickerResult
 	if result == "" {
@@ -247,7 +247,7 @@ func demoThemePicker(w *gui.Window) gui.View {
 				FloatAnchor: gui.FloatBottomLeft,
 				FloatTieOff: gui.FloatTopLeft,
 				OnSelect: func(name string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).ThemePickerResult = name
+					appState(ctx.Window).ThemePickerResult = name
 				},
 			}),
 			gui.Text(gui.TextCfg{

--- a/examples/showcase/demo_gesture.go
+++ b/examples/showcase/demo_gesture.go
@@ -9,7 +9,7 @@ import (
 
 func demoGesture(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	if app.GesturePadLabel == "" {
 		app.GesturePadLabel = "Touch or click the pad"
@@ -39,7 +39,7 @@ func demoGesture(w *gui.Window) gui.View {
 				Clip:    true,
 				OnDraw:  gestureOnDraw(app),
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.GesturePadMarkers = append(
 						a.GesturePadMarkers,
 						GestureMarker{X: ctx.Event.MouseX, Y: ctx.Event.MouseY},
@@ -49,7 +49,7 @@ func demoGesture(w *gui.Window) gui.View {
 					a.GesturePadVersion++
 				},
 				OnGesture: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					gestureOnGesture(a, ctx.Event)
 				},
 			}),

--- a/examples/showcase/demo_graphics.go
+++ b/examples/showcase/demo_graphics.go
@@ -698,7 +698,7 @@ func demoDrawCanvas(w *gui.Window) gui.View {
 	chartData := []float32{2, 5, 3, 8, 6, 4, 7, 9, 5, 10, 8, 6, 11, 7}
 	barData := []float32{40, 65, 50, 80, 55, 70}
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	return gui.Column(gui.ContainerCfg{
 		Sizing:     gui.FillFit,
@@ -789,7 +789,7 @@ func demoDrawCanvasInteractive(app *ShowcaseApp) gui.View {
 				"arrow keys move marker", hint)
 		},
 		OnKeyDown: func(ctx gui.EventCtx) {
-			app := gui.State[ShowcaseApp](ctx.Window)
+			app := appState(ctx.Window)
 			dx, dy := float32(0), float32(0)
 			switch ctx.Event.KeyCode {
 			case gui.KeyLeft:
@@ -1049,7 +1049,7 @@ func demoShader(w *gui.Window) gui.View {
 	})
 
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	elapsed := float32(time.Since(app.ShaderStartTime).Milliseconds()) / 1000.0
 
 	return gui.Column(gui.ContainerCfg{

--- a/examples/showcase/demo_input.go
+++ b/examples/showcase/demo_input.go
@@ -10,7 +10,7 @@ import (
 
 func demoInput(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -27,7 +27,7 @@ func demoInput(w *gui.Window) gui.View {
 				Label:    "Spell Check",
 				Selected: app.InputSpellCheck,
 				OnClick: func(ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).InputSpellCheck = !gui.State[ShowcaseApp](ctx.Window).InputSpellCheck
+					appState(ctx.Window).InputSpellCheck = !appState(ctx.Window).InputSpellCheck
 				},
 			}),
 			labeledRow(t, "Text", gui.Input(gui.InputCfg{
@@ -37,7 +37,7 @@ func demoInput(w *gui.Window) gui.View {
 				Placeholder: "Enter text...",
 				SpellCheck:  app.InputSpellCheck,
 				OnTextChanged: func(s string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).InputText = s
+					appState(ctx.Window).InputText = s
 				},
 			})),
 			labeledRow(t, "Password", gui.Input(gui.InputCfg{
@@ -47,7 +47,7 @@ func demoInput(w *gui.Window) gui.View {
 				Placeholder: "Enter password...",
 				IsPassword:  true,
 				OnTextChanged: func(s string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).InputPassword = s
+					appState(ctx.Window).InputPassword = s
 				},
 			})),
 			labeledRow(t, "Phone", gui.Input(gui.InputCfg{
@@ -57,7 +57,7 @@ func demoInput(w *gui.Window) gui.View {
 				Placeholder: "(555) 000-0000",
 				MaskPreset:  gui.MaskPhoneUS,
 				OnTextChanged: func(s string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).InputPhone = s
+					appState(ctx.Window).InputPhone = s
 				},
 			})),
 			labeledRow(t, "Expiry", gui.Input(gui.InputCfg{
@@ -67,7 +67,7 @@ func demoInput(w *gui.Window) gui.View {
 				Placeholder: "MM/YY",
 				MaskPreset:  gui.MaskExpiryMMYY,
 				OnTextChanged: func(s string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).InputExpiry = s
+					appState(ctx.Window).InputExpiry = s
 				},
 			})),
 			labeledRow(t, "Multiline", gui.Input(gui.InputCfg{
@@ -79,7 +79,7 @@ func demoInput(w *gui.Window) gui.View {
 				Height:      90,
 				SpellCheck:  app.InputSpellCheck,
 				OnTextChanged: func(s string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).InputMultiline = s
+					appState(ctx.Window).InputMultiline = s
 				},
 			})),
 		},
@@ -87,7 +87,7 @@ func demoInput(w *gui.Window) gui.View {
 }
 
 func demoNumericInput(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	titleStyle := gui.CurrentTheme().B3
 	bodyStyle := gui.CurrentTheme().N3
 
@@ -107,10 +107,10 @@ func demoNumericInput(w *gui.Window) gui.View {
 				Width:    220,
 				Sizing:   gui.FixedFit,
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).NumericENText = text
+					appState(ctx.Window).NumericENText = text
 				},
 				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					app.NumericENValue = value
 					app.NumericENText = text
 				},
@@ -132,10 +132,10 @@ func demoNumericInput(w *gui.Window) gui.View {
 				Width:  220,
 				Sizing: gui.FixedFit,
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).NumericDEText = text
+					appState(ctx.Window).NumericDEText = text
 				},
 				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					app.NumericDEValue = value
 					app.NumericDEText = text
 				},
@@ -154,10 +154,10 @@ func demoNumericInput(w *gui.Window) gui.View {
 				Width:    220,
 				Sizing:   gui.FixedFit,
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).NumericCurrencyText = text
+					appState(ctx.Window).NumericCurrencyText = text
 				},
 				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					app.NumericCurrencyValue = value
 					app.NumericCurrencyText = text
 				},
@@ -176,10 +176,10 @@ func demoNumericInput(w *gui.Window) gui.View {
 				Width:    220,
 				Sizing:   gui.FixedFit,
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).NumericPercentText = text
+					appState(ctx.Window).NumericPercentText = text
 				},
 				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					app.NumericPercentValue = value
 					app.NumericPercentText = text
 				},
@@ -198,10 +198,10 @@ func demoNumericInput(w *gui.Window) gui.View {
 				Width:  220,
 				Sizing: gui.FixedFit,
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).NumericPlainText = text
+					appState(ctx.Window).NumericPlainText = text
 				},
 				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					app.NumericPlainValue = value
 					app.NumericPlainText = text
 				},
@@ -212,7 +212,7 @@ func demoNumericInput(w *gui.Window) gui.View {
 }
 
 func demoColorPicker(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	c := app.ColorPickerColor
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -224,7 +224,7 @@ func demoColorPicker(w *gui.Window) gui.View {
 				Label:    "Show HSL",
 				Selected: app.ColorPickerHSL,
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.ColorPickerHSL = !a.ColorPickerHSL
 				},
 			}),
@@ -233,7 +233,7 @@ func demoColorPicker(w *gui.Window) gui.View {
 				Color:   c,
 				ShowHSL: app.ColorPickerHSL,
 				OnColorChange: func(color gui.Color, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).ColorPickerColor = color
+					appState(ctx.Window).ColorPickerColor = color
 				},
 			}),
 			gui.Text(gui.TextCfg{
@@ -254,7 +254,7 @@ func demoColorPicker(w *gui.Window) gui.View {
 // and reads it back, so they stay in sync with no state of their own.
 func demoColorComponents(app *ShowcaseApp) gui.View {
 	set := func(v gui.HSLA, ctx gui.EventCtx) {
-		gui.State[ShowcaseApp](ctx.Window).ColorHSLA = v
+		appState(ctx.Window).ColorHSLA = v
 	}
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -313,7 +313,7 @@ func demoColorComponents(app *ShowcaseApp) gui.View {
 }
 
 func demoDatePicker(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	selected := "none"
 	if len(app.DatePickerDates) > 0 {
 		parts := make([]string, 0, len(app.DatePickerDates))
@@ -338,7 +338,7 @@ func demoDatePicker(w *gui.Window) gui.View {
 						Dates:          app.DatePickerDates,
 						SelectMultiple: true,
 						OnSelect: func(dates []time.Time, ctx gui.EventCtx) {
-							gui.State[ShowcaseApp](ctx.Window).DatePickerDates = append([]time.Time(nil), dates...)
+							appState(ctx.Window).DatePickerDates = append([]time.Time(nil), dates...)
 						},
 					}),
 				},
@@ -352,7 +352,7 @@ func demoDatePicker(w *gui.Window) gui.View {
 }
 
 func demoDatePickerRoller(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(10),
@@ -363,7 +363,7 @@ func demoDatePickerRoller(w *gui.Window) gui.View {
 				Focusable:    true,
 				SelectedDate: app.RollerDate,
 				OnChange: func(date time.Time, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).RollerDate = date
+					appState(ctx.Window).RollerDate = date
 				},
 			}),
 			gui.Text(gui.TextCfg{
@@ -375,7 +375,7 @@ func demoDatePickerRoller(w *gui.Window) gui.View {
 }
 
 func demoInputDate(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FitFit,
 		Spacing: gui.SomeF(10),
@@ -390,7 +390,7 @@ func demoInputDate(w *gui.Window) gui.View {
 					if len(dates) == 0 {
 						return
 					}
-					gui.State[ShowcaseApp](ctx.Window).InputDate = dates[0]
+					appState(ctx.Window).InputDate = dates[0]
 				},
 			}),
 			gui.Text(gui.TextCfg{
@@ -402,7 +402,7 @@ func demoInputDate(w *gui.Window) gui.View {
 }
 
 func demoForms(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	form := &app.Form
 
 	// Register fields each frame so the form runtime tracks them.
@@ -423,14 +423,14 @@ func demoForms(w *gui.Window) gui.View {
 		Spacing: gui.SomeF(12),
 		Padding: gui.NoPadding,
 		OnSubmit: func(e gui.FormSubmitEvent, ctx gui.EventCtx) {
-			app := gui.State[ShowcaseApp](ctx.Window)
+			app := appState(ctx.Window)
 			app.Form.SubmitMessage = fmt.Sprintf(
 				"Submitted username=%s, email=%s",
 				strings.TrimSpace(e.Values["username"]),
 				strings.TrimSpace(e.Values["email"]))
 		},
 		OnReset: func(e gui.FormResetEvent, ctx gui.EventCtx) {
-			app := gui.State[ShowcaseApp](ctx.Window)
+			app := appState(ctx.Window)
 			app.Form.Username = e.Values["username"]
 			app.Form.Email = e.Values["email"]
 			app.Form.AgeText = e.Values["age"]
@@ -445,11 +445,11 @@ func demoForms(w *gui.Window) gui.View {
 				Text:        form.Username,
 				Placeholder: "username",
 				OnTextChanged: func(s string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).Form.Username = s
+					appState(ctx.Window).Form.Username = s
 					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, usernameAdapterCfg(s), gui.FormTriggerChange)
 				},
 				OnBlur: func(ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, usernameAdapterCfg(app.Form.Username), gui.FormTriggerBlur)
 				},
 			})),
@@ -463,11 +463,11 @@ func demoForms(w *gui.Window) gui.View {
 				Text:        form.Email,
 				Placeholder: "user@example.com",
 				OnTextChanged: func(s string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).Form.Email = s
+					appState(ctx.Window).Form.Email = s
 					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, emailAdapterCfg(s), gui.FormTriggerChange)
 				},
 				OnBlur: func(ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, emailAdapterCfg(app.Form.Email), gui.FormTriggerBlur)
 				},
 			})),
@@ -484,11 +484,11 @@ func demoForms(w *gui.Window) gui.View {
 				Text:     form.AgeText,
 				Value:    form.AgeValue,
 				OnTextChanged: func(text string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).Form.AgeText = text
+					appState(ctx.Window).Form.AgeText = text
 					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, ageAdapterCfg(text), gui.FormTriggerChange)
 				},
 				OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-					app := gui.State[ShowcaseApp](ctx.Window)
+					app := appState(ctx.Window)
 					app.Form.AgeValue = value
 					app.Form.AgeText = text
 					gui.FormOnFieldEvent(ctx.Window, ctx.Layout, ageAdapterCfg(text), gui.FormTriggerBlur)

--- a/examples/showcase/demo_layout.go
+++ b/examples/showcase/demo_layout.go
@@ -213,7 +213,7 @@ func demoOverflowPanel(w *gui.Window) gui.View {
 
 func demoExpandPanel(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
@@ -234,7 +234,7 @@ func demoExpandPanel(w *gui.Window) gui.View {
 					},
 				}),
 				OnToggle: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.ExpandOpen = !a.ExpandOpen
 				},
 			}),
@@ -244,7 +244,7 @@ func demoExpandPanel(w *gui.Window) gui.View {
 
 func demoSidebar(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
@@ -257,7 +257,7 @@ func demoSidebar(w *gui.Window) gui.View {
 					gui.Text(gui.TextCfg{Text: "Toggle Sidebar", TextStyle: t.N3}),
 				},
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.SidebarOpen = !a.SidebarOpen
 				},
 			}),
@@ -300,7 +300,7 @@ func demoSidebar(w *gui.Window) gui.View {
 }
 
 func demoSplitter(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	mainRatio := int(app.SplitterMainState.Ratio * 100)
 	detailRatio := int(app.SplitterDetailState.Ratio * 100)
@@ -337,7 +337,7 @@ func demoSplitter(w *gui.Window) gui.View {
 }
 
 func showcaseSplitterMain(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Splitter(gui.SplitterCfg{
 		ID:          "catalog-splitter-main",
 		Focusable:   true,
@@ -363,7 +363,7 @@ func showcaseSplitterMain(w *gui.Window) gui.View {
 }
 
 func showcaseSplitterDetail(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Splitter(gui.SplitterCfg{
 		ID:                  "catalog-splitter-detail",
 		Focusable:           true,
@@ -431,7 +431,7 @@ func showcaseSplitterPane(title, note string, accent gui.Color) gui.View {
 }
 
 func onShowcaseSplitterMainChange(ratio float32, collapsed gui.SplitterCollapsed, ctx gui.EventCtx) {
-	app := gui.State[ShowcaseApp](ctx.Window)
+	app := appState(ctx.Window)
 	app.SplitterMainState = gui.SplitterStateNormalize(gui.SplitterState{
 		Ratio:     ratio,
 		Collapsed: collapsed,
@@ -439,7 +439,7 @@ func onShowcaseSplitterMainChange(ratio float32, collapsed gui.SplitterCollapsed
 }
 
 func onShowcaseSplitterDetailChange(ratio float32, collapsed gui.SplitterCollapsed, ctx gui.EventCtx) {
-	app := gui.State[ShowcaseApp](ctx.Window)
+	app := appState(ctx.Window)
 	app.SplitterDetailState = gui.SplitterStateNormalize(gui.SplitterState{
 		Ratio:     ratio,
 		Collapsed: collapsed,
@@ -515,7 +515,7 @@ type multiWindowChildState struct {
 
 func demoMultiWindow(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	childActive := app.MultiWindowChildID != 0 &&
 		w.App() != nil &&
@@ -559,7 +559,7 @@ func demoMultiWindow(w *gui.Window) gui.View {
 						Width:  320,
 						Height: 220,
 						OnInit: func(child *gui.Window) {
-							sa := gui.State[ShowcaseApp](parent)
+							sa := appState(parent)
 							sa.MultiWindowChildID = child.PlatformID()
 							parent.UpdateWindow()
 							child.UpdateView(multiWindowChildView(parent))
@@ -600,7 +600,7 @@ func multiWindowChildView(parent *gui.Window) func(*gui.Window) gui.View {
 						cs := gui.State[multiWindowChildState](ctx.Window)
 						cs.Message = "Sent!"
 						parent.QueueCommand(func(p *gui.Window) {
-							gui.State[ShowcaseApp](p).DialogResult =
+							appState(p).DialogResult =
 								"Hello from child window"
 							p.UpdateWindow()
 						})
@@ -626,7 +626,7 @@ func multiWindowChildView(parent *gui.Window) func(*gui.Window) gui.View {
 					OnClick: func(ctx gui.EventCtx) {
 						ctx.Window.Close()
 						parent.QueueCommand(func(p *gui.Window) {
-							gui.State[ShowcaseApp](p).MultiWindowChildID = 0
+							appState(p).MultiWindowChildID = 0
 							p.UpdateWindow()
 						})
 					},
@@ -649,7 +649,7 @@ func multiWindowStatus(t gui.Theme, active bool) gui.View {
 
 func demoPrinting(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
@@ -668,7 +668,7 @@ func demoPrinting(w *gui.Window) gui.View {
 							gui.Text(gui.TextCfg{Text: "Export PDF", TextStyle: t.N3}),
 						},
 						OnClick: func(ctx gui.EventCtx) {
-							a := gui.State[ShowcaseApp](ctx.Window)
+							a := appState(ctx.Window)
 							outPath := filepath.Join(os.TempDir(), "showcase_export.pdf")
 							job := gui.NewPrintJob()
 							job.OutputPath = outPath
@@ -690,7 +690,7 @@ func demoPrinting(w *gui.Window) gui.View {
 							gui.Text(gui.TextCfg{Text: "Print", TextStyle: t.N3}),
 						},
 						OnClick: func(ctx gui.EventCtx) {
-							a := gui.State[ShowcaseApp](ctx.Window)
+							a := appState(ctx.Window)
 							job := gui.NewPrintJob()
 							job.Title = "showcase Print"
 							r := ctx.Window.RunPrintJob(job)

--- a/examples/showcase/demo_navigation.go
+++ b/examples/showcase/demo_navigation.go
@@ -3,7 +3,7 @@ package main
 import "github.com/go-gui-org/go-gui/gui"
 
 func demoBreadcrumb(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -20,7 +20,7 @@ func demoBreadcrumb(w *gui.Window) gui.View {
 				},
 				Selected: app.BCSelected,
 				OnSelect: func(id string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).BCSelected = id
+					appState(ctx.Window).BCSelected = id
 				},
 			}),
 			gui.Text(gui.TextCfg{
@@ -32,7 +32,7 @@ func demoBreadcrumb(w *gui.Window) gui.View {
 }
 
 func demoTabControl(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.TabControl(gui.TabControlCfg{
 		ID:        "tab-demo",
@@ -68,13 +68,13 @@ func demoTabControl(w *gui.Window) gui.View {
 		},
 		Selected: app.TabSelected,
 		OnSelect: func(id string, ctx gui.EventCtx) {
-			gui.State[ShowcaseApp](ctx.Window).TabSelected = id
+			appState(ctx.Window).TabSelected = id
 		},
 	})
 }
 
 func demoMenus(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	return gui.Menubar(w, gui.MenubarCfg{
 		ID: "menubar-demo",
@@ -184,7 +184,7 @@ func demoMenus(w *gui.Window) gui.View {
 							TextStyle:        gui.CurrentTheme().MenubarStyle.TextStyle,
 							PlaceholderStyle: gui.CurrentTheme().MenubarStyle.TextStyle,
 							OnTextChanged: func(s string, ctx gui.EventCtx) {
-								gui.State[ShowcaseApp](ctx.Window).MenuSearchText = s
+								appState(ctx.Window).MenuSearchText = s
 							},
 						}),
 					},
@@ -201,7 +201,7 @@ func demoMenus(w *gui.Window) gui.View {
 
 func demoCommandPalette(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	const paletteID = "cmd-palette"
 
@@ -235,7 +235,7 @@ func demoCommandPalette(w *gui.Window) gui.View {
 					{ID: "search", Label: "Search", Icon: gui.IconSearch, Group: "Edit"},
 				},
 				OnAction: func(id string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).PaletteAction = id
+					appState(ctx.Window).PaletteAction = id
 				},
 			}),
 		},

--- a/examples/showcase/demo_overlays.go
+++ b/examples/showcase/demo_overlays.go
@@ -7,7 +7,7 @@ import (
 
 func demoDialog(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
@@ -30,7 +30,7 @@ func demoDialog(w *gui.Window) gui.View {
 								Body:       "This is a message dialog.",
 								DialogType: gui.DialogMessage,
 								OnOkYes: func(w *gui.Window) {
-									gui.State[ShowcaseApp](w).DialogResult = "OK"
+									appState(w).DialogResult = "OK"
 								},
 							})
 						},
@@ -47,10 +47,10 @@ func demoDialog(w *gui.Window) gui.View {
 								Body:       "Are you sure you want to proceed?",
 								DialogType: gui.DialogConfirm,
 								OnOkYes: func(w *gui.Window) {
-									gui.State[ShowcaseApp](w).DialogResult = "Yes"
+									appState(w).DialogResult = "Yes"
 								},
 								OnCancelNo: func(w *gui.Window) {
-									gui.State[ShowcaseApp](w).DialogResult = "No"
+									appState(w).DialogResult = "No"
 								},
 							})
 						},
@@ -67,10 +67,10 @@ func demoDialog(w *gui.Window) gui.View {
 								Body:       "Enter your name:",
 								DialogType: gui.DialogPrompt,
 								OnReply: func(reply string, w *gui.Window) {
-									gui.State[ShowcaseApp](w).DialogResult = "Reply: " + reply
+									appState(w).DialogResult = "Reply: " + reply
 								},
 								OnCancelNo: func(w *gui.Window) {
-									gui.State[ShowcaseApp](w).DialogResult = "Cancelled"
+									appState(w).DialogResult = "Cancelled"
 								},
 							})
 						},
@@ -105,7 +105,7 @@ func demoDialog(w *gui.Window) gui.View {
 									}),
 								},
 								OnOkYes: func(w *gui.Window) {
-									gui.State[ShowcaseApp](w).DialogResult = "Custom OK"
+									appState(w).DialogResult = "Custom OK"
 								},
 							})
 						},
@@ -129,12 +129,12 @@ func demoDialog(w *gui.Window) gui.View {
 						OnClick: func(ctx gui.EventCtx) {
 							np := ctx.Window.NativePlatformBackend()
 							if np == nil {
-								gui.State[ShowcaseApp](ctx.Window).DialogResult = "No native platform"
+								appState(ctx.Window).DialogResult = "No native platform"
 								ctx.Consume()
 								return
 							}
 							r := np.ShowOpenDialog("Open File", "", nil, false)
-							a := gui.State[ShowcaseApp](ctx.Window)
+							a := appState(ctx.Window)
 							if len(r.Paths) > 0 {
 								a.DialogResult = "Opened: " + r.Paths[0].Path
 							} else {
@@ -152,12 +152,12 @@ func demoDialog(w *gui.Window) gui.View {
 						OnClick: func(ctx gui.EventCtx) {
 							np := ctx.Window.NativePlatformBackend()
 							if np == nil {
-								gui.State[ShowcaseApp](ctx.Window).DialogResult = "No native platform"
+								appState(ctx.Window).DialogResult = "No native platform"
 								ctx.Consume()
 								return
 							}
 							r := np.ShowSaveDialog("Save File", "", "untitled.txt", ".txt", nil, true)
-							a := gui.State[ShowcaseApp](ctx.Window)
+							a := appState(ctx.Window)
 							if len(r.Paths) > 0 {
 								a.DialogResult = "Save: " + r.Paths[0].Path
 							} else {
@@ -175,12 +175,12 @@ func demoDialog(w *gui.Window) gui.View {
 						OnClick: func(ctx gui.EventCtx) {
 							np := ctx.Window.NativePlatformBackend()
 							if np == nil {
-								gui.State[ShowcaseApp](ctx.Window).DialogResult = "No native platform"
+								appState(ctx.Window).DialogResult = "No native platform"
 								ctx.Consume()
 								return
 							}
 							r := np.ShowFolderDialog("Select Folder", "")
-							a := gui.State[ShowcaseApp](ctx.Window)
+							a := appState(ctx.Window)
 							if len(r.Paths) > 0 {
 								a.DialogResult = "Folder: " + r.Paths[0].Path
 							} else {
@@ -200,7 +200,7 @@ func demoDialog(w *gui.Window) gui.View {
 
 func demoNotification(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
@@ -218,7 +218,7 @@ func demoNotification(w *gui.Window) gui.View {
 						Title: "showcase",
 						Body:  "Hello from go-gui showcase!",
 						OnDone: func(r gui.NativeNotificationResult, w *gui.Window) {
-							a := gui.State[ShowcaseApp](w)
+							a := appState(w)
 							switch r.Status {
 							case gui.NotificationOK:
 								a.NotifyResult = "Notification sent"
@@ -283,10 +283,10 @@ func demoInspector(w *gui.Window) gui.View {
 
 func demoContextMenu(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	action := func(id string, ctx gui.EventCtx) {
-		gui.State[ShowcaseApp](ctx.Window).ContextMenuResult = id
+		appState(ctx.Window).ContextMenuResult = id
 		ctx.Consume()
 	}
 

--- a/examples/showcase/demo_selection.go
+++ b/examples/showcase/demo_selection.go
@@ -7,7 +7,7 @@ import (
 )
 
 func demoToggle(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
@@ -18,7 +18,7 @@ func demoToggle(w *gui.Window) gui.View {
 				Label:    "Toggle",
 				Selected: app.ToggleA,
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.ToggleA = !a.ToggleA
 				},
 			}),
@@ -27,7 +27,7 @@ func demoToggle(w *gui.Window) gui.View {
 				Label:    "Checkbox",
 				Selected: app.CheckboxA,
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.CheckboxA = !a.CheckboxA
 				},
 			}),
@@ -36,7 +36,7 @@ func demoToggle(w *gui.Window) gui.View {
 }
 
 func demoSwitch(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	return gui.Row(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
@@ -48,7 +48,7 @@ func demoSwitch(w *gui.Window) gui.View {
 				Label:    "Enable feature",
 				Selected: app.SwitchA,
 				OnClick: func(ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					a.SwitchA = !a.SwitchA
 				},
 			}),
@@ -57,7 +57,7 @@ func demoSwitch(w *gui.Window) gui.View {
 }
 
 func demoRadio(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	options := []struct{ label, value string }{
 		{"Go", "go"},
 		{"Rust", "rust"},
@@ -71,7 +71,7 @@ func demoRadio(w *gui.Window) gui.View {
 			Label:    opt.label,
 			Selected: app.RadioValue == v,
 			OnClick: func(ctx gui.EventCtx) {
-				gui.State[ShowcaseApp](ctx.Window).RadioValue = v
+				appState(ctx.Window).RadioValue = v
 			},
 		})
 	}
@@ -84,7 +84,7 @@ func demoRadio(w *gui.Window) gui.View {
 }
 
 func demoRadioGroup(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -101,7 +101,7 @@ func demoRadioGroup(w *gui.Window) gui.View {
 					gui.NewRadioOption("Zig", "zig"),
 				},
 				OnSelect: func(v string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).RadioValue = v
+					appState(ctx.Window).RadioValue = v
 				},
 			}),
 			gui.Text(gui.TextCfg{Text: "Row layout", TextStyle: t.B3}),
@@ -114,7 +114,7 @@ func demoRadioGroup(w *gui.Window) gui.View {
 					gui.NewRadioOption("Zig", "zig"),
 				},
 				OnSelect: func(v string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).RadioValue = v
+					appState(ctx.Window).RadioValue = v
 				},
 			}),
 		},
@@ -122,7 +122,7 @@ func demoRadioGroup(w *gui.Window) gui.View {
 }
 
 func demoSelect(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -140,7 +140,7 @@ func demoSelect(w *gui.Window) gui.View {
 				Selected:    app.SelectValue,
 				Options:     []string{"Go", "Rust", "Zig", "C", "Python", "TypeScript"},
 				OnSelect: func(sel []string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).SelectValue = sel
+					appState(ctx.Window).SelectValue = sel
 				},
 			}),
 			sectionLabel(t, "Multi-Select"),
@@ -151,7 +151,7 @@ func demoSelect(w *gui.Window) gui.View {
 				SelectMultiple: true,
 				Options:        []string{"Go", "Rust", "Zig", "C", "Python", "TypeScript"},
 				OnSelect: func(sel []string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).SelectValue = sel
+					appState(ctx.Window).SelectValue = sel
 				},
 			}),
 		},
@@ -159,7 +159,7 @@ func demoSelect(w *gui.Window) gui.View {
 }
 
 func demoListBox(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -195,7 +195,7 @@ func demoListBox(w *gui.Window) gui.View {
 					gui.NewListBoxOption("lua", "Lua", "lua"),
 				},
 				OnSelect: func(ids []string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).ListBoxSelected = ids
+					appState(ctx.Window).ListBoxSelected = ids
 				},
 			}),
 		},
@@ -203,7 +203,7 @@ func demoListBox(w *gui.Window) gui.View {
 }
 
 func demoCombobox(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -222,7 +222,7 @@ func demoCombobox(w *gui.Window) gui.View {
 				Options:     []string{"Go", "Rust", "Zig", "C", "C++", "Python", "TypeScript", "JavaScript", "Ruby", "Elixir"},
 				Sizing:      gui.FillFit,
 				OnSelect: func(v string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).ComboboxValue = v
+					appState(ctx.Window).ComboboxValue = v
 				},
 			}),
 		},
@@ -230,7 +230,7 @@ func demoCombobox(w *gui.Window) gui.View {
 }
 
 func demoDragReorder(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 
 	// Tab content panels (simple label per tab).
@@ -269,7 +269,7 @@ func demoDragReorder(w *gui.Window) gui.View {
 				Data:        app.DragListItems,
 				Reorderable: true,
 				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					from, to := gui.ReorderIndices(
 						dragListIDs(a.DragListItems), movedID, beforeID)
 					if from >= 0 {
@@ -287,7 +287,7 @@ func demoDragReorder(w *gui.Window) gui.View {
 				Sizing:      gui.FillFit,
 				Reorderable: true,
 				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					from, to := gui.ReorderIndices(
 						dragTabIDs(a.DragTabItems), movedID, beforeID)
 					if from >= 0 {
@@ -295,7 +295,7 @@ func demoDragReorder(w *gui.Window) gui.View {
 					}
 				},
 				OnSelect: func(id string, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).DragTabSel = id
+					appState(ctx.Window).DragTabSel = id
 				},
 			}),
 
@@ -308,7 +308,7 @@ func demoDragReorder(w *gui.Window) gui.View {
 				Scrollable:  true,
 				Reorderable: true,
 				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
-					a := gui.State[ShowcaseApp](ctx.Window)
+					a := appState(ctx.Window)
 					dragTreeReorder(a, movedID, beforeID)
 				},
 			}),
@@ -366,7 +366,7 @@ func dragTreeReorderNodes(
 }
 
 func demoSlider(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 	return gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
@@ -384,7 +384,7 @@ func demoSlider(w *gui.Window) gui.View {
 				Max:    100,
 				Sizing: gui.FillFit,
 				OnChange: func(v float32, ctx gui.EventCtx) {
-					gui.State[ShowcaseApp](ctx.Window).RangeValue = v
+					appState(ctx.Window).RangeValue = v
 				},
 			}),
 		},

--- a/examples/showcase/demo_svg_spinner.go
+++ b/examples/showcase/demo_svg_spinner.go
@@ -139,7 +139,7 @@ var svgSpinnerGroups = map[string][]gui.SvgSpinnerKind{
 }
 
 func demoSvgSpinner(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	t := gui.CurrentTheme()
 
 	category := app.SvgSpinnerCategory
@@ -195,7 +195,7 @@ func demoSvgSpinner(w *gui.Window) gui.View {
 						Options:  svgSpinnerCategories,
 						OnSelect: func(sel []string, ctx gui.EventCtx) {
 							if len(sel) > 0 {
-								gui.State[ShowcaseApp](ctx.Window).SvgSpinnerCategory = sel[0]
+								appState(ctx.Window).SvgSpinnerCategory = sel[0]
 							}
 						},
 					}),

--- a/examples/showcase/demo_theme.go
+++ b/examples/showcase/demo_theme.go
@@ -11,7 +11,7 @@ import (
 
 func demoThemeGen(w *gui.Window) gui.View {
 	t := gui.CurrentTheme()
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	strategies := []string{"mono", "complement", "analogous", "triadic", "warm", "cool"}
 	pickerColor := app.ThemeGenSeed
 	if app.ThemeGenPickText {
@@ -37,7 +37,7 @@ func demoThemeGen(w *gui.Window) gui.View {
 			Radius:   gui.SomeF(12),
 			Content:  []gui.View{gui.Text(gui.TextCfg{Text: strategyLabel(sv), TextStyle: textStyle})},
 			OnClick: func(ctx gui.EventCtx) {
-				gui.State[ShowcaseApp](ctx.Window).ThemeGenStrategy = sv
+				appState(ctx.Window).ThemeGenStrategy = sv
 				applyGenTheme(ctx.Window)
 			},
 		})
@@ -69,7 +69,7 @@ func demoThemeGen(w *gui.Window) gui.View {
 								ID:    "theme-gen-cp",
 								Color: pickerColor,
 								OnColorChange: func(c gui.Color, ctx gui.EventCtx) {
-									app := gui.State[ShowcaseApp](ctx.Window)
+									app := appState(ctx.Window)
 									if app.ThemeGenPickText {
 										app.ThemeGenText = c
 									} else {
@@ -100,10 +100,10 @@ func demoThemeGen(w *gui.Window) gui.View {
 												Width:    80,
 												Sizing:   gui.FixedFit,
 												OnTextChanged: func(text string, ctx gui.EventCtx) {
-													gui.State[ShowcaseApp](ctx.Window).ThemeGenRadiusText = text
+													appState(ctx.Window).ThemeGenRadiusText = text
 												},
 												OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-													app := gui.State[ShowcaseApp](ctx.Window)
+													app := appState(ctx.Window)
 													app.ThemeGenRadiusText = text
 													if v, ok := value.Value(); ok {
 														app.ThemeGenRadius = float32(v)
@@ -130,10 +130,10 @@ func demoThemeGen(w *gui.Window) gui.View {
 												Width:    80,
 												Sizing:   gui.FixedFit,
 												OnTextChanged: func(text string, ctx gui.EventCtx) {
-													gui.State[ShowcaseApp](ctx.Window).ThemeGenBorderText = text
+													appState(ctx.Window).ThemeGenBorderText = text
 												},
 												OnValueCommit: func(value gui.Opt[float64], text string, ctx gui.EventCtx) {
-													app := gui.State[ShowcaseApp](ctx.Window)
+													app := appState(ctx.Window)
 													app.ThemeGenBorderText = text
 													if v, ok := value.Value(); ok {
 														app.ThemeGenBorder = float32(v)
@@ -164,7 +164,7 @@ func demoThemeGen(w *gui.Window) gui.View {
 								Label:    "Edit text color",
 								Selected: app.ThemeGenPickText,
 								OnClick: func(ctx gui.EventCtx) {
-									gui.State[ShowcaseApp](ctx.Window).ThemeGenPickText = !gui.State[ShowcaseApp](ctx.Window).ThemeGenPickText
+									appState(ctx.Window).ThemeGenPickText = !appState(ctx.Window).ThemeGenPickText
 								},
 							}),
 							gui.Row(gui.ContainerCfg{
@@ -178,7 +178,7 @@ func demoThemeGen(w *gui.Window) gui.View {
 										Content: []gui.View{gui.Text(gui.TextCfg{Text: "Reset Dark", TextStyle: t.N3})},
 										OnClick: func(ctx gui.EventCtx) {
 											ctx.Window.SetTheme(gui.ThemeDark.WithBorders(true))
-											syncThemeGenFromCfg(gui.State[ShowcaseApp](ctx.Window), gui.ThemeDark.WithBorders(true).Cfg)
+											syncThemeGenFromCfg(appState(ctx.Window), gui.ThemeDark.WithBorders(true).Cfg)
 										},
 									}),
 									gui.Button(gui.ButtonCfg{
@@ -187,7 +187,7 @@ func demoThemeGen(w *gui.Window) gui.View {
 										Content: []gui.View{gui.Text(gui.TextCfg{Text: "Reset Light", TextStyle: t.N3})},
 										OnClick: func(ctx gui.EventCtx) {
 											ctx.Window.SetTheme(gui.ThemeLight.WithBorders(true))
-											syncThemeGenFromCfg(gui.State[ShowcaseApp](ctx.Window), gui.ThemeLight.WithBorders(true).Cfg)
+											syncThemeGenFromCfg(appState(ctx.Window), gui.ThemeLight.WithBorders(true).Cfg)
 										},
 									}),
 								},
@@ -214,7 +214,7 @@ func demoThemeGen(w *gui.Window) gui.View {
 													if result.Status != gui.DialogOK || len(result.Paths) == 0 {
 														return
 													}
-													app := gui.State[ShowcaseApp](w)
+													app := appState(w)
 													cfg := generateThemeCfg(
 														app.ThemeGenSeed,
 														app.ThemeGenStrategy,
@@ -251,11 +251,11 @@ func demoThemeGen(w *gui.Window) gui.View {
 													path := result.Paths[0].Path
 													cfg, err := themeCfgLoad(path)
 													if err != nil {
-														gui.State[ShowcaseApp](w).ThemeGenName = err.Error()
+														appState(w).ThemeGenName = err.Error()
 														return
 													}
 													w.SetTheme(gui.ThemeMaker(cfg))
-													app := gui.State[ShowcaseApp](w)
+													app := appState(w)
 													syncThemeGenFromCfg(app, cfg)
 													app.ThemeGenName = filepath.Base(path)
 												},
@@ -277,7 +277,7 @@ func demoThemeGen(w *gui.Window) gui.View {
 								Width:    140,
 								Sizing:   gui.FixedFit,
 								OnChange: func(v float32, ctx gui.EventCtx) {
-									gui.State[ShowcaseApp](ctx.Window).ThemeGenTint = v
+									appState(ctx.Window).ThemeGenTint = v
 									applyGenTheme(ctx.Window)
 								},
 							}),
@@ -357,7 +357,7 @@ func syncThemeGenFromCfg(app *ShowcaseApp, cfg gui.ThemeCfg) {
 }
 
 func applyGenTheme(w *gui.Window) {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	cfg := generateThemeCfg(
 		app.ThemeGenSeed,
 		app.ThemeGenStrategy,

--- a/examples/showcase/detail.go
+++ b/examples/showcase/detail.go
@@ -6,7 +6,7 @@ import (
 )
 
 func detailPanel(w *gui.Window) gui.View {
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 	entries := filteredEntries(app)
 
 	if len(entries) == 0 {
@@ -143,7 +143,7 @@ func docButton(showDocs bool) gui.View {
 			gui.Text(gui.TextCfg{Text: gui.IconBook, TextStyle: gui.CurrentTheme().Icon4}),
 		},
 		OnClick: func(ctx gui.EventCtx) {
-			gui.State[ShowcaseApp](ctx.Window).ShowDocs = !gui.State[ShowcaseApp](ctx.Window).ShowDocs
+			appState(ctx.Window).ShowDocs = !appState(ctx.Window).ShowDocs
 		},
 	})
 }

--- a/examples/showcase/main.go
+++ b/examples/showcase/main.go
@@ -28,7 +28,7 @@ func main() {
 		Height: 700,
 		OnInit: func(w *gui.Window) {
 			loadEmbeddedLocales()
-			sa := gui.State[ShowcaseApp](w)
+			sa := appState(w)
 			syncThemeGenFromCfg(sa, gui.CurrentTheme().Cfg)
 			_ = w.RegisterCommands(
 				gui.Command{
@@ -42,7 +42,7 @@ func main() {
 					ID: "sc.count", Label: "Count", Icon: gui.IconPlus,
 					Shortcut: gui.Shortcut{Key: gui.KeyF5, Modifiers: gui.ModShift},
 					Execute: func(_ *gui.Event, w *gui.Window) {
-						gui.State[ShowcaseApp](w).CmdButtonCount++
+						appState(w).CmdButtonCount++
 					},
 				},
 				gui.Command{

--- a/examples/showcase/showcase_test.go
+++ b/examples/showcase/showcase_test.go
@@ -420,7 +420,7 @@ func TestDetailPanel_BumpsAbortCounterWhenNavigatingAwayFromTree(t *testing.T) {
 func TestDemoPagesHaveNoIDDefects(t *testing.T) {
 	w := gui.NewTestWindow(gui.WindowCfg{State: newShowcaseApp()})
 	w.UpdateView(mainView)
-	app := gui.State[ShowcaseApp](w)
+	app := appState(w)
 
 	for _, entry := range demoEntries {
 		app.SelectedGroup = entry.Group

--- a/examples/showcase/state.go
+++ b/examples/showcase/state.go
@@ -186,6 +186,14 @@ type GestureMarker struct {
 	LongPress bool
 }
 
+// appState is the typed state accessor for the showcase window.
+// Every demo repeats appState(w); centralizing the
+// type assertion here keeps call sites one word and the type
+// mention in one place.
+func appState(w *gui.Window) *ShowcaseApp {
+	return gui.State[ShowcaseApp](w)
+}
+
 func newShowcaseApp() *ShowcaseApp {
 	return &ShowcaseApp{
 		ShaderStartTime:      time.Now(),

--- a/examples/solitaire/main.go
+++ b/examples/solitaire/main.go
@@ -44,6 +44,13 @@ type App struct {
 	DragActive bool
 }
 
+// state is the typed state accessor for this window. Callbacks
+// reach the app state through it instead of repeating
+// gui.State[App](...) at every site.
+func state(w *gui.Window) *App {
+	return gui.State[App](w)
+}
+
 const blinkAnim = "solitaire-blink"
 
 func main() {
@@ -64,7 +71,7 @@ func main() {
 				Delay:  500 * time.Millisecond,
 				Repeat: true,
 				Callback: func(_ *gui.Animate, w *gui.Window) {
-					app := gui.State[App](w)
+					app := state(w)
 					app.LandingFrame++
 					// Auto-complete check.
 					if app.Screen == ScreenPlaying &&
@@ -87,7 +94,7 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 	if e.Type != gui.EventKeyDown {
 		return
 	}
-	app := gui.State[App](w)
+	app := state(w)
 	switch e.KeyCode {
 	case gui.KeyN:
 		if app.Screen == ScreenPlaying {
@@ -105,7 +112,7 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 // --- View routing ---
 
 func mainView(w *gui.Window) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	// Allowlisted viewport use: both screens place cards, the status bar
 	// and the win overlay at absolute pixel positions.
 	ww, wh := w.WindowSize()
@@ -153,7 +160,7 @@ func colX(col int) float32 { return boardPadX + float32(col)*colStride }
 // --- Landing page ---
 
 func landingView(w *gui.Window, ww, wh float32) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	theme := gui.CurrentTheme()
 	blink := app.LandingFrame%2 == 0
 
@@ -256,7 +263,7 @@ func modeButton(w *gui.Window, title string, mode DrawMode, color gui.Color) gui
 			}),
 		},
 		OnClick: func(ctx gui.EventCtx) {
-			app := gui.State[App](ctx.Window)
+			app := state(ctx.Window)
 			app.Game = NewGame(mode, nil)
 			app.Screen = ScreenPlaying
 		},
@@ -287,7 +294,7 @@ func miniCard(rank, suit string, color gui.Color) gui.View {
 // --- Game view ---
 
 func gameView(w *gui.Window, ww, wh float32) gui.View {
-	app := gui.State[App](w)
+	app := state(w)
 	game := app.Game
 	theme := gui.CurrentTheme()
 
@@ -337,7 +344,7 @@ func stockView(game *Game) gui.View {
 			if ctx.Event.MouseButton != gui.MouseLeft {
 				return
 			}
-			app := gui.State[App](ctx.Window)
+			app := state(ctx.Window)
 			app.Game.Draw()
 			ctx.Consume()
 		})
@@ -347,7 +354,7 @@ func stockView(game *Game) gui.View {
 		if ctx.Event.MouseButton != gui.MouseLeft {
 			return
 		}
-		app := gui.State[App](ctx.Window)
+		app := state(ctx.Window)
 		app.Game.Draw()
 		ctx.Event.IsHandled = true
 	})
@@ -384,7 +391,7 @@ func wasteViews(app *App) []gui.View {
 
 func makeWasteClickHandler() func(gui.EventCtx) {
 	return func(ctx gui.EventCtx) {
-		app := gui.State[App](ctx.Window)
+		app := state(ctx.Window)
 		game := app.Game
 		tw := game.TopWaste()
 		if tw == nil {
@@ -486,7 +493,7 @@ func tableauViews(app *App, col int) []gui.View {
 
 func makeTableauClickHandler(col, cardIdx int) func(gui.EventCtx) {
 	return func(ctx gui.EventCtx) {
-		app := gui.State[App](ctx.Window)
+		app := state(ctx.Window)
 		game := app.Game
 
 		// Right-click: auto-place top card to foundation.
@@ -603,12 +610,12 @@ func startDrag(app *App, layout *gui.Layout, e *gui.Event, w *gui.Window, src Dr
 
 	w.MouseLock(gui.MouseLockCfg{
 		MouseMove: func(ctx gui.EventCtx) {
-			a := gui.State[App](ctx.Window)
+			a := state(ctx.Window)
 			a.DragMouseX = ctx.Event.MouseX
 			a.DragMouseY = ctx.Event.MouseY
 		},
 		MouseUp: func(ctx gui.EventCtx) {
-			a := gui.State[App](ctx.Window)
+			a := state(ctx.Window)
 			ctx.Window.MouseUnlock()
 			dropCards(a, ctx.Event.MouseX, ctx.Event.MouseY)
 			a.DragActive = false

--- a/examples/termgrid/main.go
+++ b/examples/termgrid/main.go
@@ -23,7 +23,7 @@ type App struct {
 }
 
 func main() {
-	gui.SetTheme(gui.ThemeDark)
+	gui.SetTheme(gui.ThemeDark.WithBorders(false))
 
 	app := &App{cells: buildCells()}
 

--- a/gui/constructors_test.go
+++ b/gui/constructors_test.go
@@ -1,0 +1,186 @@
+package gui
+
+import "testing"
+
+// These tests cover the thin convenience constructors (issue #325).
+// Each asserts that the helper forwards exactly the caller's arguments
+// to the Cfg form — no new behavior, no surprise defaults beyond the
+// documented padding.
+
+func TestTextButtonStructure(t *testing.T) {
+	w := newTestWindow()
+	v := TextButton("tb", "Click Me", noop)
+	layout := generateViewLayout(v, w)
+
+	if len(layout.Children) != 1 {
+		t.Fatalf("got %d children, want 1", len(layout.Children))
+	}
+	if got := layout.Children[0].Shape.TC.Text; got != "Click Me" {
+		t.Fatalf("button label = %q, want %q", got, "Click Me")
+	}
+	if got := layout.Shape.Padding; got != NewPadding(8, 16, 8, 16) {
+		t.Fatalf("padding = %v, want NewPadding(8, 16, 8, 16)", got)
+	}
+}
+
+func TestTextButtonClickFires(t *testing.T) {
+	type state struct{ clicks int }
+	w := NewTestWindow(WindowCfg{State: &state{}})
+	w.TestRender(func(w *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				TextButton("tb", "Click Me", func(ctx EventCtx) {
+					State[state](ctx.Window).clicks++
+				}),
+			},
+		})
+	})
+
+	if err := w.TestClick("tb"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if got := State[state](w).clicks; got != 1 {
+		t.Fatalf("clicks = %d, want 1", got)
+	}
+}
+
+func TestLabelZeroStyleDefaults(t *testing.T) {
+	w := newTestWindow()
+	layout := generateViewLayout(Label("hi", TextStyle{}), w)
+	if layout.Shape.TC.Text != "hi" {
+		t.Fatalf("text = %q, want %q", layout.Shape.TC.Text, "hi")
+	}
+	if got := *layout.Shape.TC.TextStyle; got != DefaultTextStyle {
+		t.Fatalf("style = %v, want DefaultTextStyle", got)
+	}
+}
+
+func TestLabelKeepsExplicitStyle(t *testing.T) {
+	w := newTestWindow()
+	style := TextStyle{Size: 24}
+	layout := generateViewLayout(Label("hi", style), w)
+	if got := *layout.Shape.TC.TextStyle; got.Size != 24 {
+		t.Fatalf("style size = %v, want 24", got.Size)
+	}
+}
+
+func TestLabeledToggleForwards(t *testing.T) {
+	w := newTestWindow()
+
+	sel := generateViewLayout(LabeledToggle("t1", "Accept", true, noop), w)
+	if sel.Shape.A11YRole != AccessRoleCheckbox {
+		t.Fatalf("role = %v, want checkbox", sel.Shape.A11YRole)
+	}
+	if sel.Shape.A11YState != AccessStateChecked {
+		t.Fatalf("state = %v, want checked", sel.Shape.A11YState)
+	}
+	if len(sel.Children) != 2 {
+		t.Fatalf("got %d children, want 2 (box + label)", len(sel.Children))
+	}
+	if got := sel.Children[1].Shape.TC.Text; got != "Accept" {
+		t.Fatalf("label = %q, want %q", got, "Accept")
+	}
+
+	unsel := generateViewLayout(LabeledToggle("t2", "Accept", false, noop), w)
+	if unsel.Shape.A11YState != AccessStateNone {
+		t.Fatalf("state = %v, want none", unsel.Shape.A11YState)
+	}
+}
+
+func TestLabeledToggleClickFires(t *testing.T) {
+	type state struct{ hits int }
+	w := NewTestWindow(WindowCfg{State: &state{}})
+	w.TestRender(func(w *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				LabeledToggle("t1", "Accept", false, func(ctx EventCtx) {
+					State[state](ctx.Window).hits++
+				}),
+			},
+		})
+	})
+
+	if err := w.TestClick("t1"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if got := State[state](w).hits; got != 1 {
+		t.Fatalf("hits = %d, want 1", got)
+	}
+}
+
+func TestLabeledSwitchForwards(t *testing.T) {
+	w := newTestWindow()
+
+	sel := generateViewLayout(LabeledSwitch("s1", "Auto", true, noop), w)
+	if sel.Shape.A11YRole != AccessRoleSwitchToggle {
+		t.Fatalf("role = %v, want switch-toggle", sel.Shape.A11YRole)
+	}
+	if sel.Shape.A11YState != AccessStateChecked {
+		t.Fatalf("state = %v, want checked", sel.Shape.A11YState)
+	}
+	if len(sel.Children) != 2 {
+		t.Fatalf("got %d children, want 2 (pill + label)", len(sel.Children))
+	}
+	if got := sel.Children[1].Shape.TC.Text; got != "Auto" {
+		t.Fatalf("label = %q, want %q", got, "Auto")
+	}
+
+	unsel := generateViewLayout(LabeledSwitch("s2", "Auto", false, noop), w)
+	if unsel.Shape.A11YState != AccessStateNone {
+		t.Fatalf("state = %v, want none", unsel.Shape.A11YState)
+	}
+}
+
+func TestLabeledSwitchClickFires(t *testing.T) {
+	type state struct{ hits int }
+	w := NewTestWindow(WindowCfg{State: &state{}})
+	w.TestRender(func(w *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				LabeledSwitch("s1", "Auto", true, func(ctx EventCtx) {
+					State[state](ctx.Window).hits++
+				}),
+			},
+		})
+	})
+
+	if err := w.TestClick("s1"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if got := State[state](w).hits; got != 1 {
+		t.Fatalf("hits = %d, want 1", got)
+	}
+}
+
+func TestSimpleWindowForwards(t *testing.T) {
+	type appState struct{ n int }
+
+	var installed func(*Window) View
+	w := SimpleWindow("T", 400, 300, &appState{n: 7}, func(w *Window) {
+		installed = func(w *Window) View { return Label("root", TextStyle{}) }
+		w.UpdateView(installed)
+	})
+
+	if w.Config.Title != "T" || w.Config.Width != 400 || w.Config.Height != 300 {
+		t.Fatalf("config = %+v, want Title=T 400x300", w.Config)
+	}
+	if got := State[appState](w).n; got != 7 {
+		t.Fatalf("state = %d, want 7", got)
+	}
+	if w.Config.OnInit == nil {
+		t.Fatal("OnInit not wired")
+	}
+
+	// Backends invoke OnInit after NewWindow; simulate that and render.
+	// composeLayout may wrap the root, so locate the text shape by content.
+	w.Config.OnInit(w)
+	layout := w.TestRender(nil)
+	if _, ok := layout.FindLayout(func(l Layout) bool {
+		return l.Shape.TC != nil && l.Shape.TC.Text == "root"
+	}); !ok {
+		t.Fatalf("rendered view missing text %q", "root")
+	}
+}

--- a/gui/styles_widget_test.go
+++ b/gui/styles_widget_test.go
@@ -26,9 +26,9 @@ func TestDefaultScrollbarStyle(t *testing.T) {
 	}
 }
 
-// ThemeDark is borderless by design — bordered is the separate
-// dark-bordered preset, or Theme.WithBorders(true). What every widget
-// style must have is a real corner radius, so a widget never renders
+// ThemeDark is bordered since 2026-08 (see baseDarkCfg); callers who
+// want the old borderless look use Theme.WithBorders(false). What every
+// widget style must have is a real corner radius, so a widget never renders
 // with square corners just because a style went unpopulated.
 func TestDefaultWidgetStylesRadius(t *testing.T) {
 	styles := []struct {

--- a/gui/theme_defaults.go
+++ b/gui/theme_defaults.go
@@ -74,6 +74,13 @@ func baseDarkCfg() ThemeCfg {
 	cfg.TitlebarDark = true
 	cfg.TextStyleDef = DefaultTextStyle
 	cfg.ColorError = RGBA(218, 54, 51, 255)
+	// Bordered by default since 2026-08: the call-site count behind
+	// issue #325 found 90 of 104 example files explicitly calling
+	// SetTheme(ThemeDark.WithBorders(true)), so bordered is what
+	// applications actually want. Theme.WithBorders(false) restores
+	// the borderless look. The "dark-bordered" preset is now identical
+	// to ThemeDark but stays registered for name-based theme selection.
+	cfg.SizeBorder = sizeBorderDef
 	return cfg
 }
 
@@ -140,10 +147,11 @@ func init() {
 	themeDarkNoPaddingCfg.Radius = radiusNone
 	themeDarkNoPadding = ThemeMaker(themeDarkNoPaddingCfg)
 
-	// Dark bordered.
+	// Dark bordered. Now identical to ThemeDark (baseDarkCfg carries
+	// the border); kept registered for backward compatibility with
+	// name-based theme selection.
 	themeDarkBorderedCfg = baseDarkCfg()
 	themeDarkBorderedCfg.Name = "dark-bordered"
-	themeDarkBorderedCfg.SizeBorder = sizeBorderDef
 	themeDarkBordered = ThemeMaker(themeDarkBorderedCfg)
 
 	// Light.

--- a/gui/theme_defaults_test.go
+++ b/gui/theme_defaults_test.go
@@ -35,6 +35,24 @@ func TestDarkThemeColors(t *testing.T) {
 	}
 }
 
+// ThemeDark carries the border since 2026-08 (issue #325 call-site
+// count: 90 of 104 examples opt in via WithBorders(true)); the flip
+// must keep WithBorders(false) able to restore the borderless look.
+func TestDarkThemeBorderedDefault(t *testing.T) {
+	if ThemeDark.Cfg.SizeBorder != sizeBorderDef {
+		t.Errorf("ThemeDark SizeBorder = %v, want %v",
+			ThemeDark.Cfg.SizeBorder, sizeBorderDef)
+	}
+	if got := ThemeDark.WithBorders(false).Cfg.SizeBorder; got != 0 {
+		t.Errorf("WithBorders(false) SizeBorder = %v, want 0", got)
+	}
+	// dark-bordered is now an exact duplicate of dark; keep them in
+	// lockstep so name-based selection cannot drift from ThemeDark.
+	if themeDarkBordered.Cfg.SizeBorder != ThemeDark.Cfg.SizeBorder {
+		t.Error("dark-bordered preset diverged from ThemeDark")
+	}
+}
+
 func TestLightThemeColors(t *testing.T) {
 	if ThemeLight.ColorBackground != colorBackgroundLight {
 		t.Error("light background mismatch")

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -101,6 +101,21 @@ func buttonOnHover(ctx EventCtx) {
 	}
 }
 
+// TextButton is the thin form of Button for the common case: one
+// label on a clickable button. The padding default (8, 16, 8, 16) is
+// the most common explicit padding across the examples; a caller that
+// wants the theme default or a custom inset uses Button directly.
+func TextButton(id, label string, onClick func(EventCtx)) View {
+	return Button(ButtonCfg{
+		ID:      id,
+		OnClick: onClick,
+		Padding: NewPadding(8, 16, 8, 16),
+		Content: []View{
+			Text(TextCfg{Text: label}),
+		},
+	})
+}
+
 // Button creates a clickable button. Delegates to Row with
 // package-level amend_layout for focus coloring and on_hover
 // for cursor/color state changes. Colors are stored in a pooled

--- a/gui/view_switch.go
+++ b/gui/view_switch.go
@@ -26,6 +26,20 @@ type SwitchCfg struct {
 	Selected      bool
 }
 
+// LabeledSwitch is the thin form of Switch for the common case: a
+// label next to a pill switch in its initial selected state. Callers
+// needing TextStyle, Colors, Width, or the rest of SwitchCfg use
+// Switch directly.
+// exportaudit:keep — convenience form; no example uses it yet
+func LabeledSwitch(id, label string, selected bool, onClick func(EventCtx)) View {
+	return Switch(SwitchCfg{
+		ID:       id,
+		Label:    label,
+		Selected: selected,
+		OnClick:  onClick,
+	})
+}
+
 // Switch creates a pill-shaped toggle switch.
 func Switch(cfg SwitchCfg) View {
 	applySwitchDefaults(&cfg)

--- a/gui/view_text.go
+++ b/gui/view_text.go
@@ -124,6 +124,14 @@ func (tv *textView) GenerateLayout(w *Window) Layout {
 	return layout
 }
 
+// Label is the thin form of Text for the common case: a text string
+// and a style. Pass the zero TextStyle to get the default theme
+// style. Callers needing Focusable, Sizing, Mode, or the rest of
+// TextCfg use Text directly.
+func Label(text string, style TextStyle) View {
+	return Text(TextCfg{Text: text, TextStyle: style})
+}
+
 // Text creates a text view for displaying text content.
 func Text(cfg TextCfg) View {
 	if cfg.Invisible {

--- a/gui/view_toggle.go
+++ b/gui/view_toggle.go
@@ -30,6 +30,20 @@ type ToggleCfg struct {
 	Selected    bool
 }
 
+// LabeledToggle is the thin form of Toggle for the common case: a
+// label next to a checkbox in its initial selected state. Callers
+// needing TextStyle, Colors, Size, or the rest of ToggleCfg use
+// Toggle directly.
+// exportaudit:keep — convenience form; no example uses it yet
+func LabeledToggle(id, label string, selected bool, onClick func(EventCtx)) View {
+	return Toggle(ToggleCfg{
+		ID:       id,
+		Label:    label,
+		Selected: selected,
+		OnClick:  onClick,
+	})
+}
+
 // Toggle creates a toggle/checkbox view.
 func Toggle(cfg ToggleCfg) View {
 	applyToggleDefaults(&cfg)

--- a/gui/window_cfg.go
+++ b/gui/window_cfg.go
@@ -72,6 +72,20 @@ type WindowCfg struct {
 	DebugTimeTravel bool
 }
 
+// SimpleWindow is the thin form of NewWindow for the common case:
+// title, size, state, and an OnInit that wires the root view. Any
+// caller needing the rest of WindowCfg (OnCloseRequest, ImageFetcher,
+// FixedSize, ...) uses NewWindow directly.
+func SimpleWindow(title string, w, h int, state any, onInit func(*Window)) *Window {
+	return NewWindow(WindowCfg{
+		Title:  title,
+		Width:  w,
+		Height: h,
+		State:  state,
+		OnInit: onInit,
+	})
+}
+
 // NewWindow creates a Window from the given configuration.
 func NewWindow(cfg WindowCfg) *Window {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Closes #325. Adds thin convenience constructors backed by a field-frequency count over 103 example files, plus two follow-on decisions that analysis surfaced.

## Convenience constructors (issue #325)

```go
func SimpleWindow(title string, w, h int, state any, onInit func(*Window)) *Window
func TextButton(id, label string, onClick func(EventCtx)) View
func Label(text string, style TextStyle) View
func LabeledToggle(id, label string, selected bool, onClick func(EventCtx)) View
func LabeledSwitch(id, label string, selected bool, onClick func(EventCtx)) View
```

- Pure forwards to the existing `Cfg` forms; no new behavior, no Cfg variants.
- `ID` stays an explicit parameter — identity remains caller-owned.
- `TextButton` defaults padding to `NewPadding(8, 16, 8, 16)` (30 of 56 paddings in examples are exactly this).
- `LabeledToggle`/`LabeledSwitch` carry `// exportaudit:keep` (no external consumer yet; included per the issue's final list).
- README and `examples/get_started` lead with the short forms; the `Cfg` form follows under "Full control".

## ThemeDark bordered by default

90 of 104 example files call `SetTheme(ThemeDark.WithBorders(true))` explicitly. `baseDarkCfg` now sets `SizeBorder = sizeBorderDef`, so `ThemeDark` and the implicit app default are bordered. `dark-bordered` stays registered for name-based selection (now identical to `ThemeDark`); `Theme.WithBorders(false)` restores the old look — applied to termgrid and custom_shader, which relied on it. Fixes a latent inconsistency: showcase's tinted themes derived from `ThemeDark.Cfg` were borderless while the rest of the showcase was bordered.

## State accessor pattern in examples

`gui.State[X](w)` at every call site repeats the type assertion; 8 examples now centralize it behind one accessor (showcase `appState`, others `state`), with the type mention in exactly one place. Also renamed animations' `State` type to `AppState` (`gui.State[State](w)` read as a tautology).

## Testing

`gui/constructors_test.go` covers structure, click dispatch, a11y state forwarding, and window wiring for all five helpers; `TestDarkThemeBorderedDefault` pins the border flip and the `WithBorders(false)` escape hatch. Full `make prepush` gate green.