### PR TITLE
feat(gui): add gui.Separator, a first-class divider widget (issue #334)

### DIFF
--- a/examples/particles/main.go
+++ b/examples/particles/main.go
@@ -223,10 +223,9 @@ func landingView(w *gui.Window, ww, wh float32) gui.View {
 				Text:      "ARCADE SECTOR 2026",
 				TextStyle: ts(theme.M3, 14, colorNeonCyan.WithOpacity(0.6)),
 			}),
-			gui.Rectangle(gui.RectangleCfg{
-				Width:  300,
-				Height: 2,
-				Sizing: gui.FixedFixed,
+			gui.Separator(gui.SeparatorCfg{
+				Length: 300,
+				Size:   2,
 				Color:  colorNeonCyan.WithOpacity(0.3),
 			}),
 			gui.Button(gui.ButtonCfg{
@@ -251,10 +250,9 @@ func landingView(w *gui.Window, ww, wh float32) gui.View {
 				Text:      "CLICK TO START",
 				TextStyle: ts(theme.B3, 16, startColor),
 			}),
-			gui.Rectangle(gui.RectangleCfg{
-				Width:  300,
-				Height: 1,
-				Sizing: gui.FixedFixed,
+			gui.Separator(gui.SeparatorCfg{
+				Length: 300,
+				Size:   1,
 				Color:  colorNeonCyan.WithOpacity(0.15),
 			}),
 			gui.Text(gui.TextCfg{

--- a/examples/showcase/embedded.go
+++ b/examples/showcase/embedded.go
@@ -205,6 +205,7 @@ type themeCfgJSON struct {
 	ColorActive      colorJSON     `json:"color_active"`
 	ColorBorder      colorJSON     `json:"color_border"`
 	ColorBorderFocus colorJSON     `json:"color_border_focus"`
+	ColorSeparator   colorJSON     `json:"color_separator"`
 	ColorSelect      colorJSON     `json:"color_select"`
 	TitlebarDark     bool          `json:"titlebar_dark"`
 }
@@ -263,6 +264,7 @@ func themeCfgJSONFromCfg(cfg gui.ThemeCfg) themeCfgJSON {
 		ColorActive:      colorJSONFromColor(cfg.ColorActive),
 		ColorBorder:      colorJSONFromColor(cfg.ColorBorder),
 		ColorBorderFocus: colorJSONFromColor(cfg.ColorBorderFocus),
+		ColorSeparator:   colorJSONFromColor(cfg.ColorSeparator),
 		ColorSelect:      colorJSONFromColor(cfg.ColorSelect),
 		TitlebarDark:     cfg.TitlebarDark,
 		SizeBorder:       cfg.SizeBorder,
@@ -285,6 +287,7 @@ func (cfg themeCfgJSON) toThemeCfg() gui.ThemeCfg {
 		ColorActive:      cfg.ColorActive.toColor(),
 		ColorBorder:      cfg.ColorBorder.toColor(),
 		ColorBorderFocus: cfg.ColorBorderFocus.toColor(),
+		ColorSeparator:   cfg.ColorSeparator.toColor(),
 		ColorSelect:      cfg.ColorSelect.toColor(),
 		TitlebarDark:     cfg.TitlebarDark,
 		SizeBorder:       cfg.SizeBorder,

--- a/examples/showcase/helpers.go
+++ b/examples/showcase/helpers.go
@@ -17,14 +17,11 @@ func safeFloat(v, fallback float32) float32 {
 	return v
 }
 
+// line returns a horizontal divider rule. The theme's divider color
+// applies; the top inset is the demo's breathing room above the rule.
 func line() gui.View {
-	return gui.Row(gui.ContainerCfg{
-		Sizing:     gui.FillFit,
-		Height:     1,
-		Padding:    gui.NewPadding(3, 0, 0, 0),
-		SizeBorder: gui.NoBorder,
-		Radius:     gui.NoRadius,
-		Color:      gui.CurrentTheme().ColorActive,
+	return gui.Separator(gui.SeparatorCfg{
+		Inset: gui.NewPadding(3, 0, 0, 0),
 	})
 }
 

--- a/examples/showcase/showcase_test.go
+++ b/examples/showcase/showcase_test.go
@@ -195,9 +195,17 @@ func TestDetailPanelWelcomeWrappersHaveNoBorder(t *testing.T) {
 	if got, want := line.Shape.SizeBorder, float32(0); got != want {
 		t.Fatalf("layout.Children[0].Children[1].Shape.SizeBorder = %v, want %v", got, want)
 	}
-	// line() returns a single Row node; Height 1 renders the separator.
-	if got, want := line.Shape.Height, float32(1); got != want {
-		t.Fatalf("layout.Children[0].Children[1].Shape.Height = %v, want %v", got, want)
+	// line() is a gui.Separator: a transparent inset wrapper around the
+	// rule node.
+	if len(line.Children) == 0 {
+		t.Fatal("len(layout.Children[0].Children[1].Children) = 0, want the rule")
+	}
+	rule := line.Children[0]
+	if got, want := rule.Shape.SizeBorder, float32(0); got != want {
+		t.Fatalf("rule.Shape.SizeBorder = %v, want %v", got, want)
+	}
+	if got, want := rule.Shape.Height, float32(1); got != want {
+		t.Fatalf("rule.Shape.Height = %v, want %v", got, want)
 	}
 }
 

--- a/gui/list_core.go
+++ b/gui/list_core.go
@@ -427,17 +427,8 @@ func listCoreSubheadingView(item listCoreItem, cfg listCoreCfg) View {
 				Text:      item.Label,
 				TextStyle: cfg.subheadingStyle,
 			}),
-			Row(ContainerCfg{
-				Padding: NoPadding,
-				Sizing:  FillFit,
-				Content: []View{
-					Rectangle(RectangleCfg{
-						Width:  1,
-						Height: 1,
-						Sizing: FillFit,
-						Color:  cfg.subheadingStyle.Color,
-					}),
-				},
+			Separator(SeparatorCfg{
+				Color: cfg.subheadingStyle.Color,
 			}),
 		},
 	})

--- a/gui/styles_widget.go
+++ b/gui/styles_widget.go
@@ -31,6 +31,13 @@ type ScrollbarStyle struct {
 	GapEnd          float32
 }
 
+// SeparatorStyle defines divider rule visual properties.
+// exportaudit:keep — reachable from an exported signature
+type SeparatorStyle struct {
+	Color Color
+	Size  float32
+}
+
 // RadioStyle defines radio button visual properties.
 // exportaudit:keep — reachable from an exported signature
 type RadioStyle struct {
@@ -124,4 +131,6 @@ var (
 	defaultToggleStyle ToggleStyle
 
 	defaultSelectStyle SelectStyle
+
+	defaultSeparatorStyle SeparatorStyle
 )

--- a/gui/styles_widget_defaults_test.go
+++ b/gui/styles_widget_defaults_test.go
@@ -81,6 +81,7 @@ func TestDefaultStylesMirrorThemeDark(t *testing.T) {
 		{defaultColorPickerStyle, ThemeDark.colorPickerStyle, "defaultColorPickerStyle"},
 		{DefaultDataGridStyle, ThemeDark.dataGridStyle, "DefaultDataGridStyle"},
 		{defaultSkeletonStyle, ThemeDark.skeletonStyle, "defaultSkeletonStyle"},
+		{defaultSeparatorStyle, ThemeDark.separatorStyle, "defaultSeparatorStyle"},
 		{defaultInspectorStyle, ThemeDark.inspectorStyle, "defaultInspectorStyle"},
 	}
 

--- a/gui/theme.go
+++ b/gui/theme.go
@@ -118,6 +118,7 @@ type Theme struct {
 	expandPanelStyle    ExpandPanelStyle
 	ScrollbarStyle      ScrollbarStyle
 	skeletonStyle       SkeletonStyle
+	separatorStyle      SeparatorStyle
 
 	// Layout constants.
 	PaddingSmall  Padding
@@ -216,6 +217,7 @@ type ThemeCfg struct {
 	sizeProgressBar  float32
 	sizeSlider       float32
 	sizeSliderThumb  float32
+	sizeSeparator    float32
 	ColorBackground  Color
 	ColorPanel       Color
 	ColorInterior    Color
@@ -224,6 +226,7 @@ type ThemeCfg struct {
 	ColorActive      Color
 	ColorBorder      Color
 	ColorBorderFocus Color
+	ColorSeparator   Color
 	ColorSelect      Color
 	ColorSuccess     Color
 	ColorWarning     Color
@@ -348,5 +351,6 @@ func applyTheme(t Theme) {
 	defaultColorPickerStyle = t.colorPickerStyle
 	DefaultDataGridStyle = t.dataGridStyle
 	defaultSkeletonStyle = t.skeletonStyle
+	defaultSeparatorStyle = t.separatorStyle
 	defaultInspectorStyle = t.inspectorStyle
 }

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -26,6 +26,18 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 		borderFocus = cfg.ColorSelect
 	}
 
+	// Separator role: a divider is an edge, and reusing ColorBorder
+	// would couple the two forever. Unset falls back to the border
+	// color so existing themes keep their look without restating it.
+	colorSeparator := cfg.ColorSeparator
+	if !colorSeparator.IsSet() {
+		colorSeparator = cfg.ColorBorder
+	}
+	sizeSeparator := cfg.sizeSeparator
+	if sizeSeparator == 0 {
+		sizeSeparator = 1
+	}
+
 	// Scrollbar radius: none if cfg.Radius is none.
 	sbRadius := cfg.RadiusSmall
 	if cfg.Radius == radiusNone {
@@ -273,6 +285,10 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			Color:          cfg.ColorInterior,
 			ColorHighlight: cfg.ColorInterior.Add(RGBA(20, 20, 20, 0)),
 			Radius:         cfg.RadiusSmall,
+		},
+		separatorStyle: SeparatorStyle{
+			Color: colorSeparator,
+			Size:  sizeSeparator,
 		},
 		sliderStyle: SliderStyle{
 			Size:             cfg.sizeSlider,

--- a/gui/theme_maker_test.go
+++ b/gui/theme_maker_test.go
@@ -155,6 +155,22 @@ func TestThemeMakerBorderFocusExplicitWins(t *testing.T) {
 	}
 }
 
+// An explicit separator color and thickness win over the fallbacks.
+func TestThemeMakerSeparatorExplicitWins(t *testing.T) {
+	cfg := baseCfg()
+	cfg.ColorSeparator = RGBA(10, 20, 30, 255)
+	cfg.sizeSeparator = 4
+
+	theme := ThemeMaker(cfg)
+	if !theme.separatorStyle.Color.eq(cfg.ColorSeparator) {
+		t.Errorf("separatorStyle.Color = %v, want %v",
+			theme.separatorStyle.Color, cfg.ColorSeparator)
+	}
+	if theme.separatorStyle.Size != 4 {
+		t.Errorf("separatorStyle.Size = %f, want 4", theme.separatorStyle.Size)
+	}
+}
+
 // The scrollbar radius keys off cfg.Radius, NOT cfg.RadiusSmall — so a
 // square-cornered theme squares the scrollbar even when RadiusSmall is
 // rounded. This is the surprising half of the branch.
@@ -297,5 +313,13 @@ func TestThemeMakerZeroCfg(t *testing.T) {
 	if theme.InputStyle.PlaceholderStyle.Color.A != 100 {
 		t.Errorf("placeholder alpha = %d, want 100",
 			theme.InputStyle.PlaceholderStyle.Color.A)
+	}
+	// Separator falls back to the border color and 1px thickness.
+	if theme.separatorStyle.Color != theme.ColorBorder {
+		t.Errorf("separatorStyle.Color = %v, want ColorBorder %v",
+			theme.separatorStyle.Color, theme.ColorBorder)
+	}
+	if theme.separatorStyle.Size != 1 {
+		t.Errorf("separatorStyle.Size = %f, want 1", theme.separatorStyle.Size)
 	}
 }

--- a/gui/view_listbox_items.go
+++ b/gui/view_listbox_items.go
@@ -244,17 +244,8 @@ func listBoxItemContent(dat ListBoxOption, cfg ListBoxCfg) View {
 					Text:      dat.Name,
 					TextStyle: cfg.subheadingStyle,
 				}),
-				Row(ContainerCfg{
-					Padding: NoPadding,
-					Sizing:  FillFit,
-					Content: []View{
-						Rectangle(RectangleCfg{
-							Width:  1,
-							Height: 1,
-							Sizing: FillFit,
-							Color:  cfg.subheadingStyle.Color,
-						}),
-					},
+				Separator(SeparatorCfg{
+					Color: cfg.subheadingStyle.Color,
 				}),
 			},
 		})

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -286,10 +286,8 @@ func mdRenderTable(
 }
 
 func mdRenderHR(cfg MarkdownCfg) View {
-	return Rectangle(RectangleCfg{
-		Sizing: FillFixed,
-		Height: 1,
-		Color:  cfg.Style.hRColor,
+	return Separator(SeparatorCfg{
+		Color: cfg.Style.hRColor,
 	})
 }
 
@@ -371,10 +369,8 @@ func mdRenderHeading(
 	if (block.HeaderLevel == 1 && cfg.Style.h1Separator) ||
 		(block.HeaderLevel == 2 && cfg.Style.h2Separator) {
 		headingContent = append(headingContent,
-			Rectangle(RectangleCfg{
-				Sizing: FillFixed,
-				Height: 1,
-				Color:  cfg.Style.hRColor,
+			Separator(SeparatorCfg{
+				Color: cfg.Style.hRColor,
 			}))
 	}
 	views = append(views, Column(ContainerCfg{

--- a/gui/view_menu_item.go
+++ b/gui/view_menu_item.go
@@ -73,16 +73,9 @@ func MenuSubmenu(id, text string, submenu []MenuItemCfg) MenuItemCfg {
 // menuItem builds the View for a single menu item.
 func menuItem(menubarCfg MenubarCfg, itemCfg MenuItemCfg, extra ...View) View {
 	if itemCfg.Separator {
-		return Column(ContainerCfg{
-			Sizing:  FillFit,
-			Padding: NewPadding(2, 0, 2, 0),
-			Content: []View{
-				Rectangle(RectangleCfg{
-					Height: 1,
-					Sizing: FillFit,
-					Color:  menubarCfg.ColorBorder,
-				}),
-			},
+		return Separator(SeparatorCfg{
+			Color: menubarCfg.ColorBorder,
+			Inset: NewPadding(2, 0, 2, 0),
 		})
 	}
 

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -302,17 +302,9 @@ func selectSubHeaderView(cfg *SelectCfg, option string) View {
 					}),
 				},
 			}),
-			Row(ContainerCfg{
-				Padding: padTBLR(0, PadMedium),
-				Sizing:  FillFit,
-				Content: []View{
-					Rectangle(RectangleCfg{
-						Width:  1,
-						Height: 1,
-						Sizing: FillFit,
-						Color:  cfg.subheadingStyle.Color,
-					}),
-				},
+			Separator(SeparatorCfg{
+				Color: cfg.subheadingStyle.Color,
+				Inset: NewPadding(0, PadMedium, 0, PadMedium),
 			}),
 		},
 	})

--- a/gui/view_separator.go
+++ b/gui/view_separator.go
@@ -1,0 +1,86 @@
+package gui
+
+// SeparatorCfg configures a divider rule.
+//
+// A separator is a thin colored box: horizontal by default, filling the
+// parent's width at the theme thickness. Vertical separators fill the
+// parent's height at the theme thickness. The theme's divider color and
+// thickness apply unless overridden.
+type SeparatorCfg struct {
+	A11YCfg
+	ID       string
+	Vertical bool    // default horizontal
+	Color    Color   // zero takes the theme's divider color
+	Size     float32 // ergonomics-audit:opt-plain — zero means "theme default thickness", not a 0px rule a caller means
+	Inset    Padding // transparent margin around the rule
+	Length   float32 // rule extent along its long axis; zero fills the parent
+}
+
+// Separator draws a divider rule. The rule never takes a border or
+// radius from the theme — a separator is an edge, so a border around
+// it is never wanted.
+func Separator(cfg SeparatorCfg) View {
+	// Theme defaults resolve at generation time via the mirror
+	// applyTheme fills (see the theme phase rule).
+	style := defaultSeparatorStyle
+	size := cfg.Size
+	if size == 0 {
+		size = style.Size
+	}
+	color := cfg.Color
+	if !color.IsSet() {
+		color = style.Color
+	}
+
+	// The rule itself is a borderless, radius-free box. Padding must be
+	// explicit: a bare container would otherwise inherit the theme's
+	// border (doubling the height) and radius.
+	rule := ContainerCfg{
+		ID:         cfg.ID,
+		A11YCfg:    cfg.A11YCfg,
+		Color:      color,
+		Padding:    NoPadding,
+		SizeBorder: NoBorder,
+		Radius:     NoRadius,
+		Sizing:     FixedFixed,
+	}
+	if cfg.Vertical {
+		rule.Width = size
+		if cfg.Length > 0 {
+			rule.Height = cfg.Length
+		} else {
+			rule.Sizing = FixedFill
+		}
+	} else {
+		rule.Height = size
+		if cfg.Length > 0 {
+			rule.Width = cfg.Length
+		} else {
+			rule.Sizing = FillFixed
+		}
+	}
+
+	ruleView := container(rule)
+	if !cfg.Inset.IsSet() {
+		return ruleView
+	}
+	// The inset wrapper is transparent; the rule fills it, so the
+	// padding reads as margin around the rule. Along the parent's
+	// cross axis the wrapper still fills (Inset only ever insets the
+	// rule itself). The wrapper is borderless: a theme border here
+	// would eat into the rule's fill width.
+	if cfg.Vertical {
+		return Row(ContainerCfg{
+			Padding:    cfg.Inset,
+			Sizing:     FixedFill,
+			SizeBorder: NoBorder,
+			Content:    []View{ruleView},
+		})
+	}
+	return Column(ContainerCfg{
+		Padding:    cfg.Inset,
+		Sizing:     FillFit,
+		SizeBorder: NoBorder,
+		Content:    []View{ruleView},
+	})
+}

--- a/gui/view_separator_test.go
+++ b/gui/view_separator_test.go
@@ -1,0 +1,207 @@
+package gui
+
+import "testing"
+
+// separatorWindow renders a separator inside a fill root so its
+// arranged geometry can be asserted. The root is pinned borderless and
+// padding-free so the fill area is exactly the window.
+func separatorWindow(t *testing.T, vertical bool, cfg SeparatorCfg) *Window {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{Width: 400, Height: 300})
+	w.TestRender(func(win *Window) View {
+		root := ContainerCfg{
+			Sizing:     FillFill,
+			Padding:    NoPadding,
+			SizeBorder: NoBorder,
+			Content:    []View{Separator(cfg)},
+		}
+		if vertical {
+			return Row(root)
+		}
+		return Column(root)
+	})
+	return w
+}
+
+func TestSeparatorHorizontalFillsParentWidth(t *testing.T) {
+	restoreTheme(t)
+	SetTheme(ThemeDark)
+	w := separatorWindow(t, false, SeparatorCfg{ID: "sep"})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Width, 400) {
+		t.Errorf("width = %f, want 400 (fill)", sep.Shape.Width)
+	}
+	if !f32AreClose(sep.Shape.Height, 1) {
+		t.Errorf("height = %f, want theme thickness 1", sep.Shape.Height)
+	}
+	if sep.Shape.SizeBorder != 0 {
+		t.Errorf("SizeBorder = %f, want 0 (a separator never carries a border)",
+			sep.Shape.SizeBorder)
+	}
+}
+
+func TestSeparatorVerticalFillsParentHeight(t *testing.T) {
+	restoreTheme(t)
+	SetTheme(ThemeDark)
+	w := separatorWindow(t, true, SeparatorCfg{ID: "sep", Vertical: true})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Height, 300) {
+		t.Errorf("height = %f, want 300 (fill)", sep.Shape.Height)
+	}
+	if !f32AreClose(sep.Shape.Width, 1) {
+		t.Errorf("width = %f, want theme thickness 1", sep.Shape.Width)
+	}
+}
+
+// A bordered theme must not add a border around the rule or change its
+// thickness — that is the silent collapse bug the widget exists to kill.
+func TestSeparatorThicknessUnaffectedByBorders(t *testing.T) {
+	restoreTheme(t)
+	SetTheme(ThemeDark.WithBorders(true))
+	w := separatorWindow(t, false, SeparatorCfg{ID: "sep"})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Height, ThemeDark.separatorStyle.Size) {
+		t.Errorf("height = %f, want theme thickness %f under a bordered theme",
+			sep.Shape.Height, ThemeDark.separatorStyle.Size)
+	}
+	if sep.Shape.SizeBorder != 0 {
+		t.Errorf("SizeBorder = %f, want 0 under a bordered theme",
+			sep.Shape.SizeBorder)
+	}
+}
+
+func TestSeparatorCustomSizeAndColor(t *testing.T) {
+	w := separatorWindow(t, false, SeparatorCfg{
+		ID:    "sep",
+		Size:  3,
+		Color: Red,
+	})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Height, 3) {
+		t.Errorf("height = %f, want 3", sep.Shape.Height)
+	}
+	if sep.Shape.Color != Red {
+		t.Errorf("color = %v, want %v", sep.Shape.Color, Red)
+	}
+}
+
+func TestSeparatorZeroColorFallsBackToTheme(t *testing.T) {
+	restoreTheme(t)
+	SetTheme(ThemeDark)
+	w := separatorWindow(t, false, SeparatorCfg{ID: "sep"})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if sep.Shape.Color != ThemeDark.separatorStyle.Color {
+		t.Errorf("color = %v, want theme %v",
+			sep.Shape.Color, ThemeDark.separatorStyle.Color)
+	}
+}
+
+func TestSeparatorLengthFixesLongAxis(t *testing.T) {
+	w := separatorWindow(t, false, SeparatorCfg{
+		ID:     "sep",
+		Length: 100,
+	})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Width, 100) {
+		t.Errorf("width = %f, want 100 (fixed length)", sep.Shape.Width)
+	}
+}
+
+func TestSeparatorVerticalLength(t *testing.T) {
+	w := separatorWindow(t, true, SeparatorCfg{
+		ID:       "sep",
+		Vertical: true,
+		Length:   50,
+	})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Height, 50) {
+		t.Errorf("height = %f, want 50 (fixed length)", sep.Shape.Height)
+	}
+}
+
+// Inset is transparent margin: the rule shrinks by the inset on both
+// sides of the long axis, and the widget still spans the parent.
+func TestSeparatorInsetShrinksRule(t *testing.T) {
+	w := separatorWindow(t, false, SeparatorCfg{
+		ID:    "sep",
+		Inset: NewPadding(0, 10, 0, 10),
+	})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Width, 380) {
+		t.Errorf("width = %f, want 380 (400 minus 10+10 inset)", sep.Shape.Width)
+	}
+	if !f32AreClose(sep.Shape.Height, 1) {
+		t.Errorf("height = %f, want 1", sep.Shape.Height)
+	}
+}
+
+// A vertical separator with an inset wraps in a row: the rule keeps the
+// theme thickness and still fills the parent's height.
+func TestSeparatorVerticalInset(t *testing.T) {
+	w := separatorWindow(t, true, SeparatorCfg{
+		ID:       "sep",
+		Vertical: true,
+		Inset:    NewPadding(10, 0, 10, 0),
+	})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if !f32AreClose(sep.Shape.Width, 1) {
+		t.Errorf("width = %f, want theme thickness 1", sep.Shape.Width)
+	}
+	if !f32AreClose(sep.Shape.Height, 280) {
+		t.Errorf("height = %f, want 280 (300 minus 10+10 inset)", sep.Shape.Height)
+	}
+}
+
+func TestSeparatorA11YLabel(t *testing.T) {
+	w := separatorWindow(t, false, SeparatorCfg{
+		ID:      "sep",
+		A11YCfg: A11YCfg{A11YLabel: "divider"},
+	})
+
+	sep := findShapeByID(&w.layout, "sep")
+	if sep == nil {
+		t.Fatal("separator shape not found")
+	}
+	if sep.Shape.a11Y == nil {
+		t.Fatal("a11y nil")
+	}
+	if sep.Shape.a11Y.Label != "divider" {
+		t.Errorf("label = %q, want %q", sep.Shape.a11Y.Label, "divider")
+	}
+}


### PR DESCRIPTION
Closes #334

Adds `gui.Separator(SeparatorCfg)`: a thin divider rule that fills its
parent by default at the theme's divider color and thickness.

- Horizontal is `FillFixed`, vertical is `FixedFill` — the case that
  silently collapses today (a Fit box with no content arranges to
  zero) is now the default, not something the caller must get right.
- The rule is always borderless and radius-free; a bordered theme can
  no longer double its height.
- `ColorSeparator`/`sizeSeparator` are new ThemeMaker roles (fallback:
  `ColorBorder` / 1px) via a `separatorStyle` + `defaultSeparatorStyle`
  mirror, following the single-source rule.
- `Length` pins the rule's long axis; `Inset` adds transparent margin.
- Migrates the eight hand-rolled divider sites: markdown HR + h2
  rule, select/listbox/list-core subheading rules, menu separators,
  showcase `line()`, particles landing rules.

The datagrid resize handle is deliberately left alone — it is an
interactive hit target, not a divider.

Verification: arrange tests assert fill + thickness under the bordered
default theme; `make prepush` green.