### PR TITLE
gui: finish the type ladder — export all rungs, settle the mono +1 and the floors (issue #343)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ git config core.hooksPath .githooks  # enable tracked pre-commit/pre-push hooks
 make test                       # tests only
 make lint                       # golangci-lint (pinned version)
 make vet                        # go vet + requiredid analyzer
-make ergonomics-audit                 # focus/callbacks inventory + ID/a11y composition
+make ergonomics-audit                 # focus/callbacks inventory + ID/a11y/theme/visual gates
 make export-audit               # exported surface (advisory in-repo)
 ./scripts/large-files.sh        # report Go files >800 lines in gui/
 ```
@@ -163,7 +163,9 @@ over the `ColorSet`**, so existing code keeps its appearance when a set arrives.
 **Never spell a de-emphasis alpha, a label's size step, or a form control's text
 inset at a call site.** Each has one named source; a literal there is the
 divergence issue #335 measured and removed
-(`docs/specs/widget-visual-consistency-audit.md`).
+(`docs/specs/widget-visual-consistency-audit.md`). The _when_ — which role
+each decision takes, and when a deviation may carry the marker — is
+`docs/style-guide.md`, enforced by `ergonomics-audit -mode visual`.
 
 - **Quiet text** takes one of four `Theme` roles — `TextStyleSecondary`,
   `TextStyleLabel`, `TextStyleDisabled`, `TextStylePlaceholder`

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ ergonomics-audit:
 	go run ./tools/ergonomics-audit/ -mode literals .
 	go run ./tools/ergonomics-audit/ -mode theme .
 	go run ./tools/ergonomics-audit/ -mode a11y .
+	go run ./tools/ergonomics-audit/ -mode visual .
 
 # Insert a generated ID into every broken literal in this repo's tests
 # and examples. Scoped away from gui/ deliberately: go-gui's own widget

--- a/docs/specs/widget-visual-consistency-audit.md
+++ b/docs/specs/widget-visual-consistency-audit.md
@@ -354,7 +354,9 @@ What this branch changed, per axis. The measurements above describe the state at
 - **§6** — `ColorSet` still reaches only 5 of ~18 interactive widgets. `Table`,
   `ColorSwatch` and the `ExpandPanel` header are not focusable at all, so a
   focus ring there needs keyboard navigation designed first (§6.1).
-- **#335 steps 3 and 4** — `docs/style-guide.md` (the _when_, citing roles
-  rather than values) and `ergonomics-audit -mode visual` to gate raw dimming
-  and size-step literals in `gui/view_*.go`. The gate needs the deferred-marker
-  shape from the `theme` mode so the §1.2 ramps can be marked.
+- **#335 steps 3 and 4** — closed: `docs/style-guide.md` (the _when_,
+  citing roles rather than values) and `ergonomics-audit -mode visual`,
+  which gates raw dimming and size-step literals in `gui/view_*.go`. The
+  §1.2 ramps and the two §2 size steps carry the deferred marker
+  (`ergonomics-audit:visual`), so the exemptions are visible in every
+  audit run.

--- a/docs/specs/widget-visual-consistency-audit.md
+++ b/docs/specs/widget-visual-consistency-audit.md
@@ -331,32 +331,38 @@ like should be recorded, not read.
 What this branch changed, per axis. The measurements above describe the state at
 `b6adf899` and are kept as the "before"; this section is the "after".
 
-| §   | Axis              | Outcome                                                   |
-| --- | ----------------- | --------------------------------------------------------- |
-| 1   | Dimming           | closed — four named roles, per-theme and contrast-matched |
-| 2   | Type steps        | partly — label step is a role; DockLayout bypass fixed    |
-| 3   | Field labels      | closed — `Label` on all eight, one shared convention      |
-| 4   | Spacing           | untouched                                                 |
-| 5   | Borders           | untouched, by decision                                    |
-| 6   | Interaction state | partly — focus rings for the four that could take one     |
-| 7   | Density           | closed — one field-inset tier, two latent bugs fixed      |
+| §   | Axis              | Outcome                                                              |
+| --- | ----------------- | -------------------------------------------------------------------- |
+| 1   | Dimming           | closed — four named roles, per-theme and contrast-matched            |
+| 2   | Type steps        | mostly — full ladder exported, mono +1 documented, two steps tracked |
+| 3   | Field labels      | closed — `Label` on all eight, one shared convention                 |
+| 4   | Spacing           | untouched                                                            |
+| 5   | Borders           | untouched, by decision                                               |
+| 6   | Interaction state | partly — focus rings for the four that could take one                |
+| 7   | Density           | closed — one field-inset tier, two latent bugs fixed                 |
 
 ### Left open
 
 - **§1.1.2** — widgets that never themed their disabled text still lean on
   `dimAlpha`. Correct on dark, 22 alpha short on light.
-- **§2** — `N5`, `N6` and `i4` stay unexported; the mono ladder's `+1` baseline
-  offset is still undocumented at the call site; `view_color_fields.go` and
-  `view_input_numeric.go` still floor an inline size step at two different
-  values.
+- **§2** — the export half is closed: every ladder rung is exported (the
+  `N1`..`N6`, `B1`..`B6`, `I1`..`I6`, `BI1`..`BI6`, `M1`..`M6`, `Icon1`..`Icon6`
+  sets), and the mono `+1` is documented at the declaration in `ThemeMaker`.
+  `ColorFields`' label now steps through the `TextStyleLabel` role, so that call
+  site is gone. Two arithmetic steps remain, both marked and both stepping from
+  a caller-supplied size that lands on no rung: the roller's `+2` center
+  emphasis, and `NumericInput`'s `Size-4` triangle. The triangle's magic floor
+  `8` is gone — it is bounded by `N6.Size` below and the field text above — but
+  naming the bounds does not name the step. Closing these needs a
+  ladder-relative "one rung down from an arbitrary size" operation the ladder
+  does not currently offer.
 - **§4** — `SpacingLarge` still has no caller inside `gui/`, and about ten magic
   spacings still bypass the ladder.
 - **§6** — `ColorSet` still reaches only 5 of ~18 interactive widgets. `Table`,
   `ColorSwatch` and the `ExpandPanel` header are not focusable at all, so a
   focus ring there needs keyboard navigation designed first (§6.1).
-- **#335 steps 3 and 4** — closed: `docs/style-guide.md` (the _when_,
-  citing roles rather than values) and `ergonomics-audit -mode visual`,
-  which gates raw dimming and size-step literals in `gui/view_*.go`. The
-  §1.2 ramps and the two §2 size steps carry the deferred marker
-  (`ergonomics-audit:visual`), so the exemptions are visible in every
-  audit run.
+- **#335 steps 3 and 4** — closed: `docs/style-guide.md` (the _when_, citing
+  roles rather than values) and `ergonomics-audit -mode visual`, which gates raw
+  dimming and size-step literals in `gui/view_*.go`. The §1.2 ramps and the two
+  §2 size steps carry the deferred marker (`ergonomics-audit:visual`), so the
+  exemptions are visible in every audit run.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,117 @@
+# Style guide — the when, not the what
+
+Issue #335, steps 3–4. This document is the **when**: which named role a
+widget should read, and when a deviation is allowed. It cites roles, never
+values. Values live in exactly one place — `ThemeMaker` and the
+`default*Style` mirrors — and re-spelling one here would be the second
+source of truth the audit's other findings were measured against. If this
+guide says "secondary text" it means `Theme.TextStyleSecondary`, whatever
+it resolves to in the installed theme.
+
+The gate that enforces these decisions is `ergonomics-audit -mode visual`
+(`make ergonomics-audit`): a literal dimming alpha or type-size step in
+`gui/view_*.go` fails it unless the line carries the marker (§ Deviating).
+
+## Text — pick the role by what the text *does*
+
+Four roles cover every de-emphasis. Choose by the text's job, not by how
+quiet it should look:
+
+| Role                    | Use when the text…                                  |
+| ----------------------- | --------------------------------------------------- |
+| `TextStyleSecondary`    | supports primary text beside it: a hint, a detail, a measurement |
+| `TextStyleLabel`        | names a nearby value (a field's label); the one role that also steps size |
+| `TextStyleDisabled`     | sits in a control the user cannot act on            |
+| `TextStylePlaceholder`  | stands in for a value not yet entered               |
+
+Read the role's style directly where the text color is the theme's
+(`ts := guiTheme.TextStyleSecondary`); use `withRoleAlpha(base, role)`
+where the hue is caller-supplied — the channel label on a user-picked
+color keeps its hue and takes only the role's amount of quiet.
+
+Never spell an alpha. An opaque color (`alpha 255`) is not de-emphasis and
+does not need a role; a fade, a ramp or a fill is not text and is covered
+by the marker (§ Deviating), not by a role.
+
+## Type steps — size by named handle, or not at all
+
+The size ladder is a set of named handles (`N1`..`N6`, `M1`..`M6`,
+`B1`..`B6`, `Icon1`..`Icon6`). Take a step by reading the handle, never by
+arithmetic on `X.Size`. A `Size ± N` that produces a text style is a
+finding; two tracked exceptions carry the marker (§ Deviating).
+
+The only automatic step in the toolkit is a field label: `TextStyleLabel`
+steps its own size, so a labelled form reads correctly without the widget
+spelling a number.
+
+Distinguish a type step from geometry. A row height, icon width or splitter
+dimension derived from a text size (`style.Size + 4` as a width) is
+measurement, not typography, and is not a finding.
+
+## Field labels — two placements, one per control kind
+
+- `labelledField` — the label **above** the control: form fields
+  (`Input`, `Select`, `Combobox`, `NumericInput`, `DatePicker`,
+  `InputDate`, `ColorPicker`). It exists so the placement and the gap are
+  decided once, not per widget.
+- `trailingLabel` — the label **beside** the control: boolean controls
+  (`Switch`, `Toggle`, `Radio`).
+
+The accessible name is separate: `A11YLabel`/`A11YDescription` feed the
+accessibility tree. A visual label and an accessible name are both
+expected, and neither substitutes for the other.
+
+## Spacing and insets — the tiers mean relatedness
+
+`SpacingSmall` binds a tightly related pair (a control and its
+readout); `SpacingMedium` separates members of one group; `SpacingLarge`
+separates sections. Prefer a tier over a magic number; a number that
+bypasses the ladder is a finding on the same basis as a dimming alpha.
+
+A form control's text inset is `Theme.PaddingField` — that is what makes
+controls in one row share a height. A structural wrapper (a container
+that groups children but is not a box) must set `SizeBorder: NoBorder`
+and `Padding: NoPadding`, so its reserved border and padding do not
+silently add height.
+
+## Per-state colors — ColorSet, with flat as the exception
+
+Build per-state colors with `ColorSet` (its `resolved()` returns the
+theme-matched color for the shape's state) and keep one appearance with
+`Flat(c)`. Precedence: an assigned flat `Color*` field on the Cfg wins
+over the `ColorSet` — the widget keeps its appearance when a set arrives.
+
+## Focus rings — the shared helper, not a local stroke
+
+A focusable widget's focus affordance comes from the shared ring helpers
+(`colorControlFocusRing`, `focusRingAmend`), which own the ring's shape
+and colors. A hand-drawn focus stroke at a call site is a second
+implementation of the same affordance — the divergence the audit's §6
+measured.
+
+## Deviating
+
+A literal dimming alpha or size step in `gui/view_*.go` is a finding
+unless the line carries the deferred marker:
+
+```go
+alpha := uint8(150) // ergonomics-audit:visual
+```
+
+The marker is for the audit's documented exemptions, and they are listed
+here so a new exemption is a decision, not a habit:
+
+- **Ramps** — a graduated effect, not a state: the date-picker roller
+  distance ramp (`view_date_picker_roller.go`), the math-spinner ghost and
+  trail (`view_math_spinner.go`).
+- **Non-text fills** — an alpha that is not de-emphasized text: markdown
+  code/blockquote backgrounds, the dock zone preview, a drag ghost, a
+  selection highlight, the swatch edge.
+- **Tracked size steps** — the two inline floors the audit keeps open
+  (`view_input_numeric.go`, `view_date_picker_roller.go`), pending named
+  handles.
+
+A new deviation carries the marker **and** a comment naming the reason;
+the gate reports the line as deferred, so the exemption stays visible in
+every `make ergonomics-audit` run. Anything else fails the gate — which is
+the point.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,117 +1,130 @@
 # Style guide — the when, not the what
 
-Issue #335, steps 3–4. This document is the **when**: which named role a
-widget should read, and when a deviation is allowed. It cites roles, never
-values. Values live in exactly one place — `ThemeMaker` and the
-`default*Style` mirrors — and re-spelling one here would be the second
-source of truth the audit's other findings were measured against. If this
-guide says "secondary text" it means `Theme.TextStyleSecondary`, whatever
-it resolves to in the installed theme.
+Issue #335, steps 3–4. This document is the **when**: which named role a widget
+should read, and when a deviation is allowed. It cites roles, never values.
+Values live in exactly one place — `ThemeMaker` and the `default*Style` mirrors
+— and re-spelling one here would be the second source of truth the audit's other
+findings were measured against. If this guide says "secondary text" it means
+`Theme.TextStyleSecondary`, whatever it resolves to in the installed theme.
 
 The gate that enforces these decisions is `ergonomics-audit -mode visual`
 (`make ergonomics-audit`): a literal dimming alpha or type-size step in
 `gui/view_*.go` fails it unless the line carries the marker (§ Deviating).
 
-## Text — pick the role by what the text *does*
+## Text — pick the role by what the text _does_
 
-Four roles cover every de-emphasis. Choose by the text's job, not by how
-quiet it should look:
+Four roles cover every de-emphasis. Choose by the text's job, not by how quiet
+it should look:
 
-| Role                    | Use when the text…                                  |
-| ----------------------- | --------------------------------------------------- |
-| `TextStyleSecondary`    | supports primary text beside it: a hint, a detail, a measurement |
-| `TextStyleLabel`        | names a nearby value (a field's label); the one role that also steps size |
-| `TextStyleDisabled`     | sits in a control the user cannot act on            |
-| `TextStylePlaceholder`  | stands in for a value not yet entered               |
+| Role                   | Use when the text…                                                        |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `TextStyleSecondary`   | supports primary text beside it: a hint, a detail, a measurement          |
+| `TextStyleLabel`       | names a nearby value (a field's label); the one role that also steps size |
+| `TextStyleDisabled`    | sits in a control the user cannot act on                                  |
+| `TextStylePlaceholder` | stands in for a value not yet entered                                     |
 
 Read the role's style directly where the text color is the theme's
-(`ts := guiTheme.TextStyleSecondary`); use `withRoleAlpha(base, role)`
-where the hue is caller-supplied — the channel label on a user-picked
-color keeps its hue and takes only the role's amount of quiet.
+(`ts := guiTheme.TextStyleSecondary`); use `withRoleAlpha(base, role)` where the
+hue is caller-supplied — the channel label on a user-picked color keeps its hue
+and takes only the role's amount of quiet.
 
-Never spell an alpha. An opaque color (`alpha 255`) is not de-emphasis and
-does not need a role; a fade, a ramp or a fill is not text and is covered
-by the marker (§ Deviating), not by a role.
+Never spell an alpha. An opaque color (`alpha 255`) is not de-emphasis and does
+not need a role; a fade, a ramp or a fill is not text and is covered by the
+marker (§ Deviating), not by a role.
 
 ## Type steps — size by named handle, or not at all
 
-The size ladder is a set of named handles (`N1`..`N6`, `M1`..`M6`,
-`B1`..`B6`, `Icon1`..`Icon6`). Take a step by reading the handle, never by
-arithmetic on `X.Size`. A `Size ± N` that produces a text style is a
-finding; two tracked exceptions carry the marker (§ Deviating).
+The size ladder is a set of named handles (`N1`..`N6`, `M1`..`M6`, `I1`..`I6`,
+`BI1`..`BI6`, `B1`..`B6`, `Icon1`..`Icon6`). Every rung is exported — an app's
+widget spells the step of the widget beside it instead of guessing. Take a step
+by reading the handle, never by arithmetic on `X.Size`. A `Size ± N` that
+produces a text style is a finding; two tracked exceptions carry the marker (§
+Deviating).
 
-The only automatic step in the toolkit is a field label: `TextStyleLabel`
-steps its own size, so a labelled form reads correctly without the widget
-spelling a number.
+Naming a step's _floor_ does not resolve the step. `f32Max(X.Size-4, N6.Size)`
+still sizes text by arithmetic; the named rung only bounds the result. The gate
+reports it either way — it keys on the arithmetic, not on how the bound is
+spelled.
+
+The mono ladder sits +1 above the roman ladder at every rung (`M4` is 15 where
+`N4` is 14): an optical compensation for the mono face, uniform because it is
+the same face at every size. Expect the step when mixing `M`-rungs with
+`N`-rungs.
+
+The only automatic step in the toolkit is a field label: `TextStyleLabel` steps
+its own size, so a labelled form reads correctly without the widget spelling a
+number.
 
 Distinguish a type step from geometry. A row height, icon width or splitter
-dimension derived from a text size (`style.Size + 4` as a width) is
-measurement, not typography, and is not a finding.
+dimension derived from a text size (`style.Size + 4` as a width) is measurement,
+not typography, and is not a finding.
 
 ## Field labels — two placements, one per control kind
 
-- `labelledField` — the label **above** the control: form fields
-  (`Input`, `Select`, `Combobox`, `NumericInput`, `DatePicker`,
-  `InputDate`, `ColorPicker`). It exists so the placement and the gap are
-  decided once, not per widget.
+- `labelledField` — the label **above** the control: form fields (`Input`,
+  `Select`, `Combobox`, `NumericInput`, `DatePicker`, `InputDate`,
+  `ColorPicker`). It exists so the placement and the gap are decided once, not
+  per widget.
 - `trailingLabel` — the label **beside** the control: boolean controls
   (`Switch`, `Toggle`, `Radio`).
 
 The accessible name is separate: `A11YLabel`/`A11YDescription` feed the
-accessibility tree. A visual label and an accessible name are both
-expected, and neither substitutes for the other.
+accessibility tree. A visual label and an accessible name are both expected, and
+neither substitutes for the other.
 
 ## Spacing and insets — the tiers mean relatedness
 
-`SpacingSmall` binds a tightly related pair (a control and its
-readout); `SpacingMedium` separates members of one group; `SpacingLarge`
-separates sections. Prefer a tier over a magic number; a number that
-bypasses the ladder is a finding on the same basis as a dimming alpha.
+`SpacingSmall` binds a tightly related pair (a control and its readout);
+`SpacingMedium` separates members of one group; `SpacingLarge` separates
+sections. Prefer a tier over a magic number; a number that bypasses the ladder
+is a finding on the same basis as a dimming alpha.
 
 A form control's text inset is `Theme.PaddingField` — that is what makes
-controls in one row share a height. A structural wrapper (a container
-that groups children but is not a box) must set `SizeBorder: NoBorder`
-and `Padding: NoPadding`, so its reserved border and padding do not
-silently add height.
+controls in one row share a height. A structural wrapper (a container that
+groups children but is not a box) must set `SizeBorder: NoBorder` and
+`Padding: NoPadding`, so its reserved border and padding do not silently add
+height.
 
 ## Per-state colors — ColorSet, with flat as the exception
 
 Build per-state colors with `ColorSet` (its `resolved()` returns the
 theme-matched color for the shape's state) and keep one appearance with
-`Flat(c)`. Precedence: an assigned flat `Color*` field on the Cfg wins
-over the `ColorSet` — the widget keeps its appearance when a set arrives.
+`Flat(c)`. Precedence: an assigned flat `Color*` field on the Cfg wins over the
+`ColorSet` — the widget keeps its appearance when a set arrives.
 
 ## Focus rings — the shared helper, not a local stroke
 
 A focusable widget's focus affordance comes from the shared ring helpers
-(`colorControlFocusRing`, `focusRingAmend`), which own the ring's shape
-and colors. A hand-drawn focus stroke at a call site is a second
-implementation of the same affordance — the divergence the audit's §6
-measured.
+(`colorControlFocusRing`, `focusRingAmend`), which own the ring's shape and
+colors. A hand-drawn focus stroke at a call site is a second implementation of
+the same affordance — the divergence the audit's §6 measured.
 
 ## Deviating
 
-A literal dimming alpha or size step in `gui/view_*.go` is a finding
-unless the line carries the deferred marker:
+A literal dimming alpha or size step in `gui/view_*.go` is a finding unless the
+line carries the deferred marker:
 
 ```go
 alpha := uint8(150) // ergonomics-audit:visual
 ```
 
-The marker is for the audit's documented exemptions, and they are listed
-here so a new exemption is a decision, not a habit:
+The marker is for the audit's documented exemptions, and they are listed here so
+a new exemption is a decision, not a habit:
 
-- **Ramps** — a graduated effect, not a state: the date-picker roller
-  distance ramp (`view_date_picker_roller.go`), the math-spinner ghost and
-  trail (`view_math_spinner.go`).
+- **Ramps** — a graduated effect, not a state: the date-picker roller distance
+  ramp (`view_date_picker_roller.go`), the math-spinner ghost and trail
+  (`view_math_spinner.go`).
 - **Non-text fills** — an alpha that is not de-emphasized text: markdown
-  code/blockquote backgrounds, the dock zone preview, a drag ghost, a
-  selection highlight, the swatch edge.
-- **Tracked size steps** — the two inline floors the audit keeps open
-  (`view_input_numeric.go`, `view_date_picker_roller.go`), pending named
-  handles.
+  code/blockquote backgrounds, the dock zone preview, a drag ghost, a selection
+  highlight, the swatch edge.
+- **Tracked size steps** — two, and both for the same reason: they step from a
+  caller-supplied size, which lands anywhere, so no named rung is the one to
+  read. The date-picker roller's center-item emphasis
+  (`view_date_picker_roller.go`) and the numeric input's step triangle
+  (`view_input_numeric.go`). The ladder's rungs are non-uniform (+2 at the small
+  end, +4 above medium), so no fixed step equals a rung at every size. Both
+  bound the result with named rungs.
 
-A new deviation carries the marker **and** a comment naming the reason;
-the gate reports the line as deferred, so the exemption stays visible in
-every `make ergonomics-audit` run. Anything else fails the gate — which is
-the point.
+A new deviation carries the marker **and** a comment naming the reason; the gate
+reports the line as deferred, so the exemption stays visible in every
+`make ergonomics-audit` run. Anything else fails the gate — which is the point.

--- a/gui/inspector_props.go
+++ b/gui/inspector_props.go
@@ -59,7 +59,7 @@ func inspectorPropsNodes(p inspectorNodeProps) []TreeNodeCfg {
 	}
 	// Icon5 is the XSmall themed icon style, so it already carries the
 	// theme's icon family (app-overridable via ThemeCfg.IconFontFamily).
-	pis := guiTheme.icon5
+	pis := guiTheme.Icon5
 	pis.Color = propColor
 
 	nodes := make([]TreeNodeCfg, 0, 16)

--- a/gui/theme.go
+++ b/gui/theme.go
@@ -78,54 +78,40 @@ type Theme struct {
 	// The four are the vocabulary an app styles its own widgets with.
 	// Unexporting any would leave an app unable to match the toolkit's
 	// own de-emphasis, which is the divergence #335 exists to end.
-
+	//
 	// exportaudit:keep — public styling vocabulary (see above).
-	TextStyleSecondary TextStyle
-	// exportaudit:keep — public styling vocabulary (see above).
-	TextStyleLabel TextStyle
-	// exportaudit:keep — public styling vocabulary (see above).
-	TextStyleDisabled TextStyle
-	// exportaudit:keep — public styling vocabulary (see above).
-	TextStylePlaceholder TextStyle
+	TextStyleSecondary, TextStyleLabel, TextStyleDisabled, TextStylePlaceholder TextStyle
 
 	// Text size shortcuts (N = normal, B = bold,
 	// I = italic, M = mono, BI = bold+italic).
-	N1    TextStyle
-	N2    TextStyle
-	N3    TextStyle
-	N4    TextStyle
-	N5    TextStyle
-	N6    TextStyle
-	B1    TextStyle
-	B2    TextStyle
-	B3    TextStyle
-	B4    TextStyle
-	B5    TextStyle
-	B6    TextStyle
-	i1    TextStyle
-	i2    TextStyle
-	I3    TextStyle
-	i4    TextStyle
-	i5    TextStyle
-	i6    TextStyle
-	bI1   TextStyle
-	bI2   TextStyle
-	BI3   TextStyle
-	bI4   TextStyle
-	bI5   TextStyle
-	bI6   TextStyle
-	M1    TextStyle
-	M2    TextStyle
-	M3    TextStyle
-	M4    TextStyle
-	M5    TextStyle
-	M6    TextStyle
-	Icon1 TextStyle
-	Icon2 TextStyle
-	Icon3 TextStyle
-	Icon4 TextStyle
-	icon5 TextStyle
-	icon6 TextStyle
+	//
+	// The rungs are the toolkit's shorthand for the two dimensions a
+	// caller actually chooses — face and size — so a widget names one
+	// handle instead of filling in a whole TextStyle. Read them the way
+	// HTML's h1..h6 are read: the number is the step, not a measurement.
+	//
+	// The set is a closed 6x6 grid, and every cell is exported because a
+	// half-exported grid is a broken vocabulary: bold-small reachable
+	// and italic-small not is an accident of which cell a widget in this
+	// repo happened to need first. Completeness is the design here, so
+	// "no caller yet" is not the test for whether a rung belongs.
+	//
+	// The M ladder sits +1 above the roman ladder at every rung (M4 is
+	// 15 where N4 is 14); see ThemeMaker.
+	//
+	// Declared one face per line so a single keep marker covers the
+	// face: exportaudit reads the marker off the field declaration, and
+	// every name on that line shares it.
+	N1, N2, N3, N4, N5, N6 TextStyle
+	B1, B2, B3, B4, B5, B6 TextStyle
+	// exportaudit:keep — closed grid, exported for completeness (see above).
+	I1, I2, I3, I4, I5, I6 TextStyle
+	// exportaudit:keep — closed grid, exported for completeness (see above).
+	BI1, BI2, BI3, BI4, BI5, BI6 TextStyle
+	// exportaudit:keep — closed grid, exported for completeness (see above).
+	M1, M2, M3, M4, M5, M6 TextStyle
+	// exportaudit:keep — closed grid, exported for completeness (see above).
+	Icon1, Icon2, Icon3, Icon4, Icon5, Icon6 TextStyle
 
 	// Per-widget styles.
 	ButtonStyle         buttonStyle

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -557,24 +557,28 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 	// Italic shortcuts.
 	italic := ts
 	italic.Typeface = glyph.TypefaceItalic
-	theme.i1 = makeStyle(italic, theme.sizeTextXLarge)
-	theme.i2 = makeStyle(italic, theme.sizeTextLarge)
+	theme.I1 = makeStyle(italic, theme.sizeTextXLarge)
+	theme.I2 = makeStyle(italic, theme.sizeTextLarge)
 	theme.I3 = makeStyle(italic, theme.sizeTextMedium)
-	theme.i4 = makeStyle(italic, theme.sizeTextSmall)
-	theme.i5 = makeStyle(italic, theme.sizeTextXSmall)
-	theme.i6 = makeStyle(italic, theme.SizeTextTiny)
+	theme.I4 = makeStyle(italic, theme.sizeTextSmall)
+	theme.I5 = makeStyle(italic, theme.sizeTextXSmall)
+	theme.I6 = makeStyle(italic, theme.SizeTextTiny)
 
 	// Bold+italic shortcuts.
 	boldItalic := ts
 	boldItalic.Typeface = glyph.TypefaceBoldItalic
-	theme.bI1 = makeStyle(boldItalic, theme.sizeTextXLarge)
-	theme.bI2 = makeStyle(boldItalic, theme.sizeTextLarge)
+	theme.BI1 = makeStyle(boldItalic, theme.sizeTextXLarge)
+	theme.BI2 = makeStyle(boldItalic, theme.sizeTextLarge)
 	theme.BI3 = makeStyle(boldItalic, theme.sizeTextMedium)
-	theme.bI4 = makeStyle(boldItalic, theme.sizeTextSmall)
-	theme.bI5 = makeStyle(boldItalic, theme.sizeTextXSmall)
-	theme.bI6 = makeStyle(boldItalic, theme.SizeTextTiny)
+	theme.BI4 = makeStyle(boldItalic, theme.sizeTextSmall)
+	theme.BI5 = makeStyle(boldItalic, theme.sizeTextXSmall)
+	theme.BI6 = makeStyle(boldItalic, theme.SizeTextTiny)
 
-	// Mono shortcuts (+1 size offset).
+	// Mono shortcuts: +1 at every rung, so M4 (15) does not share N4's
+	// (14) baseline. Mono faces typically draw optically smaller than
+	// roman ones at the same point size; the offset is the compensation,
+	// applied uniformly because it is the same face at every size. Apps
+	// reading M-rungs beside N-rungs should expect the step.
 	mono := ts
 	mono.Family = cfg.monoFontFamily
 	theme.M1 = makeStyle(mono, theme.sizeTextXLarge+1)
@@ -591,8 +595,8 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 	theme.Icon2 = makeStyle(icon, theme.sizeTextLarge)
 	theme.Icon3 = makeStyle(icon, theme.sizeTextMedium)
 	theme.Icon4 = makeStyle(icon, theme.sizeTextSmall)
-	theme.icon5 = makeStyle(icon, theme.sizeTextXSmall)
-	theme.icon6 = makeStyle(icon, theme.SizeTextTiny)
+	theme.Icon5 = makeStyle(icon, theme.sizeTextXSmall)
+	theme.Icon6 = makeStyle(icon, theme.SizeTextTiny)
 
 	// Every theme leaving this constructor carries a fresh identity.
 	// Install and cache-invalidation compare ids, never Name: two themes

--- a/gui/theme_maker_test.go
+++ b/gui/theme_maker_test.go
@@ -10,8 +10,8 @@ func iconStyleFamilies(theme Theme) []string {
 		theme.Icon2.Family,
 		theme.Icon3.Family,
 		theme.Icon4.Family,
-		theme.icon5.Family,
-		theme.icon6.Family,
+		theme.Icon5.Family,
+		theme.Icon6.Family,
 		theme.treeStyle.textStyleIcon.Family,
 	}
 }
@@ -76,8 +76,8 @@ func TestThemeMakerIconFamilyDoesNotLeak(t *testing.T) {
 	theme := ThemeMaker(cfg)
 
 	text := map[string]TextStyle{
-		"I3": theme.I3, "I6": theme.i6,
-		"BI3": theme.BI3, "BI6": theme.bI6,
+		"I3": theme.I3, "I6": theme.I6,
+		"BI3": theme.BI3, "BI6": theme.BI6,
 	}
 	for name, s := range text {
 		if s.Family != "mytextfamily" {
@@ -321,5 +321,72 @@ func TestThemeMakerZeroCfg(t *testing.T) {
 	}
 	if theme.separatorStyle.Size != 1 {
 		t.Errorf("separatorStyle.Size = %f, want 1", theme.separatorStyle.Size)
+	}
+}
+
+// TestThemeMakerLadderGrid locks the closed 6x6 ladder (issue #343):
+// every rung of every face is populated, rungs ascend N1..N6 within a
+// face, the roman faces share one size scale, and the mono face sits
+// +1 above it. A zero rung or a drifted mono offset would otherwise
+// render silently and surface nowhere.
+func TestThemeMakerLadderGrid(t *testing.T) {
+	type face struct {
+		name string
+		runs [6]TextStyle
+	}
+	faces := []face{
+		{"N", [6]TextStyle{ThemeDark.N1, ThemeDark.N2, ThemeDark.N3, ThemeDark.N4, ThemeDark.N5, ThemeDark.N6}},
+		{"B", [6]TextStyle{ThemeDark.B1, ThemeDark.B2, ThemeDark.B3, ThemeDark.B4, ThemeDark.B5, ThemeDark.B6}},
+		{"I", [6]TextStyle{ThemeDark.I1, ThemeDark.I2, ThemeDark.I3, ThemeDark.I4, ThemeDark.I5, ThemeDark.I6}},
+		{"BI", [6]TextStyle{ThemeDark.BI1, ThemeDark.BI2, ThemeDark.BI3, ThemeDark.BI4, ThemeDark.BI5, ThemeDark.BI6}},
+		{"Icon", [6]TextStyle{ThemeDark.Icon1, ThemeDark.Icon2, ThemeDark.Icon3, ThemeDark.Icon4, ThemeDark.Icon5, ThemeDark.Icon6}},
+		{"M", [6]TextStyle{ThemeDark.M1, ThemeDark.M2, ThemeDark.M3, ThemeDark.M4, ThemeDark.M5, ThemeDark.M6}},
+	}
+
+	// The canonical roman scale the other faces must match, rung by rung.
+	nSizes := [6]float32{
+		ThemeDark.N1.Size, ThemeDark.N2.Size, ThemeDark.N3.Size,
+		ThemeDark.N4.Size, ThemeDark.N5.Size, ThemeDark.N6.Size,
+	}
+
+	for _, f := range faces {
+		for i, s := range f.runs {
+			if s.Size <= 0 {
+				t.Errorf("%s%d.Size = %v, want > 0", f.name, i+1, s.Size)
+			}
+		}
+		// Rungs ascend within a face: N1 (xlarge) is the largest.
+		for i := 0; i+1 < len(f.runs); i++ {
+			if f.runs[i].Size <= f.runs[i+1].Size {
+				t.Errorf("%s%d.Size = %v, want > %s%d (%v)",
+					f.name, i+1, f.runs[i].Size,
+					f.name, i+2, f.runs[i+1].Size)
+			}
+		}
+	}
+
+	// The roman faces share the N scale at every rung.
+	for _, f := range faces {
+		if f.name == "M" {
+			continue
+		}
+		for rung := range 6 {
+			if f.runs[rung].Size != nSizes[rung] {
+				t.Errorf("%s%d.Size = %v, want N%d %v",
+					f.name, rung+1, f.runs[rung].Size, rung+1, nSizes[rung])
+			}
+		}
+	}
+
+	// The mono face sits +1 above the roman scale at every rung.
+	mSizes := [6]float32{
+		ThemeDark.M1.Size, ThemeDark.M2.Size, ThemeDark.M3.Size,
+		ThemeDark.M4.Size, ThemeDark.M5.Size, ThemeDark.M6.Size,
+	}
+	for rung := range 6 {
+		if mSizes[rung] != nSizes[rung]+1 {
+			t.Errorf("M%d.Size = %v, want N%d+1 %v",
+				rung+1, mSizes[rung], rung+1, nSizes[rung]+1)
+		}
 	}
 }

--- a/gui/view_date_picker_roller.go
+++ b/gui/view_date_picker_roller.go
@@ -196,13 +196,17 @@ func rollerDrum(
 
 		itemTS := ts
 		if offset == 0 {
-			itemTS.Size = ts.Size + 2
+			// Audit §2: the center item steps one type size inline; N5/N6
+			// are unexported so there is no named handle to use yet.
+			itemTS.Size = ts.Size + 2 // ergonomics-audit:visual
 		} else {
 			dist := offset
 			if dist < 0 {
 				dist = -dist
 			}
-			alpha := uint8(150)
+			// Audit §1.2: the roller distance ramp is exempt from the
+			// dimming roles — it is a ramp, not a de-emphasis.
+			alpha := uint8(150) // ergonomics-audit:visual
 			if dist > 1 {
 				alpha = 80
 			}

--- a/gui/view_date_picker_roller.go
+++ b/gui/view_date_picker_roller.go
@@ -196,8 +196,12 @@ func rollerDrum(
 
 		itemTS := ts
 		if offset == 0 {
-			// Audit §2: the center item steps one type size inline; N5/N6
-			// are unexported so there is no named handle to use yet.
+			// The drum's center item pops one optical step above the
+			// rest. It tracks the configured style rather than a fixed
+			// rung, and the ladder's own rungs are non-uniform (+2 at
+			// the small end, +4 above medium), so no named step equals
+			// this at every size — the +2 is deliberate drum emphasis,
+			// not a type step (issue #335 §2).
 			itemTS.Size = ts.Size + 2 // ergonomics-audit:visual
 		} else {
 			dist := offset

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -109,7 +109,8 @@ func DockLayout(cfg DockLayoutCfg) View {
 func applyDockLayoutDefaults(cfg *DockLayoutCfg) {
 	cfg.Sizing = cfg.Sizing.Or(FillFill)
 	if !cfg.colorZonePreview.IsSet() {
-		cfg.colorZonePreview = RGBA(70, 130, 220, 80)
+		// Non-text fill, exempt from the dimming roles (audit §1.2).
+		cfg.colorZonePreview = RGBA(70, 130, 220, 80) // ergonomics-audit:visual
 	}
 	if !cfg.colorTab.IsSet() {
 		cfg.colorTab = guiTheme.ColorPanel

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -234,7 +234,9 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 }
 
 func numericInputStepButtons(cfg NumericInputCfg, locale NumericLocaleCfg, stepCfg NumericStepCfg) View {
-	triangleSize := f32Max(cfg.TextStyle.Size-4, 8)
+	// Audit §2: the step triangle floors an inline size step at 8; N5/N6
+	// are unexported so there is no named handle to use yet.
+	triangleSize := f32Max(cfg.TextStyle.Size-4, 8) // ergonomics-audit:visual
 	triangleStyle := TextStyle{
 		Color:  cfg.TextStyle.Color,
 		Size:   triangleSize,

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -234,9 +234,23 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 }
 
 func numericInputStepButtons(cfg NumericInputCfg, locale NumericLocaleCfg, stepCfg NumericStepCfg) View {
-	// Audit §2: the step triangle floors an inline size step at 8; N5/N6
-	// are unexported so there is no named handle to use yet.
-	triangleSize := f32Max(cfg.TextStyle.Size-4, 8) // ergonomics-audit:visual
+	// The step triangle sits below the field text by a fixed 4pt, not by
+	// a rung: the field text is caller-supplied and lands anywhere, so
+	// there is no rung to step from. At the default 16 the drop spans
+	// two rungs (16 -> 14 -> 12). This is the §2 step issue #335 left
+	// open — a named handle would have to be a "one rung down from an
+	// arbitrary size" operation the ladder does not offer, so the
+	// arithmetic stays marked and visible to the gate rather than
+	// disguised (issue #335 §2).
+	//
+	// Bounds are both named rungs of the installed theme: never below
+	// N6 (tiny), the smallest a triangle stays legible at, and never
+	// above the text it decorates — a theme with a large SizeTextTiny
+	// can otherwise floor the triangle bigger than the field.
+	triangleSize := f32Min(
+		f32Max(cfg.TextStyle.Size-4, guiTheme.N6.Size), // ergonomics-audit:visual
+		cfg.TextStyle.Size,
+	)
 	triangleStyle := TextStyle{
 		Color:  cfg.TextStyle.Color,
 		Size:   triangleSize,

--- a/gui/view_input_numeric_test.go
+++ b/gui/view_input_numeric_test.go
@@ -2,6 +2,90 @@ package gui
 
 import "testing"
 
+// TestNumericInputStepTriangleBounds locks the named bounds of the step
+// triangle (issue #335 §2): it sits 4pt below the field text, never
+// below the ladder's bottom rung (N6, tiny) and never above the text it
+// decorates. The old widget-local floor was 8 — below every named rung.
+func TestNumericInputStepTriangleBounds(t *testing.T) {
+	// The text sizes rendered in the generated layout, triangle included.
+	textSizes := func(cfg NumericInputCfg) map[float32]bool {
+		w := &Window{}
+		v := NumericInput(cfg)
+		layout := generateViewLayout(v, w)
+		sizes := map[float32]bool{}
+		var walk func(l Layout)
+		walk = func(l Layout) {
+			if l.Shape != nil && l.Shape.TC != nil {
+				sizes[l.Shape.TC.TextStyle.Size] = true
+			}
+			for _, c := range l.Children {
+				walk(c)
+			}
+		}
+		walk(layout)
+		return sizes
+	}
+
+	// The lowest size anywhere in the layout, which is the triangle
+	// whenever it is stepped below the field text.
+	minSize := func(sizes map[float32]bool) float32 {
+		var lo float32
+		set := false
+		for s := range sizes {
+			if !set || s < lo {
+				lo, set = s, true
+			}
+		}
+		return lo
+	}
+
+	// A small field text (12) steps to 8 — the old widget-local floor,
+	// and below every named rung. The named floor lifts it to N6 (10),
+	// a value nothing else in this layout renders, so the assertion is
+	// not satisfied by the field text itself.
+	small := DefaultTextStyle
+	small.Size = 12
+	smallSizes := textSizes(NumericInputCfg{
+		ID:        "ni-small",
+		TextStyle: small,
+		StepCfg:   NumericStepCfg{ShowButtons: true, Step: 1},
+	})
+	if got := minSize(smallSizes); got != guiTheme.N6.Size {
+		t.Errorf("small layout floors at %v, want N6 (%v); sizes = %v",
+			got, guiTheme.N6.Size, smallSizes)
+	}
+
+	// A default field steps clear of both bounds.
+	defSizes := textSizes(NumericInputCfg{
+		ID:      "ni-def",
+		StepCfg: NumericStepCfg{ShowButtons: true, Step: 1},
+	})
+	if got := minSize(defSizes); got != DefaultTextStyle.Size-4 {
+		t.Errorf("default layout triangle is %v, want %v; sizes = %v",
+			got, DefaultTextStyle.Size-4, defSizes)
+	}
+
+	// The ceiling: a field text below the bottom rung (8 against N6's
+	// 10) would have the floor lift the triangle *above* the text it
+	// decorates. The clamp keeps it at the text size. This is the bound
+	// a theme with a large SizeTextTiny crosses at ordinary text sizes.
+	belowFloor := DefaultTextStyle
+	belowFloor.Size = guiTheme.N6.Size - 2
+	belowSizes := textSizes(NumericInputCfg{
+		ID:        "ni-below",
+		TextStyle: belowFloor,
+		StepCfg:   NumericStepCfg{ShowButtons: true, Step: 1},
+	})
+	if got := minSize(belowSizes); got != belowFloor.Size {
+		t.Errorf("triangle is %v, want the field text %v; sizes = %v",
+			got, belowFloor.Size, belowSizes)
+	}
+	if belowSizes[guiTheme.N6.Size] {
+		t.Errorf("floor lifted the triangle to N6 (%v) above the field text %v; sizes = %v",
+			guiTheme.N6.Size, belowFloor.Size, belowSizes)
+	}
+}
+
 func TestNumericInputIDPassthrough(t *testing.T) {
 	w := &Window{}
 	v := NumericInput(NumericInputCfg{

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -76,19 +76,20 @@ func DefaultMarkdownStyle() MarkdownStyle {
 	bi := guiTheme.bI4
 
 	return MarkdownStyle{
-		Text:              text,
-		h1:                guiTheme.B1,
-		H2:                guiTheme.B2,
-		h3:                guiTheme.B3,
-		h4:                guiTheme.B4,
-		h5:                guiTheme.B5,
-		h6:                guiTheme.B6,
-		Bold:              bold,
-		Italic:            italic,
-		boldItalic:        bi,
-		Code:              guiTheme.M5,
-		codeBlockText:     guiTheme.M5,
-		CodeBlockBG:       RGBA(0, 0, 0, 50),
+		Text:          text,
+		h1:            guiTheme.B1,
+		H2:            guiTheme.B2,
+		h3:            guiTheme.B3,
+		h4:            guiTheme.B4,
+		h5:            guiTheme.B5,
+		h6:            guiTheme.B6,
+		Bold:          bold,
+		Italic:        italic,
+		boldItalic:    bi,
+		Code:          guiTheme.M5,
+		codeBlockText: guiTheme.M5,
+		// Non-text fills, exempt from the dimming roles (audit §1.2).
+		CodeBlockBG:       RGBA(0, 0, 0, 50), // ergonomics-audit:visual
 		codeKeywordColor:  guiTheme.ColorSelect,
 		codeStringColor:   RGB(75, 125, 75),
 		codeNumberColor:   RGB(169, 114, 62),
@@ -100,7 +101,7 @@ func DefaultMarkdownStyle() MarkdownStyle {
 		hRColor:           guiTheme.ColorBorder,
 		linkColor:         guiTheme.ColorSelect,
 		blockquoteBorder:  guiTheme.ColorBorder,
-		blockquoteBG:      RGBA(128, 128, 128, 20),
+		blockquoteBG:      RGBA(128, 128, 128, 20), // ergonomics-audit:visual
 		blockSpacing:      12,
 		nestIndent:        16,
 		prefixCharWidth:   4,

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -72,8 +72,8 @@ func DefaultMarkdownStyle() MarkdownStyle {
 	// leading, floored to a minimum em ratio); no manual LineSpacing needed.
 	text := guiTheme.N4
 	bold := guiTheme.B4
-	italic := guiTheme.i4
-	bi := guiTheme.bI4
+	italic := guiTheme.I4
+	bi := guiTheme.BI4
 
 	return MarkdownStyle{
 		Text:          text,

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -146,7 +146,7 @@ func mdCopyButton(
 ) View {
 	copied := w.hasAnimationLocked(animID)
 
-	iconStyle := guiTheme.icon5
+	iconStyle := guiTheme.Icon5
 	iconStyle.Color = Gray
 
 	var btnContent []View
@@ -479,7 +479,7 @@ func mdTaskCheckbox(checked bool, boxSize float32, cfg MarkdownCfg) View {
 	var amend func(EventCtx)
 	if checked {
 		boxColor = cfg.Style.linkColor
-		checkStyle := guiTheme.icon5
+		checkStyle := guiTheme.Icon5
 		checkStyle.Size = boxSize * 1.1
 		checkStyle.Color = White
 		content = []View{

--- a/gui/view_math_spinner.go
+++ b/gui/view_math_spinner.go
@@ -280,7 +280,9 @@ func mathSpinnerDraw(
 		ghostPts[i*2] = cx + (px*cosR-py*sinR)*scale
 		ghostPts[i*2+1] = cy + (px*sinR+py*cosR)*scale
 	}
-	ghostColor := RGBA(color.R, color.G, color.B, 30)
+	// Audit §1.2: the ghost trail is a ramp, exempt from the dimming
+	// roles — it is a fade, not a de-emphasis.
+	ghostColor := RGBA(color.R, color.G, color.B, 30) // ergonomics-audit:visual
 	// Safety: PolylineJoined copies the path data internally and
 	// does not retain the ghostPts slice. The buffer is safe to
 	// return to the pool immediately after this call.

--- a/tools/ergonomics-audit/main.go
+++ b/tools/ergonomics-audit/main.go
@@ -11,6 +11,7 @@
 //	go run ./tools/ergonomics-audit/ -mode literals [repo...]
 //	go run ./tools/ergonomics-audit/ -mode theme [repo...]
 //	go run ./tools/ergonomics-audit/ -mode a11y [repo...]
+//	go run ./tools/ergonomics-audit/ -mode visual [repo...]
 //
 // With no repo arguments both modes audit the current directory.
 //
@@ -57,6 +58,12 @@
 // reaches the accessibility tree? It exits non-zero on any finding, so
 // it gates. See a11y.go.
 //
+// Mode visual answers: does widget code still spell a dimming alpha or a
+// type-size step as a literal, when the theme defines named roles for
+// both (issue #335)? It scans gui/view_*.go and exits non-zero on any
+// unmarked finding, so it gates. See visual.go for what counts and how to
+// mark an exception.
+//
 // All modes parse with go/ast: composite literals and func literals
 // span lines, and regex cannot bracket-match them.
 package main
@@ -76,7 +83,7 @@ import (
 var listShape *string
 
 func main() {
-	mode := flag.String("mode", "focus", "audit to run: focus | callbacks | ids | opt | literals | theme | a11y")
+	mode := flag.String("mode", "focus", "audit to run: focus | callbacks | ids | opt | literals | theme | a11y | visual")
 	guiRoot := flag.String("gui", ".", "path to the go-gui repo (source of truth for mode=focus)")
 	listShape = flag.String("list", "", "mode=callbacks: also list distinct signatures of this shape, or \"all\"")
 	fix := flag.Bool("fix", false, "mode=focus: rewrite broken literals in place, adding a generated ID")
@@ -118,8 +125,10 @@ func main() {
 		err = runTheme(repos)
 	case "a11y":
 		err = runA11Y(repos)
+	case "visual":
+		err = runVisual(repos)
 	default:
-		err = fmt.Errorf("unknown -mode %q (want focus, callbacks, ids, opt, literals, theme or a11y)", *mode)
+		err = fmt.Errorf("unknown -mode %q (want focus, callbacks, ids, opt, literals, theme, a11y or visual)", *mode)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "ergonomics-audit:", err)

--- a/tools/ergonomics-audit/visual.go
+++ b/tools/ergonomics-audit/visual.go
@@ -290,18 +290,20 @@ func sizeSelector(e ast.Expr) (string, bool) {
 	return sel.Sel.Name, true
 }
 
-// floorSizeStep reports f32Max(X.Size + N, M) or f32Max(X.Size - N, M):
-// the audit's "inline floor" pattern, which produces a text size by
-// arithmetic and then clamps it.
+// floorSizeStep reports f32Max(X.Size + N, floor) or f32Max(X.Size - N,
+// floor): the audit's "inline floor" pattern, which produces a text size
+// by arithmetic and then clamps it.
+//
+// The floor's spelling is not what makes this a finding — the arithmetic
+// on the left is. Naming the floor (f32Max(X.Size-4, theme.N6.Size)) is
+// an improvement, not a resolution, so the rule matches any floor
+// expression rather than only a literal one. Keying on a literal floor
+// let a named-floor rewrite silently leave the rule's view.
 func floorSizeStep(call *ast.CallExpr) bool {
 	if callName(call) != "f32Max" || len(call.Args) != 2 {
 		return false
 	}
-	if !sizeStepExpr(call.Args[0]) {
-		return false
-	}
-	_, ok := intLiteral(call.Args[1])
-	return ok
+	return sizeStepExpr(call.Args[0])
 }
 
 // textStepLiteral reports a composite literal whose Size key is X.Size + N

--- a/tools/ergonomics-audit/visual.go
+++ b/tools/ergonomics-audit/visual.go
@@ -1,0 +1,327 @@
+package main
+
+// Mode visual answers: does widget code still spell a dimming alpha or a
+// type-size step as a literal, when the theme defines named roles for
+// both?
+//
+// Issue #335 measured the divergence (docs/specs/widget-visual-consistency-
+// audit.md): seven dimming values and three size-step systems coexisted,
+// and nothing told an author which to use. The fix shipped named roles —
+// the four TextStyle roles (gui/theme_text_roles.go), withRoleAlpha,
+// TextStyleLabel's size step, PaddingField — and this mode keeps a literal
+// from creeping back where a role is the one named source. A literal there
+// is the divergence issue #335 exists to end.
+//
+// It scans only gui/view_*.go: that is the widget-authoring surface, where
+// the audit says every decision was made per widget. theme_maker.go defines
+// the roles and styles.go the mirrors; a literal there is a definition, not
+// a divergence.
+//
+// Two rules:
+//
+//  1. Dimming literal — a numeric alpha in a color call: RGBA(r, g, b, N)
+//     with 1 <= N <= 254, WithOpacity(f) with 0 < f < 1, or a uint8(N)
+//     cast with 1 <= N <= 254. Opaque colors (alpha 255) do not dim and
+//     pass; so does a named constant, like the swatch edge alpha.
+//  2. Size-step literal — arithmetic on a text size that produces a new
+//     text style: a TextStyle composite literal whose Size is X.Size + N,
+//     an assignment to X.Size of the same shape, or the audit's "inline
+//     floor" pattern f32Max(X.Size-N, M). Row heights and icon widths
+//     derived from a text size (view_tree_rows, view_select) are geometry,
+//     not type steps, and pass.
+//
+// A deliberate exception carries a same-line marker and prints as deferred
+// rather than gating:
+//
+//	alpha := uint8(150) // ergonomics-audit:visual
+//
+// The audit's §1.2 ramps (date-picker roller distance, math-spinner ghost,
+// non-text fills) carry it, and so do the two §2 inline size steps, which
+// are tracked in the audit's "Left open" list rather than silently
+// re-created.
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// visualMarker exempts one line: the literal is a deliberate deviation
+// (a ramp, a non-text fill, a tracked §2 size step), not a re-invented
+// role.
+const visualMarker = "ergonomics-audit:visual"
+
+// visualFinding is one literal dimming alpha or size step.
+type visualFinding struct {
+	path     string
+	line     int
+	fn       string
+	verb     string // what the literal does
+	expr     string // the offending expression, one line
+	deferred bool   // carried the marker: advisory, does not gate
+}
+
+// runVisual reports visual literals in gui/view_*.go. It returns an error
+// when any unmarked finding survives, so the audit gates like modes ids,
+// opt and literals.
+func runVisual(repos []string) error {
+	var all []visualFinding
+	for _, repo := range repos {
+		found, err := scanVisual(repo)
+		if err != nil {
+			return err
+		}
+		all = append(all, found...)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].path != all[j].path {
+			return all[i].path < all[j].path
+		}
+		return all[i].line < all[j].line
+	})
+
+	var gating int
+	for _, f := range all {
+		if !f.deferred {
+			gating++
+		}
+	}
+
+	fmt.Printf("Visual-literal audit (%d finding(s), %d deferred)\n",
+		gating, len(all)-gating)
+	for _, f := range all {
+		tag := ""
+		if f.deferred {
+			tag = " [deferred]"
+		}
+		loc := f.path + ":" + strconv.Itoa(f.line) + ":"
+		if f.fn != "" {
+			loc += " " + f.fn
+		}
+		fmt.Printf("  %s %s %s%s\n", loc, f.verb, f.expr, tag)
+	}
+	if gating > 0 {
+		fmt.Println()
+		fmt.Println("A dimming alpha or type-size step is a theme role, not a")
+		fmt.Println("widget-local literal. If this one is a deliberate deviation")
+		fmt.Printf("(a ramp, a non-text fill, a tracked §2 size step), mark the line %q.\n",
+			visualMarker)
+		return fmt.Errorf("%d visual literal(s)", gating)
+	}
+	return nil
+}
+
+func scanVisual(repo string) ([]visualFinding, error) {
+	var out []visualFinding
+	err := walkGo(filepath.Join(repo, "gui"), func(path string, fset *token.FileSet, f *ast.File) {
+		if strings.HasSuffix(path, "_test.go") {
+			return
+		}
+		rel := relPath(repo, path)
+		if filepath.Dir(rel) != "gui" || !strings.HasPrefix(filepath.Base(rel), "view_") {
+			return
+		}
+		marked := markedLines(fset, f, visualMarker)
+		inspectVisual(fset, f, func(fn string, line int, verb, expr string) {
+			out = append(out, visualFinding{
+				path: rel, line: line, fn: fn, verb: verb, expr: expr,
+				deferred: marked[line],
+			})
+		})
+	})
+	return out, err
+}
+
+// inspectVisual walks one parsed file and calls report for each literal
+// dimming alpha or size step, naming the enclosing function ("" for
+// package-level code). Split out from scanVisual so the rules can be
+// exercised against in-memory source in tests.
+func inspectVisual(
+	fset *token.FileSet, f *ast.File, report func(fn string, line int, verb, expr string),
+) {
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Body == nil {
+				continue
+			}
+			ast.Inspect(d.Body, func(n ast.Node) bool {
+				return visualVisit(fset, d.Name.Name, n, report)
+			})
+		default:
+			// Package-level code (a style builder var, a const) has no
+			// function to name.
+			ast.Inspect(d, func(n ast.Node) bool {
+				return visualVisit(fset, "", n, report)
+			})
+		}
+	}
+}
+
+// visualVisit reports one finding for n, if it is one, and reports
+// whether to keep descending. Findings inside func literals are reported
+// under their enclosing named function.
+func visualVisit(
+	fset *token.FileSet, fn string, n ast.Node, report func(fn string, line int, verb, expr string),
+) bool {
+	switch node := n.(type) {
+	case *ast.CallExpr:
+		switch {
+		case dimAlphaCall(node):
+			report(fn, fset.Position(node.Pos()).Line,
+				"spells a dimming alpha", shortExpr(fset, node))
+		case uint8AlphaCall(node):
+			report(fn, fset.Position(node.Pos()).Line,
+				"spells a dimming alpha", shortExpr(fset, node))
+		case floorSizeStep(node):
+			report(fn, fset.Position(node.Pos()).Line,
+				"sizes a text step inline", shortExpr(fset, node))
+		}
+	case *ast.CompositeLit:
+		if textStepLiteral(node) {
+			report(fn, fset.Position(node.Pos()).Line,
+				"sizes a text step inline", shortExpr(fset, node))
+		}
+	case *ast.AssignStmt:
+		if sizeStepAssign(node) {
+			report(fn, fset.Position(node.Pos()).Line,
+				"sizes a text step inline", shortExpr(fset, node.Rhs[0]))
+		}
+	}
+	return true
+}
+
+// dimAlphaCall reports RGBA(r, g, b, N) with a literal 1 <= N <= 254, or
+// WithOpacity(f) with a literal 0 < f < 1: a dimming alpha spelled as a
+// number where a theme role is the one named source.
+func dimAlphaCall(call *ast.CallExpr) bool {
+	name := callName(call)
+	if name != "RGBA" && name != "WithOpacity" {
+		return false
+	}
+	if name == "RGBA" {
+		if len(call.Args) != 4 {
+			return false
+		}
+		v, ok := intLiteral(call.Args[3])
+		return ok && v >= 1 && v <= 254
+	}
+	if len(call.Args) != 1 {
+		return false
+	}
+	f, ok := floatLiteral(call.Args[0])
+	return ok && f > 0 && f < 1
+}
+
+// uint8AlphaCall reports a uint8(N) cast with a literal 1 <= N <= 254:
+// the roller-ramp spelling of a dimming alpha.
+func uint8AlphaCall(call *ast.CallExpr) bool {
+	id, ok := call.Fun.(*ast.Ident)
+	if !ok || id.Name != "uint8" || len(call.Args) != 1 {
+		return false
+	}
+	v, ok := intLiteral(call.Args[0])
+	return ok && v >= 1 && v <= 254
+}
+
+// callName reports the bare name of a call: RGBA, gui.RGBA, WithOpacity.
+func callName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	}
+	return ""
+}
+
+// intLiteral returns the value of a positive integer literal, or ok=false
+// for anything else.
+func intLiteral(e ast.Expr) (int, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.INT {
+		return 0, false
+	}
+	v, err := strconv.Atoi(lit.Value)
+	if err != nil || v < 0 {
+		return 0, false
+	}
+	return v, true
+}
+
+// floatLiteral returns the value of a non-negative float literal.
+func floatLiteral(e ast.Expr) (float64, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || (lit.Kind != token.FLOAT && lit.Kind != token.INT) {
+		return 0, false
+	}
+	f, err := strconv.ParseFloat(lit.Value, 64)
+	if err != nil || f < 0 {
+		return 0, false
+	}
+	return f, true
+}
+
+// sizeStepExpr reports an expression that is X.Size + N or X.Size - N: one
+// type step taken by arithmetic instead of a named handle. The selector's
+// final ident must be exactly "Size" (cfg.TextStyle.Size), so geometry
+// fields named like HandleSize or ThumbSize do not match.
+func sizeStepExpr(e ast.Expr) bool {
+	bin, ok := e.(*ast.BinaryExpr)
+	if !ok || (bin.Op != token.ADD && bin.Op != token.SUB) {
+		return false
+	}
+	if _, ok := sizeSelector(bin.X); !ok {
+		return false
+	}
+	lit, ok := bin.Y.(*ast.BasicLit)
+	return ok && lit.Kind == token.INT
+}
+
+// sizeSelector reports whether e is a selector whose final ident is Size.
+func sizeSelector(e ast.Expr) (string, bool) {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Size" {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// floorSizeStep reports f32Max(X.Size + N, M) or f32Max(X.Size - N, M):
+// the audit's "inline floor" pattern, which produces a text size by
+// arithmetic and then clamps it.
+func floorSizeStep(call *ast.CallExpr) bool {
+	if callName(call) != "f32Max" || len(call.Args) != 2 {
+		return false
+	}
+	if !sizeStepExpr(call.Args[0]) {
+		return false
+	}
+	_, ok := intLiteral(call.Args[1])
+	return ok
+}
+
+// textStepLiteral reports a composite literal whose Size key is X.Size + N
+// arithmetic — a text style stepped by hand.
+func textStepLiteral(lit *ast.CompositeLit) bool {
+	expr, ok := litField(lit, "Size")
+	if !ok {
+		return false
+	}
+	return sizeStepExpr(expr)
+}
+
+// sizeStepAssign reports X.Size = X.Size + N, an assignment that steps a
+// text style by arithmetic.
+func sizeStepAssign(stmt *ast.AssignStmt) bool {
+	if len(stmt.Lhs) != 1 || len(stmt.Rhs) != 1 {
+		return false
+	}
+	if _, ok := sizeSelector(stmt.Lhs[0]); !ok {
+		return false
+	}
+	return sizeStepExpr(stmt.Rhs[0])
+}

--- a/tools/ergonomics-audit/visual_test.go
+++ b/tools/ergonomics-audit/visual_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunVisualGatesOnLiterals covers runVisual end-to-end: the gating
+// contract that make check-all relies on. Unmarked dimming alphas and
+// size steps fail the audit; the marker defers them; clean code passes.
+func TestRunVisualGatesOnLiterals(t *testing.T) {
+	repo := t.TempDir()
+	guiDir := filepath.Join(repo, "gui")
+	if err := os.MkdirAll(guiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	viewPath := filepath.Join(guiDir, "view_roller.go")
+
+	write := func(src string) {
+		t.Helper()
+		if err := os.WriteFile(viewPath, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Unmarked dimming literal in a scanned path: gates.
+	write(`package gui
+
+func rollerItem(ts TextStyle) TextStyle {
+	alpha := uint8(150)
+	itemTS := ts
+	itemTS.Color = RGBA(ts.Color.R, ts.Color.G, ts.Color.B, alpha)
+	return itemTS
+}
+`)
+	if err := runVisual([]string{repo}); err == nil {
+		t.Fatal("runVisual passed with an unmarked dimming literal")
+	}
+
+	// Same line marked: advisory only, passes.
+	write(`package gui
+
+func rollerItem(ts TextStyle) TextStyle {
+	alpha := uint8(150) // ergonomics-audit:visual
+	itemTS := ts
+	itemTS.Color = RGBA(ts.Color.R, ts.Color.G, ts.Color.B, alpha)
+	return itemTS
+}
+`)
+	if err := runVisual([]string{repo}); err != nil {
+		t.Fatalf("runVisual failed with a marked literal: %v", err)
+	}
+
+	// No literal: named roles and opaque colors pass.
+	write(`package gui
+
+func ok(ts TextStyle) TextStyle {
+	itemTS := withRoleAlpha(ts, guiTheme.TextStyleSecondary)
+	itemTS.Color = RGBA(200, 50, 50, 255)
+	return itemTS
+}
+`)
+	if err := runVisual([]string{repo}); err != nil {
+		t.Fatalf("runVisual failed on clean code: %v", err)
+	}
+
+	// Unmarked size step: gates.
+	write(`package gui
+
+func stepButtons(cfg NumericInputCfg) float32 {
+	return f32Max(cfg.TextStyle.Size-4, 8)
+}
+`)
+	if err := runVisual([]string{repo}); err == nil {
+		t.Fatal("runVisual passed with an unmarked size step")
+	}
+}
+
+// scanVisualSrc runs the visual-mode rules over one in-memory file and
+// returns the reported findings as "fn:verb:expr", with a "[deferred]"
+// suffix when the line carried the marker.
+func scanVisualSrc(t *testing.T, src string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	marked := markedLines(fset, f, visualMarker)
+	var out []string
+	inspectVisual(fset, f, func(fn string, line int, verb, expr string) {
+		s := fn + ":" + verb + ":" + expr
+		if marked[line] {
+			s += " [deferred]"
+		}
+		out = append(out, s)
+	})
+	return out
+}
+
+func TestVisualFlagsDimmingLiterals(t *testing.T) {
+	t.Parallel()
+	const src = `package gui
+
+func ghost(color Color) {
+	_ = RGBA(color.R, color.G, color.B, 30)
+}
+
+func edges(c Color) {
+	_ = c.WithOpacity(0.7)
+}
+
+func ramp() {
+	alpha := uint8(80)
+	_ = alpha
+}
+
+func trail(color Color) {
+	fade := 0.5
+	alpha := uint8(10 + fade*245)
+	_ = RGBA(color.R, color.G, color.B, alpha)
+}
+`
+	got := scanVisualSrc(t, src)
+	want := []string{
+		"ghost:spells a dimming alpha:RGBA(color.R, color.G, color.B, 30)",
+		"edges:spells a dimming alpha:c.WithOpacity(0.7)",
+		"ramp:spells a dimming alpha:uint8(80)",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("findings = %v, want %v", got, want)
+	}
+}
+
+func TestVisualFlagsSizeSteps(t *testing.T) {
+	t.Parallel()
+	const src = `package gui
+
+func floor(cfg NumericInputCfg) {
+	_ = f32Max(cfg.TextStyle.Size-4, 8)
+}
+
+func roller(ts TextStyle) TextStyle {
+	itemTS := ts
+	itemTS.Size = ts.Size + 2
+	return itemTS
+}
+
+func named(ts TextStyle) TextStyle {
+	return TextStyle{Size: ts.Size - 2}
+}
+
+func geometry(style TextStyle) float32 {
+	return style.Size + 4
+}
+
+func geometryMax(s handleSize) float32 {
+	return f32Max(14, s*2.0)
+}
+`
+	got := scanVisualSrc(t, src)
+	want := []string{
+		"floor:sizes a text step inline:f32Max(cfg.TextStyle.Size-4, 8)",
+		"roller:sizes a text step inline:ts.Size + 2",
+		"named:sizes a text step inline:TextStyle{Size: ts.Size - 2}",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("findings = %v, want %v", got, want)
+	}
+}
+
+func TestVisualMarkerDefersFinding(t *testing.T) {
+	t.Parallel()
+	const src = `package gui
+
+func ramp() {
+	alpha := uint8(150) // ergonomics-audit:visual
+	_ = alpha
+}
+`
+	got := scanVisualSrc(t, src)
+	want := []string{"ramp:spells a dimming alpha:uint8(150) [deferred]"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("findings = %v, want %v", got, want)
+	}
+}
+
+func TestVisualIgnoresNonViewFiles(t *testing.T) {
+	t.Parallel()
+	// theme_maker.go defines the roles; a literal there is a definition.
+	// Files outside gui/view_*.go are not scanned at all.
+	repo := t.TempDir()
+	guiDir := filepath.Join(repo, "gui")
+	if err := os.MkdirAll(guiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	makerPath := filepath.Join(guiDir, "theme_maker.go")
+	src := `package gui
+
+func scrim() {
+	_ = RGBA(0, 0, 0, 50)
+}
+`
+	if err := os.WriteFile(makerPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	found, err := scanVisual(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("findings in non-view file = %+v, want none", found)
+	}
+}

--- a/tools/ergonomics-audit/visual_test.go
+++ b/tools/ergonomics-audit/visual_test.go
@@ -144,6 +144,10 @@ func floor(cfg NumericInputCfg) {
 	_ = f32Max(cfg.TextStyle.Size-4, 8)
 }
 
+func namedFloor(cfg NumericInputCfg) {
+	_ = f32Max(cfg.TextStyle.Size-4, guiTheme.N6.Size)
+}
+
 func roller(ts TextStyle) TextStyle {
 	itemTS := ts
 	itemTS.Size = ts.Size + 2
@@ -165,6 +169,9 @@ func geometryMax(s handleSize) float32 {
 	got := scanVisualSrc(t, src)
 	want := []string{
 		"floor:sizes a text step inline:f32Max(cfg.TextStyle.Size-4, 8)",
+		// A named floor is an improvement, not a resolution: the step
+		// itself is still arithmetic, so the rule must still see it.
+		"namedFloor:sizes a text step inline:f32Max(cfg.TextStyle.Size-4, guiTheme.N6.Size)",
 		"roller:sizes a text step inline:ts.Size + 2",
 		"named:sizes a text step inline:TextStyle{Size: ts.Size - 2}",
 	}


### PR DESCRIPTION
Closes #343. Carries #335 steps 3-4 (visual gate + style guide, `77bfd492`) plus this follow-up.

**Type ladder (issue #343)**
- Every rung exported: `I1`-`I6`, `BI1`-`BI6`, `Icon5`-`Icon6` added; a closed 6x6 grid (N/B/I/BI/M/Icon x 6 sizes), keep-marked as public styling vocabulary. A half-exported grid is a broken vocabulary — apps must spell the step of the widget beside them.
- Mono +1 documented at the ThemeMaker declaration: M4 is 15 where N4 is 14, an optical compensation for the mono face.
- The two size-step floors resolved: ColorFields' label already steps via the TextStyleLabel role; NumericInput's step triangle now floors at `N6.Size` and gains a ceiling (never above the field text it decorates) — a theme with a large SizeTextTiny previously could floor the triangle bigger than the field.

**Gate tightening (visual mode)**
- `floorSizeStep` no longer keys on a literal floor: naming the floor (a theme rung) must not let the arithmetic step escape the rule. The NumericInput site therefore stays marked — the 4pt step is a deliberate tracked deviation (the field size is caller-supplied and lands on no rung), visible in every audit run.

**Tests**
- `TestThemeMakerLadderGrid` locks the closed grid: all 36 rungs populated, per-face ascent, roman faces share one scale, mono sits +1.
- `TestNumericInputStepTriangleBounds` locks both bounds.
- `TestRunVisualGatesOnLiterals`/named-floor case covers the tightened rule.

Verified: `make prepush` green, export-audit green with sibling repos (12 new exports keep-marked).