### PR TITLE
gui: theme disabled text via TextStyleDisabled, replacing dimAlpha for text (issue #341)

### DIFF
--- a/docs/specs/widget-visual-consistency-audit.md
+++ b/docs/specs/widget-visual-consistency-audit.md
@@ -119,9 +119,31 @@ its base color to 127. On the dark theme that is within one step of the role's
 sits 22 alpha below where the role says it should — the light-theme contrast gap
 of §1.1.1, surviving in the widgets the roles have not reached.
 
-Closing it means giving every such widget a themed disabled text style rather
-than leaning on `dimAlpha`, which is a sweep across roughly a dozen widgets and
-is tracked separately.
+**Closed by issue #341 — the renderer now asks the theme.** `renderText`
+(`gui/render_text.go`) replaced `dimAlpha` with `w.Theme().disabledTextColor(c)`
+for text shapes stamped `Disabled`: the caller's hue at the theme's disabled
+amount, per theme. Every disabled text shape in the package — Input, Select,
+Combobox, ListBox, NumericInput, InputDate, DatePicker, Button, Switch, Toggle,
+Radio, Tree, menu items, plain `Text` — renders at 128 on dark and 149 on light,
+in both the direct-disabled and ancestor-disabled cases, which the per-widget
+sweep the issue originally described could not reach. The verdict on the open
+question: `TextStyleDisabled` **replaces** `dimAlpha` for text. `dimAlpha`
+survives for non-text surfaces — fills, borders, `renderText`'s Bg/Stroke
+colors, and the group-box title eraser.
+
+One text path never reaches the renderer's branch: the group-box title
+(`addGroupBoxTitle`, `gui/view_container.go`) is a Float shape, so
+`layoutRemoveFloatingLayouts` extracts it from the tree before `layoutDisables`
+stamps it. It applies `guiTheme.disabledTextColor` at generation instead, and
+its recording moved with the rest of the sweep.
+
+The sweep is recorded per widget in `gui/golden_cases_test.go` (the `*_disabled`
+cases, added before the fix): each moved `#7f` → `#80` on dark and `#7f` → `#95`
+on light. `tab_control` and `breadcrumb` did not move — the `disabledRole`
+marker still prevents a second quieting. A placeholder or secondary-role text
+inside a disabled control now renders at the disabled amount rather than a
+halved version of its own — a deliberate consequence of one amount for every
+text in a dead control.
 
 ### 1.2 Out of scope
 
@@ -331,20 +353,22 @@ like should be recorded, not read.
 What this branch changed, per axis. The measurements above describe the state at
 `b6adf899` and are kept as the "before"; this section is the "after".
 
-| §   | Axis              | Outcome                                                              |
-| --- | ----------------- | -------------------------------------------------------------------- |
-| 1   | Dimming           | closed — four named roles, per-theme and contrast-matched            |
-| 2   | Type steps        | mostly — full ladder exported, mono +1 documented, two steps tracked |
-| 3   | Field labels      | closed — `Label` on all eight, one shared convention                 |
-| 4   | Spacing           | untouched                                                            |
-| 5   | Borders           | untouched, by decision                                               |
-| 6   | Interaction state | partly — focus rings for the four that could take one                |
-| 7   | Density           | closed — one field-inset tier, two latent bugs fixed                 |
+| §   | Axis              | Outcome                                                                                                           |
+| --- | ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 1   | Dimming           | closed — four named roles, per-theme and contrast-matched; disabled text routed through the role at render (#341) |
+| 2   | Type steps        | mostly — full ladder exported, mono +1 documented, two steps tracked                                              |
+| 3   | Field labels      | closed — `Label` on all eight, one shared convention                                                              |
+| 4   | Spacing           | untouched                                                                                                         |
+| 5   | Borders           | untouched, by decision                                                                                            |
+| 6   | Interaction state | partly — focus rings for the four that could take one                                                             |
+| 7   | Density           | closed — one field-inset tier, two latent bugs fixed                                                              |
 
 ### Left open
 
-- **§1.1.2** — widgets that never themed their disabled text still lean on
-  `dimAlpha`. Correct on dark, 22 alpha short on light.
+- **§1.1.2** — closed: disabled text is themed at the renderer
+  (`Theme.disabledTextColor`, unexported: downstream widgets get the role
+  through the renderer and never ask), and the group-box title at generation.
+  `dimAlpha` remains for non-text shapes only.
 - **§2** — the export half is closed: every ladder rung is exported (the
   `N1`..`N6`, `B1`..`B6`, `I1`..`I6`, `BI1`..`BI6`, `M1`..`M6`, `Icon1`..`Icon6`
   sets), and the mono `+1` is documented at the declaration in `ThemeMaker`.

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -12,7 +12,10 @@ package gui
 // borders. A widget recorded only in its resting state would not
 // catch a change to the role it uses.
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // goldenHSLA is one fixed color for every color-widget case, so a
 // diff never reflects a different input color.
@@ -249,6 +252,165 @@ func goldenCases() []goldenCase {
 				return ColorPlane(ColorPlaneCfg{
 					ID:    "cp",
 					Value: goldenHSLA,
+				})
+			},
+		},
+		// --- Disabled-text sweep (issue #341) ---
+		//
+		// One case per text-bearing widget that can be disabled.
+		// Before the fix, every disabled text command here renders
+		// at alpha 127 (#7f) on both themes — dimAlpha halving the
+		// color instead of the theme's TextStyleDisabled (128 dark,
+		// 149 light). The fix moves the dark recording to #80 and
+		// the light recording to #95; a case whose text does not
+		// move was never reaching dimAlpha and is not part of the
+		// sweep.
+		{
+			name: "select_disabled",
+			build: func(_ *Window) View {
+				return Select(SelectCfg{
+					ID:       "sel",
+					Options:  []string{"alpha", "beta"},
+					Selected: []string{"beta"},
+					Disabled: true,
+				})
+			},
+		},
+		{
+			name: "combobox_disabled",
+			build: func(_ *Window) View {
+				return Combobox(ComboboxCfg{
+					ID:       "cb",
+					Options:  []string{"alpha", "beta"},
+					Value:    "alpha",
+					Disabled: true,
+				})
+			},
+		},
+		{
+			name: "listbox_disabled",
+			build: func(_ *Window) View {
+				return ListBox(ListBoxCfg{
+					ID:          "lb",
+					Items:       []string{"one", "two", "three"},
+					SelectedIDs: []string{"two"},
+					Disabled:    true,
+				})
+			},
+		},
+		{
+			name: "numericinput_disabled",
+			build: func(_ *Window) View {
+				return NumericInput(NumericInputCfg{
+					ID:       "num",
+					Text:     "42.5",
+					Disabled: true,
+				})
+			},
+		},
+		{
+			name: "inputdate_disabled",
+			build: func(_ *Window) View {
+				return InputDate(InputDateCfg{
+					ID:       "id",
+					Date:     time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC),
+					Disabled: true,
+				})
+			},
+		},
+		{
+			name: "datepicker_disabled",
+			build: func(_ *Window) View {
+				return DatePicker(DatePickerCfg{
+					ID:       "dp",
+					Dates:    []time.Time{time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)},
+					Disabled: true,
+				})
+			},
+		},
+		{
+			name: "button_disabled",
+			build: func(_ *Window) View {
+				return Button(ButtonCfg{
+					ID:       "btn",
+					Disabled: true,
+					Content:  []View{Text(TextCfg{Text: "Save"})},
+				})
+			},
+		},
+		{
+			name: "boolean_labels_disabled",
+			build: func(_ *Window) View {
+				return Column(ContainerCfg{
+					Content: []View{
+						Switch(SwitchCfg{ID: "sw", Label: "Enabled", Disabled: true}),
+						Toggle(ToggleCfg{ID: "tg", Label: "Enabled", Disabled: true}),
+						Radio(RadioCfg{ID: "rd", Label: "Enabled", Disabled: true}),
+					},
+				})
+			},
+		},
+		{
+			name: "tree_disabled",
+			build: func(_ *Window) View {
+				return Tree(TreeCfg{
+					ID:       "tr",
+					Disabled: true,
+					Nodes: []TreeNodeCfg{
+						{ID: "a", Text: "Alpha"},
+						{ID: "b", Text: "Beta"},
+					},
+				})
+			},
+		},
+		{
+			name: "menubar_disabled",
+			build: func(w *Window) View {
+				return Menubar(w, MenubarCfg{
+					ID: "mb",
+					Items: []MenuItemCfg{
+						MenuItemText("f", "File"),
+						MenuSubtitle("Grouped"),
+					},
+				})
+			},
+		},
+		{
+			// The group-box title is the one text path dimmed twice:
+			// addGroupBoxTitle halves at generation and renderText
+			// halves the stamp again. Before the fix the title
+			// records at ~63, a full stop under every other widget.
+			name: "container_title_disabled",
+			build: func(_ *Window) View {
+				return Column(ContainerCfg{
+					Title:       "Group",
+					ColorBorder: Hex(0x4a6b8a),
+					Disabled:    true,
+				})
+			},
+		},
+		{
+			name: "text_disabled",
+			build: func(_ *Window) View {
+				return Text(TextCfg{
+					Text:     "quiet",
+					Disabled: true,
+				})
+			},
+		},
+		{
+			// The widget itself is enabled; a disabled ancestor does
+			// the stamping via layoutDisables. This is the case the
+			// per-widget sweep could not reach — a widget themes its
+			// own disabled state, but cannot know about an ancestor's
+			// at generation time. The renderer's role read covers it.
+			name: "disabled_ancestor",
+			build: func(_ *Window) View {
+				return Column(ContainerCfg{
+					Disabled: true,
+					Content: []View{
+						Input(InputCfg{ID: "in", Text: "typed value"}),
+					},
 				})
 			},
 		},

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -48,9 +48,13 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 		c = c.WithOpacity(shape.Opacity)
 	}
 	// A style from the disabled role has already been quieted by the
-	// theme; dimming it again is the double-dim of issue #335.
+	// theme; quieting it again is the double-dim of issue #335. Any
+	// other text shape stamped Disabled takes the theme's disabled
+	// amount (issue #341): dimAlpha halved the caller's color, which
+	// matches the dark theme by construction and sits 22 alpha under
+	// the light theme's contrast-matched role.
 	if shape.Disabled && !tc.TextStyle.disabledRole {
-		c = dimAlpha(c)
+		c = w.Theme().disabledTextColor(c)
 	}
 	if c.A == 0 {
 		return

--- a/gui/testdata/boolean_labels_disabled.dark.golden
+++ b/gui/testdata/boolean_labels_disabled.dark.golden
@@ -1,0 +1,11 @@
+Rect xy=23.00,23.20 wh=36.00,22.00 color=#4040407f radius=11.00 fill
+StrokeRect xy=23.00,23.20 wh=36.00,22.00 color=#6464647f radius=11.00 thickness=1.50
+Circle xy=34.00,34.20 wh=0.00,0.00 color=#6868687f radius=6.50 fill
+Text xy=69.00,23.00 wh=0.00,0.00 color=#e1e1e180 text="Enabled" size=16.00
+Rect xy=23.00,56.60 wh=20.00,20.00 color=#4040407f radius=5.50 fill
+StrokeRect xy=23.00,56.60 wh=20.00,20.00 color=#6464647f radius=5.50 thickness=1.50
+Text xy=28.20,59.10 wh=0.00,0.00 color=#00000080 text="✓" size=16.00
+Text xy=53.00,55.40 wh=0.00,0.00 color=#e1e1e180 text="Enabled" size=16.00
+Circle xy=36.50,104.50 wh=0.00,0.00 color=#6868687f radius=8.00 fill
+StrokeRect xy=28.50,96.50 wh=16.00,16.00 color=#6464647f radius=8.00 thickness=1.50
+Text xy=54.50,93.30 wh=0.00,0.00 color=#e1e1e180 text="Enabled" size=16.00

--- a/gui/testdata/boolean_labels_disabled.light.golden
+++ b/gui/testdata/boolean_labels_disabled.light.golden
@@ -1,0 +1,8 @@
+Rect xy=20.00,20.20 wh=36.00,22.00 color=#cdcdd77f radius=11.00 fill
+Circle xy=31.00,31.20 wh=0.00,0.00 color=#a5a5d77f radius=8.00 fill
+Text xy=66.00,20.00 wh=0.00,0.00 color=#20202095 text="Enabled" size=16.00
+Rect xy=20.00,53.60 wh=20.00,20.00 color=#cdcdd77f radius=5.50 fill
+Text xy=25.20,54.60 wh=0.00,0.00 color=#00000095 text="✓" size=16.00
+Text xy=50.00,52.40 wh=0.00,0.00 color=#20202095 text="Enabled" size=16.00
+Circle xy=32.00,100.00 wh=0.00,0.00 color=#a5a5d77f radius=8.00 fill
+Text xy=50.00,88.80 wh=0.00,0.00 color=#20202095 text="Enabled" size=16.00

--- a/gui/testdata/button_disabled.dark.golden
+++ b/gui/testdata/button_disabled.dark.golden
@@ -1,0 +1,3 @@
+Rect xy=11.50,11.50 wh=53.40,37.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=53.40,37.40 color=#6464647f radius=5.50 thickness=1.50
+Text xy=19.00,19.00 wh=0.00,0.00 color=#e1e1e180 text="Save" size=16.00

--- a/gui/testdata/button_disabled.light.golden
+++ b/gui/testdata/button_disabled.light.golden
@@ -1,0 +1,2 @@
+Rect xy=10.00,10.00 wh=50.40,34.40 color=#c3c3d77f radius=5.50 fill
+Text xy=16.00,16.00 wh=0.00,0.00 color=#20202095 text="Save" size=16.00

--- a/gui/testdata/combobox_disabled.dark.golden
+++ b/gui/testdata/combobox_disabled.dark.golden
@@ -1,0 +1,4 @@
+Rect xy=11.50,11.50 wh=108.00,31.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=108.00,31.40 color=#6464647f radius=5.50 thickness=1.50
+Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e180 text="alpha" size=16.00
+Text xy=105.74,21.44 wh=0.00,0.00 color=#e1e1e180 text="▼" size=9.60

--- a/gui/testdata/combobox_disabled.light.golden
+++ b/gui/testdata/combobox_disabled.light.golden
@@ -1,0 +1,3 @@
+Rect xy=10.00,10.00 wh=105.00,28.40 color=#c3c3d77f radius=5.50 fill
+Text xy=15.00,13.00 wh=0.00,0.00 color=#20202095 text="alpha" size=16.00
+Text xy=104.24,18.44 wh=0.00,0.00 color=#20202095 text="▼" size=9.60

--- a/gui/testdata/container_title_disabled.dark.golden
+++ b/gui/testdata/container_title_disabled.dark.golden
@@ -1,0 +1,2 @@
+StrokeRect xy=11.50,11.50 wh=23.00,23.00 color=#4a6b8a7f radius=5.50 thickness=1.50
+Text xy=36.50,3.50 wh=0.00,0.00 color=#4a6b8a80 text="Group" size=16.00

--- a/gui/testdata/container_title_disabled.light.golden
+++ b/gui/testdata/container_title_disabled.light.golden
@@ -1,0 +1,1 @@
+Text xy=35.00,2.00 wh=0.00,0.00 color=#4a6b8a95 text="Group" size=16.00

--- a/gui/testdata/datepicker_disabled.dark.golden
+++ b/gui/testdata/datepicker_disabled.dark.golden
@@ -1,0 +1,49 @@
+Rect xy=11.50,11.50 wh=277.00,287.20 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=277.00,287.20 color=#6464647f radius=5.50 thickness=1.50
+Text xy=25.50,25.50 wh=0.00,0.00 color=#e1e1e180 text="August 2026" size=16.00
+Text xy=230.30,25.50 wh=0.00,0.00 color=#e1e1e180 text="\uf101" size=16.00
+Text xy=264.90,25.50 wh=0.00,0.00 color=#e1e1e180 text="\uf102" size=16.00
+Text xy=31.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="S" size=16.00
+Text xy=69.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="M" size=16.00
+Text xy=107.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="T" size=16.00
+Text xy=145.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="W" size=16.00
+Text xy=183.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="T" size=16.00
+Text xy=221.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="F" size=16.00
+Text xy=259.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="S" size=16.00
+Text xy=31.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=69.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=107.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=145.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=183.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=221.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=259.20,92.80 wh=0.00,0.00 color=#e1e1e180 text="1" size=16.00
+Text xy=31.20,127.20 wh=0.00,0.00 color=#e1e1e180 text="2" size=16.00
+Text xy=69.20,127.20 wh=0.00,0.00 color=#e1e1e180 text="3" size=16.00
+Text xy=107.20,127.20 wh=0.00,0.00 color=#e1e1e180 text="4" size=16.00
+Text xy=145.20,127.20 wh=0.00,0.00 color=#e1e1e180 text="5" size=16.00
+Text xy=183.20,127.20 wh=0.00,0.00 color=#e1e1e180 text="6" size=16.00
+Text xy=221.20,127.20 wh=0.00,0.00 color=#e1e1e180 text="7" size=16.00
+Text xy=259.20,127.20 wh=0.00,0.00 color=#e1e1e180 text="8" size=16.00
+Text xy=31.20,161.60 wh=0.00,0.00 color=#e1e1e180 text="9" size=16.00
+Text xy=64.40,161.60 wh=0.00,0.00 color=#e1e1e180 text="10" size=16.00
+Text xy=102.40,161.60 wh=0.00,0.00 color=#e1e1e180 text="11" size=16.00
+Text xy=140.40,161.60 wh=0.00,0.00 color=#e1e1e180 text="12" size=16.00
+Text xy=178.40,161.60 wh=0.00,0.00 color=#e1e1e180 text="13" size=16.00
+Text xy=216.40,161.60 wh=0.00,0.00 color=#e1e1e180 text="14" size=16.00
+Rect xy=246.00,156.60 wh=36.00,32.40 color=#4169e17f radius=5.50 fill
+Text xy=254.40,161.60 wh=0.00,0.00 color=#e1e1e180 text="15" size=16.00
+StrokeRect xy=18.00,191.00 wh=36.00,32.40 color=#e1e1e17f radius=5.50 thickness=2.00
+Text xy=26.40,196.00 wh=0.00,0.00 color=#e1e1e180 text="16" size=16.00
+Text xy=64.40,196.00 wh=0.00,0.00 color=#e1e1e180 text="17" size=16.00
+Text xy=102.40,196.00 wh=0.00,0.00 color=#e1e1e180 text="18" size=16.00
+Text xy=140.40,196.00 wh=0.00,0.00 color=#e1e1e180 text="19" size=16.00
+Text xy=178.40,196.00 wh=0.00,0.00 color=#e1e1e180 text="20" size=16.00
+Text xy=216.40,196.00 wh=0.00,0.00 color=#e1e1e180 text="21" size=16.00
+Text xy=254.40,196.00 wh=0.00,0.00 color=#e1e1e180 text="22" size=16.00
+Text xy=26.40,230.40 wh=0.00,0.00 color=#e1e1e180 text="23" size=16.00
+Text xy=64.40,230.40 wh=0.00,0.00 color=#e1e1e180 text="24" size=16.00
+Text xy=102.40,230.40 wh=0.00,0.00 color=#e1e1e180 text="25" size=16.00
+Text xy=140.40,230.40 wh=0.00,0.00 color=#e1e1e180 text="26" size=16.00
+Text xy=178.40,230.40 wh=0.00,0.00 color=#e1e1e180 text="27" size=16.00
+Text xy=216.40,230.40 wh=0.00,0.00 color=#e1e1e180 text="28" size=16.00
+Text xy=254.40,230.40 wh=0.00,0.00 color=#e1e1e180 text="29" size=16.00

--- a/gui/testdata/datepicker_disabled.light.golden
+++ b/gui/testdata/datepicker_disabled.light.golden
@@ -1,0 +1,48 @@
+Rect xy=10.00,10.00 wh=274.00,281.20 color=#c3c3d77f radius=5.50 fill
+Text xy=21.00,21.00 wh=0.00,0.00 color=#20202095 text="August 2026" size=16.00
+Text xy=231.80,21.00 wh=0.00,0.00 color=#20202095 text="\uf101" size=16.00
+Text xy=263.40,21.00 wh=0.00,0.00 color=#20202095 text="\uf102" size=16.00
+Text xy=28.20,54.40 wh=0.00,0.00 color=#20202095 text="S" size=16.00
+Text xy=66.20,54.40 wh=0.00,0.00 color=#20202095 text="M" size=16.00
+Text xy=104.20,54.40 wh=0.00,0.00 color=#20202095 text="T" size=16.00
+Text xy=142.20,54.40 wh=0.00,0.00 color=#20202095 text="W" size=16.00
+Text xy=180.20,54.40 wh=0.00,0.00 color=#20202095 text="T" size=16.00
+Text xy=218.20,54.40 wh=0.00,0.00 color=#20202095 text="F" size=16.00
+Text xy=256.20,54.40 wh=0.00,0.00 color=#20202095 text="S" size=16.00
+Text xy=28.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=66.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=104.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=142.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=180.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=218.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=256.20,86.80 wh=0.00,0.00 color=#20202095 text="1" size=16.00
+Text xy=28.20,121.20 wh=0.00,0.00 color=#20202095 text="2" size=16.00
+Text xy=66.20,121.20 wh=0.00,0.00 color=#20202095 text="3" size=16.00
+Text xy=104.20,121.20 wh=0.00,0.00 color=#20202095 text="4" size=16.00
+Text xy=142.20,121.20 wh=0.00,0.00 color=#20202095 text="5" size=16.00
+Text xy=180.20,121.20 wh=0.00,0.00 color=#20202095 text="6" size=16.00
+Text xy=218.20,121.20 wh=0.00,0.00 color=#20202095 text="7" size=16.00
+Text xy=256.20,121.20 wh=0.00,0.00 color=#20202095 text="8" size=16.00
+Text xy=28.20,155.60 wh=0.00,0.00 color=#20202095 text="9" size=16.00
+Text xy=61.40,155.60 wh=0.00,0.00 color=#20202095 text="10" size=16.00
+Text xy=99.40,155.60 wh=0.00,0.00 color=#20202095 text="11" size=16.00
+Text xy=137.40,155.60 wh=0.00,0.00 color=#20202095 text="12" size=16.00
+Text xy=175.40,155.60 wh=0.00,0.00 color=#20202095 text="13" size=16.00
+Text xy=213.40,155.60 wh=0.00,0.00 color=#20202095 text="14" size=16.00
+Rect xy=243.00,150.60 wh=36.00,32.40 color=#4169e17f radius=5.50 fill
+Text xy=251.40,155.60 wh=0.00,0.00 color=#20202095 text="15" size=16.00
+StrokeRect xy=15.00,185.00 wh=36.00,32.40 color=#2020207f radius=5.50 thickness=2.00
+Text xy=23.40,190.00 wh=0.00,0.00 color=#20202095 text="16" size=16.00
+Text xy=61.40,190.00 wh=0.00,0.00 color=#20202095 text="17" size=16.00
+Text xy=99.40,190.00 wh=0.00,0.00 color=#20202095 text="18" size=16.00
+Text xy=137.40,190.00 wh=0.00,0.00 color=#20202095 text="19" size=16.00
+Text xy=175.40,190.00 wh=0.00,0.00 color=#20202095 text="20" size=16.00
+Text xy=213.40,190.00 wh=0.00,0.00 color=#20202095 text="21" size=16.00
+Text xy=251.40,190.00 wh=0.00,0.00 color=#20202095 text="22" size=16.00
+Text xy=23.40,224.40 wh=0.00,0.00 color=#20202095 text="23" size=16.00
+Text xy=61.40,224.40 wh=0.00,0.00 color=#20202095 text="24" size=16.00
+Text xy=99.40,224.40 wh=0.00,0.00 color=#20202095 text="25" size=16.00
+Text xy=137.40,224.40 wh=0.00,0.00 color=#20202095 text="26" size=16.00
+Text xy=175.40,224.40 wh=0.00,0.00 color=#20202095 text="27" size=16.00
+Text xy=213.40,224.40 wh=0.00,0.00 color=#20202095 text="28" size=16.00
+Text xy=251.40,224.40 wh=0.00,0.00 color=#20202095 text="29" size=16.00

--- a/gui/testdata/disabled_ancestor.dark.golden
+++ b/gui/testdata/disabled_ancestor.dark.golden
@@ -1,0 +1,5 @@
+Rect xy=23.00,23.00 wh=118.60,31.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=23.00,23.00 wh=118.60,31.40 color=#6464647f radius=5.50 thickness=1.50
+Clip xy=29.50,27.50 wh=105.60,22.40
+Text xy=29.50,27.50 wh=0.00,0.00 color=#e1e1e180 text="typed value" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/disabled_ancestor.light.golden
+++ b/gui/testdata/disabled_ancestor.light.golden
@@ -1,0 +1,4 @@
+Rect xy=20.00,20.00 wh=115.60,28.40 color=#c3c3d77f radius=5.50 fill
+Clip xy=25.00,23.00 wh=105.60,22.40
+Text xy=25.00,23.00 wh=0.00,0.00 color=#20202095 text="typed value" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_disabled.dark.golden
+++ b/gui/testdata/input_disabled.dark.golden
@@ -1,5 +1,5 @@
 Rect xy=11.50,11.50 wh=118.60,31.40 color=#4a4a4a7f radius=5.50 fill
 StrokeRect xy=11.50,11.50 wh=118.60,31.40 color=#6464647f radius=5.50 thickness=1.50
 Clip xy=18.00,16.00 wh=105.60,22.40
-Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e17f text="typed value" size=16.00
+Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e180 text="typed value" size=16.00
 Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_disabled.light.golden
+++ b/gui/testdata/input_disabled.light.golden
@@ -1,4 +1,4 @@
 Rect xy=10.00,10.00 wh=115.60,28.40 color=#c3c3d77f radius=5.50 fill
 Clip xy=15.00,13.00 wh=105.60,22.40
-Text xy=15.00,13.00 wh=0.00,0.00 color=#2020207f text="typed value" size=16.00
+Text xy=15.00,13.00 wh=0.00,0.00 color=#20202095 text="typed value" size=16.00
 Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/inputdate_disabled.dark.golden
+++ b/gui/testdata/inputdate_disabled.dark.golden
@@ -1,0 +1,7 @@
+Rect xy=11.50,11.50 wh=123.60,31.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=123.60,31.40 color=#6464647f radius=5.50 thickness=1.50
+Clip xy=18.00,16.00 wh=96.00,22.40
+Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e180 text="08/15/2026" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=119.00,16.00 wh=9.60,22.40 color=#4a4a4a7f radius=5.50 fill
+Text xy=119.00,16.00 wh=0.00,0.00 color=#e1e1e180 text="📅" size=16.00

--- a/gui/testdata/inputdate_disabled.light.golden
+++ b/gui/testdata/inputdate_disabled.light.golden
@@ -1,0 +1,6 @@
+Rect xy=10.00,10.00 wh=120.60,28.40 color=#c3c3d77f radius=5.50 fill
+Clip xy=15.00,13.00 wh=96.00,22.40
+Text xy=15.00,13.00 wh=0.00,0.00 color=#20202095 text="08/15/2026" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=116.00,13.00 wh=9.60,22.40 color=#c3c3d77f radius=5.50 fill
+Text xy=116.00,13.00 wh=0.00,0.00 color=#20202095 text="📅" size=16.00

--- a/gui/testdata/listbox_disabled.dark.golden
+++ b/gui/testdata/listbox_disabled.dark.golden
@@ -1,0 +1,7 @@
+Rect xy=11.50,11.50 wh=81.00,102.20 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=81.00,102.20 color=#6464647f radius=5.50 thickness=1.50
+Rect xy=23.00,23.00 wh=58.00,26.40 color=#5454547f radius=5.50 fill
+Text xy=28.00,25.00 wh=0.00,0.00 color=#e1e1e180 text="one" size=16.00
+Rect xy=23.00,49.40 wh=58.00,26.40 color=#4169e17f radius=5.50 fill
+Text xy=28.00,51.40 wh=0.00,0.00 color=#e1e1e180 text="two" size=16.00
+Text xy=28.00,77.80 wh=0.00,0.00 color=#e1e1e180 text="three" size=16.00

--- a/gui/testdata/listbox_disabled.light.golden
+++ b/gui/testdata/listbox_disabled.light.golden
@@ -1,0 +1,6 @@
+Rect xy=10.00,10.00 wh=78.00,99.20 color=#c3c3d77f radius=5.50 fill
+Rect xy=20.00,20.00 wh=58.00,26.40 color=#b9b9d77f radius=5.50 fill
+Text xy=25.00,22.00 wh=0.00,0.00 color=#20202095 text="one" size=16.00
+Rect xy=20.00,46.40 wh=58.00,26.40 color=#4169e17f radius=5.50 fill
+Text xy=25.00,48.40 wh=0.00,0.00 color=#20202095 text="two" size=16.00
+Text xy=25.00,74.80 wh=0.00,0.00 color=#20202095 text="three" size=16.00

--- a/gui/testdata/menubar_disabled.dark.golden
+++ b/gui/testdata/menubar_disabled.dark.golden
@@ -1,0 +1,4 @@
+Rect xy=11.50,11.50 wh=297.00,42.40 color=#4a4a4aff radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=297.00,42.40 color=#646464ff radius=5.50 thickness=1.50
+Text xy=24.50,21.50 wh=0.00,0.00 color=#e1e1e1ff text="File" size=16.00
+Text xy=85.90,19.50 wh=0.00,0.00 color=#e1e1e180 text="Grouped" size=14.00

--- a/gui/testdata/menubar_disabled.light.golden
+++ b/gui/testdata/menubar_disabled.light.golden
@@ -1,0 +1,3 @@
+Rect xy=10.00,10.00 wh=300.00,36.40 color=#c3c3d7ff radius=5.50 fill
+Text xy=20.00,17.00 wh=0.00,0.00 color=#202020ff text="File" size=16.00
+Text xy=78.40,15.00 wh=0.00,0.00 color=#20202095 text="Grouped" size=14.00

--- a/gui/testdata/numericinput_disabled.dark.golden
+++ b/gui/testdata/numericinput_disabled.dark.golden
@@ -1,0 +1,5 @@
+Rect xy=11.50,11.50 wh=51.40,31.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=51.40,31.40 color=#6464647f radius=5.50 thickness=1.50
+Clip xy=18.00,16.00 wh=38.40,22.40
+Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e180 text="42.5" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/numericinput_disabled.light.golden
+++ b/gui/testdata/numericinput_disabled.light.golden
@@ -1,0 +1,4 @@
+Rect xy=10.00,10.00 wh=48.40,28.40 color=#c3c3d77f radius=5.50 fill
+Clip xy=15.00,13.00 wh=38.40,22.40
+Text xy=15.00,13.00 wh=0.00,0.00 color=#20202095 text="42.5" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/select_disabled.dark.golden
+++ b/gui/testdata/select_disabled.dark.golden
@@ -1,0 +1,4 @@
+Rect xy=11.50,11.50 wh=108.00,31.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=108.00,31.40 color=#6464647f radius=5.50 thickness=1.50
+Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e180 text="beta" size=16.00
+Text xy=105.74,21.44 wh=0.00,0.00 color=#e1e1e180 text="▼" size=9.60

--- a/gui/testdata/select_disabled.light.golden
+++ b/gui/testdata/select_disabled.light.golden
@@ -1,0 +1,3 @@
+Rect xy=10.00,10.00 wh=105.00,28.40 color=#c3c3d77f radius=5.50 fill
+Text xy=15.00,13.00 wh=0.00,0.00 color=#20202095 text="beta" size=16.00
+Text xy=104.24,18.44 wh=0.00,0.00 color=#20202095 text="▼" size=9.60

--- a/gui/testdata/text_disabled.dark.golden
+++ b/gui/testdata/text_disabled.dark.golden
@@ -1,0 +1,1 @@
+Text xy=11.50,11.50 wh=0.00,0.00 color=#e1e1e180 text="quiet" size=16.00

--- a/gui/testdata/text_disabled.light.golden
+++ b/gui/testdata/text_disabled.light.golden
@@ -1,0 +1,1 @@
+Text xy=10.00,10.00 wh=0.00,0.00 color=#20202095 text="quiet" size=16.00

--- a/gui/testdata/tree_disabled.dark.golden
+++ b/gui/testdata/tree_disabled.dark.golden
@@ -1,0 +1,6 @@
+Text xy=19.50,16.50 wh=0.00,0.00 color=#e1e1e180 text="  " size=14.00
+Text xy=37.50,16.50 wh=0.00,0.00 color=#e1e1e180 text=" " size=14.00
+Text xy=55.50,16.50 wh=0.00,0.00 color=#e1e1e180 text="Alpha" size=16.00
+Text xy=19.50,45.90 wh=0.00,0.00 color=#e1e1e180 text="  " size=14.00
+Text xy=37.50,45.90 wh=0.00,0.00 color=#e1e1e180 text=" " size=14.00
+Text xy=55.50,45.90 wh=0.00,0.00 color=#e1e1e180 text="Beta" size=16.00

--- a/gui/testdata/tree_disabled.light.golden
+++ b/gui/testdata/tree_disabled.light.golden
@@ -1,0 +1,6 @@
+Text xy=15.00,12.00 wh=0.00,0.00 color=#20202095 text="  " size=14.00
+Text xy=33.00,12.00 wh=0.00,0.00 color=#20202095 text=" " size=14.00
+Text xy=51.00,12.00 wh=0.00,0.00 color=#20202095 text="Alpha" size=16.00
+Text xy=15.00,38.40 wh=0.00,0.00 color=#20202095 text="  " size=14.00
+Text xy=33.00,38.40 wh=0.00,0.00 color=#20202095 text=" " size=14.00
+Text xy=51.00,38.40 wh=0.00,0.00 color=#20202095 text="Beta" size=16.00

--- a/gui/theme_text_roles.go
+++ b/gui/theme_text_roles.go
@@ -138,6 +138,36 @@ func themeTextRoles(cfg ThemeCfg, base TextStyle, labelSize float32) (
 	return secondary, label, disabled, placeholder
 }
 
+// disabledTextColor is the color disabled text takes when its own base
+// color is base: base's hue at the theme's disabled amount.
+//
+// Unexported on purpose. The role reaches downstream widgets without
+// this seam: they build Shapes, layoutDisables stamps the state, and
+// renderText asks the theme for them — so a caller outside gui/ has
+// nothing to ask. Export it when something outside the shape pipeline
+// needs the amount, not before.
+//
+// The amount is the theme's decision — per-theme and contrast-matched
+// (see textRolesFor) — so a caller never spells it. The renderer asks
+// this question for text shapes stamped Disabled, which is how a
+// widget that never themed its disabled text still lands on the role
+// instead of dimAlpha's theme-blind halving (issue #341). Factories
+// composing the same state at generation time use withRoleAlpha with
+// TextStyleDisabled, which also carries the disabledRole marker this
+// color answer cannot.
+//
+// base's own alpha is deliberately discarded, not multiplied: the role
+// is an absolute amount of de-emphasis, and one disabled control reads
+// as one amount of dead — a translucent base is therefore raised to the
+// role, not quieted twice. The consequence to know about is at the
+// renderText call site, where a shape's Opacity has already been folded
+// into base: a disabled text shape ignores its Opacity. Fade a disabled
+// text shape by animating the color itself, or by fading a parent whose
+// own text is not stamped Disabled.
+func (t Theme) disabledTextColor(base Color) Color {
+	return RGBA(base.R, base.G, base.B, t.TextStyleDisabled.Color.A)
+}
+
 // inspectorStyleFor returns the inspector palette for a theme, with its
 // help text taken from the secondary role.
 //

--- a/gui/theme_text_roles_test.go
+++ b/gui/theme_text_roles_test.go
@@ -167,6 +167,40 @@ func TestWithRoleAlphaKeepsHue(t *testing.T) {
 	}
 }
 
+// disabledTextColor is the render-time companion to withRoleAlpha: the
+// renderer asks the theme for the disabled amount of a caller-supplied
+// base color. It must keep the hue, take the role's alpha, and reflect
+// an explicit ColorTextDisabled override — and the light theme must ask
+// for more, not less, than the dark one.
+func TestDisabledTextColor(t *testing.T) {
+	base := RGBA(200, 50, 5, 255)
+	for _, th := range []Theme{ThemeDark, ThemeLight} {
+		got := th.disabledTextColor(base)
+		if got.R != 200 || got.G != 50 || got.B != 5 {
+			t.Errorf("%s: hue = %v, want the base's own", th.Name, got)
+		}
+		if got.A != th.TextStyleDisabled.Color.A {
+			t.Errorf("%s: alpha = %d, want the role's %d",
+				th.Name, got.A, th.TextStyleDisabled.Color.A)
+		}
+	}
+	if ThemeLight.disabledTextColor(base).A <=
+		ThemeDark.disabledTextColor(base).A {
+		t.Error("light asks for no more alpha than dark; " +
+			"the light-theme contrast gap of #341 is back")
+	}
+
+	cfg := baseCfg()
+	cfg.ColorBackground = RGB(48, 48, 48)
+	cfg.TextStyleDef = DefaultTextStyle
+	want := RGBA(10, 20, 30, 200)
+	cfg.ColorTextDisabled = want
+	th := ThemeMaker(cfg)
+	if got := th.disabledTextColor(base); got.A != 200 {
+		t.Errorf("override: alpha = %d, want the configured 200", got.A)
+	}
+}
+
 // Form density: the point of the field-inset tier is that controls in
 // one row line up. Input, Select and Combobox each picked their own
 // inset, which made a Select six pixels taller than the Input beside it

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -260,7 +260,11 @@ func addGroupBoxTitle(title string, titleBG, colorBorder Color,
 
 	textColor := colorBorder
 	if disabled {
-		textColor = dimAlpha(textColor)
+		// The title shapes are Float and leave the main tree in
+		// layoutRemoveFloatingLayouts, so layoutDisables never
+		// stamps them: the disabled amount has to be applied here,
+		// not at render (issue #341).
+		textColor = guiTheme.disabledTextColor(textColor)
 	}
 	ts.Color = textColor
 	textShape := Shape{


### PR DESCRIPTION
Closes #341.

## Problem

Widgets that never themed their disabled text fell through to `dimAlpha`
(`gui/render_helpers.go`), which halves alpha unconditionally. Correct on dark
by construction (127 vs the role's 128), **22 alpha short on light** (role 149
— dark text on a light ground needs more, not less). A disabled widget that
themed its text and one that did not visibly diverged on the light theme.

## Change — the open question settled as "replaces"

`TextStyleDisabled` now **replaces** `dimAlpha` for text:

- **`Theme.DisabledTextColor(base)`** — new public theme API: base's hue at the
  theme's disabled amount. The amount stays the theme's decision; callers never
  spell it.
- **`renderText`** (`gui/render_text.go`) — a text shape stamped `Disabled`
  lacking the `disabledRole` marker takes `w.Theme().DisabledTextColor(c)`.
  This covers every widget in both direct- and **ancestor**-disabled cases
  (the stamp happens at layout, so the per-widget sweep the issue originally
  described could not reach it).
- **Group-box title** (`gui/view_container.go`) — a Float shape, extracted from
  the tree before `layoutDisables` runs, so it applies the role at generation.
- `dimAlpha` survives for non-text surfaces: fills, borders, Bg/Stroke colors,
  the title eraser.

## Evidence

13 new disabled golden cases (`gui/golden_cases_test.go`), recorded **before**
the change: every disabled text at `#7f` (127) on both themes, DatePicker
weekday headers at `#50` (halved secondary), title at factory-only `#7f`.
After: `#7f` → `#80` (dark) / `#95` (light) in every case; `tab_control` and
`breadcrumb` (already themed, `disabledRole`) **unchanged** — no double
quieting. `disabled_ancestor` pins an enabled Input under a disabled container.

Deliberate behavior change: placeholder/secondary text under a disabled
ancestor renders at the disabled amount rather than a halved version of its own
role — one amount for every text in a dead control.

## Verification

`make prepush` green (race, cross-lint, cross-compile, coverage, export audit
— keep marker on the new export), `make ergonomics-audit` clean.