### PR TITLE
gui: Button and the tabs take the cap band, with a glyph opt-out (issue #346)

### DIFF
--- a/docs/specs/text-optical-centring.md
+++ b/docs/specs/text-optical-centring.md
@@ -67,6 +67,33 @@ a boolean, because the choice was never binary: those are three different
 answers, and which is right is a property of the widget's text, not of the
 correction.
 
+## The rule, once the widgets had all been judged
+
+Each widget was decided on its own evidence, and the same split kept coming
+back. It is worth stating as a rule, because it is what a new widget should be
+read against:
+
+- **A value takes its own ink.** A badge's count, a progress bar's readout: the
+  thing being centred is that string, and centring each on its own ink is what
+  keeps two of them side by side consistent. A descender is left where metric
+  centring put it.
+- **A label takes the face's cap band.** A button, a tab, a menu item, a select:
+  the text names a control, the eye reads it by its caps, and a row or a list of
+  them must agree whatever any one of them happens to say. A descender hangs
+  below centre, which is how a control label is set.
+- **A glyph takes its own ink, always.** An icon or a symbol has no cap band to
+  centre on. `TextStyle.glyphRole` marks one; the theme's `Icon` rungs carry the
+  mark, and `glyphStyle(ts)` is the spelling for a symbol drawn in an ordinary
+  text face — a numeric input's step triangles, a toast's `×`, an overflow
+  panel's `⋮`. A glyph child inside a container correcting on the cap band opts
+  itself back onto its own ink, so an icon button needs no special-casing at the
+  call site.
+- **Editable text takes a content-free band or nothing**, per the rule above.
+
+Nothing here is measurable from the run: an arrow's ink can sit inside the cap
+band exactly as a word's does. That is why the glyph case is a marker on the
+style rather than a test on the string.
+
 The content-free form cannot jitter: there is no way to pass it the live text.
 `ColorFields` uses it — it is editable, but its alphabet is digits and hex — and
 so do `InputDate` (a date mask: digits and separators) and `NumericInput` (its
@@ -122,12 +149,34 @@ menubar item's ink centre sat 2.0 above its highlight box's centre; after, 0.5
 below — the same residual an exactly centred badge records. All three submenu
 labels, descending and not, moved by the same 3 device pixels.
 
-The consequence worth knowing: a descender-bearing `Select` label sits about 1.4
-logical pixels lower than the same string in a `Button` beside it, because
-`Button` measures its run and leaves a descender where it was. `Button` labels
-are static per call site, so nothing forced the choice there; moving `Button`
-and the tabs to the cap band would remove the difference and is a decision, not
-a fix.
+## Button and the tabs followed, and what it cost
+
+`Button` measured its run until the menu work made the disagreement plain: a
+descending label sat about 1.4 logical pixels higher in a `Button` than in the
+`Select` or menu item beside it. It now takes the cap band too, and with it
+`TabControl`, `CommandButton` and the date picker's cells, which are all built
+on `Button`.
+
+Measured at 48pt on the real render, in device pixels: a `PICK` button's ink is
+dead centre in its box before and after — a cap-only label is where the two
+bands already agreed — while the `gypsy` button moved down 8, landing on the
+same baseline as `PICK`. That shared baseline is the whole point, and it is what
+`button` and `button_descender` now record as a pair.
+
+Two costs, both real and both bounded:
+
+- **A digit-only button label sits slightly low** — 1.5 device pixels at 48pt,
+  0.5 at 16 — because figures measure shorter than caps. The widgets that _know_
+  their label is digits opt into the figure band with the unexported
+  `ButtonCfg.opticalDigitLabel`: the date picker's day cells and its
+  adjacent-month cells do. An application's own button cannot, deliberately —
+  the alphabet is a guarantee only the widget building the label can make, the
+  same reasoning as `InputCfg.opticalDigitCenter`.
+- **An icon button needed the glyph role** to keep its arrow on its own ink.
+  Without it the cap band would have shifted the glyph by whatever the icon
+  face's `"H"` measures, or — where that face has no `H` — by the blind fallback
+  ratio. The date picker's month-nav arrows are the case in the recordings: they
+  must not move, and they do not.
 
 The measured form is safe precisely where jitter cannot arise: a badge's label
 changes when the app changes it, not per keystroke. Measuring the run there is
@@ -217,20 +266,32 @@ Two forms, because widgets reach the correction at two different times:
 `color_fields`, `button_disabled`, `tab_control`, `datepicker_disabled`,
 `inputdate_disabled`, `numericinput_disabled` and the five `select_*` cases
 moved. `select_placeholder_descender` records level with `select_placeholder`,
-which is what a revert to the measured form would break. `badge_descender` and
-`button_descender` are the counter-cases: they must **not** move, and they are
-what would catch the correction reverting to a per-face constant applied to
-every run. The plain `input` case is the third counter-case, and the one that
-pins the opt-in: general text must stay metrically centred. `TextMeasurer` is
-nil under the golden harness, so those files pin the fallback-ratio path: that
-the correction happens and by how much, not what a given font measures.
-`menu_open_descender` opens a menu for one frame (menu selection is `nsMenu`
-keyed by the menubar's ID) and records `Copy` and `Paste` at the same offset
-from their own row: the measured form would move one and not the other, which is
-the pitch defect the band exists to avoid. Its shortcut-hint sibling is a unit
-test rather than a golden, because `Shortcut.String()` renders macOS glyphs on
-darwin and words elsewhere, so the recording would not be portable.
-`examples/optical_centring/` is the probe for what a golden cannot show.
+which is what a revert to the measured form would break, and `button_descender`
+records level with `button` for the same reason. `badge_descender` is the
+counter-case that must **not** move: it is the value rule, and it is what would
+catch the cap band being applied to everything. The plain `input` case is the
+second counter-case, and the one that pins the opt-in: general text must stay
+metrically centred. `TextMeasurer` is nil under the golden harness, so those
+files pin the fallback-ratio path: that the correction happens and by how much,
+not what a given font measures.
+
+**That nil measurer is also the harness's blind spot, and it is why the band
+choices are pinned by unit tests as well.** With no ink to measure, the run, cap
+and figure bands all fall back to a ratio keyed on the run's letters, so they
+coincide for a cap-only label and for an icon glyph alike — a golden cannot tell
+which band a widget took. `gui/text_optical_test.go` supplies a measurer that
+reports a different ink box per run, which makes the three bands disagree by
+construction, and asserts that a glyph-role child keeps its own ink under the
+cap band and that `opticalDigitLabel` reaches the figure band. An icon-button
+golden was written and then dropped for exactly this reason: it recorded the
+same numbers either way. `menu_open_descender` opens a menu for one frame (menu
+selection is `nsMenu` keyed by the menubar's ID) and records `Copy` and `Paste`
+at the same offset from their own row: the measured form would move one and not
+the other, which is the pitch defect the band exists to avoid. Its shortcut-hint
+sibling is a unit test rather than a golden, because `Shortcut.String()` renders
+macOS glyphs on darwin and words elsewhere, so the recording would not be
+portable. `examples/optical_centring/` is the probe for what a golden cannot
+show.
 
 Two goldens changed for a reason that is not the correction: the golden harness
 now pins the window clock (`setVirtualNow`) and `datePickerMonth` reads
@@ -252,17 +313,23 @@ label+shortcut row where there is a hint; a `CustomView` item is skipped, since
 its content is the app's to place). `Menubar`'s top-level items and every
 submenu item are the same factory, so both take it.
 
-`Badge`, `ProgressBar`'s readout, `ColorFields`, `InputDate`, `NumericInput`,
-and **`Button`** — which is what `TabControl`, `CommandButton` and the date
-picker's cells are built from, so all of those inherit it. Measured on screen, a
-button label at 48pt went from 6.5 device pixels high to 0.5 low.
+**`Button`** (cap band; figure band where `opticalDigitLabel` says the label is
+digits) — which is what `TabControl`, `CommandButton` and the date picker's
+cells are built from, so all of those inherit it. Measured on screen, a button
+label at 48pt went from 6.5 device pixels high to dead centre.
 
-`Button` sets the hook on its `ContainerCfg` rather than through
-`cv.userAmendLayout`, and `buttonAmendLayout` calls the correction before its
-own early return. Both details matter for one reason: that path returns early
-for a disabled or click-less button, so routing the correction through it would
-leave a disabled label sitting a pixel above the enabled one beside it. `button`
-and `button_disabled` are recorded as a pair to keep that honest.
+`Button` corrects from `buttonAmendLayout` rather than through
+`cv.userAmendLayout`, and does it before that function's early return. Both
+details matter for one reason: the path returns early for a disabled or
+click-less button, so routing the correction through it would leave a disabled
+label sitting a pixel above the enabled one beside it. `button` and
+`button_disabled` are recorded as a pair to keep that honest. The
+`AmendLayout: opticalCenterText` still on the inner `ContainerCfg` is there only
+to guarantee the shape gets an events record, which a bubble-text `Button`
+otherwise has no reason to allocate.
+
+`Badge` and `ProgressBar`'s readout (their own ink — they are values, not
+labels), `ColorFields`, `InputDate`, `NumericInput`.
 
 Still uncorrected: `Input` and every editable control whose alphabet is _not_
 constrained (by the rule above), and the widgets that centre text without going

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -110,8 +110,24 @@ for a second reason: measuring each run would move a descender-free label while
 leaving its neighbour, and uneven baselines read down the whole list. The same
 disagreement between two badges side by side does not.
 
-Which form depends on who supplies the string. A widget-owned label is measured
-per run, so a count centres exactly and a label with a descender is left alone.
+Which form depends on what the text **is**, and the split is worth learning as
+one rule:
+
+- a **value** — a badge's count, a progress readout — is centred on its own ink;
+- a **label** — a button, tab, menu item, select — on the face's cap band;
+- a **glyph** — an icon, a step triangle, a `×` — always on its own ink, and it
+  says so through its style: the theme's `Icon` rungs carry the mark, and
+  `glyphStyle(ts)` applies it to a symbol drawn in a text face. A glyph child
+  inside a cap-band container corrects itself, so an icon button needs nothing
+  at the call site;
+- **editable text** takes a content-free band, or none at all.
+
+A digit-only label is the one case that needs saying out loud: figures measure
+shorter than caps, so a widget that knows its label is digits opts into the
+figure band (`ButtonCfg.opticalDigitLabel`, as the date picker's cells do). An
+application cannot — the alphabet is a guarantee only the widget building the
+label can make.
+
 Editable text takes the content-free form — `opticalCenterFieldText` as a hook,
 `colorFieldPadding` as padding — because an offset that follows the content
 moves the baseline as the user types. A widget wrapping `Input` opts in with the

--- a/examples/optical_centring/main.go
+++ b/examples/optical_centring/main.go
@@ -53,10 +53,13 @@ func mainView(w *gui.Window) gui.View {
 
 	rows := []gui.View{
 		gui.Label("Optical centring probe — issue #346", th.B2),
-		gui.Label("corrected: badge, button, tab, progress readout, "+
-			"colour fields. uncorrected: plain text, input. a run that "+
-			"descends is skipped, so the gypsy rows should sit level "+
-			"across all three columns.", th.TextStyleSecondary),
+		gui.Label("corrected: badge and progress readout on their own "+
+			"ink; button, tab, select and menu on the face's cap band; "+
+			"colour fields and masked inputs on its figures. "+
+			"uncorrected: plain text, input. a badge that descends is "+
+			"left alone, while a button that descends is not — the "+
+			"badge is a value, the button is a label.",
+			th.TextStyleSecondary),
 		gui.Separator(gui.SeparatorCfg{}),
 		// Select re-labels itself as the selection changes, so it takes
 		// the content-free cap-band form: both of these must sit at the
@@ -153,6 +156,15 @@ func sizeRow(size float32, text string) gui.View {
 			gui.Button(gui.ButtonCfg{
 				ID:      gui.ScopeIDN("probe", "btn_"+text, int(size)),
 				Content: []gui.View{gui.Text(gui.TextCfg{Text: text, TextStyle: ts})},
+				OnClick: func(gui.EventCtx) {},
+			}),
+			// A cap-only button beside the row's own spelling. Buttons
+			// take the cap band, so this one and the "gypsy" button a
+			// row down must sit at the same height in their boxes —
+			// that is the property, and it is only visible as a pair.
+			gui.Button(gui.ButtonCfg{
+				ID:      gui.ScopeIDN("probe", "btncap_"+text, int(size)),
+				Content: []gui.View{gui.Text(gui.TextCfg{Text: "PICK", TextStyle: ts})},
 				OnClick: func(gui.EventCtx) {},
 			}),
 			gui.Text(gui.TextCfg{Text: text, TextStyle: ts}),

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -489,8 +489,11 @@ func goldenCases() []goldenCase {
 			},
 		},
 		{
-			// The button counter-case: a label that descends keeps
-			// metric centring, exactly as the badge one does.
+			// A descending label takes the same offset as a cap-only
+			// one: a button is a control whose text is a label, and a
+			// row of them must agree. This records level with `button`
+			// (issue #346); measuring the run would leave this one
+			// behind.
 			name: "button_descender",
 			build: func(_ *Window) View {
 				return Button(ButtonCfg{

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -459,6 +459,11 @@ type shapeButtonColors struct {
 	colorClick       Color
 	ColorFocus       Color
 	ColorBorderFocus Color
+	// opticalDigits centres the button's label on the face's figure
+	// band instead of its cap band, for a button whose label is digits
+	// by construction — a date picker's day cell. Set from the
+	// unexported ButtonCfg.opticalDigitLabel; see buttonAmendLayout.
+	opticalDigits bool
 }
 
 // shapeEffects holds optional visual effect fields.

--- a/gui/styles.go
+++ b/gui/styles.go
@@ -90,6 +90,24 @@ type TextStyle struct {
 	// mechanism. It rides along through the ordinary struct copies
 	// widgets make of a TextStyle.
 	disabledRole bool
+	// glyphRole marks a style whose runs are icon glyphs rather than
+	// text, because it came from the theme's icon family.
+	//
+	// Optical centring needs the distinction and cannot measure it: a
+	// label is centred on the face's cap band, which is what the eye
+	// reads a control's label by, while a glyph has no cap band to
+	// speak of and must be centred on its own ink — the same answer
+	// centerGlyphOnInk gives a checkbox's check. An arrow's ink can sit
+	// inside the cap band exactly as a word's does, so no geometric
+	// test separates them; the style has to say which it is (issue
+	// #346).
+	//
+	// Unexported and set only where a style takes the icon family
+	// (gui/theme_maker.go), for the same reason disabledRole is: a
+	// widget states what the text is, never what the correction should
+	// do about it. It rides along through the ordinary struct copies
+	// widgets make of a TextStyle.
+	glyphRole bool
 }
 
 // mergeTextStyle fills zero fields in s from fallback.

--- a/gui/testdata/button_descender.dark.golden
+++ b/gui/testdata/button_descender.dark.golden
@@ -1,3 +1,3 @@
 Rect xy=11.50,11.50 wh=120.60,37.40 color=#4a4a4aff radius=5.50 fill
 StrokeRect xy=11.50,11.50 wh=120.60,37.40 color=#646464ff radius=5.50 thickness=1.50
-Text xy=19.00,19.00 wh=0.00,0.00 color=#e1e1e1ff text="Apply gypsy" size=16.00
+Text xy=19.00,20.42 wh=0.00,0.00 color=#e1e1e1ff text="Apply gypsy" size=16.00

--- a/gui/testdata/button_descender.light.golden
+++ b/gui/testdata/button_descender.light.golden
@@ -1,2 +1,2 @@
 Rect xy=10.00,10.00 wh=117.60,34.40 color=#c3c3d7ff radius=5.50 fill
-Text xy=16.00,16.00 wh=0.00,0.00 color=#202020ff text="Apply gypsy" size=16.00
+Text xy=16.00,17.42 wh=0.00,0.00 color=#202020ff text="Apply gypsy" size=16.00

--- a/gui/testdata/datepicker_disabled.dark.golden
+++ b/gui/testdata/datepicker_disabled.dark.golden
@@ -1,6 +1,6 @@
 Rect xy=11.50,11.50 wh=277.00,287.20 color=#4a4a4a7f radius=5.50 fill
 StrokeRect xy=11.50,11.50 wh=277.00,287.20 color=#6464647f radius=5.50 thickness=1.50
-Text xy=25.50,25.50 wh=0.00,0.00 color=#e1e1e180 text="August 2026" size=16.00
+Text xy=25.50,26.92 wh=0.00,0.00 color=#e1e1e180 text="August 2026" size=16.00
 Text xy=230.30,26.92 wh=0.00,0.00 color=#e1e1e180 text="\uf101" size=16.00
 Text xy=264.90,26.92 wh=0.00,0.00 color=#e1e1e180 text="\uf102" size=16.00
 Text xy=31.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="S" size=16.00
@@ -10,40 +10,40 @@ Text xy=145.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="W" size=16.00
 Text xy=183.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="T" size=16.00
 Text xy=221.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="F" size=16.00
 Text xy=259.20,60.40 wh=0.00,0.00 color=#e1e1e180 text="S" size=16.00
-Text xy=31.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
-Text xy=69.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
-Text xy=107.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
-Text xy=145.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
-Text xy=183.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
-Text xy=221.20,92.30 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
-Text xy=259.20,94.22 wh=0.00,0.00 color=#e1e1e180 text="1" size=16.00
-Text xy=31.20,128.62 wh=0.00,0.00 color=#e1e1e180 text="2" size=16.00
-Text xy=69.20,128.62 wh=0.00,0.00 color=#e1e1e180 text="3" size=16.00
-Text xy=107.20,128.62 wh=0.00,0.00 color=#e1e1e180 text="4" size=16.00
-Text xy=145.20,128.62 wh=0.00,0.00 color=#e1e1e180 text="5" size=16.00
-Text xy=183.20,128.62 wh=0.00,0.00 color=#e1e1e180 text="6" size=16.00
-Text xy=221.20,128.62 wh=0.00,0.00 color=#e1e1e180 text="7" size=16.00
-Text xy=259.20,128.62 wh=0.00,0.00 color=#e1e1e180 text="8" size=16.00
-Text xy=31.20,163.02 wh=0.00,0.00 color=#e1e1e180 text="9" size=16.00
-Text xy=64.40,163.02 wh=0.00,0.00 color=#e1e1e180 text="10" size=16.00
-Text xy=102.40,163.02 wh=0.00,0.00 color=#e1e1e180 text="11" size=16.00
-Text xy=140.40,163.02 wh=0.00,0.00 color=#e1e1e180 text="12" size=16.00
-Text xy=178.40,163.02 wh=0.00,0.00 color=#e1e1e180 text="13" size=16.00
-Text xy=216.40,163.02 wh=0.00,0.00 color=#e1e1e180 text="14" size=16.00
+Text xy=31.20,93.43 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=69.20,93.43 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=107.20,93.43 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=145.20,93.43 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=183.20,93.43 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=221.20,93.43 wh=0.00,0.00 color=#e1e1e180 text=" " size=16.00
+Text xy=259.20,93.93 wh=0.00,0.00 color=#e1e1e180 text="1" size=16.00
+Text xy=31.20,128.33 wh=0.00,0.00 color=#e1e1e180 text="2" size=16.00
+Text xy=69.20,128.33 wh=0.00,0.00 color=#e1e1e180 text="3" size=16.00
+Text xy=107.20,128.33 wh=0.00,0.00 color=#e1e1e180 text="4" size=16.00
+Text xy=145.20,128.33 wh=0.00,0.00 color=#e1e1e180 text="5" size=16.00
+Text xy=183.20,128.33 wh=0.00,0.00 color=#e1e1e180 text="6" size=16.00
+Text xy=221.20,128.33 wh=0.00,0.00 color=#e1e1e180 text="7" size=16.00
+Text xy=259.20,128.33 wh=0.00,0.00 color=#e1e1e180 text="8" size=16.00
+Text xy=31.20,162.73 wh=0.00,0.00 color=#e1e1e180 text="9" size=16.00
+Text xy=64.40,162.73 wh=0.00,0.00 color=#e1e1e180 text="10" size=16.00
+Text xy=102.40,162.73 wh=0.00,0.00 color=#e1e1e180 text="11" size=16.00
+Text xy=140.40,162.73 wh=0.00,0.00 color=#e1e1e180 text="12" size=16.00
+Text xy=178.40,162.73 wh=0.00,0.00 color=#e1e1e180 text="13" size=16.00
+Text xy=216.40,162.73 wh=0.00,0.00 color=#e1e1e180 text="14" size=16.00
 Rect xy=246.00,156.60 wh=36.00,32.40 color=#4169e17f radius=5.50 fill
-Text xy=254.40,163.02 wh=0.00,0.00 color=#e1e1e180 text="15" size=16.00
+Text xy=254.40,162.73 wh=0.00,0.00 color=#e1e1e180 text="15" size=16.00
 StrokeRect xy=18.00,191.00 wh=36.00,32.40 color=#e1e1e17f radius=5.50 thickness=2.00
-Text xy=26.40,197.42 wh=0.00,0.00 color=#e1e1e180 text="16" size=16.00
-Text xy=64.40,197.42 wh=0.00,0.00 color=#e1e1e180 text="17" size=16.00
-Text xy=102.40,197.42 wh=0.00,0.00 color=#e1e1e180 text="18" size=16.00
-Text xy=140.40,197.42 wh=0.00,0.00 color=#e1e1e180 text="19" size=16.00
-Text xy=178.40,197.42 wh=0.00,0.00 color=#e1e1e180 text="20" size=16.00
-Text xy=216.40,197.42 wh=0.00,0.00 color=#e1e1e180 text="21" size=16.00
-Text xy=254.40,197.42 wh=0.00,0.00 color=#e1e1e180 text="22" size=16.00
-Text xy=26.40,231.82 wh=0.00,0.00 color=#e1e1e180 text="23" size=16.00
-Text xy=64.40,231.82 wh=0.00,0.00 color=#e1e1e180 text="24" size=16.00
-Text xy=102.40,231.82 wh=0.00,0.00 color=#e1e1e180 text="25" size=16.00
-Text xy=140.40,231.82 wh=0.00,0.00 color=#e1e1e180 text="26" size=16.00
-Text xy=178.40,231.82 wh=0.00,0.00 color=#e1e1e180 text="27" size=16.00
-Text xy=216.40,231.82 wh=0.00,0.00 color=#e1e1e180 text="28" size=16.00
-Text xy=254.40,231.82 wh=0.00,0.00 color=#e1e1e180 text="29" size=16.00
+Text xy=26.40,197.13 wh=0.00,0.00 color=#e1e1e180 text="16" size=16.00
+Text xy=64.40,197.13 wh=0.00,0.00 color=#e1e1e180 text="17" size=16.00
+Text xy=102.40,197.13 wh=0.00,0.00 color=#e1e1e180 text="18" size=16.00
+Text xy=140.40,197.13 wh=0.00,0.00 color=#e1e1e180 text="19" size=16.00
+Text xy=178.40,197.13 wh=0.00,0.00 color=#e1e1e180 text="20" size=16.00
+Text xy=216.40,197.13 wh=0.00,0.00 color=#e1e1e180 text="21" size=16.00
+Text xy=254.40,197.13 wh=0.00,0.00 color=#e1e1e180 text="22" size=16.00
+Text xy=26.40,231.53 wh=0.00,0.00 color=#e1e1e180 text="23" size=16.00
+Text xy=64.40,231.53 wh=0.00,0.00 color=#e1e1e180 text="24" size=16.00
+Text xy=102.40,231.53 wh=0.00,0.00 color=#e1e1e180 text="25" size=16.00
+Text xy=140.40,231.53 wh=0.00,0.00 color=#e1e1e180 text="26" size=16.00
+Text xy=178.40,231.53 wh=0.00,0.00 color=#e1e1e180 text="27" size=16.00
+Text xy=216.40,231.53 wh=0.00,0.00 color=#e1e1e180 text="28" size=16.00
+Text xy=254.40,231.53 wh=0.00,0.00 color=#e1e1e180 text="29" size=16.00

--- a/gui/testdata/datepicker_disabled.light.golden
+++ b/gui/testdata/datepicker_disabled.light.golden
@@ -1,5 +1,5 @@
 Rect xy=10.00,10.00 wh=274.00,281.20 color=#c3c3d77f radius=5.50 fill
-Text xy=21.00,21.00 wh=0.00,0.00 color=#20202095 text="August 2026" size=16.00
+Text xy=21.00,22.42 wh=0.00,0.00 color=#20202095 text="August 2026" size=16.00
 Text xy=231.80,22.42 wh=0.00,0.00 color=#20202095 text="\uf101" size=16.00
 Text xy=263.40,22.42 wh=0.00,0.00 color=#20202095 text="\uf102" size=16.00
 Text xy=28.20,54.40 wh=0.00,0.00 color=#20202095 text="S" size=16.00
@@ -9,40 +9,40 @@ Text xy=142.20,54.40 wh=0.00,0.00 color=#20202095 text="W" size=16.00
 Text xy=180.20,54.40 wh=0.00,0.00 color=#20202095 text="T" size=16.00
 Text xy=218.20,54.40 wh=0.00,0.00 color=#20202095 text="F" size=16.00
 Text xy=256.20,54.40 wh=0.00,0.00 color=#20202095 text="S" size=16.00
-Text xy=28.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
-Text xy=66.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
-Text xy=104.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
-Text xy=142.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
-Text xy=180.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
-Text xy=218.20,84.80 wh=0.00,0.00 color=#20202095 text=" " size=16.00
-Text xy=256.20,88.22 wh=0.00,0.00 color=#20202095 text="1" size=16.00
-Text xy=28.20,122.62 wh=0.00,0.00 color=#20202095 text="2" size=16.00
-Text xy=66.20,122.62 wh=0.00,0.00 color=#20202095 text="3" size=16.00
-Text xy=104.20,122.62 wh=0.00,0.00 color=#20202095 text="4" size=16.00
-Text xy=142.20,122.62 wh=0.00,0.00 color=#20202095 text="5" size=16.00
-Text xy=180.20,122.62 wh=0.00,0.00 color=#20202095 text="6" size=16.00
-Text xy=218.20,122.62 wh=0.00,0.00 color=#20202095 text="7" size=16.00
-Text xy=256.20,122.62 wh=0.00,0.00 color=#20202095 text="8" size=16.00
-Text xy=28.20,157.02 wh=0.00,0.00 color=#20202095 text="9" size=16.00
-Text xy=61.40,157.02 wh=0.00,0.00 color=#20202095 text="10" size=16.00
-Text xy=99.40,157.02 wh=0.00,0.00 color=#20202095 text="11" size=16.00
-Text xy=137.40,157.02 wh=0.00,0.00 color=#20202095 text="12" size=16.00
-Text xy=175.40,157.02 wh=0.00,0.00 color=#20202095 text="13" size=16.00
-Text xy=213.40,157.02 wh=0.00,0.00 color=#20202095 text="14" size=16.00
+Text xy=28.20,85.93 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=66.20,85.93 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=104.20,85.93 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=142.20,85.93 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=180.20,85.93 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=218.20,85.93 wh=0.00,0.00 color=#20202095 text=" " size=16.00
+Text xy=256.20,87.93 wh=0.00,0.00 color=#20202095 text="1" size=16.00
+Text xy=28.20,122.33 wh=0.00,0.00 color=#20202095 text="2" size=16.00
+Text xy=66.20,122.33 wh=0.00,0.00 color=#20202095 text="3" size=16.00
+Text xy=104.20,122.33 wh=0.00,0.00 color=#20202095 text="4" size=16.00
+Text xy=142.20,122.33 wh=0.00,0.00 color=#20202095 text="5" size=16.00
+Text xy=180.20,122.33 wh=0.00,0.00 color=#20202095 text="6" size=16.00
+Text xy=218.20,122.33 wh=0.00,0.00 color=#20202095 text="7" size=16.00
+Text xy=256.20,122.33 wh=0.00,0.00 color=#20202095 text="8" size=16.00
+Text xy=28.20,156.73 wh=0.00,0.00 color=#20202095 text="9" size=16.00
+Text xy=61.40,156.73 wh=0.00,0.00 color=#20202095 text="10" size=16.00
+Text xy=99.40,156.73 wh=0.00,0.00 color=#20202095 text="11" size=16.00
+Text xy=137.40,156.73 wh=0.00,0.00 color=#20202095 text="12" size=16.00
+Text xy=175.40,156.73 wh=0.00,0.00 color=#20202095 text="13" size=16.00
+Text xy=213.40,156.73 wh=0.00,0.00 color=#20202095 text="14" size=16.00
 Rect xy=243.00,150.60 wh=36.00,32.40 color=#4169e17f radius=5.50 fill
-Text xy=251.40,157.02 wh=0.00,0.00 color=#20202095 text="15" size=16.00
+Text xy=251.40,156.73 wh=0.00,0.00 color=#20202095 text="15" size=16.00
 StrokeRect xy=15.00,185.00 wh=36.00,32.40 color=#2020207f radius=5.50 thickness=2.00
-Text xy=23.40,191.42 wh=0.00,0.00 color=#20202095 text="16" size=16.00
-Text xy=61.40,191.42 wh=0.00,0.00 color=#20202095 text="17" size=16.00
-Text xy=99.40,191.42 wh=0.00,0.00 color=#20202095 text="18" size=16.00
-Text xy=137.40,191.42 wh=0.00,0.00 color=#20202095 text="19" size=16.00
-Text xy=175.40,191.42 wh=0.00,0.00 color=#20202095 text="20" size=16.00
-Text xy=213.40,191.42 wh=0.00,0.00 color=#20202095 text="21" size=16.00
-Text xy=251.40,191.42 wh=0.00,0.00 color=#20202095 text="22" size=16.00
-Text xy=23.40,225.82 wh=0.00,0.00 color=#20202095 text="23" size=16.00
-Text xy=61.40,225.82 wh=0.00,0.00 color=#20202095 text="24" size=16.00
-Text xy=99.40,225.82 wh=0.00,0.00 color=#20202095 text="25" size=16.00
-Text xy=137.40,225.82 wh=0.00,0.00 color=#20202095 text="26" size=16.00
-Text xy=175.40,225.82 wh=0.00,0.00 color=#20202095 text="27" size=16.00
-Text xy=213.40,225.82 wh=0.00,0.00 color=#20202095 text="28" size=16.00
-Text xy=251.40,225.82 wh=0.00,0.00 color=#20202095 text="29" size=16.00
+Text xy=23.40,191.13 wh=0.00,0.00 color=#20202095 text="16" size=16.00
+Text xy=61.40,191.13 wh=0.00,0.00 color=#20202095 text="17" size=16.00
+Text xy=99.40,191.13 wh=0.00,0.00 color=#20202095 text="18" size=16.00
+Text xy=137.40,191.13 wh=0.00,0.00 color=#20202095 text="19" size=16.00
+Text xy=175.40,191.13 wh=0.00,0.00 color=#20202095 text="20" size=16.00
+Text xy=213.40,191.13 wh=0.00,0.00 color=#20202095 text="21" size=16.00
+Text xy=251.40,191.13 wh=0.00,0.00 color=#20202095 text="22" size=16.00
+Text xy=23.40,225.53 wh=0.00,0.00 color=#20202095 text="23" size=16.00
+Text xy=61.40,225.53 wh=0.00,0.00 color=#20202095 text="24" size=16.00
+Text xy=99.40,225.53 wh=0.00,0.00 color=#20202095 text="25" size=16.00
+Text xy=137.40,225.53 wh=0.00,0.00 color=#20202095 text="26" size=16.00
+Text xy=175.40,225.53 wh=0.00,0.00 color=#20202095 text="27" size=16.00
+Text xy=213.40,225.53 wh=0.00,0.00 color=#20202095 text="28" size=16.00
+Text xy=251.40,225.53 wh=0.00,0.00 color=#20202095 text="29" size=16.00

--- a/gui/text_optical.go
+++ b/gui/text_optical.go
@@ -241,6 +241,21 @@ func fallbackOffset(style TextStyle, probe string, ratio float32) float32 {
 	return style.Size * ratio
 }
 
+// glyphStyle marks a style whose runs are symbol glyphs rather than
+// text: a triangle, a multiplication sign standing in for a close
+// button, a vertical ellipsis. Such a run has no cap band to centre on
+// and must keep its own ink, the way an icon-font glyph does — the
+// theme's Icon rungs carry the mark already, and this is the spelling
+// for a symbol drawn in an ordinary text face (issue #346).
+//
+// It is a function rather than a field a caller sets so the mark stays
+// unexported and searchable: every glyph-in-a-button in the toolkit
+// goes through here.
+func glyphStyle(ts TextStyle) TextStyle {
+	ts.glyphRole = true
+	return ts
+}
+
 // opticalCenterText is an AmendLayout hook that moves a container's
 // direct text children down onto their optical centre. Use it on a
 // container that centres text the widget itself owns — a badge's count,
@@ -336,9 +351,26 @@ func opticalCenterChildren(ctx EventCtx, band opticalBand) {
 		// The style comes from the shape, so a field showing its
 		// placeholder is corrected for the placeholder's face rather
 		// than the text style it will have once typed into.
+		// A blank run is *not* skipped on a content-free band, and
+		// that is the point of one: an empty digit field still shows a
+		// caret, whose position comes from this shape, so declining to
+		// move it would step the caret the moment the first character
+		// arrived. The measured band declines a blank run inside
+		// opticalTextOffset, where the question is about ink.
 		style := textStyleOrDefault(txt)
+		// A content-free band is a claim about an alphabet, and an icon
+		// glyph is not in one. Centring an arrow on the icon face's cap
+		// band would shift it by whatever that face's "H" measures — a
+		// notdef box, or nothing at all, in a face drawn for symbols —
+		// where its own ink is the answer the toolkit already gives a
+		// single glyph elsewhere (centerGlyphOnInk). The style says
+		// which it is, because no measurement can.
+		effective := band
+		if style.glyphRole && band != opticalBandRun {
+			effective = opticalBandRun
+		}
 		var off float32
-		switch band {
+		switch effective {
 		case opticalBandDigit:
 			off = ctx.Window.opticalDigitOffset(style)
 		case opticalBandCap:

--- a/gui/text_optical_test.go
+++ b/gui/text_optical_test.go
@@ -1,0 +1,129 @@
+package gui
+
+import "testing"
+
+// iconProbeRune stands in for an icon face's glyph: a private-use
+// codepoint, which is where icon fonts put their symbols.
+const iconProbeRune = "\ue000"
+
+// runInkMeasurer reports a different ink box per run. That is what makes
+// the three bands distinguishable at all: with one box for every string
+// the run, cap and figure bands agree, and a test asserting which one a
+// widget took would pass whatever the widget did — which is exactly the
+// hole the golden harness has, since it runs with no measurer.
+type runInkMeasurer struct {
+	stubTextMeasurer
+	ink map[string]InkBounds
+}
+
+func (m *runInkMeasurer) TextInkBounds(text string, _ TextStyle) (
+	InkBounds, bool,
+) {
+	b, ok := m.ink[text]
+	return b, ok
+}
+
+// bandTestWindow returns a window whose face is 20 tall and whose bands
+// disagree by construction:
+//
+//	"H" (the cap probe)  ink 2..14, centre  8 → cap offset   +2
+//	"0" (the digit probe) ink 4..14, centre  9 → digit offset +1
+//	an icon glyph         ink 6..16, centre 11 → run offset    0 (clamped)
+//
+// The icon is the case the marker exists for: its own ink already sits
+// below the box centre, so the right correction for it is none, while
+// the cap band would push it down by two.
+func bandTestWindow() *Window {
+	w := newTestWindow()
+	w.SetTextMeasurer(&runInkMeasurer{
+		stubTextMeasurer: stubTextMeasurer{charWidth: 10, fontHeight: 20},
+		ink: map[string]InkBounds{
+			opticalProbe:      {Y: 2, Height: 12, Width: 10},
+			opticalDigitProbe: {Y: 4, Height: 10, Width: 10},
+			"Save":            {Y: 2, Height: 12, Width: 40},
+			iconProbeRune:     {Y: 6, Height: 10, Width: 10},
+		},
+	})
+	return w
+}
+
+// bandTestFrame is a container holding one text child at a known Y, so a
+// hook run can be read as a displacement.
+func bandTestFrame(text string, style TextStyle) Layout {
+	frame := Layout{Shape: &Shape{X: 0, Y: 0, Width: 100, Height: 20}}
+	frame.Children = []Layout{{Shape: &Shape{
+		shapeType: shapeText,
+		X:         0, Y: 0, Width: 40, Height: 20,
+		TC: &shapeTextConfig{Text: text, TextStyle: &style},
+	}}}
+	return frame
+}
+
+// An icon glyph has no cap band to speak of, so a container correcting
+// its children on the face's caps must leave the glyph on its own ink —
+// the answer centerGlyphOnInk gives a checkbox's check. Without the
+// style's glyph role there is no way to tell an arrow from a word:
+// either can sit inside the cap band (issue #346).
+func TestOpticalCapBandLeavesGlyphsOnTheirOwnInk(t *testing.T) {
+	w := bandTestWindow()
+
+	iconStyle := TextStyle{Size: 16, glyphRole: true}
+	frame := bandTestFrame(iconProbeRune, iconStyle)
+	opticalCenterChildren(EventCtx{&frame, nil, w}, opticalBandCap)
+	if got := frame.Children[0].Shape.Y; got != 0 {
+		t.Errorf("icon glyph moved by %v, want 0 (its ink is already low)",
+			got)
+	}
+
+	// The same container, same band, a label rather than a glyph: this
+	// one takes the cap band, or the test above would pass with the
+	// correction switched off entirely.
+	labelFrame := bandTestFrame("Save", TextStyle{Size: 16})
+	opticalCenterChildren(EventCtx{&labelFrame, nil, w}, opticalBandCap)
+	if got := labelFrame.Children[0].Shape.Y; got != 2 {
+		t.Errorf("label moved by %v, want the cap offset 2", got)
+	}
+}
+
+// A blank run keeps taking a content-free correction: an empty digit
+// field still shows a caret, positioned from this shape, and declining
+// to move it would step the caret as soon as a character arrived. The
+// measured band is the one that declines — there the question is about
+// ink, and a blank run has none.
+func TestOpticalCenterBlankRunFollowsTheBand(t *testing.T) {
+	w := bandTestWindow()
+
+	frame := bandTestFrame(" ", TextStyle{Size: 16})
+	opticalCenterChildren(EventCtx{&frame, nil, w}, opticalBandDigit)
+	if got := frame.Children[0].Shape.Y; got != 1 {
+		t.Errorf("blank run on the figure band moved by %v, want 1", got)
+	}
+
+	runFrame := bandTestFrame(" ", TextStyle{Size: 16})
+	opticalCenterChildren(EventCtx{&runFrame, nil, w}, opticalBandRun)
+	if got := runFrame.Children[0].Shape.Y; got != 0 {
+		t.Errorf("blank run on the measured band moved by %v, want 0", got)
+	}
+}
+
+// A button whose label is digits by construction takes the figure band:
+// figures measure shorter than caps, so the cap band would land them as
+// far low as an uncorrected label sits high.
+func TestButtonDigitLabelTakesFigureBand(t *testing.T) {
+	w := bandTestWindow()
+	frame := bandTestFrame("0", TextStyle{Size: 16})
+	frame.Shape.bc = &shapeButtonColors{opticalDigits: true}
+	buttonAmendLayout(EventCtx{&frame, nil, w})
+	if got := frame.Children[0].Shape.Y; got != 1 {
+		t.Errorf("digit label moved by %v, want the figure offset 1", got)
+	}
+
+	// The same button without the flag reads the cap band, which is the
+	// default for every other label.
+	capFrame := bandTestFrame("Save", TextStyle{Size: 16})
+	capFrame.Shape.bc = &shapeButtonColors{}
+	buttonAmendLayout(EventCtx{&capFrame, nil, w})
+	if got := capFrame.Children[0].Shape.Y; got != 2 {
+		t.Errorf("label moved by %v, want the cap offset 2", got)
+	}
+}

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -211,9 +211,10 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			Radius:      cfg.Radius,
 			TextStyle:   ts,
 			textStyleIcon: TextStyle{
-				Color:  ts.Color,
-				Size:   cfg.sizeTextSmall,
-				Family: iconFamily,
+				Color:     ts.Color,
+				Size:      cfg.sizeTextSmall,
+				Family:    iconFamily,
+				glyphRole: true,
 			},
 			indent:  25,
 			Spacing: 0,
@@ -591,6 +592,10 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 	// Icon font shortcuts.
 	icon := ts
 	icon.Family = iconFamily
+	// Runs in this family are glyphs, not text: optical centring must
+	// centre them on their own ink rather than on a cap band the face
+	// does not really have.
+	icon.glyphRole = true
 	theme.Icon1 = makeStyle(icon, theme.sizeTextXLarge)
 	theme.Icon2 = makeStyle(icon, theme.sizeTextLarge)
 	theme.Icon3 = makeStyle(icon, theme.sizeTextMedium)

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -63,6 +63,17 @@ type ButtonCfg struct {
 	FloatTieOff floatAttach
 	Disabled    bool
 	Invisible   bool
+	// opticalDigitLabel centres this button's label on the face's
+	// figure band rather than its cap band. Digits measure shorter than
+	// caps, so a digit-only label centred on the cap band lands as far
+	// low as an uncorrected one sits high — the overshoot measured on
+	// NumericInput (issue #346).
+	//
+	// Unexported and opt-in, like InputCfg.opticalDigitCenter: the
+	// alphabet is a guarantee only the widget building the label can
+	// make. A date picker's day cell can; an app's button holding a
+	// count it also relabels cannot.
+	opticalDigitLabel bool
 
 	// Accessibility
 	A11YRole AccessRole
@@ -72,7 +83,19 @@ func buttonAmendLayout(ctx EventCtx) {
 	// Unconditional: the correction is a property of the label, not of
 	// the button's state, and the early return below covers only the
 	// hover/focus colouring and the caller's own hook.
-	opticalCenterText(ctx)
+	//
+	// The cap band, not the run: a button is a control whose text is a
+	// label, and a strip of tabs or a toolbar row is a list at a
+	// regular pitch, where measuring each run would drop a
+	// descender-free label and leave its descending neighbour behind.
+	// A label holding digits by construction says so and takes the
+	// figure band; an icon child opts itself back onto its own ink
+	// through the style's glyph role (issue #346).
+	band := opticalBandCap
+	if ctx.Layout.Shape.bc != nil && ctx.Layout.Shape.bc.opticalDigits {
+		band = opticalBandDigit
+	}
+	opticalCenterChildren(ctx, band)
 	if ctx.Layout.Shape.Disabled ||
 		!ctx.Layout.Shape.hasEvents() ||
 		ctx.Layout.Shape.events.OnClick == nil {
@@ -177,11 +200,14 @@ func Button(cfg ButtonCfg) View {
 		OnClick:      onClick,
 		clickOnSpace: true,
 		clickOnEnter: true,
-		// A button's label is text the widget owns, so it takes the
-		// optical correction (issue #346); tabs, command buttons and
-		// every other widget built on Button inherit it here.
+		// A button's label takes the optical correction (issue #346);
+		// tabs, command buttons and every other widget built on Button
+		// inherit it. The hook here is not the one that runs —
+		// buttonAmendLayout replaces it and picks the band — it is what
+		// guarantees the shape gets an events record at all, which a
+		// bubble-text Button otherwise has no reason to allocate.
 		//
-		// Set on the cfg rather than through cv.userAmendLayout because
+		// Not routed through cv.userAmendLayout, because
 		// that slot is reached from buttonAmendLayout, which returns
 		// early for a disabled or click-less button — a disabled label
 		// would then sit a pixel above the enabled one beside it. This
@@ -198,6 +224,7 @@ func Button(cfg ButtonCfg) View {
 	cv.colorBorderFocus = cfg.Colors.BorderFocus
 	cv.userOnHover = cfg.OnHover
 	cv.userAmendLayout = cfg.AmendLayout
+	cv.opticalDigits = cfg.opticalDigitLabel
 
 	return cv
 }

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -178,6 +178,7 @@ type containerView struct {
 	isButton         bool
 	userOnHover      func(EventCtx)
 	userAmendLayout  func(EventCtx)
+	opticalDigits    bool
 	colorHover       Color
 	colorClick       Color
 	colorFocus       Color
@@ -196,6 +197,7 @@ func (cv *containerView) GenerateLayout(w *Window) Layout {
 			ColorBorderFocus: cv.colorBorderFocus,
 			OnHover:          cv.userOnHover,
 			OnAmend:          cv.userAmendLayout,
+			opticalDigits:    cv.opticalDigits,
 		}
 		if w != nil {
 			layout.Shape.bc = w.scratch.buttonColors.alloc(bc)

--- a/gui/view_date_picker_calendar.go
+++ b/gui/view_date_picker_calendar.go
@@ -106,15 +106,19 @@ func datePickerMonth(
 					// decorative case FocusDisabled exists for, so opt
 					// out rather than invent an ID for empty space.
 					cells = append(cells, Button(ButtonCfg{
-						FocusDisabled: true,
-						Color:         ColorTransparent,
-						Colors:        ColorSet{Border: ColorTransparent},
-						Disabled:      true,
-						MinWidth:      cellSize,
-						MaxWidth:      cellSize,
-						MaxHeight:     cellSize,
-						Padding:       paddingThree,
-						Content:       []View{Text(TextCfg{Text: " "})},
+						// Same band as the cells it stands among, so
+						// the whole grid is corrected once and the
+						// recording does not carry an odd one out.
+						opticalDigitLabel: true,
+						FocusDisabled:     true,
+						Color:             ColorTransparent,
+						Colors:            ColorSet{Border: ColorTransparent},
+						Disabled:          true,
+						MinWidth:          cellSize,
+						MaxWidth:          cellSize,
+						MaxHeight:         cellSize,
+						Padding:           paddingThree,
+						Content:           []View{Text(TextCfg{Text: " "})},
 					}))
 				}
 				continue
@@ -148,16 +152,20 @@ func datePickerMonth(
 			dayVal := d
 			cfgID := cfg.ID
 			cells = append(cells, Button(ButtonCfg{
-				ID:         ScopeIDN(cfg.ID, "day", d),
-				MinWidth:   cellSize,
-				MaxWidth:   cellSize,
-				MaxHeight:  cellSize,
-				Color:      cellColor,
-				Colors:     ColorSet{Hover: colorHover, Click: cfg.ColorSelect, Border: borderColor},
-				SizeBorder: SomeF(2),
-				Radius:     Some(radius),
-				Padding:    paddingThree,
-				Disabled:   disabled,
+				ID: ScopeIDN(cfg.ID, "day", d),
+				// A day number is digits by construction, and figures
+				// measure shorter than caps: on the cap band every cell
+				// would land low (issue #346).
+				opticalDigitLabel: true,
+				MinWidth:          cellSize,
+				MaxWidth:          cellSize,
+				MaxHeight:         cellSize,
+				Color:             cellColor,
+				Colors:            ColorSet{Hover: colorHover, Click: cfg.ColorSelect, Border: borderColor},
+				SizeBorder:        SomeF(2),
+				Radius:            Some(radius),
+				Padding:           paddingThree,
+				Disabled:          disabled,
 				Content: []View{Text(TextCfg{
 					Text: dayStr, TextStyle: ts,
 				})},
@@ -235,13 +243,16 @@ func datePickerAdjacentCell(
 	}
 
 	return Button(ButtonCfg{
-		ID:        ScopeIDN(ScopeID(cfg.ID, "day", idSuffix), "", adjDay),
-		Color:     ColorTransparent,
-		Colors:    ColorSet{Border: ColorTransparent},
-		MinWidth:  cellSize,
-		MaxWidth:  cellSize,
-		MaxHeight: cellSize,
-		Padding:   paddingThree,
+		ID: ScopeIDN(ScopeID(cfg.ID, "day", idSuffix), "", adjDay),
+		// Digits, like the in-month cells beside it, and it has to sit
+		// level with them.
+		opticalDigitLabel: true,
+		Color:             ColorTransparent,
+		Colors:            ColorSet{Border: ColorTransparent},
+		MinWidth:          cellSize,
+		MaxWidth:          cellSize,
+		MaxHeight:         cellSize,
+		Padding:           paddingThree,
 		Content: []View{Text(TextCfg{
 			Text:      strconv.Itoa(adjDay),
 			TextStyle: ts,

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -341,9 +341,9 @@ func dockTabButton(
 			Content: []View{
 				Text(TextCfg{
 					Text: "×", // ×
-					TextStyle: mergeTextStyle(
+					TextStyle: glyphStyle(mergeTextStyle(
 						TextStyle{Size: guiTheme.sizeTextSmall},
-						DefaultTextStyle),
+						DefaultTextStyle)),
 				}),
 			},
 		}))

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -256,11 +256,13 @@ func numericInputStepButtons(cfg NumericInputCfg, locale NumericLocaleCfg, stepC
 		f32Max(cfg.TextStyle.Size-4, guiTheme.N6.Size), // ergonomics-audit:visual
 		cfg.TextStyle.Size,
 	)
-	triangleStyle := TextStyle{
+	// A triangle is a glyph, not a label: it keeps its own ink
+	// rather than taking the face's cap band (issue #346).
+	triangleStyle := glyphStyle(TextStyle{
 		Color:  cfg.TextStyle.Color,
 		Size:   triangleSize,
 		Family: cfg.TextStyle.Family,
-	}
+	})
 	baseColor := cfg.Color
 
 	stepUpID := ""

--- a/gui/view_overflow_panel.go
+++ b/gui/view_overflow_panel.go
@@ -54,7 +54,7 @@ func OverflowPanel(w *Window, cfg OverflowPanelCfg) View {
 		triggerContent = []View{
 			Text(TextCfg{
 				Text:      "\u22EE",
-				TextStyle: DefaultTextStyle,
+				TextStyle: glyphStyle(DefaultTextStyle),
 			}),
 		}
 	}

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -180,7 +180,9 @@ func toastItemView(toast *toastNotification, style ToastStyle) View {
 		ID:         toastBtnID(id, "dismiss"),
 		Color:      ColorTransparent,
 		SizeBorder: NoBorder,
-		Content:    []View{Text(TextCfg{Text: "\u00d7", TextStyle: style.TextStyle})},
+		Content: []View{Text(TextCfg{
+			Text: "\u00d7", TextStyle: glyphStyle(style.TextStyle),
+		})},
 		OnClick: func(ctx EventCtx) {
 			toastStartExit(ctx.Window, id)
 		},


### PR DESCRIPTION
Stacked on #350 — review that first; this PR's base is `issue-346-optical-centring` and it should be rebased onto `main` once #350 merges.

Follow-up to #346. A button's text is a **label**, not a value: the eye reads it by its caps, and a strip of tabs or a row of buttons has to agree whatever any one of them says. `Button` measured its own run until now, which left a descending label about 1.4 logical pixels above the same string in the `Select` or menu item beside it. It now centres on the face's cap band, and `TabControl`, `CommandButton` and the date picker's cells inherit that.

Measured at 48pt on the real render, device pixels:

| button | before | after |
| --- | --- | --- |
| `PICK` (cap-only) | dead centre | dead centre — the two bands already agreed here |
| `gypsy` (descends) | 8 px higher | on `PICK`'s baseline |

That shared baseline is the property; `button` and `button_descender` now record level as a pair.

## The two things a blanket switch would have broken

**An icon button.** `buttonAmendLayout` corrects every direct text child, and a glyph is one. On the cap band an arrow would be shifted by whatever the *icon face's* `"H"` measures — or by the blind fallback ratio where that face has no `H`. No geometric test separates a glyph from a word (an arrow's ink sits inside the cap band as readily), so `TextStyle` carries an unexported `glyphRole`, set by the theme's `Icon` rungs and by `glyphStyle()` for a symbol drawn in an ordinary text face: the numeric input's step triangles, the toast and dock close crosses, the overflow panel's ellipsis. A glyph child opts itself back onto its own ink, so no call site special-cases an icon.

**A digit label.** Figures measure shorter than caps, so digits on the cap band land as far low as an uncorrected label sits high — 1.5 device px at 48pt, 0.5 at 16. `ButtonCfg.opticalDigitLabel` is the unexported opt-in, taken by the date picker's day cells, its adjacent-month cells, and the blank spacers among them so the grid is corrected once. An application's own button cannot opt in, deliberately: the alphabet is a guarantee only the widget building the label can make — the same reasoning as `InputCfg.opticalDigitCenter`. The residual cost is documented rather than hidden.

## One thing tried and reverted

Skipping blank runs. An empty digit field still shows a caret positioned from that shape, so declining to move it steps the caret the moment the first character arrives. `TestInputOpticalCenterDoesNotFollowContent` caught it.

## Gates

The golden harness runs with a nil measurer, where every band falls back to the same letter-keyed ratio — so **a golden cannot tell which band a widget took**. An icon-button golden was written and dropped for recording identical numbers either way. `gui/text_optical_test.go` supplies a measurer reporting a different ink box per run, making the three bands disagree by construction, and pins the glyph opt-out, the digit opt-in and the blank-run rule.

`make check-all`, `make ergonomics-audit`, `make export-audit` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)