### PR TITLE
gui: variable-height virtualized lists and index-addressed scrolling (issue #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,51 @@ and this project adheres to
 
 ### Added
 
+- **`VirtualList` — virtualized lists whose rows may differ in height, and
+  index-addressed scrolling** (issue #332). Virtualization was arithmetic over
+  one scalar row height, which is exact for a widget that owns its row shape and
+  useless for rows the caller builds; and a row virtualization had not built
+  could not be scrolled to at all, because `scrollToView` resolves through
+  `FindByID`.
+  - `VirtualList`/`VirtualListCfg` build only the rows near the viewport and
+    hold the rest of the space in two spacers, sized from a per-list prefix-sum
+    (Fenwick) height model that seeds from an estimate and converges on measured
+    heights. `ItemHeight` is the cheap path — exact from frame 1, no
+    measurement. `ItemKey` stores measured heights under a stable identity, so
+    an insert, delete or reorder keeps each height on its own item. `OverscanPx`
+    tunes how far past the viewport rows are built, in pixels rather than rows.
+  - `Window.ScrollToIndex`, `ScrollToIndexAt(frac)`, `ScrollIndexIntoView` and
+    `ScrollToEnd` address rows by index through the height model, so they reach
+    rows that do not exist this frame. `ScrollToEnd` is the correct
+    pin-to-bottom: `ScrollVerticalToPct(id, 1)` takes a percentage of a content
+    height that virtualized rows only estimate, so it drifts.
+    `Window.InvalidateListHeights` re-measures a list whose content changed
+    under a stable key.
+  - `ListBox`, `Table`, `Tree`, `Combobox` and the command palette register the
+    uniform (O(1), no per-item storage) form of the same model, so the index API
+    works on them too. Index spaces differ per widget — a frozen table header is
+    data index 0 but sits outside the scrollable, and the combobox indexes its
+    _filtered_ items.
+  - `Window.VirtualListFocusedIndex` / `SetVirtualListFocusedIndex`: an unbuilt
+    row has no shape to hold focus, so a virtual list's keyboard focus is an
+    index on the list.
+  - A row must not turn the width `ItemView` hands it into a width it demands:
+    `MinWidth` taken from that argument ratchets the list wider every frame, and
+    each width change re-wraps every row, so the list never settles. `Debug`
+    reports it (the `DebugListBoxNoHeight` category) after four consecutive
+    frames of widening with the window unchanged.
+  - See `docs/specs/virtualized-variable-height-lists.md` and
+    `examples/virtual_list`.
+
 - **Keyboard navigation for `Table`, `ColorSwatch` and the `ExpandPanel`
-  header** — the three widgets the #335 audit recorded as "not focusable"
-  (issue #345).
+  header** — the three widgets the #335 audit recorded as "not focusable" (issue
+  #345).
   - `TableCfg.Focusable` opts a table into the tab order. Focus lands on the
     table; Up/Down/Home/End move an active row — tinted with the hover color,
     scrolled into view under virtualization, and synced to mouse clicks — and
-    Enter/Space activate the active row the way a click would. Selection
-    follows movement when `OnSelect` is set; Shift extends a range under
-    `MultiSelect`. `TableCfg.ColorBorderFocus` (theme-backed) paints the focus
-    ring.
+    Enter/Space activate the active row the way a click would. Selection follows
+    movement when `OnSelect` is set; Shift extends a range under `MultiSelect`.
+    `TableCfg.ColorBorderFocus` (theme-backed) paints the focus ring.
   - The `ExpandPanel` header now joins the tab order ahead of the panel body's
     own focusables; Space/Enter toggle it. `ExpandPanelCfg.ColorBorderFocus`
     (theme-backed) paints the ring.
@@ -33,10 +68,9 @@ and this project adheres to
   of v0.54.0 already used. Additive and zero visual change: the surviving flat
   `Color*` fields still win over the set when both are set (the `applyTo`
   precedence), so existing callers keep their appearance. `ColorSelect` and
-  `ColorHighlight`, which have no set slot, stay flat. Inline
-  `ColorSet{...}` constructions inside gui/ and gui/datagrid/ resolve at the
-  construction site instead of relying on the receiving widget to resolve
-  (issue #342).
+  `ColorHighlight`, which have no set slot, stay flat. Inline `ColorSet{...}`
+  constructions inside gui/ and gui/datagrid/ resolve at the construction site
+  instead of relying on the receiving widget to resolve (issue #342).
 - **Named text roles on `Theme`** — `TextStyleSecondary`, `TextStyleLabel`,
   `TextStyleDisabled`, `TextStylePlaceholder`, with matching
   `ThemeCfg.ColorText*` overrides. A widget that wants quiet text now names the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,12 +64,12 @@ silent no-op — the widget renders and clicks but never joins the tab order. Th
 `requiredid` analyzer flags this, and `gui.Debug` reports it at runtime.
 
 **Input controls are focusable by default (v0.36.0); opt out with
-`FocusDisabled`, never with `Focusable: false`.** Fifteen Cfgs default on:
+`FocusDisabled`, never with `Focusable: false`.** Sixteen Cfgs default on:
 `Button`, `ColorPicker`, `Combobox`, `DatePicker`, `Input`, `InputDate`,
 `ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`, `Slider`,
-`Switch`, `Toggle`, `Tree`. Everything else is opt-in via `Focusable: true`. See
-`docs/specs/focusable-default-input.md`; run `ergonomics-audit -mode focus` for
-the current inventory.
+`Switch`, `Toggle`, `Tree`, `VirtualList`. Everything else is opt-in via
+`Focusable: true`. See `docs/specs/focusable-default-input.md`; run
+`ergonomics-audit -mode focus` for the current inventory.
 
 **`Shape.ID` is a leaf; identity is the effective ID.** `resolveShapeIDs`
 (`gui/id_resolve.go`, run from `layoutArrange`) stamps `Shape.effID` = the leaf
@@ -163,8 +163,8 @@ over the `ColorSet`**, so existing code keeps its appearance when a set arrives.
 **Never spell a de-emphasis alpha, a label's size step, or a form control's text
 inset at a call site.** Each has one named source; a literal there is the
 divergence issue #335 measured and removed
-(`docs/specs/widget-visual-consistency-audit.md`). The _when_ — which role
-each decision takes, and when a deviation may carry the marker — is
+(`docs/specs/widget-visual-consistency-audit.md`). The _when_ — which role each
+decision takes, and when a deviation may carry the marker — is
 `docs/style-guide.md`, enforced by `ergonomics-audit -mode visual`.
 
 - **Quiet text** takes one of four `Theme` roles — `TextStyleSecondary`,

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ func mainView(w *gui.Window) gui.View {
 ```
 
 `gui.Label(text, style)` — pass the zero `TextStyle{}` for the default theme
-style. `gui.TextButton(id, label, onClick)` and `gui.SimpleWindow` are the
-same thin forwards; the `ID` argument stays explicit because identity is
+style. `gui.TextButton(id, label, onClick)` and `gui.SimpleWindow` are the same
+thin forwards; the `ID` argument stays explicit because identity is
 caller-owned.
 
 ### Full control
@@ -138,6 +138,10 @@ sharing the same rendering pipeline and event system.
 - **50+ widgets** — buttons, inputs, sliders, tables, trees, tabs, menus,
   dialogs, toasts, DataGrid with virtualization (CSV/XLSX/PDF export), Markdown
   and RTF views, SVG rendering, and more
+- **Virtualized lists, uniform or not** — `ListBox`, `Table` and `Tree`
+  virtualize rows they own; `VirtualList` handles rows the app builds, of
+  heights only the layout engine knows, and `Window.ScrollToIndex` addresses a
+  row that does not exist yet
 - **GPU-accelerated** — Metal (macOS), OpenGL (Linux/Windows), WebGL/WASM
   (browser), Metal/UIKit (iOS)
 - **Animation subsystem** — keyframe, spring, tween, hero transitions, color

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -22,10 +22,10 @@ Input{ID: "name", FocusDisabled: true} // not in the tab order
 Most input controls are focusable by default: `Button`, `ColorChannelSlider`,
 `ColorPicker`, `ColorPlane`, `ColorWheel`, `Combobox`, `DatePicker`, `Input`,
 `InputDate`, `ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`,
-`Slider`, `Switch`, `Toggle`, `Tree`. Everything else opts in with
-`Focusable: true`. If a control never answers the keyboard, the usual cause is a
-missing `ID`. The `requiredid` analyzer and the `DebugMissingIDs` gate report
-it. See `docs/specs/focusable-default-input.md`.
+`Slider`, `Switch`, `Toggle`, `Tree`, `VirtualList`. Everything else opts in
+with `Focusable: true`. If a control never answers the keyboard, the usual cause
+is a missing `ID`. The `requiredid` analyzer and the `DebugMissingIDs` gate
+report it. See `docs/specs/focusable-default-input.md`.
 
 ## ID scoping
 
@@ -106,6 +106,60 @@ The mask inherits down the tree, and only down: a snapped container snaps
 everything inside it, and a child cannot escape the container's mask. The hero
 transition (`Shape.Hero`) ignores `AnimSnap` — it is already an explicit
 per-shape opt-in.
+
+## Virtualized lists
+
+`ListBox`, `Table`, `Tree` and `Combobox` virtualize automatically when the
+scroll container has a bounded height (`Scrollable` plus `Height`, `MaxHeight`,
+or — `ListBox` only — a height Fill sizing resolved last frame). Every row is
+the same height there, which is exact because the widget owns the row shape.
+
+For rows the app builds, of heights only the layout engine knows, use
+`VirtualList`:
+
+```go
+gui.VirtualList(gui.VirtualListCfg{
+    ID:        "feed",
+    ItemCount: len(msgs),
+    Sizing:    gui.FillFill,
+    // Optional but wanted whenever items can be inserted or reordered:
+    // measured heights follow the key, not the index.
+    ItemKey: func(i int) string { return msgs[i].ID },
+    ItemView: func(i int, width float32) gui.View {
+        // width is the inner width recorded by the previous arrange.
+        // It is 0 on the first frame.
+        return card(msgs[i], gui.ScopeIDN("feed", "row", i), width)
+    },
+})
+```
+
+Set `ItemHeight` when the height is cheap to compute: heights are then exact
+from the first frame and nothing is measured. Put spacing _inside_ the row — the
+list's own spacing is fixed at zero, because a gap between rows is height the
+model does not account for.
+
+**Use `width` for decisions, never for a minimum.** A row that sets `MinWidth`
+from it asks the list for at least the width the list just reported; the row's
+own border pushes that further, the list widens, and the cycle repeats every
+frame — re-wrapping and re-measuring each time, so nothing settles. Rows fill
+the width they are handed through `Sizing`. `gui.Debug(true)` reports the
+ratchet.
+
+Scroll by index, not by ID or percentage — a row outside the viewport has no
+shape for `FindByID` to resolve, and the content height under virtualization is
+an estimate, so a percentage drifts:
+
+```go
+w.ScrollToIndex("feed", 4000)          // row at the viewport top
+w.ScrollToIndexAt("feed", 4000, 0.5)   // centred
+w.ScrollIndexIntoView("feed", 4000)    // nearest edge; no-op when visible
+w.ScrollToEnd("feed")                  // pin to bottom, exactly
+```
+
+These work on the uniform widgets too, in each one's own index space (a frozen
+table header is data index 0 but sits outside the scrollable). Call
+`w.InvalidateListHeights(id)` when a row's content changed under a stable key —
+nothing detects that. See `docs/specs/virtualized-variable-height-lists.md`.
 
 ## The one-event rule
 

--- a/docs/specs/virtualized-variable-height-lists.md
+++ b/docs/specs/virtualized-variable-height-lists.md
@@ -1,0 +1,234 @@
+# Spec: variable-height virtualized lists and index-addressed scrolling
+
+Status: **implemented** — issue #332.
+
+Two halves of one problem.
+
+**Virtualization was arithmetic over one scalar.** `listCoreVisibleRange`
+(`gui/list_core.go`) divides the scroll offset by a single `rowHeight`, and the
+content height is faked with transparent spacer rectangles sized
+`rowCount × rowHeight`. That is exact for a widget that owns its row shape and
+useless for rows the caller builds — a chat transcript, a feed, a log view, a
+card list.
+
+**Rows could not be addressed by index.** `scrollToView` resolves through
+`FindByID`, so a row virtualization never built is structurally unreachable.
+`ScrollVerticalToPct` inherits the fictional content height, so `pct = 1` lands
+near the end rather than at it and pin-to-bottom drifts with every append.
+
+The outcome is a `VirtualList` widget, a per-list height model, and a public
+index-addressed scroll API that works on the new widget **and** on the five
+existing uniform ones.
+
+## The height model
+
+`gui/list_height_model.go`. One type, two shapes:
+
+- **uniform** — every row is `rowH` tall. No per-item storage, every query is
+  arithmetic. This is what the existing widgets already assume, which is why the
+  retrofit costs them one line.
+- **variable** — per-item heights in a Fenwick (binary indexed) tree, seeded
+  from an estimate and refined by measurement. `Prefix` and `IndexAt` are O(log
+  n), a point update O(log n), a full rebuild O(n).
+
+### Why an exact tree rather than a sampled average
+
+go-shirei's `widgets.VirtualList` (zlib; design reference, not copied) samples
+the first N and last N rows and extrapolates an average. That is cheaper and
+stateless, and its own documentation records what it costs: a thumb that jumps
+and a false bottom on a corpus whose row heights are regionally skewed — a feed
+of short acknowledgements followed by long posts is exactly that shape.
+
+An exact prefix-sum tree pays 12 B/item and a staleness problem in exchange for
+a scrollbar that means what it shows. Both costs are answered rather than
+accepted:
+
+- staleness — `ItemKey` (below);
+- memory — above `listHeightMaxVariable` (~4M items) the model falls back to
+  uniform and reports it under `gui.Debug` (the `DebugListBoxNoHeight`
+  category).
+
+### Why the tree is float64 while the heights are float32
+
+At a million rows the running prefix reaches ~3×10⁷ px, where one float32 ULP is
+~4 px. That is visible jitter, and worse, it makes the prefix sequence
+non-monotonic — so the `IndexAt` binary-lifting search can return an index whose
+span does not contain `y`. The heights themselves stay float32 because they are
+pixel measurements; only the accumulation needs the range.
+
+### Why shirei's per-frame `Measure` does not port
+
+shirei measures every candidate row each frame and caches nothing. In go-gui the
+layout passes mutate ID-keyed window state (`layoutOverflow`'s overflow map,
+`resolveShapeIDs`) and draw shapes from the frame-scoped pool. Measuring N rows
+per frame would both allocate and corrupt per-window state. Measurement here is
+therefore observation of rows that were built anyway — the `listBoxAmendLayout`
+idiom — which is what makes the write-back and the re-anchor necessary.
+
+### Heights are keyed, positions are indexed
+
+`heights`/`tree` hold the current frame's index order; `byKey` holds what was
+actually measured, under the caller's `ItemKey`. A count change rebuilds the
+tree by walking `ItemKey(i)` and taking `byKey[k]`, so an insert, a delete or a
+reorder keeps every measured height on its own item. Without `ItemKey` the model
+is index-keyed: an insert at the front shifts every measured height by one and
+rows render at a neighbour's height until re-measured.
+`Window.InvalidateListHeights` is the escape hatch, and is also the only answer
+for content edited under a _stable_ key — nothing detects that.
+
+`byKey` is bounded: when it outgrows the live count by `listHeightKeyLoadFactor`
+it is replaced by one holding only live keys, so a long-running feed does not
+accumulate forever.
+
+## The write-back and the re-anchor
+
+One `AmendLayout` on the list's scroll container, not one per row. `layoutAmend`
+fires children-first, so every row's `Shape.Height` is final. Child position
+`leadOffset + k` maps to item `builtFirst + k` — recorded by the view phase,
+never reverse-parsed from a row ID.
+
+The re-anchor keys on the **row under the viewport top**, not on `first`:
+
+```
+anchor = IndexAt(-scrollY)
+before = Prefix(anchor)
+... write each built row's measured height ...
+delta  = Prefix(anchor) - before
+scrollY -= delta
+```
+
+Keying on `first` cannot work: rows above `first` sit inside the leading spacer
+and are never measured, so `Prefix(first)` does not move and the delta is
+structurally always zero.
+
+`IndexAt` carries a boundary tolerance for this, and it is not cosmetic. The
+offset a re-anchor stores **is** a `Prefix`, rounded to float32 on its way out
+while the tree sums in float64. Exactly on a row boundary that rounding lands a
+hair below it and the walk answers with the row above — one ULP of error, a
+whole row of displacement, and the correction then moves the reader by that
+row's height. The tolerance is one float32 ULP of `y` plus a sub-pixel floor.
+`TestListHeightModelIndexAtMonotonic` asserts `IndexAt(Prefix(i)) == i` over a
+corpus of deliberately fractional heights; whole-pixel heights give prefixes
+that are exact in float32 and ask nothing.
+
+The already-positioned children are shifted by the same amount, as scroll
+anchoring shifts them. This is the part that is easy to get wrong. This frame's
+rows were laid out at their _actual_ heights above a leading spacer sized from
+the _stale_ model, so they already sit off by exactly that delta; correcting
+only the stored offset fixes the next frame and leaves this one visibly
+displaced. `TestVirtualListWriteBackHoldsTheAnchorRow` is the layout-level
+guard.
+
+## Index-addressed scrolling
+
+`gui/scroll_index.go`. Public on `*Window`: `ScrollToIndex`,
+`ScrollToIndexAt(frac)`, `ScrollIndexIntoView`, `ScrollToEnd`, plus
+`InvalidateListHeights`.
+
+A request is applied immediately when the list has already been generated, and
+queued either way. `layoutApplyVirtualScrolls` runs **after**
+`layoutApplyScrollAnchors` and before `layoutDisables`. The position is not
+negotiable: `layoutAdjustScrollOffsets` is the _first_ position pass and
+zero-fills any scrollable with no stored entry, so an offset written before it
+is clobbered on a list nobody has scrolled yet — which is the exact case
+`ScrollToIndex` exists for. By the new pass the arranged height and
+`contentHeight` are both known, so the clamp is real.
+`TestScrollToIndexOnNeverScrolledList` pins it.
+
+A far jump into never-measured rows lands estimate-accurate. The request stays
+live for `virtualScrollMaxAge` frames and re-applies, so it converges as the
+rows it caused to be built are measured. A uniform model is exact on the first
+application and the request drops immediately. A jump also drops any pending
+`scrollAnchor` for the same scrollable — both write the same key, and the
+explicit jump is the later intent.
+
+## The retrofit: index spaces
+
+Each existing virtualized widget registers a uniform model with exactly the
+`rowHeight` its own spacers use, so the index API agrees with the arithmetic
+already on screen.
+
+| Site                          | Index space                                                          |
+| ----------------------------- | -------------------------------------------------------------------- |
+| `gui/view_listbox.go`         | `cfg.Data`, subheadings included                                     |
+| `gui/view_table.go`           | `cfg.Data`; `indexBase = dataStart`, so a frozen header sits outside |
+| `gui/view_tree_rows.go`       | the **flat** row index, not the node index; re-registered per frame  |
+| `gui/view_combobox.go`        | the **filtered** items — moves with the query                        |
+| `gui/view_command_palette.go` | the **filtered** items — moves with the query                        |
+
+Known limits inherited rather than fixed here:
+
+- Virtualization triggers on `Scrollable && height > 0`. Only `ListBox` falls
+  back to the height arrange recorded last frame, so a Fill-sized `Table` or
+  `Tree` never virtualizes and therefore registers no model.
+- The table emits separator rectangles between rows that may not be inside
+  `tableEstimateRowHeight`. The registered model inherits that error rather than
+  introducing a second one.
+
+## VirtualList
+
+`gui/view_virtual_list.go` and `_build.go` (split for the 800-line gate).
+
+- **No `Virtualize` flag.** Virtualization turns on automatically when the
+  scroll container has a bounded height, following the existing convention;
+  `VirtualList` is scrollable by construction. Height source: `Cfg.Height` →
+  `MaxHeight` → the inner height the amend hook recorded last frame.
+- **Bounded first-frame probe.** Under Fill sizing frame 1 has no height. The
+  `ListBox` precedent builds _every_ row there; at a million rows that is a
+  hang, so a `virtualListProbeRows` window is built instead — enough for arrange
+  to record a height.
+- **Overscan in pixels, not rows.** A row count is meaningless when rows differ
+  in height. A row count remains as a secondary cap against pathological
+  corpora.
+- **Spacing fixed at zero.** A gap between rows is height the model does not
+  account for, and every position below would drift by one gap per row. Space
+  rows from inside `ItemView`.
+- **Focus is an index, not a shape.** An unbuilt row has no effective ID, so the
+  focused row lives in a `StateMap` keyed by list ID. `VirtualListFocusedIndex`
+  / `SetVirtualListFocusedIndex` read and write it; arrow keys move it and call
+  `ScrollIndexIntoView`, so focus lands one frame later. Tab traverses only
+  built rows.
+- Row IDs are the caller's to compose, with `ScopeIDN(listID, "row", i)` — an ID
+  containing `:` is absolute, which is what keeps a row's identity stable while
+  the window it lives in scrolls.
+
+## The width ratchet
+
+The one mistake that makes a virtual list misbehave with nothing to catch: a row
+that turns the width `ItemView` is **handed** into a width it **demands**.
+`MinWidth: width - padding` looks like it cancels out, and does not — the row's
+border pushes the demand a few pixels past the width the list just reported, so
+the list widens, reports the wider width, and is asked for wider still. Every
+frame. And because a width change invalidates the wrap, every frame also
+re-wraps and re-measures every built row, which reads as text reflowing under
+the pointer and a scroll position that will not sit still.
+`examples/virtual_list` shipped with exactly this bug.
+
+Nothing about it looks like a failure from inside the widget, so the widget
+reports it: `virtualListNoteWidth` counts consecutive frames of widening with
+the window standing still — the window moving is what separates a resize, which
+stops, from a ratchet, which does not — and warns after four under [Debug]. Rows
+fill the width they are given through `Sizing`; the argument is for decisions,
+not for minimums.
+
+## Known limits
+
+1. **Without `ItemKey` the model is index-keyed** (above).
+2. **Width is one frame late.** `ItemView(i, width)` receives the inner width
+   recorded by the previous arrange; it is 0 on frame 1. After a resize the
+   heights are stale for one frame. The width change does **not** discard them:
+   a height measured for a row at a slightly different wrap predicts that row
+   better than one estimate shared by the whole corpus, and the rows on screen
+   are re-measured that frame anyway. Discarding them re-seated the reader from
+   the estimate on every frame of a resize drag. The anchor is captured before
+   the change and restored after either way.
+3. **Practical row ceiling.** `Shape.Y`, `scrollY`, `contentHeight` and the
+   spacer heights are float32 throughout the engine, so past ~10⁷ px of content
+   the scroll system quantizes regardless of the model's precision.
+
+## Attribution
+
+go-shirei `widgets/scroll.go` and `docs/virtual-list.md` (zlib) were read as a
+design reference for the problem shape and the failure modes worth documenting.
+No code was copied; the height model here is deliberately a different design,
+for the reasons above.

--- a/examples/virtual_list/README.md
+++ b/examples/virtual_list/README.md
@@ -1,0 +1,41 @@
+# virtual_list
+
+A virtualized message feed of 50,000 cards whose rows differ in height. Row
+height falls out of the wrapped body text, so nothing — not the app, not the
+widget — knows a row's height until the layout engine has measured it.
+
+## Run
+
+```
+go run ./examples/virtual_list
+```
+
+## What it demonstrates
+
+- **Variable row heights.** `VirtualList` builds only the rows near the viewport
+  and holds the rest of the space in two transparent spacers, sized from a
+  prefix-sum tree that converges on measured heights. The existing virtualized
+  widgets (`ListBox`, `Table`, `Tree`) divide by one scalar row height instead,
+  which is exact for the rows they own and useless for rows the caller builds.
+- **Index-addressed scrolling.** The Jump box calls
+  `Window.ScrollToIndexAt(id, n, 0.5)`. The target row does not exist yet, so
+  there is no ID to resolve and no view to find — `scrollToView` structurally
+  cannot reach it.
+- **Pin to bottom.** A background goroutine appends a message every second. With
+  the toggle on, `Window.ScrollToEnd` re-pins after each append.
+  `ScrollVerticalToPct(id, 1)` is the wrong tool: under virtualization the
+  content height is assembled from spacers over estimated rows, so a percentage
+  drifts.
+- **`ItemKey`.** Heights are stored under the key, so a measured height follows
+  its message when others are inserted above it.
+
+## Things worth copying
+
+- Row IDs are composed with `gui.ScopeIDN(listID, "row", i)`, never by hand —
+  `make ergonomics-audit` (mode `ids`) fails a literal `:`.
+- The body text takes the `width` argument `ItemView` receives. That is the
+  inner width the list recorded during the previous frame's arrange, which is
+  what makes the measured height meaningful.
+- Spacing between rows lives _inside_ the row. The list's own spacing is fixed
+  at zero, because a gap between rows would be height the model does not account
+  for.

--- a/examples/virtual_list/main.go
+++ b/examples/virtual_list/main.go
@@ -1,0 +1,236 @@
+// The virtual_list example demonstrates a virtualized list whose rows
+// differ in height: a message feed of 50,000 cards, none of which
+// knows its own height until the layout engine measures it.
+//
+// It exercises the three things a uniform virtualized list cannot do:
+// rows of differing heights, jumping to a row by index rather than by
+// ID, and pinning to the bottom while a background goroutine appends.
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend"
+)
+
+const listID = "feed"
+
+// message is one row. Body length varies, so the row height varies
+// with it — and only after wrapping, which is why the list measures
+// rather than computes.
+type message struct {
+	Who  string
+	Body string
+	Seq  int
+}
+
+type App struct {
+	Messages []message
+	JumpText string
+	Pinned   bool
+}
+
+// lorem supplies bodies of visibly different lengths.
+var lorem = []string{
+	"ack",
+	"Rebased onto main and re-ran the gate; all green.",
+	"The measurement lands one frame late by construction: the view " +
+		"phase runs before sizing, so a row's height is known only " +
+		"after arrange. That is what the height model absorbs — it " +
+		"seeds from an estimate and converges on what was measured.",
+	"Shipping tomorrow.",
+	"A long one: virtualization means the rows outside the viewport " +
+		"are never built, so their space has to come from somewhere. " +
+		"Two transparent spacers hold it, sized from the prefix-sum " +
+		"tree. Scroll far enough and the spacer above you is standing " +
+		"in for tens of thousands of rows that have never existed.",
+}
+
+func newMessage(i int) message {
+	return message{
+		Seq:  i,
+		Who:  [...]string{"ana", "bo", "cy", "dee"}[i%4],
+		Body: lorem[i%len(lorem)],
+	}
+}
+
+func main() {
+	const size = 50_000
+	msgs := make([]message, size)
+	for i := range msgs {
+		msgs[i] = newMessage(i)
+	}
+
+	gui.SetTheme(gui.ThemeDark.WithBorders(true))
+
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  &App{Messages: msgs},
+		Title:  "VirtualList — variable row heights",
+		Width:  520,
+		Height: 620,
+		OnInit: func(w *gui.Window) {
+			w.UpdateView(mainView)
+			go appender(w)
+		},
+	})
+
+	backend.Run(w)
+}
+
+// appender adds a message every second, so the pin-to-bottom toggle
+// has something to follow. Window state is main-goroutine only, so
+// the mutation goes through QueueCommand.
+func appender(w *gui.Window) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for range time.Tick(time.Second) {
+		w.QueueCommand(func(w *gui.Window) {
+			app := gui.State[App](w)
+			msg := newMessage(len(app.Messages) + rng.Intn(3))
+			// Seq is the row's ItemKey, so it has to be unique: the
+			// random part above only varies who and what, and two rows
+			// sharing a key would share one measured height.
+			msg.Seq = len(app.Messages)
+			app.Messages = append(app.Messages, msg)
+			if app.Pinned {
+				// The reason ScrollToEnd exists: the content height
+				// under virtualization is assembled from spacers over
+				// estimated rows, so a percentage-based "scroll to
+				// 100%" drifts a little further off with every append.
+				w.ScrollToEnd(listID)
+			}
+			w.UpdateWindow()
+		})
+	}
+}
+
+func mainView(w *gui.Window) gui.View {
+	app := gui.State[App](w)
+	theme := gui.CurrentTheme()
+
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		Spacing: gui.Some(theme.SpacingMedium),
+		Padding: gui.PadAll(10),
+		Content: []gui.View{
+			controls(app),
+			gui.VirtualList(gui.VirtualListCfg{
+				ID:        listID,
+				ItemCount: len(app.Messages),
+				Sizing:    gui.FillFill,
+				// Identity, so a height measured for a message follows
+				// that message when others are inserted above it.
+				ItemKey: func(i int) string {
+					return strconv.Itoa(app.Messages[i].Seq)
+				},
+				ItemView: func(i int, _ float32) gui.View {
+					return card(app.Messages[i], i, w)
+				},
+			}),
+			gui.Text(gui.TextCfg{
+				Text: fmt.Sprintf("%d messages · focused row %d",
+					len(app.Messages),
+					w.VirtualListFocusedIndex(listID)),
+				TextStyle: theme.TextStyleSecondary,
+			}),
+		},
+	})
+}
+
+// controls is the jump-to-index box and the pin toggle.
+func controls(app *App) gui.View {
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Spacing: gui.Some(gui.CurrentTheme().SpacingSmall),
+		VAlign:  gui.VAlignMiddle,
+		Content: []gui.View{
+			gui.Input(gui.InputCfg{
+				ID:          "jump_to",
+				Text:        app.JumpText,
+				Placeholder: "row number",
+				Width:       120,
+				OnTextChanged: func(s string, ctx gui.EventCtx) {
+					gui.State[App](ctx.Window).JumpText = s
+				},
+			}),
+			gui.TextButton("jump", "Jump", func(ctx gui.EventCtx) {
+				a := gui.State[App](ctx.Window)
+				n, err := strconv.Atoi(a.JumpText)
+				if err != nil {
+					return
+				}
+				// Index-addressed: the target row does not exist yet,
+				// so there is no ID to resolve and no view to find.
+				ctx.Window.ScrollToIndexAt(listID, n, 0.5)
+			}),
+			gui.TextButton("top", "Top", func(ctx gui.EventCtx) {
+				ctx.Window.ScrollToIndex(listID, 0)
+			}),
+			gui.TextButton("end", "End", func(ctx gui.EventCtx) {
+				ctx.Window.ScrollToEnd(listID)
+			}),
+			gui.Toggle(gui.ToggleCfg{
+				ID:       "pin",
+				Label:    "Pin to bottom",
+				Selected: app.Pinned,
+				OnClick: func(ctx gui.EventCtx) {
+					a := gui.State[App](ctx.Window)
+					a.Pinned = !a.Pinned
+					if a.Pinned {
+						ctx.Window.ScrollToEnd(listID)
+					}
+				},
+			}),
+		},
+	})
+}
+
+// card builds one row. Its height falls out of the wrapped body text,
+// which is exactly the case a scalar row height cannot describe.
+//
+// It ignores ItemView's width argument, and that is the point worth
+// copying: the width a row is *given* must not become a width the row
+// *demands*. Setting MinWidth from it — even minus the row's own
+// padding — asks the list for a content width at least as wide as the
+// one it just reported, and the row's border pushes that a few pixels
+// further every frame. The list then widens without bound, and since a
+// width change invalidates the wrap, every frame re-wraps and
+// re-measures. Rows fill the width they are handed through Sizing;
+// use the argument for decisions (a compact layout under some
+// threshold), never for a minimum.
+func card(m message, i int, w *gui.Window) gui.View {
+	theme := gui.CurrentTheme()
+	bg := theme.ColorPanel
+	if i == w.VirtualListFocusedIndex(listID) {
+		bg = theme.ColorSelect
+	}
+	return gui.Column(gui.ContainerCfg{
+		// Composed, never hand-joined: ergonomics-audit mode `ids`
+		// fails a literal ":" here.
+		ID:      gui.ScopeIDN(listID, "row", i),
+		Sizing:  gui.FillFit,
+		Color:   bg,
+		Padding: gui.PadAll(8),
+		// Row spacing lives inside the row: the list itself is fixed
+		// at zero spacing, because a gap between rows is height the
+		// model does not account for.
+		Spacing: gui.Some(theme.SpacingTight),
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{
+				Text:      fmt.Sprintf("#%d — %s", m.Seq, m.Who),
+				TextStyle: theme.TextStyleLabel,
+			}),
+			gui.Text(gui.TextCfg{
+				Text: m.Body,
+				Mode: gui.TextModeWrap,
+				// Fill horizontally, fit vertically: the wrap happens
+				// against whatever width the row is allocated, and the
+				// height that falls out of it is what the list measures.
+				Sizing: gui.FillFit,
+			}),
+		},
+	})
+}

--- a/examples/virtual_list/main_test.go
+++ b/examples/virtual_list/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestMainViewNoPanic(t *testing.T) {
+	t.Parallel()
+	gui.SetTheme(gui.ThemeDark.WithBorders(true))
+	msgs := make([]message, 200)
+	for i := range msgs {
+		msgs[i] = newMessage(i)
+	}
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  &App{Messages: msgs},
+		Width:  520,
+		Height: 620,
+	})
+	_ = mainView(w).GenerateLayout(w)
+}
+
+// TestJumpToIndexIsAddressable pins the half of the example that the
+// uniform widgets cannot do: addressing a row that was never built.
+func TestJumpToIndexIsAddressable(t *testing.T) {
+	msgs := make([]message, 5_000)
+	for i := range msgs {
+		msgs[i] = newMessage(i)
+	}
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  &App{Messages: msgs},
+		Width:  520,
+		Height: 620,
+	})
+	// A full frame, not a bare GenerateLayout: the index-addressed
+	// scroll is converted inside the layout pipeline, after the pass
+	// that would otherwise zero-fill a never-scrolled list.
+	w.TestRender(mainView)
+	w.ScrollToIndex(listID, 4_000)
+	w.TestRender(nil)
+	// Default 0: absent entry means unscrolled, which is the failure.
+	if off := w.ScrollY().GetOr(listID, 0); off >= 0 {
+		t.Fatalf("offset = %v, want a scrolled list", off)
+	}
+}

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -66,9 +66,12 @@ const (
 	// consuming it while an ancestor also received it.
 	// exportaudit:keep — const name collides with the debugUnconsumed helper
 	DebugUnconsumed
-	// DebugListBoxNoHeight reports a scrollable listbox that resolved to
-	// height 0, which disables virtualization so every row builds each
-	// frame.
+	// DebugListBoxNoHeight reports virtualization that degraded: a
+	// scrollable listbox resolved to height 0, so every row builds each
+	// frame; a variable-height list whose item count passed the
+	// per-item storage cap, so it fell back to a uniform row height; or
+	// a virtual list that widens frame after frame because its rows
+	// demand the width they were handed.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugListBoxNoHeight
 
@@ -198,6 +201,13 @@ const (
 	// debugCheckListBoxNoHeight fires from the listbox view phase
 	// rather than from the layout audit; see listBoxVisibleRange.
 	debugCheckListBoxNoHeight
+	// debugCheckListHeightsCapped fires from the list height registry
+	// when a variable-height list is too large for per-item storage.
+	debugCheckListHeightsCapped
+	// debugCheckListWidthRatchet fires from the VirtualList measurement
+	// hook when the list widens frame after frame with the window
+	// standing still; see virtualListNoteWidth.
+	debugCheckListWidthRatchet
 	// debugCheckUnscopedID reports an identity that has no ID-bearing
 	// ancestor, so it is still a window-global name.
 	debugCheckUnscopedID
@@ -214,7 +224,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugMissingIDs
 	case debugCheckUnconsumed:
 		return DebugUnconsumed
-	case debugCheckListBoxNoHeight:
+	case debugCheckListBoxNoHeight, debugCheckListHeightsCapped,
+		debugCheckListWidthRatchet:
 		return DebugListBoxNoHeight
 	case debugCheckUnscopedID:
 		return DebugUnscopedIDs

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -659,6 +659,47 @@ func goldenCases() []goldenCase {
 			},
 		},
 		{
+			// A variable-height virtualized list, scrolled into the
+			// middle so both spacers and the row window are recorded.
+			// This is the pixel-level guard on the spacer arithmetic:
+			// a leading spacer sized from the wrong prefix moves every
+			// row, and reading GenerateLayout would not show it —
+			// spacer heights only become geometry after arrange.
+			name: "virtual_list",
+			build: func(w *Window) View {
+				const id = "vl"
+				rowH := func(i int, _ float32) float32 {
+					if i%3 == 0 {
+						return 44
+					}
+					return 22
+				}
+				// Fixed offset rather than a driven scroll: a golden
+				// pins appearance, and an offset set here is the same
+				// every run.
+				w.scrollY().Set(id, -300)
+				return VirtualList(VirtualListCfg{
+					ID:         id,
+					ItemCount:  400,
+					Height:     160,
+					Sizing:     FillFixed,
+					OverscanPx: 20,
+					ItemHeight: rowH,
+					ItemView: func(i int, _ float32) View {
+						return Column(ContainerCfg{
+							ID:         ScopeIDN(id, "row", i),
+							Height:     rowH(i, 0),
+							Sizing:     FillFixed,
+							SizeBorder: NoBorder,
+							Content: []View{Text(TextCfg{
+								Text: "row " + itoa(i),
+							})},
+						})
+					},
+				})
+			},
+		},
+		{
 			// The resting menubar: only menubar_disabled exists today,
 			// which cannot see a change to the resting colors.
 			name: "menubar",

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -33,6 +33,7 @@ func layoutPipeline(layout *Layout, w *Window) {
 	fx, fy := floatAttachLayout(layout, w.windowRect())
 	layoutPositions(layout, fx, fy, w)
 	layoutApplyScrollAnchors(layout, w)
+	layoutApplyVirtualScrolls(layout, w)
 	layoutDisables(layout, false)
 
 	// Post-position passes.

--- a/gui/list_core_alloc_bench_test.go
+++ b/gui/list_core_alloc_bench_test.go
@@ -185,3 +185,68 @@ func BenchmarkListBoxGenerateLayout(b *testing.B) {
 		}
 	})
 }
+
+// BenchmarkVirtualListGenerateLayout pins the property that matters
+// for a virtualized list: the per-frame cost is a function of the
+// *visible* rows, not of the corpus. The assertion in the alloc gate
+// is invariance across ItemCount, not an absolute number — a build
+// that starts scaling with the data is the regression, whatever the
+// constant happens to be on the day.
+func BenchmarkVirtualListGenerateLayout(b *testing.B) {
+	for _, n := range []int{1_000, 100_000, 1_000_000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			w := newTestWindow()
+			cfg := virtualListCfg("bench-vl", n, 300)
+			cfg.ItemHeight = func(i int, _ float32) float32 {
+				return virtualListRowH(i)
+			}
+			v := VirtualList(cfg)
+			// Land mid-corpus so both spacers exist and the range walk
+			// is a real Fenwick descent rather than a top-of-list hit.
+			_ = generateViewLayout(v, w)
+			m, _ := listHeightLookup(w, "bench-vl")
+			w.scrollY().Set("bench-vl", -m.Prefix(n/2))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				w.scratch.resetViewPools()
+				_ = generateViewLayout(v, w)
+			}
+		})
+	}
+}
+
+// TestVirtualListAllocsAreFlat is the gate form of the benchmark
+// above: the per-frame allocation count must not grow with the item
+// count. A build that starts touching every item shows up here as a
+// thousand-fold difference, long before it shows up as a slow frame.
+func TestVirtualListAllocsAreFlat(t *testing.T) {
+	measure := func(n int) float64 {
+		w := newTestWindow()
+		cfg := virtualListCfg("flat-vl", n, 300)
+		cfg.ItemHeight = func(i int, _ float32) float32 {
+			return virtualListRowH(i)
+		}
+		v := VirtualList(cfg)
+		_ = generateViewLayout(v, w)
+		m, _ := listHeightLookup(w, "flat-vl")
+		w.scrollY().Set("flat-vl", -m.Prefix(n/2))
+		res := testing.Benchmark(func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				w.scratch.resetViewPools()
+				_ = generateViewLayout(v, w)
+			}
+		})
+		return float64(res.AllocsPerOp())
+	}
+	small, big := measure(1_000), measure(1_000_000)
+	if small == 0 {
+		t.Fatal("benchmark reported no allocations")
+	}
+	if ratio := big / small; ratio > 1.05 {
+		t.Fatalf("allocs/op grew with ItemCount: %v at 1k, %v at 1M",
+			small, big)
+	}
+}

--- a/gui/list_height_model.go
+++ b/gui/list_height_model.go
@@ -1,0 +1,450 @@
+package gui
+
+import "math/bits"
+
+// list_height_model.go — the per-list height model behind
+// variable-height virtualization and index-addressed scrolling.
+//
+// Two shapes share one type:
+//
+//   - uniform: every row is rowH tall, so every query is arithmetic
+//     and nothing is stored per item. This is exactly what the
+//     existing ListBox/Table/Tree/Combobox virtualization already
+//     assumes, which is why registering it costs those widgets one
+//     line and buys them the index-addressed scroll API.
+//   - variable: per-item heights in a Fenwick (binary indexed) tree,
+//     seeded from an estimate and refined by measurement. Prefix and
+//     IndexAt are O(log n), a point update O(log n), a full rebuild
+//     O(n).
+//
+// The tree is float64 while the heights themselves are float32, and
+// that is deliberate: at a million rows the running prefix reaches
+// ~3e7 px where one float32 ULP is ~4 px. That is visible jitter,
+// and — worse — it makes the prefix sequence non-monotonic, so the
+// IndexAt search can return an index whose span does not contain y.
+//
+// Heights are keyed, positions are indexed. heights/tree hold the
+// current frame's index order; byKey holds what was actually
+// measured, under the caller's ItemKey. Rebuilding the tree from
+// byKey is what lets an insert, a delete or a reorder keep every
+// measured height on its own item instead of on whatever now sits at
+// that index.
+
+// listHeightModel is one list's height model. Pure data plus
+// arithmetic — it never touches a Window.
+type listHeightModel struct {
+	// heights holds the current index order (variable only). It is
+	// the "old" side of the delta an incremental update applies.
+	heights []float32
+	// tree is the Fenwick tree, 1-based, len n+1 (variable only).
+	tree []float64
+	// byKey holds measured heights under the caller's ItemKey, so
+	// they survive a reorder. Nil when the list is index-keyed.
+	byKey map[string]float32
+
+	// heightFn is the caller's cheap path: when supplied, an item's
+	// height is computed rather than measured, so a new item is seeded
+	// exactly and the write-back is unnecessary. Stored on the model
+	// rather than captured in a closure so re-registering it every
+	// frame costs no allocation.
+	heightFn func(i int, width float32) float32
+
+	// keyAt is the caller's identity function. Held on the model so
+	// both the rebuild and the measurement write-back read one source.
+	keyAt func(i int) string
+
+	rowH      float32 // uniform only
+	staticTop float32 // content above item 0 inside the scrollable
+	estimate  float32 // seed for items never measured
+	width     float32 // inner width the heights were measured at
+
+	// measuredW and viewportH are what the arrange pass recorded for
+	// this list last frame — the same AmendLayout hook that writes row
+	// heights back. The view phase cannot know either: under Fill
+	// sizing both are decided after generation. hSeen distinguishes
+	// "not laid out yet" from "laid out to nothing".
+	measuredW float32
+	viewportH float32
+
+	// builtFirst/builtCount/leadOffset describe the row window the
+	// view phase emitted, so the write-back can map a child position
+	// back to an item index without parsing row IDs.
+	builtFirst int
+	builtCount int
+	leadOffset int
+
+	n         int
+	indexBase int // caller index of model item 0 (table freeze)
+
+	// widthRun counts consecutive frames the list widened while the
+	// window stood still, and lastWinW is the window width those
+	// frames were seen at. Together they separate a resize, which
+	// stops, from a row that demands the width it was handed, which
+	// does not; see virtualListNoteWidth.
+	widthRun int
+	lastWinW int
+
+	themeID uint64
+	uniform bool
+	hSeen   bool
+}
+
+const (
+	// listHeightMinRow floors a measured height. A zero would let the
+	// IndexAt walk yield first > last, and a negative one would break
+	// the tree's monotonicity outright.
+	listHeightMinRow = float32(1)
+
+	// listHeightEps is the write-back deadband, in pixels. Below it a
+	// measurement is treated as noise: writing it would churn the tree
+	// and re-anchor the scroll offset every frame for no visible gain.
+	listHeightEps = float32(0.5)
+
+	// listHeightMaxVariable caps per-item storage. Above it the model
+	// falls back to uniform (12 B/item is ~50 MB at this size) and the
+	// registry warns under Debug.
+	listHeightMaxVariable = 1 << 22
+
+	// listHeightKeyLoadFactor bounds byKey relative to the live item
+	// count, so a long-running feed cannot grow the measured-height
+	// map without limit.
+	listHeightKeyLoadFactor = 4
+)
+
+// newUniformHeightModel returns an O(1) model for a list whose rows
+// all have the same height.
+func newUniformHeightModel(n int, rowH, staticTop float32, indexBase int) *listHeightModel {
+	return &listHeightModel{
+		uniform:   true,
+		rowH:      f32Max(rowH, listHeightMinRow),
+		staticTop: staticTop,
+		estimate:  rowH,
+		n:         max(n, 0),
+		indexBase: indexBase,
+	}
+}
+
+// newVariableHeightModel returns a model with per-item storage, every
+// item seeded at estimate.
+func newVariableHeightModel(n int, estimate, staticTop float32) *listHeightModel {
+	m := &listHeightModel{
+		estimate:  f32Max(estimate, listHeightMinRow),
+		staticTop: staticTop,
+	}
+	m.Resize(n)
+	return m
+}
+
+// Count returns the number of items the model covers.
+func (m *listHeightModel) Count() int { return m.n }
+
+// Total returns the full content height, staticTop included.
+func (m *listHeightModel) Total() float32 { return m.Prefix(m.n) }
+
+// Prefix returns the offset of item i from the top of the scrollable
+// content: staticTop plus the heights of items [0, i). i is clamped,
+// so Prefix(0) is staticTop and Prefix(n) is the total.
+func (m *listHeightModel) Prefix(i int) float32 {
+	i = clampInt(i, 0, m.n)
+	if m.uniform {
+		return m.staticTop + float32(i)*m.rowH
+	}
+	sum := float64(0)
+	for j := i; j > 0; j -= j & (-j) {
+		sum += m.tree[j]
+	}
+	return m.staticTop + float32(sum)
+}
+
+// Height returns item i's height, or the estimate when i is out of
+// range (a caller mid-mutation may ask about an item the model has
+// not seen yet).
+func (m *listHeightModel) Height(i int) float32 {
+	if m.uniform {
+		return m.rowH
+	}
+	if i < 0 || i >= m.n {
+		return m.estimate
+	}
+	return m.heights[i]
+}
+
+// IndexAt returns the item whose span contains y, where y is measured
+// from the top of the scrollable content (the same origin as Prefix).
+// y above the first item returns 0; y past the end returns n-1. An
+// empty model returns 0.
+func (m *listHeightModel) IndexAt(y float32) int {
+	if m.n == 0 {
+		return 0
+	}
+	y -= m.staticTop
+	if y <= 0 {
+		return 0
+	}
+	if m.uniform {
+		// Same boundary tolerance as the variable path below: i*rowH
+		// rounded to float32 and divided back can land just under i.
+		return clampInt(int(float64(y)/float64(m.rowH)+
+			(1.0/(1<<23))), 0, m.n-1)
+	}
+	// Fenwick binary lifting: walk the highest power-of-two stride
+	// down, taking a step whenever the running prefix stays <= y. The
+	// result is the count of items that fit strictly above y, i.e. the
+	// index of the item containing it.
+	//
+	// y arrives as a float32 — a stored scroll offset, or a Prefix
+	// result rounded on its way out — while the tree accumulates in
+	// float64. On an exact row boundary that rounding lands a hair
+	// *below* the boundary and the walk answers with the row above.
+	// One ULP of error, a whole row of displacement: the anchor the
+	// write-back re-seats on is then the wrong row, and the correction
+	// moves the reader by that row's height. The tolerance is one
+	// float32 ULP of y plus a sub-pixel floor.
+	target := float64(y)
+	eps := target*(1.0/(1<<23)) + 1.0/1024
+	idx := 0
+	running := float64(0)
+	for stride := m.highBit(); stride > 0; stride >>= 1 {
+		next := idx + stride
+		if next > m.n {
+			continue
+		}
+		if running+m.tree[next] <= target+eps {
+			idx = next
+			running += m.tree[next]
+		}
+	}
+	return clampInt(idx, 0, m.n-1)
+}
+
+// highBit returns the largest power of two <= n, the starting stride
+// for the IndexAt walk.
+func (m *listHeightModel) highBit() int {
+	if m.n < 1 {
+		return 1
+	}
+	return 1 << (bits.Len(uint(m.n)) - 1)
+}
+
+// SetHeight records a measured height for item i and returns the
+// signed change applied. A change smaller than the deadband is
+// ignored and returns 0, so a stable list stops writing after the
+// first measured frame.
+func (m *listHeightModel) SetHeight(i int, h float32) float32 {
+	if m.uniform || i < 0 || i >= m.n || !f32IsFinite(h) {
+		return 0
+	}
+	h = f32Max(h, listHeightMinRow)
+	old := m.heights[i]
+	delta := h - old
+	if f32Abs(delta) < listHeightEps {
+		return 0
+	}
+	m.heights[i] = h
+	m.add(i, float64(delta))
+	return delta
+}
+
+// add applies a delta to item i in the Fenwick tree.
+func (m *listHeightModel) add(i int, delta float64) {
+	for j := i + 1; j <= m.n; j += j & (-j) {
+		m.tree[j] += delta
+	}
+}
+
+// Resize grows or shrinks the model to n items. Growth seeds the new
+// items at the estimate, reuses the heights capacity when it can, and
+// extends the Fenwick tree in place — an existing node's span does
+// not change when the tree grows — so the append-only path (a feed
+// appending at the bottom) costs O(added · log n) with no per-append
+// reallocation, never a full rebuild.
+func (m *listHeightModel) Resize(n int) {
+	n = max(n, 0)
+	if m.uniform {
+		m.n = n
+		return
+	}
+	if n == m.n && m.tree != nil {
+		return
+	}
+	if n < m.n {
+		// Shrink: rebuilding is O(n) and simpler than unwinding the
+		// tree's partial sums item by item.
+		m.heights = m.heights[:n]
+		m.n = n
+		m.rebuildTree()
+		return
+	}
+	if cap(m.heights) >= n {
+		m.heights = m.heights[:n]
+	} else {
+		grown := make([]float32, n, growCap(cap(m.heights), n))
+		copy(grown, m.heights)
+		m.heights = grown
+	}
+	for i := m.n; i < n; i++ {
+		m.heights[i] = m.seed(i)
+	}
+	m.n = n
+	if len(m.tree) <= 1 {
+		// Never built (or shrunk to nothing): the O(n) rebuild beats
+		// n incremental O(log n) insertions.
+		m.rebuildTree()
+	} else {
+		m.growTree()
+	}
+}
+
+// growTree appends Fenwick nodes for items seeded since the tree was
+// last built, leaving existing nodes untouched. Node i covers the
+// span (i-lowbit(i), i], which decomposes into heights[i-1] plus the
+// already-final nodes i-1, i-2, i-4, … above the span's start — so
+// each appended node costs O(log n).
+func (m *listHeightModel) growTree() {
+	if len(m.tree) == 0 {
+		m.tree = append(m.tree[:0], 0)
+	}
+	for i := len(m.tree); i <= m.n; i++ {
+		s := float64(m.heights[i-1])
+		for step := 1; step < i&(-i); step <<= 1 {
+			s += m.tree[i-step]
+		}
+		m.tree = append(m.tree, s)
+	}
+}
+
+// rebuildTree rebuilds the Fenwick tree from heights in O(n) by
+// propagating each node into its parent once — never n·log n.
+func (m *listHeightModel) rebuildTree() {
+	if cap(m.tree) >= m.n+1 {
+		m.tree = m.tree[:m.n+1]
+		clear(m.tree)
+	} else {
+		m.tree = make([]float64, m.n+1)
+	}
+	for i := 1; i <= m.n; i++ {
+		m.tree[i] += float64(m.heights[i-1])
+	}
+	for i := 1; i <= m.n; i++ {
+		if parent := i + (i & (-i)); parent <= m.n {
+			m.tree[parent] += m.tree[i]
+		}
+	}
+}
+
+// ResetToEstimate drops every measured height and reseeds the model.
+// Used when the measurement premise changed — a width or theme change
+// invalidates heights that are still perfectly well-formed.
+func (m *listHeightModel) ResetToEstimate(estimate float32) {
+	m.estimate = f32Max(estimate, listHeightMinRow)
+	if m.uniform {
+		m.rowH = m.estimate
+		return
+	}
+	m.reseed()
+	clear(m.byKey)
+}
+
+// RebuildFromKeys re-seats the model at n items, taking each item's
+// height from byKey under keyAt(i) and falling back to the estimate
+// for keys never measured. This is what makes an insert, a delete or
+// a reorder free: heights follow their key, not their index.
+//
+// It also bounds byKey — when the measured map has outgrown the live
+// count by the load factor, it is replaced by one holding only the
+// live keys, so a long-running feed does not accumulate forever.
+func (m *listHeightModel) RebuildFromKeys(n int) {
+	n = max(n, 0)
+	if m.uniform || m.keyAt == nil || m.byKey == nil {
+		m.Resize(n)
+		return
+	}
+	if m.heightFn != nil {
+		// The caller computes heights, so a rebuild is a reseed and
+		// the keyed store has nothing better to offer.
+		m.Resize(n)
+		m.reseed()
+		return
+	}
+	if cap(m.heights) >= n {
+		m.heights = m.heights[:n]
+	} else {
+		m.heights = make([]float32, n)
+	}
+	evict := len(m.byKey) > listHeightKeyLoadFactor*max(n, 1)
+	var live map[string]float32
+	if evict {
+		live = make(map[string]float32, n)
+	}
+	for i := range n {
+		k := m.keyAt(i)
+		h, ok := m.byKey[k]
+		if !ok || h <= 0 {
+			h = m.seed(i)
+		}
+		m.heights[i] = h
+		if evict && ok {
+			live[k] = h
+		}
+	}
+	if evict {
+		m.byKey = live
+	}
+	m.n = n
+	m.rebuildTree()
+}
+
+// RecordKeyed writes a measured height through both the indexed tree
+// and the keyed store, so the measurement survives the next rebuild.
+// Returns the change the tree took, for the re-anchor delta.
+func (m *listHeightModel) RecordKeyed(i int, key string, h float32) float32 {
+	delta := m.SetHeight(i, h)
+	m.recordKey(key, h)
+	return delta
+}
+
+// recordKey writes a measured height into the keyed store alone. The
+// write-back calls it only when the tree actually changed, so a
+// settled list stops paying keyAt and a map write per row per frame.
+func (m *listHeightModel) recordKey(key string, h float32) {
+	if m.byKey != nil && key != "" && f32IsFinite(h) {
+		m.byKey[key] = f32Max(h, listHeightMinRow)
+	}
+}
+
+// seed returns the height a never-measured item starts at: the
+// caller's own answer when it has one, the estimate otherwise.
+func (m *listHeightModel) seed(i int) float32 {
+	if m.heightFn != nil {
+		if h := m.heightFn(i, m.width); h > 0 && f32IsFinite(h) {
+			return f32Max(h, listHeightMinRow)
+		}
+	}
+	return m.estimate
+}
+
+// reseed recomputes every height from seed: the caller's height
+// function when there is one, the estimate otherwise. O(n) arithmetic
+// plus a tree rebuild.
+func (m *listHeightModel) reseed() {
+	for i := range m.heights {
+		m.heights[i] = m.seed(i)
+	}
+	m.rebuildTree()
+}
+
+// enableKeys allocates the keyed store. Called when the caller
+// supplies an ItemKey; an index-keyed list never pays for it.
+func (m *listHeightModel) enableKeys(n int) {
+	if m.byKey == nil {
+		m.byKey = make(map[string]float32, max(n, 8))
+	}
+}
+
+// clampInt clamps v into [lo, hi]. hi < lo returns lo.
+func clampInt(v, lo, hi int) int {
+	if hi < lo {
+		return lo
+	}
+	return min(max(v, lo), hi)
+}

--- a/gui/list_height_model_test.go
+++ b/gui/list_height_model_test.go
@@ -1,0 +1,299 @@
+package gui
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// naivePrefix is the reference the Fenwick tree is checked against.
+func naivePrefix(heights []float32, staticTop float32, i int) float32 {
+	sum := float64(staticTop)
+	for j := 0; j < i && j < len(heights); j++ {
+		sum += float64(heights[j])
+	}
+	return float32(sum)
+}
+
+func TestListHeightModelPrefixMatchesNaive(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	const n = 500
+	m := newVariableHeightModel(n, 20, 13)
+	heights := make([]float32, n)
+	for i := range n {
+		heights[i] = float32(4 + rng.Intn(400))
+		m.SetHeight(i, heights[i])
+	}
+	for i := 0; i <= n; i++ {
+		got := m.Prefix(i)
+		want := naivePrefix(heights, 13, i)
+		if f32Abs(got-want) > 0.5 {
+			t.Fatalf("Prefix(%d) = %v, want %v", i, got, want)
+		}
+	}
+	if f32Abs(m.Total()-naivePrefix(heights, 13, n)) > 0.5 {
+		t.Fatalf("Total = %v", m.Total())
+	}
+}
+
+func TestListHeightModelIndexAtMonotonic(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	const n = 300
+	m := newVariableHeightModel(n, 20, 7)
+	for i := range n {
+		// Fractional, deliberately: whole-pixel heights give prefixes
+		// that are exact in float32, which hides every rounding
+		// question the boundary assertion below exists to ask.
+		m.SetHeight(i, float32(4+rng.Intn(120))+rng.Float32())
+	}
+	// Every item's own span must resolve back to that item.
+	for i := range n {
+		top := m.Prefix(i)
+		mid := top + m.Height(i)/2
+		if got := m.IndexAt(mid); got != i {
+			t.Fatalf("IndexAt(mid of %d) = %d", i, got)
+		}
+		if got := m.IndexAt(top + 0.01); got != i {
+			t.Fatalf("IndexAt(top of %d) = %d", i, got)
+		}
+		// Exactly on the boundary, which is the case that matters: the
+		// scroll offset a re-anchor stores *is* a Prefix, rounded to
+		// float32 on its way out while the tree sums in float64. Round
+		// low by one ULP and the walk answers with the row above — one
+		// row of displacement at the anchor, from an error too small to
+		// see. Nudging by 0.01 first, as the assertion above does, hides
+		// it.
+		if got := m.IndexAt(top); got != i {
+			t.Fatalf("IndexAt(Prefix(%d)) = %d — boundary rounding", i, got)
+		}
+	}
+	// Out of range clamps rather than walking off either end.
+	if got := m.IndexAt(-5000); got != 0 {
+		t.Fatalf("IndexAt(negative) = %d, want 0", got)
+	}
+	if got := m.IndexAt(m.Total() + 5000); got != n-1 {
+		t.Fatalf("IndexAt(past end) = %d, want %d", got, n-1)
+	}
+	// Monotonic across a fine sweep.
+	prev := 0
+	for y := float32(0); y < m.Total(); y += 3 {
+		cur := m.IndexAt(y)
+		if cur < prev {
+			t.Fatalf("IndexAt not monotonic at y=%v: %d after %d", y, cur, prev)
+		}
+		prev = cur
+	}
+}
+
+func TestListHeightModelUniformIsExact(t *testing.T) {
+	m := newUniformHeightModel(1000, 24, 10, 0)
+	if got := m.Prefix(0); got != 10 {
+		t.Fatalf("Prefix(0) = %v, want staticTop 10", got)
+	}
+	if got := m.Prefix(4); got != 10+4*24 {
+		t.Fatalf("Prefix(4) = %v", got)
+	}
+	if got := m.IndexAt(10 + 24*7.5); got != 7 {
+		t.Fatalf("IndexAt = %d, want 7", got)
+	}
+	if got := m.IndexAt(0); got != 0 {
+		t.Fatalf("IndexAt(0) = %d, want 0", got)
+	}
+	// A uniform model stores nothing per item.
+	if m.heights != nil || m.tree != nil {
+		t.Fatal("uniform model allocated per-item storage")
+	}
+}
+
+func TestListHeightModelResizeKeepsMeasured(t *testing.T) {
+	m := newVariableHeightModel(10, 20, 0)
+	for i := range 10 {
+		m.SetHeight(i, float32(30+i))
+	}
+	m.Resize(15)
+	for i := range 10 {
+		if got := m.Height(i); got != float32(30+i) {
+			t.Fatalf("grow lost height %d: %v", i, got)
+		}
+	}
+	for i := 10; i < 15; i++ {
+		if got := m.Height(i); got != 20 {
+			t.Fatalf("grown item %d = %v, want estimate 20", i, got)
+		}
+	}
+	if want := naivePrefix(m.heights, 0, 15); f32Abs(m.Total()-want) > 0.5 {
+		t.Fatalf("Total after grow = %v, want %v", m.Total(), want)
+	}
+	m.Resize(4)
+	if m.Count() != 4 {
+		t.Fatalf("Count after shrink = %d", m.Count())
+	}
+	if want := naivePrefix(m.heights, 0, 4); f32Abs(m.Total()-want) > 0.5 {
+		t.Fatalf("Total after shrink = %v, want %v", m.Total(), want)
+	}
+}
+
+func TestListHeightModelRebuildEqualsIncremental(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	const n = 257 // not a power of two, so the lifting walk skips
+	inc := newVariableHeightModel(n, 20, 0)
+	direct := newVariableHeightModel(n, 20, 0)
+	for i := range n {
+		h := float32(5 + rng.Intn(90))
+		inc.SetHeight(i, h)
+		direct.heights[i] = h
+	}
+	direct.rebuildTree()
+	for i := 0; i <= n; i++ {
+		if f32Abs(inc.Prefix(i)-direct.Prefix(i)) > 0.5 {
+			t.Fatalf("prefix mismatch at %d: %v vs %v",
+				i, inc.Prefix(i), direct.Prefix(i))
+		}
+	}
+}
+
+func TestListHeightModelKeysSurviveReorder(t *testing.T) {
+	keys := []string{"a", "b", "c", "d"}
+	m := newVariableHeightModel(len(keys), 20, 0)
+	m.enableKeys(len(keys))
+	want := map[string]float32{"a": 100, "b": 200, "c": 300, "d": 400}
+	for i, k := range keys {
+		m.RecordKeyed(i, k, want[k])
+	}
+
+	// Insert at the front: every measured height must follow its key.
+	keys = append([]string{"z"}, keys...)
+	m.keyAt = func(i int) string { return keys[i] }
+	m.RebuildFromKeys(len(keys))
+	if got := m.Height(0); got != 20 {
+		t.Fatalf("new item took a neighbour's height: %v", got)
+	}
+	for i := 1; i < len(keys); i++ {
+		if got := m.Height(i); got != want[keys[i]] {
+			t.Fatalf("key %q height = %v, want %v",
+				keys[i], got, want[keys[i]])
+		}
+	}
+
+	// Full reverse: same requirement, no index survives.
+	for i, j := 0, len(keys)-1; i < j; i, j = i+1, j-1 {
+		keys[i], keys[j] = keys[j], keys[i]
+	}
+	m.keyAt = func(i int) string { return keys[i] }
+	m.RebuildFromKeys(len(keys))
+	for i := range keys {
+		w, ok := want[keys[i]]
+		if !ok {
+			w = 20
+		}
+		if got := m.Height(i); got != w {
+			t.Fatalf("after reverse, key %q = %v, want %v", keys[i], got, w)
+		}
+	}
+}
+
+func TestListHeightModelKeyEvictionBounded(t *testing.T) {
+	m := newVariableHeightModel(1, 20, 0)
+	m.enableKeys(1)
+	// Measure 400 keys but keep only two live.
+	for i := range 400 {
+		m.n = 1
+		m.RecordKeyed(0, string(rune('A'+i%26))+itoa(i), float32(30+i%40))
+	}
+	if len(m.byKey) < 100 {
+		t.Fatalf("precondition: byKey too small (%d)", len(m.byKey))
+	}
+	live := []string{"A0", "B1"}
+	m.keyAt = func(i int) string { return live[i] }
+	m.RebuildFromKeys(len(live))
+	if len(m.byKey) > listHeightKeyLoadFactor*len(live) {
+		t.Fatalf("byKey not evicted: %d entries for %d live",
+			len(m.byKey), len(live))
+	}
+}
+
+func TestListHeightModelDeadband(t *testing.T) {
+	m := newVariableHeightModel(3, 20, 0)
+	if d := m.SetHeight(1, 60); d != 40 {
+		t.Fatalf("first write delta = %v, want 40", d)
+	}
+	if d := m.SetHeight(1, 60.2); d != 0 {
+		t.Fatalf("sub-deadband write returned %v, want 0", d)
+	}
+	if got := m.Height(1); got != 60 {
+		t.Fatalf("deadband write mutated height: %v", got)
+	}
+	// A height below the floor is clamped, never zero or negative.
+	m.SetHeight(2, -5)
+	if got := m.Height(2); got != listHeightMinRow {
+		t.Fatalf("negative height = %v, want %v", got, listHeightMinRow)
+	}
+}
+
+func TestListHeightModelGrowTreeEqualsRebuild(t *testing.T) {
+	// Growth extends the Fenwick tree in place (growTree); its sums
+	// must match a from-scratch rebuild over the same heights.
+	m := newVariableHeightModel(100, 20, 0)
+	for i := range 100 {
+		m.SetHeight(i, float32(5+i%37))
+	}
+	m.Resize(150) // append-only growth, twice
+	m.Resize(1000)
+
+	direct := newVariableHeightModel(1000, 20, 0)
+	copy(direct.heights, m.heights)
+	direct.rebuildTree()
+	for i := 0; i <= 1000; i += 7 {
+		if f32Abs(m.Prefix(i)-direct.Prefix(i)) > 0.5 {
+			t.Fatalf("prefix mismatch at %d: %v vs %v",
+				i, m.Prefix(i), direct.Prefix(i))
+		}
+	}
+}
+
+func TestListHeightModelEmptyAndOutOfRange(t *testing.T) {
+	m := newVariableHeightModel(0, 20, 5)
+	if got := m.IndexAt(100); got != 0 {
+		t.Fatalf("IndexAt on empty model = %d, want 0", got)
+	}
+	if got := m.Total(); got != 5 {
+		t.Fatalf("Total of empty model = %v, want the staticTop 5", got)
+	}
+	if got := m.Height(3); got != 20 {
+		t.Fatalf("out-of-range Height = %v, want the estimate 20", got)
+	}
+	if got := m.SetHeight(3, 40); got != 0 {
+		t.Fatalf("out-of-range SetHeight applied a delta %v, want 0", got)
+	}
+
+	m.Resize(10)
+	// y above the content and y past the end clamp to the ends.
+	if got := m.IndexAt(-50); got != 0 {
+		t.Fatalf("IndexAt above content = %d, want 0", got)
+	}
+	if got := m.IndexAt(1e9); got != 9 {
+		t.Fatalf("IndexAt past the end = %d, want 9", got)
+	}
+	// Prefix clamps its argument at both ends.
+	if got := m.Prefix(-3); got != m.Prefix(0) {
+		t.Fatalf("Prefix(-3) = %v, want Prefix(0) = %v", got, m.Prefix(0))
+	}
+	if got := m.Prefix(99); got != m.Total() {
+		t.Fatalf("Prefix past the end = %v, want Total %v", got, m.Total())
+	}
+}
+
+// itoa is a tiny local helper so the test needs no strconv import
+// alongside the repo's own conventions.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [12]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/gui/list_height_registry.go
+++ b/gui/list_height_registry.go
@@ -1,0 +1,231 @@
+package gui
+
+// list_height_registry.go — per-window storage for list height
+// models, plus the invalidation rules.
+//
+// Models are keyed by the **effective** scroll ID, byte-identical to
+// the key w.scrollY() uses, because every index↔offset conversion
+// pairs a model lookup with a scroll-offset read. A key mismatch
+// fails silently — the scroll lands somewhere plausible and wrong —
+// so listHeightKeyMatchesScrollKey asserts it in the tests.
+
+// listHeightModels returns the per-window model store. Values are
+// pointers so an AmendLayout write-back mutates in place, the same
+// arrangement listBoxCache uses.
+func listHeightModels(w *Window) *BoundedMap[string, *listHeightModel] {
+	return StateMap[string, *listHeightModel](w, nsListHeights, capModerate)
+}
+
+// listHeightLookup returns the model registered for a scroll ID
+// without creating the store. Cold path: the index-addressed scroll
+// API calls it before a list has necessarily been generated.
+func listHeightLookup(w *Window, scrollID string) (*listHeightModel, bool) {
+	if w == nil || scrollID == "" {
+		return nil, false
+	}
+	store := StateMapRead[string, *listHeightModel](w, nsListHeights)
+	if store == nil {
+		return nil, false
+	}
+	m, ok := store.Get(scrollID)
+	if !ok || m == nil || m.Count() == 0 {
+		return nil, false
+	}
+	return m, true
+}
+
+// listHeightRegisterUniform records the O(1) model for a list whose
+// rows share one height. This is the retrofit seam: a widget that
+// already virtualizes by dividing by a scalar registers exactly the
+// rowHeight its own spacers use, so the index API stays consistent
+// with the arithmetic already on screen.
+//
+// scrollID must be the effective ID (w.EffID(cfg.ID)). staticTop is
+// content inside the scrollable that sits above item 0; indexBase is
+// the caller index of model item 0, which is how a frozen table
+// header keeps data index 0 outside the scrollable range.
+func listHeightRegisterUniform(
+	w *Window, scrollID string, n int, rowH, staticTop float32, indexBase int,
+) {
+	if w == nil || scrollID == "" || n <= 0 || rowH <= 0 || !f32IsFinite(rowH) {
+		return
+	}
+	store := listHeightModels(w)
+	cur, ok := store.Get(scrollID)
+	if !ok || cur == nil || !cur.uniform {
+		store.Set(scrollID,
+			newUniformHeightModel(n, rowH, staticTop, indexBase))
+		return
+	}
+	// Reuse in place: a uniform model has no per-item storage, so
+	// re-registering every frame must not allocate.
+	cur.rowH = f32Max(rowH, listHeightMinRow)
+	cur.estimate = cur.rowH
+	cur.staticTop = staticTop
+	cur.indexBase = indexBase
+	cur.n = n
+}
+
+// listHeightAnchor captures where the viewport currently sits, as an
+// item index plus an offset into that item, so a change that moves
+// every prefix below it can be undone in scroll-offset terms.
+type listHeightAnchor struct {
+	within float32
+	index  int
+	valid  bool
+}
+
+// listHeightCaptureAnchor records the item under the viewport top.
+// scrollY is the stored (negative-down) offset.
+func listHeightCaptureAnchor(m *listHeightModel, scrollY float32) listHeightAnchor {
+	if m == nil || m.Count() == 0 || !f32IsFinite(scrollY) {
+		return listHeightAnchor{}
+	}
+	y := -scrollY
+	idx := m.IndexAt(y)
+	return listHeightAnchor{index: idx, within: y - m.Prefix(idx), valid: true}
+}
+
+// listHeightRestoreAnchor returns the scroll offset that puts the
+// captured anchor back under the viewport top. The result is clamped
+// only at the top; the bottom clamp needs the arranged viewport
+// height, and layoutAdjustScrollOffsets applies it every frame.
+func listHeightRestoreAnchor(m *listHeightModel, a listHeightAnchor) (float32, bool) {
+	if m == nil || !a.valid || m.Count() == 0 {
+		return 0, false
+	}
+	off := -(m.Prefix(min(a.index, m.Count()-1)) + a.within)
+	if !f32IsFinite(off) {
+		return 0, false
+	}
+	return f32Min(off, 0), true
+}
+
+// listHeightSpec is what a variable-height list declares about
+// itself each frame. Bundled rather than passed as six parameters
+// because every field is read together and the caller builds it in
+// one place.
+type listHeightSpec struct {
+	keyAt     func(int) string
+	heightFn  func(i int, width float32) float32
+	estimate  float32
+	staticTop float32
+	width     float32
+	n         int
+}
+
+// listHeightEnsureVariable returns the variable-height model for a
+// list, creating it and applying the invalidation rules:
+//
+//   - width change — the heights were measured at a different inner
+//     width, so every one of them is a guess again;
+//   - theme change — text metrics moved under the same premise;
+//   - count change — re-seat the items, taking each measured height
+//     from its key when the caller supplies one, so an insert or a
+//     reorder costs nothing.
+//
+// A reset preserves the reader's position: the anchor is captured
+// before the model changes and the scroll offset restored after, so
+// the correction is a stored-offset edit rather than a visible jump.
+func listHeightEnsureVariable(
+	w *Window, scrollID string, spec listHeightSpec,
+) *listHeightModel {
+	n, width := spec.n, spec.width
+	if n > listHeightMaxVariable {
+		// Per-item storage is ~12 B, so past the cap a variable model
+		// costs tens of megabytes. Fall back to the uniform path,
+		// which is exact-in-shape and wrong only in the amount no
+		// estimate could get right at that size.
+		if DebugEnabled() {
+			w.debugWarn(debugCheckListHeightsCapped, scrollID,
+				"list %q has %d items, past the %d-item cap for "+
+					"per-item heights; falling back to a uniform row "+
+					"height, so positions follow the estimate",
+				scrollID, n, listHeightMaxVariable)
+		}
+		listHeightRegisterUniform(w, scrollID, n,
+			spec.estimate, spec.staticTop, 0)
+		m, _ := listHeightModels(w).Get(scrollID)
+		return m
+	}
+	store := listHeightModels(w)
+	m, ok := store.Get(scrollID)
+	if !ok || m == nil || m.uniform {
+		m = &listHeightModel{
+			estimate:  f32Max(spec.estimate, listHeightMinRow),
+			staticTop: spec.staticTop,
+			width:     width,
+			heightFn:  spec.heightFn,
+			themeID:   guiTheme.id,
+		}
+		m.keyAt = spec.keyAt
+		if spec.keyAt != nil {
+			m.enableKeys(n)
+		}
+		m.Resize(n)
+		store.Set(scrollID, m)
+		return m
+	}
+	m.keyAt = spec.keyAt
+	if spec.keyAt != nil {
+		m.enableKeys(n)
+	}
+	m.heightFn = spec.heightFn
+	m.staticTop = spec.staticTop
+	m.estimate = f32Max(spec.estimate, listHeightMinRow)
+
+	sy := w.scrollY()
+	// Default 0: absent entry means the list has not been scrolled.
+	scrollY := sy.GetOr(scrollID, 0)
+	anchor := listHeightCaptureAnchor(m, scrollY)
+
+	switch {
+	case !f32AreClose(m.width, width) || m.themeID != guiTheme.id:
+		m.width = width
+		m.themeID = guiTheme.id
+		m.Resize(n)
+		if m.heightFn != nil {
+			// The cheap path is exact at the new width, so recompute.
+			m.reseed()
+		}
+		// Measured heights are deliberately kept. They describe a wrap
+		// that no longer applies, but a height measured for *this* row
+		// still predicts it better than one estimate shared by the whole
+		// corpus, and the rows on screen are re-measured this frame
+		// anyway. Dropping them made every frame of a window resize
+		// re-seat the reader from the estimate — and turned an app that
+		// widens its own list (see examples/virtual_list) from slightly
+		// wrong into a list that re-wrapped on every frame.
+	case n != m.Count():
+		m.RebuildFromKeys(n)
+	default:
+		return m // nothing moved; leave the offset alone
+	}
+
+	if off, restored := listHeightRestoreAnchor(m, anchor); restored {
+		sy.Set(scrollID, off)
+	}
+	return m
+}
+
+// InvalidateListHeights drops every measured height for the given
+// list, so the next frames re-measure from the estimate. Call it when
+// a row's content changed under a stable key — nothing detects that,
+// because the model keys on identity, not on content. id is the
+// effective scroll ID. Main goroutine only.
+// exportaudit:keep — the only escape hatch for content edited under a
+// stable key; nothing detects that case
+func (w *Window) InvalidateListHeights(id string) {
+	m, ok := listHeightLookup(w, id)
+	if !ok || m.uniform {
+		return
+	}
+	sy := w.scrollY()
+	// Default 0: absent entry means the list has not been scrolled.
+	anchor := listHeightCaptureAnchor(m, sy.GetOr(id, 0))
+	m.ResetToEstimate(m.estimate)
+	if off, restored := listHeightRestoreAnchor(m, anchor); restored {
+		sy.Set(id, off)
+	}
+	w.UpdateWindow()
+}

--- a/gui/list_height_registry_test.go
+++ b/gui/list_height_registry_test.go
@@ -1,0 +1,130 @@
+package gui
+
+import "testing"
+
+// registryTestSpec is a variable list of n rows seeded at 20 px.
+func registryTestSpec(n int, width float32) listHeightSpec {
+	return listHeightSpec{n: n, estimate: 20, width: width}
+}
+
+func TestListHeightRegistryReusesTheModel(t *testing.T) {
+	w := newTestWindow()
+	m1 := listHeightEnsureVariable(w, "lst", registryTestSpec(10, 100))
+	m1.SetHeight(3, 200)
+	m2 := listHeightEnsureVariable(w, "lst", registryTestSpec(10, 100))
+	if m1 != m2 {
+		t.Fatal("re-registering replaced the model")
+	}
+	if got := m2.Height(3); got != 200 {
+		t.Fatalf("measured height lost on re-registration: %v", got)
+	}
+}
+
+func TestListHeightRegistryWidthChangeKeepsMeasuredHeights(t *testing.T) {
+	w := newTestWindow()
+	m := listHeightEnsureVariable(w, "lst", registryTestSpec(100, 100))
+	for i := range 100 {
+		m.SetHeight(i, 50)
+	}
+	// Sit on row 40 with a 7 px offset into it.
+	w.scrollY().Set("lst", -(m.Prefix(40) + 7))
+
+	// A width change makes every measured height stale — they describe
+	// a wrap that no longer applies — but it must not throw them away.
+	// A height measured for *this* row predicts it better than one
+	// estimate shared by the corpus, and dropping them re-seated the
+	// reader from the estimate on every frame of a window resize.
+	m = listHeightEnsureVariable(w, "lst", registryTestSpec(100, 250))
+	if got := m.Height(40); got != 50 {
+		t.Fatalf("measured height dropped on a width change: %v", got)
+	}
+	// Default 0: absent entry means unscrolled.
+	got := w.scrollY().GetOr("lst", 0)
+	if want := -(m.Prefix(40) + 7); f32Abs(got-want) > 0.5 {
+		t.Fatalf("anchor not preserved across the width change: %v, "+
+			"want %v", got, want)
+	}
+}
+
+func TestListHeightRegistryCountChangeKeepsKeyedHeights(t *testing.T) {
+	w := newTestWindow()
+	keys := []string{"a", "b", "c"}
+	spec := listHeightSpec{
+		n: len(keys), estimate: 20, width: 100,
+		keyAt: func(i int) string { return keys[i] },
+	}
+	m := listHeightEnsureVariable(w, "lst", spec)
+	for i, k := range keys {
+		m.RecordKeyed(i, k, float32(100+i))
+	}
+
+	keys = append([]string{"new"}, keys...)
+	spec.n = len(keys)
+	m = listHeightEnsureVariable(w, "lst", spec)
+	if got := m.Height(0); got != 20 {
+		t.Fatalf("inserted row = %v, want the estimate", got)
+	}
+	for i := 1; i < len(keys); i++ {
+		if want := float32(100 + i - 1); m.Height(i) != want {
+			t.Fatalf("key %q = %v, want %v", keys[i], m.Height(i), want)
+		}
+	}
+}
+
+func TestInvalidateListHeightsResetsAndHoldsAnchor(t *testing.T) {
+	w := newTestWindow()
+	m := listHeightEnsureVariable(w, "lst", registryTestSpec(50, 100))
+	for i := range 50 {
+		m.SetHeight(i, 80)
+	}
+	w.scrollY().Set("lst", -m.Prefix(20))
+
+	w.InvalidateListHeights("lst")
+	if got := m.Height(20); got != 20 {
+		t.Fatalf("height survived the invalidate: %v", got)
+	}
+	if got := w.scrollY().GetOr("lst", 0); f32Abs(got+m.Prefix(20)) > 0.5 {
+		t.Fatalf("anchor not preserved: %v, want %v", got, -m.Prefix(20))
+	}
+	// A uniform model has nothing to invalidate and must not panic.
+	listHeightRegisterUniform(w, "uni", 10, 24, 0, 0)
+	w.InvalidateListHeights("uni")
+	w.InvalidateListHeights("nobody")
+}
+
+func TestListHeightRegisterUniformDoesNotReallocate(t *testing.T) {
+	w := newTestWindow()
+	listHeightRegisterUniform(w, "uni", 100, 24, 6, 1)
+	m1, _ := listHeightLookup(w, "uni")
+	listHeightRegisterUniform(w, "uni", 120, 24, 6, 1)
+	m2, _ := listHeightLookup(w, "uni")
+	if m1 != m2 {
+		t.Fatal("re-registering a uniform model replaced it")
+	}
+	if m2.Count() != 120 {
+		t.Fatalf("count = %d, want 120", m2.Count())
+	}
+	if m2.Prefix(0) != 6 {
+		t.Fatalf("staticTop lost: %v", m2.Prefix(0))
+	}
+	if m2.indexBase != 1 {
+		t.Fatalf("indexBase = %d, want 1", m2.indexBase)
+	}
+}
+
+func TestListHeightRegistryCapsPerItemStorage(t *testing.T) {
+	// Past the cap the model must fall back to uniform rather than
+	// allocating tens of megabytes of per-item heights.
+	w := newTestWindow()
+	m := listHeightEnsureVariable(w, "huge",
+		registryTestSpec(listHeightMaxVariable+1, 100))
+	if m == nil {
+		t.Fatal("no model registered past the cap")
+	}
+	if !m.uniform {
+		t.Fatal("model past the cap kept per-item storage")
+	}
+	if m.heights != nil || m.tree != nil {
+		t.Fatal("capped model allocated per-item storage")
+	}
+}

--- a/gui/scratch_pools.go
+++ b/gui/scratch_pools.go
@@ -111,6 +111,15 @@ type scratchPools struct {
 	// header, and per-node Children headers stay internally consistent.
 	layoutChildrenArena []Layout
 
+	// viewArena is a grow-only, frame-scoped arena for the []View
+	// slices a widget builds for its children during the view phase.
+	// It exists beside layoutChildrenArena rather than reusing it
+	// because that one hands out []Layout, and beside a scratchSlice
+	// because a scratchSlice hands out one shared buffer that nested
+	// lists would alias. Reset to len=0 in resetViewPools; the
+	// realloc-safety argument is layoutChildrenArena's.
+	viewArena []View
+
 	floatingLayouts      []*Layout
 	floatingLayoutPool   []*Layout
 	placeholderShapePool []*Shape
@@ -213,6 +222,45 @@ func (p *scratchPools) resetViewPools() {
 	} else {
 		p.layoutChildrenArena = p.layoutChildrenArena[:0]
 	}
+	if cap(p.viewArena) > viewArenaRetainMax {
+		p.viewArena = make([]View, 0, viewArenaShrinkTo)
+	} else {
+		p.viewArena = p.viewArena[:0]
+	}
+}
+
+const (
+	viewArenaRetainMax = 1 << 14 // 16 384 View interface values
+	viewArenaShrinkTo  = 1 << 10 // 1 024
+
+	// maxViewReservation bounds a single reservation, matching
+	// maxLayoutChildrenReservation's reasoning: beyond it a standalone
+	// slice keeps arena memory from being held across frames.
+	maxViewReservation = 1 << 20
+)
+
+// takeViews reserves a pinned, zero-length subslice with capacity n
+// from the frame-scoped view arena. The cap is pinned to n so the
+// caller's appends cannot bleed into a later reservation, which is
+// what makes nested lists safe. Callers must not retain the slice
+// past the frame — appendChildViews copies out of it.
+func (p *scratchPools) takeViews(n int) []View {
+	if n <= 0 {
+		return nil
+	}
+	if n > maxViewReservation {
+		return make([]View, 0, n)
+	}
+	start := len(p.viewArena)
+	need := start + n
+	if cap(p.viewArena) < need {
+		grown := make([]View, need, growCap(cap(p.viewArena), need))
+		copy(grown, p.viewArena)
+		p.viewArena = grown
+	} else {
+		p.viewArena = p.viewArena[:need]
+	}
+	return p.viewArena[start:start:need]
 }
 
 const (

--- a/gui/scroll_index.go
+++ b/gui/scroll_index.go
@@ -1,0 +1,249 @@
+package gui
+
+import "slices"
+
+// scroll_index.go — index-addressed scrolling.
+//
+// The existing scroll surface addresses a *view*: scrollToView
+// resolves an ID through FindByID, so it structurally cannot reach a
+// row virtualization has not built. Percent scrolling is no answer
+// either, because under virtualization the content height is a
+// fiction assembled from spacers. Index addressing goes through the
+// height model instead, which knows where item i sits whether or not
+// the row exists this frame.
+//
+// A request is applied immediately when the list has already been
+// generated, and queued otherwise. The queued form mirrors
+// scrollAnchor (gui/scroll_anchor.go), including its "not in this
+// layer's tree, stay pending" branch, because layoutPipeline runs per
+// layer and a floating subtree's pass does not contain the list.
+
+// virtualScrollMode selects how the target index is aligned in the
+// viewport.
+type virtualScrollMode uint8
+
+const (
+	// virtualScrollAt aligns the item by frac: 0 puts its top at the
+	// viewport top, 0.5 centres it, 1 puts its bottom at the bottom.
+	virtualScrollAt virtualScrollMode = iota
+	// virtualScrollIntoView moves by the least amount that makes the
+	// item visible, and does nothing when it already is.
+	virtualScrollIntoView
+	// virtualScrollEnd pins the list to the bottom of its content.
+	virtualScrollEnd
+)
+
+// virtualScrollReq is a pending index-addressed scroll.
+type virtualScrollReq struct {
+	scrollID string
+	frac     float32
+	index    int
+	frame    uint64 // frameCount at request time
+	mode     virtualScrollMode
+}
+
+// virtualScrollMaxAge is how many frames a request stays live. It is
+// longer than scrollAnchorMaxAge on purpose: a far jump into rows
+// that have never been measured lands estimate-accurate, and re-
+// applying while the newly built rows are measured is what converges
+// it onto the real position.
+const virtualScrollMaxAge = 4
+
+// ScrollToIndex scrolls the given list so item index sits at the top
+// of the viewport. id is the list's effective scroll ID; index is in
+// the widget's own index space (see the retrofit table in
+// docs/specs/virtualized-variable-height-lists.md — a frozen table
+// header, for instance, is data index 0 but sits outside the
+// scrollable). Main goroutine only.
+func (w *Window) ScrollToIndex(id string, index int) {
+	w.scrollIndexRequest(id, index, virtualScrollAt, 0)
+}
+
+// ScrollToIndexAt scrolls the given list so item index lands at frac
+// of the viewport: 0 top, 0.5 middle, 1 bottom. Main goroutine only.
+func (w *Window) ScrollToIndexAt(id string, index int, frac float32) {
+	w.scrollIndexRequest(id, index, virtualScrollAt,
+		f32Clamp(frac, 0, 1))
+}
+
+// ScrollIndexIntoView scrolls the given list by the least amount that
+// brings item index fully into the viewport, and does nothing when it
+// is already visible. This is the one to call when moving a selection
+// with the arrow keys. Main goroutine only.
+// exportaudit:keep — the selection-following form of the index API
+func (w *Window) ScrollIndexIntoView(id string, index int) {
+	w.scrollIndexRequest(id, index, virtualScrollIntoView, 0)
+}
+
+// ScrollToEnd pins the given list to the bottom of its content. It
+// differs from ScrollVerticalToPct(id, 1) under virtualization, where
+// the content height is assembled from spacers over an estimated row
+// height and a percentage therefore drifts. Main goroutine only.
+func (w *Window) ScrollToEnd(id string) {
+	w.scrollIndexRequest(id, 0, virtualScrollEnd, 0)
+}
+
+// scrollIndexRequest applies the request against the current layout
+// when it can, and queues it either way so later passes converge it
+// as rows are measured.
+func (w *Window) scrollIndexRequest(
+	id string, index int, mode virtualScrollMode, frac float32,
+) {
+	if w == nil || id == "" {
+		return
+	}
+	r := virtualScrollReq{
+		scrollID: id,
+		index:    index,
+		frac:     frac,
+		frame:    w.frameCount,
+		mode:     mode,
+	}
+	// A jump and a pending anchor both write the same offset; the
+	// explicit jump is the later intent, so drop the anchor.
+	w.dropScrollAnchor(id)
+	scrollSmoothCancel(w, id, scrollAxisY)
+
+	if sc, ok := findScrollLayout(w, id); ok {
+		applyVirtualScroll(r, sc, w, false)
+	}
+	w.queueVirtualScroll(r)
+	w.UpdateWindow()
+}
+
+// queueVirtualScroll records the request, replacing any pending one
+// for the same scrollable — last write wins, as with scroll anchors.
+func (w *Window) queueVirtualScroll(r virtualScrollReq) {
+	for i := range w.virtualScrolls {
+		if w.virtualScrolls[i].scrollID == r.scrollID {
+			w.virtualScrolls[i] = r
+			return
+		}
+	}
+	w.virtualScrolls = append(w.virtualScrolls, r)
+}
+
+// dropVirtualScroll removes a pending index-addressed scroll for a
+// scrollable. Called (via scrollSmoothCancel) whenever a direct
+// offset write lands, so a still-converging request cannot snap the
+// user's own scroll back.
+func (w *Window) dropVirtualScroll(scrollID string) {
+	w.virtualScrolls = slices.DeleteFunc(w.virtualScrolls,
+		func(r virtualScrollReq) bool { return r.scrollID == scrollID })
+}
+
+// dropScrollAnchor removes a pending anchor for a scrollable.
+func (w *Window) dropScrollAnchor(scrollID string) {
+	w.scrollAnchors = slices.DeleteFunc(w.scrollAnchors,
+		func(a scrollAnchor) bool { return a.scrollID == scrollID })
+}
+
+// layoutApplyVirtualScrolls consumes pending index-addressed scrolls.
+//
+// It must run after layoutPositions and layoutApplyScrollAnchors:
+// layoutAdjustScrollOffsets is the *first* position pass and zero-
+// fills any scrollable with no stored entry, so an offset written
+// before it is clobbered on a list the user has never scrolled — the
+// exact case ScrollToIndex exists for. By this point the arranged
+// height and contentHeight are both known, so the clamp is real.
+func layoutApplyVirtualScrolls(layout *Layout, w *Window) {
+	if len(w.virtualScrolls) == 0 {
+		return
+	}
+	kept := w.virtualScrolls[:0]
+	for _, r := range w.virtualScrolls {
+		sc, ok := findLayoutByScrollID(layout, r.scrollID)
+		if !ok {
+			// Not in this layer's tree; a later pass may have it.
+			if w.frameCount-r.frame <= virtualScrollMaxAge {
+				kept = append(kept, r)
+			}
+			continue
+		}
+		// Keep converging while the request is young: a jump into
+		// never-measured rows only lands exactly once those rows have
+		// been built and written back. A uniform model is exact on the
+		// first application, so it settles immediately.
+		if !applyVirtualScroll(r, sc, w, true) &&
+			w.frameCount-r.frame <= virtualScrollMaxAge {
+			kept = append(kept, r)
+		}
+	}
+	w.virtualScrolls = kept
+}
+
+// applyVirtualScroll converts one request to a scroll offset through
+// the list's height model. shift moves the already-positioned
+// children so the correction never renders as a jump; the immediate
+// (pre-layout) path passes false, because that frame's positions are
+// recomputed from the stored offset anyway. The result reports
+// whether re-applying can no longer change anything — a variable
+// model keeps refining while its rows are measured.
+func applyVirtualScroll(
+	r virtualScrollReq, sc *Layout, w *Window, shift bool,
+) (settled bool) {
+	m, ok := listHeightLookup(w, r.scrollID)
+	if !ok {
+		return true
+	}
+	settled = m.uniform
+	viewH := sc.Shape.Height - sc.Shape.paddingHeight()
+	if viewH <= 0 || !f32IsFinite(viewH) {
+		return settled
+	}
+	maxOffset := scrollMaxOffsetY(sc)
+	sy := w.scrollY()
+	// Default 0: absent entry means the list has not been scrolled.
+	old := sy.GetOr(r.scrollID, 0)
+
+	target, want := virtualScrollTarget(r, m, viewH, maxOffset, old)
+	if !want {
+		return
+	}
+	target = f32Clamp(target, maxOffset, 0)
+	if !f32IsFinite(target) || target == old {
+		return
+	}
+	sy.Set(r.scrollID, target)
+	if shift {
+		// Positions are absolute after the position pass, so moving the
+		// scrollable does not move its children (see scrollAnchor).
+		dy := target - old
+		for i := range sc.Children {
+			scrollAnchorShiftY(&sc.Children[i], dy)
+		}
+		scrollSmoothShiftY(w, r.scrollID, dy)
+	}
+	fireOnScroll(sc, w)
+	return settled
+}
+
+// virtualScrollTarget computes the offset a request asks for. The
+// second result is false when the request is satisfied already, which
+// is how ScrollIndexIntoView stays a no-op on a visible row.
+func virtualScrollTarget(
+	r virtualScrollReq, m *listHeightModel,
+	viewH, maxOffset, cur float32,
+) (float32, bool) {
+	if r.mode == virtualScrollEnd {
+		return maxOffset, true
+	}
+	i := clampInt(r.index-m.indexBase, 0, m.Count()-1)
+	top := m.Prefix(i)
+	h := m.Height(i)
+	if r.mode == virtualScrollIntoView {
+		visTop := -cur
+		visBot := visTop + viewH
+		switch {
+		case top < visTop:
+			return -top, true
+		case top+h > visBot:
+			return -(top + h - viewH), true
+		default:
+			return 0, false // already visible
+		}
+	}
+	// frac aligns the item's box inside the viewport: at frac 0 the
+	// slack is 0, at 1 it is the whole viewport minus the item.
+	return -(top - r.frac*(viewH-h)), true
+}

--- a/gui/scroll_index_test.go
+++ b/gui/scroll_index_test.go
@@ -1,0 +1,248 @@
+package gui
+
+import (
+	"strconv"
+	"testing"
+)
+
+// scrollIndexListWindow runs a real frame pipeline over a scrollable
+// ListBox — the uniform retrofit path — so the index API is tested
+// against the same offsets the widget itself virtualizes from.
+func scrollIndexListWindow(id string, n int) *Window {
+	w := NewWindow(WindowCfg{State: new(int), Width: 300, Height: 400})
+	w.viewGenerator = func(*Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{ListBox(ListBoxCfg{
+				ID:         id,
+				Scrollable: true,
+				Height:     200,
+				Sizing:     FillFixed,
+				Data:       listBoxTestData(n),
+			})},
+		})
+	}
+	w.refreshLayout = true
+	w.FrameFn()
+	return w
+}
+
+func TestListHeightModelKeyMatchesScrollKey(t *testing.T) {
+	// A model keyed differently from w.scrollY() fails silently — the
+	// scroll lands somewhere plausible and wrong — so the equality is
+	// asserted rather than assumed.
+	w := scrollIndexListWindow("lb-key", 500)
+	sc, ok := findScrollLayout(w, "lb-key")
+	if !ok {
+		t.Fatal("scrollable listbox not found in the layout")
+	}
+	key := sc.Shape.idKey()
+	if _, ok = listHeightLookup(w, key); !ok {
+		t.Fatalf("no height model under the scroll key %q", key)
+	}
+}
+
+func TestScrollToIndexOnNeverScrolledList(t *testing.T) {
+	// The regression this pass exists for: layoutAdjustScrollOffsets
+	// is the first position pass and zero-fills any scrollable with no
+	// stored entry, so an offset written before it is clobbered on a
+	// list nobody has scrolled yet.
+	w := scrollIndexListWindow("lb-jump", 500)
+	m, ok := listHeightLookup(w, "lb-jump")
+	if !ok {
+		t.Fatal("height model not registered")
+	}
+
+	w.ScrollToIndex("lb-jump", 300)
+	w.refreshLayout = true
+	w.FrameFn()
+
+	// Default 0: absent entry means unscrolled — which is the failure
+	// this test is about.
+	got := w.scrollY().GetOr("lb-jump", 0)
+	if want := -m.Prefix(300); f32Abs(got-want) > 1 {
+		t.Fatalf("offset = %v, want %v (row 300 at the viewport top)",
+			got, want)
+	}
+}
+
+func TestScrollIndexIntoViewIsANoOpWhenVisible(t *testing.T) {
+	w := scrollIndexListWindow("lb-view", 500)
+	before := w.scrollY().GetOr("lb-view", 0)
+	w.ScrollIndexIntoView("lb-view", 1)
+	w.refreshLayout = true
+	w.FrameFn()
+	if after := w.scrollY().GetOr("lb-view", 0); after != before {
+		t.Fatalf("visible row moved the offset: %v -> %v", before, after)
+	}
+
+	// A row below the fold moves by the least amount: its bottom edge
+	// lands on the viewport bottom, not its top on the viewport top.
+	m, _ := listHeightLookup(w, "lb-view")
+	w.ScrollIndexIntoView("lb-view", 40)
+	w.refreshLayout = true
+	w.FrameFn()
+	sc, _ := findScrollLayout(w, "lb-view")
+	viewH := sc.Shape.Height - sc.Shape.paddingHeight()
+	got := w.scrollY().GetOr("lb-view", 0)
+	want := -(m.Prefix(40) + m.Height(40) - viewH)
+	if f32Abs(got-want) > 1 {
+		t.Fatalf("offset = %v, want %v (nearest-edge landing)", got, want)
+	}
+}
+
+func TestScrollToEndPinsTheBottom(t *testing.T) {
+	w := scrollIndexListWindow("lb-end", 500)
+	w.ScrollToEnd("lb-end")
+	w.refreshLayout = true
+	w.FrameFn()
+	sc, _ := findScrollLayout(w, "lb-end")
+	got := w.scrollY().GetOr("lb-end", 0)
+	if want := scrollMaxOffsetY(sc); f32Abs(got-want) > 1 {
+		t.Fatalf("offset = %v, want the bottom %v", got, want)
+	}
+	if got >= 0 {
+		t.Fatalf("offset = %v, want a scrolled-down list", got)
+	}
+}
+
+func TestScrollToIndexAtFraction(t *testing.T) {
+	w := scrollIndexListWindow("lb-frac", 500)
+	m, _ := listHeightLookup(w, "lb-frac")
+	sc, _ := findScrollLayout(w, "lb-frac")
+	viewH := sc.Shape.Height - sc.Shape.paddingHeight()
+
+	w.ScrollToIndexAt("lb-frac", 200, 0.5)
+	w.refreshLayout = true
+	w.FrameFn()
+	got := w.scrollY().GetOr("lb-frac", 0)
+	want := -(m.Prefix(200) - 0.5*(viewH-m.Height(200)))
+	if f32Abs(got-want) > 1 {
+		t.Fatalf("centred offset = %v, want %v", got, want)
+	}
+}
+
+func TestScrollToIndexConvergesOnAVariableList(t *testing.T) {
+	// A far jump into never-measured rows lands estimate-accurate.
+	// The request stays live for a few frames so the rows it built get
+	// measured and the landing is corrected.
+	cfg := virtualListCfg("vl-jump", 600, 200)
+	w := virtualListWindow(t, cfg)
+	virtualListFrame(w)
+
+	w.ScrollToIndex("vl-jump", 300)
+	for range virtualScrollMaxAge + 2 {
+		virtualListFrame(w)
+	}
+	m, _ := listHeightLookup(w, "vl-jump")
+	got := w.scrollY().GetOr("vl-jump", 0)
+	if want := -m.Prefix(300); f32Abs(got-want) > 2 {
+		t.Fatalf("offset = %v, want %v after convergence", got, want)
+	}
+	// The row itself must be at the viewport top, which is the claim a
+	// caller actually cares about.
+	row, ok := w.layout.FindByID(ScopeIDN("vl-jump", "row", 300))
+	if !ok {
+		t.Fatal("row 300 not built after the jump")
+	}
+	sc, _ := findScrollLayout(w, "vl-jump")
+	top := sc.Shape.Y + sc.Shape.PaddingTop()
+	if f32Abs(row.Shape.Y-top) > 2 {
+		t.Fatalf("row 300 at y=%v, want the viewport top %v",
+			row.Shape.Y, top)
+	}
+	// And the queue drains rather than re-applying forever.
+	if len(w.virtualScrolls) != 0 {
+		t.Fatalf("pending requests = %d, want 0", len(w.virtualScrolls))
+	}
+}
+
+func TestUserScrollDropsPendingIndexScroll(t *testing.T) {
+	// A variable-height jump stays queued for a few frames so it can
+	// converge — but a direct offset write (wheel, scrollbar drag) is
+	// the later intent, and the still-pending request must not snap
+	// the user back on the next frame.
+	cfg := virtualListCfg("vl-drop", 600, 200)
+	w := virtualListWindow(t, cfg)
+	virtualListFrame(w)
+
+	w.ScrollToIndex("vl-drop", 300)
+	virtualListFrame(w)
+	if len(w.virtualScrolls) == 0 {
+		t.Fatal("request settled immediately; the test needs it pending")
+	}
+
+	w.scrollVerticalBy("vl-drop", 120)
+	if len(w.virtualScrolls) != 0 {
+		t.Fatalf("pending requests = %d after a direct scroll, want 0",
+			len(w.virtualScrolls))
+	}
+	m, _ := listHeightLookup(w, "vl-drop")
+	topBefore := m.IndexAt(-w.scrollY().GetOr("vl-drop", 0))
+	virtualListFrame(w)
+	// The raw offset may legitimately move — the write-back re-anchors
+	// as newly built rows are measured — but the row under the viewport
+	// top must stay the user's, not snap back to the jump target.
+	topAfter := m.IndexAt(-w.scrollY().GetOr("vl-drop", 0))
+	if absInt(topAfter-topBefore) > 1 {
+		t.Fatalf("viewport top moved row %d -> %d after the user scroll",
+			topBefore, topAfter)
+	}
+	if len(w.virtualScrolls) != 0 {
+		t.Fatalf("request re-queued: %d pending", len(w.virtualScrolls))
+	}
+}
+
+// absInt is a tiny local helper for index distances.
+func absInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func TestScrollToIndexOnTableRespectsFreeze(t *testing.T) {
+	// With Freeze the first data row is the header and sits outside
+	// the scrollable, which indexBase records. A caller passing a data
+	// index must still land on that row.
+	data := make([]TableRowCfg, 200)
+	for i := range data {
+		s := strconv.Itoa(i)
+		data[i] = TableRowCfg{ID: "r" + s, Cells: []TableCellCfg{
+			{Value: "row " + s}, {Value: "value"},
+		}}
+	}
+	w := NewWindow(WindowCfg{State: new(int), Width: 400, Height: 400})
+	w.viewGenerator = func(*Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{Table(TableCfg{
+				ID:           "tbl",
+				Scrollable:   true,
+				FreezeHeader: true,
+				Height:       200,
+				Sizing:       FillFixed,
+				Data:         data,
+			})},
+		})
+	}
+	w.refreshLayout = true
+	w.FrameFn()
+
+	scrollID := tableScrollID(&TableCfg{ID: "tbl"}, true)
+	m, ok := listHeightLookup(w, scrollID)
+	if !ok {
+		t.Fatalf("no height model under %q", scrollID)
+	}
+	if m.indexBase != 1 {
+		t.Fatalf("indexBase = %d, want 1 (frozen header)", m.indexBase)
+	}
+	w.ScrollToIndex(scrollID, 100)
+	w.refreshLayout = true
+	w.FrameFn()
+	got := w.scrollY().GetOr(scrollID, 0)
+	// Data index 100 is model item 99: the header is not scrollable.
+	if want := -m.Prefix(99); f32Abs(got-want) > 1 {
+		t.Fatalf("offset = %v, want %v", got, want)
+	}
+}

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -233,6 +233,15 @@ func scrollSmoothArm(w *Window, id string, axis scrollAxis, displayed, maxOffset
 // programmatic) is not overwritten by an in-flight ease. No-op if none
 // active. Main goroutine only.
 func scrollSmoothCancel(w *Window, id string, axis scrollAxis) {
+	if axis == scrollAxisY {
+		// The same later-intent rule covers a pending index-addressed
+		// scroll: it re-applies for a few frames while its rows are
+		// measured (layoutApplyVirtualScrolls), and would snap the
+		// direct write back. scrollIndexRequest cancels before it
+		// queues, so it never drops its own request. Outside animMu:
+		// virtualScrolls is main-goroutine state.
+		w.dropVirtualScroll(id)
+	}
 	w.animMu.Lock()
 	defer w.animMu.Unlock()
 	if w.scrollSmooth == nil {

--- a/gui/state_registry.go
+++ b/gui/state_registry.go
@@ -184,6 +184,8 @@ const (
 	nsSelectHL            = "gui.select.highlight"
 	nsListBoxFocus        = "gui.listbox.focus"
 	nsListBoxCache        = "gui.listbox.cache"
+	nsListHeights         = "gui.list.heights"
+	nsVirtualListFocus    = "gui.virtual_list.focus"
 	nsProgress            = "gui.progress"
 	nsSidebar             = "gui.sidebar"
 	nsCombobox            = "gui.combobox"

--- a/gui/testdata/virtual_list.dark.golden
+++ b/gui/testdata/virtual_list.dark.golden
@@ -1,0 +1,9 @@
+Rect xy=11.50,11.50 wh=297.00,160.00 color=#4a4a4aff radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=297.00,160.00 color=#646464ff radius=5.50 thickness=1.50
+Clip xy=23.00,23.00 wh=274.00,137.00
+Text xy=33.00,41.00 wh=0.00,0.00 color=#e1e1e1ff text="row 10" size=16.00
+Text xy=33.00,63.00 wh=0.00,0.00 color=#e1e1e1ff text="row 11" size=16.00
+Text xy=33.00,85.00 wh=0.00,0.00 color=#e1e1e1ff text="row 12" size=16.00
+Text xy=33.00,129.00 wh=0.00,0.00 color=#e1e1e1ff text="row 13" size=16.00
+Text xy=33.00,151.00 wh=0.00,0.00 color=#e1e1e1ff text="row 14" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/virtual_list.light.golden
+++ b/gui/testdata/virtual_list.light.golden
@@ -1,0 +1,8 @@
+Rect xy=10.00,10.00 wh=300.00,160.00 color=#c3c3d7ff radius=5.50 fill
+Clip xy=20.00,20.00 wh=280.00,140.00
+Text xy=30.00,38.00 wh=0.00,0.00 color=#202020ff text="row 10" size=16.00
+Text xy=30.00,60.00 wh=0.00,0.00 color=#202020ff text="row 11" size=16.00
+Text xy=30.00,82.00 wh=0.00,0.00 color=#202020ff text="row 12" size=16.00
+Text xy=30.00,126.00 wh=0.00,0.00 color=#202020ff text="row 13" size=16.00
+Text xy=30.00,148.00 wh=0.00,0.00 color=#202020ff text="row 14" size=16.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -145,6 +145,9 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		scrollY = w.scrollY().GetOr(dropdownScrollID, 0)
 	}
 	first, last := listCoreVisibleRange(len(filtered), rowH, listH, scrollY)
+	// Index space: the *filtered* items, so it moves with the query.
+	listHeightRegisterUniform(w, dropdownScrollID, len(filtered),
+		rowH, 0, 0)
 
 	// Build dropdown content.
 	onSelect := cfg.OnSelect

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -129,6 +129,8 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 		scrollY = w.scrollY().GetOr(scrollID, 0)
 	}
 	first, last := listCoreVisibleRange(len(filtered), rowH, cfg.MaxHeight, scrollY)
+	// Index space: the *filtered* items, so it moves with the query.
+	listHeightRegisterUniform(w, scrollID, len(filtered), rowH, 0, 0)
 
 	onAction := cfg.OnAction
 	paletteID := id

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -350,6 +350,10 @@ func listBoxVisibleRange(
 		scrollY := w.scrollY().GetOr(cfg.ID, 0)
 		first, last = listCoreVisibleRange(
 			len(cfg.Data), rowH, listH, scrollY)
+		// Register the same rowH the spacers use, so ScrollToIndex
+		// agrees with the arithmetic already on screen. Index space:
+		// cfg.Data, subheadings included.
+		listHeightRegisterUniform(w, cfg.ID, len(cfg.Data), rowH, 0, 0)
 	} else {
 		virtualize = false
 		if cfg.Scrollable && cache.hSeen &&

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -261,6 +261,11 @@ func tableView(cfg TableCfg, w *Window) View {
 			dataCount, rowHeight, listHeight, scrollY)
 		first = vFirst + dataStart
 		last = vLast + dataStart
+		// Index space: cfg.Data. With Freeze, data row 0 is the frozen
+		// header and sits outside the scrollable, which is what
+		// indexBase records.
+		listHeightRegisterUniform(w, scrollID, dataCount,
+			rowHeight, 0, dataStart)
 	}
 
 	rows := tableBuildRows(&cfg, columnWidths, cellBorder,

--- a/gui/view_tree_rows.go
+++ b/gui/view_tree_rows.go
@@ -84,6 +84,10 @@ func treeVisibleRange(
 	}
 	// Default 0: unscrolled position when no offset recorded yet.
 	scrollY := w.scrollY().GetOr(scrollID, 0)
+	// Index space: the *flat* row index, not the node index. Re-
+	// registered every frame because flatRows is rebuilt whenever a
+	// node expands or collapses.
+	listHeightRegisterUniform(w, scrollID, totalRows, rowHeight, 0, 0)
 	return listCoreVisibleRange(totalRows, rowHeight, treeHeight, scrollY)
 }
 

--- a/gui/view_virtual_list.go
+++ b/gui/view_virtual_list.go
@@ -1,0 +1,244 @@
+package gui
+
+// view_virtual_list.go — a virtualized list whose rows may differ in
+// height. The Cfg, the factory and GenerateLayout live here; the
+// range arithmetic, the spacers and the measurement write-back are in
+// view_virtual_list_build.go.
+//
+// The existing virtualized widgets (ListBox, Table, Tree, Combobox)
+// own their row shape, so one scalar row height describes them
+// exactly and they keep the O(1) path. VirtualList is for the case
+// that scalar rules out: rows the caller builds, of heights only the
+// layout engine knows — a chat transcript, a feed, a log view, a card
+// list.
+
+// VirtualListCfg configures a [VirtualList].
+//
+// # Heights
+//
+// Supply ItemHeight when the height is cheap to compute: it is then
+// exact from the first frame and nothing is measured. Without it the
+// list measures the rows it builds and refines a prefix-sum model, so
+// positions converge over the first frames a region is visited and
+// the scrollbar tightens as the reader travels.
+//
+// # Identity
+//
+// Supply ItemKey when the items can be inserted, deleted or
+// reordered. Measured heights are stored under the key, so they
+// follow their item; without it the model is index-keyed and an
+// insert at the front leaves every row rendering at its neighbour's
+// height until re-measured (call [Window.InvalidateListHeights] to
+// force that). Content edited under a *stable* key needs an explicit
+// invalidate either way — nothing detects it.
+//
+// # Scrolling
+//
+// The list is scrollable by construction and its scroll state is
+// keyed by ID. Address rows by index with [Window.ScrollToIndex],
+// [Window.ScrollToIndexAt], [Window.ScrollIndexIntoView] and
+// [Window.ScrollToEnd]; ScrollVerticalToPct is the wrong tool here,
+// because it takes a percentage of a content height that virtualized
+// rows only estimate.
+type VirtualListCfg struct {
+	A11YCfg
+
+	// ItemView builds row i. width is the list's inner content width,
+	// as recorded by the previous frame's arrange — it is 0 on the
+	// first frame and one frame stale after a resize.
+	//
+	// Use it for decisions, never for a minimum. A row that sets
+	// MinWidth from it asks the list for at least the width the list
+	// just reported; the row's own border and padding push that a few
+	// pixels further, and the list widens every frame without bound —
+	// re-wrapping and re-measuring each time, so it never settles.
+	// Rows fill the width they are given through Sizing. [Debug]
+	// reports the ratchet if it happens anyway.
+	ItemView func(i int, width float32) View
+
+	// ItemHeight returns row i's height without building it. Optional;
+	// when set the model never measures and never re-anchors.
+	// exportaudit:keep — the cheap path, for apps whose rows compute
+	ItemHeight func(i int, width float32) float32
+
+	// ItemKey returns a stable identity for row i. Optional; see the
+	// Identity section above.
+	ItemKey func(i int) string
+
+	// OnKeyDown fires on the list container. It runs after the built-in
+	// arrow/Home/End handling, which consumes the keys it acts on.
+	OnKeyDown func(EventCtx)
+
+	ID string `gui:"required"`
+
+	Padding    Padding
+	Radius     Opt[float32]
+	SizeBorder Opt[float32]
+
+	// ItemCount is the number of rows. Rows outside the viewport are
+	// not built; their space is held by two spacer rectangles.
+	ItemCount int
+
+	// OverscanPx is how far beyond each viewport edge rows are built,
+	// in pixels. Pixels rather than rows because a row count means
+	// nothing when rows differ in height. Zero takes half a viewport.
+	// exportaudit:keep — tuning knob for apps with unusual row sizes
+	OverscanPx float32
+
+	// Height sets the list's height directly. Virtualization needs a
+	// resolved height: with Height or MaxHeight the list virtualizes
+	// from the first frame; under Fill sizing the height is read back
+	// from the previous frame's arrange, and the first frame builds a
+	// bounded probe range instead of the whole corpus.
+	Height    float32
+	MinWidth  float32
+	MaxWidth  float32
+	MinHeight float32
+	MaxHeight float32
+
+	Color       Color
+	ColorBorder Color
+	// ColorBorderFocus is the border while the list holds focus.
+	// Unset takes the theme's.
+	ColorBorderFocus Color
+	// Colors sets the per-state colors. Color above is the shorthand
+	// for Colors.Base and wins over it, as do the other flat Color*
+	// fields over their slots.
+	Colors ColorSet
+
+	Sizing Sizing
+
+	// FocusDisabled opts out of the default-on focus. Focus also
+	// requires a non-empty ID; without one the control is inert.
+	FocusDisabled bool
+	Disabled      bool
+	Invisible     bool
+}
+
+type virtualListView struct {
+	cfg VirtualListCfg
+}
+
+// VirtualList creates a virtualized list whose rows may differ in
+// height. It requires an ID (scroll state, the height model and the
+// focused index are all keyed by it) and an ItemView.
+func VirtualList(cfg VirtualListCfg) View {
+	RequireID("VirtualList", cfg.ID)
+	applyVirtualListDefaults(&cfg)
+	return &virtualListView{cfg: cfg}
+}
+
+// applyVirtualListDefaults fills unset styling from the theme's list
+// box style. VirtualList deliberately shares it rather than
+// introducing a second list appearance — the two widgets differ in
+// how rows are sized, not in how a list looks.
+func applyVirtualListDefaults(cfg *VirtualListCfg) {
+	d := &defaultListBoxStyle
+	cfg.Colors = cfg.Colors.resolved(cfg.Color, themeColorSet(
+		d.Color, Color{}, Color{},
+		Color{}, d.ColorBorder, d.ColorBorderFocus,
+	))
+	cfg.Colors.applyTo(&cfg.Color, nil, nil, nil,
+		&cfg.ColorBorder, &cfg.ColorBorderFocus)
+	if !cfg.Padding.IsSet() {
+		cfg.Padding = d.Padding
+	}
+}
+
+func (lv *virtualListView) GenerateLayout(w *Window) Layout {
+	cfg := &lv.cfg
+	// One resolved identity for the scroll offset, the height model
+	// and the focused index; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
+
+	m := virtualListModel(cfg, w)
+	first, last, lead, trail, probe := virtualListRange(cfg, m, w)
+	m.builtFirst = first
+	m.builtCount = max(last-first+1, 0)
+	m.leadOffset = 0
+	if lead > 0 {
+		m.leadOffset = 1
+	}
+	if probe && DebugEnabled() && m.hSeen && cfg.ItemCount > 0 {
+		// Arrange has run and still gave the list no height, so every
+		// frame rebuilds a probe window instead of the real viewport.
+		w.debugWarn(debugCheckListBoxNoHeight, cfg.ID,
+			"VirtualList %q resolved to height 0, so it builds a "+
+				"%d-row probe every frame instead of virtualizing; "+
+				"set Height/MaxHeight or give it sizing that "+
+				"allocates height",
+			cfg.ID, virtualListProbeRows)
+	}
+
+	dn := &defaultListBoxStyle
+	layout := Layout{Shape: w.allocShape(buildContainerShape(
+		&ContainerCfg{
+			ID:       cfg.ID,
+			axis:     axisTopToBottom,
+			A11YRole: AccessRoleList,
+			A11YCfg: A11YCfg{
+				A11YLabel:       a11yLabel(cfg.A11YLabel, cfg.ID),
+				A11YDescription: cfg.A11YDescription,
+			},
+			Focusable:   !cfg.FocusDisabled,
+			Scrollable:  true,
+			AmendLayout: virtualListAmend(m, cfg.ColorBorderFocus),
+			OnKeyDown:   virtualListKeyDown(cfg),
+			Width:       cfg.MaxWidth,
+			Height:      cfg.Height,
+			MinWidth:    cfg.MinWidth,
+			MaxWidth:    cfg.MaxWidth,
+			MinHeight:   cfg.MinHeight,
+			MaxHeight:   cfg.MaxHeight,
+			Color:       cfg.Color,
+			ColorBorder: cfg.ColorBorder,
+			SizeBorder:  Some(cfg.SizeBorder.Get(dn.SizeBorder)),
+			Radius:      Some(cfg.Radius.Get(dn.Radius)),
+			Padding:     cfg.Padding,
+			Sizing:      cfg.Sizing,
+			// Fixed at 0: a gap between rows is height the model does
+			// not know about, and every row position would drift by
+			// one gap per row. Space rows from inside ItemView.
+			Spacing:   SomeF(0),
+			Disabled:  cfg.Disabled,
+			Invisible: cfg.Invisible,
+		}, w))}
+
+	// The parent shape must exist before the children generate: their
+	// IDs resolve under its scope (see appendChildViews).
+	appendChildViews(w, &layout,
+		virtualListChildren(cfg, m, w, first, last, lead, trail))
+	return layout
+}
+
+// virtualListModel registers this frame's height model, applying the
+// count/width/theme invalidation rules.
+func virtualListModel(cfg *VirtualListCfg, w *Window) *listHeightModel {
+	// The width the heights were measured at is what the previous
+	// frame's arrange recorded; on frame 1 there is none, and rows are
+	// built at width 0 (documented on ItemView).
+	var width float32
+	if prev, ok := listHeightLookup(w, cfg.ID); ok {
+		width = prev.measuredW
+	}
+	return listHeightEnsureVariable(w, cfg.ID, listHeightSpec{
+		n:        max(cfg.ItemCount, 0),
+		estimate: virtualListEstimate(cfg, width),
+		width:    width,
+		keyAt:    cfg.ItemKey,
+		heightFn: cfg.ItemHeight,
+	})
+}
+
+// virtualListEstimate seeds unmeasured rows. The caller's own
+// function wins; otherwise the shared list row estimate, which is
+// what the uniform widgets already assume.
+func virtualListEstimate(cfg *VirtualListCfg, width float32) float32 {
+	if cfg.ItemHeight != nil && cfg.ItemCount > 0 {
+		if h := cfg.ItemHeight(0, width); h > 0 && f32IsFinite(h) {
+			return h
+		}
+	}
+	return listCoreRowHeightEstimate(
+		defaultListBoxStyle.textStyleNormal, listBoxItemPad)
+}

--- a/gui/view_virtual_list_build.go
+++ b/gui/view_virtual_list_build.go
@@ -1,0 +1,321 @@
+package gui
+
+// view_virtual_list_build.go — the range arithmetic, the spacers, the
+// measurement write-back and the keyboard handling for VirtualList.
+// Split from view_virtual_list.go to keep both files inside the
+// 800-line gate (./scripts/large-files.sh).
+
+const (
+	// virtualListProbeRows bounds the first frame under Fill sizing,
+	// where no height is known yet. The ListBox precedent builds every
+	// row in that situation; at a million rows that is a hang, so a
+	// probe window is built instead — enough to let arrange record a
+	// height, after which the real range takes over.
+	virtualListProbeRows = 64
+
+	// virtualListMaxBuiltRows caps how many rows one frame may build,
+	// as a backstop against a corpus of one-pixel rows or a viewport
+	// that resolved absurdly tall. The pixel overscan is the primary
+	// control; this only bounds the pathological case.
+	virtualListMaxBuiltRows = 512
+
+	// virtualListOverscanFrac is the default overscan, as a fraction
+	// of the viewport height on each edge.
+	virtualListOverscanFrac = 0.5
+)
+
+// virtualListRange computes the row window to build plus the two
+// spacer heights that stand in for everything outside it. probe
+// reports the no-height-yet case, which the caller warns about under
+// Debug.
+func virtualListRange(
+	cfg *VirtualListCfg, m *listHeightModel, w *Window,
+) (first, last int, lead, trail float32, probe bool) {
+	n := m.Count()
+	if n == 0 || cfg.ItemView == nil {
+		return 0, -1, 0, 0, false
+	}
+	viewH := virtualListViewportH(cfg, m)
+	if viewH <= 0 {
+		// No height yet: build a bounded probe so arrange has
+		// something to measure, and hold the rest in the trailing
+		// spacer so the scrollbar is not wildly wrong meanwhile.
+		last = min(n-1, virtualListProbeRows-1)
+		return 0, last, 0, m.Total() - m.Prefix(last+1), true
+	}
+
+	// Default 0: absent entry means the list has not been scrolled.
+	scrollY := w.scrollY().GetOr(cfg.ID, 0)
+	over := cfg.OverscanPx
+	// NaN escapes the <= 0 default check and would poison the range
+	// arithmetic below; treat any non-finite overscan as unset.
+	if over <= 0 || !f32IsFinite(over) {
+		over = viewH * virtualListOverscanFrac
+	}
+	first = m.IndexAt(-scrollY - over)
+	last = m.IndexAt(-scrollY + viewH + over)
+	if last-first+1 > virtualListMaxBuiltRows {
+		last = first + virtualListMaxBuiltRows - 1
+	}
+	last = clampInt(last, first, n-1)
+	return first, last, m.Prefix(first), m.Total() - m.Prefix(last+1), false
+}
+
+// virtualListViewportH resolves the height virtualization measures
+// against: Cfg.Height, then MaxHeight, then the inner height arrange
+// recorded last frame. The first two are outer heights, so padding
+// *and border* come off — a container reserves border space whether
+// or not it paints one; the recorded one is already inner.
+func virtualListViewportH(cfg *VirtualListCfg, m *listHeightModel) float32 {
+	inset := cfg.Padding.Height() +
+		2*cfg.SizeBorder.Get(defaultListBoxStyle.SizeBorder)
+	if h := cfg.Height; h > 0 {
+		return h - inset
+	}
+	if h := cfg.MaxHeight; h > 0 {
+		return h - inset
+	}
+	return m.viewportH
+}
+
+// virtualListChildren builds the frame's children: a leading spacer
+// for everything above the window, the rows themselves, a trailing
+// spacer for everything below. The []View comes from the frame-scoped
+// arena — appendChildViews copies out of it and retains nothing.
+func virtualListChildren(
+	cfg *VirtualListCfg, m *listHeightModel, w *Window,
+	first, last int, lead, trail float32,
+) []View {
+	if last < first || cfg.ItemView == nil {
+		return nil
+	}
+	n := last - first + 1
+	if lead > 0 {
+		n++
+	}
+	if trail > 0 {
+		n++
+	}
+	views := w.scratch.takeViews(n)
+	if lead > 0 {
+		views = append(views, virtualListSpacer(lead))
+	}
+	for i := first; i <= last; i++ {
+		v := cfg.ItemView(i, m.width)
+		if v == nil {
+			// Keep the child positions aligned with the row indices:
+			// appendChildViews skips a nil, which would shift every
+			// later row's measurement onto the wrong item.
+			v = virtualListSpacer(0)
+		}
+		views = append(views, v)
+	}
+	if trail > 0 {
+		views = append(views, virtualListSpacer(trail))
+	}
+	return views
+}
+
+// virtualListSpacer is the transparent rectangle standing in for rows
+// that were not built.
+func virtualListSpacer(h float32) View {
+	return Rectangle(RectangleCfg{
+		Color:  ColorTransparent,
+		Height: h,
+		Sizing: FillFixed,
+	})
+}
+
+// virtualListWidthRatchetRuns is how many consecutive frames of
+// unexplained widening it takes to report one. A window resize widens
+// the list too, but it stops; a row that demands the width it was
+// handed never does.
+const virtualListWidthRatchetRuns = 4
+
+// virtualListNoteWidth records the inner width arrange resolved and
+// watches for the one mistake that makes a virtual list misbehave
+// without any error: a row turning the width ItemView is handed into a
+// width it demands. MinWidth from that argument asks the list for at
+// least the width it just reported, the row's own border pushes that a
+// few pixels further, and the list widens every frame — which, because
+// a width change invalidates the wrap, re-wraps and re-measures every
+// frame too. Nothing about it looks like a failure from inside; the
+// list just never settles.
+func virtualListNoteWidth(w *Window, m *listHeightModel, id string, iw float32) {
+	// Only growth with the window standing still counts: that is what
+	// separates the ratchet from a resize the user asked for.
+	if iw > m.measuredW+listHeightEps && m.lastWinW == w.windowWidth {
+		m.widthRun++
+	} else {
+		m.widthRun = 0
+	}
+	m.measuredW, m.lastWinW = iw, w.windowWidth
+	if m.widthRun >= virtualListWidthRatchetRuns && DebugEnabled() {
+		w.debugWarn(debugCheckListWidthRatchet, id,
+			"list %q has widened on %d consecutive frames with the "+
+				"window unchanged (now %.0f px): a row is demanding the "+
+				"width ItemView handed it — MinWidth taken from that "+
+				"argument ratchets, and each width change re-wraps every "+
+				"row", id, m.widthRun, iw)
+	}
+}
+
+// virtualListAmend is the list's single AmendLayout: one hook on the
+// scroll container rather than one per row. layoutAmend fires
+// children-first, so every row's Shape.Height is final by the time
+// this runs.
+func virtualListAmend(m *listHeightModel, colorBorderFocus Color) func(EventCtx) {
+	return amendAll(
+		virtualListMeasure(m),
+		focusRingAmend(Color{}, colorBorderFocus),
+	)
+}
+
+// virtualListMeasure records the arranged geometry and writes the
+// built rows' measured heights back into the model.
+//
+// The re-anchor is the subtle half. Rows above the built window sit
+// inside the leading spacer and are never measured, so the model's
+// prefix up to `first` does not move; a measurement therefore shifts
+// every position from `first` down by the accumulated delta. Keying
+// the correction on the row under the viewport top — not on `first`,
+// where the delta is structurally always zero — and moving the stored
+// offset by that delta is what holds the reader still across the
+// frame boundary.
+//
+// The already-positioned children are shifted to match, for the same
+// reason scroll anchoring shifts them: this frame's rows were laid
+// out at their *actual* heights above a leading spacer sized from the
+// stale model, so they already sit off by exactly that delta. Without
+// the shift the correction lands one frame late and reads as a jump.
+func virtualListMeasure(m *listHeightModel) func(EventCtx) {
+	return func(ctx EventCtx) {
+		ly := ctx.Layout
+		if ly == nil || ly.Shape == nil || ctx.Window == nil {
+			return
+		}
+		sh := ly.Shape
+		if iw := sh.Width - sh.paddingWidth(); iw > 0 && f32IsFinite(iw) {
+			virtualListNoteWidth(ctx.Window, m, sh.idKey(), iw)
+		}
+		if ih := sh.Height - sh.paddingHeight(); ih > 0 && f32IsFinite(ih) {
+			m.viewportH = ih
+		}
+		m.hSeen = true
+		if m.heightFn != nil || m.builtCount == 0 || m.uniform {
+			return // the caller computes heights; nothing to measure
+		}
+
+		scrollID := sh.idKey()
+		sy := ctx.Window.scrollY()
+		// Default 0: absent entry means the list has not been scrolled.
+		scrollY := sy.GetOr(scrollID, 0)
+		anchor := m.IndexAt(-scrollY)
+		before := m.Prefix(anchor)
+
+		for k := range m.builtCount {
+			ci := m.leadOffset + k
+			if ci >= len(ly.Children) {
+				break
+			}
+			child := ly.Children[ci].Shape
+			if child == nil {
+				continue
+			}
+			idx := m.builtFirst + k
+			// The keyed write is gated on the tree actually changing,
+			// so a settled list stops paying keyAt (typically a string
+			// allocation) per built row per frame. A first measurement
+			// inside the deadband stays unkeyed; a rebuild then seeds
+			// it from the estimate, off by under listHeightEps.
+			if delta := m.SetHeight(idx, child.Height); delta != 0 &&
+				m.keyAt != nil {
+				m.recordKey(m.keyAt(idx), child.Height)
+			}
+		}
+
+		delta := m.Prefix(anchor) - before
+		if delta == 0 {
+			return
+		}
+		// Negative-down offsets: growing the content above the anchor
+		// by delta means scrolling delta further to stay put. The top
+		// clamp is applied here; the bottom one needs next frame's
+		// content height, and layoutAdjustScrollOffsets applies it.
+		next := f32Min(scrollY-delta, 0)
+		if !f32IsFinite(next) || next == scrollY {
+			return
+		}
+		sy.Set(scrollID, next)
+		// Positions are absolute after the position pass, so moving the
+		// scrollable would not move its children (see scrollAnchor).
+		dy := next - scrollY
+		for i := range ly.Children {
+			scrollAnchorShiftY(&ly.Children[i], dy)
+		}
+		scrollSmoothShiftY(ctx.Window, scrollID, dy)
+	}
+}
+
+// VirtualListFocusedIndex returns the row index a virtual list's
+// keyboard navigation currently sits on. ItemView reads it to render
+// the focused row — an unbuilt row has no shape to hold focus, so the
+// focus lives on the list and is expressed as an index.
+func (w *Window) VirtualListFocusedIndex(id string) int {
+	return StateReadOr(w, nsVirtualListFocus, id, 0)
+}
+
+// SetVirtualListFocusedIndex moves a virtual list's keyboard focus to
+// index and scrolls it into view. Main goroutine only.
+// exportaudit:keep — the write half of the focused-index pair
+func (w *Window) SetVirtualListFocusedIndex(id string, index int) {
+	StateMap[string, int](w, nsVirtualListFocus, capModerate).
+		Set(id, max(index, 0))
+	w.ScrollIndexIntoView(id, index)
+}
+
+// virtualListKeyDown moves the focused index and keeps it in view.
+// Focus lands on the row one frame later, once the index-addressed
+// scroll has built it — which is why the arrow keys move an index
+// rather than calling SetFocus on a row that may not exist.
+func virtualListKeyDown(cfg *VirtualListCfg) func(EventCtx) {
+	id := cfg.ID
+	count := cfg.ItemCount
+	user := cfg.OnKeyDown
+	return func(ctx EventCtx) {
+		if ctx.Event != nil && count > 0 {
+			cur := ctx.Window.VirtualListFocusedIndex(id)
+			next := virtualListNavigate(ctx.Event.KeyCode, cur, count)
+			if next != cur {
+				ctx.Window.SetVirtualListFocusedIndex(id, next)
+				ctx.Consume()
+				return
+			}
+		}
+		if user != nil {
+			user(ctx)
+		}
+	}
+}
+
+// virtualListNavigate maps a key to a new focused index. Page moves a
+// fixed row count rather than a viewport's worth: under variable
+// heights "a viewport of rows" is not a number the view phase has.
+func virtualListNavigate(key KeyCode, cur, count int) int {
+	const pageRows = 10
+	switch key {
+	case KeyUp:
+		return clampInt(cur-1, 0, count-1)
+	case KeyDown:
+		return clampInt(cur+1, 0, count-1)
+	case KeyPageUp:
+		return clampInt(cur-pageRows, 0, count-1)
+	case KeyPageDown:
+		return clampInt(cur+pageRows, 0, count-1)
+	case KeyHome:
+		return 0
+	case KeyEnd:
+		return count - 1
+	}
+	return cur
+}

--- a/gui/view_virtual_list_test.go
+++ b/gui/view_virtual_list_test.go
@@ -1,0 +1,390 @@
+package gui
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// virtualListRowH is the test corpus: a tall row every tenth item, so
+// no single scalar row height describes the list and the arithmetic
+// the uniform path uses would land in the wrong place.
+func virtualListRowH(i int) float32 {
+	if i%10 == 0 {
+		return 400
+	}
+	return 20
+}
+
+// virtualListCfg builds a list over n rows of virtualListRowH. Each
+// row is a fixed-height rectangle inside an identified container, so
+// a test can find a named row's arranged position.
+func virtualListCfg(id string, n int, h float32) VirtualListCfg {
+	return VirtualListCfg{
+		ID:        id,
+		ItemCount: n,
+		Height:    h,
+		// FillFixed, not a bare Height: a Fit-sized container grows to
+		// its content, and a scrollable that grew has nothing to clip.
+		Sizing:  FillFixed,
+		Padding: PaddingNone,
+		ItemView: func(i int, _ float32) View {
+			return Column(ContainerCfg{
+				ID:         ScopeIDN(id, "row", i),
+				SizeBorder: NoBorder,
+				Padding:    NoPadding,
+				Sizing:     FillFixed,
+				Height:     virtualListRowH(i),
+				Content: []View{Rectangle(RectangleCfg{
+					Color:  RGB(20, 20, 20),
+					Height: virtualListRowH(i),
+					Sizing: FillFixed,
+				})},
+			})
+		},
+	}
+}
+
+func TestVirtualListBuildsOnlyTheVisibleRange(t *testing.T) {
+	w := newTestWindow()
+	cfg := virtualListCfg("vl-range", 10_000, 300)
+	// The cheap path: heights are exact from frame 1, so the range is
+	// too and the test does not depend on convergence.
+	cfg.ItemHeight = func(i int, _ float32) float32 {
+		return virtualListRowH(i)
+	}
+	v := VirtualList(cfg)
+
+	layout := generateViewLayout(v, w)
+	if n := len(layout.Children); n > 120 {
+		t.Fatalf("children = %d, want the visible range only", n)
+	}
+	// Row 0 is 400 px tall, so a 300 px viewport with half a viewport
+	// of overscan cannot reach row 2.
+	if n := len(layout.Children); n < 2 {
+		t.Fatalf("children = %d, want rows plus a trailing spacer", n)
+	}
+	last := layout.Children[len(layout.Children)-1]
+	if !last.Shape.Color.eq(ColorTransparent) {
+		t.Error("trailing spacer missing")
+	}
+
+	m, ok := listHeightLookup(w, "vl-range")
+	if !ok {
+		t.Fatal("height model not registered")
+	}
+	// 1000 tall rows + 9000 short ones.
+	if want := float32(1000*400 + 9000*20); f32Abs(m.Total()-want) > 1 {
+		t.Fatalf("modelled content height = %v, want %v", m.Total(), want)
+	}
+}
+
+func TestVirtualListNaNOverscanFallsBackToDefault(t *testing.T) {
+	// NaN escapes an `<= 0` check, and a NaN overscan would poison
+	// every range comparison into false — first and last both 0.
+	w := newTestWindow()
+	cfg := virtualListCfg("vl-nan", 1000, 200)
+	cfg.OverscanPx = float32(math.NaN())
+	cfg.ItemHeight = func(i int, _ float32) float32 {
+		return virtualListRowH(i)
+	}
+	generateViewLayout(VirtualList(cfg), w)
+
+	m, _ := listHeightLookup(w, "vl-nan")
+	w.scrollY().Set("vl-nan", -m.Prefix(500))
+	first, last, _, _, probe := virtualListRange(&cfg, m, w)
+	if probe {
+		t.Fatal("configured Height must not take the probe path")
+	}
+	if first == 0 || last <= first {
+		t.Fatalf("range [%d, %d] ignored the scroll position", first, last)
+	}
+}
+
+func TestVirtualListScrolledRangeSkipsToTheRightRow(t *testing.T) {
+	w := newTestWindow()
+	cfg := virtualListCfg("vl-scroll", 1000, 200)
+	cfg.OverscanPx = 1 // pin the window to the viewport itself
+	cfg.ItemHeight = func(i int, _ float32) float32 {
+		return virtualListRowH(i)
+	}
+	v := VirtualList(cfg)
+	generateViewLayout(v, w) // register the model
+
+	m, _ := listHeightLookup(w, "vl-scroll")
+	// Put the viewport top exactly on row 25.
+	w.scrollY().Set("vl-scroll", -m.Prefix(25))
+
+	first, last, lead, _, probe := virtualListRange(&cfg, m, w)
+	if probe {
+		t.Fatal("configured Height must not take the probe path")
+	}
+	// A 1 px overscan still reaches one row above the viewport top,
+	// so the window starts at 24 and must cover 25.
+	if first != 24 {
+		t.Fatalf("first = %d, want 24", first)
+	}
+	if last < 25 {
+		t.Fatalf("last = %d, want at least 25", last)
+	}
+	if f32Abs(lead-m.Prefix(first)) > 0.5 {
+		t.Fatalf("leading spacer = %v, want %v", lead, m.Prefix(first))
+	}
+}
+
+func TestVirtualListProbesWhenHeightUnresolved(t *testing.T) {
+	w := newTestWindow()
+	cfg := virtualListCfg("vl-probe", 100_000, 0)
+	cfg.Sizing = FillFill
+	cfg.ItemHeight = func(i int, _ float32) float32 {
+		return virtualListRowH(i)
+	}
+	v := VirtualList(cfg)
+
+	// Frame 1: no arranged height. The ListBox precedent builds every
+	// row here; at this corpus size that is a hang, so the probe
+	// window is the whole point.
+	first := generateViewLayout(v, w)
+	if n := len(first.Children); n > virtualListProbeRows+2 {
+		t.Fatalf("frame 1 children = %d, want a bounded probe", n)
+	}
+	if len(first.Children) < 2 {
+		t.Fatal("probe frame built nothing")
+	}
+
+	// Arrange resolves a height; the amend hook records it.
+	first.Shape.Height = 300
+	first.Shape.Width = 200
+	first.Shape.events.AmendLayout(EventCtx{&first, nil, w})
+
+	m, _ := listHeightLookup(w, "vl-probe")
+	if want := 300 - first.Shape.paddingHeight(); m.viewportH != want {
+		t.Fatalf("recorded viewport height = %v, want %v",
+			m.viewportH, want)
+	}
+	_, _, _, _, probe := virtualListRange(&cfg, m, w)
+	if probe {
+		t.Fatal("still probing after arrange recorded a height")
+	}
+}
+
+// virtualListWindow runs a real frame pipeline over a virtual list,
+// which is what makes the measurement write-back observable: the
+// heights come from arrange, not from the view phase.
+func virtualListWindow(t *testing.T, cfg VirtualListCfg) *Window {
+	t.Helper()
+	w := NewWindow(WindowCfg{State: new(int), Width: 400, Height: 400})
+	w.viewGenerator = func(*Window) View {
+		return Column(ContainerCfg{
+			Sizing:  FillFill,
+			Content: []View{VirtualList(cfg)},
+		})
+	}
+	return w
+}
+
+func virtualListFrame(w *Window) {
+	w.refreshLayout = true
+	w.FrameFn()
+}
+
+func TestVirtualListMeasurementConverges(t *testing.T) {
+	cfg := virtualListCfg("vl-measure", 500, 200)
+	w := virtualListWindow(t, cfg)
+
+	virtualListFrame(w)
+	m, ok := listHeightLookup(w, "vl-measure")
+	if !ok {
+		t.Fatal("height model not registered")
+	}
+	// Frame 1 estimates every row; frame 1's amend measures the built
+	// ones. Row 0 is 400 px and no estimate is close to that.
+	if got := m.Height(0); f32Abs(got-400) > 1 {
+		t.Fatalf("row 0 measured %v after one frame, want 400", got)
+	}
+	virtualListFrame(w)
+	if got := m.Height(1); f32Abs(got-20) > 1 {
+		t.Fatalf("row 1 measured %v, want 20", got)
+	}
+	// A settled list stops writing: a third frame must not move
+	// anything the second frame already recorded.
+	before := m.Total()
+	virtualListFrame(w)
+	if f32Abs(m.Total()-before) > 0.5 {
+		t.Fatalf("total moved on a settled frame: %v -> %v",
+			before, m.Total())
+	}
+}
+
+func TestVirtualListWriteBackHoldsTheAnchorRow(t *testing.T) {
+	// The layout-level guard on the re-anchor rule: a row under the
+	// viewport top must not move when the rows above it are re-
+	// measured. Keying the correction on `first` instead of on the
+	// anchor makes this fail — the delta there is structurally zero,
+	// because rows above the built window sit inside the leading
+	// spacer and are never measured, so the content slides instead.
+	cfg := virtualListCfg("vl-anchor", 500, 200)
+	w := virtualListWindow(t, cfg)
+	virtualListFrame(w)
+
+	m, _ := listHeightLookup(w, "vl-anchor")
+	// Land the viewport top on row 41 by hand rather than through
+	// ScrollToIndex: a queued jump keeps re-targeting as the model
+	// converges, which is a different behaviour (see the scroll-index
+	// tests) and would mask this one.
+	w.scrollY().Set("vl-anchor", -m.Prefix(41))
+	virtualListFrame(w) // builds rows around 41 and measures them
+
+	anchorID := ScopeIDN("vl-anchor", "row", 41)
+	yOf := func() (float32, bool) {
+		ly, ok := w.layout.FindByID(anchorID)
+		if !ok {
+			return 0, false
+		}
+		return ly.Shape.Y, true
+	}
+	y1, ok := yOf()
+	if !ok {
+		t.Fatalf("anchor row %q not built", anchorID)
+	}
+	virtualListFrame(w)
+	y2, ok := yOf()
+	if !ok {
+		t.Fatalf("anchor row %q left the built range", anchorID)
+	}
+	if f32Abs(y1-y2) > 1 {
+		t.Fatalf("anchor row moved across the write-back frame: "+
+			"%v -> %v", y1, y2)
+	}
+}
+
+func TestVirtualListItemKeySurvivesInsert(t *testing.T) {
+	keys := []string{"a", "b", "c", "d", "e"}
+	cfg := VirtualListCfg{
+		ID:        "vl-key",
+		Height:    200,
+		ItemCount: len(keys),
+		ItemKey:   func(i int) string { return keys[i] },
+		ItemView: func(i int, _ float32) View {
+			return Rectangle(RectangleCfg{
+				Height: 30, Sizing: FillFixed,
+			})
+		},
+	}
+	w := newTestWindow()
+	generateViewLayout(VirtualList(cfg), w)
+	m, ok := listHeightLookup(w, "vl-key")
+	if !ok {
+		t.Fatal("model not registered")
+	}
+	for i, k := range keys {
+		m.RecordKeyed(i, k, float32(100+10*i))
+	}
+
+	// Prepend, then re-generate: every measured height must still be
+	// on its own key.
+	keys = append([]string{"z"}, keys...)
+	cfg.ItemCount = len(keys)
+	generateViewLayout(VirtualList(cfg), w)
+	for i := 1; i < len(keys); i++ {
+		want := float32(100 + 10*(i-1))
+		if got := m.Height(i); f32Abs(got-want) > 0.5 {
+			t.Fatalf("key %q height = %v, want %v", keys[i], got, want)
+		}
+	}
+}
+
+func TestVirtualListFocusedIndexNavigates(t *testing.T) {
+	cfg := virtualListCfg("vl-focus", 100, 200)
+	w := virtualListWindow(t, cfg)
+	virtualListFrame(w)
+
+	if got := w.VirtualListFocusedIndex("vl-focus"); got != 0 {
+		t.Fatalf("initial focused index = %d, want 0", got)
+	}
+	if got := virtualListNavigate(KeyDown, 0, 100); got != 1 {
+		t.Fatalf("KeyDown = %d, want 1", got)
+	}
+	if got := virtualListNavigate(KeyEnd, 0, 100); got != 99 {
+		t.Fatalf("KeyEnd = %d, want 99", got)
+	}
+	if got := virtualListNavigate(KeyUp, 0, 100); got != 0 {
+		t.Fatalf("KeyUp at the top = %d, want 0", got)
+	}
+
+	w.SetVirtualListFocusedIndex("vl-focus", 60)
+	virtualListFrame(w)
+	if got := w.VirtualListFocusedIndex("vl-focus"); got != 60 {
+		t.Fatalf("focused index = %d, want 60", got)
+	}
+	// Moving focus must have brought the row into view.
+	m, _ := listHeightLookup(w, "vl-focus")
+	// Default 0: absent entry means unscrolled.
+	off := w.scrollY().GetOr("vl-focus", 0)
+	if -off > m.Prefix(60) || -off+m.viewportH < m.Prefix(60) {
+		t.Fatalf("row 60 not in view: offset %v, row top %v, viewport %v",
+			off, m.Prefix(60), m.viewportH)
+	}
+}
+
+func TestVirtualListHasNoDuplicateIDs(t *testing.T) {
+	// The spacers carry no ID and the rows carry one each, so a
+	// rendered list must be clean. A spacer that acquired the list's
+	// ID, or a row window that built an index twice, shows up here.
+	cfg := virtualListCfg("vl-ids", 400, 200)
+	w := virtualListWindow(t, cfg)
+	virtualListFrame(w)
+	if found := w.TestDuplicateIDs(); len(found) != 0 {
+		t.Fatalf("duplicate effective IDs: %v", found)
+	}
+}
+
+func TestVirtualListWidthRatchetWarns(t *testing.T) {
+	// The failure this catches has no error state to observe: rows
+	// that turn the width they are handed into a width they demand
+	// widen the list a little every frame, and because a width change
+	// re-wraps them, the list never settles. examples/virtual_list
+	// shipped with exactly that bug — MinWidth: width - padding, which
+	// omits the row's own border — so the widget reports it.
+	//
+	// Driven through the recorder rather than a laid-out list: what
+	// makes a row overflow its allocation is a property of the app's
+	// whole tree, and the rule under test is only "growth the window
+	// does not explain, on consecutive frames".
+	prevOn := DebugEnabled()
+	Debug(true)
+	defer Debug(prevOn)
+
+	w := newTestWindow()
+	var found []string
+	w.debug.collect = &found
+	m := &listHeightModel{}
+	w.windowWidth = 800
+	for i := range virtualListWidthRatchetRuns + 1 {
+		virtualListNoteWidth(w, m, "vl-ratchet", 400+float32(i)*3)
+	}
+	if len(found) != 1 {
+		t.Fatalf("want one ratchet warning, got %v", found)
+	}
+	if !strings.Contains(found[0], "vl-ratchet") {
+		t.Errorf("warning does not name the list: %q", found[0])
+	}
+
+	// A resize widens the list too, and must stay quiet: the window
+	// moving is the explanation.
+	w2 := newTestWindow()
+	var quiet []string
+	w2.debug.collect = &quiet
+	m2 := &listHeightModel{}
+	for i := range virtualListWidthRatchetRuns + 4 {
+		w2.windowWidth = 800 + i*3
+		virtualListNoteWidth(w2, m2, "vl-resize", 400+float32(i)*3)
+	}
+	// A settled list is quiet too.
+	for range virtualListWidthRatchetRuns + 1 {
+		virtualListNoteWidth(w2, m2, "vl-resize", m2.measuredW)
+	}
+	if len(quiet) != 0 {
+		t.Fatalf("warned on a resize: %v", quiet)
+	}
+}

--- a/gui/window.go
+++ b/gui/window.go
@@ -162,6 +162,11 @@ type Window struct {
 	// consumed by the layout pipeline. See Window.ScrollAnchor.
 	scrollAnchors []scrollAnchor
 
+	// virtualScrolls holds pending index-addressed scroll requests for
+	// lists whose height model was not registered yet, consumed by the
+	// layout pipeline. See Window.ScrollToIndex.
+	virtualScrolls []virtualScrollReq
+
 	windowToast
 
 	// Embedded concern groups.


### PR DESCRIPTION
Closes #332.

## Part 1 — variable row heights

New `gui.VirtualList` widget with a per-list height model (`gui/list_height_model.go`):
- caller-supplied `ItemHeight` fn, or auto-measure of the built rows (gated to first-measurement so a settled list stops paying per-row work)
- Fenwick tree for prefix sums; in-place `growTree` on append so a feed costs O(added · log n) with no rebuild
- `OverscanPx` (NaN-safe), scroll-to-index with convergence while never-measured rows land

The uniform-height path (`listCoreVisibleRange`) is untouched.

## Part 2 — index-addressed scrolling

`Window.ScrollToIndex` (and `ScrollToIndexAt` with a viewport fraction, `ScrollToEnd`), which resolve through the height model instead of `FindByID` — so they address rows virtualization has not built. Requests keep converging for a few frames while rows measure; a direct user scroll drops the pending request so it cannot snap the user back.

## Also

- `examples/virtual_list/` demo, `docs/specs/virtualized-variable-height-lists.md`
- golden tests in both themes; unit tests for the height model (grow-vs-rebuild parity, empty/out-of-range, deadband), range building, convergence, user-scroll preemption, Table freeze, NaN overscan