### PR TITLE
gui: step Backspace/arrows by grapheme cluster in input fallback (issue #330)

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -18,6 +18,7 @@ Go toolchain pin: `go 1.26.0`.
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio decode + mixing (sound effects, music, mixer, fade) for `gui/audio`. |
 | `github.com/jezek/xgb` | v1.3.1 | Pure-Go X11 windowing + events for the native Linux backend (`gui/backend/gl`). |
 | `github.com/jfreymuth/pulse` | v0.1.2 | Pure-Go PulseAudio native-protocol client. Default Linux audio output sink (`gui/audio/output_pulse.go`), keeping `CGO_ENABLED=0` builds cgo-free. Needs a running PulseAudio/PipeWire server. |
+| `github.com/rivo/uniseg` | v0.4.7 | UAX #29 grapheme segmentation for the input caret-motion fallback (`gui/grapheme.go`) and go-glyph. |
 | `github.com/tdewolff/parse/v2` | v2.8.16 | CSS tokenizer for the SVG `<style>` / `style=""` cascade pipeline. |
 | `github.com/yuin/goldmark` | v1.8.5 | Markdown parser (markdown widget + showcase docs). |
 | `github.com/yuin/goldmark-emoji` | v1.0.6 | Goldmark extension: `:emoji:` shortcodes. |
@@ -41,7 +42,6 @@ Pulled in transitively; listed for completeness.
 | `github.com/mewkiz/flac` | v1.0.12 | gopxl/beep (FLAC decode) |
 | `github.com/mewkiz/pkg` | v0.0.0-20230226050401-4010bf0fec14 | mewkiz/flac (FLAC decode) |
 | `github.com/pkg/errors` | v0.9.1 | gopxl/beep (audio) |
-| `github.com/rivo/uniseg` | v0.4.7 | grapheme segmentation (chroma/glyph) |
 | `golang.org/x/image` | v0.45.0 | go-glyph (pure-Go rasterization) |
 | `golang.org/x/mobile` | v0.0.0-20260602190626-68735029466e | gobind tool (Android AAR builds) |
 | `golang.org/x/sync` | v0.22.0 | x/tools |

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gopxl/beep/v2 v2.1.1
 	github.com/jezek/xgb v1.3.1
 	github.com/jfreymuth/pulse v0.1.2
+	github.com/rivo/uniseg v0.4.7
 	github.com/tdewolff/parse/v2 v2.8.16
 	github.com/yuin/goldmark v1.8.5
 	github.com/yuin/goldmark-emoji v1.0.6
@@ -30,7 +31,6 @@ require (
 	github.com/mewkiz/flac v1.0.12 // indirect
 	github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/image v0.45.0 // indirect
 	golang.org/x/mobile v0.0.0-20260602190626-68735029466e // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/gui/grapheme.go
+++ b/gui/grapheme.go
@@ -1,0 +1,69 @@
+package gui
+
+// Grapheme-boundary helpers for the caret-motion fallback path. When no
+// glyph layout exists (nil textMeasurer — headless tests, defensive
+// fallback), edit state has no shaped cluster information, so boundaries
+// are recomputed here with UAX #29 via rivo/uniseg — the same
+// segmentation go-glyph uses to build its valid cursor positions. That
+// keeps fallback motion and delete agreeing with the shaped path on
+// where the caret may rest.
+
+import (
+	"sort"
+	"unicode/utf8"
+
+	"github.com/rivo/uniseg"
+)
+
+// graphemeStops returns the rune indices at which the caret may rest in
+// text — every grapheme-cluster boundary, including 0 and the end. The
+// nil-measurer fallback computes this set once per motion or delete;
+// the shaped path needs no equivalent because glyph.Layout carries the
+// positions already.
+func graphemeStops(text string) []int {
+	stops := make([]int, 0, utf8.RuneCountInString(text)+1)
+	stops = append(stops, 0)
+	runeIdx := 0
+	gr := uniseg.NewGraphemes(text)
+	for gr.Next() {
+		runeIdx += utf8.RuneCountInString(gr.Str())
+		stops = append(stops, runeIdx)
+	}
+	return stops
+}
+
+// prevGraphemeStop returns the largest stop strictly before pos, or 0
+// when there is none — the fallback for Backspace and Left-arrow
+// granularity.
+func prevGraphemeStop(stops []int, pos int) int {
+	i := sort.SearchInts(stops, pos)
+	if i == 0 {
+		return 0
+	}
+	return stops[i-1]
+}
+
+// nextGraphemeStop returns the smallest stop strictly after pos, or the
+// final stop (end of text) when there is none — the fallback for Delete
+// and Right-arrow granularity.
+func nextGraphemeStop(stops []int, pos int) int {
+	i := sort.Search(len(stops), func(i int) bool { return stops[i] > pos })
+	if i == len(stops) {
+		return stops[len(stops)-1]
+	}
+	return stops[i]
+}
+
+// closestGraphemeStop returns the stop nearest pos, preferring the one
+// on the left when equidistant — the fallback snap for vertical motion,
+// whose rune-column target can land inside a cluster on the target line.
+func closestGraphemeStop(stops []int, pos int) int {
+	i := sort.SearchInts(stops, pos)
+	if i == len(stops) {
+		return stops[len(stops)-1]
+	}
+	if i > 0 && pos-stops[i-1] <= stops[i]-pos {
+		return stops[i-1]
+	}
+	return stops[i]
+}

--- a/gui/grapheme_test.go
+++ b/gui/grapheme_test.go
@@ -1,0 +1,79 @@
+package gui
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestGraphemeStops(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want []int
+	}{
+		{"ascii", "ab", []int{0, 1, 2}},
+		{"empty", "", []int{0}},
+		// Skin-tone modifier joins its base emoji.
+		{"skin tone", "\U0001F44D\U0001F3FD", []int{0, 2}},
+		// Four emoji joined by three ZWJ form one cluster.
+		{"zwj family",
+			"\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466",
+			[]int{0, 7}},
+		// Combining mark stays with its base.
+		{"combining", "a\u0301b", []int{0, 2, 3}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := graphemeStops(c.text)
+			if !slices.Equal(got, c.want) {
+				t.Fatalf("graphemeStops(%q) = %v, want %v", c.text, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPrevNextGraphemeStop(t *testing.T) {
+	stops := []int{0, 1, 8}
+	cases := []struct {
+		pos  int
+		prev int
+		next int
+	}{
+		{0, 0, 1}, // at start: prev clamps to 0
+		{1, 0, 8}, // on a boundary
+		{5, 1, 8}, // mid-cluster: cluster start and end
+		{8, 1, 8}, // at end: next stays
+	}
+	for _, c := range cases {
+		if got := prevGraphemeStop(stops, c.pos); got != c.prev {
+			t.Errorf("prevGraphemeStop(stops, %d) = %d, want %d", c.pos, got, c.prev)
+		}
+		if got := nextGraphemeStop(stops, c.pos); got != c.next {
+			t.Errorf("nextGraphemeStop(stops, %d) = %d, want %d", c.pos, got, c.next)
+		}
+	}
+}
+
+func TestClosestGraphemeStop(t *testing.T) {
+	stops := []int{0, 1, 8}
+	cases := []struct {
+		pos  int
+		want int
+	}{
+		{4, 1},  // nearer to 1 than 8
+		{5, 8},  // nearer to 8 than 1
+		{10, 8}, // past the end: clamp to last stop
+		{1, 1},  // on a boundary: itself
+	}
+	for _, c := range cases {
+		if got := closestGraphemeStop(stops, c.pos); got != c.want {
+			t.Errorf("closestGraphemeStop(stops, %d) = %d, want %d", c.pos, got, c.want)
+		}
+	}
+
+	// Equidistant: prefer the left stop.
+	tie := []int{0, 2, 6}
+	if got := closestGraphemeStop(tie, 4); got != 2 {
+		t.Errorf("closestGraphemeStop(tie, 4) = %d, want 2", got)
+	}
+}

--- a/gui/input_state.go
+++ b/gui/input_state.go
@@ -178,7 +178,10 @@ func inputSetTextAndCursorAtEnd(oldText, newText string, focusID string, w *Wind
 	})
 }
 
-// inputDelete removes text at cursor or selected range.
+// inputDelete removes text at cursor or selected range. A plain
+// (unselected) delete removes one whole grapheme cluster — the same
+// granularity the glyph-backed path gives — so the nil-measurer
+// fallback never splits an emoji or combining sequence.
 // forwardDelete=true for Delete key, false for Backspace.
 func inputDelete(text string, focusID string, forwardDelete bool, w *Window) (string, bool) {
 	runes := []rune(text)
@@ -205,19 +208,26 @@ func inputDelete(text string, focusID string, forwardDelete bool, w *Window) (st
 		if cursorPos == len(runes) && forwardDelete {
 			return text, true
 		}
-		delPos := cursorPos
+		// No glyph layout behind this path (nil textMeasurer), so
+		// cluster boundaries are recomputed with UAX #29 — the same
+		// segmentation shaping produces — keeping Backspace/Delete
+		// whole-cluster in the fallback as well.
+		stops := graphemeStops(text)
+		delPos, delEnd := cursorPos, cursorPos
 		if !forwardDelete {
-			delPos = cursorPos - 1
+			delPos = prevGraphemeStop(stops, cursorPos)
+		} else {
+			delEnd = nextGraphemeStop(stops, cursorPos)
 		}
-		if delPos < 0 || delPos >= len(runes) {
+		if delPos < 0 || delPos >= len(runes) || delEnd > len(runes) {
 			return text, false
 		}
-		result := make([]rune, 0, len(runes)-1)
+		result := make([]rune, 0, len(runes)-(delEnd-delPos))
 		result = append(result, runes[:delPos]...)
-		result = append(result, runes[delPos+1:]...)
+		result = append(result, runes[delEnd:]...)
 		runes = result
 		if !forwardDelete {
-			cursorPos--
+			cursorPos = delPos
 		}
 	}
 

--- a/gui/input_state_test.go
+++ b/gui/input_state_test.go
@@ -126,6 +126,8 @@ func TestForwardDeleteOnEmoji(t *testing.T) {
 }
 
 func TestBackspaceCombiningChar(t *testing.T) {
+	// e + combining acute is one grapheme: Backspace removes the
+	// whole cluster, not just the combining mark (issue #330).
 	w := newTestWindow()
 	id := "f10013"
 	setInputState(w, id, inputState{CursorPos: 2})
@@ -133,8 +135,8 @@ func TestBackspaceCombiningChar(t *testing.T) {
 	if !ok {
 		t.Fatal("expected ok")
 	}
-	if got != "e" {
-		t.Fatalf("got %q, want %q", got, "e")
+	if got != "" {
+		t.Fatalf("got %q, want %q", got, "")
 	}
 }
 

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -136,7 +136,7 @@ func makeInputOnKeyDown(hcfg inputHandlerCfg) func(EventCtx) {
 			inputKeyLeft(imap, id, is, text, pos,
 				isShift, isWordMod, gl, glOK)
 		case KeyRight:
-			inputKeyRight(imap, id, is, text, pos, runeLen,
+			inputKeyRight(imap, id, is, text, pos,
 				isShift, isWordMod, gl, glOK)
 		case KeyHome:
 			inputKeyHome(imap, id, is, text, pos,

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -31,8 +31,9 @@ func inputKeyLeft(
 			newPos = byteToRuneIndex(text,
 				gl.MoveCursorLeft(byteIdx))
 		} else {
-			newPos = pos - 1
-			newPos = max(newPos, 0)
+			// No glyph layout: snap to the previous UAX #29 grapheme
+			// boundary so the caret never rests mid-cluster.
+			newPos = prevGraphemeStop(graphemeStops(text), pos)
 		}
 		updateCursorAndSelection(imap, id, is,
 			newPos, isShift)
@@ -41,7 +42,7 @@ func inputKeyLeft(
 
 func inputKeyRight(
 	imap *BoundedMap[string, inputState], id string, is inputState,
-	text string, pos, runeLen int, isShift, isWordMod bool,
+	text string, pos int, isShift, isWordMod bool,
 	gl glyph.Layout, glOK bool,
 ) {
 	if isWordMod {
@@ -66,8 +67,9 @@ func inputKeyRight(
 			newPos = byteToRuneIndex(text,
 				gl.MoveCursorRight(byteIdx))
 		} else {
-			newPos = pos + 1
-			newPos = min(newPos, runeLen)
+			// No glyph layout: snap to the next UAX #29 grapheme
+			// boundary so the caret never rests mid-cluster.
+			newPos = nextGraphemeStop(graphemeStops(text), pos)
 		}
 		updateCursorAndSelection(imap, id, is,
 			newPos, isShift)
@@ -185,6 +187,10 @@ func inputKeyVertical(
 		} else {
 			newPos = moveCursorDown([]rune(text), pos)
 		}
+		// Line-column math is rune-based; snap the result to the
+		// nearest cluster boundary so vertical motion cannot park
+		// the caret inside a multi-rune grapheme.
+		newPos = closestGraphemeStop(graphemeStops(text), newPos)
 	}
 	updateCursorAndSelection(imap, id, is,
 		newPos, isShift)

--- a/gui/view_input_layout_test.go
+++ b/gui/view_input_layout_test.go
@@ -216,18 +216,41 @@ func TestInputDeleteGraphemeForward(t *testing.T) {
 	}
 }
 
-func TestInputDeleteGraphemeFallbackRunes(t *testing.T) {
-	// Without a text measurer, deletion falls back to rune-based
-	// inputDelete — still removes exactly one rune, no panic.
+func TestInputDeleteGraphemeFallbackCluster(t *testing.T) {
+	// Without a text measurer, deletion falls back to UAX #29
+	// boundaries computed by gui — a whole grapheme per keystroke,
+	// same granularity as the shaped path.
 	w := newTestWindow() // no textMeasurer
-	layout := inputLayoutWithText(t, "ab", nil)
 	focusID := "f-fallback"
+
+	// ASCII: one rune per cluster, behaves exactly as before.
+	layout := inputLayoutWithText(t, "ab", nil)
 	StateMap[string, inputState](w, nsInput, capMany).Set(
 		focusID, inputState{CursorPos: 1})
-
 	got, changed := inputDeleteGrapheme("ab", focusID, false, layout, w)
 	if !changed || got != "b" {
 		t.Fatalf("fallback backspace = (%q, %v), want (\"b\", true)", got, changed)
+	}
+
+	// ZWJ family emoji: one Backspace removes all seven runes.
+	text := "a\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466"
+	layout = inputLayoutWithText(t, text, nil)
+	StateMap[string, inputState](w, nsInput, capMany).Set(
+		focusID, inputState{CursorPos: utf8RuneCount(text)})
+	got, changed = inputDeleteGrapheme(text, focusID, false, layout, w)
+	if !changed || got != "a" {
+		t.Fatalf("fallback cluster backspace = (%q, %v), want (\"a\", true)", got, changed)
+	}
+	if is := inputStateOrDefault(focusID, w); is.CursorPos != 1 {
+		t.Fatalf("cursor = %d, want 1", is.CursorPos)
+	}
+
+	// Forward delete from after "a" removes the whole cluster too.
+	StateMap[string, inputState](w, nsInput, capMany).Set(
+		focusID, inputState{CursorPos: 1})
+	got, changed = inputDeleteGrapheme(text, focusID, true, layout, w)
+	if !changed || got != "a" {
+		t.Fatalf("fallback cluster forward = (%q, %v), want (\"a\", true)", got, changed)
 	}
 }
 

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -611,6 +611,129 @@ func TestInputOnKeyDownLeftCollapsesSelection(t *testing.T) {
 	}
 }
 
+// --- Grapheme-cluster caret motion (issue #330) ---
+
+// seedInputGlyphLayout stamps a fake glyph layout onto the input's
+// inner text shape so the key handler's navigation takes the shaped
+// path headlessly. cursors are the byte indices valid as cursor
+// positions — the cluster boundaries a real measurer would produce.
+func seedInputGlyphLayout(t *testing.T, ctx *inputTestCtx, text string, cursors []int) {
+	t.Helper()
+	ctx.w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	if len(ctx.layout.Children) == 0 || len(ctx.layout.Children[0].Children) == 0 {
+		t.Fatal("input layout missing inner text shape")
+	}
+	shape := ctx.layout.Children[0].Children[0].Shape
+	if shape.TC == nil {
+		t.Fatal("inner child is not a text shape")
+	}
+	style := textStyleOrDefault(shape)
+	shape.TC.textLayout = glyphCursorLayout(text, cursors)
+	shape.TC.textLayoutWidth = plainTextLayoutWidthArg(shape, shape.TC, style)
+	shape.TC.textLayoutText = text
+	shape.TC.textLayoutStyle = style
+	shape.TC.textLayoutMode = shape.TC.TextMode
+	shape.TC.textLayoutValid = true
+}
+
+func TestInputArrowLeftGraphemeGlyphPath(t *testing.T) {
+	// 👍🏽 = base + skin-tone modifier, one cluster: Left from the end
+	// lands before the cluster, never between base and modifier.
+	text := "\U0001F44D\U0001F3FD"
+	ctx := newInputTest(text, "f620", utf8RuneCount(text))
+	seedInputGlyphLayout(t, ctx, text, []int{0, len(text)})
+	ctx.fireKeyDown(KeyLeft, ModNone)
+	if is := ctx.state(); is.CursorPos != 0 {
+		t.Fatalf("cursor=%d, want 0", is.CursorPos)
+	}
+}
+
+func TestInputArrowRightGraphemeGlyphPath(t *testing.T) {
+	// 🇺🇸 = two regional indicators, one cluster: Right from before it
+	// steps past the whole cluster in one key.
+	text := "\U0001F1FA\U0001F1F8"
+	ctx := newInputTest(text, "f621", 0)
+	seedInputGlyphLayout(t, ctx, text, []int{0, len(text)})
+	ctx.fireKeyDown(KeyRight, ModNone)
+	if is := ctx.state(); is.CursorPos != utf8RuneCount(text) {
+		t.Fatalf("cursor=%d, want %d", is.CursorPos, utf8RuneCount(text))
+	}
+}
+
+func TestInputShiftLeftGraphemeGlyphPath(t *testing.T) {
+	// Shift+Left from the end of a ZWJ family emoji extends the
+	// selection by the whole cluster, not one rune.
+	text := "a\U0001F468\u200D\U0001F469\u200D\U0001F467"
+	ctx := newInputTest(text, "f622", utf8RuneCount(text))
+	seedInputGlyphLayout(t, ctx, text, []int{0, 1, len(text)})
+	ctx.fireKeyDown(KeyLeft, ModShift)
+	is := ctx.state()
+	if is.CursorPos != 1 {
+		t.Fatalf("cursor=%d, want 1", is.CursorPos)
+	}
+	if is.selectBeg != uint32(utf8RuneCount(text)) || is.selectEnd != 1 {
+		t.Fatalf("sel=%d-%d, want %d-1", is.selectBeg, is.selectEnd,
+			utf8RuneCount(text))
+	}
+}
+
+func TestInputArrowLeftGraphemeFallback(t *testing.T) {
+	// No glyph layout: Left snaps to the previous UAX #29 boundary.
+	text := "\U0001F44D\U0001F3FD"
+	ctx := newInputTest(text, "f623", utf8RuneCount(text))
+	ctx.fireKeyDown(KeyLeft, ModNone)
+	if is := ctx.state(); is.CursorPos != 0 {
+		t.Fatalf("cursor=%d, want 0", is.CursorPos)
+	}
+}
+
+func TestInputArrowRightGraphemeFallback(t *testing.T) {
+	// No glyph layout: Right steps past the whole cluster in one key.
+	text := "\U0001F1FA\U0001F1F8"
+	ctx := newInputTest(text, "f624", 0)
+	ctx.fireKeyDown(KeyRight, ModNone)
+	if is := ctx.state(); is.CursorPos != utf8RuneCount(text) {
+		t.Fatalf("cursor=%d, want %d", is.CursorPos, utf8RuneCount(text))
+	}
+}
+
+func TestInputBackspaceGraphemeFallback(t *testing.T) {
+	// One Backspace on a ZWJ family emoji removes the whole cluster,
+	// leaving the leading "a".
+	text := "a\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466"
+	ctx := newInputTest(text, "f625", utf8RuneCount(text))
+	ctx.fireKeyDown(KeyBackspace, ModNone)
+	if ctx.lastText != "a" {
+		t.Fatalf("text=%q, want %q", ctx.lastText, "a")
+	}
+	if is := ctx.state(); is.CursorPos != 1 {
+		t.Fatalf("cursor=%d, want 1", is.CursorPos)
+	}
+}
+
+func TestInputForwardDeleteGraphemeFallback(t *testing.T) {
+	// Forward Delete at the start of a skin-tone emoji removes the
+	// whole cluster — symmetric with Backspace.
+	text := "\U0001F44D\U0001F3FD"
+	ctx := newInputTest(text, "f626", 0)
+	ctx.fireKeyDown(KeyDelete, ModNone)
+	if ctx.lastText != "" {
+		t.Fatalf("text=%q, want empty", ctx.lastText)
+	}
+}
+
+func TestInputArrowDownGraphemeFallback(t *testing.T) {
+	// Down from the end of "ab" onto a line whose ZWJ emoji starts at
+	// the target column: rune-column math lands at rune 5 (inside the
+	// cluster); the fallback snaps to the nearest boundary, 4.
+	text := "ab\na\U0001F468\u200D\U0001F469\u200D\U0001F467"
+	ctx := newInputTestMultiline(text, "f627", 2)
+	ctx.fireKeyDown(KeyDown, ModNone)
+	if is := ctx.state(); is.CursorPos != 4 {
+		t.Fatalf("cursor=%d, want 4", is.CursorPos)
+	}
+}
+
 // --- Cursor movement helpers ---
 
 func TestMoveCursorWordLeft(t *testing.T) {

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -234,7 +234,7 @@ func rtfSelectOnKeyDown(ctx EventCtx) {
 		inputKeyLeft(imap, id, is, flatText, pos,
 			isShift, isWordMod, gl, true)
 	case KeyRight:
-		inputKeyRight(imap, id, is, flatText, pos, runeLen,
+		inputKeyRight(imap, id, is, flatText, pos,
 			isShift, isWordMod, gl, true)
 	case KeyHome:
 		inputKeyHome(imap, id, is, flatText, pos,

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -284,7 +284,7 @@ func textOnKeyDown(ctx EventCtx) {
 		inputKeyLeft(imap, id, is, text, pos,
 			isShift, isWordMod, gl, glOK)
 	case KeyRight:
-		inputKeyRight(imap, id, is, text, pos, runeLen,
+		inputKeyRight(imap, id, is, text, pos,
 			isShift, isWordMod, gl, glOK)
 	case KeyHome:
 		inputKeyHome(imap, id, is, text, pos,

--- a/tools/depsdoc/main.go
+++ b/tools/depsdoc/main.go
@@ -37,6 +37,7 @@ var directPurpose = map[string]string{
 	"github.com/ebitengine/purego":    "cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends.",
 	"github.com/gopxl/beep/v2":        "Audio decode + mixing (sound effects, music, mixer, fade) for `gui/audio`.",
 	"github.com/jfreymuth/pulse":      "Pure-Go PulseAudio native-protocol client. Default Linux audio output sink (`gui/audio/output_pulse.go`), keeping `CGO_ENABLED=0` builds cgo-free. Needs a running PulseAudio/PipeWire server.",
+	"github.com/rivo/uniseg":          "UAX #29 grapheme segmentation for the input caret-motion fallback (`gui/grapheme.go`) and go-glyph.",
 	"github.com/tdewolff/parse/v2":    "CSS tokenizer for the SVG `<style>` / `style=\"\"` cascade pipeline.",
 	"github.com/alecthomas/chroma/v2": "Syntax highlighting in the markdown widget.",
 	"github.com/yuin/goldmark":        "Markdown parser (markdown widget + showcase docs).",


### PR DESCRIPTION
## Summary

Backspace/Delete and arrow keys now step by grapheme cluster (UAX #29) instead of by rune in the input fallback path — emoji, ZWJ families, and combining sequences are never split mid-cluster.

## Background

The production path was already grapheme-correct: with a glyph layout present, Backspace/Delete go through `glyph.DeleteBackward/Forward` and arrows through `gl.MoveCursorLeft/Right/Up/Down`, which only land on valid cursor positions. The broken path was the nil-`textMeasurer` fallback, which stepped rune-by-rune, plus a total absence of arrow-motion grapheme tests.

## Changes

- **`gui/grapheme.go`** (new): UAX #29 cluster-boundary helpers (`graphemeStops`, `prevGraphemeStop`, `nextGraphemeStop`, `closestGraphemeStop`) via `rivo/uniseg` — the same segmentation go-glyph uses to build valid cursor positions, so fallback motion agrees with the shaped path on where the caret may rest.
- **`gui/input_state.go`**: `inputDelete` no-selection branch deletes a whole cluster (backward `[prevStop, cursor)`, forward `[cursor, nextStop)`), mirroring `glyph.DeleteBackward/Forward` semantics.
- **`gui/view_input_keys.go`**: fallback branches of `inputKeyLeft`/`inputKeyRight` snap to prev/next boundary; `inputKeyVertical` snaps the rune-column target to the nearest boundary so Up/Down cannot park the caret inside a cluster. Dead `runeLen` param removed from `inputKeyRight` (3 call sites updated).
- **`rivo/uniseg`** promoted from indirect to direct dependency (was already in the module graph via go-glyph).
- **Tests**: unit tests for the stops helpers; arrow/shift-arrow/backspace/forward-delete/vertical tests on both the glyph path (headless via seeded `glyph.Layout`) and the fallback path; existing rune-stepping assertions updated to the cluster behavior (issue #330's case list).

## Verification

`make check`, `make lint`, `go test ./...` clean. Word motion (issue #329) deliberately untouched.