### PR TITLE
gui: surface >5-stop gradient resampling under Debug, keep web uncapped (issue #327)

### DIFF
--- a/gui/backend/android/draw.go
+++ b/gui/backend/android/draw.go
@@ -42,7 +42,7 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 		case gui.RenderBlur:
 			b.drawBlur(r)
 		case gui.RenderGradient:
-			b.drawGradient(r)
+			b.drawGradient(w, r)
 		case gui.RenderGradientBorder:
 			b.drawGradientBorder(r)
 		case gui.RenderImage:
@@ -200,7 +200,7 @@ func (b *Backend) drawBlur(r *gui.RenderCmd) {
 	C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
-func (b *Backend) drawGradient(r *gui.RenderCmd) {
+func (b *Backend) drawGradient(w *gui.Window, r *gui.RenderCmd) {
 	if r.Gradient == nil || len(r.Gradient.Stops) == 0 ||
 		r.W <= 0 || r.H <= 0 {
 		return
@@ -208,7 +208,7 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s
-	w := r.W * s
+	width := r.W * s
 	h := r.H * s
 	rad := r.Radius * s
 
@@ -217,13 +217,16 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	if len(stops) == 0 {
 		return
 	}
+	if len(stops) < len(r.Gradient.Stops) {
+		w.DebugGradientResampled(r.X, r.Y, len(stops), len(r.Gradient.Stops))
+	}
 
-	tm := gpu.PackGradientUniforms(r.Gradient, stops, w, h)
+	tm := gpu.PackGradientUniforms(r.Gradient, stops, width, h)
 
 	b.SetPipeline(pipeGradient)
 	C.glesSetTM((*C.float)(&tm[0]))
 
-	verts := gpu.BuildQuad(x, y, w, h, gui.White, rad, 0)
+	verts := gpu.BuildQuad(x, y, width, h, gui.White, rad, 0)
 	C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -38,7 +38,7 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 		case gui.RenderBlur:
 			b.drawBlur(r)
 		case gui.RenderGradient:
-			b.drawGradient(r)
+			b.drawGradient(w, r)
 		case gui.RenderGradientBorder:
 			b.drawGradientBorder(r)
 		case gui.RenderImage:
@@ -207,7 +207,7 @@ func (b *Backend) drawBlur(r *gui.RenderCmd) {
 		r.Color, rad+expand, blur)
 }
 
-func (b *Backend) drawGradient(r *gui.RenderCmd) {
+func (b *Backend) drawGradient(w *gui.Window, r *gui.RenderCmd) {
 	if r.Gradient == nil || len(r.Gradient.Stops) == 0 ||
 		r.W <= 0 || r.H <= 0 {
 		return
@@ -215,7 +215,7 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	s := b.dpiScale
 	x := r.X * s
 	y := r.Y * s
-	w := r.W * s
+	width := r.W * s
 	h := r.H * s
 	rad := r.Radius * s
 
@@ -224,14 +224,17 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	if len(stops) == 0 {
 		return
 	}
+	if len(stops) < len(r.Gradient.Stops) {
+		w.DebugGradientResampled(r.X, r.Y, len(stops), len(r.Gradient.Stops))
+	}
 
-	tm := gpu.PackGradientUniforms(r.Gradient, stops, w, h)
+	tm := gpu.PackGradientUniforms(r.Gradient, stops, width, h)
 
 	b.usePipeline(&b.pipelines.gradient)
 	gogl.UniformMatrix4fv(b.pipelines.gradient.uTM, 1, false,
 		&tm[0])
 
-	b.drawQuad(x, y, w, h, gui.White, rad, 0)
+	b.drawQuad(x, y, width, h, gui.White, rad, 0)
 }
 
 func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {

--- a/gui/backend/ios/draw.go
+++ b/gui/backend/ios/draw.go
@@ -42,7 +42,7 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 		case gui.RenderBlur:
 			b.drawBlur(r)
 		case gui.RenderGradient:
-			b.drawGradient(r)
+			b.drawGradient(w, r)
 		case gui.RenderGradientBorder:
 			b.drawGradientBorder(r)
 		case gui.RenderImage:
@@ -200,7 +200,7 @@ func (b *Backend) drawBlur(r *gui.RenderCmd) {
 	C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
-func (b *Backend) drawGradient(r *gui.RenderCmd) {
+func (b *Backend) drawGradient(w *gui.Window, r *gui.RenderCmd) {
 	if r.Gradient == nil || len(r.Gradient.Stops) == 0 ||
 		r.W <= 0 || r.H <= 0 {
 		return
@@ -208,7 +208,7 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	s := b.DPIScale
 	x := r.X * s
 	y := r.Y * s
-	w := r.W * s
+	width := r.W * s
 	h := r.H * s
 	rad := r.Radius * s
 
@@ -217,13 +217,16 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 	if len(stops) == 0 {
 		return
 	}
+	if len(stops) < len(r.Gradient.Stops) {
+		w.DebugGradientResampled(r.X, r.Y, len(stops), len(r.Gradient.Stops))
+	}
 
-	tm := gpu.PackGradientUniforms(r.Gradient, stops, w, h)
+	tm := gpu.PackGradientUniforms(r.Gradient, stops, width, h)
 
 	b.SetPipeline(pipeGradient)
 	C.metalSetTM((*C.float)(&tm[0]))
 
-	verts := gpu.BuildQuad(x, y, w, h, gui.White, rad, 0)
+	verts := gpu.BuildQuad(x, y, width, h, gui.White, rad, 0)
 	C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 

--- a/gui/backend/metal/draw.go
+++ b/gui/backend/metal/draw.go
@@ -43,7 +43,7 @@ func (b *windowState) renderersDraw(w *gui.Window) {
 		case gui.RenderBlur:
 			b.drawBlur(r)
 		case gui.RenderGradient:
-			b.drawGradient(r)
+			b.drawGradient(w, r)
 		case gui.RenderGradientBorder:
 			b.drawGradientBorder(r)
 		case gui.RenderImage:
@@ -209,7 +209,7 @@ func (b *windowState) drawBlur(r *gui.RenderCmd) {
 	C.metalDrawQuad(b.ctx, (*C.float)(unsafe.Pointer(&verts[0])))
 }
 
-func (b *windowState) drawGradient(r *gui.RenderCmd) {
+func (b *windowState) drawGradient(w *gui.Window, r *gui.RenderCmd) {
 	if r.Gradient == nil || len(r.Gradient.Stops) == 0 ||
 		r.W <= 0 || r.H <= 0 {
 		return
@@ -217,7 +217,7 @@ func (b *windowState) drawGradient(r *gui.RenderCmd) {
 	s := b.dpiScale
 	x := r.X * s
 	y := r.Y * s
-	w := r.W * s
+	width := r.W * s
 	h := r.H * s
 	rad := r.Radius * s
 
@@ -226,14 +226,17 @@ func (b *windowState) drawGradient(r *gui.RenderCmd) {
 	if len(stops) == 0 {
 		return
 	}
+	if len(stops) < len(r.Gradient.Stops) {
+		w.DebugGradientResampled(r.X, r.Y, len(stops), len(r.Gradient.Stops))
+	}
 
-	tm := gpu.PackGradientUniforms(r.Gradient, stops, w, h)
+	tm := gpu.PackGradientUniforms(r.Gradient, stops, width, h)
 
 	C.metalSetPipeline(b.ctx, C.int(pipeGradient))
 	C.metalSetMVP(b.ctx, (*C.float)(&b.mvp[0]))
 	C.metalSetTM(b.ctx, (*C.float)(&tm[0]))
 
-	verts := gpu.BuildQuad(x, y, w, h, gui.White, rad, 0)
+	verts := gpu.BuildQuad(x, y, width, h, gui.White, rad, 0)
 	C.metalDrawQuad(b.ctx, (*C.float)(unsafe.Pointer(&verts[0])))
 }
 

--- a/gui/backend/web/backend.go
+++ b/gui/backend/web/backend.go
@@ -34,7 +34,6 @@ type Backend struct {
 	height    int
 
 	normBuf      []gui.GradientStop
-	sampledBuf   []gui.GradientStop
 	imgCache     map[string]js.Value
 	failedImages map[string]struct{}
 	clipDepth    int

--- a/gui/backend/web/draw.go
+++ b/gui/backend/web/draw.go
@@ -310,8 +310,8 @@ func (b *Backend) drawGradient(r *gui.RenderCmd) {
 		r.W <= 0 || r.H <= 0 {
 		return
 	}
-	stops := gui.NormalizeGradientStopsInto(
-		r.Gradient.Stops, &b.normBuf, &b.sampledBuf)
+	stops := gui.NormalizeGradientStops(
+		r.Gradient.Stops, &b.normBuf)
 	if len(stops) == 0 {
 		return
 	}
@@ -360,8 +360,8 @@ func (b *Backend) drawGradientBorder(r *gui.RenderCmd) {
 	if r.Gradient == nil || len(r.Gradient.Stops) == 0 {
 		return
 	}
-	stops := gui.NormalizeGradientStopsInto(
-		r.Gradient.Stops, &b.normBuf, &b.sampledBuf)
+	stops := gui.NormalizeGradientStops(
+		r.Gradient.Stops, &b.normBuf)
 	if len(stops) == 0 {
 		return
 	}

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -74,6 +74,11 @@ const (
 	// demand the width they were handed.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugListBoxNoHeight
+	// DebugGradientResampled reports a fill gradient with more stops
+	// than the GPU shader uniforms can carry, silently resampled to
+	// evenly spaced stops on GPU backends.
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugGradientResampled
 
 	// DebugUnscopedIDs reports a focusable or scrollable shape whose ID
 	// resolves to itself — no ID-bearing ancestor above it — so its
@@ -92,7 +97,7 @@ const (
 	// would fire on most widgets in a small app.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
-		DebugListBoxNoHeight
+		DebugListBoxNoHeight | DebugGradientResampled
 )
 
 func init() {
@@ -126,6 +131,8 @@ func envTruthy(name string) bool {
 //   - a shape with an OnMouseLeave and no ID (the callback never fires)
 //   - a scrollable listbox that resolved to height 0 (virtualization
 //     off, every row builds each frame)
+//   - a fill gradient with more stops than the GPU shader uniform limit
+//     (silently resampled to evenly spaced stops on GPU backends)
 //
 // It also reports, from dispatch rather than from the frame audit, any
 // consume-class callback that relies on automatic handling while an
@@ -211,6 +218,10 @@ const (
 	// debugCheckUnscopedID reports an identity that has no ID-bearing
 	// ancestor, so it is still a window-global name.
 	debugCheckUnscopedID
+	// debugCheckGradientResampled fires from the GPU backends' draw
+	// pass when a fill gradient has more stops than the shader uniform
+	// layout can carry.
+	debugCheckGradientResampled
 )
 
 // checkCategory maps an internal check to the public category that
@@ -229,6 +240,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugListBoxNoHeight
 	case debugCheckUnscopedID:
 		return DebugUnscopedIDs
+	case debugCheckGradientResampled:
+		return DebugGradientResampled
 	}
 	return 0
 }
@@ -426,6 +439,27 @@ func (w *Window) debugWarn(check debugCheck, subject, format string, args ...any
 	// Diagnostics are best-effort; a failed write to stderr is not
 	// something a GUI frame can act on.
 	_, _ = fmt.Fprintf(debugOut, "gui: "+format+"\n", args...)
+}
+
+// DebugGradientResampled reports a fill gradient whose stops exceeded
+// the GPU shader uniform limit and were resampled to evenly spaced
+// positions, degrading its appearance. Called by the GPU backends'
+// draw pass; x, y is the gradient rect origin, used as the warn-once
+// discriminator.
+func (w *Window) DebugGradientResampled(x, y float32, kept, total int) {
+	// NaN never equals itself, so a NaN map key could never match and
+	// the warn-once memory would grow a key every frame. Fold NaN in
+	// the discriminator only; the message keeps the true position.
+	if x != x {
+		x = 0
+	}
+	if y != y {
+		y = 0
+	}
+	w.debugWarn(debugCheckGradientResampled,
+		fmt.Sprintf("gradient %g,%g", x, y),
+		"gradient at (%g, %g) has %d stops; resampled to %d "+
+			"(GPU shader uniform limit)", x, y, total, kept)
 }
 
 // debugPath renders a tree path as "0/3/1". The root is "root".

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"math"
 	"strings"
 	"testing"
 )
@@ -253,6 +254,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckUnconsumed, DebugUnconsumed},
 		{debugCheckListBoxNoHeight, DebugListBoxNoHeight},
 		{debugCheckUnscopedID, DebugUnscopedIDs},
+		{debugCheckGradientResampled, DebugGradientResampled},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
@@ -262,11 +264,71 @@ func TestCheckCategoryMapping(t *testing.T) {
 	// DebugAll covers every category Debug(true) turns on.
 	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
 	// a design property, not a defect.
-	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight {
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled {
 		t.Fatal("DebugAll must cover every category Debug(true) enables")
 	}
 	if DebugAll&DebugUnscopedIDs != 0 {
 		t.Fatal("DebugUnscopedIDs must stay opt-in, outside DebugAll")
+	}
+}
+
+// A gradient resample is reported once per rect and only while its
+// category is on, and the counts in the message are the degraded and
+// original stop counts.
+func TestDebugGradientResampledWarnOnce(t *testing.T) {
+	buf := captureDebugMask(t, DebugGradientResampled)
+	w := &Window{}
+
+	w.DebugGradientResampled(10, 20, 5, 7)
+	w.DebugGradientResampled(10, 20, 5, 7)
+	got := buf.String()
+	if !strings.Contains(got, "gradient at (10, 20) has 7 stops; resampled to 5") {
+		t.Fatalf("want resample finding with both counts, got %q", got)
+	}
+	if n := strings.Count(got, "resampled"); n != 1 {
+		t.Fatalf("warn-once: want 1 finding, got %d", n)
+	}
+
+	// A different rect is a distinct finding.
+	w.DebugGradientResampled(100, 200, 5, 9)
+	got = buf.String()
+	if n := strings.Count(got, "resampled"); n != 2 {
+		t.Fatalf("want a second finding for a new rect, got %d", n)
+	}
+}
+
+// The gradient check is dispatch-side: it must stay silent under a
+// mask that does not include it, and not remember the miss either.
+func TestDebugGradientResampledCategoryGate(t *testing.T) {
+	buf := captureDebug(t)
+	DebugCategories(DebugMissingIDs)
+	w := &Window{}
+
+	w.DebugGradientResampled(0, 0, 5, 7)
+	if got := buf.String(); got != "" {
+		t.Fatalf("category off must be silent, got %q", got)
+	}
+
+	DebugCategories(0)
+	buf.Reset()
+	DebugCategories(DebugGradientResampled)
+	w.DebugGradientResampled(0, 0, 5, 7)
+	if n := strings.Count(buf.String(), "resampled"); n != 1 {
+		t.Fatalf("re-enabled category must re-report, got %d", n)
+	}
+}
+
+// NaN coords would never match a warn-once key, so the finding must
+// fold to (0, 0) and dedupe against the (0, 0) finding.
+func TestDebugGradientResampledNaNFolds(t *testing.T) {
+	buf := captureDebugMask(t, DebugGradientResampled)
+	w := &Window{}
+	nan := float32(math.NaN())
+
+	w.DebugGradientResampled(nan, nan, 5, 7)
+	w.DebugGradientResampled(0, 0, 5, 7)
+	if n := strings.Count(buf.String(), "resampled"); n != 1 {
+		t.Fatalf("NaN coords must fold to (0, 0) and dedupe, got %d findings", n)
 	}
 }
 

--- a/gui/render_gradient.go
+++ b/gui/render_gradient.go
@@ -135,12 +135,14 @@ func SampleGradientStopColor(stops []GradientStop, pos float32) Color {
 	return stops[len(stops)-1].Color
 }
 
-// NormalizeGradientStopsInto is the non-allocating variant that
-// reuses caller-provided slices.
-func NormalizeGradientStopsInto(stops []GradientStop, norm, sampled *[]GradientStop) []GradientStop {
+// NormalizeGradientStops clamps every stop position to [0,1] and
+// sorts by position, preserving the full stop count. Backends whose
+// gradient path has no stop limit — the web backend's canvas
+// gradients — use this instead of NormalizeGradientStopsInto so
+// fidelity is never resampled away.
+func NormalizeGradientStops(stops []GradientStop, norm *[]GradientStop) []GradientStop {
 	if len(stops) == 0 {
 		*norm = (*norm)[:0]
-		*sampled = (*sampled)[:0]
 		return nil
 	}
 	*norm = (*norm)[:0]
@@ -151,9 +153,22 @@ func NormalizeGradientStopsInto(stops []GradientStop, norm, sampled *[]GradientS
 		*norm = append(*norm, GradientStop{Color: s.Color, Pos: clampUnit(s.Pos)})
 	}
 	slices.SortFunc(*norm, compareStops)
-	if len(*norm) <= gradientShaderStopLimit {
+	return *norm
+}
+
+// NormalizeGradientStopsInto is the non-allocating variant that
+// reuses caller-provided slices. Stops beyond gradientShaderStopLimit
+// are resampled to evenly spaced positions; NormalizeGradientStops is
+// the no-resample variant for backends without a stop limit.
+func NormalizeGradientStopsInto(stops []GradientStop, norm, sampled *[]GradientStop) []GradientStop {
+	result := NormalizeGradientStops(stops, norm)
+	if result == nil {
 		*sampled = (*sampled)[:0]
-		return *norm
+		return nil
+	}
+	if len(result) <= gradientShaderStopLimit {
+		*sampled = (*sampled)[:0]
+		return result
 	}
 	*sampled = (*sampled)[:0]
 	if cap(*sampled) < gradientShaderStopLimit {
@@ -162,7 +177,7 @@ func NormalizeGradientStopsInto(stops []GradientStop, norm, sampled *[]GradientS
 	for i := range gradientShaderStopLimit {
 		samplePos := float32(i) / float32(gradientShaderStopLimit-1)
 		*sampled = append(*sampled, GradientStop{
-			Color: SampleGradientStopColor(*norm, samplePos),
+			Color: SampleGradientStopColor(result, samplePos),
 			Pos:   samplePos,
 		})
 	}

--- a/gui/render_gradient_test.go
+++ b/gui/render_gradient_test.go
@@ -232,6 +232,69 @@ func TestNormalizeGradientStopsIntoOverLimit(t *testing.T) {
 	}
 }
 
+// NormalizeGradientStops keeps every stop: it is the no-resample
+// variant for backends without a stop limit (web canvas gradients).
+func TestNormalizeGradientStopsKeepsAll(t *testing.T) {
+	stops := make([]GradientStop, 10)
+	for i := range stops {
+		stops[i] = GradientStop{
+			Color: RGBA(uint8(i*25), 0, 0, 255),
+			Pos:   float32(i) / 9.0,
+		}
+	}
+	// Out-of-range and unsorted input exercises the clamp and sort.
+	stops[9].Pos = 1.5
+	stops[8].Pos = -0.5
+	norm := make([]GradientStop, 0, 16)
+	result := NormalizeGradientStops(stops, &norm)
+	if len(result) != 10 {
+		t.Fatalf("want all 10 stops preserved, got %d", len(result))
+	}
+	if result[0].Pos != 0 {
+		t.Errorf("first pos: got %v, want 0.0", result[0].Pos)
+	}
+	if result[9].Pos != 1 {
+		t.Errorf("last pos: got %v, want 1.0 (clamped)", result[9].Pos)
+	}
+	for i := 1; i < len(result); i++ {
+		if result[i-1].Pos > result[i].Pos {
+			t.Fatalf("stops must be sorted, index %d: %v > %v",
+				i, result[i-1].Pos, result[i].Pos)
+		}
+	}
+}
+
+func TestNormalizeGradientStopsEmpty(t *testing.T) {
+	norm := make([]GradientStop, 0)
+	if got := NormalizeGradientStops(nil, &norm); got != nil {
+		t.Errorf("want nil, got %v", got)
+	}
+}
+
+// NaN positions must fold to 0 (clampUnit) rather than poison the
+// sort order or the output positions.
+func TestNormalizeGradientStopsNaNPosition(t *testing.T) {
+	nan := float32(math.NaN())
+	stops := []GradientStop{
+		{Color: RGBA(0, 255, 0, 255), Pos: 1},
+		{Color: RGBA(255, 0, 0, 255), Pos: nan},
+		{Color: RGBA(0, 0, 255, 255), Pos: 0.5},
+	}
+	norm := make([]GradientStop, 0, 8)
+	result := NormalizeGradientStops(stops, &norm)
+	if len(result) != 3 {
+		t.Fatalf("want 3 stops, got %d", len(result))
+	}
+	for i, s := range result {
+		if s.Pos != s.Pos {
+			t.Fatalf("stop %d keeps a NaN position", i)
+		}
+		if s.Pos < 0 || s.Pos > 1 {
+			t.Fatalf("stop %d out of range: %v", i, s.Pos)
+		}
+	}
+}
+
 func TestNormalizeGradientStopsIntoReuse(t *testing.T) {
 	stops := []GradientStop{
 		{Color: RGBA(0, 0, 0, 255), Pos: 0},


### PR DESCRIPTION
## Summary

Fixes issue #327: `gradientShaderStopLimit = 5` resampled every >5-stop gradient to five evenly spaced stops **silently** on every backend.

### Changes

- **Web backend**: `drawGradient`/`drawGradientBorder` now use new `gui.NormalizeGradientStops` (clamp + sort only) instead of `NormalizeGradientStopsInto`. Canvas `addColorStop` has no stop cap, so >5-stop gradients render at full fidelity — the issue's claim that web was already uncapped was wrong in the code; it was degraded by the shared normalization.
- **Debug warning**: new `DebugGradientResampled` category (in `DebugAll`) + `(*Window).DebugGradientResampled`, emitted by the four GPU backends (`drawGradient` now takes `*Window`) when a fill gradient was resampled. Warn-once per rect; reports both stop counts. `GradientBorderRects` samples raw stops, so borders were never degraded and need no warning.
- **Refactor**: `NormalizeGradientStopsInto` delegates to `NormalizeGradientStops`, behavior byte-identical (verified against existing tests).
- **Hardening**: NaN rect coords fold to 0 in the warn-once key (NaN map keys never match — would have grown the map a key per frame).

### Notes

- The GPU cap stays 5: the `[16]float32` uniform packs 5 stops + metadata with no spare floats (shader slot 6 is duplicated). Raising it needs a second uniform across MSL/GLSL/Android C — tracked as follow-up (issue option 1).
- Android/iOS edits mirror the gl/metal pattern; couldn't be compiled on this host (no NDK/iOS SDK).

### Tests

- `TestNormalizeGradientStopsKeepsAll`, `TestNormalizeGradientStopsEmpty`, `TestNormalizeGradientStopsNaNPosition`
- `TestDebugGradientResampledWarnOnce`, `TestDebugGradientResampledCategoryGate`, `TestDebugGradientResampledNaNFolds`
- `TestCheckCategoryMapping` + `DebugAll` coverage assertion updated

Full gate (`make prepush`) green locally.