### PR TITLE
gui: coalesce input undo runs so a sentence undoes as one step (issue #328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,15 @@ and this project adheres to
 
 ### Fixed
 
+- **`Input` undo recorded every keystroke as its own step, evicting the whole
+  history after 50 characters** (issue #328). Consecutive edits of the same kind
+  — a typing run, a backspace chain — now coalesce into one undo step whose
+  anchor is the state before the run began, so Ctrl+Z after typing a sentence
+  undoes the sentence, and a long run no longer pushes older history out of the
+  50-entry cap. A run breaks on caret motion or click, on a drag selection, on
+  paste or any multi-rune insert (IME commits included), on a programmatic text
+  set, and on a change of edit kind (typing after backspace and backspace after
+  typing are separate steps).
 - **`Input` ignored the theme's own padding** (issue #335). `InputStyle.Padding`
   was dead: the widget fell back to a hardcoded inset, so a theme author editing
   it saw `Container` and `ListBox` move while `Input` stayed put. `Input`'s

--- a/gui/input_state.go
+++ b/gui/input_state.go
@@ -12,7 +12,8 @@ type inputState struct {
 	selectBeg      uint32
 	selectEnd      uint32
 	cursorOffset   float32
-	cursorTrailing bool // prefer end-of-previous-line at wrap boundaries
+	cursorTrailing bool  // prefer end-of-previous-line at wrap boundaries
+	lastEditOp     uint8 // kind of edit the current undo run holds (issue #328)
 }
 
 // InputMemento stores a snapshot for undo/redo.
@@ -44,6 +45,16 @@ const (
 
 const undoMaxSize = 50
 
+// Undo run kinds for inputState.lastEditOp. Consecutive edits of the
+// same kind coalesce into one undo step; inputOpNone breaks the run
+// and always pushes, so caret motion, paste, and programmatic text
+// sets each start a fresh undo step.
+const (
+	inputOpNone uint8 = iota
+	inputOpInsert
+	inputOpDelete
+)
+
 func inputStateOrDefault(focusID string, w *Window) inputState {
 	m := StateMap[string, inputState](w, nsInput, capMany)
 	if v, ok := m.Get(focusID); ok {
@@ -62,12 +73,20 @@ func inputMementoFromState(text string, is inputState) inputMemento {
 	}
 }
 
-func inputPushUndo(is inputState, text string) *BoundedStack[inputMemento] {
+// inputPushUndo records a text edit for undo, coalescing it with the
+// previous edit when both are the same kind (insert or delete) and no
+// selection was involved, so a typing run undoes as one step instead
+// of one per character (issue #328). The pre-run state stays at the
+// top of the stack for the whole run; the caller stores the op it
+// passed as the new lastEditOp.
+func inputPushUndo(is inputState, text string, op uint8) *BoundedStack[inputMemento] {
 	stack := is.Undo
 	if stack == nil {
 		stack = newBoundedStack[inputMemento](undoMaxSize)
 	}
-	stack.Push(inputMementoFromState(text, is))
+	if op == inputOpNone || op != is.lastEditOp || is.selectBeg != is.selectEnd {
+		stack.Push(inputMementoFromState(text, is))
+	}
 	return stack
 }
 
@@ -154,12 +173,19 @@ func inputInsert(text string, insertText string, focusID string, w *Window) stri
 	}
 
 	nextText := string(runes)
-	undo := inputPushUndo(is, text)
+	op := inputOpInsert
+	if len(insertRunes) > 1 {
+		// Multi-rune inserts (paste, IME commits) are one undo step
+		// even after a typing run, so they break the run.
+		op = inputOpNone
+	}
+	undo := inputPushUndo(is, text, op)
 	imap := StateMap[string, inputState](w, nsInput, capMany)
 	imap.Set(focusID, inputState{
 		CursorPos:    cursorPos,
 		cursorOffset: -1,
 		Undo:         undo,
+		lastEditOp:   op,
 	})
 	return nextText
 }
@@ -169,7 +195,8 @@ func inputInsert(text string, insertText string, focusID string, w *Window) stri
 // positional cursor mapping is unreliable.
 func inputSetTextAndCursorAtEnd(oldText, newText string, focusID string, w *Window) {
 	is := inputStateOrDefault(focusID, w)
-	undo := inputPushUndo(is, oldText)
+	// A programmatic text set is never part of a typing run.
+	undo := inputPushUndo(is, oldText, inputOpNone)
 	imap := StateMap[string, inputState](w, nsInput, capMany)
 	imap.Set(focusID, inputState{
 		CursorPos:    utf8RuneCount(newText),
@@ -232,12 +259,13 @@ func inputDelete(text string, focusID string, forwardDelete bool, w *Window) (st
 	}
 
 	nextText := string(runes)
-	undo := inputPushUndo(is, text)
+	undo := inputPushUndo(is, text, inputOpDelete)
 	imap := StateMap[string, inputState](w, nsInput, capMany)
 	imap.Set(focusID, inputState{
 		CursorPos:    cursorPos,
 		cursorOffset: -1,
 		Undo:         undo,
+		lastEditOp:   inputOpDelete,
 	})
 	return nextText, true
 }
@@ -356,6 +384,9 @@ func updateCursorAndSelection(
 		is.selectEnd = 0
 	}
 	is.CursorPos = newPos
+	// Any caret motion breaks the current undo run, so edits after
+	// navigation form their own undo step (issue #328).
+	is.lastEditOp = inputOpNone
 	imap.Set(focusID, is)
 }
 

--- a/gui/input_state_test.go
+++ b/gui/input_state_test.go
@@ -296,6 +296,239 @@ func TestUndoRedoBasic(t *testing.T) {
 	}
 }
 
+// --- Undo coalescing (issue #328) ---
+
+// typeTypedRun types each rune of typed as its own one-rune insert
+// into an empty field and returns the accumulated text.
+func typeTypedRun(t *testing.T, typed string, id string, w *Window) string {
+	t.Helper()
+	text := ""
+	for _, ch := range typed {
+		text = inputInsert(text, string(ch), id, w)
+	}
+	return text
+}
+
+// Consecutive single-rune inserts must coalesce: typing "hello" then
+// one Ctrl+Z restores "".
+func TestUndoCoalescesTypingRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30001"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := typeTypedRun(t, "hello", id, w)
+	if got := inputUndo(text, id, w); got != "" {
+		t.Fatalf("one undo: got %q, want empty", got)
+	}
+}
+
+// Caret motion breaks the run: typing "x" after moving the caret is
+// its own undo step, and undoing twice restores "".
+func TestUndoBreaksRunOnCaretMotion(t *testing.T) {
+	w := newTestWindow()
+	id := "f30002"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := typeTypedRun(t, "hello", id, w)
+	imap := StateMap[string, inputState](w, nsInput, capMany)
+	updateCursorAndSelection(imap, id, inputStateOrDefault(id, w), 1, false)
+	text = inputInsert(text, "x", id, w)
+	undo1 := inputUndo(text, id, w)
+	if undo1 != "hello" {
+		t.Fatalf("undo 1: got %q, want %q", undo1, "hello")
+	}
+	undo2 := inputUndo(undo1, id, w)
+	if undo2 != "" {
+		t.Fatalf("undo 2: got %q, want empty", undo2)
+	}
+}
+
+// A selection-replacing edit pushes its own anchor: select all, type
+// "x", one Ctrl+Z restores "hello" in full.
+func TestUndoSelectionReplaceIsOneStep(t *testing.T) {
+	w := newTestWindow()
+	id := "f30003"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := typeTypedRun(t, "hello", id, w)
+	inputSelectAll(text, id, w)
+	text = inputInsert(text, "x", id, w)
+	if text != "x" {
+		t.Fatalf("replace: got %q, want %q", text, "x")
+	}
+	if got := inputUndo(text, id, w); got != "hello" {
+		t.Fatalf("undo: got %q, want %q", got, "hello")
+	}
+}
+
+// Masked typing coalesces like plain typing: three digits into a
+// phone mask, one Ctrl+Z restores the empty field (issue #328).
+func TestUndoCoalescesMaskedTypingRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30008"
+	setInputState(w, id, inputState{CursorPos: 0})
+	compiled, err := compileInputMask(inputMaskFromPreset(MaskPhoneUS), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hcfg := inputHandlerCfg{CompiledMask: &compiled}
+	text := ""
+	for _, ch := range "555" {
+		text, _ = inputTextChange(hcfg, nil, text, string(ch), id, w)
+	}
+	if got := inputUndo(text, id, w); got != "" {
+		t.Fatalf("one undo: got %q, want empty", got)
+	}
+}
+
+// Masked deletes coalesce too: two masked backspaces undo as one step
+// back to the pre-delete text (issue #328).
+func TestUndoCoalescesMaskedDeleteRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30009"
+	setInputState(w, id, inputState{CursorPos: 0})
+	compiled, err := compileInputMask(inputMaskFromPreset(MaskPhoneUS), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hcfg := inputHandlerCfg{CompiledMask: &compiled}
+	text := ""
+	for _, ch := range "555" {
+		text, _ = inputTextChange(hcfg, nil, text, string(ch), id, w)
+	}
+	pre := text
+	text, _ = inputHandleDelete(text, id, false, &compiled, nil, w)
+	text, _ = inputHandleDelete(text, id, false, &compiled, nil, w)
+	if text == pre {
+		t.Fatal("masked deletes changed nothing")
+	}
+	if got := inputUndo(text, id, w); got != pre {
+		t.Fatalf("one undo: got %q, want %q", got, pre)
+	}
+}
+
+// A multi-rune IME commit through the masked path breaks the run:
+// committing "55" then typing "5" takes two Ctrl+Z steps (issue
+// #328).
+func TestUndoIMEBreaksMaskedRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30010"
+	setInputState(w, id, inputState{CursorPos: 0})
+	compiled, err := compileInputMask(inputMaskFromPreset(MaskPhoneUS), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hcfg := inputHandlerCfg{CompiledMask: &compiled}
+	text, _ := inputTextChange(hcfg, nil, "", "55", id, w)
+	text, _ = inputTextChange(hcfg, nil, text, "5", id, w)
+	undo1 := inputUndo(text, id, w)
+	if undo1 == "" {
+		t.Fatal("undo 1 must restore pre-IME text, not the whole run")
+	}
+	if got := inputUndo(undo1, id, w); got != "" {
+		t.Fatalf("undo 2: got %q, want empty", got)
+	}
+}
+
+// A programmatic text set breaks the run: typing after a
+// PreTextChange-adjusted set undoes back to the set text, not to the
+// pre-run state (issue #328).
+func TestUndoProgrammaticSetBreaksRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30011"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := typeTypedRun(t, "hello", id, w)
+	inputSetTextAndCursorAtEnd(text, "HELLO", id, w)
+	text = inputInsert("HELLO", "!", id, w)
+	undo1 := inputUndo(text, id, w)
+	if undo1 != "HELLO" {
+		t.Fatalf("undo 1: got %q, want %q", undo1, "HELLO")
+	}
+	undo2 := inputUndo(undo1, id, w)
+	if undo2 != "hello" {
+		t.Fatalf("undo 2: got %q, want %q", undo2, "hello")
+	}
+}
+
+// A multi-rune insert (paste) breaks the run: pasting "abc" then
+// typing "d" takes two Ctrl+Z steps to get back to "".
+func TestUndoPasteBreaksRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30004"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := inputInsert("", "abc", id, w)
+	text = inputInsert(text, "d", id, w)
+	undo1 := inputUndo(text, id, w)
+	if undo1 != "abc" {
+		t.Fatalf("undo 1: got %q, want %q", undo1, "abc")
+	}
+	undo2 := inputUndo(undo1, id, w)
+	if undo2 != "" {
+		t.Fatalf("undo 2: got %q, want empty", undo2)
+	}
+}
+
+// A delete after an insert run is a different edit kind and starts
+// its own step: type "ab", backspace, undo restores "ab" then "".
+func TestUndoDeleteBreaksInsertRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30005"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := typeTypedRun(t, "ab", id, w)
+	text, _ = inputDelete(text, id, false, w)
+	if text != "a" {
+		t.Fatalf("delete: got %q, want %q", text, "a")
+	}
+	undo1 := inputUndo(text, id, w)
+	if undo1 != "ab" {
+		t.Fatalf("undo 1: got %q, want %q", undo1, "ab")
+	}
+	undo2 := inputUndo(undo1, id, w)
+	if undo2 != "" {
+		t.Fatalf("undo 2: got %q, want empty", undo2)
+	}
+}
+
+// Consecutive deletes coalesce too: three backspaces undo as one.
+func TestUndoCoalescesDeleteRun(t *testing.T) {
+	w := newTestWindow()
+	id := "f30006"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := typeTypedRun(t, "abcdef", id, w)
+	text, _ = inputDelete(text, id, false, w)
+	text, _ = inputDelete(text, id, false, w)
+	text, _ = inputDelete(text, id, false, w)
+	if text != "abc" {
+		t.Fatalf("delete: got %q, want %q", text, "abc")
+	}
+	undo1 := inputUndo(text, id, w)
+	if undo1 != "abcdef" {
+		t.Fatalf("undo: got %q, want %q", undo1, "abcdef")
+	}
+}
+
+// A 60-character run is one undo entry, so previously pushed history
+// survives instead of being evicted by the 50-entry cap.
+func TestUndoLongRunDoesNotEvictHistory(t *testing.T) {
+	w := newTestWindow()
+	id := "f30007"
+	setInputState(w, id, inputState{CursorPos: 0})
+	text := inputInsert("", "seed", id, w)
+	text = inputInsert(text, "seed2", id, w)
+	for range 60 {
+		text = inputInsert(text, "x", id, w)
+	}
+	undo1 := inputUndo(text, id, w)
+	if undo1 != "seedseed2" {
+		t.Fatalf("undo 1: got %q, want %q", undo1, "seedseed2")
+	}
+	undo2 := inputUndo(undo1, id, w)
+	if undo2 != "seed" {
+		t.Fatalf("undo 2: got %q, want %q", undo2, "seed")
+	}
+	undo3 := inputUndo(undo2, id, w)
+	if undo3 != "" {
+		t.Fatalf("undo 3: got %q, want empty", undo3)
+	}
+}
+
 // --- Select all ---
 
 func TestSelectAll(t *testing.T) {

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -11,10 +11,25 @@ func inputTextChange(hcfg inputHandlerCfg, layout *Layout, text, ins string, id 
 		is := inputStateOrDefault(id, w)
 		res := inputMaskInsert(text, is.CursorPos, is.selectBeg, is.selectEnd, ins, mask)
 		if res.Changed {
-			undo := inputPushUndo(is, text)
+			// IME commits are multi-rune; they break the run the way
+			// inputInsert does for a paste. Only the ">1 rune"
+			// question matters, and ins is caller-sized input that
+			// inputMaskInsert bounds, so count with an early exit.
+			n := 0
+			for range ins {
+				n++
+				if n > 1 {
+					break
+				}
+			}
+			op := inputOpInsert
+			if n > 1 {
+				op = inputOpNone
+			}
+			undo := inputPushUndo(is, text, op)
 			text = res.Text
 			StateMap[string, inputState](w, nsInput, capMany).Set(id, inputState{
-				CursorPos: res.CursorPos, Undo: undo,
+				CursorPos: res.CursorPos, Undo: undo, lastEditOp: op,
 			})
 			return text, true
 		}

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -215,7 +215,8 @@ func inputKeyPaste(
 			cis.selectBeg,
 			cis.selectEnd, clip, mask)
 		if res.Changed {
-			undo := inputPushUndo(cis, text)
+			// A paste is never part of a typing run.
+			undo := inputPushUndo(cis, text, inputOpNone)
 			StateMap[string, inputState](
 				w, nsInput, capMany,
 			).Set(id, inputState{
@@ -282,11 +283,11 @@ func inputHandleDelete(
 		if !res.Changed {
 			return text, false
 		}
-		undo := inputPushUndo(is, text)
+		undo := inputPushUndo(is, text, inputOpDelete)
 		StateMap[string, inputState](
 			w, nsInput, capMany,
 		).Set(id, inputState{
-			CursorPos: res.CursorPos, Undo: undo,
+			CursorPos: res.CursorPos, Undo: undo, lastEditOp: inputOpDelete,
 		})
 		return res.Text, true
 	}

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -137,12 +137,13 @@ func inputDeleteGrapheme(
 		return text, false
 	}
 	newPos := byteToRuneIndex(res.NewText, res.CursorPos)
-	undo := inputPushUndo(is, text)
+	undo := inputPushUndo(is, text, inputOpDelete)
 	imap := StateMap[string, inputState](w, nsInput, capMany)
 	imap.Set(focusID, inputState{
 		CursorPos:    newPos,
 		cursorOffset: -1,
 		Undo:         undo,
+		lastEditOp:   inputOpDelete,
 	})
 	return res.NewText, true
 }
@@ -220,6 +221,9 @@ func (d *inputDragState) updateSelection(rp int, w *Window) {
 		is.selectEnd = uint32(rp)
 	}
 	is.cursorOffset = -1
+	// Drag selection is caret motion: break any undo run so a
+	// subsequent edit starts a fresh undo step (issue #328).
+	is.lastEditOp = inputOpNone
 	imap.Set(d.focusID, is)
 	resetBlinkCursorVisible(w)
 }

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -444,6 +444,34 @@ func TestInputOnCharRedo(t *testing.T) {
 	}
 }
 
+// Typing one character at a time through the real OnChar pipeline
+// must coalesce into a single undo step: one Ctrl+Z restores "", and
+// one redo restores the whole run (issue #328).
+func TestInputUndoCoalescesTypingRun(t *testing.T) {
+	ctx := newInputTest("", "f508", 0)
+	for _, ch := range "hello" {
+		ctx.fireChar(uint32(ch))
+		ctx.layout = generateViewLayout(Input(InputCfg{
+			Text: ctx.lastText,
+			ID:   "f508",
+			OnTextChanged: func(newText string, _ EventCtx) {
+				ctx.lastText = newText
+			},
+		}), ctx.w)
+	}
+	if ctx.lastText != "hello" {
+		t.Fatalf("typing: got %q, want %q", ctx.lastText, "hello")
+	}
+	ctx.fireKeyDown(KeyZ, ModCtrl)
+	if ctx.lastText != "" {
+		t.Fatalf("undo: got %q, want empty", ctx.lastText)
+	}
+	ctx.fireKeyDown(KeyZ, ModCtrl|ModShift)
+	if ctx.lastText != "hello" {
+		t.Fatalf("redo: got %q, want %q", ctx.lastText, "hello")
+	}
+}
+
 func TestInputSelectAll(t *testing.T) {
 	ctx := newInputTest("abc", "f508", 1)
 	ctx.fireKeyDown(KeyA, ModCtrl)


### PR DESCRIPTION
Fixes #328.

Every keystroke pushed its own undo memento, so typing 50 characters evicted
the entire prior history and Ctrl+Z walked back one character at a time.
Consecutive edits of the same kind now coalesce into one undo step whose
anchor is the state before the run began.

- `inputState` gains `lastEditOp`; `inputPushUndo` pushes only when the edit
  kind differs, a selection is active, or the op is a forced break.
- Run breaks: caret motion/click, drag selection, paste and any multi-rune
  insert (IME commits included), programmatic text sets, and edit-kind
  changes (typing after backspace, backspace after typing).
- 11 new tests: unit-level run coalescing/breaks/eviction survival plus an
  end-to-end test through the real OnChar pipeline; masked-input and IME
  paths covered.