### PR TITLE
Headless software rendering: CPU rasterizer + RenderToPNG (issue #333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to
 
 ### Added
 
+- **Headless frame rendering: a software rasterizer and `RenderToPNG`** (issue
+  #333). go-gui could not produce a pixel image of a frame without a GPU and a
+  window, which ruled out CI screenshots and pixel-level regression tests.
+  - New package `gui/backend/soft`: `RenderToImage(w, scale)`,
+    `RenderToPNG(w, scale, path)` and `Release(w)`. It replays the same flat
+    `[]RenderCmd` stream the GPU backends and the PDF printer consume, so no
+    existing backend changes and none consults it. `scale` is the device pixel
+    ratio; a window that has not rendered yet has its `OnInit` run first, so the
+    same window value passed to `backend.Run` can be passed here instead.
+  - Text is real, not approximated. The package implements `glyph.DrawBackend`
+    over a CPU framebuffer and installs the resulting `glyph.TextSystem` as the
+    window's `gui.TextMeasurer`, so shaping, metrics and glyph rasterization are
+    the code the GPU backends already run — go-glyph is pure Go.
+  - `(*Window).SetHeadlessRender` / `HeadlessRender` mark a window as rendering
+    headlessly, suppressing wall-clock-driven visuals (today the blinking caret)
+    so repeated captures of one window state produce the same pixels.
+  - Phase 1 covers clip, rect, stroke rect, circle, line, gradient, gradient
+    border, image and every text kind. SVG, shadow, blur, filter, stencil,
+    rotation and terminal-grid commands are accepted and skipped; custom shaders
+    stay unsupported by design. See `docs/specs/headless-software-rendering.md`
+    and `examples/headless_png/`.
+
 - **`VirtualList` — virtualized lists whose rows may differ in height, and
   index-addressed scrolling** (issue #332). Virtualization was arithmetic over
   one scalar row height, which is exact for a widget that owns its row shape and

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ sharing the same rendering pipeline and event system.
   frame-by-frame; implement `Snapshotter` on your state type and set
   `DebugTimeTravel: true`
 - **Headless testing** — all layout and widget logic runs without a display
+- **Headless rendering** — `gui/backend/soft` rasterizes a frame to a PNG on the
+  CPU, with real text metrics and no GPU, for CI screenshots and pixel-level
+  regression tests
 - **Cross-platform integration** — native file dialogs, menus, notifications,
   print/PDF, system tray, IME, a11y, spell check
 - **go-glyph powered** — professional text shaping, rendering, bidirectional

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -22,6 +22,7 @@ Go toolchain pin: `go 1.26.0`.
 | `github.com/tdewolff/parse/v2` | v2.8.16 | CSS tokenizer for the SVG `<style>` / `style=""` cascade pipeline. |
 | `github.com/yuin/goldmark` | v1.8.5 | Markdown parser (markdown widget + showcase docs). |
 | `github.com/yuin/goldmark-emoji` | v1.0.6 | Goldmark extension: `:emoji:` shortcodes. |
+| `golang.org/x/image` | v0.45.0 | Antialiased vector rasterization for the headless software renderer (`gui/backend/soft`). Also pulled in by go-glyph. |
 | `golang.org/x/mod` | v0.40.0 | Module version parsing; imported by `requiredid` analyzer. |
 | `golang.org/x/sys` | v0.47.0 | Win32 + WGL syscalls for the native Windows backend (`gui/backend/gl`, `winkey`). |
 | `golang.org/x/tools` | v0.49.0 | `go/analysis` framework for the `requiredid` analyzer (`tools/`). |
@@ -42,7 +43,6 @@ Pulled in transitively; listed for completeness.
 | `github.com/mewkiz/flac` | v1.0.12 | gopxl/beep (FLAC decode) |
 | `github.com/mewkiz/pkg` | v0.0.0-20230226050401-4010bf0fec14 | mewkiz/flac (FLAC decode) |
 | `github.com/pkg/errors` | v0.9.1 | gopxl/beep (audio) |
-| `golang.org/x/image` | v0.45.0 | go-glyph (pure-Go rasterization) |
 | `golang.org/x/mobile` | v0.0.0-20260602190626-68735029466e | gobind tool (Android AAR builds) |
 | `golang.org/x/sync` | v0.22.0 | x/tools |
 | `golang.org/x/text` | v0.41.0 | misc. text processing (transitive) |

--- a/docs/specs/headless-software-rendering.md
+++ b/docs/specs/headless-software-rendering.md
@@ -1,0 +1,147 @@
+# Headless software rendering
+
+Issue #333. Status: phase 1 landed.
+
+## Problem
+
+go-gui could not produce a pixel image of a frame without a GPU and a window.
+Every backend under `gui/backend/` is GPU-backed or native, so there was no way
+to take a screenshot in CI, no way to write a pixel-level regression test, and
+no starting point for a software backend.
+
+## Approach
+
+The render pipeline already terminates in a flat `[]gui.RenderCmd`, and
+`gui/print_pdf.go` already proves that stream replays outside a backend. The
+software rasterizer is a third consumer of the same input, not a pipeline
+change: no existing backend is touched and none consults it.
+
+Two findings shaped the design.
+
+**go-glyph is pure Go.** It shapes and rasterizes through `go-text/typesetting`
+with no `import "C"`, so text works on CPU.
+
+**`glyph.DrawBackend` is a six-method interface.** Implementing it over a CPU
+framebuffer (`gui/backend/soft/glyph_backend.go`) yields every text render kind
+— `RenderText`, `RenderLayout`, `RenderLayoutTransformed`, `RenderRTF`,
+`RenderTextPath`, text gradients — from the same `glyph.TextSystem` the GPU
+backends drive, and supplies a real `gui.TextMeasurer` as a side effect. This
+removes the issue's stated obstacle: headless frames are measured with true font
+metrics, not the approximate extents a nil measurer falls back to.
+
+## Placement
+
+The package is `gui/backend/soft`, not package `gui` as the issue proposed.
+`gui/svg` imports `gui`, so a rasterizer inside `gui` could never call
+`SetSvgParser` and every SVG would render blank. A subpackage has everything it
+needs: the `Render*` constants are exported (only the `renderKind` type is not),
+`RenderCmd`'s fields are exported, and the one unexported payload — `textPath` —
+is reachable through `gui.ComputeTextPathPlacements`. `gui/backend/gl` is the
+existence proof.
+
+## API
+
+```go
+func RenderToImage(w *gui.Window, scale float32) (*image.RGBA, error)
+func RenderToPNG(w *gui.Window, scale float32, path string) error
+func Release(w *gui.Window)
+```
+
+`scale` is the device pixel ratio; `scale <= 0` means 1. A window that has not
+rendered yet has its `WindowCfg.OnInit` run first, as a backend would, so the
+same window value passed to `backend.Run` can be passed here instead.
+
+Preparation is idempotent and keeps the warm glyph atlas, so driving state
+between captures — `TestClick`, `SetFocus`, render again — costs only the frame.
+`Release` frees the text system for callers that render many windows in one
+process.
+
+## How a frame is rendered
+
+1. Prepare: build a `glyph.TextSystem` over the software draw backend, register
+   the bundled icon font and `gui.AppFontPaths` / `AppFontData`, install it as
+   the window's `gui.TextMeasurer`, and install `svg.New()` as the SVG parser.
+2. `w.BackingScale = scale` — read during layout by `text_optical.go` and
+   `text_ink.go`, so it must be set before the frame, not only used by the
+   blitter.
+3. `w.SetHeadlessRender(true)`, then `w.TestRender(nil)` to settle one frame,
+   then `w.Renderers()` for the command stream.
+4. Replay the stream twice (below), then hand back the buffer as an
+   `*image.RGBA`. The buffer is premultiplied, which is what `image.RGBA` is, so
+   the PNG boundary is zero-copy.
+
+### Why the stream is replayed twice
+
+go-glyph rasterizes a glyph into a staging buffer when it is first drawn but
+only hands the page to the backend at `Commit`. On screen the next frame
+corrects the sampling; a one-shot capture has no next frame. The first pass
+therefore draws the text kinds with a nil target — shaping and rasterization
+run, the quads are discarded — and `Commit` uploads the atlas. Shapes,
+gradients and images are skipped on the warm pass and drawn once, for real,
+in the second.
+
+### Rasterization
+
+Everything reduces to one operation: composite a source through a coverage mask,
+restricted to the clip rect. The mask comes from `golang.org/x/image/vector`,
+which antialiases every edge; the source is a solid color (`image.Uniform`), a
+gradient sampler, or a scaled image sampler. Two consequences worth naming:
+
+- A stroke rect is one path, not two draws: the outer rounded rect plus the
+  inner one wound backwards, which the rasterizer's signed accumulation turns
+  into a hole.
+- Clipping is free. The mask is allocated at the intersection of the shape's
+  bounding box and the clip rect, so geometry outside it is never rasterized.
+  `RenderClip` replaces the clip rather than nesting it, matching the scissor
+  semantics the GPU backends and `gui/print_pdf.go` implement; a degenerate rect
+  restores the full buffer.
+
+Gradients are **not** resampled to five stops. That cap is a shader uniform
+budget; a CPU sampler has none, so the full stop list is honoured — the same
+choice the web backend's canvas gradients make.
+
+## Reproducibility
+
+`(*Window).SetHeadlessRender` is window-scoped, not a process global: theme,
+focus and state are all window-owned here and this belongs with them. It
+suppresses visuals whose appearance depends on wall-clock time — today the
+blinking caret, gated in `inputCursorOn`. The caret was already off headlessly
+(no animation goroutine drives the blink atomic), so the flag turns an accident
+of timing into a guarantee, and gives any later wall-clock visual one place to
+consult. It is deliberately not a general "no animation" switch.
+
+go-shirei's `ResetInputSession` has no counterpart here: go-gui's leak surface —
+focus, hover, mouse position — is per-`Window`, so two captures share state only
+when the caller reuses the window, which is the point of `RenderToImage` taking
+one.
+
+## Phase split
+
+Phase 1 (landed) covers `RenderClip`, `RenderRect`, `RenderStrokeRect`,
+`RenderCircle`, `RenderLine`, `RenderGradient`, `RenderGradientBorder`,
+`RenderImage`, and every text kind.
+
+Deferred to phase 2 (issue #360): `RenderSvg` (barycentric triangle
+rasterization over `Triangles`/`VertexColors`, honouring `HasXform`, `RotAngle`,
+`VertexAlphaScale`), `RenderShadow` and `RenderBlur` (separable box-blur
+passes), `RenderFilterBegin/End/Composite` (offscreen buffer plus
+`ColorMatrix`), `RenderStencilBegin/End`, `RenderRotateBegin/End`, and
+`RenderTermGrid`. `RenderCustomShader` stays unsupported by design — it is GLSL.
+
+The deferred kinds are listed in one explicit `case` in
+`gui/backend/soft/draw.go` rather than caught by a `default`, so a newly added
+render kind is a compile-visible decision. This follows the precedent in
+`gui/print_pdf.go`.
+
+## Not in this phase
+
+Pixel golden images (issue #361). Platform font variance and antialiasing
+stability make them a separate decision from the renderer itself; the tests here
+assert pixel values from constructed command streams instead, which is
+platform-independent.
+
+## Attribution
+
+The design of go-shirei's headless renderer (zlib, © 2025 Judi Systems) was
+cited as prior art for the `HeadlessRender` and `HeadlessScale` ideas. No code
+was copied.

--- a/examples/headless_png/README.md
+++ b/examples/headless_png/README.md
@@ -1,0 +1,21 @@
+# headless_png
+
+Renders a window to a PNG with no GPU and no window on screen, using the
+software rasterizer in `gui/backend/soft`.
+
+```
+go run ./examples/headless_png/            # writes headless.png
+go run ./examples/headless_png/ shot.png   # writes shot.png
+```
+
+The window is built exactly as it would be for `backend.Run` — same
+`gui.SimpleWindow`, same view function. `soft.RenderToPNG` runs `OnInit`,
+settles one frame and rasterizes it on the CPU, so the only difference from a
+real run is the last step.
+
+The `2` in `soft.RenderToPNG(w, 2, out)` is the device pixel ratio: `1` gives
+one device pixel per logical pixel, `2` captures at Retina density.
+
+Useful for CI screenshots and pixel-level regression tests. See
+`docs/specs/headless-software-rendering.md` for what the renderer covers; SVG,
+shadow, blur and filter commands are skipped in this phase.

--- a/examples/headless_png/main.go
+++ b/examples/headless_png/main.go
@@ -1,0 +1,53 @@
+// This example renders a window to a PNG with no GPU and no window on
+// screen, using the software rasterizer in gui/backend/soft.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/soft"
+)
+
+type App struct {
+	Clicks int
+}
+
+func main() {
+	out := "headless.png"
+	if len(os.Args) > 1 {
+		out = os.Args[1]
+	}
+
+	// A window built exactly as it would be for backend.Run — the
+	// software renderer runs OnInit itself, as a backend does.
+	w := gui.SimpleWindow("Headless", 320, 200, &App{Clicks: 3},
+		func(w *gui.Window) {
+			w.UpdateView(mainView)
+		})
+
+	// Scale 2 captures at Retina density; 1 is one device pixel per
+	// logical pixel.
+	if err := soft.RenderToPNG(w, 2, out); err != nil {
+		log.Fatalf("render: %v", err)
+	}
+	fmt.Printf("wrote %s\n", out)
+}
+
+func mainView(w *gui.Window) gui.View {
+	app := gui.State[App](w)
+
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		HAlign:  gui.HAlignCenter,
+		VAlign:  gui.VAlignMiddle,
+		Spacing: gui.SomeF(12),
+		Content: []gui.View{
+			gui.Label("Rendered without a GPU", gui.CurrentTheme().B1),
+			gui.TextButton("hp_counter",
+				fmt.Sprintf("%d Clicks", app.Clicks), nil),
+		},
+	})
+}

--- a/examples/headless_png/main_test.go
+++ b/examples/headless_png/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/soft"
+)
+
+func TestRendersToPNG(t *testing.T) {
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  &App{Clicks: 3},
+		Width:  320,
+		Height: 200,
+		OnInit: func(win *gui.Window) { win.UpdateView(mainView) },
+	})
+	t.Cleanup(func() { soft.Release(w) })
+
+	path := filepath.Join(t.TempDir(), "shot.png")
+	if err := soft.RenderToPNG(w, 2, path); err != nil {
+		t.Fatalf("RenderToPNG: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Fatal("empty PNG")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/tdewolff/parse/v2 v2.8.16
 	github.com/yuin/goldmark v1.8.5
 	github.com/yuin/goldmark-emoji v1.0.6
+	golang.org/x/image v0.45.0
 	golang.org/x/mod v0.40.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/tools v0.49.0
@@ -31,7 +32,6 @@ require (
 	github.com/mewkiz/flac v1.0.12 // indirect
 	github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/image v0.45.0 // indirect
 	golang.org/x/mobile v0.0.0-20260602190626-68735029466e // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/gui/backend/soft/doc.go
+++ b/gui/backend/soft/doc.go
@@ -1,0 +1,24 @@
+// Package soft renders a go-gui frame to an image on the CPU: no GPU, no
+// window, no event loop.
+//
+// It is a third consumer of the same flat []gui.RenderCmd stream the GPU
+// backends and the PDF printer replay, so it is purely additive — no other
+// backend changes and none of them consult it.
+//
+// Typical use is a screenshot or a pixel-level regression test:
+//
+//	w := gui.SimpleWindow("Demo", 400, 300, &App{}, func(w *gui.Window) {
+//		w.UpdateView(mainView)
+//	})
+//	err := soft.RenderToPNG(w, 2, "demo.png")
+//
+// Text is real, not approximated: the package builds a go-glyph TextSystem
+// over a software glyph.DrawBackend and installs it as the window's
+// gui.TextMeasurer, so shaping, metrics and glyph rasterization are the
+// same code the GPU backends run.
+//
+// Phase 1 covers the core command kinds — clip, rect, stroke rect, circle,
+// line, gradient, gradient border, image, and every text kind. SVG,
+// shadow, blur, filter and stencil commands are accepted and skipped; see
+// docs/specs/headless-software-rendering.md for the phase split.
+package soft

--- a/gui/backend/soft/draw.go
+++ b/gui/backend/soft/draw.go
@@ -1,0 +1,98 @@
+package soft
+
+import (
+	"image"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// renderer replays a []gui.RenderCmd stream into a buffer. It is the CPU
+// analogue of gui/backend/gl's Backend.renderersDraw: same dispatch, same
+// per-command scaling by the device pixel ratio.
+type renderer struct {
+	buf   *buffer
+	scale float32
+
+	textSys   *glyph.TextSystem
+	glyphBack *glyphBackend
+
+	// images caches decoded sources by the RenderCmd.Resource string.
+	images map[string]*image.NRGBA
+
+	allowedImageRoots []string
+	maxImageBytes     int64
+	maxImagePixels    int64
+
+	// warm marks the atlas-warming pass: only the text kinds run, so
+	// shapes, gradients and images rasterize exactly once.
+	warm bool
+
+	// Scratch buffers reused across commands.
+	placements []glyph.GlyphPlacement
+	normStops  []gui.GradientStop
+}
+
+// drawAll replays every command in cmds. With warm set it draws only the
+// text kinds: that pass exists to rasterize glyphs into the atlas, and its
+// quads are discarded against a nil glyph target.
+func (r *renderer) drawAll(cmds []gui.RenderCmd) {
+	for i := range cmds {
+		cmd := &cmds[i]
+		if r.warm {
+			switch cmd.Kind {
+			case gui.RenderText, gui.RenderLayout, gui.RenderRTF,
+				gui.RenderLayoutTransformed, gui.RenderTextPath:
+			default:
+				continue
+			}
+		}
+		switch cmd.Kind {
+		case gui.RenderClip:
+			r.buf.setClip(cmd.X*r.scale, cmd.Y*r.scale,
+				cmd.W*r.scale, cmd.H*r.scale)
+		case gui.RenderRect:
+			r.drawRect(cmd)
+		case gui.RenderStrokeRect:
+			r.drawStrokeRect(cmd)
+		case gui.RenderCircle:
+			r.drawCircle(cmd)
+		case gui.RenderLine:
+			r.drawLine(cmd)
+		case gui.RenderGradient:
+			r.drawGradient(cmd)
+		case gui.RenderGradientBorder:
+			r.drawGradientBorder(cmd)
+		case gui.RenderImage:
+			r.drawImage(cmd)
+		case gui.RenderText:
+			r.drawText(cmd)
+		case gui.RenderLayout, gui.RenderRTF:
+			r.drawLayout(cmd)
+		case gui.RenderLayoutTransformed:
+			r.drawLayoutTransformed(cmd)
+		case gui.RenderTextPath:
+			r.drawTextPath(cmd)
+
+		// Phase 2 (see docs/specs/headless-software-rendering.md).
+		// Listed explicitly rather than caught by a default so a new
+		// render kind is a compile-visible decision, following the
+		// precedent in gui/print_pdf.go.
+		case gui.RenderNone,
+			gui.RenderSvg,
+			gui.RenderShadow,
+			gui.RenderBlur,
+			gui.RenderFilterBegin,
+			gui.RenderFilterEnd,
+			gui.RenderFilterComposite,
+			gui.RenderStencilBegin,
+			gui.RenderStencilEnd,
+			gui.RenderRotateBegin,
+			gui.RenderRotateEnd,
+			gui.RenderCustomShader,
+			gui.RenderTermGrid,
+			gui.RenderLayoutPlaced:
+		}
+	}
+}

--- a/gui/backend/soft/draw_gradient.go
+++ b/gui/backend/soft/draw_gradient.go
@@ -1,0 +1,115 @@
+package soft
+
+import (
+	"image"
+	"image/color"
+	"math"
+
+	"golang.org/x/image/vector"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// gradientSrc samples a gui.GradientDef at absolute device coordinates.
+// It reproduces the GPU gradient shader's parameterisation: the quad is
+// mapped to uv in [-1,1], a linear gradient projects uv onto the
+// direction vector, a radial one measures distance from the centre
+// against the larger half-extent.
+type gradientSrc struct {
+	stops  []gui.GradientStop
+	cx, cy float32 // centre, device px
+	hw, hh float32 // half extents, device px
+	dx, dy float32 // linear direction
+	radius float32 // radial target radius
+	radial bool
+	// nr is the scratch color each At returns: vector.Draw consumes
+	// the sample immediately, so one instance can be re-pointed.
+	nr color.NRGBA
+}
+
+func (g *gradientSrc) ColorModel() color.Model { return color.NRGBAModel }
+
+// Bounds covers the whole plane: the rasterizer clips to the draw region
+// and never consults the source's bounds.
+func (g *gradientSrc) Bounds() image.Rectangle {
+	const big = 1 << 29
+	return image.Rect(-big, -big, big, big)
+}
+
+func (g *gradientSrc) At(x, y int) color.Color {
+	// Sample at the pixel centre.
+	u := (float32(x) + 0.5 - g.cx) / g.hw
+	v := (float32(y) + 0.5 - g.cy) / g.hh
+	var t float32
+	if g.radial {
+		px, py := u*g.hw, v*g.hh
+		t = float32(math.Hypot(float64(px), float64(py))) / g.radius
+	} else {
+		t = (u*g.dx+v*g.dy)*0.5 + 0.5
+	}
+	c := gui.SampleGradientStopColor(g.stops, min(max(t, 0), 1))
+	g.nr = color.NRGBA{R: c.R, G: c.G, B: c.B, A: c.A}
+	return &g.nr
+}
+
+// drawGradient fills a (possibly rounded) rect with a gradient.
+//
+// Unlike the GPU path it does not resample to five stops: a CPU sampler
+// has no uniform budget, so the full stop list is honoured — the same
+// choice the web backend's canvas gradients make.
+func (r *renderer) drawGradient(cmd *gui.RenderCmd) {
+	if cmd.Gradient == nil || cmd.W <= 0 || cmd.H <= 0 {
+		return
+	}
+	stops := gui.NormalizeGradientStops(cmd.Gradient.Stops, &r.normStops)
+	if len(stops) == 0 {
+		return
+	}
+	s := r.scale
+	x, y, w, h := cmd.X*s, cmd.Y*s, cmd.W*s, cmd.H*s
+	rad := cmd.Radius * s
+
+	src := &gradientSrc{
+		stops: stops,
+		cx:    x + w/2,
+		cy:    y + h/2,
+		hw:    w / 2,
+		hh:    h / 2,
+	}
+	if cmd.Gradient.Type == gui.GradientRadial {
+		src.radial = true
+		src.radius = max(src.hw, src.hh)
+	} else {
+		// GradientDir wants logical extents; direction is scale-free.
+		src.dx, src.dy = gui.GradientDir(cmd.Gradient, cmd.W, cmd.H)
+	}
+
+	region := r.buf.region(x, y, w, h)
+	r.buf.fillPath(region, src,
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathRoundRect(z, ox, oy, x, y, w, h, rad, false)
+		})
+}
+
+// drawGradientBorder paints the four edge strips, each a flat sample of
+// the gradient, exactly as the GPU backends do.
+func (r *renderer) drawGradientBorder(cmd *gui.RenderCmd) {
+	if cmd.Gradient == nil || len(cmd.Gradient.Stops) == 0 {
+		return
+	}
+	s := r.scale
+	rects := gui.GradientBorderRects(cmd)
+	for i := range rects {
+		rc := &rects[i]
+		if rc.W <= 0 || rc.H <= 0 || rc.Color.A == 0 {
+			continue
+		}
+		x, y := rc.X*s, rc.Y*s
+		w, h := rc.W*s, rc.H*s
+		region := r.buf.region(x, y, w, h)
+		r.buf.fillPath(region, r.buf.solid(rc.Color),
+			func(z *vector.Rasterizer, ox, oy float32) {
+				pathRect(z, ox, oy, x, y, w, h)
+			})
+	}
+}

--- a/gui/backend/soft/draw_image.go
+++ b/gui/backend/soft/draw_image.go
@@ -1,0 +1,166 @@
+package soft
+
+import (
+	"image"
+	"image/color"
+	"log"
+	"math"
+
+	"golang.org/x/image/vector"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
+)
+
+// imageSrc scales a decoded source into a destination rect, sampling
+// bilinearly in straight-alpha space at absolute device coordinates.
+//
+// nr is the scratch color each At returns: vector.Draw consumes the
+// sample immediately, so one instance can be re-pointed (the same
+// reasoning as buffer.solid's reusable image.Uniform).
+type imageSrc struct {
+	src            *image.NRGBA
+	dstX, dstY     float32
+	scaleX, scaleY float32 // source pixels per device pixel
+	srcW, srcH     int
+	stride         int
+	nr             color.NRGBA
+}
+
+func newImageSrc(src *image.NRGBA, x, y, w, h float32) *imageSrc {
+	b := src.Bounds()
+	sw, sh := b.Dx(), b.Dy()
+	return &imageSrc{
+		src:    src,
+		dstX:   x,
+		dstY:   y,
+		scaleX: float32(sw) / w,
+		scaleY: float32(sh) / h,
+		srcW:   sw,
+		srcH:   sh,
+		stride: src.Stride,
+	}
+}
+
+func (s *imageSrc) ColorModel() color.Model { return color.NRGBAModel }
+
+func (s *imageSrc) Bounds() image.Rectangle {
+	const big = 1 << 29
+	return image.Rect(-big, -big, big, big)
+}
+
+func (s *imageSrc) At(x, y int) color.Color {
+	// Pixel centre → continuous source coordinate → texel centre.
+	fx := (float32(x)+0.5-s.dstX)*s.scaleX - 0.5
+	fy := (float32(y)+0.5-s.dstY)*s.scaleY - 0.5
+	x0 := int(math.Floor(float64(fx)))
+	y0 := int(math.Floor(float64(fy)))
+	tx := fx - float32(x0)
+	ty := fy - float32(y0)
+
+	c00 := s.texel(x0, y0)
+	c10 := s.texel(x0+1, y0)
+	c01 := s.texel(x0, y0+1)
+	c11 := s.texel(x0+1, y0+1)
+
+	lerp := func(a, b uint8, t float32) float32 {
+		return float32(a) + (float32(b)-float32(a))*t
+	}
+	mix := func(i int) uint8 {
+		top := lerp(c00[i], c10[i], tx)
+		bot := lerp(c01[i], c11[i], tx)
+		return uint8(top + (bot-top)*ty + 0.5)
+	}
+	s.nr = color.NRGBA{R: mix(0), G: mix(1), B: mix(2), A: mix(3)}
+	return &s.nr
+}
+
+// texel reads one source pixel with edge clamping. x and y are offsets
+// into the source, so the index is plain row arithmetic — PixOffset
+// subtracts Rect.Min, which x and y already are.
+func (s *imageSrc) texel(x, y int) [4]uint8 {
+	x = min(max(x, 0), s.srcW-1)
+	y = min(max(y, 0), s.srcH-1)
+	i := y*s.stride + x*4
+	p := s.src.Pix
+	return [4]uint8{p[i], p[i+1], p[i+2], p[i+3]}
+}
+
+// drawImage paints the optional background fill, then the image itself,
+// rounded to ClipRadius.
+func (r *renderer) drawImage(cmd *gui.RenderCmd) {
+	if cmd.W <= 0 || cmd.H <= 0 {
+		return
+	}
+	s := r.scale
+	x, y, w, h := cmd.X*s, cmd.Y*s, cmd.W*s, cmd.H*s
+	region := r.buf.region(x, y, w, h)
+
+	if cmd.Color.A > 0 {
+		r.buf.fillPath(region, r.buf.solid(cmd.Color),
+			func(z *vector.Rasterizer, ox, oy float32) {
+				pathRect(z, ox, oy, x, y, w, h)
+			})
+	}
+
+	src, ok := r.resolveImage(cmd.Resource)
+	if !ok {
+		return
+	}
+	rad := cmd.ClipRadius * s
+	r.buf.fillPath(region, newImageSrc(src, x, y, w, h),
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathRoundRect(z, ox, oy, x, y, w, h, rad, false)
+		})
+}
+
+// resolveImage decodes and caches the source named by a RenderCmd's
+// Resource.
+//
+// A mem: source names a buffer in gui's in-memory registry: it has no
+// path, so it skips path resolution and the AllowedImageRoots sandbox,
+// exactly as the GPU backends do (see gui.LookupImage on why that is
+// safe).
+func (r *renderer) resolveImage(res string) (*image.NRGBA, bool) {
+	if img, ok := r.images[res]; ok {
+		return img, img != nil
+	}
+	img := r.decodeImage(res)
+	if r.images == nil {
+		r.images = make(map[string]*image.NRGBA)
+	}
+	// A failed decode is cached as nil so one bad path is logged once.
+	r.images[res] = img
+	return img, img != nil
+}
+
+func (r *renderer) decodeImage(res string) *image.NRGBA {
+	if iw, ih, pix, ok := gui.LookupImage(res); ok {
+		if iw <= 0 || ih <= 0 || len(pix) < iw*ih*4 {
+			return nil
+		}
+		return &image.NRGBA{
+			Pix:    pix,
+			Stride: iw * 4,
+			Rect:   image.Rect(0, 0, iw, ih),
+		}
+	}
+	path, err := imgload.ResolveValidatedPath(res, r.allowedImageRoots)
+	if err != nil {
+		log.Printf("soft: drawImage: %v", err)
+		return nil
+	}
+	f, err := imgload.OpenSafe(path, r.allowedImageRoots)
+	if err != nil {
+		log.Printf("soft: drawImage: %v", err)
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+	img, err := imgload.DecodeNRGBA(path, f,
+		r.maxImageBytes, r.maxImagePixels)
+	if err != nil {
+		log.Printf("soft: drawImage: %v", err)
+		return nil
+	}
+	return img
+}

--- a/gui/backend/soft/draw_shapes.go
+++ b/gui/backend/soft/draw_shapes.go
@@ -1,0 +1,106 @@
+package soft
+
+import (
+	"math"
+
+	"golang.org/x/image/vector"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// drawRect fills a (possibly rounded) rectangle.
+func (r *renderer) drawRect(cmd *gui.RenderCmd) {
+	if !cmd.Fill || cmd.Color.A == 0 {
+		return
+	}
+	s := r.scale
+	x, y, w, h := cmd.X*s, cmd.Y*s, cmd.W*s, cmd.H*s
+	rad := cmd.Radius * s
+	region := r.buf.region(x, y, w, h)
+	r.buf.fillPath(region, r.buf.solid(cmd.Color),
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathRoundRect(z, ox, oy, x, y, w, h, rad, false)
+		})
+}
+
+// drawStrokeRect paints a rectangular ring: the outer rounded rect with
+// the inner one wound backwards, so the rasterizer's signed coverage
+// cancels in the middle. A zero thickness means a fill, matching the GL
+// backend's SDF quad.
+func (r *renderer) drawStrokeRect(cmd *gui.RenderCmd) {
+	if cmd.Color.A == 0 {
+		return
+	}
+	s := r.scale
+	th := cmd.Thickness * s
+	x, y, w, h := cmd.X*s, cmd.Y*s, cmd.W*s, cmd.H*s
+	rad := cmd.Radius * s
+	if th <= 0 {
+		region := r.buf.region(x, y, w, h)
+		r.buf.fillPath(region, r.buf.solid(cmd.Color),
+			func(z *vector.Rasterizer, ox, oy float32) {
+				pathRoundRect(z, ox, oy, x, y, w, h, rad, false)
+			})
+		return
+	}
+	th = min(th, min(w, h)/2)
+	region := r.buf.region(x, y, w, h)
+	r.buf.fillPath(region, r.buf.solid(cmd.Color),
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathRoundRect(z, ox, oy, x, y, w, h, rad, false)
+			pathRoundRect(z, ox, oy, x+th, y+th,
+				w-2*th, h-2*th, rad-th, true)
+		})
+}
+
+// drawCircle fills a circle centred on (X, Y), as the GL backend does.
+func (r *renderer) drawCircle(cmd *gui.RenderCmd) {
+	if !cmd.Fill || cmd.Radius <= 0 || cmd.Color.A == 0 {
+		return
+	}
+	s := r.scale
+	rad := cmd.Radius * s
+	x, y := (cmd.X-cmd.Radius)*s, (cmd.Y-cmd.Radius)*s
+	d := 2 * rad
+	region := r.buf.region(x, y, d, d)
+	r.buf.fillPath(region, r.buf.solid(cmd.Color),
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathRoundRect(z, ox, oy, x, y, d, d, rad, false)
+		})
+}
+
+// drawLine paints a line as a quad expanded either side of the segment,
+// the same construction the GL backend uses.
+func (r *renderer) drawLine(cmd *gui.RenderCmd) {
+	if cmd.Color.A == 0 {
+		return
+	}
+	s := r.scale
+	x0, y0 := cmd.X*s, cmd.Y*s
+	x1, y1 := cmd.OffsetX*s, cmd.OffsetY*s
+	dx, dy := x1-x0, y1-y0
+	length := float32(math.Hypot(float64(dx), float64(dy)))
+	if length < 0.001 {
+		return
+	}
+	thick := max(cmd.Thickness*s, 1)
+	nx := -dy / length * thick * 0.5
+	ny := dx / length * thick * 0.5
+
+	pts := [4][2]float32{
+		{x0 + nx, y0 + ny},
+		{x1 + nx, y1 + ny},
+		{x1 - nx, y1 - ny},
+		{x0 - nx, y0 - ny},
+	}
+	minX := min(min(pts[0][0], pts[1][0]), min(pts[2][0], pts[3][0]))
+	minY := min(min(pts[0][1], pts[1][1]), min(pts[2][1], pts[3][1]))
+	maxX := max(max(pts[0][0], pts[1][0]), max(pts[2][0], pts[3][0]))
+	maxY := max(max(pts[0][1], pts[1][1]), max(pts[2][1], pts[3][1]))
+
+	region := r.buf.region(minX, minY, maxX-minX, maxY-minY)
+	r.buf.fillPath(region, r.buf.solid(cmd.Color),
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathQuad(z, ox, oy, pts)
+		})
+}

--- a/gui/backend/soft/draw_test.go
+++ b/gui/backend/soft/draw_test.go
@@ -1,0 +1,265 @@
+package soft
+
+import (
+	"image"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// newRenderer builds a renderer over a black buffer, with no text
+// system: these tests exercise the shape and clip paths only.
+func newRenderer(w, h int, scale float32) *renderer {
+	r := &renderer{buf: newBuffer(w, h), scale: scale}
+	r.buf.clear(gui.RGB(0, 0, 0))
+	return r
+}
+
+func rectCmd(x, y, w, h float32, c gui.Color) gui.RenderCmd {
+	return gui.RenderCmd{Kind: gui.RenderRect, X: x, Y: y, W: w, H: h,
+		Color: c, Fill: true}
+}
+
+func TestDrawRectCoversExactly(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{rectCmd(10, 10, 20, 20, gui.RGB(0, 255, 0))})
+
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("inside green = %d, want 255", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 9, 20); g != 0 {
+		t.Errorf("left of rect green = %d, want 0", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 30, 20); g != 0 {
+		t.Errorf("right of rect green = %d, want 0", g)
+	}
+}
+
+func TestClipSuppressesWritesOutside(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderClip, X: 0, Y: 0, W: 20, H: 40},
+		rectCmd(0, 0, 40, 40, gui.RGB(0, 255, 0)),
+	})
+
+	if _, g, _, _ := at(r.buf.img, 10, 20); g != 255 {
+		t.Errorf("inside clip green = %d, want 255", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 30, 20); g != 0 {
+		t.Errorf("outside clip green = %d, want 0 (clip leaked)", g)
+	}
+}
+
+func TestClipResetByDegenerateRect(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderClip, X: 0, Y: 0, W: 20, H: 40},
+		{Kind: gui.RenderClip}, // zero size restores the full buffer
+		rectCmd(0, 0, 40, 40, gui.RGB(0, 255, 0)),
+	})
+	if _, g, _, _ := at(r.buf.img, 30, 20); g != 255 {
+		t.Errorf("after clip reset green = %d, want 255", g)
+	}
+}
+
+func TestScaleMultipliesCoordinates(t *testing.T) {
+	r := newRenderer(40, 40, 2)
+	r.drawAll([]gui.RenderCmd{rectCmd(5, 5, 10, 10, gui.RGB(0, 255, 0))})
+
+	// At scale 2 the rect occupies device pixels [10,30).
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("inside scaled rect green = %d, want 255", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 9, 20); g != 0 {
+		t.Errorf("left of scaled rect green = %d, want 0", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 31, 20); g != 0 {
+		t.Errorf("right of scaled rect green = %d, want 0", g)
+	}
+}
+
+func TestStrokeRectIsHollow(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderStrokeRect, X: 10, Y: 10, W: 20, H: 20,
+		Thickness: 2, Color: gui.RGB(0, 255, 0),
+	}})
+
+	if _, g, _, _ := at(r.buf.img, 11, 20); g != 255 {
+		t.Errorf("on the stroke green = %d, want 255", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 0 {
+		t.Errorf("inside the ring green = %d, want 0 (not hollow)", g)
+	}
+}
+
+func TestGradientMidpointBlends(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderGradient, X: 0, Y: 0, W: 40, H: 40,
+		Gradient: &gui.GradientDef{
+			Direction: gui.GradientToRight,
+			Stops: []gui.GradientStop{
+				{Color: gui.RGB(255, 0, 0), Pos: 0},
+				{Color: gui.RGB(0, 0, 255), Pos: 1},
+			},
+		},
+	}})
+
+	if red, _, _, _ := at(r.buf.img, 1, 20); !closeTo(red, 255, 12) {
+		t.Errorf("left edge red = %d, want ~255", red)
+	}
+	if _, _, blue, _ := at(r.buf.img, 38, 20); !closeTo(blue, 255, 12) {
+		t.Errorf("right edge blue = %d, want ~255", blue)
+	}
+	red, _, blue, _ := at(r.buf.img, 20, 20)
+	if !closeTo(red, 128, 12) || !closeTo(blue, 128, 12) {
+		t.Errorf("midpoint = r%d b%d, want ~128 each", red, blue)
+	}
+}
+
+func TestCircleIsRound(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderCircle, X: 20, Y: 20, Radius: 10,
+		Color: gui.RGB(0, 255, 0), Fill: true,
+	}})
+
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("centre green = %d, want 255", g)
+	}
+	// The bounding box corner is outside the disc.
+	if _, g, _, _ := at(r.buf.img, 11, 11); g != 0 {
+		t.Errorf("bbox corner green = %d, want 0 (square, not circle)", g)
+	}
+}
+
+func TestLinePaintsOnlyTheSegment(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderLine, X: 5, Y: 20, OffsetX: 35, OffsetY: 20,
+		Thickness: 2, Color: gui.RGB(0, 255, 0),
+	}})
+
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("on the line green = %d, want 255", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 3, 20); g != 0 {
+		t.Errorf("past the start green = %d, want 0", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 37, 20); g != 0 {
+		t.Errorf("past the end green = %d, want 0", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 20, 16); g != 0 {
+		t.Errorf("above the line green = %d, want 0", g)
+	}
+}
+
+func TestRadialGradientFallsOffFromCentre(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderGradient, X: 0, Y: 0, W: 40, H: 40,
+		Gradient: &gui.GradientDef{
+			Type: gui.GradientRadial,
+			Stops: []gui.GradientStop{
+				{Color: gui.RGB(255, 0, 0), Pos: 0},
+				{Color: gui.RGB(0, 0, 255), Pos: 1},
+			},
+		},
+	}})
+
+	red, _, blue, _ := at(r.buf.img, 20, 20)
+	if red <= blue {
+		t.Errorf("centre = r%d b%d, want red dominant", red, blue)
+	}
+	red, _, blue, _ = at(r.buf.img, 1, 1)
+	if blue <= red {
+		t.Errorf("corner = r%d b%d, want blue dominant", red, blue)
+	}
+}
+
+func TestGradientBorderPaintsEdgeStrips(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderGradientBorder, X: 10, Y: 10, W: 20, H: 20,
+		Thickness: 2,
+		Gradient: &gui.GradientDef{
+			Direction: gui.GradientToRight,
+			Stops: []gui.GradientStop{
+				{Color: gui.RGB(255, 0, 0), Pos: 0},
+				{Color: gui.RGB(0, 0, 255), Pos: 1},
+			},
+		},
+	}})
+
+	// The top strip samples position 0 → red; the bottom samples
+	// 0.25 → mixed. The interior must stay untouched.
+	if red, _, _, _ := at(r.buf.img, 20, 11); red != 255 {
+		t.Errorf("top strip red = %d, want 255", red)
+	}
+	red, _, blue, _ := at(r.buf.img, 20, 28)
+	if blue == 0 || red <= blue {
+		t.Errorf("bottom strip = r%d b%d, want red dominant", red, blue)
+	}
+	if cr, cg, cb, _ := at(r.buf.img, 20, 20); cr|cg|cb != 0 {
+		t.Errorf("interior = %d,%d,%d, want untouched", cr, cg, cb)
+	}
+}
+
+func TestDrawImageMemSource(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	pix := make([]byte, 4*4*4)
+	for i := range 4 {
+		for j := range 4 {
+			k := (i*4 + j) * 4
+			pix[k], pix[k+1], pix[k+2], pix[k+3] = 0, 0, 255, 255
+		}
+	}
+	src := gui.UseImage("soft-test-img", 4, 4, pix)
+	if src == "" {
+		t.Fatal("UseImage refused the buffer")
+	}
+	t.Cleanup(func() { gui.DropImage("soft-test-img") })
+
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderImage, X: 10, Y: 10, W: 20, H: 20,
+		Resource: src,
+	}})
+
+	if _, _, blue, _ := at(r.buf.img, 20, 20); blue != 255 {
+		t.Errorf("inside the image blue = %d, want 255", blue)
+	}
+	if _, _, blue, _ := at(r.buf.img, 9, 20); blue != 0 {
+		t.Errorf("outside the image blue = %d, want 0", blue)
+	}
+}
+
+func TestUnsupportedKindsAreSkipped(t *testing.T) {
+	r := newRenderer(8, 8, 1)
+	// Phase-2 kinds must not draw and must not panic.
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderShadow, X: 0, Y: 0, W: 8, H: 8,
+			Color: gui.RGB(255, 255, 255)},
+		{Kind: gui.RenderSvg, X: 0, Y: 0, Scale: 1},
+		{Kind: gui.RenderStencilBegin},
+		{Kind: gui.RenderStencilEnd},
+	})
+	for y := range 8 {
+		for x := range 8 {
+			cr, cg, cb, _ := at(r.buf.img, x, y)
+			if cr|cg|cb != 0 {
+				t.Fatalf("pixel (%d,%d) painted by a skipped kind", x, y)
+			}
+		}
+	}
+}
+
+func TestBufferBoundsMatchScale(t *testing.T) {
+	b := newBuffer(30, 20)
+	if got := b.img.Bounds(); got != image.Rect(0, 0, 30, 20) {
+		t.Fatalf("bounds = %v", got)
+	}
+	if b.clip != b.img.Bounds() {
+		t.Fatalf("clip = %v, want full bounds", b.clip)
+	}
+}

--- a/gui/backend/soft/draw_test.go
+++ b/gui/backend/soft/draw_test.go
@@ -7,6 +7,20 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
+// at returns the pixel at (x, y) as straight RGBA components.
+func at(img *image.RGBA, x, y int) (r, g, b, a uint8) {
+	i := img.PixOffset(x, y)
+	p := img.Pix
+	return p[i], p[i+1], p[i+2], p[i+3]
+}
+
+func closeTo(got, want, tol uint8) bool {
+	if got > want {
+		return got-want <= tol
+	}
+	return want-got <= tol
+}
+
 // newRenderer builds a renderer over a black buffer, with no text
 // system: these tests exercise the shape and clip paths only.
 func newRenderer(w, h int, scale float32) *renderer {

--- a/gui/backend/soft/framebuffer.go
+++ b/gui/backend/soft/framebuffer.go
@@ -1,0 +1,216 @@
+package soft
+
+import (
+	"image"
+	"image/color"
+	"math"
+
+	"golang.org/x/image/vector"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// kappa is the circle-to-cubic-Bezier constant: the control-point
+// distance, as a fraction of the radius, that makes a cubic segment
+// approximate a quarter circle to within ~0.02%.
+const kappa = 0.5522847498
+
+// buffer is the CPU render target: a premultiplied RGBA image plus the
+// current clip rectangle, both in device pixels.
+//
+// Everything this package draws reduces to one operation — composite a
+// source (a solid color, a gradient, an image) through a coverage mask,
+// restricted to the clip rect. fillPath is that operation; the coverage
+// mask comes from x/image/vector, which antialiases every edge.
+type buffer struct {
+	img  *image.RGBA
+	clip image.Rectangle
+	rast vector.Rasterizer
+
+	// uni is the reusable solid-color source. image.NewUniform would
+	// allocate once per draw command; the rasterizer only reads it
+	// during the Draw call, so one instance can be re-pointed.
+	uni image.Uniform
+}
+
+func newBuffer(w, h int) *buffer {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	return &buffer{img: img, clip: img.Bounds()}
+}
+
+// clear paints the whole buffer with c, ignoring the clip rect. c is
+// straight (non-premultiplied) as every gui.Color is.
+func (b *buffer) clear(c gui.Color) {
+	r, g, bl, a := premul(c)
+	pix := b.img.Pix
+	for i := 0; i < len(pix); i += 4 {
+		pix[i] = r
+		pix[i+1] = g
+		pix[i+2] = bl
+		pix[i+3] = a
+	}
+}
+
+// setClip replaces the clip rect, as RenderClip does — clips do not nest
+// in the render stream. A degenerate rect restores the full buffer.
+func (b *buffer) setClip(x, y, w, h float32) {
+	if w <= 0 || h <= 0 {
+		b.clip = b.img.Bounds()
+		return
+	}
+	b.clip = deviceRect(x, y, w, h).Intersect(b.img.Bounds())
+}
+
+// region returns the pixel rectangle a shape of the given device-space
+// bounds can touch: its bounding box, clipped.
+func (b *buffer) region(x, y, w, h float32) image.Rectangle {
+	return deviceRect(x, y, w, h).Intersect(b.clip)
+}
+
+// deviceRect converts a device-space box to the pixel rectangle that can
+// be partially covered by it.
+func deviceRect(x, y, w, h float32) image.Rectangle {
+	return image.Rect(
+		int(math.Floor(float64(x))),
+		int(math.Floor(float64(y))),
+		int(math.Ceil(float64(x+w))),
+		int(math.Ceil(float64(y+h))),
+	)
+}
+
+// fillPath rasterizes the path emitted by emit and composites src through
+// the resulting coverage mask into region.
+//
+// emit receives the region origin because the rasterizer's mask is
+// indexed from region.Min: every coordinate fed to it must be device
+// space minus that origin. Geometry outside the mask is clipped by the
+// rasterizer itself, which is why the clip rect costs nothing here.
+//
+// src is sampled at absolute device coordinates (sp = region.Min), so a
+// gradient or image source does not need to know where it was clipped.
+func (b *buffer) fillPath(region image.Rectangle, src image.Image,
+	emit func(z *vector.Rasterizer, ox, oy float32)) {
+	if region.Empty() {
+		return
+	}
+	b.rast.Reset(region.Dx(), region.Dy())
+	emit(&b.rast, float32(region.Min.X), float32(region.Min.Y))
+	b.rast.Draw(b.img, region, src, region.Min)
+}
+
+// solid returns the reusable uniform source for c. Valid until the next
+// call — pass it straight to fillPath.
+func (b *buffer) solid(c gui.Color) image.Image {
+	b.uni.C = color.NRGBA{R: c.R, G: c.G, B: c.B, A: c.A}
+	return &b.uni
+}
+
+// blendPixel composites one straight-alpha source color over the pixel at
+// (x, y). Used by the paths that sample their own source — glyph atlas
+// quads — where a coverage mask would be a detour.
+//
+// Both callers iterate a region already intersected with the clip rect
+// (glyphBackend's region()), so no per-pixel clip test is needed.
+func (b *buffer) blendPixel(x, y int, sr, sg, sb, sa uint32) {
+	if sa == 0 {
+		return
+	}
+	i := b.img.PixOffset(x, y)
+	pix := b.img.Pix
+	inv := 255 - sa
+	pix[i] = uint8((sr*sa + uint32(pix[i])*inv + 127) / 255)
+	pix[i+1] = uint8((sg*sa + uint32(pix[i+1])*inv + 127) / 255)
+	pix[i+2] = uint8((sb*sa + uint32(pix[i+2])*inv + 127) / 255)
+	pix[i+3] = uint8((sa*255 + uint32(pix[i+3])*inv + 127) / 255)
+}
+
+// premul converts a straight gui.Color to premultiplied bytes.
+func premul(c gui.Color) (r, g, b, a uint8) {
+	if c.A == 255 {
+		return c.R, c.G, c.B, 255
+	}
+	a32 := uint32(c.A)
+	return uint8(uint32(c.R) * a32 / 255),
+		uint8(uint32(c.G) * a32 / 255),
+		uint8(uint32(c.B) * a32 / 255),
+		c.A
+}
+
+// --- Path builders ---
+//
+// All take device-space coordinates and the region origin to subtract.
+// A reversed contour winds the other way, which the rasterizer's signed
+// accumulation turns into a hole — that is how stroke rects get their
+// inner cut-out without a second pass.
+
+// pathRect emits an axis-aligned rectangle.
+func pathRect(z *vector.Rasterizer, ox, oy, x, y, w, h float32) {
+	x -= ox
+	y -= oy
+	z.MoveTo(x, y)
+	z.LineTo(x+w, y)
+	z.LineTo(x+w, y+h)
+	z.LineTo(x, y+h)
+	z.ClosePath()
+}
+
+// pathRoundRect emits a rectangle with radius-r corners. r is clamped to
+// half the shorter side, so a radius of half a square's width is a circle.
+// reverse winds the contour backwards.
+func pathRoundRect(z *vector.Rasterizer, ox, oy, x, y, w, h, r float32,
+	reverse bool) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	r = min(r, min(w, h)/2)
+	if r <= 0 {
+		if reverse {
+			x -= ox
+			y -= oy
+			z.MoveTo(x, y)
+			z.LineTo(x, y+h)
+			z.LineTo(x+w, y+h)
+			z.LineTo(x+w, y)
+			z.ClosePath()
+			return
+		}
+		pathRect(z, ox, oy, x, y, w, h)
+		return
+	}
+	x -= ox
+	y -= oy
+	k := r * kappa
+	x1, y1 := x+w, y+h
+	if !reverse {
+		z.MoveTo(x+r, y)
+		z.LineTo(x1-r, y)
+		z.CubeTo(x1-r+k, y, x1, y+r-k, x1, y+r)
+		z.LineTo(x1, y1-r)
+		z.CubeTo(x1, y1-r+k, x1-r+k, y1, x1-r, y1)
+		z.LineTo(x+r, y1)
+		z.CubeTo(x+r-k, y1, x, y1-r+k, x, y1-r)
+		z.LineTo(x, y+r)
+		z.CubeTo(x, y+r-k, x+r-k, y, x+r, y)
+		z.ClosePath()
+		return
+	}
+	z.MoveTo(x+r, y)
+	z.CubeTo(x+r-k, y, x, y+r-k, x, y+r)
+	z.LineTo(x, y1-r)
+	z.CubeTo(x, y1-r+k, x+r-k, y1, x+r, y1)
+	z.LineTo(x1-r, y1)
+	z.CubeTo(x1-r+k, y1, x1, y1-r+k, x1, y1-r)
+	z.LineTo(x1, y+r)
+	z.CubeTo(x1, y+r-k, x1-r+k, y, x1-r, y)
+	z.ClosePath()
+}
+
+// pathQuad emits an arbitrary four-point polygon, wound in the order
+// given. Used for lines and transformed glyph quads.
+func pathQuad(z *vector.Rasterizer, ox, oy float32, pts [4][2]float32) {
+	z.MoveTo(pts[0][0]-ox, pts[0][1]-oy)
+	z.LineTo(pts[1][0]-ox, pts[1][1]-oy)
+	z.LineTo(pts[2][0]-ox, pts[2][1]-oy)
+	z.LineTo(pts[3][0]-ox, pts[3][1]-oy)
+	z.ClosePath()
+}

--- a/gui/backend/soft/glyph_backend.go
+++ b/gui/backend/soft/glyph_backend.go
@@ -1,0 +1,200 @@
+package soft
+
+import (
+	"math"
+
+	"golang.org/x/image/vector"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// softTexture is a glyph atlas page held in ordinary memory.
+type softTexture struct {
+	pix  []byte // straight RGBA, w*h*4
+	w, h int
+}
+
+// glyphBackend implements glyph.DrawBackend over a CPU framebuffer.
+//
+// This is what makes headless text real rather than approximated: go-glyph
+// is pure Go, so handing it a software draw backend gets shaping, metrics
+// and glyph rasterization from the same code the GPU backends run. Every
+// text render kind — plain text, pre-shaped layouts, transformed layouts,
+// rich text, text on a path, text gradients — arrives through these three
+// draw methods.
+//
+// buf is re-pointed per frame by the renderer; a nil buf makes every draw
+// a no-op, which is what the atlas-warming pass wants.
+type glyphBackend struct {
+	buf      *buffer
+	textures map[glyph.TextureID]*softTexture
+	nextID   glyph.TextureID
+	scale    float32
+}
+
+func newGlyphBackend(scale float32) *glyphBackend {
+	return &glyphBackend{
+		textures: make(map[glyph.TextureID]*softTexture),
+		scale:    scale,
+	}
+}
+
+func (gb *glyphBackend) NewTexture(width, height int) glyph.TextureID {
+	gb.nextID++
+	gb.textures[gb.nextID] = &softTexture{
+		pix: make([]byte, width*height*4),
+		w:   width,
+		h:   height,
+	}
+	return gb.nextID
+}
+
+func (gb *glyphBackend) UpdateTexture(id glyph.TextureID, data []byte) {
+	tex, ok := gb.textures[id]
+	if !ok || len(data) == 0 {
+		return
+	}
+	copy(tex.pix, data)
+}
+
+func (gb *glyphBackend) DeleteTexture(id glyph.TextureID) {
+	delete(gb.textures, id)
+}
+
+func (gb *glyphBackend) DPIScale() float32 { return gb.scale }
+
+// DrawFilledRect paints an untextured rect — glyph uses it for
+// decorations such as underlines and selection bands.
+func (gb *glyphBackend) DrawFilledRect(dst glyph.Rect, c glyph.Color) {
+	if gb.buf == nil || c.A == 0 {
+		return
+	}
+	s := gb.scale
+	x, y := dst.X*s, dst.Y*s
+	w, h := dst.Width*s, dst.Height*s
+	col := gui.RGBA(c.R, c.G, c.B, c.A)
+	region := gb.buf.region(x, y, w, h)
+	gb.buf.fillPath(region, gb.buf.solid(col),
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathRect(z, ox, oy, x, y, w, h)
+		})
+}
+
+// DrawTexturedQuad blits an axis-aligned atlas region, tinted by c.
+//
+// The atlas is rasterized at the device scale already, so the mapping is
+// 1:1 at scale 1 and nearest sampling is exact; the GPU path blends with
+// SRC_ALPHA/ONE_MINUS_SRC_ALPHA over a straight-alpha texture, which is
+// what blendPixel reproduces.
+func (gb *glyphBackend) DrawTexturedQuad(id glyph.TextureID,
+	src, dst glyph.Rect, c glyph.Color) {
+
+	tex, ok := gb.textures[id]
+	if !ok || gb.buf == nil || c.A == 0 {
+		return
+	}
+	s := gb.scale
+	x0, y0 := dst.X*s, dst.Y*s
+	x1, y1 := (dst.X+dst.Width)*s, (dst.Y+dst.Height)*s
+	if x1 <= x0 || y1 <= y0 {
+		return
+	}
+	region := gb.buf.region(x0, y0, x1-x0, y1-y0)
+	if region.Empty() {
+		return
+	}
+	invW := 1 / (x1 - x0)
+	invH := 1 / (y1 - y0)
+	for py := region.Min.Y; py < region.Max.Y; py++ {
+		v := (float32(py) + 0.5 - y0) * invH
+		sy := int(src.Y + v*src.Height)
+		for px := region.Min.X; px < region.Max.X; px++ {
+			u := (float32(px) + 0.5 - x0) * invW
+			sx := int(src.X + u*src.Width)
+			gb.blendTexel(tex, sx, sy, px, py, c)
+		}
+	}
+}
+
+// DrawTexturedQuadTransformed blits an atlas region through an affine
+// transform, inverse-mapping each covered device pixel back to a texel.
+func (gb *glyphBackend) DrawTexturedQuadTransformed(id glyph.TextureID,
+	src, dst glyph.Rect, c glyph.Color, t glyph.AffineTransform) {
+
+	tex, ok := gb.textures[id]
+	if !ok || gb.buf == nil || c.A == 0 ||
+		dst.Width <= 0 || dst.Height <= 0 {
+		return
+	}
+	det := t.XX*t.YY - t.XY*t.YX
+	if det == 0 {
+		return
+	}
+	s := gb.scale
+	corners := [4][2]float32{
+		{dst.X, dst.Y},
+		{dst.X + dst.Width, dst.Y},
+		{dst.X + dst.Width, dst.Y + dst.Height},
+		{dst.X, dst.Y + dst.Height},
+	}
+	minX, minY := float32(math.MaxFloat32), float32(math.MaxFloat32)
+	maxX, maxY := -float32(math.MaxFloat32), -float32(math.MaxFloat32)
+	for i := range corners {
+		cx, cy := t.Apply(corners[i][0], corners[i][1])
+		cx *= s
+		cy *= s
+		minX, maxX = min(minX, cx), max(maxX, cx)
+		minY, maxY = min(minY, cy), max(maxY, cy)
+	}
+	region := gb.buf.region(minX, minY, maxX-minX, maxY-minY)
+	if region.Empty() {
+		return
+	}
+
+	// Inverse of the affine, applied to logical coordinates.
+	invDet := 1 / det
+	ixx, ixy := t.YY*invDet, -t.XY*invDet
+	iyx, iyy := -t.YX*invDet, t.XX*invDet
+	invS := 1 / s
+
+	for py := region.Min.Y; py < region.Max.Y; py++ {
+		dy := (float32(py) + 0.5) * invS
+		for px := region.Min.X; px < region.Max.X; px++ {
+			dx := (float32(px) + 0.5) * invS
+			ox, oy := dx-t.X0, dy-t.Y0
+			lx := ixx*ox + ixy*oy
+			ly := iyx*ox + iyy*oy
+			u := (lx - dst.X) / dst.Width
+			v := (ly - dst.Y) / dst.Height
+			if u < 0 || u >= 1 || v < 0 || v >= 1 {
+				continue
+			}
+			sx := int(src.X + u*src.Width)
+			sy := int(src.Y + v*src.Height)
+			gb.blendTexel(tex, sx, sy, px, py, c)
+		}
+	}
+}
+
+// blendTexel composites one tinted atlas texel onto a device pixel.
+func (gb *glyphBackend) blendTexel(tex *softTexture, sx, sy, px, py int,
+	c glyph.Color) {
+
+	if sx < 0 || sy < 0 || sx >= tex.w || sy >= tex.h {
+		return
+	}
+	i := (sy*tex.w + sx) * 4
+	ta := uint32(tex.pix[i+3])
+	if ta == 0 {
+		return
+	}
+	// frag = texel * tint, both straight (the GPU path's
+	// FsFilterTextureGLSL multiplies, then blends with SRC_ALPHA).
+	sr := uint32(tex.pix[i]) * uint32(c.R) / 255
+	sg := uint32(tex.pix[i+1]) * uint32(c.G) / 255
+	sb := uint32(tex.pix[i+2]) * uint32(c.B) / 255
+	sa := ta * uint32(c.A) / 255
+	gb.buf.blendPixel(px, py, sr, sg, sb, sa)
+}

--- a/gui/backend/soft/render.go
+++ b/gui/backend/soft/render.go
@@ -1,0 +1,195 @@
+package soft
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"math"
+	"os"
+	"path/filepath"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
+	"github.com/go-gui-org/go-gui/gui/svg"
+)
+
+// maxDimension caps the device-pixel size of a render, so a bad scale
+// cannot ask for a multi-gigabyte allocation.
+const maxDimension = 16384
+
+// RenderToImage settles one frame of w and software-renders it at the
+// given device pixel ratio. scale <= 0 means 1.
+//
+// The returned image is premultiplied RGBA at
+// (window width x scale, window height x scale) pixels.
+//
+// A window that has not rendered yet has its WindowCfg.OnInit run first,
+// as a backend would, and is prepared for headless rendering: a software
+// text system becomes its gui.TextMeasurer and an SVG parser is
+// installed. Preparation is idempotent and keeps the warmed glyph atlas,
+// so driving state between captures — TestClick, SetFocus, then render
+// again — costs only the frame.
+//
+// exportaudit:keep — primary API; RenderToPNG is the convenience wrapper
+func RenderToImage(w *gui.Window, scale float32) (*image.RGBA, error) {
+	if w == nil {
+		return nil, errors.New("soft: nil window")
+	}
+	if scale <= 0 {
+		scale = 1
+	}
+	tm, err := prepare(w, scale)
+	if err != nil {
+		return nil, err
+	}
+
+	logicalW, logicalH := w.WindowSize()
+	pw := int(math.Round(float64(float32(logicalW) * scale)))
+	ph := int(math.Round(float64(float32(logicalH) * scale)))
+	if pw <= 0 || ph <= 0 {
+		return nil, fmt.Errorf("soft: window has no size (%dx%d)",
+			logicalW, logicalH)
+	}
+	if pw > maxDimension || ph > maxDimension {
+		return nil, fmt.Errorf(
+			"soft: render %dx%d exceeds the %d px limit",
+			pw, ph, maxDimension)
+	}
+
+	w.BackingScale = scale
+	w.SetHeadlessRender(true)
+	w.TestRender(nil)
+	cmds := w.Renderers()
+
+	r := &renderer{
+		buf:               newBuffer(pw, ph),
+		scale:             scale,
+		textSys:           tm.textSys,
+		glyphBack:         tm.back,
+		allowedImageRoots: w.Config.AllowedImageRoots,
+		maxImageBytes: imageLimit(w.Config.MaxImageBytes,
+			imgload.DefaultMaxImageBytes),
+		maxImagePixels: imageLimit(w.Config.MaxImagePixels,
+			imgload.DefaultMaxImagePixels),
+	}
+
+	// Pass 1 warms the glyph atlas. go-glyph rasterizes a glyph into a
+	// staging buffer when it is first drawn but only hands the page to
+	// the backend at Commit, so a single-pass render would sample texels
+	// that have not been uploaded yet. On screen the next frame fixes
+	// it; a one-shot capture has no next frame. Only the text kinds
+	// draw here — their quads land on the nil glyph target and are
+	// discarded — because nothing else needs warming: shapes, gradients
+	// and images are drawn once, in pass 2.
+	r.glyphBack.buf = nil
+	r.warm = true
+	r.drawAll(cmds)
+	r.textSys.Commit()
+
+	// Pass 2 draws for real.
+	r.glyphBack.buf = r.buf
+	r.warm = false
+	r.buf.clear(backgroundColor(w))
+	r.drawAll(cmds)
+	r.textSys.Commit()
+
+	return r.buf.img, nil
+}
+
+// RenderToPNG renders w and writes the result to path as a PNG,
+// creating the parent directory if needed.
+func RenderToPNG(w *gui.Window, scale float32, path string) error {
+	img, err := RenderToImage(w, scale)
+	if err != nil {
+		return err
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err = os.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("soft: create %s: %w", dir, err)
+		}
+	}
+	f, err := os.Create(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("soft: create %s: %w", path, err)
+	}
+	if err = png.Encode(f, img); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("soft: encode %s: %w", path, err)
+	}
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("soft: close %s: %w", path, err)
+	}
+	return nil
+}
+
+// Release frees the text system this package attached to w. Call it when
+// a window that was rendered headlessly is discarded but the process
+// keeps running — a test that renders many windows, say. Rendering w
+// again after Release simply builds a fresh text system.
+// exportaudit:keep — lifecycle counterpart to RenderToImage
+func Release(w *gui.Window) {
+	if w == nil {
+		return
+	}
+	if tm, ok := w.TextMeasurer().(*textMeasurer); ok {
+		tm.textSys.Free()
+		w.SetTextMeasurer(nil)
+	}
+}
+
+// prepare wires the headless seams a backend's init would wire, and is a
+// no-op on a window already prepared at this scale.
+func prepare(w *gui.Window, scale float32) (*textMeasurer, error) {
+	if tm, ok := w.TextMeasurer().(*textMeasurer); ok {
+		if tm.scale == scale {
+			return tm, nil
+		}
+		// The glyph context is built around one DPI scale; a changed
+		// scale needs a new one, and the old atlas is dead weight.
+		tm.textSys.Free()
+	} else if w.Config.OnInit != nil && len(w.Renderers()) == 0 {
+		// First render of this window: do what a backend does before
+		// its first frame. A window that has already produced render
+		// commands has been initialized, so this cannot run twice.
+		w.Config.OnInit(w)
+	}
+
+	back := newGlyphBackend(scale)
+	textSys, err := glyph.NewTextSystem(back)
+	if err != nil {
+		return nil, fmt.Errorf("soft: text system: %w", err)
+	}
+	if data := gui.IconFontData; len(data) > 0 {
+		if aerr := textSys.AddFontBytes(data); aerr != nil {
+			return nil, fmt.Errorf("soft: icon font: %w", aerr)
+		}
+	}
+	gui.LoadAppFonts(textSys, "soft")
+
+	tm := &textMeasurer{textSys: textSys, back: back, scale: scale}
+	w.SetTextMeasurer(tm)
+	w.SetSvgParser(svg.New())
+	return tm, nil
+}
+
+// backgroundColor is the window's clear color, matching what the GPU
+// backends paint before replaying the command stream.
+func backgroundColor(w *gui.Window) gui.Color {
+	bg := w.Config.BgColor
+	if bg == (gui.Color{}) {
+		bg = w.Theme().ColorBackground
+	}
+	return bg
+}
+
+// imageLimit resolves a WindowCfg image cap, where zero or negative
+// selects the backend default.
+func imageLimit(cfg, def int64) int64 {
+	if cfg <= 0 {
+		return def
+	}
+	return cfg
+}

--- a/gui/backend/soft/render_test.go
+++ b/gui/backend/soft/render_test.go
@@ -1,0 +1,277 @@
+package soft
+
+import (
+	"image"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// newWin builds a headless window whose root is view.
+func newWin(t *testing.T, w, h int, view func(*gui.Window) gui.View) *gui.Window {
+	t.Helper()
+	win := gui.NewWindow(gui.WindowCfg{
+		Width:   w,
+		Height:  h,
+		BgColor: gui.RGB(0, 0, 0),
+		OnInit:  func(win *gui.Window) { win.UpdateView(view) },
+	})
+	t.Cleanup(func() { Release(win) })
+	return win
+}
+
+// at returns the pixel at (x, y) as straight RGBA components.
+func at(img *image.RGBA, x, y int) (r, g, b, a uint8) {
+	i := img.PixOffset(x, y)
+	p := img.Pix
+	return p[i], p[i+1], p[i+2], p[i+3]
+}
+
+func closeTo(got, want, tol uint8) bool {
+	if got > want {
+		return got-want <= tol
+	}
+	return want-got <= tol
+}
+
+func TestRenderRectPixels(t *testing.T) {
+	win := newWin(t, 100, 100, func(w *gui.Window) gui.View {
+		return gui.Column(gui.ContainerCfg{
+			Sizing:     gui.FixedFixed,
+			Width:      40,
+			Height:     40,
+			Color:      gui.RGB(255, 0, 0),
+			SizeBorder: gui.NoBorder,
+		})
+	})
+	img, err := RenderToImage(win, 1)
+	if err != nil {
+		t.Fatalf("RenderToImage: %v", err)
+	}
+	if got := img.Bounds(); got != image.Rect(0, 0, 100, 100) {
+		t.Fatalf("bounds = %v, want 100x100", got)
+	}
+	// Inside the rect: pure red.
+	if r, g, b, a := at(img, 20, 20); r != 255 || g != 0 || b != 0 || a != 255 {
+		t.Errorf("centre = %d,%d,%d,%d, want 255,0,0,255", r, g, b, a)
+	}
+	// Outside it: the window background.
+	if r, g, b, a := at(img, 90, 90); r != 0 || g != 0 || b != 0 || a != 255 {
+		t.Errorf("corner = %d,%d,%d,%d, want 0,0,0,255", r, g, b, a)
+	}
+}
+
+func TestRenderScaleDoublesGeometry(t *testing.T) {
+	view := func(w *gui.Window) gui.View {
+		return gui.Column(gui.ContainerCfg{
+			Sizing:     gui.FixedFixed,
+			Width:      40,
+			Height:     40,
+			Color:      gui.RGB(255, 0, 0),
+			SizeBorder: gui.NoBorder,
+		})
+	}
+	win := newWin(t, 100, 100, view)
+	img, err := RenderToImage(win, 2)
+	if err != nil {
+		t.Fatalf("RenderToImage: %v", err)
+	}
+	if got := img.Bounds(); got != image.Rect(0, 0, 200, 200) {
+		t.Fatalf("bounds = %v, want 200x200", got)
+	}
+	// The 40pt rect covers 80 device px, so (70,70) is inside at
+	// scale 2 and outside at scale 1.
+	if r, _, _, _ := at(img, 70, 70); r != 255 {
+		t.Errorf("(70,70) red = %d, want 255 (rect should span 80px)", r)
+	}
+	if r, _, _, _ := at(img, 90, 90); r != 0 {
+		t.Errorf("(90,90) red = %d, want 0 (past the rect)", r)
+	}
+}
+
+func TestRenderText(t *testing.T) {
+	win := newWin(t, 200, 60, func(w *gui.Window) gui.View {
+		return gui.Column(gui.ContainerCfg{
+			Sizing:     gui.FillFill,
+			SizeBorder: gui.NoBorder,
+			Content: []gui.View{
+				gui.Label("HHHH", gui.TextStyle{
+					Size:  32,
+					Color: gui.RGB(255, 255, 255),
+				}),
+			},
+		})
+	})
+	img, err := RenderToImage(win, 1)
+	if err != nil {
+		t.Fatalf("RenderToImage: %v", err)
+	}
+	if win.TextMeasurer() == nil {
+		t.Fatal("text measurer not installed")
+	}
+	if lit := countLitPixels(img); lit == 0 {
+		t.Fatal("no glyph pixels rendered; the atlas warm pass failed")
+	} else {
+		t.Logf("lit pixels: %d", lit)
+	}
+}
+
+// countLitPixels counts pixels with any channel above the antialiasing
+// threshold; glyph edges are never exact white, so exact equality would be
+// fragile.
+func countLitPixels(img *image.RGBA) int {
+	var lit int
+	for y := range img.Bounds().Dy() {
+		for x := range img.Bounds().Dx() {
+			if r, _, _, _ := at(img, x, y); r > 40 {
+				lit++
+			}
+		}
+	}
+	return lit
+}
+
+func TestRenderToPNG(t *testing.T) {
+	win := newWin(t, 60, 60, func(w *gui.Window) gui.View {
+		return gui.Column(gui.ContainerCfg{
+			Sizing:     gui.FillFill,
+			Color:      gui.RGB(0, 128, 255),
+			SizeBorder: gui.NoBorder,
+		})
+	})
+	path := filepath.Join(t.TempDir(), "out", "shot.png")
+	if err := RenderToPNG(win, 1, path); err != nil {
+		t.Fatalf("RenderToPNG: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Fatal("empty PNG")
+	}
+}
+
+// redView is a window-filling red column, used by the lifecycle tests.
+func redView(w *gui.Window) gui.View {
+	return gui.Column(gui.ContainerCfg{
+		Sizing:     gui.FillFill,
+		Color:      gui.RGB(255, 0, 0),
+		SizeBorder: gui.NoBorder,
+	})
+}
+
+func TestRenderScaleChangeRebuilds(t *testing.T) {
+	onInit := 0
+	win := gui.NewWindow(gui.WindowCfg{
+		Width:   100,
+		Height:  100,
+		BgColor: gui.RGB(0, 0, 0),
+		OnInit: func(w *gui.Window) {
+			onInit++
+			w.UpdateView(redView)
+		},
+	})
+	t.Cleanup(func() { Release(win) })
+
+	img1, err := RenderToImage(win, 1)
+	if err != nil {
+		t.Fatalf("RenderToImage(scale 1): %v", err)
+	}
+	if got := img1.Bounds(); got != image.Rect(0, 0, 100, 100) {
+		t.Fatalf("bounds = %v, want 100x100", got)
+	}
+
+	// A second render at a different scale frees the scale-1 text
+	// system and builds a fresh one; the frame must still paint.
+	img2, err := RenderToImage(win, 2)
+	if err != nil {
+		t.Fatalf("RenderToImage(scale 2): %v", err)
+	}
+	if got := img2.Bounds(); got != image.Rect(0, 0, 200, 200) {
+		t.Fatalf("bounds = %v, want 200x200", got)
+	}
+	if r, _, _, _ := at(img2, 40, 40); r != 255 {
+		t.Errorf("scaled rect red = %d, want 255", r)
+	}
+	if onInit != 1 {
+		t.Fatalf("OnInit ran %d times, want 1", onInit)
+	}
+}
+
+func TestReleaseThenRenderRebuilds(t *testing.T) {
+	win := newWin(t, 60, 60, redView)
+	if _, err := RenderToImage(win, 1); err != nil {
+		t.Fatalf("first RenderToImage: %v", err)
+	}
+	Release(win)
+	if win.TextMeasurer() != nil {
+		t.Fatal("Release left the text measurer installed")
+	}
+	img, err := RenderToImage(win, 1)
+	if err != nil {
+		t.Fatalf("render after Release: %v", err)
+	}
+	if r, _, _, _ := at(img, 30, 30); r != 255 {
+		t.Errorf("rect red = %d, want 255", r)
+	}
+}
+
+func TestRenderToImageNilWindow(t *testing.T) {
+	if _, err := RenderToImage(nil, 1); err == nil {
+		t.Fatal("nil window: want error")
+	}
+}
+
+func TestRenderToImageZeroSizeWindow(t *testing.T) {
+	win := gui.NewWindow(gui.WindowCfg{})
+	t.Cleanup(func() { Release(win) })
+	if _, err := RenderToImage(win, 1); err == nil {
+		t.Fatal("zero-size window: want error")
+	}
+}
+
+func TestRenderTextFallbackStyle(t *testing.T) {
+	win := newWin(t, 120, 60, func(w *gui.Window) gui.View {
+		return gui.Column(gui.ContainerCfg{
+			Sizing:     gui.FillFill,
+			SizeBorder: gui.NoBorder,
+			Content: []gui.View{
+				gui.Label("HHHH", gui.TextStyle{
+					Size:  32,
+					Color: gui.RGB(255, 255, 255),
+				}),
+			},
+		})
+	})
+	tm, err := prepare(win, 1)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	// Drive the command stream directly with a fallback-style
+	// RenderText (no TextStylePtr) to cover drawText's else branch
+	// and the textured-quad blend path.
+	r := &renderer{
+		buf:       newBuffer(120, 60),
+		scale:     1,
+		textSys:   tm.textSys,
+		glyphBack: tm.back,
+	}
+	cmd := gui.RenderCmd{Kind: gui.RenderText, X: 10, Y: 10,
+		Text: "HHHH", FontSize: 32, Color: gui.RGB(255, 255, 255)}
+
+	tm.back.buf = nil
+	r.drawAll([]gui.RenderCmd{cmd})
+	tm.textSys.Commit()
+	tm.back.buf = r.buf
+	r.buf.clear(gui.RGB(0, 0, 0))
+	r.drawAll([]gui.RenderCmd{cmd})
+	tm.textSys.Commit()
+
+	if lit := countLitPixels(r.buf.img); lit == 0 {
+		t.Fatal("no glyph pixels via fallback style")
+	}
+}

--- a/gui/backend/soft/render_test.go
+++ b/gui/backend/soft/render_test.go
@@ -1,3 +1,11 @@
+//go:build !wasm
+
+//
+// Every test here drives RenderToImage, which builds a go-glyph text
+// system; on wasm that construction needs a DOM (syscall/js), which the
+// node-based CI harness does not provide. draw_test.go covers the pure
+// rasterizer paths on every platform.
+
 package soft
 
 import (
@@ -20,20 +28,6 @@ func newWin(t *testing.T, w, h int, view func(*gui.Window) gui.View) *gui.Window
 	})
 	t.Cleanup(func() { Release(win) })
 	return win
-}
-
-// at returns the pixel at (x, y) as straight RGBA components.
-func at(img *image.RGBA, x, y int) (r, g, b, a uint8) {
-	i := img.PixOffset(x, y)
-	p := img.Pix
-	return p[i], p[i+1], p[i+2], p[i+3]
-}
-
-func closeTo(got, want, tol uint8) bool {
-	if got > want {
-		return got-want <= tol
-	}
-	return want-got <= tol
 }
 
 func TestRenderRectPixels(t *testing.T) {

--- a/gui/backend/soft/text.go
+++ b/gui/backend/soft/text.go
@@ -1,0 +1,161 @@
+package soft
+
+import (
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
+)
+
+// textMeasurer wraps glyph.TextSystem to implement gui.TextMeasurer.
+//
+// It doubles as this package's per-window handle on the text system: a
+// window that has already been prepared carries it as its measurer, so a
+// repeat render recovers the system (and its warm atlas) by type
+// assertion instead of a package-level cache.
+type textMeasurer struct {
+	textSys *glyph.TextSystem
+	back    *glyphBackend
+	scale   float32
+}
+
+func (tm *textMeasurer) TextWidth(text string, style gui.TextStyle) float32 {
+	w, err := tm.textSys.TextWidth(text, guiStyleToGlyphConfig(style))
+	if err != nil {
+		return 0
+	}
+	return w
+}
+
+func (tm *textMeasurer) TextHeight(text string, style gui.TextStyle) float32 {
+	h, err := tm.textSys.TextHeight(text, guiStyleToGlyphConfig(style))
+	if err != nil {
+		return 0
+	}
+	return h
+}
+
+func (tm *textMeasurer) FontHeight(style gui.TextStyle) float32 {
+	h, err := tm.textSys.FontHeight(guiStyleToGlyphConfig(style))
+	if err != nil {
+		return style.Size * 1.4
+	}
+	return h
+}
+
+func (tm *textMeasurer) FontAscent(style gui.TextStyle) float32 {
+	m, err := tm.textSys.FontMetrics(guiStyleToGlyphConfig(style))
+	if err != nil {
+		return style.Size * 0.8
+	}
+	return m.Ascender
+}
+
+// TextInkBounds returns the painted box of text, relative to the
+// top-left of its advance box — gui's optional ink-measuring capability.
+func (tm *textMeasurer) TextInkBounds(
+	text string, style gui.TextStyle) (gui.InkBounds, bool) {
+	r, ok := tm.textSys.InkBounds(text, guiStyleToGlyphConfig(style))
+	if !ok {
+		return gui.InkBounds{}, false
+	}
+	return gui.InkBounds{
+		X: r.X, Y: r.Y, Width: r.Width, Height: r.Height,
+	}, true
+}
+
+func (tm *textMeasurer) LayoutText(
+	text string, style gui.TextStyle, wrapWidth float32,
+) (glyph.Layout, error) {
+	cfg := guiStyleToGlyphConfig(style)
+	if wrapWidth > 0 {
+		cfg.Block.Width = wrapWidth
+		cfg.Block.Wrap = glyph.WrapWord
+	} else if wrapWidth < 0 {
+		cfg.Block.Width = -wrapWidth
+		cfg.Block.Wrap = glyph.WrapNone
+	}
+	return tm.textSys.LayoutText(text, cfg)
+}
+
+func (tm *textMeasurer) LayoutRichText(
+	rt glyph.RichText, cfg glyph.TextConfig,
+) (glyph.Layout, error) {
+	return tm.textSys.LayoutRichText(rt, cfg)
+}
+
+func (tm *textMeasurer) ListFontFamilies() []string {
+	return tm.textSys.ListFontFamilies()
+}
+
+func guiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {
+	return glyphconv.GuiStyleToGlyphConfig(s)
+}
+
+// --- Text render kinds ---
+
+func (r *renderer) drawText(cmd *gui.RenderCmd) {
+	if r.textSys == nil || cmd.Text == "" {
+		return
+	}
+	var cfg glyph.TextConfig
+	if cmd.TextStylePtr != nil {
+		cfg = guiStyleToGlyphConfig(*cmd.TextStylePtr)
+		cfg.Gradient = cmd.TextGradient
+	} else {
+		cfg = glyph.TextConfig{
+			Style: glyph.TextStyle{
+				FontName: cmd.FontName,
+				Size:     cmd.FontSize,
+				Color: glyph.Color{
+					R: cmd.Color.R,
+					G: cmd.Color.G,
+					B: cmd.Color.B,
+					A: cmd.Color.A,
+				},
+			},
+			Block: glyph.DefaultBlockStyle(),
+		}
+	}
+	if cmd.W > 0 {
+		cfg.Block.Wrap = glyph.WrapWord
+		cfg.Block.Width = cmd.W
+	}
+	_ = r.textSys.DrawText(cmd.X, cmd.Y, cmd.Text, cfg)
+}
+
+func (r *renderer) drawLayout(cmd *gui.RenderCmd) {
+	if r.textSys == nil || cmd.LayoutPtr == nil {
+		return
+	}
+	if cmd.TextGradient != nil {
+		r.textSys.DrawLayoutWithGradient(
+			*cmd.LayoutPtr, cmd.X, cmd.Y, cmd.TextGradient)
+		return
+	}
+	r.textSys.DrawLayout(*cmd.LayoutPtr, cmd.X, cmd.Y)
+}
+
+func (r *renderer) drawLayoutTransformed(cmd *gui.RenderCmd) {
+	if r.textSys == nil || cmd.LayoutPtr == nil ||
+		cmd.LayoutTransform == nil {
+		return
+	}
+	if cmd.TextGradient != nil {
+		r.textSys.DrawLayoutTransformedWithGradient(
+			*cmd.LayoutPtr, cmd.X, cmd.Y,
+			*cmd.LayoutTransform, cmd.TextGradient)
+		return
+	}
+	r.textSys.DrawLayoutTransformed(
+		*cmd.LayoutPtr, cmd.X, cmd.Y, *cmd.LayoutTransform)
+}
+
+func (r *renderer) drawTextPath(cmd *gui.RenderCmd) {
+	layout, placements, err := gui.ComputeTextPathPlacements(
+		cmd, r.textSys, &r.placements, guiStyleToGlyphConfig)
+	if err != nil || len(placements) == 0 {
+		return
+	}
+	r.textSys.DrawLayoutPlaced(layout, placements)
+}

--- a/gui/headless.go
+++ b/gui/headless.go
@@ -1,0 +1,26 @@
+package gui
+
+// Headless rendering is the mode a software rasterizer (gui/backend/soft)
+// renders a frame in: no GPU, no window, no animation goroutine. The flag
+// exists so wall-clock-driven visuals have one place to consult, making
+// frame output a function of window state alone.
+//
+// It is deliberately not a general "no animation" switch: animations that
+// are driven by explicit state still run.
+
+// SetHeadlessRender marks this window as rendering headlessly, which
+// suppresses visuals whose appearance depends on wall-clock time — today
+// the blinking text caret. Set it before the frame that is captured, so
+// repeated captures of the same window state produce the same pixels.
+//
+// gui/backend/soft sets this for every window it renders; call it directly
+// only when driving the frame pipeline yourself.
+func (w *Window) SetHeadlessRender(on bool) {
+	w.headlessRender = on
+}
+
+// HeadlessRender reports whether this window renders headlessly.
+// exportaudit:keep — paired reader for SetHeadlessRender
+func (w *Window) HeadlessRender() bool {
+	return w.headlessRender
+}

--- a/gui/window.go
+++ b/gui/window.go
@@ -189,6 +189,10 @@ type Window struct {
 	windowWidth  int
 	windowHeight int
 
+	// headlessRender suppresses wall-clock-driven visuals so a
+	// captured frame is reproducible. See gui/headless.go.
+	headlessRender bool
+
 	// Frame counter — incremented each FrameFn call, stamped
 	// on events for frame-based timing (double-click detection).
 	frameCount uint64
@@ -306,6 +310,12 @@ func (w *Window) clearInputSelections() {
 
 // inputCursorOn returns the input cursor blink state.
 func (w *Window) inputCursorOn() bool {
+	// A headless capture has no blink goroutine driving the atomic, so
+	// the caret is already off in practice; the gate makes that a
+	// guarantee instead of an accident of timing.
+	if w.headlessRender {
+		return false
+	}
 	return w.viewState.inputCursorOn.Load()
 }
 

--- a/tools/depsdoc/main.go
+++ b/tools/depsdoc/main.go
@@ -44,6 +44,7 @@ var directPurpose = map[string]string{
 	"github.com/yuin/goldmark-emoji":  "Goldmark extension: `:emoji:` shortcodes.",
 	"github.com/go-pdf/fpdf":          "PDF generation for the print-dialog backend.",
 	"github.com/godbus/dbus/v5":       "Linux native platform: notifications, portals.",
+	"golang.org/x/image":              "Antialiased vector rasterization for the headless software renderer (`gui/backend/soft`). Also pulled in by go-glyph.",
 	"golang.org/x/mod":                "Module version parsing; imported by `requiredid` analyzer.",
 	"golang.org/x/sys":                "Win32 + WGL syscalls for the native Windows backend (`gui/backend/gl`, `winkey`).",
 	"golang.org/x/tools":              "`go/analysis` framework for the `requiredid` analyzer (`tools/`).",


### PR DESCRIPTION
Fixes #333.

Software-rasterizes a go-gui frame to an image on the CPU: no GPU, no window, no event loop — for CI screenshots and pixel-level regression tests.

## What's in

- **`gui/backend/soft`** — `RenderToImage(w, scale)`, `RenderToPNG(w, scale, path)`, `Release(w)`. Replays the same flat `[]RenderCmd` stream the GPU backends and the PDF printer consume, so no existing backend changes.
- **Real text, not approximated** — implements `glyph.DrawBackend` over a CPU framebuffer (`golang.org/x/image/vector` rasterization); the resulting `glyph.TextSystem` is installed as the window's `gui.TextMeasurer`, so shaping/metrics/rasterization run the same pure-Go code the GPU backends use. Two-pass render warms the glyph atlas (go-glyph uploads at `Commit`).
- **`(*Window).SetHeadlessRender`** — suppresses wall-clock visuals (today the blinking caret) so repeated captures of one window state are pixel-identical.
- **Phase 1 kinds**: clip, rect, stroke rect, circle, line, gradient, gradient border, image, and every text kind. SVG/shadow/blur/filter/stencil/rotation/termgrid are accepted and skipped; custom shaders unsupported by design. Phase 2 is issue #360.
- Example `examples/headless_png/`, spec `docs/specs/headless-software-rendering.md`.

## Quality pass

- 9 new tests (lines, radial gradients, gradient borders, mem: images, scale-change rebuild, Release+re-render, nil/zero-size windows, fallback-style text).
- Per-pixel sampling allocation-free (scratch `color.NRGBA`, cached stride, reusable `image.Uniform`); warm pass filters to text kinds so shapes rasterize once.
- Parity verified against the GL gradient shader and android/web draw paths.