### PR TITLE
Soft rasterizer phase 2: SVG, shadow/blur, filters, stencil, rotation, term grid (issue #360)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ examples/bin/
 # Output
 *.out
 
+# Software-rasterizer captures. examples/headless_png writes headless.png
+# into the working directory when run with no argument; assets/*.png are
+# tracked, so this stays anchored to the repo root.
+/headless.png
+
 # iOS c-archive build artifacts
 *.a
 examples/ios_demo/ios/libgoguiapp.h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,36 @@ and this project adheres to
     headlessly, suppressing wall-clock-driven visuals (today the blinking caret)
     so repeated captures of one window state produce the same pixels.
   - Phase 1 covers clip, rect, stroke rect, circle, line, gradient, gradient
-    border, image and every text kind. SVG, shadow, blur, filter, stencil,
-    rotation and terminal-grid commands are accepted and skipped; custom shaders
-    stay unsupported by design. See `docs/specs/headless-software-rendering.md`
-    and `examples/headless_png/`.
+    border, image and every text kind. See
+    `docs/specs/headless-software-rendering.md` and `examples/headless_png/`.
+
+- **Software rasterizer phase 2: SVG, shadow and blur, filters, stencil,
+  rotation, terminal grid** (issue #360). `gui/backend/soft` now draws every
+  render kind the pipeline emits, so a headless capture is the frame rather than
+  the subset of it phase 1 could rasterize.
+  - `RenderSvg` rasterizes the tessellated triangle list, honouring `HasXform`,
+    `RotAngle` and `VertexAlphaScale` in the same order the GL backend applies
+    them. Triangles are filled in runs of one colour so a shape's interior edges
+    cancel instead of showing as antialiasing seams; a triangle with per-vertex
+    colours is interpolated barycentrically.
+  - `RenderShadow` and `RenderBlur` rasterize their rounded rect into a coverage
+    mask and blur it with three box passes, the shadow additionally erasing the
+    part that would sit under its caster.
+  - Filter, stencil and rotation brackets share one mechanism: the bracketed
+    commands draw into a pooled offscreen layer, and the matching end composites
+    it back with the effect applied — a coverage mask, an inverse-mapped
+    resample, or blur plus colour matrix plus repeated composite. Because the
+    layer is composited rather than the geometry transformed, the effects hold
+    for text and images, not only for shapes.
+  - `RenderTermGrid` renders the terminal character grid — background runs,
+    selection, cursor styles, column-pinned glyph runs and underlines — so
+    go-term can capture a terminal headlessly.
+  - Hostile input is bounded rather than trusted: blur radii and filter layer
+    counts are clamped, NaN extents and corner radii are rejected before they
+    reach the rasterizer, and compositing saturates instead of wrapping a
+    colour-matrixed pixel to near-black.
+  - `RenderCustomShader` remains unsupported by design: it is GLSL, and there is
+    no CPU equivalent to compile.
 
 - **`VirtualList` — virtualized lists whose rows may differ in height, and
   index-addressed scrolling** (issue #332). Virtualization was arithmetic over

--- a/docs/specs/headless-software-rendering.md
+++ b/docs/specs/headless-software-rendering.md
@@ -1,6 +1,6 @@
 # Headless software rendering
 
-Issue #333. Status: phase 1 landed.
+Issue #333 (phase 1), issue #360 (phase 2). Status: complete.
 
 ## Problem
 
@@ -76,9 +76,8 @@ go-glyph rasterizes a glyph into a staging buffer when it is first drawn but
 only hands the page to the backend at `Commit`. On screen the next frame
 corrects the sampling; a one-shot capture has no next frame. The first pass
 therefore draws the text kinds with a nil target — shaping and rasterization
-run, the quads are discarded — and `Commit` uploads the atlas. Shapes,
-gradients and images are skipped on the warm pass and drawn once, for real,
-in the second.
+run, the quads are discarded — and `Commit` uploads the atlas. Shapes, gradients
+and images are skipped on the warm pass and drawn once, for real, in the second.
 
 ### Rasterization
 
@@ -117,23 +116,115 @@ one.
 
 ## Phase split
 
-Phase 1 (landed) covers `RenderClip`, `RenderRect`, `RenderStrokeRect`,
+Phase 1 (issue #333) covered `RenderClip`, `RenderRect`, `RenderStrokeRect`,
 `RenderCircle`, `RenderLine`, `RenderGradient`, `RenderGradientBorder`,
 `RenderImage`, and every text kind.
 
-Deferred to phase 2 (issue #360): `RenderSvg` (barycentric triangle
-rasterization over `Triangles`/`VertexColors`, honouring `HasXform`, `RotAngle`,
-`VertexAlphaScale`), `RenderShadow` and `RenderBlur` (separable box-blur
-passes), `RenderFilterBegin/End/Composite` (offscreen buffer plus
-`ColorMatrix`), `RenderStencilBegin/End`, `RenderRotateBegin/End`, and
-`RenderTermGrid`. `RenderCustomShader` stays unsupported by design — it is GLSL.
+Phase 2 (issue #360) added `RenderSvg`, `RenderShadow`, `RenderBlur`, the filter
+bracket, the stencil bracket, the rotation bracket, and `RenderTermGrid`.
+`RenderCustomShader` stays unsupported by design — it is GLSL, and there is no
+CPU equivalent to compile.
 
-The deferred kinds are listed in one explicit `case` in
+The unsupported kinds are still listed in one explicit `case` in
 `gui/backend/soft/draw.go` rather than caught by a `default`, so a newly added
 render kind is a compile-visible decision. This follows the precedent in
 `gui/print_pdf.go`.
 
-## Not in this phase
+## Layers: one mechanism for three brackets
+
+Filters, stencil clipping and rotation all scope later drawing, and all three
+use the same construction: `RenderFilterBegin` / `RenderStencilBegin` /
+`RenderRotateBegin` re-point the render target at an offscreen layer, the
+bracketed commands draw into it unaware, and the matching end composites the
+layer back with the scoped effect applied — a coverage mask for the stencil, an
+inverse-mapped resample for the rotation, blur plus colour matrix plus repeated
+composite for the filter.
+
+The alternative — carrying a transform and a clip mask through every draw path —
+was rejected. It would have touched every phase 1 file and still not covered
+text, which goes through go-glyph's draw backend rather than this package's path
+builders. With a layer, a rotated caption and a stencil-clipped image are
+correct for free.
+
+Three consequences worth naming:
+
+- **Nesting needs no depth counter.** An inner bracket composites into the outer
+  bracket's layer, which is already masked. `RenderCmd.StencilDepth` is what the
+  GL backend uses to unwind a shared stencil buffer; a layer stack has nothing
+  to unwind, so it is read only as documentation of intent.
+- **Layers are full window size and pooled.** Full size keeps every coordinate
+  in device space, so no draw path does offset bookkeeping. The cost is bounded
+  by pooling (`renderer.layerPool`) plus a per-layer dirty box: clearing and
+  compositing walk only the pixels a bracket actually wrote.
+- **The clip carries across the bracket, and is not restored on pop.** That is
+  what the GPU backends do — a scissor survives an FBO bind — and the render
+  stream re-emits the clip it wants after `RenderStencilEnd`.
+
+An unbalanced stream is not allowed to swallow content: `finishBrackets` closes
+anything still open at the end of the pass, and an end command of the wrong kind
+is ignored rather than popping a bracket it did not open.
+
+## SVG triangles
+
+`RenderSvg` arrives as a flat triangle list with an optional colour per vertex.
+Either way the coverage for a whole command comes from a **single path**, never
+one triangle at a time: the rasterizer accumulates signed coverage across a
+path, so the interior edges triangles share cancel exactly. Rasterized
+separately, a shared edge is antialiased twice — two ~50% coverages that
+composite to 75%, not 100% — and the background shows through as a lattice of
+pale lines over every gradient.
+
+Flat geometry is therefore filled as one path in one colour. Vertex-coloured
+geometry is a mesh, and takes two passes: the same single-path coverage mask,
+plus a pooled layer holding the shading, which is composited through it. The
+shading is **written, not blended**, so a pixel two triangles both claim along a
+shared edge is painted once — their colours agree there, and blending twice
+would darken every seam of a translucent gradient. Each triangle paints every
+pixel centre inside it plus a half-pixel skirt; the skirt keeps the mesh's outer
+edge from thinning, where a pixel the mask includes at 40% can have its centre
+just outside the triangle. Interior pixels are unaffected, since the triangles
+tile and every centre inside the mesh is already claimed. Within a triangle the
+colour is the barycentric interpolation of its three vertices, the CPU
+equivalent of the GPU's varying interpolation.
+
+The vertex transform order mirrors `gui/backend/gl`'s `drawSvg`:
+`animateTransform` scale and translate, then rotation about (`RotCX`, `RotCY`),
+then the command's own `Scale` and origin. `IsClipMask` geometry is skipped, as
+it is in every other backend — no render pipeline consumes it yet.
+
+## Shadow and blur
+
+The GPU path is one SDF quad per command. The CPU path rasterizes the same
+rounded rect into a coverage mask, blurs the mask, and composites the colour
+through it; a shadow additionally multiplies in the complement of its caster's
+coverage, which is the shader's second SDF. The blur is three box passes — the
+standard Gaussian approximation, at a cost independent of the radius, which is
+what makes a large shadow affordable on a CPU. `sigmaPerBlur` documents how a
+command's blur radius maps onto a standard deviation, since the shaders ramp
+linearly across a band rather than convolving.
+
+## Bounds on hostile input
+
+A CPU rasterizer turns an unvalidated number into wall-clock time, so the phase
+2 kinds clamp what they accept rather than trusting the stream. Blur radii reach
+`soft` from widget config and from an SVG filter's `stdDev`; `clampBlur` rejects
+NaN and caps the radius at `maxBlur` device pixels, because an infinite radius
+sizes the box-blur sliding window and the failure is a hang rather than a wrong
+pixel. `blurPlanes` caps sigma again at the plane's own size, past which a box
+already averages everything. `RenderFilterBegin.Layers` is the count of
+`feMergeNode` elements in an untrusted document and each layer is a full
+composite pass, so `maxFilterLayers` caps the repeat. Corner radii and extents
+go through negated `>` comparisons, which reject NaN where `<= 0` would pass it
+on to the rasterizer as NaN control points. `maxLayerDepth` caps bracket
+nesting: past it the bracketed commands draw into the parent, which keeps the
+begin/end pairing intact and loses only the scoped effect.
+
+Compositing saturates rather than wrapping. A filter's colour matrix clamps each
+channel independently, so it can leave a pixel whose colour exceeds its own
+alpha; the unclamped premultiplied sum would pass 255 and wrap a bright pixel to
+near-black. `overPremul` is the single place that blend is spelled.
+
+## Not in either phase
 
 Pixel golden images (issue #361). Platform font variance and antialiasing
 stability make them a separate decision from the renderer itself; the tests here

--- a/gui/backend/soft/doc.go
+++ b/gui/backend/soft/doc.go
@@ -17,8 +17,16 @@
 // gui.TextMeasurer, so shaping, metrics and glyph rasterization are the
 // same code the GPU backends run.
 //
-// Phase 1 covers the core command kinds — clip, rect, stroke rect, circle,
-// line, gradient, gradient border, image, and every text kind. SVG,
-// shadow, blur, filter and stencil commands are accepted and skipped; see
-// docs/specs/headless-software-rendering.md for the phase split.
+// Every render kind the pipeline emits is drawn: clip, rect, stroke
+// rect, circle, line, gradient, gradient border, image, every text kind,
+// SVG triangles, shadow and blur, filter brackets, stencil clipping,
+// rotation brackets and the terminal grid. Filter, stencil and rotation
+// brackets render into an offscreen layer that is composited back with
+// the scoped effect applied, which is why they hold for text and images
+// and not only for shapes.
+//
+// RenderCustomShader is unsupported by design: it is GLSL, and there is
+// no CPU equivalent to compile. SVG clip-mask geometry is skipped, as it
+// is in every other backend. See
+// docs/specs/headless-software-rendering.md.
 package soft

--- a/gui/backend/soft/draw.go
+++ b/gui/backend/soft/draw.go
@@ -3,6 +3,8 @@ package soft
 import (
 	"image"
 
+	"golang.org/x/image/vector"
+
 	"github.com/go-gui-org/go-glyph"
 
 	"github.com/go-gui-org/go-gui/gui"
@@ -12,8 +14,11 @@ import (
 // analogue of gui/backend/gl's Backend.renderersDraw: same dispatch, same
 // per-command scaling by the device pixel ratio.
 type renderer struct {
-	buf   *buffer
-	scale float32
+	// buf is the current target: the window buffer, or the innermost
+	// open bracket's layer. rootBuf is always the window buffer.
+	buf     *buffer
+	rootBuf *buffer
+	scale   float32
 
 	textSys   *glyph.TextSystem
 	glyphBack *glyphBackend
@@ -29,9 +34,21 @@ type renderer struct {
 	// shapes, gradients and images rasterize exactly once.
 	warm bool
 
+	// brackets holds the open begin/end pairs — filter, stencil and
+	// rotate all scope later drawing by pushing an offscreen layer.
+	brackets  []bracket
+	layerPool []*buffer
+
 	// Scratch buffers reused across commands.
 	placements []glyph.GlyphPlacement
 	normStops  []gui.GradientStop
+	maskRast   vector.Rasterizer
+	maskPix    []uint8
+	maskPix2   []uint8
+	blurTmp    []uint8
+	svgBatch   []float32
+	termRunes  []rune
+	termCols   []int
 }
 
 // drawAll replays every command in cmds. With warm set it draws only the
@@ -43,7 +60,8 @@ func (r *renderer) drawAll(cmds []gui.RenderCmd) {
 		if r.warm {
 			switch cmd.Kind {
 			case gui.RenderText, gui.RenderLayout, gui.RenderRTF,
-				gui.RenderLayoutTransformed, gui.RenderTextPath:
+				gui.RenderLayoutTransformed, gui.RenderTextPath,
+				gui.RenderTermGrid:
 			default:
 				continue
 			}
@@ -74,24 +92,39 @@ func (r *renderer) drawAll(cmds []gui.RenderCmd) {
 			r.drawLayoutTransformed(cmd)
 		case gui.RenderTextPath:
 			r.drawTextPath(cmd)
+		case gui.RenderSvg:
+			r.drawSvg(cmd)
+		case gui.RenderShadow:
+			r.drawShadow(cmd)
+		case gui.RenderBlur:
+			r.drawBlur(cmd)
+		case gui.RenderFilterBegin:
+			r.beginFilter(cmd)
+		case gui.RenderFilterEnd:
+			r.endFilter()
+		case gui.RenderStencilBegin:
+			r.beginStencil(cmd)
+		case gui.RenderStencilEnd:
+			r.endStencil()
+		case gui.RenderRotateBegin:
+			r.beginRotation(cmd)
+		case gui.RenderRotateEnd:
+			r.endRotation()
+		case gui.RenderTermGrid:
+			r.drawTermGrid(cmd)
 
-		// Phase 2 (see docs/specs/headless-software-rendering.md).
+		// Unsupported by design, or never emitted by the render path.
 		// Listed explicitly rather than caught by a default so a new
 		// render kind is a compile-visible decision, following the
 		// precedent in gui/print_pdf.go.
+		//
+		// RenderCustomShader is GLSL: there is no CPU equivalent to
+		// compile. RenderFilterComposite is not emitted by the render
+		// path — endFilter reads the layer count from the bracket's
+		// RenderFilterBegin, as the GPU backends do.
 		case gui.RenderNone,
-			gui.RenderSvg,
-			gui.RenderShadow,
-			gui.RenderBlur,
-			gui.RenderFilterBegin,
-			gui.RenderFilterEnd,
-			gui.RenderFilterComposite,
-			gui.RenderStencilBegin,
-			gui.RenderStencilEnd,
-			gui.RenderRotateBegin,
-			gui.RenderRotateEnd,
 			gui.RenderCustomShader,
-			gui.RenderTermGrid,
+			gui.RenderFilterComposite,
 			gui.RenderLayoutPlaced:
 		}
 	}

--- a/gui/backend/soft/draw_effects.go
+++ b/gui/backend/soft/draw_effects.go
@@ -1,0 +1,283 @@
+package soft
+
+import (
+	"image"
+	"math"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// blurExpand is how far past its own box a blurred shape can paint,
+// as a multiple of the blur radius. It is the GPU path's quad
+// expansion, kept identical so the two rasterizers agree on which
+// pixels a shadow may touch.
+const blurExpand = 1.5
+
+// maxBlur caps a blur radius in device pixels. Blur radii arrive from
+// widget config and from filter primitives in untrusted SVG, where a
+// NaN or a six-digit stdDev would otherwise size a box-blur window
+// from unvalidated input; nothing legible needs more spread than this.
+const maxBlur = 512
+
+// clampBlur reduces a command's blur radius to the supported range.
+// The negated > rejects NaN as well as zero and negatives.
+func clampBlur(v float32) float32 {
+	if !(v > 0) {
+		return 0
+	}
+	return min(v, maxBlur)
+}
+
+// sigmaPerBlur converts a command's blur radius to a Gaussian standard
+// deviation. The GPU shaders ramp their SDF alpha linearly across a
+// band of width BlurRadius; a Gaussian of half that sigma puts
+// essentially all of its transition in the same band, so the two
+// agree on the visible extent of the falloff.
+const sigmaPerBlur = 0.5
+
+// drawShadow paints a blurred rounded rect offset from its caster, and
+// erases the part that would sit under the caster itself.
+//
+// The GPU path is one SDF quad evaluating two distance fields; the CPU
+// path is softRoundRect with the caster cut-out enabled.
+func (r *renderer) drawShadow(cmd *gui.RenderCmd) {
+	r.softRoundRect(cmd, cmd.OffsetX, cmd.OffsetY, true)
+}
+
+// drawBlur paints a rounded rect with a soft edge — the GPU's blur
+// pipeline, which is a shadow with no offset and no caster cut-out.
+func (r *renderer) drawBlur(cmd *gui.RenderCmd) {
+	r.softRoundRect(cmd, 0, 0, false)
+}
+
+// softRoundRect rasterizes a rounded rect into a coverage mask, blurs
+// the mask, optionally multiplies in the inverse coverage of the
+// un-offset caster, and composites the command's color through the
+// result. Both soft-edged kinds are that one construction; the shaders
+// differ only in whether the second distance field is evaluated.
+//
+// offX/offY are logical, and are what separates a shadow from its
+// caster. The size guards are written as negated > so a NaN extent
+// takes the reject branch instead of sizing a full-buffer mask that
+// rasterizes to nothing.
+func (r *renderer) softRoundRect(cmd *gui.RenderCmd, offX, offY float32,
+	cutCaster bool) {
+
+	if cmd.Color.A == 0 || !(cmd.W > 0) || !(cmd.H > 0) {
+		return
+	}
+	s := r.scale
+	w, h := cmd.W*s, cmd.H*s
+	blur := clampBlur(cmd.BlurRadius * s)
+	rad := cmd.Radius * s
+	x := (cmd.X + offX) * s
+	y := (cmd.Y + offY) * s
+
+	expand := blur * blurExpand
+	region := deviceRect(x-expand, y-expand, w+2*expand, h+2*expand).
+		Intersect(r.buf.img.Bounds())
+	if region.Empty() {
+		return
+	}
+
+	mask := r.coverageRoundRect(&r.maskPix, region, x, y, w, h, rad)
+	if mask == nil {
+		return
+	}
+	if blur > 0 {
+		boxBlurAlpha(mask, &r.blurTmp, blur*sigmaPerBlur)
+	}
+	if cutCaster {
+		// Erase the shadow where the caster covers it: the caster is
+		// the un-offset rect, and the shader's smoothstep(-1, 0, d_c)
+		// is a coverage complement.
+		caster := r.coverageRoundRect(&r.maskPix2, region,
+			cmd.X*s, cmd.Y*s, w, h, rad)
+		if caster != nil {
+			subtractCoverage(mask, caster)
+		}
+	}
+	r.compositeMask(mask, cmd.Color)
+}
+
+// compositeMask blends a straight color into the current target through
+// a coverage mask, restricted to the clip rect.
+func (r *renderer) compositeMask(mask *image.Alpha, c gui.Color) {
+	rect := mask.Rect.Intersect(r.buf.clip)
+	if rect.Empty() {
+		return
+	}
+	pr, pg, pb, pa := premul(c)
+	pix := r.buf.img.Pix
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		mi := mask.PixOffset(rect.Min.X, y)
+		di := r.buf.img.PixOffset(rect.Min.X, y)
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			m := uint32(mask.Pix[mi])
+			mi++
+			if m == 0 {
+				di += 4
+				continue
+			}
+			sr := uint32(pr) * m / 255
+			sg := uint32(pg) * m / 255
+			sb := uint32(pb) * m / 255
+			sa := uint32(pa) * m / 255
+			inv := 255 - sa
+			pix[di] = overPremul(sr, uint32(pix[di]), inv)
+			pix[di+1] = overPremul(sg, uint32(pix[di+1]), inv)
+			pix[di+2] = overPremul(sb, uint32(pix[di+2]), inv)
+			pix[di+3] = overPremul(sa, uint32(pix[di+3]), inv)
+			di += 4
+		}
+	}
+	r.buf.markDirty(rect)
+}
+
+// subtractCoverage multiplies dst by the complement of sub, in place.
+// Both masks must cover the same rectangle.
+func subtractCoverage(dst, sub *image.Alpha) {
+	n := min(len(dst.Pix), len(sub.Pix))
+	for i := range n {
+		dst.Pix[i] = uint8(uint32(dst.Pix[i]) *
+			uint32(255-sub.Pix[i]) / 255)
+	}
+}
+
+// --- Box blur ---
+//
+// Three box passes approximate a Gaussian to within about 3% — the
+// standard result — at a cost independent of the radius, which is what
+// makes a large shadow blur affordable on the CPU. Everything outside
+// the blurred rectangle counts as zero: a mask's region is expanded by
+// blurExpand before rasterizing, so the falloff is already inside it,
+// and a filter layer really is transparent out there.
+
+// boxBlurAlpha blurs a coverage mask in place.
+func boxBlurAlpha(m *image.Alpha, tmp *[]uint8, sigma float32) {
+	w, h := m.Rect.Dx(), m.Rect.Dy()
+	blurPlanes(m.Pix, w, h, m.Stride, 1, 1, tmp, sigma)
+}
+
+// boxBlurRGBA blurs every channel of rect in img in place. The pixels
+// are premultiplied, so the four channels blur independently without
+// the halo a straight-alpha blur would produce.
+func boxBlurRGBA(img *image.RGBA, rect image.Rectangle, tmp *[]uint8,
+	sigma float32) {
+
+	if rect.Empty() {
+		return
+	}
+	pix := img.Pix[img.PixOffset(rect.Min.X, rect.Min.Y):]
+	blurPlanes(pix, rect.Dx(), rect.Dy(), img.Stride, 4, 4, tmp, sigma)
+}
+
+// blurPlanes runs the three-pass box blur over every interleaved
+// channel of a strided plane.
+func blurPlanes(pix []byte, w, h, stride, pixStride, channels int,
+	tmp *[]uint8, sigma float32) {
+
+	// Negated > rejects a NaN sigma, which would otherwise reach
+	// boxRadii and size the window loops from int(NaN).
+	if w <= 0 || h <= 0 || !(sigma > 0) {
+		return
+	}
+	// A box wider than the plane already averages all of it, so a
+	// larger sigma buys nothing and only lengthens the window loops.
+	sigma = min(sigma, float32(max(w, h)))
+	radii := boxRadii(sigma)
+	need := w * h
+	if cap(*tmp) < need {
+		*tmp = make([]uint8, need)
+	}
+	scratch := (*tmp)[:need]
+	for ch := range channels {
+		for _, rad := range radii {
+			if rad <= 0 {
+				continue
+			}
+			boxPassH(pix, scratch, w, h, stride, pixStride, ch, rad)
+			boxPassV(scratch, pix, w, h, stride, pixStride, ch, rad)
+		}
+	}
+}
+
+// boxPassH averages a horizontal window into the packed scratch plane.
+func boxPassH(src []byte, dst []uint8, w, h, stride, pixStride, ch,
+	rad int) {
+
+	win := uint32(2*rad + 1)
+	for y := range h {
+		row := src[y*stride+ch:]
+		out := dst[y*w:]
+		var sum uint32
+		for i := -rad; i <= rad; i++ {
+			if i >= 0 && i < w {
+				sum += uint32(row[i*pixStride])
+			}
+		}
+		for x := range w {
+			out[x] = uint8(sum / win)
+			// Slide: drop the leftmost sample, add the next one.
+			if lo := x - rad; lo >= 0 && lo < w {
+				sum -= uint32(row[lo*pixStride])
+			}
+			if hi := x + rad + 1; hi >= 0 && hi < w {
+				sum += uint32(row[hi*pixStride])
+			}
+		}
+	}
+}
+
+// boxPassV averages a vertical window from the packed scratch plane
+// back into the interleaved destination.
+func boxPassV(src []uint8, dst []byte, w, h, stride, pixStride, ch,
+	rad int) {
+
+	win := uint32(2*rad + 1)
+	for x := range w {
+		var sum uint32
+		for i := -rad; i <= rad; i++ {
+			if i >= 0 && i < h {
+				sum += uint32(src[i*w+x])
+			}
+		}
+		for y := range h {
+			dst[y*stride+x*pixStride+ch] = uint8(sum / win)
+			if lo := y - rad; lo >= 0 && lo < h {
+				sum -= uint32(src[lo*w+x])
+			}
+			if hi := y + rad + 1; hi >= 0 && hi < h {
+				sum += uint32(src[hi*w+x])
+			}
+		}
+	}
+}
+
+// boxRadii picks three box radii whose successive application has the
+// same variance as a Gaussian of the given sigma (Kovesi's
+// approximation), so the passes land on the intended blur width rather
+// than an arbitrary one.
+func boxRadii(sigma float32) [3]int {
+	const n = 3
+	wIdeal := math.Sqrt(float64(12*sigma*sigma)/n + 1)
+	wl := int(math.Floor(wIdeal))
+	if wl%2 == 0 {
+		wl--
+	}
+	wu := wl + 2
+	mIdeal := (12*float64(sigma*sigma) - float64(n*wl*wl) -
+		float64(4*n*wl) - float64(3*n)) /
+		float64(-4*wl-4)
+	m := int(math.Round(mIdeal))
+
+	var radii [3]int
+	for i := range n {
+		size := wu
+		if i < m {
+			size = wl
+		}
+		radii[i] = max((size-1)/2, 0)
+	}
+	return radii
+}

--- a/gui/backend/soft/draw_filter.go
+++ b/gui/backend/soft/draw_filter.go
@@ -1,0 +1,97 @@
+package soft
+
+import (
+	"image"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// minFilterBlur is the blur below which the filter's blur passes are
+// skipped, matching the GPU path's `filterBlur >= 1` gate: under a
+// device pixel there is nothing to spread.
+const minFilterBlur = 1
+
+// maxFilterLayers caps the composite repeat count. Layers is the count
+// of feMergeNode elements in an SVG filter, so an untrusted document
+// can name an arbitrary number of them; past a handful the glow is
+// already saturated and each extra pass is a full-layer blend.
+const maxFilterLayers = 32
+
+// beginFilter opens a filter (glow) bracket: everything up to the
+// matching RenderFilterEnd is drawn into an offscreen layer instead of
+// the target, exactly as the GPU backends bind an FBO.
+func (r *renderer) beginFilter(cmd *gui.RenderCmd) {
+	br := r.pushLayer(bracketFilter)
+	br.blur = clampBlur(cmd.BlurRadius * r.scale)
+	br.layers = min(max(cmd.Layers, 1), maxFilterLayers)
+	br.matrix = cmd.ColorMatrix
+}
+
+// endFilter blurs the layer, applies the color matrix, and composites
+// the result once per layer — the same three passes, in the same
+// order, as the GPU path's blur / color / composite pipelines.
+//
+// The composite really is repeated: drawing the result N times is how
+// a glow gains its intensity, and repeating the blend reproduces it
+// rather than approximating it with a single scaled draw.
+func (r *renderer) endFilter() {
+	br, ok := r.popLayer(bracketFilter)
+	if !ok || br.layer == nil {
+		return
+	}
+	defer r.releaseLayer(br.layer)
+
+	rect := br.layer.dirty
+	if rect.Empty() {
+		return
+	}
+	if br.blur >= minFilterBlur {
+		// Blurring spreads paint past the drawn box, so the working
+		// rect has to grow before the passes run.
+		grow := int(br.blur*blurExpand) + 1
+		rect = rect.Inset(-grow).Intersect(br.layer.img.Bounds())
+		boxBlurRGBA(br.layer.img, rect, &r.blurTmp, br.blur)
+		br.layer.markDirty(rect)
+	}
+	if br.matrix != nil {
+		applyColorMatrix(br.layer.img, rect, br.matrix)
+	}
+	// The composite is clipped to the current clip rect, as the GPU
+	// backends' scissor survives the FBO bind: the blur may have spread
+	// the layer's paint past the clip, and that spread must not leak
+	// onto the window.
+	out := rect.Intersect(r.buf.clip)
+	for range br.layers {
+		composite(r.buf, br.layer, out, nil)
+	}
+}
+
+// applyColorMatrix multiplies every pixel by a column-major 4x4 matrix
+// and clamps, which is what FsFilterColorGLSL does. The pixels are
+// premultiplied on both sides of the multiply, as they are in the GPU
+// backends' filter texture.
+func applyColorMatrix(img *image.RGBA, rect image.Rectangle,
+	m *[16]float32) {
+
+	rect = rect.Intersect(img.Bounds())
+	if rect.Empty() {
+		return
+	}
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		i := img.PixOffset(rect.Min.X, y)
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			var in [4]float32
+			for c := range 4 {
+				in[c] = float32(img.Pix[i+c]) / 255
+			}
+			for row := range 4 {
+				v := m[row] * in[0] // column 0
+				v += m[4+row] * in[1]
+				v += m[8+row] * in[2]
+				v += m[12+row] * in[3]
+				img.Pix[i+row] = uint8(min(max(v, 0), 1)*255 + 0.5)
+			}
+			i += 4
+		}
+	}
+}

--- a/gui/backend/soft/draw_phase2_test.go
+++ b/gui/backend/soft/draw_phase2_test.go
@@ -1,0 +1,702 @@
+package soft
+
+import (
+	"image"
+	"math"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// tri builds a RenderSvg command from a flat triangle list in SVG
+// space. Scale 1 and origin 0 keep the vertex coordinates readable as
+// device pixels.
+func tri(triangles []float32, c gui.Color) gui.RenderCmd {
+	return gui.RenderCmd{
+		Kind: gui.RenderSvg, Scale: 1, Color: c, Triangles: triangles,
+	}
+}
+
+// square returns the two triangles of an axis-aligned square.
+func square(x, y, size float32) []float32 {
+	return []float32{
+		x, y, x + size, y, x + size, y + size,
+		x, y, x + size, y + size, x, y + size,
+	}
+}
+
+func TestDrawSvgFillsTriangles(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{tri(square(10, 10, 20), gui.RGB(0, 255, 0))})
+
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("inside green = %d, want 255", g)
+	}
+	// The shared diagonal of the two triangles must not show as a
+	// seam: a run is one path, so its interior edges cancel.
+	if _, g, _, _ := at(r.buf.img, 15, 15); g != 255 {
+		t.Errorf("on shared diagonal green = %d, want 255 (seam)", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 5, 20); g != 0 {
+		t.Errorf("outside green = %d, want 0", g)
+	}
+}
+
+func TestDrawSvgHonoursScaleAndOrigin(t *testing.T) {
+	r := newRenderer(40, 40, 2)
+	cmd := tri(square(0, 0, 5), gui.RGB(255, 0, 0))
+	cmd.X, cmd.Y = 5, 5
+	cmd.Scale = 2 // 5..15 logical, 10..30 device
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	if red, _, _, _ := at(r.buf.img, 20, 20); red != 255 {
+		t.Errorf("inside red = %d, want 255", red)
+	}
+	if red, _, _, _ := at(r.buf.img, 8, 8); red != 0 {
+		t.Errorf("outside red = %d, want 0", red)
+	}
+}
+
+func TestDrawSvgAppliesXformAndRotation(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	cmd := tri(square(0, 0, 10), gui.RGB(0, 0, 255))
+	// Translate to 20,20 then rotate 180 degrees about (25, 25):
+	// the square lands back on 20..30 either way, which is only true
+	// if translate runs before rotate.
+	cmd.HasXform = true
+	cmd.ScaleX, cmd.ScaleY = 1, 1
+	cmd.TransX, cmd.TransY = 20, 20
+	cmd.RotAngle = 180
+	cmd.RotCX, cmd.RotCY = 25, 25
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	if _, _, b, _ := at(r.buf.img, 25, 25); b != 255 {
+		t.Errorf("rotated square blue = %d, want 255", b)
+	}
+	if _, _, b, _ := at(r.buf.img, 5, 5); b != 0 {
+		t.Errorf("origin blue = %d, want 0 (transform not applied)", b)
+	}
+}
+
+func TestDrawSvgVertexAlphaScale(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	cmd := tri(square(10, 10, 20), gui.Color{})
+	white := gui.RGB(255, 255, 255)
+	cmd.VertexColors = []gui.Color{
+		white, white, white, white, white, white,
+	}
+	cmd.HasVertexAlpha = true
+	cmd.VertexAlphaScale = 0.5
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	// Half-alpha white over black is mid grey.
+	if red, _, _, _ := at(r.buf.img, 20, 20); !closeTo(red, 127, 2) {
+		t.Errorf("half-alpha white over black = %d, want ~127", red)
+	}
+}
+
+func TestDrawSvgInterpolatesVertexColors(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	// One triangle: red at the left vertices, green at the right.
+	cmd := tri([]float32{0, 0, 40, 0, 0, 40}, gui.Color{})
+	cmd.VertexColors = []gui.Color{
+		gui.RGB(255, 0, 0), gui.RGB(0, 255, 0), gui.RGB(255, 0, 0),
+	}
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	rl, gl, _, _ := at(r.buf.img, 2, 2)
+	rr, gr, _, _ := at(r.buf.img, 35, 2)
+	if rl <= rr {
+		t.Errorf("red %d at left vs %d at right: not interpolated",
+			rl, rr)
+	}
+	if gr <= gl {
+		t.Errorf("green %d at right vs %d at left: not interpolated",
+			gr, gl)
+	}
+}
+
+func TestDrawSvgSkipsClipMask(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	cmd := tri(square(0, 0, 40), gui.RGB(255, 0, 0))
+	cmd.IsClipMask = true
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	if red, _, _, _ := at(r.buf.img, 20, 20); red != 0 {
+		t.Errorf("clip-mask geometry painted red = %d, want 0", red)
+	}
+}
+
+func TestDrawSvgDegenerateTriangleInMesh(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	// A valid triangle plus a degenerate one (all vertices identical),
+	// which must be skipped, not divide by zero.
+	verts := []float32{
+		10, 10, 30, 10, 10, 30,
+		20, 20, 20, 20, 20, 20,
+	}
+	white := gui.RGB(255, 255, 255)
+	cmd := tri(verts, gui.Color{})
+	cmd.VertexColors = []gui.Color{
+		white, white, white, white, white, white,
+	}
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	if v, _, _, _ := at(r.buf.img, 15, 15); v != 255 {
+		t.Errorf("inside the valid triangle = %d, want 255", v)
+	}
+	if v, _, _, _ := at(r.buf.img, 5, 5); v != 0 {
+		t.Errorf("outside the mesh = %d, want 0", v)
+	}
+}
+
+func TestDrawShadowFallsOffAndClearsCaster(t *testing.T) {
+	r := newRenderer(60, 60, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderShadow, X: 20, Y: 20, W: 20, H: 20,
+		OffsetX: 8, OffsetY: 8, BlurRadius: 4,
+		Color: gui.RGB(255, 255, 255),
+	}})
+
+	// The shadow box is the caster offset by 8: 28..48 against the
+	// caster's 20..40. Inside the shadow, clear of the caster.
+	inShadow, _, _, _ := at(r.buf.img, 44, 44)
+	if inShadow < 200 {
+		t.Errorf("inside shadow = %d, want a near-opaque value",
+			inShadow)
+	}
+	// Under the caster: erased.
+	if v, _, _, _ := at(r.buf.img, 35, 35); v != 0 {
+		t.Errorf("under caster = %d, want 0 (caster not erased)", v)
+	}
+	// Falloff: dimmer just outside the shadow box than well inside.
+	edge, _, _, _ := at(r.buf.img, 50, 44)
+	if edge == 0 || edge >= inShadow {
+		t.Errorf("falloff edge = %d, inside = %d: want 0 < edge < inside",
+			edge, inShadow)
+	}
+	// Far outside the expansion: untouched.
+	if v, _, _, _ := at(r.buf.img, 58, 58); v != 0 {
+		t.Errorf("beyond blur expansion = %d, want 0", v)
+	}
+}
+
+func TestDrawBlurSoftensEdges(t *testing.T) {
+	r := newRenderer(60, 60, 1)
+	r.drawAll([]gui.RenderCmd{{
+		Kind: gui.RenderBlur, X: 20, Y: 20, W: 20, H: 20,
+		BlurRadius: 5, Color: gui.RGB(255, 255, 255),
+	}})
+
+	centre, _, _, _ := at(r.buf.img, 30, 30)
+	edge, _, _, _ := at(r.buf.img, 21, 30)
+	outside, _, _, _ := at(r.buf.img, 15, 30)
+	if centre < 200 {
+		t.Errorf("blur centre = %d, want near-opaque", centre)
+	}
+	if edge >= centre || edge == 0 {
+		t.Errorf("blur edge = %d, centre = %d: want a soft ramp",
+			edge, centre)
+	}
+	if outside >= edge {
+		t.Errorf("outside = %d, edge = %d: falloff not monotonic",
+			outside, edge)
+	}
+}
+
+func TestStencilClipsToRoundedRect(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderStencilBegin, X: 10, Y: 10, W: 20, H: 20,
+			Radius: 10, StencilDepth: 1},
+		rectCmd(0, 0, 40, 40, gui.RGB(0, 255, 0)),
+		{Kind: gui.RenderStencilEnd, X: 10, Y: 10, W: 20, H: 20,
+			Radius: 10, StencilDepth: 1},
+	})
+
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("centre of stencil green = %d, want 255", g)
+	}
+	// A radius of half the side makes a circle, so the corner of the
+	// stencil box is outside it.
+	if _, g, _, _ := at(r.buf.img, 11, 11); g != 0 {
+		t.Errorf("stencil corner green = %d, want 0 (not rounded)", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 35, 35); g != 0 {
+		t.Errorf("outside stencil green = %d, want 0 (clip leaked)", g)
+	}
+}
+
+func TestStencilNests(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderStencilBegin, X: 0, Y: 0, W: 20, H: 40,
+			StencilDepth: 1},
+		{Kind: gui.RenderStencilBegin, X: 0, Y: 0, W: 40, H: 20,
+			StencilDepth: 2},
+		rectCmd(0, 0, 40, 40, gui.RGB(0, 255, 0)),
+		{Kind: gui.RenderStencilEnd, X: 0, Y: 0, W: 40, H: 20,
+			StencilDepth: 2},
+		{Kind: gui.RenderStencilEnd, X: 0, Y: 0, W: 20, H: 40,
+			StencilDepth: 1},
+	})
+
+	// Only the intersection of the two boxes survives.
+	if _, g, _, _ := at(r.buf.img, 10, 10); g != 255 {
+		t.Errorf("intersection green = %d, want 255", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 30, 10); g != 0 {
+		t.Errorf("outside outer stencil green = %d, want 0", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 10, 30); g != 0 {
+		t.Errorf("outside inner stencil green = %d, want 0", g)
+	}
+}
+
+func TestRotationMovesContent(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderRotateBegin, RotAngle: 90, RotCX: 20,
+			RotCY: 20},
+		rectCmd(0, 18, 20, 4, gui.RGB(0, 255, 0)),
+		{Kind: gui.RenderRotateEnd},
+	})
+
+	// A horizontal bar left of centre becomes a vertical bar above
+	// centre under a 90-degree turn in y-down device space.
+	if _, g, _, _ := at(r.buf.img, 20, 10); g < 200 {
+		t.Errorf("rotated bar green = %d, want near 255", g)
+	}
+	if _, g, _, _ := at(r.buf.img, 10, 20); g > 40 {
+		t.Errorf("original bar position green = %d, want ~0", g)
+	}
+}
+
+func TestRotationZeroAngleIsIdentity(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderRotateBegin, RotCX: 20, RotCY: 20},
+		rectCmd(10, 10, 20, 20, gui.RGB(0, 255, 0)),
+		{Kind: gui.RenderRotateEnd},
+	})
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("unrotated green = %d, want 255", g)
+	}
+}
+
+func TestFilterCompositesLayersAndColorMatrix(t *testing.T) {
+	// A matrix that moves the red channel into green: column-major, so
+	// index [row + 4*col] reads "green output from red input".
+	var m [16]float32
+	m[1] = 1 // out.g = in.r
+	m[15] = 1
+
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderFilterBegin, Layers: 1, ColorMatrix: &m},
+		rectCmd(10, 10, 20, 20, gui.RGB(255, 0, 0)),
+		{Kind: gui.RenderFilterEnd},
+	})
+
+	red, green, _, alpha := at(r.buf.img, 20, 20)
+	if green != 255 || red != 0 {
+		t.Errorf("after colour matrix rgba = (%d,%d,_,%d), want red "+
+			"swapped into green", red, green, alpha)
+	}
+}
+
+func TestFilterLayersAccumulate(t *testing.T) {
+	half := gui.RGBA(255, 255, 255, 128)
+
+	one := newRenderer(20, 20, 1)
+	one.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderFilterBegin, Layers: 1},
+		rectCmd(0, 0, 20, 20, half),
+		{Kind: gui.RenderFilterEnd},
+	})
+	three := newRenderer(20, 20, 1)
+	three.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderFilterBegin, Layers: 3},
+		rectCmd(0, 0, 20, 20, half),
+		{Kind: gui.RenderFilterEnd},
+	})
+
+	v1, _, _, _ := at(one.buf.img, 10, 10)
+	v3, _, _, _ := at(three.buf.img, 10, 10)
+	if v3 <= v1 {
+		t.Errorf("three layers = %d, one layer = %d: layers did not "+
+			"accumulate", v3, v1)
+	}
+}
+
+func TestFilterBlurSpreadsPastItsBox(t *testing.T) {
+	r := newRenderer(60, 60, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderFilterBegin, Layers: 1, BlurRadius: 4},
+		rectCmd(25, 25, 10, 10, gui.RGB(255, 255, 255)),
+		{Kind: gui.RenderFilterEnd},
+	})
+
+	if v, _, _, _ := at(r.buf.img, 22, 30); v == 0 {
+		t.Error("blur did not spread outside the drawn rect")
+	}
+	centre, _, _, _ := at(r.buf.img, 30, 30)
+	outer, _, _, _ := at(r.buf.img, 22, 30)
+	if outer >= centre {
+		t.Errorf("outer = %d, centre = %d: blur is not a falloff",
+			outer, centre)
+	}
+}
+
+// TestFilterBlurRespectsClip guards the composite against leaking past
+// the clip rect: the GPU backends' scissor survives the FBO bind, so a
+// filter bracket inside a clip must not paint beyond it even when the
+// blur spreads the layer's content past the clip edge.
+func TestFilterBlurRespectsClip(t *testing.T) {
+	r := newRenderer(60, 60, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderClip, X: 0, Y: 0, W: 40, H: 60},
+		{Kind: gui.RenderFilterBegin, Layers: 1, BlurRadius: 4},
+		// The rect crosses the clip at x=40, so only 34..40 draws.
+		rectCmd(34, 20, 10, 20, gui.RGB(255, 255, 255)),
+		{Kind: gui.RenderFilterEnd},
+	})
+
+	if v, _, _, _ := at(r.buf.img, 37, 30); v < 100 {
+		t.Errorf("inside clip = %d, want bright content", v)
+	}
+	if v, _, _, _ := at(r.buf.img, 32, 30); v == 0 {
+		t.Error("blur did not spread inside the clip")
+	}
+	if v, _, _, _ := at(r.buf.img, 42, 30); v != 0 {
+		t.Errorf("past the clip = %d, want 0 (blur leaked)", v)
+	}
+}
+
+// TestPopLayerPastDepthCapRestoresNearestLayer guards the bracket
+// unwind past maxLayerDepth: a capped bracket has no layer and never
+// switched the target, so popping it must land back on the nearest real
+// layer, not jump to the root.
+func TestPopLayerPastDepthCapRestoresNearestLayer(t *testing.T) {
+	r := newRenderer(8, 8, 1)
+	for range maxLayerDepth + 2 {
+		r.beginStencil(&gui.RenderCmd{})
+	}
+	r.endStencil() // pops the last capped bracket
+	if got := r.buf; got != r.brackets[15].layer {
+		t.Fatalf("target after popping a capped bracket = %p, want "+
+			"the last real layer %p", got, r.brackets[15].layer)
+	}
+	for range maxLayerDepth + 1 {
+		r.endStencil()
+	}
+	if r.buf != r.rootBuf {
+		t.Fatalf("target after full unwind = %p, want the root", r.buf)
+	}
+}
+
+func TestValidTermGridRejectsOverflowingCellCount(t *testing.T) {
+	// Cols*Rows overflows int64 to zero; the division-form check must
+	// still reject a grid whose cell buffer is far too small, instead
+	// of accepting it and looping over an empty buffer.
+	tg := &gui.TermGridData{
+		Cols: 1 << 40, Rows: 1 << 40,
+		CellW: 10, CellH: 10,
+		Cells: make([]gui.TermCell, 16),
+	}
+	if validTermGrid(tg) {
+		t.Fatal("overflowing grid accepted")
+	}
+	full := &gui.TermGridData{
+		Cols: 4, Rows: 4, CellW: 10, CellH: 10,
+		Cells: make([]gui.TermCell, 16),
+	}
+	if !validTermGrid(full) {
+		t.Fatal("valid 4x4 grid rejected")
+	}
+}
+
+func TestUnbalancedBracketStillLands(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderStencilBegin, X: 0, Y: 0, W: 40, H: 40,
+			StencilDepth: 1},
+		rectCmd(10, 10, 20, 20, gui.RGB(0, 255, 0)),
+	})
+	r.finishBrackets()
+
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("content of unclosed bracket green = %d, want 255", g)
+	}
+}
+
+func TestMismatchedEndDoesNotUnwind(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderStencilBegin, X: 0, Y: 0, W: 40, H: 40,
+			StencilDepth: 1},
+		{Kind: gui.RenderFilterEnd}, // wrong kind: must be ignored
+		rectCmd(10, 10, 20, 20, gui.RGB(0, 255, 0)),
+	})
+	if n := len(r.brackets); n != 1 {
+		t.Fatalf("open brackets = %d, want 1", n)
+	}
+	r.finishBrackets()
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("content green = %d, want 255", g)
+	}
+}
+
+func TestLayersArePooled(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	stream := []gui.RenderCmd{
+		{Kind: gui.RenderStencilBegin, X: 0, Y: 0, W: 40, H: 40,
+			StencilDepth: 1},
+		rectCmd(0, 0, 40, 40, gui.RGB(0, 255, 0)),
+		{Kind: gui.RenderStencilEnd, X: 0, Y: 0, W: 40, H: 40,
+			StencilDepth: 1},
+	}
+	r.drawAll(stream)
+	r.drawAll(stream)
+
+	if len(r.layerPool) != 1 {
+		t.Errorf("pooled layers = %d, want 1 (a layer was not reused)",
+			len(r.layerPool))
+	}
+}
+
+func TestClearTransparentResetsPooledLayer(t *testing.T) {
+	b := newBuffer(8, 8)
+	b.clear(gui.RGB(255, 0, 0))
+	b.clearTransparent()
+
+	for y := range 8 {
+		for x := range 8 {
+			if _, _, _, a := at(b.img, x, y); a != 0 {
+				t.Fatalf("pixel (%d,%d) alpha = %d, want 0", x, y, a)
+			}
+		}
+	}
+	if !b.dirty.Empty() {
+		t.Errorf("dirty = %v, want empty", b.dirty)
+	}
+}
+
+func TestBoxBlurAlphaConservesAndSpreads(t *testing.T) {
+	rect := image.Rect(0, 0, 21, 21)
+	m := &image.Alpha{
+		Pix:    make([]uint8, 21*21),
+		Stride: 21,
+		Rect:   rect,
+	}
+	m.Pix[10*21+10] = 255
+
+	var tmp []uint8
+	boxBlurAlpha(m, &tmp, 2)
+
+	if m.Pix[10*21+10] == 255 {
+		t.Error("centre unchanged: blur did not run")
+	}
+	if m.Pix[10*21+12] == 0 {
+		t.Error("blur did not spread to a neighbour")
+	}
+	if m.Pix[0] != 0 {
+		t.Errorf("far corner = %d, want 0", m.Pix[0])
+	}
+}
+
+// TestDrawSvgShadedMeshHasNoSeam guards the artifact a per-triangle
+// rasterization produces: the two triangles of a gradient quad share a
+// diagonal, and antialiasing it twice leaves each side ~50% covered, so
+// the background shows through as a pale line. The mesh takes its
+// coverage from one path, so the diagonal must be as opaque as the
+// interior.
+func TestDrawSvgShadedMeshHasNoSeam(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+
+	// A 20x20 quad, red along the top edge and blue along the bottom,
+	// split into two triangles that share the (30,10)-(10,30) diagonal.
+	verts := []float32{
+		10, 10, 30, 10, 10, 30,
+		30, 10, 30, 30, 10, 30,
+	}
+	red, blue := gui.RGB(255, 0, 0), gui.RGB(0, 0, 255)
+	cmd := tri(verts, gui.Color{})
+	cmd.VertexColors = []gui.Color{
+		red, red, blue,
+		red, blue, blue,
+	}
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	// The pixels the diagonal actually crosses are the ones whose
+	// centre lies on it: centre (x+0.5, y+0.5) with x+y == 39. Each
+	// interpolates to some mix of red and blue over a black ground, so
+	// the two channels sum to 255 wherever coverage is full. Splitting
+	// the coverage between the two triangles halves that sum.
+	for _, p := range []image.Point{{X: 14, Y: 25}, {X: 19, Y: 20},
+		{X: 24, Y: 15}} {
+
+		cr, _, cb, _ := at(r.buf.img, p.X, p.Y)
+		if sum := int(cr) + int(cb); sum < 245 {
+			t.Errorf("diagonal at %v: r+b = %d, want ~255 (seam)",
+				p, sum)
+		}
+	}
+
+	// The mesh still ends where it should, and still interpolates.
+	if cr, _, cb, _ := at(r.buf.img, 20, 12); cr < 200 || cb > 60 {
+		t.Errorf("top of mesh = (%d, %d), want mostly red", cr, cb)
+	}
+	if cr, _, cb, _ := at(r.buf.img, 20, 28); cb < 200 || cr > 60 {
+		t.Errorf("bottom of mesh = (%d, %d), want mostly blue", cr, cb)
+	}
+	if cr, _, cb, _ := at(r.buf.img, 5, 5); cr != 0 || cb != 0 {
+		t.Errorf("outside mesh = (%d, %d), want black", cr, cb)
+	}
+}
+
+// --- Hostile geometry: nothing below may hang, panic or wrap ---
+
+// TestHostileBlurRadiiTerminate drives every blur-consuming kind with a
+// NaN, an infinite and an absurdly large radius. Blur radii reach this
+// package from widget config and from an SVG filter's stdDev, neither
+// of which is validated upstream; an unclamped radius sizes the box
+// blur's sliding window, so the failure mode is a hang rather than a
+// wrong pixel. A hang shows here as the test timeout.
+func TestHostileBlurRadiiTerminate(t *testing.T) {
+	for _, blur := range []float32{
+		float32(math.NaN()),
+		float32(math.Inf(1)),
+		float32(math.Inf(-1)),
+		1e9,
+		-5,
+	} {
+		r := newRenderer(32, 32, 1)
+		r.drawAll([]gui.RenderCmd{
+			{Kind: gui.RenderShadow, X: 8, Y: 8, W: 16, H: 16,
+				BlurRadius: blur, Color: gui.RGB(255, 0, 0)},
+			{Kind: gui.RenderBlur, X: 8, Y: 8, W: 16, H: 16,
+				BlurRadius: blur, Color: gui.RGB(0, 255, 0)},
+			{Kind: gui.RenderFilterBegin, BlurRadius: blur, Layers: 1},
+			rectCmd(8, 8, 16, 16, gui.RGB(0, 0, 255)),
+			{Kind: gui.RenderFilterEnd},
+		})
+	}
+}
+
+// TestBlurPlanesRejectsNaNSigma pins the guard directly: a NaN sigma
+// must leave the plane untouched rather than reach boxRadii, where the
+// window bound would come from int(NaN).
+func TestBlurPlanesRejectsNaNSigma(t *testing.T) {
+	m := &image.Alpha{
+		Pix:    []uint8{0, 255, 0, 0, 255, 0, 0, 255, 0},
+		Stride: 3,
+		Rect:   image.Rect(0, 0, 3, 3),
+	}
+	var tmp []uint8
+	boxBlurAlpha(m, &tmp, float32(math.NaN()))
+	if m.Pix[1] != 255 || m.Pix[0] != 0 {
+		t.Errorf("NaN sigma altered the mask: %v", m.Pix)
+	}
+}
+
+// TestShadowNaNRadiusDrawsSquare covers the corner-radius guard: a NaN
+// radius must fall back to the square path rather than feed NaN control
+// points to the rasterizer.
+func TestShadowNaNRadiusDrawsSquare(t *testing.T) {
+	r := newRenderer(32, 32, 1)
+	// Offset the shadow clear of its caster, which would otherwise
+	// erase all of it: an unoffset, unblurred shadow is fully hidden.
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderShadow, X: 8, Y: 8, W: 16, H: 16, OffsetX: 8,
+			Radius: float32(math.NaN()), Color: gui.RGB(255, 0, 0)},
+	})
+	// The visible strip is painted, and so is the corner a real radius
+	// would have cut away.
+	if red, _, _, _ := at(r.buf.img, 28, 16); red != 255 {
+		t.Errorf("shadow strip red = %d, want 255", red)
+	}
+	if red, _, _, _ := at(r.buf.img, 31, 9); red != 255 {
+		t.Errorf("corner red = %d, want 255 (square fallback)", red)
+	}
+}
+
+// TestFilterLayerCountIsCapped guards the composite repeat count, which
+// is the feMergeNode count of an untrusted SVG filter.
+func TestFilterLayerCountIsCapped(t *testing.T) {
+	r := newRenderer(8, 8, 1)
+	r.beginFilter(&gui.RenderCmd{Layers: 1 << 20})
+	if got := r.brackets[0].layers; got != maxFilterLayers {
+		t.Errorf("layers = %d, want the %d cap", got, maxFilterLayers)
+	}
+	r.endFilter()
+
+	r.beginFilter(&gui.RenderCmd{Layers: 0})
+	if got := r.brackets[0].layers; got != 1 {
+		t.Errorf("layers for an unset count = %d, want 1", got)
+	}
+	r.endFilter()
+}
+
+// TestOverPremulSaturates pins the blend clamp. A filter's color matrix
+// clamps each channel on its own, so it can leave a pixel brighter than
+// its own alpha; the unclamped sum passes 255 and wraps to near-black.
+func TestOverPremulSaturates(t *testing.T) {
+	if got := overPremul(255, 100, 255); got != 255 {
+		t.Errorf("overPremul(255, 100, 255) = %d, want 255", got)
+	}
+	if got := overPremul(0, 200, 255); got != 200 {
+		t.Errorf("overPremul(0, 200, 255) = %d, want 200", got)
+	}
+	if got := overPremul(60, 100, 128); got != 110 {
+		t.Errorf("overPremul(60, 100, 128) = %d, want 110", got)
+	}
+}
+
+// TestFilterColorMatrixDoesNotWrap is the end-to-end form of the clamp:
+// a matrix that keeps a channel while zeroing alpha must saturate the
+// destination, not wrap it darker than it started.
+func TestFilterColorMatrixDoesNotWrap(t *testing.T) {
+	r := newRenderer(16, 16, 1)
+	// Column-major: out.r = in.a, every other output channel zero.
+	var m [16]float32
+	m[12] = 1
+
+	r.drawAll([]gui.RenderCmd{
+		rectCmd(0, 0, 16, 16, gui.RGB(100, 0, 0)),
+		{Kind: gui.RenderFilterBegin, Layers: 1, ColorMatrix: &m},
+		rectCmd(4, 4, 8, 8, gui.RGB(255, 255, 255)),
+		{Kind: gui.RenderFilterEnd},
+	})
+
+	if red, _, _, _ := at(r.buf.img, 8, 8); red != 255 {
+		t.Errorf("red = %d, want 255 saturated (wrapped past 255)", red)
+	}
+}
+
+// TestFinishBracketsClosesEveryKind exercises all three end paths from
+// the unwind, not just the stencil one a single-bracket stream reaches.
+func TestFinishBracketsClosesEveryKind(t *testing.T) {
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{
+		{Kind: gui.RenderFilterBegin, Layers: 1},
+		{Kind: gui.RenderStencilBegin, X: 0, Y: 0, W: 40, H: 40,
+			StencilDepth: 1},
+		{Kind: gui.RenderRotateBegin, RotAngle: 0, RotCX: 20, RotCY: 20},
+		rectCmd(10, 10, 20, 20, gui.RGB(0, 255, 0)),
+	})
+	if n := len(r.brackets); n != 3 {
+		t.Fatalf("open brackets = %d, want 3", n)
+	}
+	r.finishBrackets()
+
+	if n := len(r.brackets); n != 0 {
+		t.Fatalf("brackets after unwind = %d, want 0", n)
+	}
+	if r.buf != r.rootBuf {
+		t.Fatal("target after unwind is not the root buffer")
+	}
+	if _, g, _, _ := at(r.buf.img, 20, 20); g != 255 {
+		t.Errorf("content green = %d, want 255", g)
+	}
+}

--- a/gui/backend/soft/draw_stencil.go
+++ b/gui/backend/soft/draw_stencil.go
@@ -1,0 +1,104 @@
+package soft
+
+import (
+	"image"
+	"math"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// beginStencil opens a rounded-rect clip. The GPU path increments a
+// stencil buffer and tests every later fragment against it; the CPU
+// path collects the bracketed drawing in a layer and composites it
+// through the same rounded rect as a coverage mask.
+//
+// Nesting therefore needs no depth counter: an inner bracket composites
+// into the outer bracket's layer, which is already masked. RenderCmd's
+// StencilDepth is what the GL backend uses to unwind its shared stencil
+// buffer, and a layer stack has no equivalent to unwind.
+func (r *renderer) beginStencil(cmd *gui.RenderCmd) {
+	s := r.scale
+	br := r.pushLayer(bracketStencil)
+	br.x, br.y = cmd.X*s, cmd.Y*s
+	br.w, br.h = cmd.W*s, cmd.H*s
+	br.radius = cmd.Radius * s
+}
+
+// endStencil closes the clip and composites the layer through it.
+func (r *renderer) endStencil() {
+	br, ok := r.popLayer(bracketStencil)
+	if !ok || br.layer == nil {
+		return
+	}
+	defer r.releaseLayer(br.layer)
+
+	region := deviceRect(br.x, br.y, br.w, br.h).
+		Intersect(r.buf.img.Bounds())
+	mask := r.coverageRoundRect(&r.maskPix, region,
+		br.x, br.y, br.w, br.h, br.radius)
+	if mask == nil {
+		return
+	}
+	composite(r.buf, br.layer, br.layer.dirty, mask)
+}
+
+// beginRotation opens a rotation bracket. Where the GPU backends push a
+// rotated MVP, this renders the bracketed commands upright into a layer
+// and rotates the finished layer on the way back — so text, gradients
+// and images rotate exactly as rectangles do, and no phase 1 draw path
+// has to know a transform is in effect.
+func (r *renderer) beginRotation(cmd *gui.RenderCmd) {
+	s := r.scale
+	br := r.pushLayer(bracketRotate)
+	br.angle = cmd.RotAngle
+	br.cx, br.cy = cmd.RotCX*s, cmd.RotCY*s
+}
+
+// endRotation closes the bracket and blits the layer back rotated.
+func (r *renderer) endRotation() {
+	br, ok := r.popLayer(bracketRotate)
+	if !ok || br.layer == nil {
+		return
+	}
+	defer r.releaseLayer(br.layer)
+
+	src := br.layer.dirty
+	if src.Empty() {
+		return
+	}
+	if br.angle == 0 {
+		composite(r.buf, br.layer, src, nil)
+		return
+	}
+	rad := float64(br.angle) * math.Pi / 180
+	sin := float32(math.Sin(rad))
+	cos := float32(math.Cos(rad))
+
+	dst := rotatedBounds(src, sin, cos, br.cx, br.cy).
+		Intersect(r.buf.clip)
+	blitTransformed(r.buf, br.layer, dst, sin, cos, br.cx, br.cy)
+}
+
+// rotatedBounds is the pixel box the rotated content can land in: the
+// four corners of src mapped forward, then bounded.
+func rotatedBounds(src image.Rectangle, sin, cos, cx, cy float32,
+) image.Rectangle {
+
+	corners := [4][2]float32{
+		{float32(src.Min.X), float32(src.Min.Y)},
+		{float32(src.Max.X), float32(src.Min.Y)},
+		{float32(src.Max.X), float32(src.Max.Y)},
+		{float32(src.Min.X), float32(src.Max.Y)},
+	}
+	minX, minY := float32(math.MaxFloat32), float32(math.MaxFloat32)
+	maxX, maxY := -float32(math.MaxFloat32), -float32(math.MaxFloat32)
+	for _, c := range corners {
+		dx, dy := c[0]-cx, c[1]-cy
+		x := cx + dx*cos - dy*sin
+		y := cy + dx*sin + dy*cos
+		minX, maxX = min(minX, x), max(maxX, x)
+		minY, maxY = min(minY, y), max(maxY, y)
+	}
+	// One pixel of slack each way covers the bilinear tap footprint.
+	return deviceRect(minX-1, minY-1, maxX-minX+2, maxY-minY+2)
+}

--- a/gui/backend/soft/draw_svg.go
+++ b/gui/backend/soft/draw_svg.go
@@ -1,0 +1,319 @@
+package soft
+
+import (
+	"image"
+	"math"
+
+	"golang.org/x/image/vector"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// drawSvg rasterizes a tessellated SVG path: a flat triangle list in
+// Triangles, optionally one color per vertex in VertexColors.
+//
+// The vertex transform order mirrors gui/backend/gl's drawSvg —
+// animateTransform scale/translate, then rotation about (RotCX, RotCY),
+// then the command's own Scale and origin — so an animated SVG lands in
+// the same place headlessly as it does on a GPU.
+//
+// Triangles are drawn as one path in a single color rather than one
+// triangle at a time. The rasterizer accumulates signed coverage across
+// a whole path, so the shared interior edges cancel exactly; rasterizing
+// each triangle separately would blend two half-covered edges at every
+// seam and draw a lattice of pale lines across every filled shape.
+func (r *renderer) drawSvg(cmd *gui.RenderCmd) {
+	if cmd.IsClipMask {
+		// Clip-mask geometry is a stencil source, not paint. No
+		// backend consumes it yet; the render path still emits it.
+		return
+	}
+	if len(cmd.Triangles) == 0 || len(cmd.Triangles)%6 != 0 {
+		return
+	}
+	numVerts := len(cmd.Triangles) / 2
+	hasVCols := len(cmd.VertexColors) == numVerts
+
+	verts := r.svgVertices(cmd, numVerts)
+	numTris := numVerts / 3
+
+	if !hasVCols {
+		r.fillTriangleRun(verts, cmd.Color)
+		return
+	}
+
+	// Vertex-colored geometry is a mesh: its triangles tile a region
+	// and share edges. Rasterized one at a time each shared edge is
+	// antialiased twice — two ~50% coverages that never sum to one —
+	// and the background shows through as a lattice of pale lines
+	// over every gradient. So the mesh takes its coverage from a
+	// single path, where the signed accumulation cancels the interior
+	// edges exactly, and the shading is filled inside that mask.
+	// The negated > rejects a NaN scale as well as a negative one:
+	// max(0, min(NaN, 1)) is NaN, and uint8(NaN) is undefined.
+	vAlpha := float32(1)
+	if cmd.HasVertexAlpha {
+		vAlpha = 0
+		if cmd.VertexAlphaScale > 0 {
+			vAlpha = min(cmd.VertexAlphaScale, 1)
+		}
+	}
+	r.fillTriangleMesh(verts, cmd.VertexColors, numTris, vAlpha)
+}
+
+// fillTriangleMesh draws a vertex-colored triangle mesh with no interior
+// seams: one antialiased coverage mask for the whole mesh, and a layer
+// holding the shading, composited through it.
+//
+// The shading is written, not blended, so a pixel claimed by two
+// triangles along a shared edge is painted once — their colors agree
+// there, and blending twice would darken every seam of a translucent
+// gradient.
+func (r *renderer) fillTriangleMesh(verts []float32, cols []gui.Color,
+	numTris int, vAlpha float32) {
+
+	minX, minY, maxX, maxY := vertsBounds(verts)
+	region := r.buf.region(minX, minY, maxX-minX, maxY-minY)
+	if region.Empty() {
+		return
+	}
+	mask := r.coveragePath(&r.maskPix, region,
+		func(z *vector.Rasterizer, ox, oy float32) {
+			for i := 0; i < numTris*6; i += 6 {
+				emitTriangle(z, ox, oy, verts[i:i+6])
+			}
+		})
+	if mask == nil {
+		return
+	}
+
+	layer := r.acquireLayer()
+	for t := range numTris {
+		shadeTriangle(layer, region, verts[t*6:t*6+6],
+			scaleAlpha(cols[t*3], vAlpha),
+			scaleAlpha(cols[t*3+1], vAlpha),
+			scaleAlpha(cols[t*3+2], vAlpha))
+	}
+	layer.markDirty(region)
+	composite(r.buf, layer, region, mask)
+	r.releaseLayer(layer)
+}
+
+// shadeTriangle writes one triangle's barycentric interpolation into dst,
+// covering every pixel centre inside it plus a half-pixel skirt.
+//
+// The skirt is what keeps the mesh's outer edge from thinning: a pixel
+// the coverage mask includes at 40% can have its centre just outside the
+// triangle, and with no color written there the antialiased edge would
+// fade to nothing. Interior pixels are unaffected — the triangles tile,
+// so every centre inside the mesh is already claimed.
+func shadeTriangle(dst *buffer, region image.Rectangle, p []float32,
+	c0, c1, c2 gui.Color) {
+
+	src := newTriSrc(p, c0, c1, c2)
+	if src == nil {
+		return
+	}
+	minX, minY, maxX, maxY := vertsBounds(p)
+	rect := deviceRect(minX-1, minY-1, maxX-minX+2, maxY-minY+2).
+		Intersect(region)
+	if rect.Empty() {
+		return
+	}
+	t0, t1, t2 := src.skirt()
+
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		i := dst.img.PixOffset(rect.Min.X, y)
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			w0, w1, w2 := src.weights(x, y)
+			if w0 < -t0 || w1 < -t1 || w2 < -t2 {
+				i += 4
+				continue
+			}
+			cr, cg, cb, ca := premul(src.mix(w0, w1, w2))
+			dst.img.Pix[i] = cr
+			dst.img.Pix[i+1] = cg
+			dst.img.Pix[i+2] = cb
+			dst.img.Pix[i+3] = ca
+			i += 4
+		}
+	}
+}
+
+// svgVertices transforms every vertex into device space, reusing the
+// scratch slice so an animated SVG does not allocate per frame.
+func (r *renderer) svgVertices(cmd *gui.RenderCmd, numVerts int) []float32 {
+	if cap(r.svgBatch) < numVerts*2 {
+		r.svgBatch = make([]float32, numVerts*2)
+	}
+	verts := r.svgBatch[:numVerts*2]
+
+	var sx, sy, tx, ty float32
+	if cmd.HasXform {
+		sx, sy, tx, ty = cmd.ScaleX, cmd.ScaleY, cmd.TransX, cmd.TransY
+	}
+	hasRot := cmd.RotAngle != 0
+	var sinA, cosA float32
+	if hasRot {
+		rad := float64(cmd.RotAngle) * math.Pi / 180
+		sinA = float32(math.Sin(rad))
+		cosA = float32(math.Cos(rad))
+	}
+
+	s := r.scale
+	for i := range numVerts {
+		vx := cmd.Triangles[i*2]
+		vy := cmd.Triangles[i*2+1]
+		if cmd.HasXform {
+			vx = vx*sx + tx
+			vy = vy*sy + ty
+		}
+		if hasRot {
+			dx := vx - cmd.RotCX
+			dy := vy - cmd.RotCY
+			vx = cmd.RotCX + dx*cosA - dy*sinA
+			vy = cmd.RotCY + dx*sinA + dy*cosA
+		}
+		verts[i*2] = (cmd.X + vx*cmd.Scale) * s
+		verts[i*2+1] = (cmd.Y + vy*cmd.Scale) * s
+	}
+	return verts
+}
+
+// fillTriangleRun fills every triangle as one path in color c.
+func (r *renderer) fillTriangleRun(verts []float32, c gui.Color) {
+	if len(verts) == 0 || c.A == 0 {
+		return
+	}
+	minX, minY, maxX, maxY := vertsBounds(verts)
+	region := r.buf.region(minX, minY, maxX-minX, maxY-minY)
+	r.buf.fillPath(region, r.buf.solid(c),
+		func(z *vector.Rasterizer, ox, oy float32) {
+			for i := 0; i < len(verts); i += 6 {
+				emitTriangle(z, ox, oy, verts[i:i+6])
+			}
+		})
+}
+
+// vertsBounds is the bounding box of an interleaved x/y vertex slice.
+func vertsBounds(verts []float32) (minX, minY, maxX, maxY float32) {
+	minX, minY = math.MaxFloat32, math.MaxFloat32
+	maxX, maxY = -math.MaxFloat32, -math.MaxFloat32
+	for i := 0; i < len(verts); i += 2 {
+		minX, maxX = min(minX, verts[i]), max(maxX, verts[i])
+		minY, maxY = min(minY, verts[i+1]), max(maxY, verts[i+1])
+	}
+	return
+}
+
+// emitTriangle adds one closed triangle contour to the path.
+func emitTriangle(z *vector.Rasterizer, ox, oy float32, p []float32) {
+	z.MoveTo(p[0]-ox, p[1]-oy)
+	z.LineTo(p[2]-ox, p[3]-oy)
+	z.LineTo(p[4]-ox, p[5]-oy)
+	z.ClosePath()
+}
+
+// scaleAlpha applies the command's vertex alpha multiplier, which
+// exists so animating opacity does not copy the vertex colors.
+func scaleAlpha(c gui.Color, mul float32) gui.Color {
+	if mul >= 1 {
+		return c
+	}
+	c.A = uint8(float32(c.A) * mul)
+	return c
+}
+
+// triSrc interpolates a triangle's vertex colors barycentrically, as
+// the GPU's varying interpolation does.
+type triSrc struct {
+	ax, ay     float32 // vertex A, the barycentric origin
+	abx, aby   float32 // A→B
+	acx, acy   float32 // A→C
+	c0, c1, c2 gui.Color
+	invDen     float32
+}
+
+// newTriSrc returns nil for a degenerate (zero-area) triangle, which
+// covers no pixels anyway.
+func newTriSrc(p []float32, c0, c1, c2 gui.Color) *triSrc {
+	abx, aby := p[2]-p[0], p[3]-p[1]
+	acx, acy := p[4]-p[0], p[5]-p[1]
+	den := abx*acy - acx*aby
+	if den == 0 {
+		return nil
+	}
+	return &triSrc{
+		ax: p[0], ay: p[1],
+		abx: abx, aby: aby,
+		acx: acx, acy: acy,
+		c0: c0, c1: c1, c2: c2,
+		invDen: 1 / den,
+	}
+}
+
+// weights returns the barycentric coordinates of the centre of pixel
+// (x, y): w1 belongs to B, w2 to C, the remainder to A. They are
+// negative outside the triangle, which is what the skirt test reads.
+func (t *triSrc) weights(x, y int) (w0, w1, w2 float32) {
+	px := float32(x) + 0.5 - t.ax
+	py := float32(y) + 0.5 - t.ay
+	w1 = (px*t.acy - t.acx*py) * t.invDen
+	w2 = (t.abx*py - px*t.aby) * t.invDen
+	return 1 - w1 - w2, w1, w2
+}
+
+// skirt returns how negative each weight may go and still be within half
+// a pixel of the triangle.
+//
+// A weight falls from 1 at its own vertex to 0 on the opposite edge, so
+// it changes by 1/h per pixel of distance, where h is the height to that
+// edge — and h is 2*area/len, with 2*area being |den|. One weight unit
+// is therefore |den|/len pixels, and half a pixel is len/(2*|den|).
+func (t *triSrc) skirt() (s0, s1, s2 float32) {
+	den := t.invDen
+	if den < 0 {
+		den = -den
+	}
+	// bc = AC - AB, the edge opposite A.
+	bcx, bcy := t.acx-t.abx, t.acy-t.aby
+	half := 0.5 * den
+	return hypot32(bcx, bcy) * half,
+		hypot32(t.acx, t.acy) * half,
+		hypot32(t.abx, t.aby) * half
+}
+
+// mix blends the three vertex colors by the given weights, clamped into
+// the simplex first: a pixel centre inside the skirt sits just outside
+// the triangle, and extrapolating past a vertex color there would
+// overshoot the gradient.
+func (t *triSrc) mix(w0, w1, w2 float32) gui.Color {
+	w0, w1, w2 = clampWeights(w0, w1, w2)
+	blend := func(a, b, c uint8) uint8 {
+		return uint8(float32(a)*w0 + float32(b)*w1 +
+			float32(c)*w2 + 0.5)
+	}
+	return gui.RGBA(
+		blend(t.c0.R, t.c1.R, t.c2.R),
+		blend(t.c0.G, t.c1.G, t.c2.G),
+		blend(t.c0.B, t.c1.B, t.c2.B),
+		blend(t.c0.A, t.c1.A, t.c2.A))
+}
+
+// hypot32 is math.Hypot without the float64 round trip; the inputs here
+// are pixel distances, far from overflow.
+func hypot32(x, y float32) float32 {
+	return float32(math.Sqrt(float64(x*x + y*y)))
+}
+
+// clampWeights clamps barycentric weights into the simplex and
+// renormalizes so they still sum to one.
+func clampWeights(w0, w1, w2 float32) (float32, float32, float32) {
+	w0, w1, w2 = max(w0, 0), max(w1, 0), max(w2, 0)
+	sum := w0 + w1 + w2
+	if sum == 0 {
+		return 1, 0, 0
+	}
+	inv := 1 / sum
+	return w0 * inv, w1 * inv, w2 * inv
+}

--- a/gui/backend/soft/draw_termgrid.go
+++ b/gui/backend/soft/draw_termgrid.go
@@ -1,0 +1,261 @@
+package soft
+
+import (
+	"math"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// defaultTermSelTint is the fallback selection highlight when the
+// caller leaves TermSelRange.Color unset. It matches the Metal
+// backend's fallback, so a headless capture of a terminal is the same
+// picture the window shows.
+var defaultTermSelTint = gui.RGBA(51, 153, 255, 100)
+
+// drawTermGrid renders a terminal character grid from the shared cell
+// buffer: background runs, selection tint, block cursor, glyph runs
+// pinned to their columns, then underline and caret decorations.
+//
+// It is a port of gui/backend/metal/termgrid.go — the draw order and
+// the run batching are what keep a grid from drifting a subpixel per
+// column — over this package's rect fill and text system.
+func (r *renderer) drawTermGrid(cmd *gui.RenderCmd) {
+	tg := cmd.TermGrid
+	if r.textSys == nil || tg == nil || !validTermGrid(tg) {
+		return
+	}
+	gx, gy := cmd.X, cmd.Y
+	cw, ch := tg.CellW, tg.CellH
+
+	cfg := guiStyleToGlyphConfig(tg.Style)
+	ascent := ch * 0.8
+	if m, err := r.textSys.FontMetrics(cfg); err == nil && m.Ascender > 0 {
+		ascent = m.Ascender
+	}
+
+	if r.warm {
+		// The warming pass exists to rasterize glyphs into the atlas;
+		// the fills would be wiped by the clear before pass 2 anyway.
+		r.termGlyphs(tg, cfg, gx, gy, cw, ch, ascent)
+		return
+	}
+
+	r.termBackgrounds(tg, gx, gy, cw, ch)
+	r.termSelection(tg, gx, gy, cw, ch)
+	r.termCursorUnder(tg, gx, gy, cw, ch)
+	r.termGlyphs(tg, cfg, gx, gy, cw, ch, ascent)
+	r.termDecorations(tg, gx, gy, cw, ch)
+}
+
+// validTermGrid rejects the degenerate geometry the render path also
+// guards against, so a malformed grid draws nothing rather than
+// looping on a NaN cell size. The cell-count check is written as a
+// division so a hostile Cols*Rows cannot overflow the check and let a
+// huge grid loop over an empty cell buffer.
+func validTermGrid(tg *gui.TermGridData) bool {
+	return tg.Cols > 0 && tg.Rows > 0 &&
+		tg.CellW > 0 && !math.IsNaN(float64(tg.CellW)) &&
+		!math.IsInf(float64(tg.CellW), 0) &&
+		tg.CellH > 0 && !math.IsNaN(float64(tg.CellH)) &&
+		!math.IsInf(float64(tg.CellH), 0) &&
+		tg.Rows <= len(tg.Cells)/tg.Cols
+}
+
+// termCellFB returns a cell's effective colors, applying reverse video.
+func termCellFB(c *gui.TermCell) (fg, bg gui.Color) {
+	fg, bg = c.FG, c.BG
+	if c.Attrs&gui.TermReverse != 0 {
+		fg, bg = bg, fg
+	}
+	return fg, bg
+}
+
+// termBackgrounds fills batched runs of same-background cells.
+func (r *renderer) termBackgrounds(tg *gui.TermGridData,
+	gx, gy, cw, ch float32) {
+
+	for row := range tg.Rows {
+		col := 0
+		for col < tg.Cols {
+			_, bg := termCellFB(&tg.Cells[row*tg.Cols+col])
+			if bg.A == 0 {
+				col++
+				continue
+			}
+			start := col
+			for col < tg.Cols {
+				_, nbg := termCellFB(&tg.Cells[row*tg.Cols+col])
+				if nbg != bg {
+					break
+				}
+				col++
+			}
+			r.fillTermRect(gx+float32(start)*cw, gy+float32(row)*ch,
+				float32(col-start)*cw, ch, bg)
+		}
+	}
+}
+
+// termSelection tints the selected cell range, row by row.
+func (r *renderer) termSelection(tg *gui.TermGridData,
+	gx, gy, cw, ch float32) {
+
+	sel := tg.Selection
+	if sel.End <= sel.Start {
+		return
+	}
+	tint := sel.Color
+	if tint.A == 0 {
+		tint = defaultTermSelTint
+	}
+	total := tg.Cols * tg.Rows
+	beg := max(sel.Start, 0)
+	end := min(sel.End, total)
+	for row := 0; row < tg.Rows && beg < end; row++ {
+		rowStart := row * tg.Cols
+		s := max(beg, rowStart)
+		e := min(end, rowStart+tg.Cols)
+		if s >= e {
+			continue
+		}
+		r.fillTermRect(gx+float32(s-rowStart)*cw, gy+float32(row)*ch,
+			float32(e-s)*cw, ch, tint)
+	}
+}
+
+// termCursorUnder draws the block cursor beneath the glyphs so the
+// character stays visible on top of it.
+func (r *renderer) termCursorUnder(tg *gui.TermGridData,
+	gx, gy, cw, ch float32) {
+
+	cur := tg.Cursor
+	if !cur.Visible || cur.Style != gui.TermCursorBlock ||
+		!inGrid(tg, cur.Col, cur.Row) {
+		return
+	}
+	r.fillTermRect(gx+float32(cur.Col)*cw, gy+float32(cur.Row)*ch,
+		cw, ch, cur.Color)
+}
+
+// termGlyphs shapes each row into foreground-color runs and draws them
+// with every glyph pinned to its cell column.
+func (r *renderer) termGlyphs(tg *gui.TermGridData, cfg glyph.TextConfig,
+	gx, gy, cw, ch, ascent float32) {
+
+	for row := range tg.Rows {
+		baseline := gy + float32(row)*ch + ascent
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Width == 0 { // continuation of a wide cell
+				col++
+				continue
+			}
+			runFG, _ := termCellFB(c)
+			r.termRunes = r.termRunes[:0]
+			r.termCols = r.termCols[:0]
+			for col < tg.Cols {
+				cell := &tg.Cells[row*tg.Cols+col]
+				if cell.Width == 0 {
+					col++
+					continue
+				}
+				fg, _ := termCellFB(cell)
+				blank := cell.Ch == 0 || cell.Ch == ' '
+				if !blank && fg != runFG {
+					break
+				}
+				glyphRune := cell.Ch
+				if blank {
+					glyphRune = ' '
+				}
+				r.termRunes = append(r.termRunes, glyphRune)
+				r.termCols = append(r.termCols, col)
+				col++
+			}
+			r.termDrawRun(cfg, runFG, gx, baseline, cw)
+		}
+	}
+}
+
+// termDrawRun shapes the accumulated run and draws its glyphs at fixed
+// cell columns, falling back to natural flow when the shaper does not
+// produce one glyph per cell (clustered or ligated runs).
+func (r *renderer) termDrawRun(cfg glyph.TextConfig, fg gui.Color,
+	gx, baseline, cw float32) {
+
+	if len(r.termCols) == 0 {
+		return
+	}
+	cfg.Style.Color = glyph.Color{R: fg.R, G: fg.G, B: fg.B, A: fg.A}
+	layout, err := r.textSys.LayoutText(string(r.termRunes), cfg)
+	if err != nil {
+		return
+	}
+	if len(layout.Glyphs) != len(r.termCols) {
+		r.textSys.DrawLayout(layout,
+			gx+float32(r.termCols[0])*cw, baseline)
+		return
+	}
+	r.placements = r.placements[:0]
+	for _, col := range r.termCols {
+		r.placements = append(r.placements, glyph.GlyphPlacement{
+			X: gx + float32(col)*cw,
+			Y: baseline,
+		})
+	}
+	r.textSys.DrawLayoutPlaced(layout, r.placements)
+}
+
+// termDecorations draws underline attributes and the bar / underline
+// cursor styles on top of the glyphs.
+func (r *renderer) termDecorations(tg *gui.TermGridData,
+	gx, gy, cw, ch float32) {
+
+	thick := max(ch*0.08, 1)
+	for row := range tg.Rows {
+		for col := range tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Attrs&gui.TermUnderline == 0 {
+				continue
+			}
+			fg, _ := termCellFB(c)
+			r.fillTermRect(gx+float32(col)*cw,
+				gy+float32(row+1)*ch-thick, cw, thick, fg)
+		}
+	}
+
+	cur := tg.Cursor
+	if !cur.Visible || !inGrid(tg, cur.Col, cur.Row) {
+		return
+	}
+	x := gx + float32(cur.Col)*cw
+	y := gy + float32(cur.Row)*ch
+	switch cur.Style {
+	case gui.TermCursorBar:
+		r.fillTermRect(x, y, max(cw*0.15, 1), ch, cur.Color)
+	case gui.TermCursorUnderline:
+		r.fillTermRect(x, y+ch-thick, cw, thick, cur.Color)
+	case gui.TermCursorBlock:
+		// Drawn under the glyph in termCursorUnder.
+	}
+}
+
+// inGrid reports whether a cell coordinate is on the grid.
+func inGrid(tg *gui.TermGridData, col, row int) bool {
+	return col >= 0 && col < tg.Cols && row >= 0 && row < tg.Rows
+}
+
+// fillTermRect fills one solid rect given in logical coordinates.
+func (r *renderer) fillTermRect(x, y, w, h float32, c gui.Color) {
+	if w <= 0 || h <= 0 || c.A == 0 {
+		return
+	}
+	cmd := gui.RenderCmd{
+		Kind: gui.RenderRect, X: x, Y: y, W: w, H: h,
+		Color: c, Fill: true,
+	}
+	r.drawRect(&cmd)
+}

--- a/gui/backend/soft/draw_test.go
+++ b/gui/backend/soft/draw_test.go
@@ -24,8 +24,9 @@ func closeTo(got, want, tol uint8) bool {
 // newRenderer builds a renderer over a black buffer, with no text
 // system: these tests exercise the shape and clip paths only.
 func newRenderer(w, h int, scale float32) *renderer {
-	r := &renderer{buf: newBuffer(w, h), scale: scale}
-	r.buf.clear(gui.RGB(0, 0, 0))
+	root := newBuffer(w, h)
+	r := &renderer{buf: root, rootBuf: root, scale: scale}
+	root.clear(gui.RGB(0, 0, 0))
 	return r
 }
 
@@ -250,13 +251,14 @@ func TestDrawImageMemSource(t *testing.T) {
 
 func TestUnsupportedKindsAreSkipped(t *testing.T) {
 	r := newRenderer(8, 8, 1)
-	// Phase-2 kinds must not draw and must not panic.
+	// RenderCustomShader is GLSL with no CPU equivalent, and
+	// RenderFilterComposite is never emitted by the render path; both
+	// must draw nothing and must not panic.
 	r.drawAll([]gui.RenderCmd{
-		{Kind: gui.RenderShadow, X: 0, Y: 0, W: 8, H: 8,
+		{Kind: gui.RenderCustomShader, X: 0, Y: 0, W: 8, H: 8,
 			Color: gui.RGB(255, 255, 255)},
-		{Kind: gui.RenderSvg, X: 0, Y: 0, Scale: 1},
-		{Kind: gui.RenderStencilBegin},
-		{Kind: gui.RenderStencilEnd},
+		{Kind: gui.RenderFilterComposite, X: 0, Y: 0, W: 8, H: 8,
+			Layers: 1},
 	})
 	for y := range 8 {
 		for x := range 8 {

--- a/gui/backend/soft/framebuffer.go
+++ b/gui/backend/soft/framebuffer.go
@@ -27,6 +27,12 @@ type buffer struct {
 	clip image.Rectangle
 	rast vector.Rasterizer
 
+	// dirty is the union of every pixel rectangle written since the
+	// buffer was last cleared. A layer composite walks it instead of
+	// the whole image, so a bracket around one small widget costs a
+	// small pass even though layers are allocated full size.
+	dirty image.Rectangle
+
 	// uni is the reusable solid-color source. image.NewUniform would
 	// allocate once per draw command; the rasterizer only reads it
 	// during the Draw call, so one instance can be re-pointed.
@@ -38,10 +44,25 @@ func newBuffer(w, h int) *buffer {
 	return &buffer{img: img, clip: img.Bounds()}
 }
 
+// markDirty widens the written-pixels box. Callers that composite their
+// own source pixel by pixel — the glyph atlas blitters — call it once
+// with the region they are about to walk.
+func (b *buffer) markDirty(r image.Rectangle) {
+	if r.Empty() {
+		return
+	}
+	if b.dirty.Empty() {
+		b.dirty = r
+		return
+	}
+	b.dirty = b.dirty.Union(r)
+}
+
 // clear paints the whole buffer with c, ignoring the clip rect. c is
 // straight (non-premultiplied) as every gui.Color is.
 func (b *buffer) clear(c gui.Color) {
 	r, g, bl, a := premul(c)
+	b.dirty = b.img.Bounds()
 	pix := b.img.Pix
 	for i := 0; i < len(pix); i += 4 {
 		pix[i] = r
@@ -78,6 +99,11 @@ func deviceRect(x, y, w, h float32) image.Rectangle {
 	)
 }
 
+// floor32 is math.Floor without the float64 round trip at the call site.
+func floor32(v float32) float32 {
+	return float32(math.Floor(float64(v)))
+}
+
 // fillPath rasterizes the path emitted by emit and composites src through
 // the resulting coverage mask into region.
 //
@@ -96,6 +122,7 @@ func (b *buffer) fillPath(region image.Rectangle, src image.Image,
 	b.rast.Reset(region.Dx(), region.Dy())
 	emit(&b.rast, float32(region.Min.X), float32(region.Min.Y))
 	b.rast.Draw(b.img, region, src, region.Min)
+	b.markDirty(region)
 }
 
 // solid returns the reusable uniform source for c. Valid until the next
@@ -122,6 +149,21 @@ func (b *buffer) blendPixel(x, y int, sr, sg, sb, sa uint32) {
 	pix[i+1] = uint8((sg*sa + uint32(pix[i+1])*inv + 127) / 255)
 	pix[i+2] = uint8((sb*sa + uint32(pix[i+2])*inv + 127) / 255)
 	pix[i+3] = uint8((sa*255 + uint32(pix[i+3])*inv + 127) / 255)
+}
+
+// overPremul composites one premultiplied source channel over one
+// destination channel: s + dst*inv/255, saturating.
+//
+// The clamp is not decoration. A filter's color matrix clamps each
+// channel independently, so it can leave a pixel whose color exceeds
+// its own alpha; the unclamped sum then passes 255 and wraps a bright
+// pixel to near-black. Saturating is what the GPU blend does.
+func overPremul(s, d, inv uint32) uint8 {
+	v := s + (d*inv+127)/255
+	if v > 255 {
+		return 255
+	}
+	return uint8(v)
 }
 
 // premul converts a straight gui.Color to premultiplied bytes.
@@ -159,11 +201,15 @@ func pathRect(z *vector.Rasterizer, ox, oy, x, y, w, h float32) {
 // reverse winds the contour backwards.
 func pathRoundRect(z *vector.Rasterizer, ox, oy, x, y, w, h, r float32,
 	reverse bool) {
-	if w <= 0 || h <= 0 {
+	// Written as negated > rather than <= so a NaN — which a hostile
+	// SVG radius or a NaN-producing animation can reach here through
+	// the shadow, blur and stencil masks — takes the reject branch
+	// instead of emitting NaN control points into the rasterizer.
+	if !(w > 0) || !(h > 0) {
 		return
 	}
 	r = min(r, min(w, h)/2)
-	if r <= 0 {
+	if !(r > 0) {
 		if reverse {
 			x -= ox
 			y -= oy

--- a/gui/backend/soft/glyph_backend.go
+++ b/gui/backend/soft/glyph_backend.go
@@ -105,6 +105,7 @@ func (gb *glyphBackend) DrawTexturedQuad(id glyph.TextureID,
 	if region.Empty() {
 		return
 	}
+	gb.buf.markDirty(region)
 	invW := 1 / (x1 - x0)
 	invH := 1 / (y1 - y0)
 	for py := region.Min.Y; py < region.Max.Y; py++ {
@@ -152,6 +153,7 @@ func (gb *glyphBackend) DrawTexturedQuadTransformed(id glyph.TextureID,
 	if region.Empty() {
 		return
 	}
+	gb.buf.markDirty(region)
 
 	// Inverse of the affine, applied to logical coordinates.
 	invDet := 1 / det

--- a/gui/backend/soft/layers.go
+++ b/gui/backend/soft/layers.go
@@ -1,0 +1,317 @@
+package soft
+
+import (
+	"image"
+	"image/draw"
+
+	"golang.org/x/image/vector"
+)
+
+// maxLayerDepth caps how deep begin/end brackets may nest before the
+// renderer stops allocating offscreen layers. A stream that deep is
+// pathological; drawing straight into the parent keeps the pairing
+// intact and loses only the scoped effect.
+const maxLayerDepth = 16
+
+// bracketKind identifies which begin/end pair opened a layer.
+type bracketKind uint8
+
+const (
+	bracketFilter bracketKind = iota
+	bracketStencil
+	bracketRotate
+)
+
+// bracket is one open begin/end pair.
+//
+// Every phase 2 kind that scopes later drawing works the same way: push
+// an offscreen layer, let the bracketed commands draw into it, then
+// composite it back with the scoped effect applied. Doing it with a
+// layer rather than with per-draw state is what keeps text, gradients
+// and images correct inside a rotation or a stencil clip without any
+// phase 1 draw path knowing the bracket exists.
+//
+// A nil layer means the depth cap was hit: the bracketed commands drew
+// straight into the parent and the matching end composites nothing.
+type bracket struct {
+	layer  *buffer
+	matrix *[16]float32 // filter: color transform
+
+	// Stencil geometry / rotation centre, device px.
+	x, y, w, h, radius float32
+	angle, cx, cy      float32
+
+	blur   float32 // filter: blur std dev, device px
+	layers int     // filter: composite count
+
+	kind bracketKind
+}
+
+// pushLayer opens a bracket and re-points the render target at a fresh
+// transparent layer. The layer inherits the parent's clip rect, and the
+// clip the bracketed commands leave behind is carried back on pop —
+// the GPU backends do not restore the scissor across an FBO bind
+// either, and the render stream re-emits the clip it wants.
+func (r *renderer) pushLayer(k bracketKind) *bracket {
+	br := bracket{kind: k}
+	if len(r.brackets) < maxLayerDepth {
+		br.layer = r.acquireLayer()
+		br.layer.clip = r.buf.clip
+		r.setTarget(br.layer)
+	}
+	r.brackets = append(r.brackets, br)
+	return &r.brackets[len(r.brackets)-1]
+}
+
+// popLayer closes the innermost bracket and restores the parent target.
+// It reports false when the stream is unbalanced or the innermost
+// bracket was opened by a different kind, in which case nothing is
+// popped: a malformed stream must not unwind a bracket it did not open.
+func (r *renderer) popLayer(k bracketKind) (bracket, bool) {
+	n := len(r.brackets)
+	if n == 0 || r.brackets[n-1].kind != k {
+		return bracket{}, false
+	}
+	br := r.brackets[n-1]
+	r.brackets = r.brackets[:n-1]
+
+	// The new target is the nearest remaining bracket with a real
+	// layer, or the root when none is left. A bracket pushed past
+	// maxLayerDepth never switched the target, so the top of the stack
+	// is not necessarily the current target.
+	parent := r.rootBuf
+	for i := n - 2; i >= 0; i-- {
+		if l := r.brackets[i].layer; l != nil {
+			parent = l
+			break
+		}
+	}
+	if br.layer != nil {
+		parent.clip = br.layer.clip
+	}
+	r.setTarget(parent)
+	return br, true
+}
+
+// setTarget re-points both the shape target and the glyph backend, so
+// text lands in the same layer everything else does. The warming pass
+// deliberately keeps a nil glyph target — its quads are discarded.
+func (r *renderer) setTarget(b *buffer) {
+	r.buf = b
+	// glyphBack is nil in tests that drive shapes only.
+	if !r.warm && r.glyphBack != nil {
+		r.glyphBack.buf = b
+	}
+}
+
+// acquireLayer returns a cleared full-size layer, reusing a pooled one
+// when there is a spare. Layers are full size rather than bracket size
+// so every coordinate stays in device space: no offset bookkeeping in
+// any draw path, and clearing costs only the pooled layer's dirty box.
+func (r *renderer) acquireLayer() *buffer {
+	if n := len(r.layerPool); n > 0 {
+		b := r.layerPool[n-1]
+		r.layerPool = r.layerPool[:n-1]
+		b.clearTransparent()
+		return b
+	}
+	bnds := r.rootBuf.img.Bounds()
+	return newBuffer(bnds.Dx(), bnds.Dy())
+}
+
+// releaseLayer returns a layer to the pool for the next bracket.
+func (r *renderer) releaseLayer(b *buffer) {
+	if b == nil {
+		return
+	}
+	r.layerPool = append(r.layerPool, b)
+}
+
+// clearTransparent zeroes the pixels written since the last clear and
+// resets the dirty box, readying a pooled layer for reuse.
+func (b *buffer) clearTransparent() {
+	r := b.dirty.Intersect(b.img.Bounds())
+	if !r.Empty() {
+		for y := r.Min.Y; y < r.Max.Y; y++ {
+			row := b.img.Pix[b.img.PixOffset(r.Min.X, y):]
+			row = row[:4*r.Dx()]
+			clear(row)
+		}
+	}
+	b.dirty = image.Rectangle{}
+	b.clip = b.img.Bounds()
+}
+
+// composite draws src over dst inside rect. Both sides are
+// premultiplied, so the blend is the plain source-over of two
+// premultiplied colors; mask, when non-nil, attenuates the source by a
+// per-pixel coverage value (the stencil's rounded-rect mask).
+func composite(dst, src *buffer, rect image.Rectangle, mask *image.Alpha) {
+	rect = rect.Intersect(dst.img.Bounds()).Intersect(src.img.Bounds())
+	if mask != nil {
+		rect = rect.Intersect(mask.Rect)
+	}
+	if rect.Empty() {
+		return
+	}
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		si := src.img.PixOffset(rect.Min.X, y)
+		di := dst.img.PixOffset(rect.Min.X, y)
+		mi := 0
+		if mask != nil {
+			mi = mask.PixOffset(rect.Min.X, y)
+		}
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			sr := uint32(src.img.Pix[si])
+			sg := uint32(src.img.Pix[si+1])
+			sb := uint32(src.img.Pix[si+2])
+			sa := uint32(src.img.Pix[si+3])
+			if mask != nil {
+				m := uint32(mask.Pix[mi])
+				mi++
+				sr = sr * m / 255
+				sg = sg * m / 255
+				sb = sb * m / 255
+				sa = sa * m / 255
+			}
+			si += 4
+			if sa == 0 && sr == 0 && sg == 0 && sb == 0 {
+				di += 4
+				continue
+			}
+			inv := 255 - sa
+			p := dst.img.Pix
+			p[di] = overPremul(sr, uint32(p[di]), inv)
+			p[di+1] = overPremul(sg, uint32(p[di+1]), inv)
+			p[di+2] = overPremul(sb, uint32(p[di+2]), inv)
+			p[di+3] = overPremul(sa, uint32(p[di+3]), inv)
+			di += 4
+		}
+	}
+	dst.markDirty(rect)
+}
+
+// coverageRoundRect rasterizes a rounded rect into an alpha mask
+// covering region, backed by the caller's scratch slice so repeated
+// brackets do not allocate. The mask is antialiased, where the GPU
+// stencil pipeline thresholds at half coverage — a CPU mask
+// multiplies, so it can keep the smooth edge.
+func (r *renderer) coverageRoundRect(scratch *[]uint8,
+	region image.Rectangle, x, y, w, h, rad float32) *image.Alpha {
+
+	return r.coveragePath(scratch, region,
+		func(z *vector.Rasterizer, ox, oy float32) {
+			pathRoundRect(z, ox, oy, x, y, w, h, rad, false)
+		})
+}
+
+// coveragePath rasterizes an arbitrary path into an alpha mask covering
+// region. draw.Src overwrites the scratch slice rather than blending
+// into whatever the last mask left there.
+func (r *renderer) coveragePath(scratch *[]uint8, region image.Rectangle,
+	emit func(z *vector.Rasterizer, ox, oy float32)) *image.Alpha {
+
+	if region.Empty() {
+		return nil
+	}
+	n := region.Dx() * region.Dy()
+	if cap(*scratch) < n {
+		*scratch = make([]uint8, n)
+	}
+	mask := &image.Alpha{
+		Pix:    (*scratch)[:n],
+		Stride: region.Dx(),
+		Rect:   region,
+	}
+	r.maskRast.Reset(region.Dx(), region.Dy())
+	r.maskRast.DrawOp = draw.Src
+	emit(&r.maskRast, float32(region.Min.X), float32(region.Min.Y))
+	r.maskRast.Draw(mask, region, image.Opaque, image.Point{})
+	return mask
+}
+
+// blitTransformed composites src over dst with a rotation about
+// (cx, cy) in device pixels, inverse-mapping each destination pixel and
+// sampling the source bilinearly.
+//
+// Rotation is applied to a finished layer rather than to each shape's
+// geometry, so text, gradients and images rotate as faithfully as
+// rectangles do and no phase 1 draw path changes.
+func blitTransformed(dst, src *buffer, rect image.Rectangle,
+	sin, cos, cx, cy float32) {
+
+	rect = rect.Intersect(dst.img.Bounds())
+	if rect.Empty() {
+		return
+	}
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		dy := float32(y) + 0.5 - cy
+		di := dst.img.PixOffset(rect.Min.X, y)
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			dx := float32(x) + 0.5 - cx
+			// Inverse rotation: the source point that lands here.
+			sx := cx + dx*cos + dy*sin
+			sy := cy - dx*sin + dy*cos
+			sr, sg, sb, sa := sampleBilinear(src, sx-0.5, sy-0.5)
+			if sa == 0 && sr == 0 && sg == 0 && sb == 0 {
+				di += 4
+				continue
+			}
+			inv := 255 - sa
+			p := dst.img.Pix
+			p[di] = overPremul(sr, uint32(p[di]), inv)
+			p[di+1] = overPremul(sg, uint32(p[di+1]), inv)
+			p[di+2] = overPremul(sb, uint32(p[di+2]), inv)
+			p[di+3] = overPremul(sa, uint32(p[di+3]), inv)
+			di += 4
+		}
+	}
+	dst.markDirty(rect)
+}
+
+// sampleBilinear reads a premultiplied sample at a continuous texel
+// coordinate, treating everything outside the image as transparent.
+func sampleBilinear(src *buffer, fx, fy float32) (r, g, b, a uint32) {
+	x0 := int(floor32(fx))
+	y0 := int(floor32(fy))
+	tx := fx - float32(x0)
+	ty := fy - float32(y0)
+	var acc [4]float32
+	texelInto(&acc, src, x0, y0, (1-tx)*(1-ty))
+	texelInto(&acc, src, x0+1, y0, tx*(1-ty))
+	texelInto(&acc, src, x0, y0+1, (1-tx)*ty)
+	texelInto(&acc, src, x0+1, y0+1, tx*ty)
+	return uint32(acc[0] + 0.5), uint32(acc[1] + 0.5),
+		uint32(acc[2] + 0.5), uint32(acc[3] + 0.5)
+}
+
+// texelInto accumulates one weighted source texel; out-of-bounds reads
+// contribute nothing, which fades a rotated layer's edge rather than
+// smearing it.
+func texelInto(acc *[4]float32, src *buffer, x, y int, w float32) {
+	bnds := src.img.Bounds()
+	if x < bnds.Min.X || y < bnds.Min.Y || x >= bnds.Max.X || y >= bnds.Max.Y {
+		return
+	}
+	i := src.img.PixOffset(x, y)
+	acc[0] += float32(src.img.Pix[i]) * w
+	acc[1] += float32(src.img.Pix[i+1]) * w
+	acc[2] += float32(src.img.Pix[i+2]) * w
+	acc[3] += float32(src.img.Pix[i+3]) * w
+}
+
+// finishBrackets closes any bracket the stream left open, so a
+// truncated or malformed command list still lands its content on the
+// window instead of dropping it with the layer.
+func (r *renderer) finishBrackets() {
+	for len(r.brackets) > 0 {
+		switch r.brackets[len(r.brackets)-1].kind {
+		case bracketFilter:
+			r.endFilter()
+		case bracketStencil:
+			r.endStencil()
+		case bracketRotate:
+			r.endRotation()
+		}
+	}
+}

--- a/gui/backend/soft/render.go
+++ b/gui/backend/soft/render.go
@@ -64,8 +64,10 @@ func RenderToImage(w *gui.Window, scale float32) (*image.RGBA, error) {
 	w.TestRender(nil)
 	cmds := w.Renderers()
 
+	root := newBuffer(pw, ph)
 	r := &renderer{
-		buf:               newBuffer(pw, ph),
+		buf:               root,
+		rootBuf:           root,
 		scale:             scale,
 		textSys:           tm.textSys,
 		glyphBack:         tm.back,
@@ -90,13 +92,16 @@ func RenderToImage(w *gui.Window, scale float32) (*image.RGBA, error) {
 	r.textSys.Commit()
 
 	// Pass 2 draws for real.
-	r.glyphBack.buf = r.buf
 	r.warm = false
-	r.buf.clear(backgroundColor(w))
+	r.setTarget(root)
+	root.clear(backgroundColor(w))
 	r.drawAll(cmds)
 	r.textSys.Commit()
+	// A stream that ended inside a begin/end bracket still has its
+	// content sitting in a layer; land it rather than drop it.
+	r.finishBrackets()
 
-	return r.buf.img, nil
+	return root.img, nil
 }
 
 // RenderToPNG renders w and writes the result to path as a PNG,

--- a/gui/backend/soft/render_test.go
+++ b/gui/backend/soft/render_test.go
@@ -248,8 +248,10 @@ func TestRenderTextFallbackStyle(t *testing.T) {
 	// Drive the command stream directly with a fallback-style
 	// RenderText (no TextStylePtr) to cover drawText's else branch
 	// and the textured-quad blend path.
+	root := newBuffer(120, 60)
 	r := &renderer{
-		buf:       newBuffer(120, 60),
+		buf:       root,
+		rootBuf:   root,
 		scale:     1,
 		textSys:   tm.textSys,
 		glyphBack: tm.back,
@@ -267,5 +269,105 @@ func TestRenderTextFallbackStyle(t *testing.T) {
 
 	if lit := countLitPixels(r.buf.img); lit == 0 {
 		t.Fatal("no glyph pixels via fallback style")
+	}
+}
+
+// --- Phase 2 kinds, end to end through a real window ---
+
+func TestRenderTermGridPixels(t *testing.T) {
+	cells := make([]gui.TermCell, 4)
+	for i := range cells {
+		cells[i] = gui.TermCell{
+			Ch:    'X',
+			FG:    gui.RGB(255, 255, 255),
+			BG:    gui.RGB(0, 0, 255),
+			Width: 1,
+		}
+	}
+	cells[3].BG = gui.RGB(255, 0, 0)
+
+	win := newWin(t, 100, 100, func(w *gui.Window) gui.View {
+		return gui.TermGrid(gui.TermGridCfg{
+			ID:    "term",
+			Cells: cells,
+			Cols:  2,
+			Rows:  2,
+			CellW: 20,
+			CellH: 20,
+		})
+	})
+	img, err := RenderToImage(win, 1)
+	if err != nil {
+		t.Fatalf("RenderToImage: %v", err)
+	}
+
+	// Cell (0,0) carries the blue background, cell (1,1) the red one.
+	if _, _, b, _ := at(img, 5, 5); b != 255 {
+		t.Errorf("cell(0,0) blue = %d, want 255", b)
+	}
+	if r, _, b, _ := at(img, 35, 35); r != 255 || b != 0 {
+		t.Errorf("cell(1,1) = r%d b%d, want the red background", r, b)
+	}
+}
+
+// TestRenderTermGridSelectionCursorAndUnderline exercises the overlay
+// branches the pixel test above leaves untouched: the selection tint,
+// the block cursor, reverse video and the underline attribute. Every
+// cell is blank so the assertions read the fills, never the glyph ink.
+func TestRenderTermGridSelectionCursorAndUnderline(t *testing.T) {
+	cells := make([]gui.TermCell, 4)
+	for i := range cells {
+		cells[i] = gui.TermCell{
+			Ch:    ' ',
+			FG:    gui.RGB(255, 255, 255),
+			BG:    gui.RGB(0, 0, 255),
+			Width: 1,
+		}
+	}
+	// (0,1): reverse swaps fg/bg, so the background becomes the FG.
+	cells[2].FG = gui.RGB(255, 0, 255)
+	cells[2].BG = gui.RGB(255, 255, 255)
+	cells[2].Attrs = gui.TermReverse
+	// (1,1): underline draws a thin foreground line along the bottom.
+	cells[3].Attrs = gui.TermUnderline
+
+	win := newWin(t, 100, 100, func(w *gui.Window) gui.View {
+		return gui.TermGrid(gui.TermGridCfg{
+			ID:    "term",
+			Cells: cells,
+			Cols:  2,
+			Rows:  2,
+			CellW: 20,
+			CellH: 20,
+			Selection: gui.TermSelRange{
+				Start: 0, End: 2, Color: gui.RGB(0, 255, 0),
+			},
+			Cursor: gui.TermCursor{
+				Col: 0, Row: 0, Visible: true,
+				Style: gui.TermCursorBlock, Color: gui.RGB(255, 0, 0),
+			},
+		})
+	})
+	img, err := RenderToImage(win, 1)
+	if err != nil {
+		t.Fatalf("RenderToImage: %v", err)
+	}
+
+	// Selection tints the whole first row over its backgrounds.
+	if _, g, _, _ := at(img, 25, 5); g != 255 {
+		t.Errorf("selection cell(1,0) green = %d, want 255", g)
+	}
+	// Reverse cell: the background is the swapped-in foreground.
+	if r, g, b, _ := at(img, 5, 25); r != 255 || g != 0 || b != 255 {
+		t.Errorf("reverse cell background = r%d g%d b%d, want magenta",
+			r, g, b)
+	}
+	// Block cursor paints the whole cell clear of any glyph.
+	if r, _, _, _ := at(img, 2, 2); r != 255 {
+		t.Errorf("cursor corner red = %d, want 255", r)
+	}
+	// Underline: a thin foreground line along the cell bottom.
+	if r, _, _, _ := at(img, 35, 39); r < 200 {
+		t.Errorf("underline red = %d, want near 255", r)
 	}
 }


### PR DESCRIPTION
Phase 2 of the headless software rasterizer (#333): `gui/backend/soft` now
draws every render kind the pipeline emits, closing out the deferred set in
issue #360.

- `RenderSvg` — barycentric triangle rasterization honouring `HasXform`,
  `RotAngle` and `VertexAlphaScale` in the GL backend's order; runs of one
  colour cancel interior edges, per-vertex colours interpolate.
- `RenderShadow` / `RenderBlur` — rounded-rect coverage mask blurred with
  three box passes; shadow erases the part under its caster.
- Filters, stencil and rotation brackets — pooled offscreen layer, composited
  back with coverage mask / inverse-mapped resample / blur+colour matrix, so
  effects hold for text and images, not only shapes.
- `RenderTermGrid` — background runs, selection, cursor styles, column-pinned
  glyph runs, underlines; go-term can capture headlessly.
- Hostile input bounded: blur/filter counts clamped, NaN extents rejected,
  saturating composite. `RenderCustomShader` stays unsupported by design.

Pixel-value tests in `draw_phase2_test.go`, spec and CHANGELOG updated.

Closes #360