### PR TITLE
gui/backend: dedupe DrawText text-config fallback across backends

### DIFF
--- a/gui/backend/android/backend.go
+++ b/gui/backend/android/backend.go
@@ -74,6 +74,10 @@ type Backend struct {
 
 	maxImageBytes  int64
 	maxImagePixels int64
+
+	// textErrLogged warns once for a persistent DrawText failure
+	// instead of spamming stderr every frame.
+	textErrLogged bool
 }
 
 // --- Pattern B only (no Pattern A / Run) ---

--- a/gui/backend/android/draw.go
+++ b/gui/backend/android/draw.go
@@ -13,9 +13,8 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/go-gui-org/go-glyph"
-
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
 )
 
@@ -405,33 +404,14 @@ func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
 		return
 	}
-	var cfg glyph.TextConfig
-	if r.TextStylePtr != nil {
-		cfg = guiStyleToGlyphConfig(*r.TextStylePtr)
-		cfg.Gradient = r.TextGradient
-	} else {
-		cfg = glyph.TextConfig{
-			Style: glyph.TextStyle{
-				FontName: r.FontName,
-				Size:     r.FontSize,
-				Color: glyph.Color{
-					R: r.Color.R,
-					G: r.Color.G,
-					B: r.Color.B,
-					A: r.Color.A,
-				},
-			},
-			Block: glyph.DefaultBlockStyle(),
-		}
-	}
-	if r.W > 0 {
-		cfg.Block.Wrap = glyph.WrapWord
-		cfg.Block.Width = r.W
-	}
+	cfg := glyphconv.GuiTextConfigFromRender(r)
 
 	b.UseGlyphPipeline()
 	b.TextQueued = true
-	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil {
+	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil && !b.textErrLogged {
+		// Warn once per backend: a persistent failure (e.g. missing
+		// font) would otherwise log every frame.
+		b.textErrLogged = true
 		log.Printf("android: DrawText: %v", err)
 	}
 	b.InvalidatePipelineState()

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -42,6 +42,10 @@ type Backend struct {
 	glyphBack    *glyphBackend
 	iconFontPath string
 
+	// textErrLogged warns once for a persistent DrawText failure
+	// instead of spamming stderr every frame.
+	textErrLogged bool
+
 	mvpStack [][16]float32
 
 	textPathPlacements []glyph.GlyphPlacement

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -7,10 +7,10 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/go-gui-org/go-glyph"
 	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
 )
@@ -403,35 +403,18 @@ func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
 		return
 	}
-	var cfg glyph.TextConfig
-	if r.TextStylePtr != nil {
-		cfg = guiStyleToGlyphConfig(*r.TextStylePtr)
-		cfg.Gradient = r.TextGradient
-	} else {
-		cfg = glyph.TextConfig{
-			Style: glyph.TextStyle{
-				FontName: r.FontName,
-				Size:     r.FontSize,
-				Color: glyph.Color{
-					R: r.Color.R,
-					G: r.Color.G,
-					B: r.Color.B,
-					A: r.Color.A,
-				},
-			},
-			Block: glyph.DefaultBlockStyle(),
-		}
-	}
-	if r.W > 0 {
-		cfg.Block.Wrap = glyph.WrapWord
-		cfg.Block.Width = r.W
-	}
+	cfg := glyphconv.GuiTextConfigFromRender(r)
 
 	// Glyph renders with its own GL calls through the
 	// glyphBackend. Need to use a simple textured-quad
 	// pipeline for it.
 	b.useGlyphPipeline()
-	_ = b.textSys.DrawText(r.X, r.Y, r.Text, cfg)
+	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil && !b.textErrLogged {
+		// Warn once per backend: a persistent failure (e.g. missing
+		// font) would otherwise log every frame.
+		b.textErrLogged = true
+		log.Printf("gl: DrawText: %v", err)
+	}
 	b.restoreAfterGlyph()
 }
 

--- a/gui/backend/internal/glyphconv/conv.go
+++ b/gui/backend/internal/glyphconv/conv.go
@@ -6,6 +6,38 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
+// GuiTextConfigFromRender builds the glyph.TextConfig for a plain
+// RenderText command: the rich style when TextStylePtr is set, the flat
+// FontName/Size/Color fallback otherwise, and the wrap-width override
+// when the command carries a width. Shared by all backends so the
+// fallback semantics cannot drift (issue #362).
+func GuiTextConfigFromRender(r *gui.RenderCmd) glyph.TextConfig {
+	var cfg glyph.TextConfig
+	if r.TextStylePtr != nil {
+		cfg = GuiStyleToGlyphConfig(*r.TextStylePtr)
+		cfg.Gradient = r.TextGradient
+	} else {
+		cfg = glyph.TextConfig{
+			Style: glyph.TextStyle{
+				FontName: r.FontName,
+				Size:     r.FontSize,
+				Color: glyph.Color{
+					R: r.Color.R,
+					G: r.Color.G,
+					B: r.Color.B,
+					A: r.Color.A,
+				},
+			},
+			Block: glyph.DefaultBlockStyle(),
+		}
+	}
+	if r.W > 0 {
+		cfg.Block.Wrap = glyph.WrapWord
+		cfg.Block.Width = r.W
+	}
+	return cfg
+}
+
 // GuiStyleToGlyphConfig converts a gui.TextStyle to a
 // glyph.TextConfig suitable for text measurement and rendering.
 func GuiStyleToGlyphConfig(s gui.TextStyle) glyph.TextConfig {

--- a/gui/backend/internal/glyphconv/conv_test.go
+++ b/gui/backend/internal/glyphconv/conv_test.go
@@ -173,3 +173,114 @@ func TestGuiStyleToGlyphConfigZeroValue(t *testing.T) {
 			gc.Block.Width)
 	}
 }
+
+// The flat fallback is what every backend renders when a RenderText
+// command has no TextStylePtr; the fields must map exactly so the six
+// backends cannot drift (issue #362).
+func TestGuiTextConfigFromRenderFallback(t *testing.T) {
+	t.Parallel()
+	r := &gui.RenderCmd{
+		FontName: "Fallback Font",
+		FontSize: 13.5,
+		Color:    gui.RGBA(10, 20, 30, 40),
+	}
+	gc := GuiTextConfigFromRender(r)
+
+	if gc.Style.FontName != "Fallback Font" {
+		t.Errorf("FontName: got %q, want %q",
+			gc.Style.FontName, "Fallback Font")
+	}
+	if gc.Style.Size != 13.5 {
+		t.Errorf("Size: got %v, want 13.5", gc.Style.Size)
+	}
+	if gc.Style.Color.R != 10 || gc.Style.Color.G != 20 ||
+		gc.Style.Color.B != 30 || gc.Style.Color.A != 40 {
+		t.Errorf("Color mismatch: got %+v", gc.Style.Color)
+	}
+	if gc.Style.BgColor != (glyph.Color{}) {
+		t.Errorf("BgColor: expected zero, got %+v", gc.Style.BgColor)
+	}
+	if gc.Gradient != nil {
+		t.Errorf("Gradient: expected nil, got %v", gc.Gradient)
+	}
+	// The fallback must not inherit the style converter's defaults:
+	// the pre-issue blocks used DefaultBlockStyle() verbatim.
+	def := glyph.DefaultBlockStyle()
+	if gc.Block.Align != def.Align || gc.Block.Wrap != def.Wrap ||
+		gc.Block.Width != def.Width || gc.Block.Indent != def.Indent ||
+		gc.Block.LineSpacing != def.LineSpacing ||
+		len(gc.Block.Tabs) != len(def.Tabs) {
+		t.Errorf("Block: got %+v, want DefaultBlockStyle %+v",
+			gc.Block, def)
+	}
+}
+
+func TestGuiTextConfigFromRenderWrapWidth(t *testing.T) {
+	t.Parallel()
+	r := &gui.RenderCmd{W: 240}
+	gc := GuiTextConfigFromRender(r)
+	if gc.Block.Wrap != glyph.WrapWord {
+		t.Errorf("Wrap: got %v, want WrapWord", gc.Block.Wrap)
+	}
+	if gc.Block.Width != 240 {
+		t.Errorf("Width: got %v, want 240", gc.Block.Width)
+	}
+
+	// No width: keep the default block style untouched.
+	gc = GuiTextConfigFromRender(&gui.RenderCmd{})
+	def := glyph.DefaultBlockStyle()
+	if gc.Block.Wrap != def.Wrap {
+		t.Errorf("Wrap: got %v, want %v", gc.Block.Wrap, def.Wrap)
+	}
+	if gc.Block.Width != def.Width {
+		t.Errorf("Width: got %v, want %v", gc.Block.Width, def.Width)
+	}
+
+	// Negative width must not enable wrapping.
+	gc = GuiTextConfigFromRender(&gui.RenderCmd{W: -100})
+	if gc.Block.Wrap != def.Wrap {
+		t.Errorf("negative width: Wrap got %v, want %v",
+			gc.Block.Wrap, def.Wrap)
+	}
+	if gc.Block.Width != def.Width {
+		t.Errorf("negative width: Width got %v, want %v",
+			gc.Block.Width, def.Width)
+	}
+}
+
+func TestGuiTextConfigFromRenderStyled(t *testing.T) {
+	t.Parallel()
+	style := gui.TextStyle{
+		Family: "Styled",
+		Size:   18,
+		Color:  gui.RGBA(1, 2, 3, 4),
+	}
+	grad := &glyph.GradientConfig{
+		Direction: glyph.GradientVertical,
+		Stops: []glyph.GradientStop{
+			{Color: glyph.Color{R: 255, A: 255}, Position: 0},
+			{Color: glyph.Color{R: 0, A: 255}, Position: 1},
+		},
+	}
+	r := &gui.RenderCmd{
+		TextStylePtr: &style,
+		TextGradient: grad,
+		W:            120,
+	}
+	gc := GuiTextConfigFromRender(r)
+
+	// Styled path must agree with the style converter, plus gradient.
+	want := GuiStyleToGlyphConfig(style)
+	want.Gradient = grad
+	want.Block.Wrap = glyph.WrapWord
+	want.Block.Width = 120
+	if gc.Style != want.Style {
+		t.Errorf("Style: got %+v, want %+v", gc.Style, want.Style)
+	}
+	if gc.Gradient != grad {
+		t.Errorf("Gradient pointer not passed through")
+	}
+	if gc.Block.Wrap != glyph.WrapWord || gc.Block.Width != 120 {
+		t.Errorf("Block: got %+v, want wrap 120", gc.Block)
+	}
+}

--- a/gui/backend/ios/backend.go
+++ b/gui/backend/ios/backend.go
@@ -76,6 +76,10 @@ type Backend struct {
 
 	maxImageBytes  int64
 	maxImagePixels int64
+
+	// textErrLogged warns once for a persistent DrawText failure
+	// instead of spamming stderr every frame.
+	textErrLogged bool
 }
 
 // --- Pattern A: Go-driven (backend.Run) ---

--- a/gui/backend/ios/draw.go
+++ b/gui/backend/ios/draw.go
@@ -13,9 +13,8 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/go-gui-org/go-glyph"
-
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
 )
 
@@ -405,33 +404,14 @@ func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
 		return
 	}
-	var cfg glyph.TextConfig
-	if r.TextStylePtr != nil {
-		cfg = guiStyleToGlyphConfig(*r.TextStylePtr)
-		cfg.Gradient = r.TextGradient
-	} else {
-		cfg = glyph.TextConfig{
-			Style: glyph.TextStyle{
-				FontName: r.FontName,
-				Size:     r.FontSize,
-				Color: glyph.Color{
-					R: r.Color.R,
-					G: r.Color.G,
-					B: r.Color.B,
-					A: r.Color.A,
-				},
-			},
-			Block: glyph.DefaultBlockStyle(),
-		}
-	}
-	if r.W > 0 {
-		cfg.Block.Wrap = glyph.WrapWord
-		cfg.Block.Width = r.W
-	}
+	cfg := glyphconv.GuiTextConfigFromRender(r)
 
 	b.UseGlyphPipeline()
 	b.TextQueued = true
-	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil {
+	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil && !b.textErrLogged {
+		// Warn once per backend: a persistent failure (e.g. missing
+		// font) would otherwise log every frame.
+		b.textErrLogged = true
 		log.Printf("ios: DrawText: %v", err)
 	}
 	b.InvalidatePipelineState()

--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -441,8 +441,12 @@ type windowState struct {
 	termRunText        []rune                 // TermGrid: scratch run text
 	termRunCols        []int                  // TermGrid: scratch run columns
 	termPlace          []glyph.GlyphPlacement // TermGrid: scratch placements
-	normBuf            []gui.GradientStop
-	sampledBuf         []gui.GradientStop
+
+	// textErrLogged warns once for a persistent DrawText failure
+	// instead of spamming stderr every frame.
+	textErrLogged bool
+	normBuf       []gui.GradientStop
+	sampledBuf    []gui.GradientStop
 
 	textures          texcache.Cache[string, metalTexture]
 	glyphBack         *metalGlyphBackend

--- a/gui/backend/metal/draw.go
+++ b/gui/backend/metal/draw.go
@@ -13,9 +13,8 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/go-gui-org/go-glyph"
-
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/imgload"
 )
@@ -425,32 +424,13 @@ func (b *windowState) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
 		return
 	}
-	var cfg glyph.TextConfig
-	if r.TextStylePtr != nil {
-		cfg = guiStyleToGlyphConfig(*r.TextStylePtr)
-		cfg.Gradient = r.TextGradient
-	} else {
-		cfg = glyph.TextConfig{
-			Style: glyph.TextStyle{
-				FontName: r.FontName,
-				Size:     r.FontSize,
-				Color: glyph.Color{
-					R: r.Color.R,
-					G: r.Color.G,
-					B: r.Color.B,
-					A: r.Color.A,
-				},
-			},
-			Block: glyph.DefaultBlockStyle(),
-		}
-	}
-	if r.W > 0 {
-		cfg.Block.Wrap = glyph.WrapWord
-		cfg.Block.Width = r.W
-	}
+	cfg := glyphconv.GuiTextConfigFromRender(r)
 
 	b.useGlyphPipeline()
-	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil {
+	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil && !b.textErrLogged {
+		// Warn once per backend: a persistent failure (e.g. missing
+		// font) would otherwise log every frame.
+		b.textErrLogged = true
 		log.Printf("metal: DrawText: %v", err)
 	}
 }

--- a/gui/backend/soft/draw.go
+++ b/gui/backend/soft/draw.go
@@ -23,6 +23,10 @@ type renderer struct {
 	textSys   *glyph.TextSystem
 	glyphBack *glyphBackend
 
+	// textErrLogged warns once for a persistent DrawText failure
+	// instead of spamming stderr every frame.
+	textErrLogged bool
+
 	// images caches decoded sources by the RenderCmd.Resource string.
 	images map[string]*image.NRGBA
 

--- a/gui/backend/soft/text.go
+++ b/gui/backend/soft/text.go
@@ -1,6 +1,8 @@
 package soft
 
 import (
+	"log"
+
 	"github.com/go-gui-org/go-glyph"
 
 	"github.com/go-gui-org/go-gui/gui"
@@ -98,30 +100,13 @@ func (r *renderer) drawText(cmd *gui.RenderCmd) {
 	if r.textSys == nil || cmd.Text == "" {
 		return
 	}
-	var cfg glyph.TextConfig
-	if cmd.TextStylePtr != nil {
-		cfg = guiStyleToGlyphConfig(*cmd.TextStylePtr)
-		cfg.Gradient = cmd.TextGradient
-	} else {
-		cfg = glyph.TextConfig{
-			Style: glyph.TextStyle{
-				FontName: cmd.FontName,
-				Size:     cmd.FontSize,
-				Color: glyph.Color{
-					R: cmd.Color.R,
-					G: cmd.Color.G,
-					B: cmd.Color.B,
-					A: cmd.Color.A,
-				},
-			},
-			Block: glyph.DefaultBlockStyle(),
-		}
+	cfg := glyphconv.GuiTextConfigFromRender(cmd)
+	if err := r.textSys.DrawText(cmd.X, cmd.Y, cmd.Text, cfg); err != nil && !r.textErrLogged {
+		// Warn once per renderer: a persistent failure (e.g. missing
+		// font) would otherwise log every frame.
+		r.textErrLogged = true
+		log.Printf("soft: DrawText: %v", err)
 	}
-	if cmd.W > 0 {
-		cfg.Block.Wrap = glyph.WrapWord
-		cfg.Block.Width = cmd.W
-	}
-	_ = r.textSys.DrawText(cmd.X, cmd.Y, cmd.Text, cfg)
 }
 
 func (r *renderer) drawLayout(cmd *gui.RenderCmd) {

--- a/gui/backend/web/backend.go
+++ b/gui/backend/web/backend.go
@@ -31,7 +31,11 @@ type Backend struct {
 	shaders   *customShaderRenderer
 	dpiScale  float32
 	width     int
-	height    int
+
+	// textErrLogged warns once for a persistent DrawText failure
+	// instead of spamming stderr every frame.
+	textErrLogged bool
+	height        int
 
 	normBuf      []gui.GradientStop
 	imgCache     map[string]js.Value

--- a/gui/backend/web/draw.go
+++ b/gui/backend/web/draw.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"syscall/js"
 
-	"github.com/go-gui-org/go-glyph"
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 )
@@ -212,28 +211,11 @@ func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
 		return
 	}
-	var cfg glyph.TextConfig
-	if r.TextStylePtr != nil {
-		cfg = glyphconv.GuiStyleToGlyphConfig(*r.TextStylePtr)
-		cfg.Gradient = r.TextGradient
-	} else {
-		cfg = glyph.TextConfig{
-			Style: glyph.TextStyle{
-				FontName: r.FontName,
-				Size:     r.FontSize,
-				Color: glyph.Color{
-					R: r.Color.R, G: r.Color.G,
-					B: r.Color.B, A: r.Color.A,
-				},
-			},
-			Block: glyph.DefaultBlockStyle(),
-		}
-	}
-	if r.W > 0 {
-		cfg.Block.Wrap = glyph.WrapWord
-		cfg.Block.Width = r.W
-	}
-	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil {
+	cfg := glyphconv.GuiTextConfigFromRender(r)
+	if err := b.textSys.DrawText(r.X, r.Y, r.Text, cfg); err != nil && !b.textErrLogged {
+		// Warn once per backend: a persistent failure (e.g. missing
+		// font) would otherwise log every frame.
+		b.textErrLogged = true
 		log.Printf("web: DrawText: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #362.

## What
The ~20-line `RenderCmd` → `glyph.TextConfig` fallback was hand-copied into all six backend draw paths and had already diverged (web collapsed the color literal formatting; more drift was inevitable). Replace all six with one shared builder, `glyphconv.GuiTextConfigFromRender`, and unify DrawText error handling on a warn-once latch.

## Behavior
- **Same config semantics** as before for every backend: rich style when `TextStylePtr` is set (plus gradient), flat `FontName/Size/Color` fallback with `DefaultBlockStyle()` otherwise, wrap override when `W > 0`.
- **gl and soft now log** DrawText errors (previously `_ =` silently dropped them) — once, not per frame.
- **web/android/metal/ios** log once per persistent failure instead of every frame.

## Tests
- `TestGuiTextConfigFromRenderFallback` — flat fallback maps exactly, Block equals `DefaultBlockStyle()` verbatim, no gradient, no bg color.
- `TestGuiTextConfigFromRenderWrapWidth` — wrap override, untouched default when no/negative width.
- `TestGuiTextConfigFromRenderStyled` — styled path agrees with `GuiStyleToGlyphConfig` + gradient + width.

## Verification
`make prepush` green (race, lint, cross-lint windows/js/darwin, cross-compile linux/windows, coverage, export audit); `make build-ios build-android` green.