### PR TITLE
Fix multiline text box height and virtualized ListBox row estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,27 @@ and this project adheres to
 
 ### Fixed
 
+- **Multi-line text sat high in its box, so `ListBox` rows read top-biased.**
+  go-glyph sizes a line box as the baseline-to-baseline advance — ascent +
+  descent + leading, floored at 1.15em — while rendering puts the baseline at
+  `FontAscent` below the shape top. The layout pass took that height verbatim,
+  so the leading below the _last_ baseline was reserved at the bottom of every
+  multiline or wrapped text shape and nothing ever painted into it: 2.4px at
+  size 16, all of it under the text. A text shape is now sized to the
+  ascent..descent box the single-line path already uses
+  (`(lines-1)*lineHeight + FontHeight`), which is also the box
+  `docs/specs/text-optical-centring.md` assumes. Inter-line spacing is
+  unchanged; only the trailing leading goes.
+- **A virtualized `ListBox` built too few rows to cover its viewport.** The row
+  height it virtualizes with was estimated as `1.4 x font size + padding`, which
+  over-counted a row by ~30% once a real text measurer was present — a row is
+  one text shape (`FontHeight`) plus its padding. Spacers, the visible range and
+  the height model `ScrollToIndex` reads all divide by that number, so a tall
+  scrolled list left a blank strip along its bottom edge that the two-row
+  overscan could not cover. The estimate now asks the measurer, falling back to
+  the same approximation the text path itself uses when there is none, and the
+  spacers take the caller's number rather than recomputing it. `Combobox`, the
+  command palette and `VirtualList` share the estimate and are fixed with it.
 - **`Input` undo recorded every keystroke as its own step, evicting the whole
   history after 50 characters** (issue #328). Consecutive edits of the same kind
   — a typing run, a backspace chain — now coalesce into one undo step whose

--- a/gui/backend/soft/render_test.go
+++ b/gui/backend/soft/render_test.go
@@ -9,6 +9,7 @@
 package soft
 
 import (
+	"fmt"
 	"image"
 	"os"
 	"path/filepath"
@@ -369,5 +370,134 @@ func TestRenderTermGridSelectionCursorAndUnderline(t *testing.T) {
 	// Underline: a thin foreground line along the cell bottom.
 	if r, _, _, _ := at(img, 35, 39); r < 200 {
 		t.Errorf("underline red = %d, want near 255", r)
+	}
+}
+
+// TestMultilineTextBoxHasNoTrailingLeading pins the fix for a ListBox
+// row reading top-biased: glyph sizes a line box as the
+// baseline-to-baseline advance (ascent + descent + leading, floored at
+// 1.15em), while rendering puts the baseline at ascent below the top.
+// The trailing leading was therefore reserved at the bottom of every
+// multiline shape and nothing painted into it, so a one-line multiline
+// shape came out taller than the same text in single-line mode.
+//
+// Measured through the real rasterizer: the coloured Fit container
+// around each Text is the shape box, so the two must span the same
+// rows.
+func TestMultilineTextBoxHasNoTrailingLeading(t *testing.T) {
+	bg := gui.RGB(255, 0, 0)
+	build := func(txt gui.TextCfg) func(*gui.Window) gui.View {
+		return func(w *gui.Window) gui.View {
+			return gui.Column(gui.ContainerCfg{
+				Color:      bg,
+				Padding:    gui.PaddingNone,
+				SizeBorder: gui.NoBorder,
+				Sizing:     gui.FitFit,
+				Content: []gui.View{
+					gui.Text(txt),
+				},
+			})
+		}
+	}
+	// bandHeight counts the rows the red container covers.
+	bandHeight := func(txt gui.TextCfg) int {
+		win := newWin(t, 200, 80, build(txt))
+		img, err := RenderToImage(win, 1)
+		if err != nil {
+			t.Fatalf("RenderToImage: %v", err)
+		}
+		rows := 0
+		for y := range 80 {
+			for x := range 200 {
+				r, g, b, _ := at(img, x, y)
+				if r > 200 && g < 60 && b < 60 {
+					rows++
+					break
+				}
+			}
+		}
+		return rows
+	}
+	single := bandHeight(gui.TextCfg{Text: "list item"})
+	multi := bandHeight(gui.TextCfg{
+		Text: "list item", Mode: gui.TextModeMultiline,
+	})
+	if single == 0 {
+		t.Fatal("single-line container did not render")
+	}
+	if multi != single {
+		t.Errorf("multiline box = %d rows, single-line = %d; "+
+			"the difference is trailing leading nothing paints into",
+			multi, single)
+	}
+}
+
+// TestListBoxVirtualizedFillsViewport pins the row-height estimate a
+// virtualized ListBox virtualizes with. The visible range is
+// listHeight/rowHeight (plus a two-row overscan), the spacers are
+// index*rowHeight, and the height model ScrollToIndex reads is
+// registered with the same number — so an estimate that over-counts
+// builds too few rows to cover the viewport and leaves the bottom of
+// a scrolled list blank. The list here is tall enough (800px) that the
+// over-count outruns the two-row overscan and the defect shows; at
+// 400px the overscan absorbs it and the test would pass either way.
+//
+// Measured through the real rasterizer, because the defect only
+// exists once a text measurer is present: with no measurer the
+// estimate and the arranged height agree by construction.
+func TestListBoxVirtualizedFillsViewport(t *testing.T) {
+	const (
+		listH  = 800
+		winH   = 840
+		winW   = 220
+		nItems = 400
+	)
+	items := make([]gui.ListBoxOption, 0, nItems)
+	for i := range nItems {
+		id := fmt.Sprintf("%03d", i)
+		items = append(items, gui.NewListBoxOption(id, "item "+id, id))
+	}
+	win := newWin(t, winW, winH, func(w *gui.Window) gui.View {
+		return gui.Column(gui.ContainerCfg{
+			Padding:    gui.PaddingNone,
+			SizeBorder: gui.NoBorder,
+			Sizing:     gui.FillFill,
+			Content: []gui.View{
+				gui.ListBox(gui.ListBoxCfg{
+					ID:         "lb",
+					Scrollable: true,
+					Height:     listH,
+					Data:       items,
+				}),
+			},
+		})
+	})
+	// Frame 1 builds the layout the scroll API needs to find.
+	if _, err := RenderToImage(win, 1); err != nil {
+		t.Fatalf("RenderToImage: %v", err)
+	}
+	win.ScrollVerticalToPct("lb", 0.5)
+	img, err := RenderToImage(win, 1)
+	if err != nil {
+		t.Fatalf("RenderToImage: %v", err)
+	}
+	// hasInk reports whether any row in [y0,y1) carries text.
+	hasInk := func(y0, y1 int) bool {
+		for y := y0; y < y1; y++ {
+			for x := range winW {
+				r, g, b, _ := at(img, x, y)
+				if r > 150 && g > 150 && b > 150 {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	// The last few pixels of the viewport, above the list bottom edge:
+	// with the estimate right, a row covers them.
+	if !hasInk(listH-14, listH) {
+		t.Error("bottom of a mid-scrolled virtualized list is blank: " +
+			"the row-height estimate over-counts, so too few rows " +
+			"are built to cover the viewport")
 	}
 }

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -322,7 +322,7 @@ func layoutPlainText(
 	if !ok {
 		return
 	}
-	shape.Height = l.Height
+	shape.Height = plainTextBoxHeight(l, style, w)
 	if tc.TextMode == TextModeMultiline &&
 		shape.Sizing.Width != sizingFixed && l.Width > 0 {
 		shape.Width = l.Width

--- a/gui/list_core.go
+++ b/gui/list_core.go
@@ -152,10 +152,23 @@ func ListVisibleRange(itemCount int, rowHeight, listHeight,
 }
 
 // listCoreRowHeightEstimate estimates row height from text
-// style + padding. No Window needed. Uses the same 1.4×
-// line-height factor as text shape layout.
-func listCoreRowHeightEstimate(style TextStyle, pad Padding) float32 {
-	return style.Size*1.4 + pad.Height()
+// style + padding. It reports what a row actually arranges to, so
+// virtualization spacers, the visible range and the registered
+// height model all agree with what lands on screen.
+//
+// A row is one text shape plus its padding, and a text shape is
+// sized to FontHeight — ascent + descent (text_optical.go) — so the
+// measurer is the source when there is one. Without a measurer the
+// text path falls back to fallbackLineHeight, and so does this: the
+// estimate tracks whichever height the layout will really use.
+func listCoreRowHeightEstimate(
+	style TextStyle, pad Padding, w *Window,
+) float32 {
+	height := fallbackLineHeight(style)
+	if w != nil && w.textMeasurer != nil {
+		height = w.textMeasurer.FontHeight(style)
+	}
+	return height + pad.Height()
 }
 
 // listCoreFuzzyScore scores a candidate against a query.

--- a/gui/text_layout.go
+++ b/gui/text_layout.go
@@ -139,3 +139,38 @@ func plainTextLayoutResolved(
 	tc.textLayoutValid = true
 	return layout, true
 }
+
+// plainTextBoxHeight converts glyph's layout height into the box
+// go-gui sizes text with.
+//
+// glyph reports Height as n whole line boxes, and a line box is the
+// baseline-to-baseline advance: ascent + descent + leading, floored at
+// 1.15em (go-glyph linespacing.go). Rendering, though, puts the first
+// baseline at FontAscent below the shape top and advances by that same
+// line height, so the leading below the *last* baseline is space
+// nothing ever paints into. Kept in the shape, it is padding only at
+// the bottom: a centred or padded row then reads visibly top-biased —
+// 2.4px at size 16, which is what a ListBox row showed.
+//
+// Dropping the trailing leading makes a one-line shape exactly
+// FontHeight, the same box the single-line path in view_text.go
+// assigns, so the two paths agree and the optical-centring model in
+// text_optical.go ("a text shape is sized to FontHeight") holds for
+// multi-line text too. Inter-line spacing is untouched: only the tail
+// goes.
+func plainTextBoxHeight(
+	l glyph.Layout, style TextStyle, w *Window,
+) float32 {
+	lines := len(l.Lines)
+	if lines == 0 || l.Height <= 0 || !f32IsFinite(l.Height) {
+		return l.Height
+	}
+	fh := fontHeight(style, w)
+	// Guard a face (or a LineSpacing) whose line box is tighter than
+	// ascent+descent: growing the shape here would be a regression.
+	lineH := l.Height / float32(lines)
+	if fh >= lineH {
+		return l.Height
+	}
+	return float32(lines-1)*lineH + fh
+}

--- a/gui/text_layout_test.go
+++ b/gui/text_layout_test.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -114,6 +115,83 @@ func TestPlainTextLayoutResolvedNilWindow(t *testing.T) {
 // reporting one line tall. Asserted as a line count rather than a pixel
 // height: the per-rune width is an approximation and may be retuned,
 // but "more text in the same width is more lines" must hold.
+// plainTextBoxHeight converts glyph's whole-line-box height into the
+// ascent..descent box the single-line path uses: the trailing leading
+// below the last baseline is dropped, inter-line spacing kept, and a
+// face whose line box is tighter than ascent+descent keeps glyph's
+// number untouched (growing the shape would be a regression).
+func TestPlainTextBoxHeight(t *testing.T) {
+	style := TextStyle{Size: 16}
+	// fh controls fontHeight via the window's measurer.
+	w := &Window{}
+	w.textMeasurer = &stubTextMeasurer{fontHeight: 20}
+
+	lines := func(n int) []glyph.Line { return make([]glyph.Line, n) }
+
+	cases := []struct {
+		name string
+		l    glyph.Layout
+		want float32
+	}{
+		{
+			name: "one line drops trailing leading",
+			l:    glyph.Layout{Height: 23, Lines: lines(1)},
+			want: 20, // fh, not the 23px line box
+		},
+		{
+			name: "two lines keep inter-line spacing",
+			l:    glyph.Layout{Height: 46, Lines: lines(2)},
+			want: 43, // 23px line box + 20px last line
+		},
+		{
+			name: "empty lines keep layout height",
+			l:    glyph.Layout{Height: 23},
+			want: 23,
+		},
+		{
+			name: "zero height passes through",
+			l:    glyph.Layout{Height: 0, Lines: lines(1)},
+			want: 0,
+		},
+		{
+			name: "non-finite height passes through untouched",
+			l:    glyph.Layout{Height: float32(math.NaN()), Lines: lines(1)},
+			want: float32(math.NaN()),
+		},
+		{
+			// fh 20 >= lineH 20: the formula would grow the shape
+			// (1*20+20 = 40 > 40 is equal here; use fh > lineH below).
+			name: "line box tighter than font height keeps layout height",
+			l:    glyph.Layout{Height: 40, Lines: lines(2)},
+			want: 40,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := plainTextBoxHeight(tc.l, style, w)
+			if tc.want != tc.want { // NaN
+				if got == got {
+					t.Errorf("got %v, want NaN", got)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// fh (24) > lineH (20): growing the shape would be a regression,
+	// so glyph's number stands even though the formula would say 44.
+	wTight := &Window{}
+	wTight.textMeasurer = &stubTextMeasurer{fontHeight: 24}
+	if got := plainTextBoxHeight(glyph.Layout{
+		Height: 40, Lines: lines(2),
+	}, style, wTight); got != 40 {
+		t.Errorf("tight line box = %v, want 40", got)
+	}
+}
+
 func TestPlainTextHeightNoMeasurer(t *testing.T) {
 	style := TextStyle{Size: 10}
 	lineH := fallbackLineHeight(style)

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -131,7 +131,8 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 	hl := prepared.HL
 
 	// Virtualization.
-	rowH := listCoreRowHeightEstimate(cfg.TextStyle, cfg.Padding.Or(PaddingNone))
+	rowH := listCoreRowHeightEstimate(
+		cfg.TextStyle, cfg.Padding.Or(PaddingNone), w)
 	pad := cfg.Padding.Or(PaddingNone)
 	listH := cfg.maxDropdownHeight - 2*sizeBorder - pad.Top - pad.Bottom
 	var scrollY float32

--- a/gui/view_combobox_test.go
+++ b/gui/view_combobox_test.go
@@ -258,10 +258,27 @@ func TestListCoreRowHeightEstimate(t *testing.T) {
 	layout := generateViewLayout(views[0], w)
 	layoutWidths(&layout)
 	layoutHeights(&layout)
-	est := listCoreRowHeightEstimate(DefaultTextStyle, PaddingSmall)
+	est := listCoreRowHeightEstimate(DefaultTextStyle, PaddingSmall, w)
 	actual := layout.Shape.Height
 	if est != actual {
 		t.Errorf("estimate=%f, actual=%f", est, actual)
+	}
+
+	// With a measurer the estimate must track FontHeight, not the
+	// 1.4em fallback — the fix that made virtualization spacers match
+	// what actually arranges on screen.
+	w.textMeasurer = &stubTextMeasurer{fontHeight: 20}
+	layout = generateViewLayout(views[0], w)
+	layoutWidths(&layout)
+	layoutHeights(&layout)
+	est = listCoreRowHeightEstimate(DefaultTextStyle, PaddingSmall, w)
+	actual = layout.Shape.Height
+	want := float32(20) + PaddingSmall.Height()
+	if est != want {
+		t.Errorf("with measurer estimate=%f, want %f", est, want)
+	}
+	if actual != est {
+		t.Errorf("with measurer actual=%f, estimate=%f", actual, est)
 	}
 }
 

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -121,7 +121,8 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 	hl := prepared.HL
 
 	// Virtualization.
-	rowH := listCoreRowHeightEstimate(cfg.TextStyle, PaddingTwoFive)
+	rowH := listCoreRowHeightEstimate(
+		cfg.TextStyle, PaddingTwoFive, w)
 	scrollID := ScopeID(id, "scroll")
 	var scrollY float32
 	if cfg.Scrollable {

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -234,7 +234,7 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 		cfg, selectedSet, focusedID, dragIdxByRow,
 		itemIDs, itemLayoutIDs, midsOffset, scrollID,
 		canReorder, dragging, drag,
-		virtualize, first, last)
+		virtualize, first, last, rowH)
 
 	if dragging && drag.currentIndex >= len(itemIDs) {
 		list = append(list,
@@ -344,7 +344,7 @@ func listBoxVisibleRange(
 	if listH <= 0 {
 		listH = cache.resolvedH
 	}
-	rowH = listCoreRowHeightEstimate(cfg.TextStyle, listBoxItemPad)
+	rowH = listCoreRowHeightEstimate(cfg.TextStyle, listBoxItemPad, w)
 	if virtualize && listH > 0 && len(cfg.Data) > 0 {
 		// Default 0: absent entry means not scrolled.
 		scrollY := w.scrollY().GetOr(cfg.ID, 0)

--- a/gui/view_listbox_items.go
+++ b/gui/view_listbox_items.go
@@ -28,6 +28,11 @@ func listBoxItemLayoutIDs(
 
 // listBoxBuildItems builds the list of item views, including
 // virtualization spacers and drag-reorder gap/ghost handling.
+//
+// rowH is the caller's row-height estimate rather than a second
+// computation of it: the spacers, the visible range and the height
+// model registered for ScrollToIndex are one arithmetic, and
+// recomputing it here is how the three drift apart.
 func listBoxBuildItems(
 	cfg *ListBoxCfg,
 	selectedSet map[string]struct{},
@@ -38,6 +43,7 @@ func listBoxBuildItems(
 	canReorder, dragging bool,
 	drag dragReorderState,
 	virtualize bool, first, last int,
+	rowH float32,
 ) ([]View, View) {
 	listCap := len(cfg.Data)
 	if virtualize && last >= first {
@@ -49,11 +55,9 @@ func listBoxBuildItems(
 	list := make([]View, 0, listCap)
 
 	if virtualize && first > 0 {
-		rh := listCoreRowHeightEstimate(
-			cfg.TextStyle, listBoxItemPad)
 		list = append(list, Rectangle(RectangleCfg{
 			Color:  ColorTransparent,
-			Height: float32(first) * rh,
+			Height: float32(first) * rowH,
 			Sizing: FillFixed,
 		}))
 	}
@@ -93,12 +97,10 @@ func listBoxBuildItems(
 	}
 
 	if virtualize && last < len(cfg.Data)-1 {
-		rh := listCoreRowHeightEstimate(
-			cfg.TextStyle, listBoxItemPad)
 		remaining := len(cfg.Data) - 1 - last
 		list = append(list, Rectangle(RectangleCfg{
 			Color:  ColorTransparent,
-			Height: float32(remaining) * rh,
+			Height: float32(remaining) * rowH,
 			Sizing: FillFixed,
 		}))
 	}

--- a/gui/view_virtual_list.go
+++ b/gui/view_virtual_list.go
@@ -223,7 +223,7 @@ func virtualListModel(cfg *VirtualListCfg, w *Window) *listHeightModel {
 	}
 	return listHeightEnsureVariable(w, cfg.ID, listHeightSpec{
 		n:        max(cfg.ItemCount, 0),
-		estimate: virtualListEstimate(cfg, width),
+		estimate: virtualListEstimate(cfg, width, w),
 		width:    width,
 		keyAt:    cfg.ItemKey,
 		heightFn: cfg.ItemHeight,
@@ -233,12 +233,14 @@ func virtualListModel(cfg *VirtualListCfg, w *Window) *listHeightModel {
 // virtualListEstimate seeds unmeasured rows. The caller's own
 // function wins; otherwise the shared list row estimate, which is
 // what the uniform widgets already assume.
-func virtualListEstimate(cfg *VirtualListCfg, width float32) float32 {
+func virtualListEstimate(
+	cfg *VirtualListCfg, width float32, w *Window,
+) float32 {
 	if cfg.ItemHeight != nil && cfg.ItemCount > 0 {
 		if h := cfg.ItemHeight(0, width); h > 0 && f32IsFinite(h) {
 			return h
 		}
 	}
 	return listCoreRowHeightEstimate(
-		defaultListBoxStyle.textStyleNormal, listBoxItemPad)
+		defaultListBoxStyle.textStyleNormal, listBoxItemPad, w)
 }


### PR DESCRIPTION
Two sibling bugs, both measured through the real soft rasterizer.

## Multiline text reserved trailing leading

glyph sizes a line box as the baseline-to-baseline advance (ascent + descent + leading, floored at 1.15em), but rendering puts the first baseline at ascent below the shape top. A multiline `Text` shape was sized with the raw line box, so trailing leading (~2.4px at size 16) sat empty under the last baseline — and a one-line multiline shape came out taller than the same text in single-line mode.

`plainTextBoxHeight` (gui/text_layout.go) now converts the layout height to the ascent..descent box: `(lines-1)*lineH + fh`, guarded so a face whose line box is tighter than ascent+descent keeps glyph's number (growing the shape would be a regression).

## Virtualized ListBox built too few rows

`listCoreRowHeightEstimate` guessed 1.4em no matter the window's text measurer, while rows actually arrange to `FontHeight` + padding — with a measurer present the estimate over-counted, the visible range built too few rows, and the bottom of a mid-scrolled list rendered blank. The estimate now asks the measurer and falls back to the same approximation the text path itself uses when there is none.

## Tests (both pins)

- `TestMultilineTextBoxHasNoTrailingLeading` — fails pre-fix (multiline box 18 rows vs single-line 16), passes post-fix.
- `TestListBoxVirtualizedFillsViewport` — a blank strip only manifests pre-fix at viewport height ≥ ~600px (the two-row overscan absorbs the error at 400px, where the first draft of the test passed either way — verified empirically). Pinned at 800px.
- New `TestPlainTextBoxHeight` unit test (6 branches) and a measurer-path case in `TestListCoreRowHeightEstimate`.

Ran `make prepush` locally: green.