### PR TITLE
fix(input): segment words by class runs in the no-layout path (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **Word motion and double-click select by rune class, not whitespace** (issue
+  #329). `Ctrl+Left`/`Ctrl+Right` and double-click treated only space, tab and
+  newline as separators, so `foo.bar.baz` was one word, `a+b` was one word, and
+  Japanese text had no interior boundaries at all — a word motion jumped the
+  whole line and a double-click selected it. A word is now a maximal run of one
+  rune class (whitespace, punctuation, word, Han, Hiragana, Katakana), so a
+  punctuation run is a word of its own and a script change ends a word.
+  Underscore stays a word rune, keeping `snake_case_name` whole, and a combining
+  mark stays attached to its base.
+  - The rules are go-glyph's, not a second copy: the no-layout path now calls
+    `glyph.WordStartLeft`, `glyph.WordStartRight` and
+    `glyph.WordBoundsInString`, which apply the same class runs as the `Layout`
+    methods the measured path already used. A window with a text measurer and
+    one without now segment identically; previously they disagreed even about
+    `\n`.
+  - `Input` double-click and double-click drag-extend never had a layout path,
+    so this is a visible fix there, not only in headless tests.
+  - `moveCursorWordRight` now lands on the next word's start rather than past
+    the current word's trailing whitespace. Identical for space-separated text.
+  - Each `Ctrl+arrow` keypress and each double-click drops one `[]rune`
+    conversion; the helpers take the string and convert at the go-glyph
+    boundary.
+
 ### Added
 
 - **Headless frame rendering: a software rasterizer and `RenderToPNG`** (issue

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Go toolchain pin: `go 1.26.0`.
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.27.0 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.2 | cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends. |
-| `github.com/go-gui-org/go-glyph` | v1.22.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.23.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio decode + mixing (sound effects, music, mixer, fade) for `gui/audio`. |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/ebitengine/purego v0.10.2
-	github.com/go-gui-org/go-glyph v1.22.0
+	github.com/go-gui-org/go-glyph v1.23.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/ebitengine/oto/v3 v3.3.2 h1:VTWBsKX9eb+dXzaF4jEwQbs4yWIdXukJ0K40KgkpY
 github.com/ebitengine/oto/v3 v3.3.2/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/go-gui-org/go-glyph v1.22.0 h1:Lk3VG4xnl/+TIB5fpEmsLDkBvJKl55CObcAKI58Ssf8=
-github.com/go-gui-org/go-glyph v1.22.0/go.mod h1:Lx2KYrLee8t34mX/ZvjUcxN+sHhwFPVF4fcXe6wkRX0=
+github.com/go-gui-org/go-glyph v1.23.0 h1:aGLszKEHk/SEi8aNyA+pHsy3MrGA+w2GcZ9kBGgZg3U=
+github.com/go-gui-org/go-glyph v1.23.0/go.mod h1:Lx2KYrLee8t34mX/ZvjUcxN+sHhwFPVF4fcXe6wkRX0=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=

--- a/gui/input_state.go
+++ b/gui/input_state.go
@@ -1,5 +1,7 @@
 package gui
 
+import "github.com/go-gui-org/go-glyph"
+
 const inputMaxInsertRunes = 65_536
 
 // InputState manages cursor, selection, and undo/redo for
@@ -390,66 +392,50 @@ func updateCursorAndSelection(
 	imap.Set(focusID, is)
 }
 
-// moveCursorWordLeft scans backwards to the previous word boundary.
-func moveCursorWordLeft(runes []rune, pos int) int {
+// Word motion with no glyph layout. The rules live in go-glyph
+// (layout_words.go) and are the same class-run rules its Layout methods
+// apply, so a window with a text measurer and one without segment text
+// identically. Never re-implement them here — one copy is the point.
+//
+// The one divergence go-glyph documents: the string helpers have no
+// grapheme-cluster data, so an emoji ZWJ sequence splits at the ZWJ where
+// the Layout path keeps it whole. Accepted; the affected path is a
+// double-click on an emoji sequence in an input.
+//
+// All three take the text and a rune index, converting at the go-glyph
+// boundary, which is cheaper than the []rune conversion these used to do
+// on every Ctrl+arrow keypress.
+
+// moveCursorWordLeft returns the rune index of the word start before pos.
+func moveCursorWordLeft(text string, pos int) int {
 	if pos <= 0 {
 		return 0
 	}
-	i := pos - 1
-	// Skip whitespace.
-	for i > 0 && isWordSep(runes[i]) {
-		i--
-	}
-	// Skip word characters.
-	for i > 0 && !isWordSep(runes[i-1]) {
-		i--
-	}
-	return i
+	return byteToRuneIndex(text,
+		glyph.WordStartLeft(text, runeToByteIndex(text, pos)))
 }
 
-// moveCursorWordRight scans forward to the next word boundary.
-func moveCursorWordRight(runes []rune, pos int) int {
-	n := len(runes)
-	if pos >= n {
-		return n
-	}
-	i := pos
-	// Skip word characters.
-	for i < n && !isWordSep(runes[i]) {
-		i++
-	}
-	// Skip whitespace.
-	for i < n && isWordSep(runes[i]) {
-		i++
-	}
-	return i
-}
-
-func isWordSep(r rune) bool {
-	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+// moveCursorWordRight returns the rune index of the word start after pos.
+// Note this lands on the next word's *start*, not past the trailing
+// whitespace of the current one — the two agree for space-separated text
+// and differ once punctuation forms words of its own.
+func moveCursorWordRight(text string, pos int) int {
+	return byteToRuneIndex(text,
+		glyph.WordStartRight(text, runeToByteIndex(text, pos)))
 }
 
 // wordBoundsAt returns the start and end rune indices of the word
-// surrounding pos. If pos is on a separator, selects the separator run.
-func wordBoundsAt(runes []rune, pos int) (int, int) {
-	n := len(runes)
-	if n == 0 {
+// surrounding pos. A punctuation run is a word of its own; if pos is on
+// whitespace, the whitespace run is selected, which is what double-click
+// does on macOS. The exception is whitespace-only text, which has no words
+// at all: the range is empty at pos, mirroring the layout path's
+// GetWordAtIndex (see glyph.WordBoundsInString).
+func wordBoundsAt(text string, pos int) (int, int) {
+	if text == "" {
 		return 0, 0
 	}
-	if pos >= n {
-		pos = n - 1
-	}
-	pos = max(pos, 0)
-	sep := isWordSep(runes[pos])
-	beg := pos
-	for beg > 0 && isWordSep(runes[beg-1]) == sep {
-		beg--
-	}
-	end := pos + 1
-	for end < n && isWordSep(runes[end]) == sep {
-		end++
-	}
-	return beg, end
+	beg, end := glyph.WordBoundsInString(text, runeToByteIndex(text, pos))
+	return byteToRuneIndex(text, beg), byteToRuneIndex(text, end)
 }
 
 // moveCursorUp moves cursor up one line in multiline text.

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -501,10 +501,8 @@ func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 			now-is.LastClickTime <= 400
 		is.LastClickTime = now
 
-		var runes []rune
 		if doubleClick {
-			runes = []rune(displayText)
-			beg, end := wordBoundsAt(runes, runePos)
+			beg, end := wordBoundsAt(displayText, runePos)
 			is.CursorPos = end
 			is.selectBeg = uint32(beg)
 			is.selectEnd = uint32(end)
@@ -534,13 +532,11 @@ func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 			anchorEnd:   is.selectEnd,
 			gl:          gl,
 			displayText: displayText,
+			wordSelect:  doubleClick,
 			txtOffX:     ly.Shape.X,
 			txtOffY:     ly.Shape.Y,
 			focusID:     focusID,
 			scrollID:    scrollID,
-		}
-		if doubleClick {
-			ds.runes = runes
 		}
 		if scrollID != "" && ctx.Layout.Parent != nil {
 			sy := ctx.Window.scrollY()

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -16,7 +16,7 @@ func inputKeyLeft(
 			newPos = byteToRuneIndex(text,
 				gl.MoveCursorWordLeft(byteIdx))
 		} else {
-			newPos = moveCursorWordLeft([]rune(text), pos)
+			newPos = moveCursorWordLeft(text, pos)
 		}
 		updateCursorAndSelection(imap, id, is,
 			newPos, isShift)
@@ -52,7 +52,7 @@ func inputKeyRight(
 			newPos = byteToRuneIndex(text,
 				gl.MoveCursorWordRight(byteIdx))
 		} else {
-			newPos = moveCursorWordRight([]rune(text), pos)
+			newPos = moveCursorWordRight(text, pos)
 		}
 		updateCursorAndSelection(imap, id, is,
 			newPos, isShift)

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -169,10 +169,10 @@ func passwordMask(text string) string {
 
 // inputDragState holds state for drag-to-select in an input.
 // Replaces ~10 closure-captured locals with explicit fields;
-// runes is non-nil iff the drag started from a double-click.
+// wordSelect is set iff the drag started from a double-click.
 type inputDragState struct {
 	displayText            string
-	runes                  []rune // non-nil = double-click word select
+	wordSelect             bool // drag extends by whole words
 	gl                     glyph.Layout
 	anchorPos, anchorEnd   uint32
 	txtOffX, txtOffY       float32
@@ -204,8 +204,8 @@ func (d *inputDragState) updateSelection(rp int, w *Window) {
 	imap := StateMap[string, inputState](w, nsInput, capMany)
 	// Default InputState{}: zero value seeds initial drag-selection state.
 	is := imap.GetOr(d.focusID, inputState{})
-	if d.runes != nil {
-		wb, we := wordBoundsAt(d.runes, rp)
+	if d.wordSelect {
+		wb, we := wordBoundsAt(d.displayText, rp)
 		if rp < int(d.anchorPos) {
 			is.selectBeg = d.anchorEnd
 			is.selectEnd = uint32(wb)

--- a/gui/view_input_layout_test.go
+++ b/gui/view_input_layout_test.go
@@ -324,9 +324,10 @@ func TestInputDragStateUpdateSelection(t *testing.T) {
 	// Double-click word drag: anchor inside "hello", pointer moves
 	// into the word → selection expands to the whole word forward.
 	dw := &inputDragState{
-		focusID:   focusID,
-		runes:     []rune("hello world"),
-		anchorPos: 0, anchorEnd: 5,
+		focusID:     focusID,
+		displayText: "hello world",
+		wordSelect:  true,
+		anchorPos:   0, anchorEnd: 5,
 	}
 	dw.updateSelection(3, w)
 	is = inputStateOrDefault(focusID, w)
@@ -337,9 +338,10 @@ func TestInputDragStateUpdateSelection(t *testing.T) {
 	// Word drag backwards: pointer before the anchor → selection
 	// runs from the word start back to the anchor end.
 	dw2 := &inputDragState{
-		focusID:   focusID,
-		runes:     []rune("hello world"),
-		anchorPos: 6, anchorEnd: 11,
+		focusID:     focusID,
+		displayText: "hello world",
+		wordSelect:  true,
+		anchorPos:   6, anchorEnd: 11,
 	}
 	dw2.updateSelection(1, w)
 	is = inputStateOrDefault(focusID, w)

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -765,41 +766,119 @@ func TestInputArrowDownGraphemeFallback(t *testing.T) {
 // --- Cursor movement helpers ---
 
 func TestMoveCursorWordLeft(t *testing.T) {
-	runes := []rune("hello world test")
-	assertEqual(t, moveCursorWordLeft(runes, 16), 12)
-	assertEqual(t, moveCursorWordLeft(runes, 12), 6)
-	assertEqual(t, moveCursorWordLeft(runes, 6), 0)
-	assertEqual(t, moveCursorWordLeft(runes, 0), 0)
+	const text = "hello world test"
+	assertEqual(t, moveCursorWordLeft(text, 16), 12)
+	assertEqual(t, moveCursorWordLeft(text, 12), 6)
+	assertEqual(t, moveCursorWordLeft(text, 6), 0)
+	assertEqual(t, moveCursorWordLeft(text, 0), 0)
 }
 
 func TestMoveCursorWordRight(t *testing.T) {
-	runes := []rune("hello world test")
-	assertEqual(t, moveCursorWordRight(runes, 0), 6)
-	assertEqual(t, moveCursorWordRight(runes, 6), 12)
-	assertEqual(t, moveCursorWordRight(runes, 12), 16)
+	const text = "hello world test"
+	assertEqual(t, moveCursorWordRight(text, 0), 6)
+	assertEqual(t, moveCursorWordRight(text, 6), 12)
+	// Past the last word start there is nowhere to go but the end.
+	assertEqual(t, moveCursorWordRight(text, 12), 16)
+	// At the end, and beyond it, the caret stays put.
+	assertEqual(t, moveCursorWordRight(text, 16), 16)
+	assertEqual(t, moveCursorWordRight(text, 100), 16)
+}
+
+// Word motion segments by rune class, so a punctuation run is a word of
+// its own and a script change ends a word (issue #329). These are the
+// same rules go-glyph applies when a layout is available.
+func TestMoveCursorWordClassRuns(t *testing.T) {
+	// Walking left from the end of a dotted identifier must stop at every
+	// component and every separator, not jump the whole token.
+	const dotted = "foo.bar.baz"
+	var left []int
+	for pos := len(dotted); pos > 0; {
+		pos = moveCursorWordLeft(dotted, pos)
+		left = append(left, pos)
+	}
+	if want := []int{8, 7, 4, 3, 0}; !slices.Equal(left, want) {
+		t.Fatalf("word-left walk over %q = %v, want %v", dotted, left, want)
+	}
+
+	// Underscore is a word rune, so snake_case stays one word.
+	assertEqual(t, moveCursorWordLeft("snake_case_name", 15), 0)
+
+	// Japanese has no spaces; script transitions are the boundaries.
+	// 日本語 | の | テキスト at rune indices 0, 3, 4.
+	const jp = "日本語のテキスト"
+	assertEqual(t, moveCursorWordRight(jp, 0), 3)
+	assertEqual(t, moveCursorWordRight(jp, 3), 4)
+	assertEqual(t, moveCursorWordLeft(jp, 8), 4)
+
+	// Right motion skips a punctuation run to land on the next word
+	// start; the old whitespace-only separator rules skipped through the
+	// whole following token instead ("foo.bar" from the dot landed past
+	// "bar", at the end of the string).
+	assertEqual(t, moveCursorWordRight("foo.bar", 3), 4)
+	assertEqual(t, moveCursorWordRight("a+b", 1), 2)
 }
 
 func TestWordBoundsAt(t *testing.T) {
-	runes := []rune("hello world test")
+	const text = "hello world test"
 	// Middle of first word.
-	b, e := wordBoundsAt(runes, 2)
+	b, e := wordBoundsAt(text, 2)
 	if b != 0 || e != 5 {
 		t.Fatalf("got %d-%d, want 0-5", b, e)
 	}
 	// On space between words.
-	b, e = wordBoundsAt(runes, 5)
+	b, e = wordBoundsAt(text, 5)
 	if b != 5 || e != 6 {
 		t.Fatalf("got %d-%d, want 5-6", b, e)
 	}
 	// Last word.
-	b, e = wordBoundsAt(runes, 14)
+	b, e = wordBoundsAt(text, 14)
 	if b != 12 || e != 16 {
 		t.Fatalf("got %d-%d, want 12-16", b, e)
 	}
 	// Empty string.
-	b, e = wordBoundsAt(nil, 0)
+	b, e = wordBoundsAt("", 0)
 	if b != 0 || e != 0 {
 		t.Fatalf("empty: got %d-%d, want 0-0", b, e)
+	}
+	// Caret past the end still selects the final word.
+	b, e = wordBoundsAt(text, 16)
+	if b != 12 || e != 16 {
+		t.Fatalf("past-end: got %d-%d, want 12-16", b, e)
+	}
+	// Whitespace-only text has no words: the range is empty at pos,
+	// matching the layout path (GetWordAtIndex reports the same).
+	b, e = wordBoundsAt("  ", 1)
+	if b != 1 || e != 1 {
+		t.Fatalf("whitespace-only: got %d-%d, want 1-1", b, e)
+	}
+}
+
+// Double-click selection follows the same class runs as word motion.
+func TestWordBoundsAtClassRuns(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		pos      int
+		beg, end int
+	}{
+		{"dotted component", "foo.bar.baz", 5, 4, 7},
+		{"separator alone", "foo.bar.baz", 3, 3, 4},
+		{"lone punctuation", "a+b", 1, 1, 2},
+		{"snake_case is one word", "snake_case_name", 3, 0, 15},
+		{"whitespace run selects the run", "hello   world", 6, 5, 8},
+		// The combining acute stays attached to its base "e".
+		{"combining mark joins base", "café", 3, 0, 5},
+		{"han run", "日本語のテキスト", 1, 0, 3},
+		{"katakana run", "日本語のテキスト", 5, 4, 8},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beg, end := wordBoundsAt(tt.text, tt.pos)
+			if beg != tt.beg || end != tt.end {
+				t.Fatalf("wordBoundsAt(%q, %d) = %d-%d, want %d-%d",
+					tt.text, tt.pos, beg, end, tt.beg, tt.end)
+			}
+		})
 	}
 }
 
@@ -1828,6 +1907,91 @@ func TestInputClickOnFocusedInputCollapsesSelectionToCaret(t *testing.T) {
 	if is.CursorPos != 8 {
 		t.Fatalf("cursor = %d, want 8", is.CursorPos)
 	}
+}
+
+// TestInputDoubleClickSelectsWord drives two real clicks through the
+// event pipeline: the second, within doubleClickThresholdMs of the first,
+// selects the class run under the caret. Issue #329 made the runs
+// go-glyph's — a punctuation run is a word of its own and a script
+// change ends a word — so the dotted-identifier cases are the fix.
+func TestInputDoubleClickSelectsWord(t *testing.T) {
+	cases := []struct {
+		name   string
+		text   string
+		runeAt int
+		beg    int
+		end    int
+	}{
+		{"plain word", "hello world", 2, 0, 5},
+		{"dotted component", "foo.bar.baz", 5, 4, 7},
+		{"separator is its own word", "foo.bar.baz", 3, 3, 4},
+		{"whitespace run selects itself", "hello  world", 5, 5, 7},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			w, ly := newInputSelWindow(t, InputCfg{
+				ID: "fdc", Text: tt.text,
+			})
+			w.SetFocus("fdc")
+			txt := inputTextShape(t, ly)
+			x, y := inputRunePoint(txt, tt.runeAt)
+			click := func() {
+				w.EventFn(&Event{Type: EventMouseDown,
+					MouseButton: MouseLeft, MouseX: x, MouseY: y})
+				w.settle()
+				w.EventFn(&Event{Type: EventMouseUp,
+					MouseButton: MouseLeft, MouseX: x, MouseY: y})
+				w.settle()
+			}
+			click()
+			click()
+			is := getInputState(w, "fdc")
+			if is.selectBeg != uint32(tt.beg) ||
+				is.selectEnd != uint32(tt.end) {
+				t.Fatalf("double-click at rune %d selected [%d,%d), "+
+					"want [%d,%d)", tt.runeAt, is.selectBeg,
+					is.selectEnd, tt.beg, tt.end)
+			}
+			if is.CursorPos != tt.end {
+				t.Fatalf("cursor = %d, want %d", is.CursorPos, tt.end)
+			}
+		})
+	}
+}
+
+// Double-click then press-drag extends the selection by whole words: the
+// press within doubleClickThresholdMs of the click builds the drag state
+// with wordSelect set, so updateSelection rounds the pointer position to
+// word bounds. Dragging from "hello" into "world" must end at [0, 11).
+func TestInputDoubleClickDragExtendsByWord(t *testing.T) {
+	w, ly := newInputSelWindow(t, InputCfg{ID: "fdc", Text: "hello world"})
+	w.SetFocus("fdc")
+	txt := inputTextShape(t, ly)
+	x0, y0 := inputRunePoint(txt, 2)
+	x1, y1 := inputRunePoint(txt, 10)
+	click := func() {
+		w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+			MouseX: x0, MouseY: y0})
+		w.settle()
+		w.EventFn(&Event{Type: EventMouseUp, MouseButton: MouseLeft,
+			MouseX: x0, MouseY: y0})
+		w.settle()
+	}
+	click()
+	click()
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x0, MouseY: y0})
+	w.settle()
+	w.EventFn(&Event{Type: EventMouseMove, MouseButton: MouseInvalid,
+		MouseX: x1, MouseY: y1})
+	w.settle()
+	is := getInputState(w, "fdc")
+	if is.selectBeg != 0 || is.selectEnd != 11 {
+		t.Fatalf("word-drag selected [%d,%d), want [0,11)",
+			is.selectBeg, is.selectEnd)
+	}
+	w.MouseCancel()
+	w.settle()
 }
 
 // --- Issue #281: capture-loss cancel zeroes the partial drag selection ---

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -66,8 +66,7 @@ func textOnClick(ctx EventCtx) {
 			beg = byteToRuneIndex(text, bBeg)
 			end = byteToRuneIndex(text, bEnd)
 		} else {
-			beg, end = wordBoundsAt(
-				[]rune(text), runePos)
+			beg, end = wordBoundsAt(text, runePos)
 		}
 		is.CursorPos = end
 		is.selectBeg = uint32(beg)
@@ -140,7 +139,6 @@ func textOnClick(ctx EventCtx) {
 		return rp
 	}
 
-	runes := []rune(text)
 	updateDragSelection := func(rp int, w *Window) {
 		dim := StateMap[string, inputState](
 			w, nsInput, capMany,
@@ -155,7 +153,7 @@ func textOnClick(ctx EventCtx) {
 				wb = byteToRuneIndex(text, bBeg)
 				we = byteToRuneIndex(text, bEnd)
 			} else {
-				wb, we = wordBoundsAt(runes, rp)
+				wb, we = wordBoundsAt(text, rp)
 			}
 			if rp < int(anchorPos) {
 				dis.selectBeg = anchorEnd


### PR DESCRIPTION
Closes #329.

Word motion in `gui/input_state.go` split on whitespace only, so `foo.bar.baz` was one word, `a+b` was one word, and CJK text had no interior boundaries at all.

## The issue understated the impact

#329 says the go-gui half is "not user-visible on its own." That is wrong, and worth correcting for anyone reading the history: `view_input.go:507` and `view_input_layout.go:208` call `wordBoundsAt` **unconditionally**, not behind the `glOK` check. `Input`s double-click and double-click-drag-extend have no layout path at all, so this was a visible defect in the widget regardless of whether a `TextMeasurer` was installed.

## Approach

The three helpers delegate to go-glyph `v1.23.0` (`WordStartLeft`, `WordStartRight`, `WordBoundsInString`, added in go-glyph#123), which apply the same class-run rules its `Layout` methods do. One source of truth: a copy of the class table here would have been the third after go-shirei and go-glyph, free to drift silently, and would have needed a zlib attribution header.

The signatures change from `[]rune` to `string`, converting at the go-glyph boundary with the existing `runeToByteIndex`/`byteToRuneIndex`. Net allocation win — `view_input_keys.go` built a `[]rune(text)` on **every** Ctrl+arrow keypress, `view_text_select.go` on every double-click.

## Two behaviour changes, both intended

- `moveCursorWordRight` now lands on the next word's *start* rather than past the trailing whitespace run. Identical for space-separated text; divergent as soon as punctuation classes exist. This is the fix, not a regression.
- The string path has no grapheme-cluster data, so an emoji ZWJ sequence splits where the layout path keeps it whole. Documented at `wordBoundsAt` and accepted — not worth pulling `rivo/uniseg` into `gui/`.

## Also

`inputDragState.runes []rune` existed only as the "drag began with a double-click" flag plus the `wordBoundsAt` input. It is now `wordSelect bool`; `displayText` was already on the struct.

## Tests

Existing three rewritten for the string signature (same expectations still hold). Two added covering every case the issue names: dotted components, `snake_case_name`, `a+b`, a whitespace run, `café` with a combining acute (a `"café"` source literal is precomposed and would not exercise `unicode.IsMark`), and Han/Hiragana/Katakana transitions.

No golden change — segmentation moves the caret and selection, and no golden case records a selection.

## Dependency

Bumps `go-glyph` to `v1.23.0` and regenerates `docs/dependencies.md`. `GOWORK=off make prepush` green — verified against the published tag, not the workspace copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)