### PR TITLE
fix(showcase): allow wasm and data: assets in the page CSP

### DIFF
--- a/examples/showcase/index.html
+++ b/examples/showcase/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-idkCI9qQG7UNLa9aJuAOTit6DCDy0tPnoGJ7tjrQMsQ='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
   <title>go-gui showcase</title>
   <style>
     * { margin: 0; padding: 0; }
@@ -45,6 +46,9 @@
   </div>
   <script src="wasm_exec.js"></script>
   <script>
+    // Clickjacking guard: never render this page inside a frame.
+    if (self !== top) top.location = self.location.href;
+
     const overlay = document.getElementById('loading-overlay');
     const label = document.getElementById('loading-label');
     const sizeEl = document.getElementById('loading-size');


### PR DESCRIPTION
The website repo's Aikido hardening pass added a CSP meta tag to the
deployed showcase page. Its script-src lacked 'wasm-unsafe-eval', so
Chrome refused to compile main.wasm and the page sat on the loading
spinner forever. font-src/img-src/media-src fell back to 'self', which
also blocked the icon font and every embedded asset — both are served
as data: URLs (gui/backend/web/backend.go, embedded_asset_web.go).

Deploy copies examples/showcase/*.html over the website repo with
force_orphan, so showcase/index.html there is generated, not source:
the hardening only survives if it lives here. Adopt the hardened head
(CSP + frame guard) with the directives wasm actually needs.

Verified against the deployed main.wasm served locally: app boots,
icon font loads, data: images render.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
