### PR TITLE
feat(theme): macOS elevation, popover shadows, and a soft focus ring

### DIFF
--- a/gui/focus_ring.go
+++ b/gui/focus_ring.go
@@ -96,7 +96,11 @@ func amendAll(fns ...func(EventCtx)) func(EventCtx) {
 // Keying is via idKey(), the effective ID, so a widget dropped inside an
 // ID-bearing container still matches the focus the window recorded.
 func focusRingAmend(colorFill, colorBorder Color) func(EventCtx) {
-	if !colorFill.IsSet() && !colorBorder.IsSet() {
+	// Captured at generation, which is the only correct time to read a
+	// theme: the bare guiTheme honours a surrounding Themed scope, while
+	// w.Theme() at amend time would ignore it.
+	ring := guiTheme.focusRing
+	if !colorFill.IsSet() && !colorBorder.IsSet() && ring == nil {
 		return nil
 	}
 	return func(ctx EventCtx) {
@@ -113,5 +117,42 @@ func focusRingAmend(colorFill, colorBorder Color) func(EventCtx) {
 		if colorBorder.IsSet() {
 			shape.ColorBorder = colorBorder
 		}
+		applyFocusRingShadow(shape, ctx.Window, ring)
+	}
+}
+
+// applyFocusRingShadow hangs the theme's focus ring on a shape that
+// currently holds focus.
+//
+// The ring is a zero-offset tinted shadow rather than a border: macOS
+// draws focus as a soft glow *outside* the control, and a border insets
+// content, which would shift a control's interior the moment it took
+// focus. renderContainer emits the shadow before the fill, so the glow
+// sits behind the control rather than over it.
+//
+// Allocating here, rather than reserving a shapeEffects at generation
+// for every focusable widget, means only the one focused shape in the
+// window pays. The pool hands out individually allocated objects and
+// grows a slice of pointers, so a pointer taken here stays valid even
+// if the pool grows again later in the frame; it is invalidated only by
+// the next view-phase reset, which is also when the shape itself dies.
+//
+// ring is theme-owned and shared by every shape in the window — assign
+// it, never write through it.
+func applyFocusRingShadow(shape *Shape, w *Window, ring *BoxShadow) {
+	if ring == nil {
+		return
+	}
+	// Shapes are rebuilt from their Cfg every frame, so an unfocused
+	// shape never carries a stale ring and there is nothing to clear.
+	if shape.fx == nil {
+		shape.fx = w.allocEffects(shapeEffects{Shadow: ring})
+		return
+	}
+	// A widget that already paints its own shadow keeps it: the ring is
+	// focus indication, not elevation, and a popover that owns both
+	// would otherwise lose the elevation it was given.
+	if shape.fx.Shadow == nil {
+		shape.fx.Shadow = ring
 	}
 }

--- a/gui/focus_ring_test.go
+++ b/gui/focus_ring_test.go
@@ -50,3 +50,144 @@ func TestFocusRingAmendUnsetIsNil(t *testing.T) {
 		t.Error("border set: want non-nil hook")
 	}
 }
+
+// applyFocusRingShadow is the whole focus-ring mechanism: it hangs a
+// theme-owned shadow on the focused shape and allocates the effects
+// record if the shape had none. The cases below are the ones that can
+// silently corrupt shared state or lose a widget's own appearance.
+func TestApplyFocusRingShadowAllocatesWhenAbsent(t *testing.T) {
+	t.Parallel()
+	w := makeWindowWithScratch()
+	ring := &BoxShadow{Color: RGB(0, 122, 255), BlurRadius: 3}
+	s := &Shape{shapeType: shapeRectangle}
+
+	applyFocusRingShadow(s, w, ring)
+
+	if s.fx == nil {
+		t.Fatal("effects not allocated for a shape that had none")
+	}
+	if s.fx.Shadow != ring {
+		t.Errorf("shadow: got %p, want the theme ring %p", s.fx.Shadow, ring)
+	}
+}
+
+// A theme with no ring must leave the shape exactly as it found it —
+// in particular it must not allocate an effects record, because that
+// is a per-frame allocation for every focusable widget in the window.
+func TestApplyFocusRingShadowNilRingIsInert(t *testing.T) {
+	t.Parallel()
+	w := makeWindowWithScratch()
+	s := &Shape{shapeType: shapeRectangle}
+
+	applyFocusRingShadow(s, w, nil)
+
+	if s.fx != nil {
+		t.Error("nil ring allocated an effects record")
+	}
+}
+
+// A shape that already carries an effects record — a gradient, say —
+// but no shadow of its own must still receive the ring, without
+// losing the effects it does have.
+func TestApplyFocusRingShadowFillsEmptyExistingEffects(t *testing.T) {
+	t.Parallel()
+	w := makeWindowWithScratch()
+	ring := &BoxShadow{Color: RGB(0, 122, 255), BlurRadius: 3}
+	s := &Shape{
+		shapeType: shapeRectangle,
+		fx:        &shapeEffects{Gradient: &GradientDef{}},
+	}
+
+	applyFocusRingShadow(s, w, ring)
+
+	if s.fx.Shadow != ring {
+		t.Errorf("shadow: got %p, want the theme ring %p", s.fx.Shadow, ring)
+	}
+	if s.fx.Gradient == nil {
+		t.Error("existing effects lost when the ring was applied")
+	}
+}
+
+// A widget that already paints its own shadow keeps it. The ring is
+// focus indication, not elevation: an elevated popover that takes
+// focus must not trade its elevation for a glow.
+func TestApplyFocusRingShadowKeepsExistingShadow(t *testing.T) {
+	t.Parallel()
+	w := makeWindowWithScratch()
+	own := &BoxShadow{Color: RGBA(0, 0, 0, 80), BlurRadius: 20}
+	ring := &BoxShadow{Color: RGB(0, 122, 255), BlurRadius: 3}
+	s := &Shape{shapeType: shapeRectangle, fx: &shapeEffects{Shadow: own}}
+
+	applyFocusRingShadow(s, w, ring)
+
+	if s.fx.Shadow != own {
+		t.Errorf("shadow: got %p, want the widget's own %p", s.fx.Shadow, own)
+	}
+}
+
+// The ring is one value shared by every shape in the window. Writing
+// through the pointer would restyle every other control at once, so
+// the mechanism must only ever assign it.
+func TestApplyFocusRingShadowDoesNotMutateTheme(t *testing.T) {
+	t.Parallel()
+	w := makeWindowWithScratch()
+	ring := &BoxShadow{Color: RGB(0, 122, 255), BlurRadius: 3}
+	before := *ring
+
+	for range 3 {
+		applyFocusRingShadow(&Shape{shapeType: shapeRectangle}, w, ring)
+	}
+
+	if *ring != before {
+		t.Errorf("theme ring mutated: got %+v, want %+v", *ring, before)
+	}
+}
+
+// Under a theme with a ring, only the focused shape gets one, and a
+// disabled shape gets none even while it holds the focus key —
+// matching the existing colour behaviour of the same hook.
+func TestFocusRingAmendAppliesShadowOnlyWhenFocused(t *testing.T) {
+	saved := guiTheme
+	t.Cleanup(func() { guiTheme = saved })
+
+	ring := &BoxShadow{Color: RGB(0, 122, 255), BlurRadius: 3}
+	cfg := baseDarkCfg()
+	cfg.Name = "ring-test"
+	cfg.focusRing = ring
+	guiTheme = ThemeMaker(cfg)
+
+	hook := focusRingAmend(Color{}, RGB(1, 2, 3))
+	if hook == nil {
+		t.Fatal("themed ring: want a hook even with colours unset")
+	}
+
+	run := func(id string, disabled bool) *Shape {
+		w := makeWindowWithScratch()
+		w.SetFocus("focused")
+		s := &Shape{shapeType: shapeRectangle, ID: id, Disabled: disabled}
+		hook(EventCtx{Layout: &Layout{Shape: s}, Window: w})
+		return s
+	}
+
+	if s := run("focused", false); s.fx == nil || s.fx.Shadow != ring {
+		t.Error("focused shape did not receive the ring")
+	}
+	if s := run("other", false); s.fx != nil {
+		t.Error("unfocused shape received a ring")
+	}
+	if s := run("focused", true); s.fx != nil {
+		t.Error("disabled shape received a ring")
+	}
+}
+
+// With no ring in the theme, the hook keeps its old contract: unset
+// colours mean no hook at all.
+func TestFocusRingAmendNoRingKeepsNilContract(t *testing.T) {
+	saved := guiTheme
+	t.Cleanup(func() { guiTheme = saved })
+	guiTheme = ThemeDark
+
+	if got := focusRingAmend(Color{}, Color{}); got != nil {
+		t.Error("no ring and no colours: want nil hook")
+	}
+}

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -460,6 +460,10 @@ type shapeButtonColors struct {
 	colorClick       Color
 	ColorFocus       Color
 	ColorBorderFocus Color
+	// focusRing is the theme's focus-ring shadow, captured at
+	// generation because buttonAmendLayout is a plain func with no
+	// closure to read guiTheme from at the right time.
+	focusRing *BoxShadow
 	// opticalDigits centres the button's label on the face's figure
 	// band instead of its cap band, for a button whose label is digits
 	// by construction — a date picker's day cell. Set from the

--- a/gui/styles_widget.go
+++ b/gui/styles_widget.go
@@ -102,6 +102,10 @@ type SelectStyle struct {
 	textStyleNormal  TextStyle
 	subheadingStyle  TextStyle
 	PlaceholderStyle TextStyle
+	// Shadow lifts the open dropdown off the content behind it. Nil
+	// on a theme that does not describe elevation, which is every
+	// theme that predates ThemeCfg.shadowPopover.
+	Shadow           *BoxShadow
 	Padding          Padding
 	MinWidth         float32
 	MaxWidth         float32

--- a/gui/styles_widget_control.go
+++ b/gui/styles_widget_control.go
@@ -140,8 +140,10 @@ type TableStyle struct {
 // ComboboxStyle defines combobox visual properties.
 // exportaudit:keep — reachable from an exported signature
 type ComboboxStyle struct {
-	TextStyle         TextStyle
-	PlaceholderStyle  TextStyle
+	TextStyle        TextStyle
+	PlaceholderStyle TextStyle
+	// Shadow lifts the open dropdown off the content behind it.
+	Shadow            *BoxShadow
 	Padding           Padding
 	SizeBorder        float32
 	Radius            float32
@@ -159,8 +161,11 @@ type ComboboxStyle struct {
 // CommandPaletteStyle defines command palette visual properties.
 // exportaudit:keep — reachable from an exported signature
 type CommandPaletteStyle struct {
-	TextStyle      TextStyle
-	detailStyle    TextStyle
+	TextStyle   TextStyle
+	detailStyle TextStyle
+	// Shadow lifts the palette off the backdrop. Modal tier, not
+	// popover tier — it floats further than a menu.
+	Shadow         *BoxShadow
 	SizeBorder     float32
 	Radius         float32
 	Width          float32
@@ -176,25 +181,30 @@ type CommandPaletteStyle struct {
 type MenubarStyle struct {
 	TextStyle         TextStyle
 	textStyleSubtitle TextStyle
-	Padding           Padding
-	paddingMenuItem   Padding
-	paddingSubmenu    Padding
-	paddingSubtitle   Padding
-	widthSubmenuMin   float32
-	widthSubmenuMax   float32
-	SizeBorder        float32
-	Radius            float32
-	radiusBorder      float32
-	radiusSubmenu     float32
-	radiusMenuItem    float32
-	Spacing           float32
-	spacingSubmenu    float32
-	Color             Color
-	ColorHover        Color
-	ColorFocus        Color
-	ColorBorder       Color
-	ColorBorderFocus  Color
-	ColorSelect       Color
+	// Shadow lifts an open menu surface — a popup menu or a submenu —
+	// off the content behind it. The menubar strip itself is flush
+	// with the window chrome and takes no elevation, so this is
+	// applied only where the menu actually floats.
+	Shadow           *BoxShadow
+	Padding          Padding
+	paddingMenuItem  Padding
+	paddingSubmenu   Padding
+	paddingSubtitle  Padding
+	widthSubmenuMin  float32
+	widthSubmenuMax  float32
+	SizeBorder       float32
+	Radius           float32
+	radiusBorder     float32
+	radiusSubmenu    float32
+	radiusMenuItem   float32
+	Spacing          float32
+	spacingSubmenu   float32
+	Color            Color
+	ColorHover       Color
+	ColorFocus       Color
+	ColorBorder      Color
+	ColorBorderFocus Color
+	ColorSelect      Color
 }
 
 // DatePickerStyle defines date picker visual properties.

--- a/gui/theme.go
+++ b/gui/theme.go
@@ -185,7 +185,13 @@ type Theme struct {
 	ColorActive     Color
 	ColorBorder     Color
 	ColorSelect     Color
-	TitlebarDark    bool
+
+	// focusRing carries ThemeCfg.focusRing through to the widgets.
+	// Read it during generation off the bare guiTheme, like any other
+	// factory-time theme read.
+	focusRing *BoxShadow
+
+	TitlebarDark bool
 }
 
 // ThemeCfg is the configuration struct for ThemeMaker.
@@ -284,6 +290,31 @@ type ThemeCfg struct {
 	ColorSuccess Color
 	ColorWarning Color
 	ColorError   Color
+
+	// Elevation. Two tiers, because that is how the platforms this
+	// exists to imitate actually think about it: a menu floats a
+	// little, a modal floats a lot. A per-widget field would be seven
+	// knobs nobody sets differently.
+	//
+	// Nil means "this theme does not describe elevation", which keeps
+	// every theme predating these fields byte-identical: nil reaches
+	// ContainerCfg.Shadow unchanged, makeContainerEffects still
+	// short-circuits, and no shapeEffects is ever allocated.
+	//
+	// Theme-owned and built once by the theme's cfg function, so
+	// assigning one into a ContainerCfg costs a pointer copy and no
+	// per-frame allocation. Never write through the pointer — one
+	// value is shared by every shape in the window.
+	shadowPopover *BoxShadow // menus, dropdowns, tooltips, toasts
+	shadowDialog  *BoxShadow // modals, command palette
+
+	// focusRing is the focus indication drawn *outside* a control's
+	// bounds, as a zero-offset tinted shadow. macOS's ring is a soft
+	// accent glow, which the inset ColorBorderFocus border cannot
+	// express at any width. Nil leaves the border ring in charge, so
+	// themes that do not set it are unaffected.
+	focusRing *BoxShadow
+
 	TitlebarDark bool
 	// exportaudit:keep — documented public API (showcase docs)
 	FillBorder bool

--- a/gui/theme_defaults.go
+++ b/gui/theme_defaults.go
@@ -113,6 +113,14 @@ var (
 	ThemeDark  Theme
 	ThemeLight Theme
 	themeBlue  Theme
+
+	// macOS platform themes; see gui/theme_macos.go. Registered as
+	// "macos" and "macos-dark", and reached by name through ThemeGet.
+	// Unexported, following themeBlue rather than ThemeDark/ThemeLight:
+	// those two are the defaults an app assigns directly, these are
+	// presets a user picks. ThemePicker lists them off the registry.
+	themeMacOS     Theme
+	themeMacOSDark Theme
 )
 
 // Unexported preset configs and derived themes — kept for
@@ -193,6 +201,10 @@ func init() {
 	themeBlueCfg = baseBlueCfg()
 	themeBlue = ThemeMaker(themeBlueCfg)
 
+	// macOS, light and dark.
+	themeMacOS = ThemeMaker(macOSCfg())
+	themeMacOSDark = ThemeMaker(macOSDarkCfg())
+
 	// Blue bordered.
 	themeBlueBorderedCfg = baseBlueCfg()
 	themeBlueBorderedCfg.Name = "blue-dark-bordered"
@@ -208,6 +220,8 @@ func init() {
 	themeRegister(themeLightBordered)
 	themeRegister(themeBlue)
 	themeRegister(themeBlueBordered)
+	themeRegister(themeMacOS)
+	themeRegister(themeMacOSDark)
 
 	// Dark is both the app default and the initially installed theme.
 	// applyTheme is what fills the default*Style mirrors — they carry no

--- a/gui/theme_elevation_frame_test.go
+++ b/gui/theme_elevation_frame_test.go
@@ -1,0 +1,165 @@
+package gui
+
+import "testing"
+
+// End-to-end checks that the elevation and focus-ring tokens survive
+// the real frame pipeline, not just the style structs.
+//
+// The mechanism they guard is easy to get wrong in a way unit tests
+// miss: a popover floats, so its shadow is emitted while some ancestor
+// clip is in force, and its blur deliberately extends past the shape's
+// own bounds.
+
+// frameCmds runs one real frame under theme and returns the emitted
+// commands. Mirrors renderGolden's setup; kept separate because these
+// cases assert on command content rather than recording a fingerprint.
+func frameCmds(t *testing.T, theme Theme, build func(*Window) View,
+	focusID string, setup func(*Window),
+) []RenderCmd {
+	t.Helper()
+	w := NewWindow(WindowCfg{State: new(int), Width: 400, Height: 300})
+	w.viewGenerator = func(win *Window) View {
+		if setup != nil {
+			setup(win)
+		}
+		return Column(ContainerCfg{
+			Sizing:  FillFill,
+			Content: []View{build(win)},
+		})
+	}
+	w.SetTheme(theme)
+	if focusID != "" {
+		w.SetFocus(focusID)
+	}
+	w.refreshLayout = true
+	w.FrameFn()
+	if len(w.renderers) == 0 {
+		t.Fatal("pipeline emitted no render commands")
+	}
+	return w.renderers
+}
+
+func countShadows(cmds []RenderCmd) int {
+	n := 0
+	for _, c := range cmds {
+		if c.Kind == RenderShadow {
+			n++
+		}
+	}
+	return n
+}
+
+// An open Select dropdown under a theme with elevation must emit a
+// shadow; under a theme without one it must emit none. The pair is the
+// point — the second half is what proves the first is the theme's
+// doing and not something the widget now always does.
+func TestOpenDropdownEmitsShadowOnlyWhenThemed(t *testing.T) {
+	build := func(*Window) View {
+		return Select(SelectCfg{
+			ID:      "picker",
+			Options: []string{"one", "two", "three"},
+		})
+	}
+	open := func(w *Window) {
+		StateMap[string, bool](w, nsSelect, capModerate).Set("picker", true)
+	}
+
+	elevated := frameCmds(t, themeMacOS, build, "", open)
+	if countShadows(elevated) == 0 {
+		t.Error("macOS theme: open dropdown emitted no shadow")
+	}
+
+	flat := frameCmds(t, ThemeDark, build, "", open)
+	if got := countShadows(flat); got != 0 {
+		t.Errorf("dark theme: got %d shadows, want 0", got)
+	}
+}
+
+// The dropdown's shadow must not be clipped away by the ancestor whose
+// scissor is in force when the float renders, and must be emitted at
+// the popover's own geometry rather than collapsed to zero.
+func TestDropdownShadowSurvivesAncestorClip(t *testing.T) {
+	cmds := frameCmds(t, themeMacOS, func(*Window) View {
+		// A clipping, scrollable ancestor is the case that would
+		// scissor a naive implementation's shadow away.
+		return Column(ContainerCfg{
+			ID:         "panel",
+			Sizing:     FillFill,
+			Clip:       true,
+			Scrollable: true,
+			Content: []View{
+				Select(SelectCfg{
+					ID:      "picker",
+					Options: []string{"one", "two", "three"},
+				}),
+			},
+		})
+	}, "", func(w *Window) {
+		StateMap[string, bool](w, nsSelect, capModerate).
+			Set("panel:picker", true)
+	})
+
+	var shadow *RenderCmd
+	for i := range cmds {
+		if cmds[i].Kind == RenderShadow {
+			shadow = &cmds[i]
+			break
+		}
+	}
+	if shadow == nil {
+		t.Fatal("no shadow emitted for a dropdown inside a clipping panel")
+	}
+	if shadow.W <= 0 || shadow.H <= 0 {
+		t.Errorf("shadow collapsed: got %vx%v", shadow.W, shadow.H)
+	}
+	if shadow.Color.A == 0 {
+		t.Error("shadow emitted fully transparent")
+	}
+}
+
+// An input's ring rides inputAmendLayout, a different wiring than the
+// button's, so it needs its own guard: a focused input under the macOS
+// theme must glow, and the same input under a ringless theme must not.
+func TestFocusedInputEmitsRingOnlyWhenThemed(t *testing.T) {
+	build := func(*Window) View {
+		return Input(InputCfg{ID: "field"})
+	}
+
+	if got := countShadows(
+		frameCmds(t, themeMacOS, build, "field", nil)); got == 0 {
+		t.Error("macOS theme: focused input emitted no focus ring")
+	}
+	if got := countShadows(
+		frameCmds(t, themeMacOS, build, "", nil)); got != 0 {
+		t.Errorf("macOS theme: unfocused input emitted %d shadows", got)
+	}
+	if got := countShadows(
+		frameCmds(t, ThemeDark, build, "field", nil)); got != 0 {
+		t.Errorf("dark theme: focused input emitted %d shadows", got)
+	}
+}
+
+// A focused Button under a theme with a ring emits one; the same
+// button unfocused, and any button under a ringless theme, emits none.
+func TestFocusedButtonEmitsRingOnlyWhenThemed(t *testing.T) {
+	build := func(*Window) View {
+		return Button(ButtonCfg{
+			ID:      "go",
+			Content: []View{Text(TextCfg{Text: "Go"})},
+			OnClick: func(EventCtx) {},
+		})
+	}
+
+	if got := countShadows(
+		frameCmds(t, themeMacOS, build, "go", nil)); got == 0 {
+		t.Error("macOS theme: focused button emitted no focus ring")
+	}
+	if got := countShadows(
+		frameCmds(t, themeMacOS, build, "", nil)); got != 0 {
+		t.Errorf("macOS theme: unfocused button emitted %d shadows", got)
+	}
+	if got := countShadows(
+		frameCmds(t, ThemeDark, build, "go", nil)); got != 0 {
+		t.Errorf("dark theme: focused button emitted %d shadows", got)
+	}
+}

--- a/gui/theme_elevation_test.go
+++ b/gui/theme_elevation_test.go
@@ -1,0 +1,148 @@
+package gui
+
+import "testing"
+
+// The elevation and focus-ring tokens are additive: a theme that does
+// not set them must produce exactly the styles it produced before they
+// existed. This is the guard that keeps every pre-existing theme — and
+// every golden recorded against one — from moving.
+func TestPresetThemesCarryNoElevation(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		theme Theme
+	}{
+		{"dark", ThemeDark},
+		{"light", ThemeLight},
+		{"blue", themeBlue},
+		{"dark-no-padding", themeDarkNoPadding},
+		{"light-bordered", themeLightBordered},
+	} {
+		for name, got := range map[string]*BoxShadow{
+			"dialog":     tc.theme.dialogStyle.Shadow,
+			"select":     tc.theme.selectStyle.Shadow,
+			"combobox":   tc.theme.comboboxStyle.Shadow,
+			"datepicker": tc.theme.datePickerStyle.Shadow,
+			"tooltip":    tc.theme.tooltipStyle.Shadow,
+			"toast":      tc.theme.toastStyle.Shadow,
+			"palette":    tc.theme.commandPaletteStyle.Shadow,
+			"submenu":    tc.theme.MenubarStyle.Shadow,
+			"focus ring": tc.theme.focusRing,
+		} {
+			if got != nil {
+				t.Errorf("%s: %s shadow set, want nil", tc.name, name)
+			}
+		}
+	}
+}
+
+// ThemeMaker fans one popover token out to every popover style and one
+// dialog token to the modal styles. Asserting the fan-out rather than
+// each widget separately is what stops a newly added popover from
+// quietly missing its elevation.
+func TestThemeMakerFansOutElevation(t *testing.T) {
+	t.Parallel()
+	popover := &BoxShadow{Color: RGBA(0, 0, 0, 80), BlurRadius: 10}
+	dialog := &BoxShadow{Color: RGBA(0, 0, 0, 120), BlurRadius: 30}
+	ring := &BoxShadow{Color: RGBA(0, 122, 255, 90), BlurRadius: 3}
+
+	cfg := baseDarkCfg()
+	cfg.Name = "elevation-test"
+	cfg.shadowPopover = popover
+	cfg.shadowDialog = dialog
+	cfg.focusRing = ring
+	th := ThemeMaker(cfg)
+
+	popovers := map[string]*BoxShadow{
+		"select":     th.selectStyle.Shadow,
+		"combobox":   th.comboboxStyle.Shadow,
+		"tooltip":    th.tooltipStyle.Shadow,
+		"toast":      th.toastStyle.Shadow,
+		"submenu":    th.MenubarStyle.Shadow,
+		"datepicker": th.datePickerStyle.Shadow,
+	}
+	for name, got := range popovers {
+		if got != popover {
+			t.Errorf("%s: got %p, want the popover token %p",
+				name, got, popover)
+		}
+	}
+
+	modals := map[string]*BoxShadow{
+		"dialog":  th.dialogStyle.Shadow,
+		"palette": th.commandPaletteStyle.Shadow,
+	}
+	for name, got := range modals {
+		if got != dialog {
+			t.Errorf("%s: got %p, want the dialog token %p",
+				name, got, dialog)
+		}
+	}
+
+	if th.focusRing != ring {
+		t.Errorf("focus ring: got %p, want %p", th.focusRing, ring)
+	}
+}
+
+// The macOS themes are the reason the tokens exist, so they must
+// actually carry them, and must be reachable by name like every other
+// preset.
+func TestMacOSThemesRegisteredAndElevated(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"macos", "macos-dark"} {
+		th, ok := ThemeGet(name)
+		if !ok {
+			t.Fatalf("%q not registered", name)
+		}
+		if th.Name != name {
+			t.Errorf("%q: Name is %q", name, th.Name)
+		}
+		if th.dialogStyle.Shadow == nil {
+			t.Errorf("%q: dialog has no elevation", name)
+		}
+		if th.selectStyle.Shadow == nil {
+			t.Errorf("%q: dropdown has no elevation", name)
+		}
+		if th.focusRing == nil {
+			t.Errorf("%q: no focus ring", name)
+		}
+	}
+
+	// The ring is tinted with the theme's own accent, so the two
+	// polarities must not share one value.
+	if themeMacOS.focusRing == themeMacOSDark.focusRing {
+		t.Error("light and dark share a focus ring; accent differs")
+	}
+}
+
+// A popover shadow has to survive as far as a RenderShadow command,
+// not merely be present on the style struct.
+func TestPopoverShadowReachesRenderer(t *testing.T) {
+	t.Parallel()
+	w := makeWindow()
+	shadow := &BoxShadow{Color: RGBA(0, 0, 0, 80), OffsetY: 5, BlurRadius: 20}
+	s := &Shape{
+		shapeType: shapeRectangle,
+		X:         10,
+		Y:         20,
+		Width:     120,
+		Height:    90,
+		Color:     RGB(255, 255, 255),
+		Radius:    6,
+		fx:        &shapeEffects{Shadow: shadow},
+	}
+	renderContainer(s, ColorTransparent, makeClip(0, 0, 500, 500), w)
+
+	if len(w.renderers) == 0 {
+		t.Fatal("no render commands emitted")
+	}
+	// Shadow first, so it lands behind the popover's own fill rather
+	// than over it.
+	if got := w.renderers[0].Kind; got != RenderShadow {
+		t.Fatalf("first command is %v, want RenderShadow", got)
+	}
+	if w.renderers[0].BlurRadius != shadow.BlurRadius {
+		t.Errorf("blur: got %v, want %v",
+			w.renderers[0].BlurRadius, shadow.BlurRadius)
+	}
+}

--- a/gui/theme_macos.go
+++ b/gui/theme_macos.go
@@ -1,0 +1,150 @@
+package gui
+
+// macOS platform theme.
+//
+// Not a pixel match for Aqua — a similar feel. What actually reads as
+// "macOS" at a glance is a short list: a light grey window ground with
+// white control interiors, hairline borders, systemBlue as the one
+// accent, gently rounded corners, floating popovers with a real
+// shadow, and a soft accent glow for focus rather than a hard border.
+//
+// The first two of those were already expressible. The last two are
+// why ThemeCfg grew shadowPopover/shadowDialog/focusRing; see the
+// comments there for why they are pointers and why nil is the
+// no-elevation answer that leaves every older theme untouched.
+
+// macOS elevation and focus values.
+//
+// Package-level vars, not literals inside the cfg functions, because
+// ThemeMaker copies the pointer into every popover style: one value
+// per theme, shared by every shape in the window, never written
+// through. The two shadows are shared across polarities — macOS does
+// not lighten its shadows in dark mode, it deepens them, and the
+// deeper of the two reads correctly on both grounds. The ring is not
+// shared; it carries the accent, which does shift.
+var (
+	// Popover tier: menus, dropdowns, tooltips, toasts. Offset down
+	// and blurred wide enough to read as floating at a glance without
+	// looking like a drop shadow from a design tool.
+	macOSShadowPopover = &BoxShadow{
+		Color:      RGBA(0, 0, 0, 76),
+		OffsetY:    5,
+		BlurRadius: 20,
+	}
+
+	// Modal tier: dialogs and the command palette. Floats further
+	// because it sits above everything, not just above the row under
+	// it.
+	macOSShadowDialog = &BoxShadow{
+		Color:      RGBA(0, 0, 0, 102),
+		OffsetY:    12,
+		BlurRadius: 32,
+	}
+
+	// Focus ring. Zero offset so the glow is concentric with the
+	// control, and a small blur so it reads as a ring rather than a
+	// cloud. Rendered behind the control's fill (renderContainer emits
+	// the shadow first), which is what keeps it from tinting the
+	// control's own interior.
+	//
+	// One per polarity, unlike the shadows: the ring is tinted with the
+	// theme's own accent, and macOS shifts that accent between light
+	// (#007AFF) and dark (#0A84FF).
+	macOSFocusRing = &BoxShadow{
+		Color:      RGBA(0, 122, 255, 90),
+		BlurRadius: 3,
+	}
+
+	macOSFocusRingDark = &BoxShadow{
+		Color:      RGBA(10, 132, 255, 110),
+		BlurRadius: 3,
+	}
+)
+
+// baseMacOSCfg returns the geometry shared by both macOS polarities.
+//
+// Starts from baseCfg so the text ladder, spacing ladder and scroll
+// deltas stay the toolkit's, and overrides only what macOS actually
+// does differently.
+func baseMacOSCfg() ThemeCfg {
+	cfg := baseCfg()
+
+	// Hairlines. sizeBorderDef (1.5) is a visible stroke; macOS draws
+	// control outlines at a single pixel and leans on fill contrast
+	// instead.
+	cfg.SizeBorder = 1
+
+	// Corner rounding. macOS buttons and fields sit near 6; menus and
+	// dialogs are rounder.
+	cfg.Radius = 6
+	cfg.RadiusSmall = 4
+	cfg.RadiusMedium = 6
+	cfg.RadiusLarge = 10
+
+	// Control geometry. The switch is a true capsule — height 22 with
+	// a 38 width gives the knob room to travel without the track
+	// looking stretched.
+	cfg.sizeSwitchWidth = 38
+	cfg.sizeSwitchHeight = 22
+	cfg.sizeScrollbar = 8
+
+	cfg.shadowPopover = macOSShadowPopover
+	cfg.shadowDialog = macOSShadowDialog
+	cfg.focusRing = macOSFocusRing
+
+	// Fonts need no override on darwin: defaultFontFamily is "", which
+	// resolves to the backend's system face, and defaultMonoFontFamily
+	// is already Menlo. Naming a family here would pin the theme to
+	// one machine's font set.
+	return cfg
+}
+
+// macOSCfg returns the light macOS ThemeCfg.
+func macOSCfg() ThemeCfg {
+	cfg := baseMacOSCfg()
+	cfg.Name = "macos"
+	cfg.ColorBackground = ColorFromString("#ECECEC")
+	cfg.ColorPanel = ColorFromString("#F5F5F5")
+	cfg.ColorInterior = ColorFromString("#FFFFFF")
+	cfg.ColorHover = ColorFromString("#F0F0F0")
+	cfg.ColorFocus = ColorFromString("#FFFFFF")
+	cfg.ColorActive = ColorFromString("#E1E1E1")
+	cfg.ColorBorder = ColorFromString("#C6C6C8")
+	cfg.ColorSelect = ColorFromString("#007AFF")
+	cfg.ColorBorderFocus = ColorFromString("#007AFF")
+	cfg.ColorSuccess = ColorFromString("#28A745")
+	cfg.ColorWarning = ColorFromString("#FF9500")
+	cfg.ColorError = ColorFromString("#FF3B30")
+	cfg.TextStyleDef = TextStyle{
+		Family: defaultFontFamily,
+		Color:  ColorFromString("#1D1D1F"),
+		Size:   sizeTextMedium,
+	}
+	return cfg
+}
+
+// macOSDarkCfg returns the dark macOS ThemeCfg.
+func macOSDarkCfg() ThemeCfg {
+	cfg := baseMacOSCfg()
+	cfg.Name = "macos-dark"
+	cfg.ColorBackground = ColorFromString("#1E1E1E")
+	cfg.ColorPanel = ColorFromString("#2A2A2A")
+	cfg.ColorInterior = ColorFromString("#3A3A3C")
+	cfg.ColorHover = ColorFromString("#464648")
+	cfg.ColorFocus = ColorFromString("#3A3A3C")
+	cfg.ColorActive = ColorFromString("#545456")
+	cfg.ColorBorder = ColorFromString("#48484A")
+	cfg.ColorSelect = ColorFromString("#0A84FF")
+	cfg.ColorBorderFocus = ColorFromString("#0A84FF")
+	cfg.ColorSuccess = ColorFromString("#32D74B")
+	cfg.ColorWarning = ColorFromString("#FF9F0A")
+	cfg.ColorError = ColorFromString("#FF453A")
+	cfg.TitlebarDark = true
+	cfg.focusRing = macOSFocusRingDark
+	cfg.TextStyleDef = TextStyle{
+		Family: defaultFontFamily,
+		Color:  ColorFromString("#FFFFFF"),
+		Size:   sizeTextMedium,
+	}
+	return cfg
+}

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -60,6 +60,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 	theme := Theme{
 		Cfg:                  cfg,
 		Name:                 cfg.Name,
+		focusRing:            cfg.focusRing,
 		TextStyleSecondary:   textSecondary,
 		TextStyleLabel:       textLabel,
 		TextStyleDisabled:    textDisabled,
@@ -173,6 +174,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			textStyleLabel:  ts,
 		},
 		selectStyle: SelectStyle{
+			Shadow:           cfg.shadowPopover,
 			MinWidth:         75,
 			MaxWidth:         200,
 			Color:            cfg.ColorInterior,
@@ -220,6 +222,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			Spacing: 0,
 		},
 		dialogStyle: DialogStyle{
+			Shadow:           cfg.shadowDialog,
 			Color:            cfg.ColorPanel,
 			ColorBorder:      cfg.ColorBorder,
 			ColorBorderFocus: borderFocus,
@@ -234,6 +237,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			TextStyle:        ts,
 		},
 		toastStyle: ToastStyle{
+			Shadow:       cfg.shadowPopover,
 			maxVisible:   5,
 			Anchor:       toastBottomRight,
 			Width:        260,
@@ -253,6 +257,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			TitleStyle:   makeStyle(ts, cfg.sizeTextMedium),
 		},
 		tooltipStyle: TooltipStyle{
+			Shadow:      cfg.shadowPopover,
 			Delay:       500 * time.Millisecond,
 			Color:       cfg.ColorInterior,
 			ColorBorder: cfg.ColorBorder,
@@ -404,6 +409,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			columnWidthMin:     20,
 		},
 		comboboxStyle: ComboboxStyle{
+			Shadow:            cfg.shadowPopover,
 			Color:             cfg.ColorInterior,
 			ColorHover:        cfg.ColorHover,
 			ColorFocus:        cfg.ColorInterior,
@@ -420,6 +426,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			PlaceholderStyle:  textPlaceholder,
 		},
 		commandPaletteStyle: CommandPaletteStyle{
+			Shadow:         cfg.shadowDialog,
 			Color:          cfg.ColorPanel,
 			ColorBorder:    cfg.ColorBorder,
 			ColorHighlight: cfg.ColorSelect,
@@ -432,6 +439,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			backdropColor:  RGBA(0, 0, 0, 120),
 		},
 		MenubarStyle: MenubarStyle{
+			Shadow:           cfg.shadowPopover,
 			widthSubmenuMin:  50,
 			widthSubmenuMax:  200,
 			Color:            cfg.ColorInterior,
@@ -458,6 +466,7 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 			},
 		},
 		datePickerStyle: DatePickerStyle{
+			Shadow:           cfg.shadowPopover,
 			cellSpacing:      cfg.SpacingTight,
 			Color:            cfg.ColorInterior,
 			ColorHover:       cfg.ColorHover,

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -104,6 +104,8 @@ func buttonAmendLayout(ctx EventCtx) {
 	if ctx.Window.IsFocus(ctx.Layout.Shape.idKey()) {
 		ctx.Layout.Shape.Color = ctx.Layout.Shape.bc.ColorFocus
 		ctx.Layout.Shape.ColorBorder = ctx.Layout.Shape.bc.ColorBorderFocus
+		applyFocusRingShadow(ctx.Layout.Shape, ctx.Window,
+			ctx.Layout.Shape.bc.focusRing)
 	}
 	if ctx.Layout.Shape.bc.OnAmend != nil {
 		ctx.Layout.Shape.bc.OnAmend(EventCtx{ctx.Layout, nil, ctx.Window})

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -224,6 +224,7 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		}
 		content = append(content, Column(ContainerCfg{
 			ID:           "dropdown",
+			Shadow:       dn.Shadow,
 			SizeBorder:   Some(sizeBorder),
 			Radius:       Some(radius),
 			ColorBorder:  cfg.ColorBorder,

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -196,6 +196,7 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 			Column(ContainerCfg{
 				ID:          cfg.ID,
 				A11YRole:    AccessRoleDialog,
+				Shadow:      dn.Shadow,
 				Color:       cfg.Color,
 				ColorBorder: cfg.ColorBorder,
 				SizeBorder:  Some(sizeBorder),

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -199,6 +199,7 @@ func (cv *containerView) GenerateLayout(w *Window) Layout {
 			OnHover:          cv.userOnHover,
 			OnAmend:          cv.userAmendLayout,
 			opticalDigits:    cv.opticalDigits,
+			focusRing:        guiTheme.focusRing,
 		}
 		if w != nil {
 			layout.Shape.bc = w.scratch.buttonColors.alloc(bc)

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -558,6 +558,8 @@ func inputAmendLayout(
 	colorBorderFocus Color, spellChk bool,
 	onBlur func(EventCtx),
 ) func(EventCtx) {
+	// Captured at generation; see focusRingAmend.
+	ring := guiTheme.focusRing
 	return func(ctx EventCtx) {
 		if !ctx.Layout.Shape.Focusable || ctx.Layout.Shape.ID == "" {
 			return
@@ -570,6 +572,7 @@ func inputAmendLayout(
 			ctx.Window.IsFocus(key)
 		if focused {
 			ctx.Layout.Shape.ColorBorder = colorBorderFocus
+			applyFocusRingShadow(ctx.Layout.Shape, ctx.Window, ring)
 		}
 
 		// Blur detection: fire commit on focus loss.

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -151,11 +151,19 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 			},
 		}))
 		content = append(content, Column(ContainerCfg{
-			Float:        true,
-			FloatAnchor:  FloatBottomLeft,
-			FloatTieOff:  FloatTopLeft,
-			Padding:      NoPadding,
-			SizeBorder:   NoBorder,
+			Float:       true,
+			FloatAnchor: FloatBottomLeft,
+			FloatTieOff: FloatTopLeft,
+			Padding:     NoPadding,
+			SizeBorder:  NoBorder,
+			// Elevation rides the floating wrapper rather than
+			// DatePicker itself, because a DatePicker placed inline in
+			// a form is not a popover and must stay flat. The wrapper
+			// exists only on the open-popup path, so it is the one
+			// place the distinction is already made. Radius matches the
+			// picker's so the shadow follows its corners.
+			Shadow:       defaultDatePickerStyle.Shadow,
+			Radius:       SomeF(defaultDatePickerStyle.Radius),
 			FloatOffsetY: -cfg.SizeBorder.Get(0),
 			// The popup floats over the form; a click inside it is the
 			// popup's, not that of the field it is covering.

--- a/gui/view_menu.go
+++ b/gui/view_menu.go
@@ -27,9 +27,15 @@ func menu(w *Window, cfg MenubarCfg) View {
 		}
 	}
 
+	var shadow *BoxShadow
+	if cfg.Float {
+		shadow = defaultMenubarStyle.Shadow
+	}
+
 	return Column(ContainerCfg{
 		ID:            cfg.ID,
 		A11YRole:      AccessRoleMenu,
+		Shadow:        shadow,
 		Color:         cfg.Color,
 		ColorBorder:   cfg.ColorBorder,
 		SizeBorder:    cfg.SizeBorder,
@@ -208,6 +214,7 @@ func menuBuild(cfg MenubarCfg, level int, items []MenuItemCfg, w *Window) []View
 				item.Submenu, w)
 
 			submenu := Column(ContainerCfg{
+				Shadow:        defaultMenubarStyle.Shadow,
 				Color:         cfg.Color,
 				ColorBorder:   cfg.ColorBorder,
 				SizeBorder:    cfg.SizeBorder,

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -134,6 +134,7 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 		}
 		content = append(content, Column(ContainerCfg{
 			ID:            "dropdown",
+			Shadow:        dn.Shadow,
 			SizeBorder:    Some(sizeBorder),
 			Radius:        Some(radius),
 			ColorBorder:   cfg.ColorBorder,

--- a/gui/view_tooltip.go
+++ b/gui/view_tooltip.go
@@ -65,6 +65,7 @@ func Tooltip(cfg TooltipCfg) View {
 		FloatOffsetX:  cfg.OffsetX.Get(-3),
 		FloatOffsetY:  cfg.OffsetY.Get(-3),
 		FloatZIndex:   cfg.FloatZIndex,
+		Shadow:        d.Shadow,
 		Color:         cfg.Color,
 		ColorBorder:   cfg.ColorBorder,
 		SizeBorder:    SomeF(cfg.SizeBorder.Get(d.SizeBorder)),


### PR DESCRIPTION
## Summary

Adds elevation and focus-ring tokens to `ThemeCfg` (`shadowPopover`, `shadowDialog`, `focusRing`) and fans them out to every popover/modal style via `ThemeMaker`. Nil means "no elevation", so every pre-existing theme stays byte-identical.

New `macos` and `macos-dark` presets (registered like other presets, reachable via `ThemeGet`):

- hairline borders, ~6px corner rounding, systemBlue accent
- popovers (menus, dropdowns, tooltips, toasts, date pickers) float on a real shadow, dialogs float higher
- focus is a soft zero-offset accent glow behind the control (via `applyFocusRingShadow` at amend time), not an inset border

## Details

- `applyFocusRingShadow`: allocates a `shapeEffects` only for the one focused shape, from the existing frame pool; never writes through the theme-owned shadow pointer
- Wired into the button, input, select, listbox, table, virtual list, and expand panel focus paths; popover widgets that already paint their own elevation keep it
- Shadow follows the date picker popup via the floating wrapper
- Menubar strip stays flush; only floating menus/submenus take elevation

## Tests

- `theme_elevation_test.go`: presets carry no elevation, `ThemeMaker` fan-out, macOS registration, shadow reaches `RenderShadow`
- `theme_elevation_frame_test.go`: end-to-end frame checks — dropdown shadow survives ancestor clip, focused button/input emit a ring only under a ringed theme
- `focus_ring_test.go`: alloc/inert/keep-own-shadow/fill-empty-effects/pointer-immutability cases