### PR TITLE
feat(theme): GNOME and Windows platform themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **`gnome`/`gnome-dark` and `windows`/`windows-dark` theme presets**
+  (issue #374 pattern). Adwaita-derived and WinUI-derived platform themes,
+  registered like the `macos` presets and reached by name through `ThemeGet`:
+  hairline borders, platform corner rounding (GNOME rounder, Windows squarer),
+  platform accent colors, and subtle popover/dialog elevation. Both keep the
+  platform's hard accent outline for focus (`ColorBorderFocus`) instead of the
+  macOS glow — `FocusRing` stays nil. Fonts stay unpinned so each resolves to
+  the machine's system face (Cantarell on GNOME, Segoe UI on Windows).
+
 ### Fixed
 
 - **Restored caller-facing `*Cfg` fields unexported by the #230 surface sweep**

--- a/gui/theme_defaults.go
+++ b/gui/theme_defaults.go
@@ -114,13 +114,19 @@ var (
 	ThemeLight Theme
 	themeBlue  Theme
 
-	// macOS platform themes; see gui/theme_macos.go. Registered as
-	// "macos" and "macos-dark", and reached by name through ThemeGet.
-	// Unexported, following themeBlue rather than ThemeDark/ThemeLight:
-	// those two are the defaults an app assigns directly, these are
-	// presets a user picks. ThemePicker lists them off the registry.
-	themeMacOS     Theme
-	themeMacOSDark Theme
+	// Platform themes; see gui/theme_macos.go, gui/theme_gnome.go and
+	// gui/theme_windows.go. Registered as "macos"/"macos-dark",
+	// "gnome"/"gnome-dark" and "windows"/"windows-dark", and reached by
+	// name through ThemeGet. Unexported, following themeBlue rather
+	// than ThemeDark/ThemeLight: those two are the defaults an app
+	// assigns directly, these are presets a user picks. ThemePicker
+	// lists them off the registry.
+	themeMacOS       Theme
+	themeMacOSDark   Theme
+	themeGnome       Theme
+	themeGnomeDark   Theme
+	themeWindows     Theme
+	themeWindowsDark Theme
 )
 
 // Unexported preset configs and derived themes — kept for
@@ -205,6 +211,14 @@ func init() {
 	themeMacOS = ThemeMaker(macOSCfg())
 	themeMacOSDark = ThemeMaker(macOSDarkCfg())
 
+	// GNOME, light and dark.
+	themeGnome = ThemeMaker(gnomeCfg())
+	themeGnomeDark = ThemeMaker(gnomeDarkCfg())
+
+	// Windows, light and dark.
+	themeWindows = ThemeMaker(windowsCfg())
+	themeWindowsDark = ThemeMaker(windowsDarkCfg())
+
 	// Blue bordered.
 	themeBlueBorderedCfg = baseBlueCfg()
 	themeBlueBorderedCfg.Name = "blue-dark-bordered"
@@ -222,6 +236,10 @@ func init() {
 	themeRegister(themeBlueBordered)
 	themeRegister(themeMacOS)
 	themeRegister(themeMacOSDark)
+	themeRegister(themeGnome)
+	themeRegister(themeGnomeDark)
+	themeRegister(themeWindows)
+	themeRegister(themeWindowsDark)
 
 	// Dark is both the app default and the initially installed theme.
 	// applyTheme is what fills the default*Style mirrors — they carry no

--- a/gui/theme_elevation_test.go
+++ b/gui/theme_elevation_test.go
@@ -84,31 +84,44 @@ func TestThemeMakerFansOutElevation(t *testing.T) {
 	}
 }
 
-// The macOS themes are the reason the tokens exist, so they must
+// The platform themes are the reason the tokens exist, so they must
 // actually carry them, and must be reachable by name like every other
-// preset.
-func TestMacOSThemesRegisteredAndElevated(t *testing.T) {
+// preset. GNOME and Windows keep the hard accent outline for focus
+// (ColorBorderFocus) rather than the macOS glow, so they must NOT
+// carry a ring.
+func TestPlatformThemesRegisteredAndElevated(t *testing.T) {
 	t.Parallel()
-	for _, name := range []string{"macos", "macos-dark"} {
-		th, ok := ThemeGet(name)
+	for _, tc := range []struct {
+		name     string
+		wantRing bool
+	}{
+		{"macos", true},
+		{"macos-dark", true},
+		{"gnome", false},
+		{"gnome-dark", false},
+		{"windows", false},
+		{"windows-dark", false},
+	} {
+		th, ok := ThemeGet(tc.name)
 		if !ok {
-			t.Fatalf("%q not registered", name)
+			t.Fatalf("%q not registered", tc.name)
 		}
-		if th.Name != name {
-			t.Errorf("%q: Name is %q", name, th.Name)
+		if th.Name != tc.name {
+			t.Errorf("%q: Name is %q", tc.name, th.Name)
 		}
 		if th.dialogStyle.Shadow == nil {
-			t.Errorf("%q: dialog has no elevation", name)
+			t.Errorf("%q: dialog has no elevation", tc.name)
 		}
 		if th.selectStyle.Shadow == nil {
-			t.Errorf("%q: dropdown has no elevation", name)
+			t.Errorf("%q: dropdown has no elevation", tc.name)
 		}
-		if th.focusRing == nil {
-			t.Errorf("%q: no focus ring", name)
+		if got := th.focusRing != nil; got != tc.wantRing {
+			t.Errorf("%q: focus ring present=%v, want %v",
+				tc.name, got, tc.wantRing)
 		}
 	}
 
-	// The ring is tinted with the theme's own accent, so the two
+	// The macOS ring is tinted with the theme's own accent, so the two
 	// polarities must not share one value.
 	if themeMacOS.focusRing == themeMacOSDark.focusRing {
 		t.Error("light and dark share a focus ring; accent differs")

--- a/gui/theme_gnome.go
+++ b/gui/theme_gnome.go
@@ -1,0 +1,133 @@
+package gui
+
+// GNOME platform theme, modelled on Adwaita / libadwaita.
+//
+// Not a pixel match for a GTK desktop — a similar feel. What reads as
+// "GNOME" at a glance: a light grey window ground with white control
+// interiors, hairline borders, the libadwaita blue as the one accent,
+// gently rounded corners (rounder than Windows, not as round as
+// nothing), and popovers that float over a subtle shadow.
+//
+// The shadow tokens exist because ThemeCfg grew
+// shadowPopover/shadowDialog in the macOS pass (issue #374); nil is
+// the no-elevation answer, and GNOME deliberately keeps it subtle.
+// Focus is NOT the macOS glow: Adwaita draws a hard accent outline,
+// which this toolkit expresses with ColorBorderFocus. That is why
+// FocusRing stays nil here.
+
+// GNOME elevation values.
+//
+// Package-level vars, not literals inside the cfg functions, because
+// ThemeMaker copies the pointer into every popover style: one value
+// per theme, shared by every shape in the window, never written
+// through. Shared across polarities, like macOS: Adwaita keeps its
+// shadows dark in dark mode, and a shadow meant for dark grey reads
+// fine on light grey too.
+//
+// Adwaita's elevation ladders are small — elevation-1 is a 1px,
+// low-alpha step, not the 5px float macOS uses — so these are tuned
+// down from the macOS pair.
+var (
+	// Popover tier: menus, dropdowns, tooltips, toasts. Just enough
+	// offset and blur to read as floating off the window ground.
+	gnomeShadowPopover = &BoxShadow{
+		Color:      RGBA(0, 0, 0, 60),
+		OffsetY:    3,
+		BlurRadius: 12,
+	}
+
+	// Modal tier: dialogs and the command palette. Floats further
+	// because it sits above everything.
+	gnomeShadowDialog = &BoxShadow{
+		Color:      RGBA(0, 0, 0, 80),
+		OffsetY:    8,
+		BlurRadius: 24,
+	}
+)
+
+// basegnomeCfg returns the geometry shared by both GNOME polarities.
+//
+// Starts from baseCfg so the text ladder, spacing ladder and scroll
+// deltas stay the toolkit's, and overrides only what GNOME actually
+// does differently.
+func basegnomeCfg() ThemeCfg {
+	cfg := baseCfg()
+
+	// Hairlines. Adwaita outlines controls at a single pixel and leans
+	// on fill contrast, the same call macOS makes.
+	cfg.SizeBorder = 1
+
+	// Corner rounding. libadwaita keeps controls rounder than Windows:
+	// ~6px buttons and entries, 9-12px menus and dialogs.
+	cfg.Radius = 6
+	cfg.RadiusSmall = 4
+	cfg.RadiusMedium = 6
+	cfg.RadiusLarge = 12
+
+	// Control geometry. Adwaita switches are the biggest of the three
+	// platforms: 40x24 with the knob travel to match.
+	cfg.SizeSwitchWidth = 40
+	cfg.SizeSwitchHeight = 24
+	cfg.SizeScrollbar = 8
+
+	cfg.ShadowPopover = gnomeShadowPopover
+	cfg.ShadowDialog = gnomeShadowDialog
+
+	// Focus stays a hard accent outline (ColorBorderFocus), never the
+	// macOS glow: FocusRing is deliberately left nil.
+	//
+	// Fonts need no override on Linux: defaultFontFamily is "", which
+	// resolves to the backend's system face (Cantarell on a GNOME
+	// desktop). Naming a family here would pin the theme to one
+	// machine's font set.
+	return cfg
+}
+
+// gnomeCfg returns the light GNOME ThemeCfg.
+func gnomeCfg() ThemeCfg {
+	cfg := basegnomeCfg()
+	cfg.Name = "gnome"
+	cfg.ColorBackground = ColorFromString("#F6F5F4")
+	cfg.ColorPanel = ColorFromString("#FAFAFA")
+	cfg.ColorInterior = ColorFromString("#FFFFFF")
+	cfg.ColorHover = ColorFromString("#F1EFEE")
+	cfg.ColorFocus = ColorFromString("#FFFFFF")
+	cfg.ColorActive = ColorFromString("#E2E0DE")
+	cfg.ColorBorder = ColorFromString("#C0BFBC")
+	cfg.ColorSelect = ColorFromString("#3584E4")
+	cfg.ColorBorderFocus = ColorFromString("#3584E4")
+	cfg.ColorSuccess = ColorFromString("#2EC27E")
+	cfg.ColorWarning = ColorFromString("#F5C211")
+	cfg.ColorError = ColorFromString("#E01B24")
+	cfg.TextStyleDef = TextStyle{
+		Family: defaultFontFamily,
+		Color:  ColorFromString("#1E1E1E"),
+		Size:   sizeTextMedium,
+	}
+	return cfg
+}
+
+// gnomeDarkCfg returns the dark GNOME ThemeCfg.
+func gnomeDarkCfg() ThemeCfg {
+	cfg := basegnomeCfg()
+	cfg.Name = "gnome-dark"
+	cfg.ColorBackground = ColorFromString("#242424")
+	cfg.ColorPanel = ColorFromString("#2E2E2E")
+	cfg.ColorInterior = ColorFromString("#1E1E1E")
+	cfg.ColorHover = ColorFromString("#333333")
+	cfg.ColorFocus = ColorFromString("#1E1E1E")
+	cfg.ColorActive = ColorFromString("#3D3D3D")
+	cfg.ColorBorder = ColorFromString("#505050")
+	cfg.ColorSelect = ColorFromString("#3584E4")
+	cfg.ColorBorderFocus = ColorFromString("#3584E4")
+	cfg.ColorSuccess = ColorFromString("#26A269")
+	cfg.ColorWarning = ColorFromString("#C88800")
+	cfg.ColorError = ColorFromString("#C01C28")
+	cfg.TitlebarDark = true
+	cfg.TextStyleDef = TextStyle{
+		Family: defaultFontFamily,
+		Color:  ColorFromString("#FFFFFF"),
+		Size:   sizeTextMedium,
+	}
+	return cfg
+}

--- a/gui/theme_winui.go
+++ b/gui/theme_winui.go
@@ -1,0 +1,133 @@
+package gui
+
+// Windows platform theme, modelled on WinUI / Fluent (Windows 11).
+//
+// Not a pixel match for WinUI — a similar feel. What reads as
+// "Windows" at a glance: a near-white window ground, white control
+// interiors, hairline borders, the WinUI blue as the one accent,
+// squarer corners than macOS or GNOME, and flyouts that float over a
+// modest shadow.
+//
+// The shadow tokens exist because ThemeCfg grew
+// shadowPopover/shadowDialog in the macOS pass (issue #374); nil is
+// the no-elevation answer, and Windows 11 keeps its flyout elevation
+// smaller than macOS's. Focus is NOT the macOS glow: WinUI draws a
+// hard accent outline, which this toolkit expresses with
+// ColorBorderFocus. That is why FocusRing stays nil here.
+
+// Windows elevation values.
+//
+// Package-level vars, not literals inside the cfg functions, because
+// ThemeMaker copies the pointer into every popover style: one value
+// per theme, shared by every shape in the window, never written
+// through. Shared across polarities, like macOS: Windows does not
+// lighten its shadows in dark mode, and a shadow meant for dark grey
+// reads fine on light grey too.
+//
+// WinUI flyout elevation is subtle — small offset, tight blur — so
+// these are tuned down from the macOS pair.
+var (
+	// Popover tier: menus, dropdowns, tooltips, toasts. Just enough
+	// offset and blur to read as floating off the window ground.
+	windowsShadowPopover = &BoxShadow{
+		Color:      RGBA(0, 0, 0, 50),
+		OffsetY:    3,
+		BlurRadius: 8,
+	}
+
+	// Modal tier: dialogs and the command palette. Floats further
+	// because it sits above everything.
+	windowsShadowDialog = &BoxShadow{
+		Color:      RGBA(0, 0, 0, 70),
+		OffsetY:    8,
+		BlurRadius: 16,
+	}
+)
+
+// basewindowsCfg returns the geometry shared by both Windows
+// polarities.
+//
+// Starts from baseCfg so the text ladder, spacing ladder and scroll
+// deltas stay the toolkit's, and overrides only what Windows actually
+// does differently.
+func basewindowsCfg() ThemeCfg {
+	cfg := baseCfg()
+
+	// Hairlines. Windows 11 outlines controls at a single pixel.
+	cfg.SizeBorder = 1
+
+	// Corner rounding. WinUI is the squarer of the three platforms:
+	// 4px controls, 2px chips, 8px flyouts.
+	cfg.Radius = 4
+	cfg.RadiusSmall = 2
+	cfg.RadiusMedium = 4
+	cfg.RadiusLarge = 8
+
+	// Control geometry. The Windows 11 toggle is a 40x20 capsule —
+	// flatter than the others. Scrollbars are chunkier than the
+	// toolkit default.
+	cfg.SizeSwitchWidth = 40
+	cfg.SizeSwitchHeight = 20
+	cfg.SizeScrollbar = 10
+
+	cfg.ShadowPopover = windowsShadowPopover
+	cfg.ShadowDialog = windowsShadowDialog
+
+	// Focus stays a hard accent outline (ColorBorderFocus), never the
+	// macOS glow: FocusRing is deliberately left nil.
+	//
+	// Fonts need no override on Windows: defaultFontFamily is "", which
+	// resolves to the backend's system face (Segoe UI on Windows).
+	// Naming a family here would pin the theme to one machine's font
+	// set.
+	return cfg
+}
+
+// windowsCfg returns the light Windows ThemeCfg.
+func windowsCfg() ThemeCfg {
+	cfg := basewindowsCfg()
+	cfg.Name = "windows"
+	cfg.ColorBackground = ColorFromString("#F3F3F3")
+	cfg.ColorPanel = ColorFromString("#FFFFFF")
+	cfg.ColorInterior = ColorFromString("#FFFFFF")
+	cfg.ColorHover = ColorFromString("#F5F5F5")
+	cfg.ColorFocus = ColorFromString("#FFFFFF")
+	cfg.ColorActive = ColorFromString("#E5E5E5")
+	cfg.ColorBorder = ColorFromString("#D1D1D1")
+	cfg.ColorSelect = ColorFromString("#005FB8")
+	cfg.ColorBorderFocus = ColorFromString("#005FB8")
+	cfg.ColorSuccess = ColorFromString("#0F7B0F")
+	cfg.ColorWarning = ColorFromString("#9D5D00")
+	cfg.ColorError = ColorFromString("#C42B1C")
+	cfg.TextStyleDef = TextStyle{
+		Family: defaultFontFamily,
+		Color:  ColorFromString("#1B1B1B"),
+		Size:   sizeTextMedium,
+	}
+	return cfg
+}
+
+// windowsDarkCfg returns the dark Windows ThemeCfg.
+func windowsDarkCfg() ThemeCfg {
+	cfg := basewindowsCfg()
+	cfg.Name = "windows-dark"
+	cfg.ColorBackground = ColorFromString("#202020")
+	cfg.ColorPanel = ColorFromString("#2B2B2B")
+	cfg.ColorInterior = ColorFromString("#3A3A3A")
+	cfg.ColorHover = ColorFromString("#3B3B3B")
+	cfg.ColorFocus = ColorFromString("#3A3A3A")
+	cfg.ColorActive = ColorFromString("#4C4C4C")
+	cfg.ColorBorder = ColorFromString("#5C5C5C")
+	cfg.ColorSelect = ColorFromString("#60CDFF")
+	cfg.ColorBorderFocus = ColorFromString("#60CDFF")
+	cfg.ColorSuccess = ColorFromString("#6CCB5F")
+	cfg.ColorWarning = ColorFromString("#FCE100")
+	cfg.ColorError = ColorFromString("#FF99A4")
+	cfg.TitlebarDark = true
+	cfg.TextStyleDef = TextStyle{
+		Family: defaultFontFamily,
+		Color:  ColorFromString("#FFFFFF"),
+		Size:   sizeTextMedium,
+	}
+	return cfg
+}


### PR DESCRIPTION
## Summary

Adds four platform theme presets following the macOS preset pattern from #374: `gnome`/`gnome-dark` (Adwaita-derived) and `windows`/`windows-dark` (WinUI-derived), registered and reachable via `ThemeGet`; the ThemePicker lists them automatically.

- Hairline borders, platform corner rounding (GNOME rounder at 6/4/6/12, Windows squarer at 4/2/4/8)
- Platform accents: `#3584E4` (Adwaita blue, both polarities), `#005FB8` light / `#60CDFF` dark (WinUI)
- Subtle popover/dialog elevation per platform, tuned down from the macOS pair
- Focus stays the platform's hard accent outline (`ColorBorderFocus`) — `FocusRing` deliberately nil on all four, unlike macOS
- Fonts unpinned so each resolves to the machine's system face (Cantarell, Segoe UI)

## Notes

- File is `theme_winui.go`, not `theme_windows.go`: the `_windows` suffix is an implicit GOOS build constraint that would exclude the file on every other platform.
- The cfg funcs are unexported (`gnomeCfg`, `windowsCfg`) mirroring `macOSCfg` — which starts lowercase and was never an export; the audit flagged the camel-cased names as new public surface.

## Tests

- `TestPlatformThemesRegisteredAndElevated` (renamed/table-driven): all six platform themes registered, carry elevation, and ring presence matches `wantRing`
- Full `make prepush` gate green; soft-rendered frames pixel-verified (backgrounds/accents match declared palettes)