### PR TITLE
layout: resolve Fit-width Wrap/Overflow against nearest definite ancestor

### DIFF
--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -161,6 +161,16 @@ table header is data index 0 but sits outside the scrollable). Call
 `w.InvalidateListHeights(id)` when a row's content changed under a stable key —
 nothing detects that. See `docs/specs/virtualized-variable-height-lists.md`.
 
+## `Wrap` with Fit width
+
+`Wrap` with a Fit width resolves as **fit-content** (issue #379): the width is
+`min(single-row sum, nearest definite-width ancestor's available)`, so the
+container wraps within its parent instead of rendering one unwrapped row wider
+than it. A Fit chain with no Fixed/Fill width above it has no width to wrap
+within and keeps the single-row sum — that combination behaves as a `Row`, not
+a wrap. When the wrap should always fill its parent, use Fill width, which is
+what every example in this repo does.
+
 ## The one-event rule
 
 Nothing is marked handled for you. A callback that acts on an event calls

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -713,6 +713,34 @@ func goldenCases() []goldenCase {
 				})
 			},
 		},
+		{
+			// A Fit-width wrap resolves against its nearest definite
+			// ancestor (issue #379): this records wrapped rows at the
+			// window width, not one unwrapped row at the content sum.
+			// 3 chips of 80 + 2 gaps of 4 fit in the 320 window; a
+			// regression to the unconstrained sum would record a single
+			// row of 12 chips at 1004px.
+			name: "wrap_fit",
+			build: func(_ *Window) View {
+				chips := make([]View, 12)
+				for i := range chips {
+					chips[i] = Column(ContainerCfg{
+						ID:         "chip-" + itoa(i),
+						Sizing:     FixedFixed,
+						Width:      80,
+						Height:     40,
+						SizeBorder: NoBorder,
+						Color:      RGBA(180, 190, 200, 255),
+					})
+				}
+				return Wrap(ContainerCfg{
+					ID:      "chips",
+					Sizing:  FitFit,
+					Spacing: SomeF(4),
+					Content: chips,
+				})
+			},
+		},
 	}
 }
 

--- a/gui/layout_overflow.go
+++ b/gui/layout_overflow.go
@@ -6,8 +6,19 @@ func layoutOverflow(layout *Layout, w *Window) {
 		layoutOverflow(&layout.Children[i], w)
 	}
 
-	if !layout.Shape.Overflow || layout.Shape.Axis != axisLeftToRight ||
-		len(layout.Children) < 2 || layout.Shape.Scrollable {
+	if !layout.Shape.Overflow || layout.Shape.Axis != axisLeftToRight {
+		return
+	}
+
+	// A Fit-width overflow container resolves against its nearest
+	// definite-width ancestor (issue #379): its fit width is the full
+	// content sum, so nothing below it ever overflows.
+	if changed, path, depth := constrainFitContainerWidth(layout); changed {
+		refitFitAncestors(layout, path[:depth])
+		layout.Shape.contentW = computeContentWidth(layout)
+	}
+
+	if len(layout.Children) < 2 || layout.Shape.Scrollable {
 		return
 	}
 

--- a/gui/layout_overflow_test.go
+++ b/gui/layout_overflow_test.go
@@ -178,3 +178,58 @@ func TestLayoutOverflowAllFit(t *testing.T) {
 		t.Error("trigger should be hidden when all children fit")
 	}
 }
+
+// TestOverflowFitWidthConstrained is the issue #379 Overflow half: a
+// Fit-width overflow container used to resolve its width to the full content
+// sum, so the hide test never fired. With the constraint it sizes against
+// its parent and hides the children that do not fit.
+func TestOverflowFitWidthConstrained(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	defer w.Close()
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisTopToBottom, Width: 100, Height: 100,
+			Sizing: FixedFixed, shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				ID:        "overflow-fit",
+				Overflow:  true,
+				Axis:      axisLeftToRight,
+				Sizing:    FitFit,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{shapeType: shapeRectangle, Width: 40}},
+				{Shape: &Shape{shapeType: shapeRectangle, Width: 40}},
+				{Shape: &Shape{shapeType: shapeRectangle, Width: 40}},
+				{Shape: &Shape{shapeType: shapeRectangle, Width: 20}}, // trigger
+			},
+		}},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutOverflow(root, w)
+
+	of := &root.Children[0]
+	if !f32AreClose(of.Shape.Width, 100) {
+		t.Errorf("overflow width: got %f, want 100", of.Shape.Width)
+	}
+	// Available = 100: child0 (40) + child1 (40) + trigger (20) fits;
+	// adding child2 (40) would reach 140 > 100, so child2 is hidden.
+	if of.Children[0].Shape.shapeType == shapeNone {
+		t.Error("child 0 should be visible")
+	}
+	if of.Children[1].Shape.shapeType == shapeNone {
+		t.Error("child 1 should be visible")
+	}
+	if of.Children[2].Shape.shapeType != shapeNone {
+		t.Error("child 2 should be hidden")
+	}
+	if of.Children[3].Shape.shapeType == shapeNone {
+		t.Error("trigger child should remain visible")
+	}
+}

--- a/gui/layout_wrap.go
+++ b/gui/layout_wrap.go
@@ -5,6 +5,99 @@ type wrapRowRange struct {
 	start, end int
 }
 
+// maxFitConstraintDepth caps the ancestor walk for Fit-width wrap/overflow
+// containers. A chain deeper than this stays unconstrained (single-row
+// behavior) rather than guessing at a width eight levels down.
+const maxFitConstraintDepth = 8
+
+// constrainFitContainerWidth resolves a Fit-width Wrap/Overflow container's
+// width against its nearest definite-width ancestor before it breaks rows
+// (or hides children). Without this the width is its own single-row content
+// sum, so a wrap measures against a width that always fits and never breaks
+// (issue #379).
+//
+// A node's width is "definite" when it does not derive from this container:
+// Fixed at generation, Fill resolved by the fill pass that just ran, or an
+// axisNone node (no child accumulation at all — Canvas/Splitter roots). A
+// Fit-width ancestor is self-derived — it includes this container's width,
+// so it contributes only its padding and, for a row, the width its other
+// children take. The result is the CSS fit-content rule: min(single-row
+// sum, available), floored at MinWidth so a container wider than its
+// ancestor still fits its widest child (the issue #378 floor).
+//
+// The walk stops with no constraint at a nil parent — an all-Fit chain has
+// no width to wrap within, so it keeps the single-row sum — and at a
+// rotated ancestor, whose dimensions a later pass swaps. The visited nodes
+// come back in path (depth of them) so the caller can re-fit and re-cache
+// exactly those.
+func constrainFitContainerWidth(layout *Layout) (changed bool, path [maxFitConstraintDepth]*Layout, depth int) {
+	if layout.Parent == nil || layout.Shape.Sizing.Width != sizingFit {
+		return false, path, 0
+	}
+	// debts accumulates what the nodes on the path consume: each node's
+	// padding plus, for a row, its other children and inter-child spacing.
+	var debts float32
+	child := layout
+	for n := layout.Parent; n != nil; n = n.Parent {
+		if n.Shape.QuarterTurns != 0 || depth == maxFitConstraintDepth {
+			return false, path, depth
+		}
+		path[depth] = n
+		depth++
+		if n.Shape.Sizing.Width == sizingFit && n.Shape.Axis != axisNone {
+			debts += n.Shape.paddingWidth()
+			if n.Shape.Axis == axisLeftToRight {
+				debts += siblingsConsumeWidth(n, child)
+			}
+			child = n
+			continue
+		}
+		available := n.Shape.Width - n.Shape.paddingWidth() - debts
+		if n.Shape.Axis == axisLeftToRight {
+			available -= siblingsConsumeWidth(n, child)
+		}
+		newW := f32Min(layout.Shape.Width, f32Max(available, 0))
+		if layout.Shape.MinWidth > 0 {
+			newW = f32Max(newW, layout.Shape.MinWidth)
+		}
+		if f32AreClose(newW, layout.Shape.Width) {
+			return false, path, depth
+		}
+		layout.Shape.Width = newW
+		return true, path, depth
+	}
+	return false, path, depth
+}
+
+// siblingsConsumeWidth returns what a row node's other visible children
+// take: their widths plus the inter-child spacing. child must be one of
+// n.Children.
+func siblingsConsumeWidth(n *Layout, child *Layout) float32 {
+	var sum float32
+	for i := range n.Children {
+		c := &n.Children[i]
+		if c == child || skipLayoutChild(c.Shape) {
+			continue
+		}
+		sum += c.Shape.Width
+	}
+	return sum + n.spacing()
+}
+
+// refitFitAncestors propagates a width constraint up the Fit ancestor chain
+// (re-fitting each from its children, as rotation does) and refreshes the
+// content-width caches the fill pass recorded before the constraint applied.
+// The height fill pass re-arms fillGen without re-caching contentW, so
+// alignment/scroll reads (applyContainerAlignment, scroll offsets, scrollbar
+// thumbs) would otherwise see the pre-constraint sum. path holds the
+// ancestors visited by constrainFitContainerWidth, definite node included.
+func refitFitAncestors(layout *Layout, path []*Layout) {
+	reaccumulateAncestors(layout.Parent)
+	for _, n := range path {
+		n.Shape.contentW = computeContentWidth(n)
+	}
+}
+
 // layoutWrapContainers restructures wrap containers into column-of-rows.
 func layoutWrapContainers(layout *Layout, w *Window) {
 	for i := range layout.Children {
@@ -13,6 +106,14 @@ func layoutWrapContainers(layout *Layout, w *Window) {
 
 	if !layout.Shape.Wrap || layout.Shape.Axis != axisLeftToRight || len(layout.Children) == 0 {
 		return
+	}
+
+	// A Fit-width wrap resolves against its nearest definite-width ancestor
+	// (issue #379). Without the constraint its width is its own single-row
+	// sum, so `available` below always fits every child and no row breaks.
+	changed, path, depth := constrainFitContainerWidth(layout)
+	if changed {
+		refitFitAncestors(layout, path[:depth])
 	}
 
 	available := layout.Shape.Width - layout.Shape.paddingWidth()
@@ -98,5 +199,13 @@ func layoutWrapContainers(layout *Layout, w *Window) {
 		for j := range layout.Children[i].Children {
 			layout.Children[i].Children[j].Parent = &layout.Children[i]
 		}
+	}
+	if changed {
+		// The wrap is now a column of rows; the fill pass cached its
+		// content width as the single-row sum, so re-cache it at the
+		// wrapped extent. Runs after the children swap — reading the
+		// flat pre-wrap children here is what the single-row sum would
+		// have been (max child, not the row extent).
+		layout.Shape.contentW = computeContentWidth(layout)
 	}
 }

--- a/gui/layout_wrap_test.go
+++ b/gui/layout_wrap_test.go
@@ -544,3 +544,509 @@ func TestWrapCardsStayInsideWindow(t *testing.T) {
 		t.Fatal("no cards resolved; test is not exercising the layout")
 	}
 }
+
+// TestWrapFitWidthConstrainedByParent is issue #379's repro: a FitFit wrap
+// used to resolve its width to the full single-row sum of its children, so
+// the row-break test measured against a width that was always wide enough
+// and the container rendered one unwrapped row wider than its parent.
+func TestWrapFitWidthConstrainedByParent(t *testing.T) {
+	const (
+		parentWidth = 400
+		childWidth  = 100
+		spacing     = 10
+		childCount  = 20
+	)
+
+	children := make([]Layout, childCount)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childWidth, Height: 30, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisTopToBottom, Width: parentWidth, Height: 600,
+			Sizing: FixedFixed, shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+				Spacing: spacing, shapeType: shapeRectangle,
+			},
+			Children: children,
+		}},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	wrap := &root.Children[0]
+	if wrap.Shape.Width > parentWidth+f32Tolerance {
+		t.Errorf("wrap width: got %f, want <= %d", wrap.Shape.Width, parentWidth)
+	}
+	if wrap.Shape.Axis != axisTopToBottom {
+		t.Error("wrap axis should flip to TTB")
+	}
+	if len(wrap.Children) < 2 {
+		t.Fatalf("rows: got %d, want 2+", len(wrap.Children))
+	}
+	// 3 per row: 3*100 + 2*10 = 320 fits, 4*100 + 3*10 = 430 does not.
+	for i := range wrap.Children {
+		var used float32
+		for j := range wrap.Children[i].Children {
+			if j > 0 {
+				used += spacing
+			}
+			used += wrap.Children[i].Children[j].Shape.Width
+		}
+		if used > parentWidth+f32Tolerance {
+			t.Errorf("row %d content: got %f, want <= %d", i, used, parentWidth)
+		}
+	}
+	if !f32AreClose(root.Shape.Width, parentWidth) {
+		t.Errorf("parent width: got %f, want %d", root.Shape.Width, parentWidth)
+	}
+}
+
+// TestWrapFitWidthUnconstrainedStaysSingleRow pins the unconstrained side of
+// the issue #379 rule: a Fit chain with no definite-width ancestor keeps the
+// single-row sum — there is no width to wrap within, so the container
+// behaves as a Row.
+func TestWrapFitWidthUnconstrainedStaysSingleRow(t *testing.T) {
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+			Spacing: 5, shapeType: shapeRectangle,
+		},
+		Children: []Layout{
+			{Shape: &Shape{Width: 30, shapeType: shapeRectangle}},
+			{Shape: &Shape{Width: 30, shapeType: shapeRectangle}},
+			{Shape: &Shape{Width: 30, shapeType: shapeRectangle}},
+		},
+	}
+
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	if !f32AreClose(root.Shape.Width, 100) {
+		t.Errorf("wrap width: got %f, want 100 (30 + 5 + 30 + 5 + 30)",
+			root.Shape.Width)
+	}
+	if root.Shape.Axis != axisLeftToRight {
+		t.Error("axis should stay LTR with no width to wrap within")
+	}
+	if len(root.Children) != 3 {
+		t.Errorf("children: got %d, want 3", len(root.Children))
+	}
+}
+
+// TestWrapFitChainRefitsColumn: a FitFit wrap inside a FitFit column inside a
+// fixed root wraps against the root's width, and the column re-fits to the
+// wrap's constrained width instead of the unconstrained sum.
+func TestWrapFitChainRefitsColumn(t *testing.T) {
+	const (
+		rootWidth  = 700
+		childWidth = 160
+		spacing    = 16
+		childCount = 50
+	)
+
+	children := make([]Layout, childCount)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childWidth, Height: 20, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisTopToBottom, Width: rootWidth, Height: 600,
+			Sizing: FixedFixed, shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				Axis: axisTopToBottom, Sizing: FitFit, shapeType: shapeRectangle,
+			},
+			Children: []Layout{{
+				Shape: &Shape{
+					Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+					Spacing: spacing, shapeType: shapeRectangle,
+				},
+				Children: children,
+			}},
+		}},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	col := &root.Children[0]
+	wrap := &col.Children[0]
+	if !f32AreClose(wrap.Shape.Width, rootWidth) {
+		t.Errorf("wrap width: got %f, want %d", wrap.Shape.Width, rootWidth)
+	}
+	if wrap.Shape.Axis != axisTopToBottom {
+		t.Error("wrap axis should flip to TTB")
+	}
+	// 4 per row: 4*160 + 3*16 = 688 fits, 5*160 + 4*16 = 864 does not.
+	if len(wrap.Children) != 13 {
+		t.Errorf("rows: got %d, want 13", len(wrap.Children))
+	}
+	// The Fit column must re-fit from the constrained wrap width rather
+	// than keep the unconstrained sum.
+	if !f32AreClose(col.Shape.Width, rootWidth) {
+		t.Errorf("column width: got %f, want %d (re-fitted)",
+			col.Shape.Width, rootWidth)
+	}
+}
+
+// TestWrapFitWidthSiblingConsumption: a Fit wrap sharing a definite row with
+// a fixed sibling wraps within the row minus the sibling and the spacing.
+func TestWrapFitWidthSiblingConsumption(t *testing.T) {
+	const (
+		rowWidth   = 700
+		childWidth = 100
+		wrapSp     = 5
+		rowSp      = 10
+		siblingW   = 100
+	)
+
+	children := make([]Layout, 20)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childWidth, Height: 30, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisLeftToRight, Width: rowWidth, Height: 100,
+			Sizing: FixedFixed, Spacing: rowSp, shapeType: shapeRectangle,
+		},
+		Children: []Layout{
+			{
+				Shape: &Shape{
+					Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+					Spacing: wrapSp, shapeType: shapeRectangle,
+				},
+				Children: children,
+			},
+			{Shape: &Shape{Width: siblingW, shapeType: shapeRectangle}},
+		},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	wrap := &root.Children[0]
+	want := float32(rowWidth - rowSp - siblingW)
+	if !f32AreClose(wrap.Shape.Width, want) {
+		t.Errorf("wrap width: got %f, want %f (%d - %d - %d)",
+			wrap.Shape.Width, want, rowWidth, rowSp, siblingW)
+	}
+	if wrap.Shape.Axis != axisTopToBottom {
+		t.Error("wrap axis should flip to TTB")
+	}
+	// 5 per row: 5*100 + 4*5 = 520 fits, 6*100 + 5*5 = 625 does not.
+	if len(wrap.Children) != 4 {
+		t.Errorf("rows: got %d, want 4", len(wrap.Children))
+	}
+}
+
+// TestWrapFitWidthMinWidthFloor: when the definite ancestor is narrower than
+// the widest child, the wrap floors at widest child + padding (the issue
+// #378 floor) instead of collapsing below its content, and still breaks rows
+// one child per row.
+func TestWrapFitWidthMinWidthFloor(t *testing.T) {
+	const (
+		parentWidth = 80
+		childWidth  = 100
+		spacing     = 5
+	)
+
+	children := make([]Layout, 3)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childWidth, Height: 20, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisTopToBottom, Width: parentWidth, Height: 300,
+			Sizing: FixedFixed, shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+				Spacing: spacing, shapeType: shapeRectangle,
+			},
+			Children: children,
+		}},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	wrap := &root.Children[0]
+	if !f32AreClose(wrap.Shape.Width, childWidth) {
+		t.Errorf("wrap width: got %f, want %d (widest child floor)",
+			wrap.Shape.Width, childWidth)
+	}
+	if wrap.Shape.Axis != axisTopToBottom {
+		t.Error("wrap axis should flip to TTB")
+	}
+	if len(wrap.Children) != 3 {
+		t.Errorf("rows: got %d, want 3 (one child per row)", len(wrap.Children))
+	}
+}
+
+// TestWrapFitCardsStayInsideWindow is issue #379 end to end: a FitFit wrap
+// of fixed-width cards inside a FillFill column, driven through a real
+// window frame. Before the fix the wrap resolved to its single-row sum and
+// every card spilled past the window edge.
+func TestWrapFitCardsStayInsideWindow(t *testing.T) {
+	const (
+		winWidth   = 700
+		cardWidth  = 160
+		spacing    = 16
+		cardCount  = 60
+		cardHeight = 170
+	)
+
+	w := NewWindow(WindowCfg{
+		State: new(int), Width: winWidth, Height: 600,
+	})
+
+	root := w.TestRender(func(*Window) View {
+		cards := make([]View, cardCount)
+		for i := range cards {
+			cards[i] = Column(ContainerCfg{
+				ID:         "card-" + itoa(i),
+				Sizing:     FixedFixed,
+				Width:      cardWidth,
+				Height:     cardHeight,
+				SizeBorder: NoBorder,
+			})
+		}
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{Wrap(ContainerCfg{
+				ID:         "cards-wrap",
+				Sizing:     FitFit,
+				Spacing:    SomeF(spacing),
+				Scrollable: true,
+				ScrollMode: ScrollVerticalOnly,
+				Content:    cards,
+			})},
+		})
+	})
+
+	wrap, ok := root.FindByID("cards-wrap")
+	if !ok {
+		t.Fatal("wrap container not found")
+	}
+	if wrap.Shape.Width > winWidth {
+		t.Errorf("wrap width: got %f, want <= %d", wrap.Shape.Width, winWidth)
+	}
+
+	right := float32(winWidth)
+	var checked int
+	for i := range cardCount {
+		card, found := root.FindByID("cards-wrap:card-" + itoa(i))
+		if !found {
+			continue // wrap may drop cards below the fold; check what exists
+		}
+		checked++
+		if edge := card.Shape.X + card.Shape.Width; edge > right+f32Tolerance {
+			t.Fatalf("card %d right edge %f exceeds window edge %f",
+				i, edge, right)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no cards resolved; test is not exercising the layout")
+	}
+}
+
+// TestWrapFitWidthRotatedAncestorUnconstrained pins the rotation stop in
+// constrainFitContainerWidth: a rotated ancestor's dimensions are swapped by
+// a later pass, so the walk must not constrain against them — the wrap keeps
+// its single-row sum.
+func TestWrapFitWidthRotatedAncestorUnconstrained(t *testing.T) {
+	const (
+		rootWidth = 200
+		childW    = 30
+		spacing   = 5
+		childN    = 20 // sum 20*30 + 19*5 = 695 > rootWidth
+	)
+
+	children := make([]Layout, childN)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childW, Height: 10, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisLeftToRight, Width: rootWidth, Height: 100,
+			Sizing: FixedFixed, QuarterTurns: 1, shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+				Spacing: spacing, shapeType: shapeRectangle,
+			},
+			Children: children,
+		}},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	wrap := &root.Children[0]
+	if !f32AreClose(wrap.Shape.Width, 695) {
+		t.Errorf("wrap width: got %f, want 695 (unconstrained)", wrap.Shape.Width)
+	}
+	if wrap.Shape.Axis != axisLeftToRight {
+		t.Error("axis should stay LTR with a rotated ancestor")
+	}
+	if len(wrap.Children) != childN {
+		t.Errorf("children: got %d, want %d", len(wrap.Children), childN)
+	}
+}
+
+// TestWrapFitWidthAncestorPadding exercises the debts path of
+// constrainFitContainerWidth: padding on a Fit ancestor and on the definite
+// root both reduce the wrap's available width.
+func TestWrapFitWidthAncestorPadding(t *testing.T) {
+	const (
+		rootWidth  = 300
+		rootPad    = 20 // 10 per side
+		childWidth = 80
+		spacing    = 5
+		childCount = 4 // sum 4*80 + 3*5 = 335 > 300-20
+	)
+
+	children := make([]Layout, childCount)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childWidth, Height: 20, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisTopToBottom, Width: rootWidth, Height: 400,
+			Sizing: FixedFixed, Padding: NewPadding(10, 10, 10, 10),
+			shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				Axis: axisTopToBottom, Sizing: FitFit,
+				Padding: NewPadding(5, 5, 5, 5), shapeType: shapeRectangle,
+			},
+			Children: []Layout{{
+				Shape: &Shape{
+					Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+					Spacing: spacing, shapeType: shapeRectangle,
+				},
+				Children: children,
+			}},
+		}},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	col := &root.Children[0]
+	wrap := &col.Children[0]
+	// available = 300 - root padding (20) - col padding (10) = 270.
+	if !f32AreClose(wrap.Shape.Width, 270) {
+		t.Errorf("wrap width: got %f, want 270 (300 - 20 - 10)",
+			wrap.Shape.Width)
+	}
+	if wrap.Shape.Axis != axisTopToBottom {
+		t.Error("wrap axis should flip to TTB")
+	}
+	// 3 per row: 3*80 + 2*5 = 250 fits in 270, 4*80 + 3*5 = 335 does not.
+	if len(wrap.Children) != 2 {
+		t.Errorf("rows: got %d, want 2", len(wrap.Children))
+	}
+	// The Fit column re-fits to the constrained wrap plus its padding.
+	if !f32AreClose(col.Shape.Width, 280) {
+		t.Errorf("column width: got %f, want 280 (wrap 270 + padding 10)",
+			col.Shape.Width)
+	}
+}
+
+// TestWrapFitWidthRefitsContentCache pins the cache refresh in
+// refitFitAncestors and the post-flip re-cache: a Fit chain's contentW values
+// must reflect the constrained width, or scroll offsets, alignment, and
+// scrollbar thumbs would read the pre-constraint single-row sum.
+func TestWrapFitWidthRefitsContentCache(t *testing.T) {
+	const (
+		rootWidth  = 300
+		childWidth = 80
+		spacing    = 5
+		childCount = 4 // sum 335 > 300
+	)
+
+	children := make([]Layout, childCount)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childWidth, Height: 20, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisTopToBottom, Width: rootWidth, Height: 400,
+			Sizing: FixedFixed, shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				Axis: axisTopToBottom, Sizing: FitFit, shapeType: shapeRectangle,
+			},
+			Children: []Layout{{
+				Shape: &Shape{
+					Axis: axisLeftToRight, Wrap: true, Sizing: FitFit,
+					Spacing: spacing, shapeType: shapeRectangle,
+				},
+				Children: children,
+			}},
+		}},
+	}
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, &Window{})
+
+	col := &root.Children[0]
+	wrap := &col.Children[0]
+	// Pre-refit both caches held the 335 single-row sum; the wrap is a TTB
+	// column of rows and the column fits from the constrained wrap width.
+	if !f32AreClose(wrap.Shape.contentW, rootWidth) {
+		t.Errorf("wrap contentW: got %f, want %d (wrapped extent)",
+			wrap.Shape.contentW, rootWidth)
+	}
+	if !f32AreClose(col.Shape.contentW, rootWidth) {
+		t.Errorf("column contentW: got %f, want %d (refitted)",
+			col.Shape.contentW, rootWidth)
+	}
+}

--- a/gui/testdata/wrap_fit.dark.golden
+++ b/gui/testdata/wrap_fit.dark.golden
@@ -1,0 +1,12 @@
+Rect xy=23.00,23.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=107.00,23.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=191.00,23.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=23.00,67.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=107.00,67.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=191.00,67.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=23.00,111.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=107.00,111.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=191.00,111.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=23.00,155.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=107.00,155.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=191.00,155.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill

--- a/gui/testdata/wrap_fit.light.golden
+++ b/gui/testdata/wrap_fit.light.golden
@@ -1,0 +1,12 @@
+Rect xy=20.00,20.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=104.00,20.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=188.00,20.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=20.00,64.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=104.00,64.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=188.00,64.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=20.00,108.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=104.00,108.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=188.00,108.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=20.00,152.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=104.00,152.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill
+Rect xy=188.00,152.00 wh=80.00,40.00 color=#b4bec8ff radius=5.50 fill

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -474,6 +474,14 @@ func Row(cfg ContainerCfg) View {
 
 // Wrap arranges content left to right, flowing to the next
 // line when container width is exceeded.
+//
+// Fit width on a Wrap resolves as fit-content (issue #379): the container
+// takes min(single-row sum, its nearest definite-width ancestor's
+// available), so it wraps within its parent instead of rendering one
+// unwrapped row wider than it. A Fit chain with no definite ancestor — no
+// Fixed/Fill width anywhere above — has no width to wrap within and keeps
+// the single-row sum (a Row). Prefer Fill width when the wrap should fill
+// the parent regardless.
 func Wrap(cfg ContainerCfg) View {
 	cfg.axis = axisLeftToRight
 	cfg.Wrap = true


### PR DESCRIPTION
Fixes #379. A `Wrap` (or `Overflow`) container with Fit width resolved to its own single-row content sum, so the row-break/hide test measured against a width that always fit and never fired — the container rendered one unwrapped row wider than its parent.

## Design (the issue's "resolve the fit width after the parent's width is known" option)

Fit width on a Wrap/Overflow now resolves as **fit-content**: `min(single-row sum, nearest definite-width ancestor's available)`, floored at `MinWidth` (the issue #378 floor).

- `constrainFitContainerWidth` walks the ancestor chain; a node is *definite* when its width doesn't derive from this container (Fixed at generation, Fill resolved by the fill pass, or axisNone — Canvas/Splitter roots).
- A Fit-width ancestor is self-derived and contributes only its padding plus, for a row, its other children's widths (debts accumulation).
- The walk stops unconstrained at a nil parent — an all-Fit chain has no width to wrap within and keeps the single-row sum, behaving as a `Row` (documented in `Wrap`'s doc comment and `docs/dx-cheat-sheet.md`) — and at rotated ancestors, whose dimensions a later pass swaps.
- `refitFitAncestors` re-fits the Fit chain (as rotation does) and refreshes the fill-pass `contentW` caches so scroll offsets/alignment read the wrapped extent, not the pre-constraint sum.

## Tests

- Constrained by Fixed column parent, unconstrained all-Fit single row, Fit chain through a column (ancestor re-fit), sibling width consumption in a definite row, MinWidth floor (one child per row), rotated-ancestor stop, padding debts, contentW cache refresh, end-to-end scrollable wrap in a real window.
- Overflow half: Fit overflow container now constrains and hides children that don't fit.
- Golden case `wrap_fit` (both themes) records the wrapped rows at window width.

The cache-refresh test caught a real bug during development: the wrap's `contentW` was re-cached before the row children swap, so scroll reads saw the flat-child max instead of the wrapped extent.