### PR TITLE
fix(gui): wrap wins over overflow on a container setting both (issue #380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to
 
 ### Fixed
 
+- **`Wrap` + `Overflow` on one container hid children that fit** (issue
+  #380). The two flags express contradictory strategies for the same
+  condition — `Wrap` breaks content onto a new row, `Overflow` hides the
+  tail behind a trigger — and nothing arbitrated between them. When a wrap
+  container's content fit a single row, `layoutWrapContainers` kept its
+  left-to-right axis and `layoutOverflow` then hid a child anyway, because
+  it reserves room for a trigger button that a wrap never has. `Wrap` now
+  wins: `layoutOverflow` skips any container with `Wrap` set, and the new
+  `DebugWrapOverflow` category (part of `DebugAll`) reports the combination
+  once per window. Scrollable containers were already unaffected.
+
 - **`Wrap` stopped wrapping once the child count grew past the window width**
   (issue #378). `layoutWidths` seeded a container's min-width floor with the
   full single-row inter-child gap sum, which is right for a plain `Row` but

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,7 @@ in the environment, walks the composed tree every frame from
 - scrollable shape with no `ID` (shares one offset with every other)
 - `OnMouseLeave` with no `ID` (callback never fires)
 - a scrollable listbox that resolved to height 0
+- a container setting both `Wrap` and `Overflow` (wrap wins; issue #380)
 - a callback that acted without `ctx.Consume()` while an ancestor also handles
 
 Findings are warn-once per window, so a real defect does not scroll past at

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -79,6 +79,11 @@ const (
 	// evenly spaced stops on GPU backends.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugGradientResampled
+	// DebugWrapOverflow reports a container that sets both Wrap and
+	// Overflow: the two are contradictory strategies for the same
+	// condition, wrap wins, and overflow is ignored.
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugWrapOverflow
 
 	// DebugUnscopedIDs reports a focusable or scrollable shape whose ID
 	// resolves to itself — no ID-bearing ancestor above it — so its
@@ -97,7 +102,7 @@ const (
 	// would fire on most widgets in a small app.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
-		DebugListBoxNoHeight | DebugGradientResampled
+		DebugListBoxNoHeight | DebugGradientResampled | DebugWrapOverflow
 )
 
 func init() {
@@ -133,6 +138,8 @@ func envTruthy(name string) bool {
 //     off, every row builds each frame)
 //   - a fill gradient with more stops than the GPU shader uniform limit
 //     (silently resampled to evenly spaced stops on GPU backends)
+//   - a container that sets both Wrap and Overflow (wrap wins, overflow
+//     is ignored)
 //
 // It also reports, from dispatch rather than from the frame audit, any
 // consume-class callback that relies on automatic handling while an
@@ -222,6 +229,9 @@ const (
 	// pass when a fill gradient has more stops than the shader uniform
 	// layout can carry.
 	debugCheckGradientResampled
+	// debugCheckWrapOverflow fires from layoutOverflow when a container
+	// sets both Wrap and Overflow; wrap wins and overflow is ignored.
+	debugCheckWrapOverflow
 )
 
 // checkCategory maps an internal check to the public category that
@@ -242,6 +252,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugUnscopedIDs
 	case debugCheckGradientResampled:
 		return DebugGradientResampled
+	case debugCheckWrapOverflow:
+		return DebugWrapOverflow
 	}
 	return 0
 }

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -255,6 +255,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckListBoxNoHeight, DebugListBoxNoHeight},
 		{debugCheckUnscopedID, DebugUnscopedIDs},
 		{debugCheckGradientResampled, DebugGradientResampled},
+		{debugCheckWrapOverflow, DebugWrapOverflow},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
@@ -264,7 +265,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 	// DebugAll covers every category Debug(true) turns on.
 	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
 	// a design property, not a defect.
-	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled {
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow {
 		t.Fatal("DebugAll must cover every category Debug(true) enables")
 	}
 	if DebugAll&DebugUnscopedIDs != 0 {
@@ -649,5 +650,89 @@ func TestDebugAllExcludesUnscopedIDs(t *testing.T) {
 	w.debugAudit(&tree)
 	if got := buf.String(); strings.Contains(got, "no ID-bearing ancestor") {
 		t.Fatalf("Debug(true) reported the advisory: %q", got)
+	}
+}
+
+// TestWrapOverflowWarning reports the issue #380 combination: a container
+// that sets both Wrap and Overflow gets a warn-once note naming it, once
+// per window. Both axes report — a wrap that broke rows flips to TTB, and
+// the finding is about the flags, not whether the content happened to fit.
+func TestWrapOverflowWarning(t *testing.T) {
+	buf := captureDebugMask(t, DebugWrapOverflow)
+	w := NewWindow(WindowCfg{})
+	defer w.Close()
+
+	report := func(layout *Layout) string {
+		layoutOverflow(layout, w)
+		return buf.String()
+	}
+
+	// Single row: axis stays LTR after the wrap pass.
+	singleRow := &Layout{
+		Shape: &Shape{
+			ID:       "wo-warn",
+			Overflow: true,
+			Wrap:     true,
+			Axis:     axisLeftToRight,
+		},
+		Children: []Layout{
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+		},
+	}
+	got := report(singleRow)
+	if !strings.Contains(got, `"wo-warn"`) ||
+		!strings.Contains(got, "sets both Wrap and Overflow") {
+		t.Fatalf("want the wrap+overflow finding, got %q", got)
+	}
+
+	// Multi row: the wrap pass flipped the axis to TTB; still reported.
+	wrapped := &Layout{
+		Shape: &Shape{
+			ID:       "wo-wrapped",
+			Overflow: true,
+			Wrap:     true,
+			Axis:     axisTopToBottom,
+		},
+		Children: []Layout{
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+		},
+	}
+	got = report(wrapped)
+	if !strings.Contains(got, `"wo-wrapped"`) {
+		t.Fatalf("want the finding for a wrapped (TTB) container, got %q", got)
+	}
+
+	// Warn-once: later passes do not repeat a finding.
+	report(singleRow)
+	report(wrapped)
+	if got := buf.String(); strings.Count(got, "sets both Wrap and Overflow") != 2 {
+		t.Fatalf("warning repeated: %q", got)
+	}
+}
+
+// The wrap+overflow warning is its own category: a mask without it must
+// stay silent at the site.
+func TestWrapOverflowGatedByCategory(t *testing.T) {
+	buf := captureDebugMask(t, DebugMissingIDs)
+	w := NewWindow(WindowCfg{})
+	defer w.Close()
+	layout := &Layout{
+		Shape: &Shape{
+			ID:       "wo-silent",
+			Overflow: true,
+			Wrap:     true,
+			Axis:     axisLeftToRight,
+		},
+		Children: []Layout{
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+		},
+	}
+
+	layoutOverflow(layout, w)
+	if got := buf.String(); got != "" {
+		t.Fatalf("mask without DebugWrapOverflow reported %q", got)
 	}
 }

--- a/gui/layout_overflow.go
+++ b/gui/layout_overflow.go
@@ -6,7 +6,33 @@ func layoutOverflow(layout *Layout, w *Window) {
 		layoutOverflow(&layout.Children[i], w)
 	}
 
-	if !layout.Shape.Overflow || layout.Shape.Axis != axisLeftToRight {
+	if !layout.Shape.Overflow {
+		return
+	}
+
+	// Wrap and Overflow are contradictory strategies for the same
+	// condition — wrap breaks content onto a new row, overflow hides the
+	// tail behind a trigger — and wrap wins (issue #380). Without the
+	// gate, a wrap whose content fits one row keeps its LTR axis and
+	// layoutOverflow hides a child even when everything fits, because it
+	// reserves room for the trigger button.
+	//
+	// Checked before the axis bail so the note fires for any wrap+overflow
+	// container: a wrap that broke rows flips to a TTB axis, and the
+	// report must not depend on whether the content happened to fit. The
+	// mask guard keeps the off-state cost at one atomic load, matching
+	// debugUnconsumed.
+	if layout.Shape.Wrap {
+		if DebugCategory(debugMask.Load())&DebugWrapOverflow != 0 {
+			key := layout.Shape.idKey()
+			w.debugWarn(debugCheckWrapOverflow, key,
+				"container %q sets both Wrap and Overflow; Overflow is "+
+					"ignored (issue #380)", key)
+		}
+		return
+	}
+
+	if layout.Shape.Axis != axisLeftToRight {
 		return
 	}
 

--- a/gui/layout_overflow_test.go
+++ b/gui/layout_overflow_test.go
@@ -106,6 +106,34 @@ func TestLayoutOverflowSkipsScrollContainer(t *testing.T) {
 	}
 }
 
+// TestLayoutOverflowSkipsWrapContainer pins issue #380: Wrap and Overflow
+// are contradictory strategies for the same condition and wrap wins, so
+// layoutOverflow must not hide a child of a Wrap container — not even in
+// the single-row case where the axis stayed LTR and the trigger-room check
+// would hide one despite the slack.
+func TestLayoutOverflowSkipsWrapContainer(t *testing.T) {
+	w := NewWindow(WindowCfg{})
+	defer w.Close()
+	layout := &Layout{
+		Shape: &Shape{
+			Overflow: true,
+			Wrap:     true,
+			Axis:     axisLeftToRight,
+			Width:    100,
+		},
+		Children: []Layout{
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+		},
+	}
+	layoutOverflow(layout, w)
+	for i, c := range layout.Children {
+		if c.Shape.shapeType == shapeNone {
+			t.Errorf("child %d should not be hidden on a Wrap container", i)
+		}
+	}
+}
+
 func TestLayoutOverflowHidesExcessChildren(t *testing.T) {
 	w := NewWindow(WindowCfg{})
 	defer w.Close()
@@ -176,6 +204,64 @@ func TestLayoutOverflowAllFit(t *testing.T) {
 	// When all fit, trigger gets hidden.
 	if layout.Children[2].Shape.shapeType != shapeNone {
 		t.Error("trigger should be hidden when all children fit")
+	}
+}
+
+// TestWrapOverflowSingleRowKeepsChildren is issue #380 end to end: a
+// FillFit wrap+overflow container whose content fits one row used to keep
+// its LTR axis, after which layoutOverflow hid a child anyway (it reserves
+// room for the trigger button). With wrap winning, every child stays
+// visible and the overflow map never records the container.
+func TestWrapOverflowSingleRowKeepsChildren(t *testing.T) {
+	const (
+		parentWidth = 700
+		childWidth  = 100
+		spacing     = 10
+		childCount  = 6 // 6*100 + 5*10 = 650 < 700, comfortably one row
+	)
+
+	children := make([]Layout, childCount)
+	for i := range children {
+		children[i] = Layout{Shape: &Shape{
+			Width: childWidth, Height: 20, shapeType: shapeRectangle,
+		}}
+	}
+
+	root := &Layout{
+		Shape: &Shape{
+			Axis: axisTopToBottom, Width: parentWidth, Height: 200,
+			Sizing: FixedFixed, shapeType: shapeRectangle,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				ID: "wo", Overflow: true, Wrap: true,
+				Axis: axisLeftToRight, Sizing: FillFit,
+				Spacing: spacing, shapeType: shapeRectangle,
+			},
+			Children: children,
+		}},
+	}
+
+	w := NewWindow(WindowCfg{})
+	defer w.Close()
+
+	layoutParents(root, nil)
+	layoutWidths(root)
+	layoutFillWidths(root, &scratchPools{})
+	layoutWrapContainers(root, w)
+	layoutOverflow(root, w)
+
+	wo := &root.Children[0]
+	if wo.Shape.Axis != axisLeftToRight {
+		t.Error("single-row wrap should keep its LTR axis")
+	}
+	for i := range wo.Children {
+		if wo.Children[i].Shape.shapeType == shapeNone {
+			t.Errorf("child %d should not be hidden", i)
+		}
+	}
+	if _, ok := w.overflow().Get("wo"); ok {
+		t.Error("overflow map must not record a wrap container")
 	}
 }
 

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -482,6 +482,10 @@ func Row(cfg ContainerCfg) View {
 // Fixed/Fill width anywhere above — has no width to wrap within and keeps
 // the single-row sum (a Row). Prefer Fill width when the wrap should fill
 // the parent regardless.
+//
+// Setting Overflow on the same container is ignored: the two express
+// contradictory strategies for the same condition and wrap wins (issue
+// #380). gui.Debug reports the combination.
 func Wrap(cfg ContainerCfg) View {
 	cfg.axis = axisLeftToRight
 	cfg.Wrap = true


### PR DESCRIPTION
## What

`Wrap` + `Overflow` on the same non-scrollable container hid children that fit. The two flags express contradictory strategies for the same condition — `Wrap` breaks content onto a new row, `Overflow` hides the tail behind a trigger — and nothing arbitrated between them.

**Cause:** `layoutWrapContainers` keeps the axis `axisLeftToRight` when content fits one row; `layoutOverflow` then accepts the container and hides its tail — even a child that fits, because it reserves room for a trigger button a wrap never has (`needed+spacing+triggerW > available`).

**Fix:** `Wrap` wins. `layoutOverflow` now skips any container with `Shape.Wrap` set, and the new `DebugWrapOverflow` category (folded into `DebugAll`) reports the combination once per window. The check runs before the axis bail, so a wrap that broke rows (TTB, the issue #378 setup) is reported too, and the report never depends on whether content happened to fit.

## Changes

- `gui/layout_overflow.go` — wrap bail + warn-once debug note (mask-guarded, one atomic load when Debug is off)
- `gui/debug.go` — new exported `DebugWrapOverflow` category, `debugCheckWrapOverflow` check, `checkCategory` mapping, `DebugAll` membership, doc bullet
- Tests: skip behavior, issue repro end-to-end (6×100+5×10=650 in 700, all children visible, overflow map untouched), warn-once + gating + TTB/LTR both reported, `checkCategory` mapping
- Docs: `Wrap` factory comment, CHANGELOG, CLAUDE.md findings list

## Verification

`make prepush` green; `go test ./...` (98 packages), `golangci-lint run ./...` clean, `make export-audit` surface clean.

Closes #380