### PR TITLE
changelog: add v0.63.0 (platform themes, wrap/overflow fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.63.0] - 2026-08-19
 
 ### Added
 


### PR DESCRIPTION
Release v0.63.0: 8 commits since v0.62.0 — GNOME/Windows theme presets, paired text colors over select fills, macOS elevation/focus ring, wrap/overflow fixes, Cfg field restorations, showcase CSP. No glyph bump required (already on v1.23.0).