### PR TITLE
chore(ci): bump golangci-lint to 2.13.1 for Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12
+          version: v2.13
 
       # The step above analyses the GOOS=linux build only, so every
       # //go:build windows file (27 of them: gl/, sni/, filedialog/,
@@ -156,7 +156,7 @@ jobs:
         env:
           GOOS: windows
         with:
-          version: v2.12
+          version: v2.13
 
       # Same blind spot as windows above, for the browser build: every
       # //go:build js file (the gui/backend/web backend) was unlinted
@@ -168,7 +168,7 @@ jobs:
           GOOS: js
           GOARCH: wasm
         with:
-          version: v2.12
+          version: v2.13
 
       # The darwin build analyses from this runner with cgo disabled
       # (automatic for cross-compilation), which covers the cgo-free
@@ -179,7 +179,7 @@ jobs:
         env:
           GOOS: darwin
         with:
-          version: v2.12
+          version: v2.13
 
       - name: Required-ID check
         run: go run ./tools/requiredid/cmd/requiredid ./...
@@ -291,7 +291,7 @@ jobs:
           CGO_CFLAGS: -isysroot ${{ env.IOS_SDK }} -arch arm64 -miphoneos-version-min=15.0
           CGO_LDFLAGS: -isysroot ${{ env.IOS_SDK }} -arch arm64 -miphoneos-version-min=15.0
         with:
-          version: v2.12
+          version: v2.13
           args: --build-tags ios ./...
 
   wasm:
@@ -423,7 +423,7 @@ jobs:
           GOARCH: arm64
           CC: ${{ env.NDK_CC }}
         with:
-          version: v2.12
+          version: v2.13
 
   benchmark:
     name: Benchmarks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,3 +78,16 @@ linters:
           - revive
       - path: gui/backend/(gl|metal|ios|android)/
         text: "unkeyed fields"
+      # SA4023 fires only under GOOS=js. os/exec is stubbed on wasm, so
+      # exec.LookPath always returns a non-nil error and staticcheck reads
+      # every `err != nil` guard around it as constant. process_monitor is
+      # the same shape one level up: its collect_other.go fallback always
+      # errors, so Collect's guard reads as constant too. Both guards are
+      # correct on the targets the code actually builds for -- buildapp is
+      # a macOS-only .app bundler -- and neither program is reachable from
+      # a wasm build. Surfaced by golangci-lint 2.13.1; 2.12 did not infer
+      # across the call.
+      - path: cmd/buildapp/
+        text: SA4023
+      - path: examples/process_monitor/
+        text: SA4023

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS  = -X github.com/go-gui-org/go-gui/gui.Version=$(VERSION) \
            -X github.com/go-gui-org/go-gui/gui.Commit=$(COMMIT)
 
-LINT_VERSION = v2.12.2
+LINT_VERSION = v2.13.1
 
 .PHONY: build-linux build-windows build-macos build-wasm build-ios build-android build-examples release clean test test-race vet lint lint-pin lint-cross cross-compile coverage-gate prepush check bench bench-gate deps-doc deps-doc-check security gosec govulncheck large-files deadcode generate-check tidy-check workflow-audit cov-report license-check ergonomics-audit ergonomics-audit-fix ergonomics-audit-fix-dry
 


### PR DESCRIPTION
Every job that runs golangci-lint is failing on main and on every open
branch:

  panic: file requires newer Go version go1.27 (application built with go1.26)
    go/types.(*Checker).handleBailout
    golangci-lint/v2/pkg/goanalysis.(*loadingPackage).convertError

setup-go resolves `go-version: stable` to go1.27.0, which landed between
the last green run on main (2026-08-19 23:25Z) and the first red one
(2026-08-20 15:00Z). The pinned golangci-lint 2.12.2 binary is built with
go1.26 and panics rather than reporting an error when go/types meets a
go1.27 stdlib source file. Nothing in the tree changed; the toolchain
moved underneath the pin.

Bumps LINT_VERSION to v2.13.1 and the six golangci-lint-action sites to
the v2.13 track, keeping the existing split where the Makefile pins exact
and the workflow follows the minor. The released v2.13.1 binary is built
with go1.27.0 (verified with `go version` on the release asset), so it
type-checks the new stdlib instead of bailing out.

2.13.1 also teaches staticcheck to infer SA4023 across a call, which
surfaces four findings under GOOS=js only: os/exec is stubbed on wasm, so
exec.LookPath always returns a non-nil error and every `err != nil` guard
around it reads as constant. cmd/buildapp is a macOS-only .app bundler and
examples/process_monitor falls back to a collect_other.go that always
errors -- both guards are correct on the targets they build for, and
neither program is reachable from a wasm build. Excluded by path in
.golangci.yml with the reasoning recorded there.

Verified: native, GOOS=windows, GOOS=darwin and GOOS=js/wasm lint clean at
2.13.1; `make prepush` exits 0. GOOS=android and GOOS=ios cannot be linted
locally (they need an NDK and an iphoneos sysroot) and are left to CI --
note that `make lint-cross` covers windows, js and darwin only, so those
two targets have no local gate at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
