### PR TITLE
fix(gui): a row's stated MinWidth is border-box, like a column's (issue #385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Visual refresh phase 1 (`docs/specs/visual-refresh.md`, sections 1 and 1b).
 - **An unsized labelled field is now 160px wide, not the width of its content.**
   Behaviour change for any app relying on a labelled `Input`, `Select`,
   `Combobox`, `NumericInput` or `InputDate` shrink-wrapping its text.
+- **A `Row`'s stated `MinWidth` is now border-box** (issue #385). `layoutWidths`
+  added the row's padding and inter-child gap sum on top of the caller's
+  `MinWidth` on a row but not on a column, so `Select` and `Combobox` (rows of
+  three children) arranged at 193px under the 160 field floor while an `Input`
+  beside them arranged at exactly 160. A row now takes a stated `MinWidth` as
+  the whole width budget — matching the column branch and `MaxWidth` — and
+  arranges narrower by its padding and spacing than before. Behaviour change for
+  any app calling `Row(ContainerCfg{MinWidth: X})`.
 
 ### Fixed
 

--- a/gui/layout_sizing.go
+++ b/gui/layout_sizing.go
@@ -386,11 +386,12 @@ func layoutWidths(layout *Layout) {
 					minWidths += layout.Children[i].Shape.MinWidth
 				}
 			}
-			if !wrapOrOverflow {
-				layout.Shape.MinWidth = f32Max(minWidths, layout.Shape.MinWidth+padding+sp)
-			} else {
-				layout.Shape.MinWidth = f32Max(minWidths, layout.Shape.MinWidth)
-			}
+			// A stated MinWidth is border-box: it counts the caller's
+			// whole width budget, padding and spacing included (matches
+			// the column branch and MaxWidth below). Padding it here made
+			// a Row and a Column state the same minimum and arrange at
+			// different widths (issue #385).
+			layout.Shape.MinWidth = f32Max(minWidths, layout.Shape.MinWidth)
 			layout.Shape.Width += padding + sp
 			if layout.Shape.MaxWidth > 0 {
 				layout.Shape.Width = f32Min(layout.Shape.MaxWidth, layout.Shape.Width)

--- a/gui/layout_sizing_test.go
+++ b/gui/layout_sizing_test.go
@@ -251,6 +251,69 @@ func TestLayoutWidthsMinWidthFloor(t *testing.T) {
 	}
 }
 
+// TestRowAndColumnMinWidthAgree guards issue #385: layoutWidths used to pad a
+// row's stated MinWidth with its padding and inter-child gap sum (content-box)
+// while the column branch read the same field as border-box, so a Row and a
+// Column with identical padding, spacing and stated MinWidth arranged at
+// different widths. A stated MinWidth is the caller's whole width budget —
+// border-box, like MaxWidth — on both axes.
+func TestRowAndColumnMinWidthAgree(t *testing.T) {
+	// minWidthBox builds a PadAll(5)/Spacing 10 box with two 40px children;
+	// childMin is the MinWidth each child carries, 0 for none.
+	minWidthBox := func(axis Axis, stated, childMin float32) *Layout {
+		return &Layout{
+			Shape: &Shape{
+				Axis:      axis,
+				MinWidth:  stated,
+				Padding:   PadAll(5),
+				Spacing:   10,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{Width: 40, MinWidth: childMin, Height: 20, shapeType: shapeRectangle}},
+				{Shape: &Shape{Width: 40, MinWidth: childMin, Height: 20, shapeType: shapeRectangle}},
+			},
+		}
+	}
+
+	row := minWidthBox(axisLeftToRight, 160, 0)
+	col := minWidthBox(axisTopToBottom, 160, 0)
+	layoutWidths(row)
+	layoutWidths(col)
+
+	if !f32AreClose(row.Shape.MinWidth, 160) {
+		t.Errorf("row MinWidth: got %f, want 160 (border-box, padding and "+
+			"spacing not added on top)", row.Shape.MinWidth)
+	}
+	if !f32AreClose(row.Shape.Width, 160) {
+		t.Errorf("row width: got %f, want 160", row.Shape.Width)
+	}
+	if !f32AreClose(col.Shape.MinWidth, 160) {
+		t.Errorf("col MinWidth: got %f, want 160", col.Shape.MinWidth)
+	}
+	if !f32AreClose(col.Shape.Width, 160) {
+		t.Errorf("col width: got %f, want 160", col.Shape.Width)
+	}
+
+	// The child-min floor still wins over a smaller stated MinWidth. The
+	// row sums its children plus gaps (5+5 padding + 10 spacing + 200);
+	// the column is cross-axis, so it takes the widest child plus padding
+	// (110). The defect is the stated-MinWidth reading, not the content
+	// floor, so both must exceed their stated 100.
+	row = minWidthBox(axisLeftToRight, 100, 100)
+	col = minWidthBox(axisTopToBottom, 100, 100)
+	layoutWidths(row)
+	layoutWidths(col)
+	if !f32AreClose(row.Shape.Width, 220) {
+		t.Errorf("row width with child mins: got %f, want 220",
+			row.Shape.Width)
+	}
+	if !f32AreClose(col.Shape.Width, 110) {
+		t.Errorf("col width with child mins: got %f, want 110 (widest child "+
+			"+ padding)", col.Shape.Width)
+	}
+}
+
 func TestLayoutHeightsMinHeightFloor(t *testing.T) {
 	root := &Layout{
 		Shape: &Shape{

--- a/gui/testdata/combobox.dark.golden
+++ b/gui/testdata/combobox.dark.golden
@@ -1,4 +1,4 @@
-Rect xy=11.50,11.50 wh=193.00,31.40 color=#4a4a4aff radius=5.50 fill
-StrokeRect xy=11.50,11.50 wh=193.00,31.40 color=#646464ff radius=5.50 thickness=1.50
+Rect xy=11.50,11.50 wh=160.00,31.40 color=#4a4a4aff radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=160.00,31.40 color=#646464ff radius=5.50 thickness=1.50
 Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e1ff text="alpha" size=16.00
-Text xy=190.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60
+Text xy=157.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60

--- a/gui/testdata/combobox.light.golden
+++ b/gui/testdata/combobox.light.golden
@@ -1,3 +1,3 @@
-Rect xy=10.00,10.00 wh=190.00,28.40 color=#c3c3d7ff radius=5.50 fill
+Rect xy=10.00,10.00 wh=160.00,28.40 color=#c3c3d7ff radius=5.50 fill
 Text xy=15.00,13.00 wh=0.00,0.00 color=#202020ff text="alpha" size=16.00
-Text xy=189.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60
+Text xy=159.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60

--- a/gui/testdata/combobox_disabled.dark.golden
+++ b/gui/testdata/combobox_disabled.dark.golden
@@ -1,4 +1,4 @@
-Rect xy=11.50,11.50 wh=193.00,31.40 color=#4a4a4a7f radius=5.50 fill
-StrokeRect xy=11.50,11.50 wh=193.00,31.40 color=#6464647f radius=5.50 thickness=1.50
+Rect xy=11.50,11.50 wh=160.00,31.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=160.00,31.40 color=#6464647f radius=5.50 thickness=1.50
 Text xy=18.00,16.00 wh=0.00,0.00 color=#e1e1e180 text="alpha" size=16.00
-Text xy=190.74,21.44 wh=0.00,0.00 color=#e1e1e180 text="▼" size=9.60
+Text xy=157.74,21.44 wh=0.00,0.00 color=#e1e1e180 text="▼" size=9.60

--- a/gui/testdata/combobox_disabled.light.golden
+++ b/gui/testdata/combobox_disabled.light.golden
@@ -1,3 +1,3 @@
-Rect xy=10.00,10.00 wh=190.00,28.40 color=#c3c3d77f radius=5.50 fill
+Rect xy=10.00,10.00 wh=160.00,28.40 color=#c3c3d77f radius=5.50 fill
 Text xy=15.00,13.00 wh=0.00,0.00 color=#20202095 text="alpha" size=16.00
-Text xy=189.24,18.44 wh=0.00,0.00 color=#20202095 text="▼" size=9.60
+Text xy=159.24,18.44 wh=0.00,0.00 color=#20202095 text="▼" size=9.60

--- a/gui/testdata/select.dark.golden
+++ b/gui/testdata/select.dark.golden
@@ -1,4 +1,4 @@
-Rect xy=11.50,11.50 wh=193.00,31.40 color=#4a4a4aff radius=5.50 fill
-StrokeRect xy=11.50,11.50 wh=193.00,31.40 color=#646464ff radius=5.50 thickness=1.50
+Rect xy=11.50,11.50 wh=160.00,31.40 color=#4a4a4aff radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=160.00,31.40 color=#646464ff radius=5.50 thickness=1.50
 Text xy=18.00,17.42 wh=0.00,0.00 color=#e1e1e1ff text="beta" size=16.00
-Text xy=190.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60
+Text xy=157.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60

--- a/gui/testdata/select.light.golden
+++ b/gui/testdata/select.light.golden
@@ -1,3 +1,3 @@
-Rect xy=10.00,10.00 wh=190.00,28.40 color=#c3c3d7ff radius=5.50 fill
+Rect xy=10.00,10.00 wh=160.00,28.40 color=#c3c3d7ff radius=5.50 fill
 Text xy=15.00,14.42 wh=0.00,0.00 color=#202020ff text="beta" size=16.00
-Text xy=189.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60
+Text xy=159.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60

--- a/gui/testdata/select_disabled.dark.golden
+++ b/gui/testdata/select_disabled.dark.golden
@@ -1,4 +1,4 @@
-Rect xy=11.50,11.50 wh=193.00,31.40 color=#4a4a4a7f radius=5.50 fill
-StrokeRect xy=11.50,11.50 wh=193.00,31.40 color=#6464647f radius=5.50 thickness=1.50
+Rect xy=11.50,11.50 wh=160.00,31.40 color=#4a4a4a7f radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=160.00,31.40 color=#6464647f radius=5.50 thickness=1.50
 Text xy=18.00,17.42 wh=0.00,0.00 color=#e1e1e180 text="beta" size=16.00
-Text xy=190.74,21.44 wh=0.00,0.00 color=#e1e1e180 text="▼" size=9.60
+Text xy=157.74,21.44 wh=0.00,0.00 color=#e1e1e180 text="▼" size=9.60

--- a/gui/testdata/select_disabled.light.golden
+++ b/gui/testdata/select_disabled.light.golden
@@ -1,3 +1,3 @@
-Rect xy=10.00,10.00 wh=190.00,28.40 color=#c3c3d77f radius=5.50 fill
+Rect xy=10.00,10.00 wh=160.00,28.40 color=#c3c3d77f radius=5.50 fill
 Text xy=15.00,14.42 wh=0.00,0.00 color=#20202095 text="beta" size=16.00
-Text xy=189.24,18.44 wh=0.00,0.00 color=#20202095 text="▼" size=9.60
+Text xy=159.24,18.44 wh=0.00,0.00 color=#20202095 text="▼" size=9.60

--- a/gui/testdata/select_focused.dark.golden
+++ b/gui/testdata/select_focused.dark.golden
@@ -1,4 +1,4 @@
-Rect xy=11.50,11.50 wh=193.00,31.40 color=#5e5e5eff radius=5.50 fill
-StrokeRect xy=11.50,11.50 wh=193.00,31.40 color=#4169e1ff radius=5.50 thickness=1.50
+Rect xy=11.50,11.50 wh=160.00,31.40 color=#5e5e5eff radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=160.00,31.40 color=#4169e1ff radius=5.50 thickness=1.50
 Text xy=18.00,17.42 wh=0.00,0.00 color=#e1e1e1ff text="beta" size=16.00
-Text xy=190.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60
+Text xy=157.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60

--- a/gui/testdata/select_focused.light.golden
+++ b/gui/testdata/select_focused.light.golden
@@ -1,3 +1,3 @@
-Rect xy=10.00,10.00 wh=190.00,28.40 color=#afafd7ff radius=5.50 fill
+Rect xy=10.00,10.00 wh=160.00,28.40 color=#afafd7ff radius=5.50 fill
 Text xy=15.00,14.42 wh=0.00,0.00 color=#202020ff text="beta" size=16.00
-Text xy=189.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60
+Text xy=159.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60

--- a/gui/testdata/select_labelled.dark.golden
+++ b/gui/testdata/select_labelled.dark.golden
@@ -1,5 +1,5 @@
 Text xy=11.50,11.50 wh=0.00,0.00 color=#e1e1e1b2 text="Variant" size=12.00
-Rect xy=11.50,33.30 wh=193.00,31.40 color=#4a4a4aff radius=5.50 fill
-StrokeRect xy=11.50,33.30 wh=193.00,31.40 color=#646464ff radius=5.50 thickness=1.50
+Rect xy=11.50,33.30 wh=160.00,31.40 color=#4a4a4aff radius=5.50 fill
+StrokeRect xy=11.50,33.30 wh=160.00,31.40 color=#646464ff radius=5.50 thickness=1.50
 Text xy=18.00,39.22 wh=0.00,0.00 color=#e1e1e1ff text="beta" size=16.00
-Text xy=190.74,43.24 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60
+Text xy=157.74,43.24 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60

--- a/gui/testdata/select_labelled.light.golden
+++ b/gui/testdata/select_labelled.light.golden
@@ -1,4 +1,4 @@
 Text xy=10.00,10.00 wh=0.00,0.00 color=#202020ba text="Variant" size=12.00
-Rect xy=10.00,31.80 wh=190.00,28.40 color=#c3c3d7ff radius=5.50 fill
+Rect xy=10.00,31.80 wh=160.00,28.40 color=#c3c3d7ff radius=5.50 fill
 Text xy=15.00,36.22 wh=0.00,0.00 color=#202020ff text="beta" size=16.00
-Text xy=189.24,40.24 wh=0.00,0.00 color=#202020ff text="▼" size=9.60
+Text xy=159.24,40.24 wh=0.00,0.00 color=#202020ff text="▼" size=9.60

--- a/gui/testdata/select_placeholder.dark.golden
+++ b/gui/testdata/select_placeholder.dark.golden
@@ -1,4 +1,4 @@
-Rect xy=11.50,11.50 wh=193.00,31.40 color=#4a4a4aff radius=5.50 fill
-StrokeRect xy=11.50,11.50 wh=193.00,31.40 color=#646464ff radius=5.50 thickness=1.50
+Rect xy=11.50,11.50 wh=160.00,31.40 color=#4a4a4aff radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=160.00,31.40 color=#646464ff radius=5.50 thickness=1.50
 Text xy=18.00,17.42 wh=0.00,0.00 color=#e1e1e164 text="choose one" size=16.00
-Text xy=190.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60
+Text xy=157.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60

--- a/gui/testdata/select_placeholder.light.golden
+++ b/gui/testdata/select_placeholder.light.golden
@@ -1,3 +1,3 @@
-Rect xy=10.00,10.00 wh=190.00,28.40 color=#c3c3d7ff radius=5.50 fill
+Rect xy=10.00,10.00 wh=160.00,28.40 color=#c3c3d7ff radius=5.50 fill
 Text xy=15.00,14.42 wh=0.00,0.00 color=#2020207c text="choose one" size=16.00
-Text xy=189.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60
+Text xy=159.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60

--- a/gui/testdata/select_placeholder_descender.dark.golden
+++ b/gui/testdata/select_placeholder_descender.dark.golden
@@ -1,4 +1,4 @@
-Rect xy=11.50,11.50 wh=193.00,31.40 color=#4a4a4aff radius=5.50 fill
-StrokeRect xy=11.50,11.50 wh=193.00,31.40 color=#646464ff radius=5.50 thickness=1.50
+Rect xy=11.50,11.50 wh=188.76,31.40 color=#4a4a4aff radius=5.50 fill
+StrokeRect xy=11.50,11.50 wh=188.76,31.40 color=#646464ff radius=5.50 thickness=1.50
 Text xy=18.00,17.42 wh=0.00,0.00 color=#e1e1e164 text="pick a language" size=16.00
-Text xy=190.74,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60
+Text xy=186.50,21.44 wh=0.00,0.00 color=#e1e1e1ff text="▼" size=9.60

--- a/gui/testdata/select_placeholder_descender.light.golden
+++ b/gui/testdata/select_placeholder_descender.light.golden
@@ -1,3 +1,3 @@
-Rect xy=10.00,10.00 wh=190.00,28.40 color=#c3c3d7ff radius=5.50 fill
+Rect xy=10.00,10.00 wh=179.76,28.40 color=#c3c3d7ff radius=5.50 fill
 Text xy=15.00,14.42 wh=0.00,0.00 color=#2020207c text="pick a language" size=16.00
-Text xy=189.24,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60
+Text xy=179.00,18.44 wh=0.00,0.00 color=#202020ff text="▼" size=9.60


### PR DESCRIPTION
Fixes #385.

## Problem

`layoutWidths` padded a row's stated `MinWidth` with its padding and
inter-child gap sum (content-box), while the column branch read the same
field as border-box. Two controls with the same declared minimum arranged
at different widths: `Select`/`Combobox` (rows of three children) landed at
193 under the `SizeFieldMinWidth` floor of 160 while an `Input` beside them
landed at exactly 160 — a `Select` and an `Input` in one form row did not
line up.

## Fix

`gui/layout_sizing.go:389-394` — the two branches collapse into one
border-box read:

```go
layout.Shape.MinWidth = f32Max(minWidths, layout.Shape.MinWidth)
```

The wrap/overflow special case added in #378 exists only because the
non-wrap path padded; border-box matches the column branch and `MaxWidth`.
The `minWidths` content floor (children + padding + spacing) is unchanged
and still wins via `f32Max`.

## Tests

- `TestRowAndColumnMinWidthAgree` — a Row and a Column with identical
  `PadAll(5)`/`Spacing 10`/`MinWidth 160` now both arrange at 160; the
  child-min floor still beats a smaller stated minimum on both axes.
- 16 `select*`/`combobox*` goldens re-recorded in both themes — every
  change is the container width 193→160 (or fill-distributed), chevron
  tracking the right edge; no color/inset movement. Diff read before kept.
- `make prepush` green.

## Changelog

Unreleased → Changed: a `Row`'s stated `MinWidth` is now border-box —
behaviour change for any app calling `Row(ContainerCfg{MinWidth: X})`.