### PR TITLE
fix(macos): Option+printable shortcuts reach the app (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS Option+printable shortcuts reach the app** (#393) — `keyDown:` routed
+  every key through `interpretKeyEvents:` and treated any resulting preedit as
+  an input-method claim, so on the US layout Option+I (the circumflex dead key)
+  never arrived as `ModAlt|KeyI`, and the pending accent then composed itself
+  into the next keystroke. A preedit started with no editable text widget
+  focused is now discarded and the key-down delivered. CJK composition and
+  Option+e → é inside a focused input are unchanged.
+- **A key the input method declines mid-composition reaches the widget** (#393)
+  — `keyDown:` claimed every key while a composition was live, so Tab could not
+  leave a field with a dead key pending: the accent committed, `insertTab:` came
+  straight back through `doCommandBySelector:`, and the key was dropped anyway.
+  A declined key is now delivered, held back just long enough for the
+  composition it committed to arrive first, so the text lands in the field being
+  left rather than the one taking focus.
+
+### Changed
+
+- **The platform input method is activated only for editable text widgets**
+  (#393). `IMEStart`/`IMEStop` used to fire on any focus change to any focusable
+  widget; they now follow the focused widget's edit context, decided each frame
+  from the arranged tree (`gui/ime_context.go`,
+  `docs/specs/ime-text-context.md`). This is the contract the backends already
+  documented: Windows keeps the IMM context detached, X11 no longer sends ibus a
+  `FocusIn` for a button, and the web backend no longer moves DOM focus into its
+  hidden `<input>`. A consumer text widget not built on `Input` — one that
+  handles `EventChar` itself and sets no `focusOwner` — no longer composes dead
+  keys; plain characters still arrive.
+
 ## [v0.64.0] - 2026-08-21
 
 Visual refresh (`docs/specs/visual-refresh.md`, phases 1–8): type ladder and

--- a/docs/specs/ime-text-context.md
+++ b/docs/specs/ime-text-context.md
@@ -1,0 +1,116 @@
+# IME activation is a text-edit context, not focus
+
+Issue #393. Status: implemented.
+
+## Problem
+
+`Window.setFocusLocked` called `NativePlatform.IMEStart()` on every focus change
+to any focusable widget — buttons, sliders, listboxes, splitters. The platform
+input method was therefore live whenever anything at all held focus.
+
+On macOS that has a visible cost. `MetalContentView.keyDown:` routes every key
+through `interpretKeyEvents:`, and the old code treated any resulting preedit as
+the input method's claim, so `metalPollEvent` dropped the key-down. On the US
+layout Option+I is the circumflex dead key, so `ModAlt|KeyI` never reached Go
+and the app's Option shortcut did nothing. Worse, the accent stayed pending and
+composed itself into the next keystroke. Option+arrow shortcuts worked only
+because arrows produce no preedit.
+
+The other backends already assumed the narrower contract. `ime_win32.go` says
+outright that "composition only becomes possible once a text widget takes
+focus"; on X11 `IMEStart` is an ibus `FocusIn`; on web it creates a hidden
+`<input>` and moves DOM focus into it.
+
+## Rule
+
+The platform input method is activated only while an **editable text context**
+holds focus: a widget that can commit a composition.
+
+`shapeIsIMEEditTarget` (`gui/ime_context.go`) decides it from the arranged tree,
+using the same discriminators `render_text.go` already uses to decide where a
+preedit is drawn:
+
+- a text shape whose `focusOwner` is set — only input widgets set it
+  (`view_input.go`), so a selection-only focusable `Text` is excluded — and
+  whose `TC.textReadOnly` is false, since a read-only input stays focusable for
+  its caret but can never commit;
+- a focusable term grid, which consumes typed text directly.
+
+`(*Window).syncIMEEditContext` runs from `buildRenderers` and pushes only
+transitions, preserving the issue #156 invariant that re-asserting focus on the
+widget that already holds it does not cycle the input context.
+
+Moving between two text fields does cycle it. `IMEStop` is what cancels a
+composition still live inside the engine — an ibus `FocusOut`, the IMM context
+detach, the web hidden `<input>` being removed — so skipping it would let a
+half-typed word commit into the field that just took focus. The activation is
+therefore keyed on the focused ID as well as on the boolean.
+
+## Why the render pass, not `setFocusLocked`
+
+An ID alone cannot say whether a widget is editable, and `SetFocus` is
+legitimately called from inside a `View` function, where `w.layout` still holds
+the previous frame — a newly created input is not in it yet. The arranged tree
+in `buildRenderers` is the first place the answer exists. Reporting platform
+state from the render pass has precedent: `renderText` reports the caret rect
+through `IMESetRect` the same way.
+
+## macOS dead-key rule
+
+`imeSettleAfterKeyWasComposing:` decides who owns a key, in order:
+
+1. a composition already in flight owns everything, arrows and Return included;
+2. no preedit — the key is the widget's;
+3. a preedit started **with** an edit context focused is real input (a CJK first
+   letter, or the first half of Option+e → é) and the key is claimed;
+4. a preedit started **without** one is an unwanted dead key: it is discarded
+   (`unmarkText`, an empty `METAL_EVENT_IME_COMP` to clear Go's preedit, and
+   `[self.inputContext discardMarkedText]` to drop it inside the input source),
+   and the key-down goes to the app.
+
+Step 4's discard is what keeps a stray accent from composing into the next
+keystroke.
+
+## A key the input source declines
+
+`doCommandBySelector:` is the input source handing a key back: it inspected the
+key, declined it as text input, and returned it as a command for the widget.
+`_imeDeclinedKey` records that, and it outranks a live composition — step 1
+above applies only to keys the input source actually consumed.
+
+Without it, Tab could not leave a field that had a dead key pending. The
+observed callback order for Option+e then Tab is:
+
+```
+insertText: ´              the accent commits
+doCommandBySelector: insertTab:   the key comes back
+```
+
+so `wasComposing` was true and the Tab was dropped, leaving focus stuck in the
+field with the accent already typed.
+
+Because the commit is queued before the key comes back, delivering the key
+immediately would move focus before the text landed, and the accent would be
+typed into the widget that just took focus. `metalPollEvent` therefore holds a
+declined key for one poll whenever the same keystroke queued text
+(`_deferredKey`), releasing it once the queue has drained.
+
+The consequence, deliberate: inside a focused text field macOS keeps native
+behaviour and an Option+letter shortcut does not fire, where X11 delivers the
+key-down and suppresses only the character.
+
+## Tests
+
+- `gui/ime_context_test.go` — the predicate table, that focusing a button starts
+  nothing while focusing an input starts exactly once, and that moving between
+  two fields cycles the context.
+- `gui/ime_test.go: TestIMEStartNotRepeatedOnRefocusSameID` — the #156
+  invariant, now driven through the render pass.
+- `metalTestContentViewIsFirstResponder` — key delivery no longer depends on the
+  IME activation path, which used to install the first responder.
+- `metalTestIMEKeySuppressedWhileComposing` — a key the input source consumed
+  mid-composition is claimed, one it declined reaches the widget, and an idle
+  key is untouched.
+- `metalTestIMEDeadKeyDeliveredWithoutTextContext` — the four-way decision
+  above, run from the main-thread block in `gui/backend/metal/icon_test.go`
+  (`GO_GUI_MAIN_THREAD_TESTS=1`).

--- a/gui/backend/CLAUDE.md
+++ b/gui/backend/CLAUDE.md
@@ -31,3 +31,17 @@ correct participation in these systems. When platform-native behavior is broken
 - Ask "what would a Cocoa developer check first?" — the answer is usually event
   masks, tracking areas, or run-loop configuration, not application-level cursor
   or menu logic.
+
+## IME activation contract
+
+`NativePlatform.IMEStart` / `IMEStop` mean "an **editable text** widget has
+focus", not "something has focus". The gui layer decides this per frame from the
+arranged tree (`gui/ime_context.go`); a backend must not widen it.
+
+The reason is not cosmetic. An active input context routes keystrokes through
+the platform's text-input machinery, which on macOS turns Option+printable into
+a dead key and swallows the app's shortcut (issue #393); on Windows it attaches
+the IMM context, and on web it moves DOM focus into a hidden `<input>`. A
+preedit that appears with no edit context is a dead key nobody asked for and
+must be discarded, or it composes into the next keystroke. See
+`docs/specs/ime-text-context.md`.

--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -36,6 +36,8 @@ void metalTestResetIMEQueue(void);
 int metalTestPopTextEvent(void);
 int metalTestIMEClientConformance(void *windowHandle);
 int metalTestIMEKeySuppressedWhileComposing(void *windowHandle);
+int metalTestIMEDeadKeyDeliveredWithoutTextContext(void *windowHandle);
+int metalTestContentViewIsFirstResponder(void *windowHandle);
 void metalTestStartLiveResize(void *windowHandle);
 void metalTestEndLiveResize(void *windowHandle);
 int metalTestLayerPresentsWithTransaction(void *windowHandle);
@@ -159,6 +161,21 @@ func testIMEClientConformance(handle C.GoGuiNSWindow) bool {
 // method owns does not also reach the widget.
 func testIMEKeySuppressedWhileComposing(handle C.GoGuiNSWindow) bool {
 	return C.metalTestIMEKeySuppressedWhileComposing(
+		unsafe.Pointer(handle)) != 0
+}
+
+// testIMEDeadKeyDeliveredWithoutTextContext checks that an Option key
+// that produces a dead-key preedit still reaches the app as a key-down
+// when no editable text widget is focused (issue #393).
+func testIMEDeadKeyDeliveredWithoutTextContext(handle C.GoGuiNSWindow) bool {
+	return C.metalTestIMEDeadKeyDeliveredWithoutTextContext(
+		unsafe.Pointer(handle)) != 0
+}
+
+// testContentViewIsFirstResponder checks keys reach the view without
+// the input method having been activated.
+func testContentViewIsFirstResponder(handle C.GoGuiNSWindow) bool {
+	return C.metalTestContentViewIsFirstResponder(
 		unsafe.Pointer(handle)) != 0
 }
 

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -138,6 +138,21 @@ func runMainThreadTests() {
 		panic("IME key suppression: raw key leaked while composing")
 	}
 
+	// 7d. With no editable text widget focused, a dead-key preedit is
+	//     not the input method's claim: Option+I is a circumflex on
+	//     the US layout, and swallowing it killed every Option
+	//     shortcut and composed the accent into the next keystroke.
+	if !testIMEDeadKeyDeliveredWithoutTextContext(b.window) {
+		panic("IME dead key: Option shortcut did not reach the app")
+	}
+
+	// 7e. And keys must reach the view without the input method: the
+	//     IME activation path is what used to install the first
+	//     responder, and it no longer runs for non-text widgets.
+	if !testContentViewIsFirstResponder(b.window) {
+		panic("first responder: content view does not receive keys")
+	}
+
 	// 8. metalAppFinishLaunch must not crash — validates the C function
 	//    exists, links, and can be called from Go. Regression test
 	//    for the activation call added before the event loop.

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -86,6 +86,24 @@ static int             _liveResizeStarted;
 // reverts — so the raw key must not also reach the widget, or the
 // field's own caret moves under the preedit.
 static int             _imeConsumedKey;
+// Set by doCommandBySelector: during interpretKeyEvents:, cleared by
+// keyDown: before it. The input source calls it to hand a key back:
+// it inspected the key, declined it as text input, and returned it as
+// a command for the widget. That is the signal that the key is the
+// widget's even mid-composition (issue #393).
+static int             _imeDeclinedKey;
+
+// A key-down held back for one poll. When the input source declines a
+// key that also committed a composition — Tab on a pending dead key
+// commits the accent through insertText: and returns insertTab: here —
+// the commit is already on the text queue and must reach Go first.
+// Tab moves focus, so delivering the key first would land the
+// committed text in the widget that just took focus.
+static int             _deferredKey;
+static unsigned short  _deferredKeyCode;
+static unsigned int    _deferredKeyMods;
+static int             _deferredKeyRepeat;
+static unsigned int    _deferredKeyWindow;
 
 // ─── Text-input event queue (IME) ──────────────────────────────
 //
@@ -200,6 +218,8 @@ static uint32_t _nextWindowID = 1;
 @property (nonatomic, copy)   NSAttributedString *markedText;
 @property (nonatomic, assign) NSRange     markedRange;
 @property (nonatomic, assign) NSRange     selRange;
+// Declared so the test hooks below the @implementation can call it.
+- (void)imeSettleAfterKeyWasComposing:(BOOL)wasComposing;
 @end
 
 @implementation MetalContentView
@@ -264,11 +284,49 @@ static uint32_t _nextWindowID = 1;
 // insertText: fires for printable characters. Non-printable
 // keys (arrows, etc.) return to Go as EventKeyDown.
 - (void)keyDown:(NSEvent *)event {
-    // A composition already in progress means the input method owns
-    // this key. So does a key that starts one: it produced a preedit,
-    // not a command.
     BOOL wasComposing = (_markedText != nil);
+    _imeDeclinedKey = 0;
     [self interpretKeyEvents:@[event]];
+    [self imeSettleAfterKeyWasComposing:wasComposing];
+}
+
+// imeSettleAfterKeyWasComposing decides who owns the key
+// interpretKeyEvents: just processed, and cleans up a preedit nobody
+// asked for.
+//
+// Split out of keyDown: so a test can drive it: a synthetic NSEvent
+// cannot make the real input source produce a dead key, so the test
+// stages the preedit with setMarkedText: and calls this directly.
+- (void)imeSettleAfterKeyWasComposing:(BOOL)wasComposing {
+    // Nothing editable is focused, so this preedit is unwanted: on the
+    // US layout Option+I is a dead circumflex, which swallowed the
+    // app's Option shortcut and then composed itself into the next
+    // keystroke (issue #393). Drop it and let the key-down through.
+    if (_markedText != nil && !_imeActive) {
+        [self unmarkText];
+        // setMarkedText: already queued the preedit and unmarkText is
+        // silent by design (see insertText:), so clear Go's
+        // composition state explicitly.
+        pushTextEvent(METAL_EVENT_IME_COMP, "", _windowID, 0, 0);
+        // Discards the dead key inside the input source itself.
+        // Without it the next keystroke still composes against the
+        // cancelled accent.
+        [self.inputContext discardMarkedText];
+        return;
+    }
+    // The input source handed the key back rather than consuming it,
+    // so it belongs to the widget — even mid-composition. Tab on a
+    // pending dead key arrives exactly this way: the accent commits
+    // through insertText: and insertTab: comes back here. Claiming it
+    // left focus stuck in the field with the accent already typed.
+    if (_imeDeclinedKey) {
+        return;
+    }
+    // What the input source did consume belongs to it: a composition
+    // in flight owns arrows and Return (the engine walks its own
+    // clauses with them), and so does a key that starts a preedit over
+    // an editable widget — a CJK first letter, or the first half of
+    // Option+e on the way to é.
     if (wasComposing || _markedText != nil) {
         _imeConsumedKey = 1;
     }
@@ -284,8 +342,13 @@ static uint32_t _nextWindowID = 1;
 
 // Suppress system beep for unhandled key commands (arrows, etc.).
 // Go handles all key events through the event loop.
+// The input source calls this for a key it declined as text input.
+// Recording that is what lets keyDown: tell "the IME consumed this"
+// from "the IME handed it back" — see imeSettleAfterKeyWasComposing:.
 - (void)doCommandBySelector:(SEL)selector {
-    // Intentionally empty — no beep.
+    _imeDeclinedKey = 1;
+    // Otherwise intentionally empty — Go handles every key command,
+    // and calling super would beep on the ones it does not.
 }
 
 // ─── NSTextInputClient (IME) ───────────────────────────────────
@@ -631,6 +694,12 @@ GoGuiNSWindow metalWindowCreate(const char *title, int width, int height,
     }
     contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     [win setContentView:contentView];
+    // Key delivery must not depend on the input method being active:
+    // metalWindowIMESetActive also calls makeFirstResponder:, and since
+    // issue #393 it fires only for editable text widgets. Pinning the
+    // content view as the initial first responder keeps every other
+    // window receiving keys.
+    [win setInitialFirstResponder:contentView];
 
     [win setCollectionBehavior:NSWindowCollectionBehaviorMoveToActiveSpace];
     [win makeKeyAndOrderFront:nil];
@@ -924,6 +993,19 @@ int metalPollEvent(int timeoutMs) {
     // residual composition) in order and intact.
     if (popTextEvent()) return 1;
 
+    // Text queue drained: release a key-down held back so the
+    // composition it committed reached Go first.
+    if (_deferredKey) {
+        _deferredKey = 0;
+        if (_evText) { free(_evText); _evText = NULL; }
+        _evType      = METAL_EVENT_KEY_DOWN;
+        _evKeyCode   = _deferredKeyCode;
+        _evModifiers = _deferredKeyMods;
+        _evKeyRepeat = _deferredKeyRepeat;
+        _evWindowID  = _deferredKeyWindow;
+        return 1;
+    }
+
     // Non-blocking dequeue.
     event = [NSApp nextEventMatchingMask:ALL_EVENTS
                                untilDate:nil
@@ -989,6 +1071,19 @@ int metalPollEvent(int timeoutMs) {
     // as the queued composition or commit instead.
     if (_imeConsumedKey && _evType == METAL_EVENT_KEY_DOWN) {
         _evType = METAL_EVENT_NONE;
+    } else if (_imeDeclinedKey && _textQCount > 0 &&
+               _evType == METAL_EVENT_KEY_DOWN) {
+        // The input source declined this key but committed text on the
+        // way — Tab on a pending dead key commits the accent, then
+        // returns insertTab:. Hold the key until the commit has been
+        // delivered: Tab moves focus, and the accent belongs to the
+        // field being left, not the one taking focus.
+        _deferredKey       = 1;
+        _deferredKeyCode   = _evKeyCode;
+        _deferredKeyMods   = _evModifiers;
+        _deferredKeyRepeat = _evKeyRepeat;
+        _deferredKeyWindow = _evWindowID;
+        _evType            = METAL_EVENT_NONE;
     }
     _imeConsumedKey = 0;
 
@@ -1536,10 +1631,16 @@ int metalTestLayerPresentsWithTransaction(void *windowHandle) {
     return ((CAMetalLayer *)layer).presentsWithTransaction ? 1 : 0;
 }
 
-// Drive keyDown: with a composition in progress and report whether the
-// raw key was claimed by the input method. A key that reaches the
-// widget while composing moves the field's caret out from under the
-// preedit and can fire Enter/Escape actions the user never meant.
+// Report whether a key mid-composition goes to the input method or to
+// the widget. A key that reaches the widget while composing moves the
+// field's caret out from under the preedit and can fire Enter/Escape
+// actions the user never meant — but a key the input source *declines*
+// must still reach the widget, or Tab cannot leave the field.
+//
+// The decision method is driven directly rather than through a
+// synthetic NSEvent: the real input source has no composition of its
+// own here, so it declines every key handed to interpretKeyEvents: and
+// could only ever exercise the declined branch.
 int metalTestIMEKeySuppressedWhileComposing(void *windowHandle) {
     if (!windowHandle) return 0;
     GoGuiWindow *gw = (GoGuiWindow *)windowHandle;
@@ -1548,35 +1649,109 @@ int metalTestIMEKeySuppressedWhileComposing(void *windowHandle) {
     if (![cv isKindOfClass:[MetalContentView class]]) return 0;
     MetalContentView *view = (MetalContentView *)cv;
 
-    NSEvent *key = [NSEvent keyEventWithType:NSEventTypeKeyDown
-                                    location:NSZeroPoint
-                               modifierFlags:0
-                                   timestamp:0
-                                windowNumber:[gw->nsWindow windowNumber]
-                                     context:nil
-                                  characters:@""
-                 charactersIgnoringModifiers:@""
-                                   isARepeat:NO
-                                     keyCode:123]; // left arrow
-    if (!key) return 0;
-
-    // Composing: the key belongs to the input method.
+    // A composition only exists over an editable widget.
+    view.imeActive = YES;
     [view setMarkedText:@"あい"
           selectedRange:NSMakeRange(0, 2)
        replacementRange:NSMakeRange(NSNotFound, 0)];
-    _imeConsumedKey = 0;
-    [view keyDown:key];
-    int suppressed = _imeConsumedKey;
 
-    // Not composing: the key is the widget's to handle.
-    [view unmarkText];
+    // Consumed by the input method — an arrow walking its clauses.
+    _imeDeclinedKey = 0;
     _imeConsumedKey = 0;
-    [view keyDown:key];
+    [view imeSettleAfterKeyWasComposing:YES];
+    int suppressed = (_imeConsumedKey == 1);
+
+    // Declined by the input method: it inspected the key and handed it
+    // back through doCommandBySelector:, so it is the widget's. This is
+    // Tab on a pending dead key — the accent commits and insertTab:
+    // returns, and claiming it left focus stuck in the field (#393).
+    _imeDeclinedKey = 1;
+    _imeConsumedKey = 0;
+    [view imeSettleAfterKeyWasComposing:YES];
+    int declinedReachesWidget = (_imeConsumedKey == 0);
+
+    // Not composing at all: the key is the widget's to handle.
+    view.imeActive = NO;
+    [view unmarkText];
+    _imeDeclinedKey = 0;
+    _imeConsumedKey = 0;
+    [view imeSettleAfterKeyWasComposing:NO];
     int deliveredWhenIdle = (_imeConsumedKey == 0);
 
+    _imeDeclinedKey = 0;
     _imeConsumedKey = 0;
     metalTestResetIMEQueue();
-    return (suppressed && deliveredWhenIdle) ? 1 : 0;
+    return (suppressed && declinedReachesWidget && deliveredWhenIdle) ? 1 : 0;
+}
+
+// Key delivery must not depend on the input method. Since issue #393
+// metalWindowIMESetActive — which also calls makeFirstResponder: —
+// fires only for editable text widgets, so a window whose app never
+// focuses one must still be its content view's responder.
+int metalTestContentViewIsFirstResponder(void *windowHandle) {
+    if (!windowHandle) return 0;
+    GoGuiWindow *gw = (GoGuiWindow *)windowHandle;
+    if (!gw->nsWindow) return 0;
+    return [gw->nsWindow firstResponder] == gw->nsWindow.contentView ? 1 : 0;
+}
+
+// Drive the preedit decision an Option+printable key produces and
+// report whether the key reaches the app when no editable text widget
+// is focused. On the US layout Option+I is the circumflex dead key: it
+// starts a composition, which used to claim the key and leave the app
+// shortcut dead (issue #393), and left the accent pending so the next
+// keystroke composed against it.
+//
+// A synthetic NSEvent cannot make the real input source emit a dead
+// key, so the preedit is staged with setMarkedText: and the decision
+// method is called directly.
+int metalTestIMEDeadKeyDeliveredWithoutTextContext(void *windowHandle) {
+    if (!windowHandle) return 0;
+    GoGuiWindow *gw = (GoGuiWindow *)windowHandle;
+    if (!gw->nsWindow) return 0;
+    NSView *cv = gw->nsWindow.contentView;
+    if (![cv isKindOfClass:[MetalContentView class]]) return 0;
+    MetalContentView *view = (MetalContentView *)cv;
+
+    // No text context: the dead key is discarded and the key-down goes
+    // to the app as the shortcut it is.
+    view.imeActive = NO;
+    _imeDeclinedKey = 0;
+    _imeConsumedKey = 0;
+    metalTestResetIMEQueue();
+    [view setMarkedText:@"\u02c6"
+          selectedRange:NSMakeRange(0, 1)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+    [view imeSettleAfterKeyWasComposing:NO];
+    int deliveredToApp = (_imeConsumedKey == 0);
+    int preeditDropped = ([view hasMarkedText] == NO);
+    // The staged preedit plus the empty one that clears it in Go.
+    int queuedClear = (metalTestIMEQueueDepth() == 2);
+
+    // Editable text focused: the same dead key is the first half of an
+    // accent (Option+e then e -> é) and stays with the input method.
+    view.imeActive = YES;
+    _imeDeclinedKey = 0;
+    _imeConsumedKey = 0;
+    metalTestResetIMEQueue();
+    [view setMarkedText:@"\u02c6"
+          selectedRange:NSMakeRange(0, 1)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+    [view imeSettleAfterKeyWasComposing:NO];
+    int claimedWhenEditing = (_imeConsumedKey == 1 && [view hasMarkedText]);
+
+    // A live composition outranks both: it owns the keyboard whatever
+    // is focused.
+    _imeConsumedKey = 0;
+    [view imeSettleAfterKeyWasComposing:YES];
+    int claimedWhileComposing = (_imeConsumedKey == 1);
+
+    view.imeActive = NO;
+    [view unmarkText];
+    _imeConsumedKey = 0;
+    metalTestResetIMEQueue();
+    return (deliveredToApp && preeditDropped && queuedClear &&
+            claimedWhenEditing && claimedWhileComposing) ? 1 : 0;
 }
 
 // Verify the NSTextInputClient answers an input method needs to commit

--- a/gui/ime_context.go
+++ b/gui/ime_context.go
@@ -1,0 +1,98 @@
+package gui
+
+// ime_context.go — deciding when the platform input method is live.
+//
+// The input method must be active only while an editable text widget
+// holds focus. It is not a "something is focused" signal: on macOS an
+// active input context routes every keystroke through
+// interpretKeyEvents:, which turns Option+I into a dead circumflex
+// instead of the ModAlt shortcut the app asked for (issue #393). The
+// Windows backend documents the same contract it was never given
+// ("composition only becomes possible once a text widget takes
+// focus", gui/backend/gl/ime_win32.go), and on X11 IMEStart is an
+// ibus FocusIn that a button has no business claiming.
+
+// shapeIsIMEEditTarget reports whether shape is the editable text
+// context an input method would write into — the shape that hosts the
+// preedit in renderText.
+//
+// focusOwner is the discriminator: only input widgets set it
+// (view_input.go), so a selection-only focusable Text is excluded. A
+// read-only input is excluded too: it stays focusable for its caret
+// and selection but can never commit a composition, which is the same
+// rule render_text.go applies to preedit rendering.
+//
+// A focusable terminal grid is an edit target as well — it consumes
+// typed text directly and has no Text shape of its own.
+func shapeIsIMEEditTarget(s *Shape) bool {
+	if s == nil {
+		return false
+	}
+	if s.shapeType == shapeTermGrid {
+		return s.Focusable
+	}
+	return s.TC != nil && s.focusOwner != "" && !s.TC.textReadOnly
+}
+
+// findIMEEditTarget reports whether the focused widget's edit target
+// is somewhere in this subtree. The walk short-circuits on the first
+// match and is skipped entirely when nothing is focused, so the cost
+// is one partial tree walk per frame with a focused widget.
+func findIMEEditTarget(layout *Layout, w *Window) bool {
+	if layout.Shape == nil {
+		return false
+	}
+	if shapeIsIMEEditTarget(layout.Shape) &&
+		w.IsFocus(layout.Shape.focusKey()) {
+		return true
+	}
+	for i := range layout.Children {
+		if findIMEEditTarget(&layout.Children[i], w) {
+			return true
+		}
+	}
+	return false
+}
+
+// syncIMEEditContext starts or stops the platform input method as the
+// focused widget gains or loses an editable text context.
+//
+// Called from the render pass rather than from setFocusLocked: the ID
+// alone cannot say whether the widget is editable, and SetFocus is
+// legitimately called from inside a View function, where the tree in
+// hand is the previous frame's and a newly created input is not in it
+// yet. Talking to the platform from the render pass has precedent —
+// renderText reports the caret rect the same way.
+//
+// Only transitions are pushed, so re-asserting focus on the widget
+// that already holds it does not re-activate the input method (the
+// invariant issue #156 established). Moving between two text fields
+// does cycle it: a composition still live inside the engine belongs
+// to the field being left, and IMEStop is what cancels it — an ibus
+// FocusOut, the IMM context detach, the web hidden input being
+// removed.
+func (w *Window) syncIMEEditContext() {
+	editing := w.viewState.focusID != "" && findIMEEditTarget(&w.layout, w)
+	id := ""
+	if editing {
+		id = w.viewState.focusID
+	}
+	if editing == w.viewState.imeEditContext &&
+		id == w.viewState.imeEditFocusID {
+		return
+	}
+	wasEditing := w.viewState.imeEditContext
+	w.viewState.imeEditContext = editing
+	w.viewState.imeEditFocusID = id
+
+	np := w.nativePlatform
+	if np == nil {
+		return
+	}
+	if wasEditing {
+		np.IMEStop()
+	}
+	if editing {
+		np.IMEStart()
+	}
+}

--- a/gui/ime_context_test.go
+++ b/gui/ime_context_test.go
@@ -1,0 +1,228 @@
+package gui
+
+import "testing"
+
+// imeEditTargetLayout builds the shape tree an Input produces: a
+// focusable container claiming the ID, wrapping the text shape that
+// only references it through focusOwner.
+func imeEditTargetLayout(id string) Layout {
+	return Layout{
+		Shape: &Shape{},
+		Children: []Layout{{
+			Shape: &Shape{ID: id, Focusable: true},
+			Children: []Layout{{
+				Shape: &Shape{
+					shapeType:  shapeText,
+					focusOwner: id,
+					TC:         &shapeTextConfig{Text: "hi"},
+				},
+			}},
+		}},
+	}
+}
+
+func TestShapeIsIMEEditTarget(t *testing.T) {
+	cases := []struct {
+		name  string
+		shape *Shape
+		want  bool
+	}{
+		{"nil", nil, false},
+		{
+			"input text shape",
+			&Shape{
+				shapeType:  shapeText,
+				focusOwner: "in",
+				TC:         &shapeTextConfig{},
+			},
+			true,
+		},
+		{
+			"read-only input never commits a composition",
+			&Shape{
+				shapeType:  shapeText,
+				focusOwner: "in",
+				TC:         &shapeTextConfig{textReadOnly: true},
+			},
+			false,
+		},
+		{
+			"selection-only text is focusable but not editable",
+			&Shape{
+				shapeType: shapeText,
+				Focusable: true,
+				ID:        "label",
+				TC:        &shapeTextConfig{},
+			},
+			false,
+		},
+		{
+			"focusable term grid consumes typed text",
+			&Shape{shapeType: shapeTermGrid, Focusable: true},
+			true,
+		},
+		{
+			"read-only term grid",
+			&Shape{shapeType: shapeTermGrid},
+			false,
+		},
+		{"button", &Shape{Focusable: true, ID: "b"}, false},
+	}
+	for _, c := range cases {
+		if got := shapeIsIMEEditTarget(c.shape); got != c.want {
+			t.Errorf("%s: shapeIsIMEEditTarget = %v, want %v",
+				c.name, got, c.want)
+		}
+	}
+}
+
+// Focusing a non-text widget must leave the platform input method
+// alone. On macOS an active input context routes every key through
+// interpretKeyEvents:, which swallows Option+printable shortcuts as
+// dead keys (issue #393).
+func TestIMENotStartedForNonTextWidget(t *testing.T) {
+	w := newTestWindow()
+	spy := &imeSpyPlatform{}
+	w.SetNativePlatform(spy)
+	w.layout = Layout{
+		Shape:    &Shape{},
+		Children: []Layout{{Shape: &Shape{ID: "btn", Focusable: true}}},
+	}
+
+	w.SetFocus("btn")
+	w.syncIMEEditContext()
+	if spy.starts != 0 {
+		t.Fatalf("IMEStart calls for a focused button = %d, want 0",
+			spy.starts)
+	}
+	if spy.stops != 0 {
+		t.Fatalf("IMEStop calls with nothing to stop = %d, want 0",
+			spy.stops)
+	}
+}
+
+// Losing focus entirely stops the input method.
+func TestIMEStoppedOnBlur(t *testing.T) {
+	w := newTestWindow()
+	spy := &imeSpyPlatform{}
+	w.SetNativePlatform(spy)
+	w.layout = imeEditTargetLayout("in")
+
+	w.SetFocus("in")
+	w.syncIMEEditContext()
+	if spy.starts != 1 {
+		t.Fatalf("IMEStart calls = %d, want 1", spy.starts)
+	}
+	w.ClearFocus()
+	w.syncIMEEditContext()
+	if spy.stops != 1 {
+		t.Fatalf("IMEStop calls after blur = %d, want 1", spy.stops)
+	}
+}
+
+// End-to-end through the real widgets and a real frame: the predicate
+// must match the shape tree Input actually builds, not just a
+// hand-assembled one.
+func TestIMEEditContextThroughRealFrame(t *testing.T) {
+	cases := []struct {
+		name    string
+		build   func() View
+		focusID string
+		want    bool
+	}{
+		{
+			"input",
+			func() View { return Input(InputCfg{ID: "field"}) },
+			"field",
+			true,
+		},
+		{
+			"read-only input",
+			func() View {
+				return Input(InputCfg{ID: "field", ReadOnly: true})
+			},
+			"field",
+			false,
+		},
+		{
+			"button",
+			func() View { return Button(ButtonCfg{ID: "btn", Label: "go"}) },
+			"btn",
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := NewWindow(WindowCfg{
+				State: new(int), Width: 200, Height: 100,
+			})
+			spy := &imeSpyPlatform{}
+			w.SetNativePlatform(spy)
+			w.viewGenerator = func(_ *Window) View {
+				return Column(ContainerCfg{
+					Sizing:  FillFill,
+					Content: []View{c.build()},
+				})
+			}
+			w.SetFocus(c.focusID)
+			w.refreshLayout = true
+			w.FrameFn()
+
+			if got := spy.starts > 0; got != c.want {
+				t.Fatalf("IMEStart fired = %v (starts=%d), want %v",
+					got, spy.starts, c.want)
+			}
+		})
+	}
+}
+
+// The focus ID is the effective one, and Input's inner text shape
+// carries only the leaf in focusOwner. resolveShapeIDs reconciles the
+// two; assert the edit context still resolves under a scope.
+func TestIMEEditContextUnderIDScope(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int), Width: 200, Height: 100})
+	spy := &imeSpyPlatform{}
+	w.SetNativePlatform(spy)
+	w.viewGenerator = func(_ *Window) View {
+		return Column(ContainerCfg{
+			ID:      "panel",
+			Sizing:  FillFill,
+			Content: []View{Input(InputCfg{ID: "field"})},
+		})
+	}
+	w.SetFocus("panel:field")
+	w.refreshLayout = true
+	w.FrameFn()
+
+	if spy.starts != 1 {
+		t.Fatalf("IMEStart calls for a scoped input = %d, want 1",
+			spy.starts)
+	}
+}
+
+// Moving from one text field to another must cycle the platform input
+// method. IMEStop is what cancels a composition still live inside the
+// engine (ibus FocusOut, the IMM context detach, the web hidden input
+// being removed); without it a half-typed word commits into the field
+// that just took focus.
+func TestIMECycledBetweenTextFields(t *testing.T) {
+	w := newTestWindow()
+	spy := &imeSpyPlatform{}
+	w.SetNativePlatform(spy)
+
+	w.layout = imeEditTargetLayout("a")
+	w.SetFocus("a")
+	w.syncIMEEditContext()
+	if spy.starts != 1 || spy.stops != 0 {
+		t.Fatalf("first field: starts=%d stops=%d, want 1 and 0",
+			spy.starts, spy.stops)
+	}
+
+	w.layout = imeEditTargetLayout("b")
+	w.SetFocus("b")
+	w.syncIMEEditContext()
+	if spy.stops != 1 || spy.starts != 2 {
+		t.Fatalf("second field: starts=%d stops=%d, want 2 and 1",
+			spy.starts, spy.stops)
+	}
+}

--- a/gui/ime_test.go
+++ b/gui/ime_test.go
@@ -167,19 +167,24 @@ func TestIMEPreservedOnRefocusSameID(t *testing.T) {
 
 // The other half of #156: re-focusing must not re-activate the platform
 // input context either, which on macOS re-ran makeFirstResponder:
-// mid-composition.
+// mid-composition. Driven through the render pass since #393, which
+// moved the decision there — an ID alone cannot say whether the
+// focused widget is editable.
 func TestIMEStartNotRepeatedOnRefocusSameID(t *testing.T) {
 	w := newTestWindow()
 	spy := &imeSpyPlatform{}
 	w.SetNativePlatform(spy)
+	w.layout = imeEditTargetLayout("f1")
 
 	w.SetFocus("f1")
+	w.syncIMEEditContext()
 	if spy.starts != 1 {
 		t.Fatalf("IMEStart calls after first focus = %d, want 1",
 			spy.starts)
 	}
 	for range 5 {
 		w.SetFocus("f1")
+		w.syncIMEEditContext()
 	}
 	if spy.starts != 1 {
 		t.Fatalf("IMEStart calls after refocus = %d, want 1", spy.starts)
@@ -188,10 +193,12 @@ func TestIMEStartNotRepeatedOnRefocusSameID(t *testing.T) {
 		t.Fatalf("IMEStop calls after refocus = %d, want 0", spy.stops)
 	}
 
-	// A real focus change still cycles the input context.
+	// Focus moves to a widget that is not a text context: the input
+	// method stops and does not start again.
 	w.SetFocus("f2")
-	if spy.stops != 1 || spy.starts != 2 {
-		t.Fatalf("after focus change: starts=%d stops=%d, want 2 and 1",
+	w.syncIMEEditContext()
+	if spy.stops != 1 || spy.starts != 1 {
+		t.Fatalf("after focus change: starts=%d stops=%d, want 1 and 1",
 			spy.starts, spy.stops)
 	}
 }

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -46,17 +46,13 @@ func (w *Window) setFocusLocked(id string) {
 			w.animationAddLocked(newBlinkCursorAnimation())
 		}
 	}
-	// Same reasoning: only a real focus *change* touches the platform
-	// IME. prev != "" alone suffices for the stop — the enclosing
-	// id != prev already rules out a no-op transition.
-	if np := w.nativePlatform; np != nil && id != prev {
-		if prev != "" {
-			np.IMEStop()
-		}
-		if id != "" {
-			np.IMEStart()
-		}
-	}
+	// The platform IME is not switched here. Whether the new widget is
+	// an *editable text* context — the only thing an input method may
+	// be activated for — cannot be answered from an ID, and SetFocus is
+	// legitimately called from inside a View function, where w.layout
+	// still holds the previous frame and a newly created input is not
+	// in it yet. syncIMEEditContext decides it from the arranged tree
+	// each frame instead (gui/ime_context.go, issue #393).
 }
 
 // resetBlinkCursorVisible resets the blink timer so the cursor

--- a/gui/window_state.go
+++ b/gui/window_state.go
@@ -97,6 +97,12 @@ type ViewState struct {
 	diagramRequestSeq uint64
 	focusID           string
 
+	// imeEditFocusID is the focus ID syncIMEEditContext last activated
+	// the input method for. Moving between two text fields must cycle
+	// the platform context so a composition left live in the engine
+	// does not commit into the field that just took focus.
+	imeEditFocusID string
+
 	// idScope is the effective ID of the innermost ID-bearing shape
 	// currently being generated. Maintained by generateViewLayout and
 	// read by (*Window).EffID; empty outside the view phase.
@@ -108,6 +114,10 @@ type ViewState struct {
 	inputCursorOn            atomic.Bool
 	menuKeyNav               bool
 	externalAPIWarningLogged bool
+	// imeEditContext is the last IME activation pushed to the
+	// platform: true while the focused widget is an editable text
+	// context. Kept so syncIMEEditContext pushes transitions only.
+	imeEditContext bool
 }
 
 // State returns a typed pointer to the user-supplied state.

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -321,6 +321,10 @@ func composeLayout(layers []Layout, w *Window) Layout {
 func (w *Window) buildRenderers(bgColor Color, clip drawClip) {
 	w.renderers = w.renderers[:0]
 	w.scratch.resetRenderPools()
+	// The arranged tree is the only place that says whether the
+	// focused widget is editable, so the platform input method is
+	// switched here rather than at focus time (gui/ime_context.go).
+	w.syncIMEEditContext()
 	renderLayout(&w.layout, bgColor, clip, w)
 	if inspectorSupported && w.inspectorEnabled {
 		inspectorInjectWireframe(w)


### PR DESCRIPTION
Fixes #393.

## The bug

`MetalContentView.keyDown:` routed **every** keystroke through
`interpretKeyEvents:` and then claimed the key for the input method whenever a
preedit existed afterwards. On the US layout Option+I is the circumflex dead
key, so AppKit started a composition and the `ModAlt|KeyI` key-down never
reached Go. Option+arrows worked only because arrows produce no preedit. Any
Option+printable app shortcut was dead on macOS.

Two causes stacked:

1. The claim fired regardless of whether a text-edit context existed.
2. `imeActive` was itself wrong — `setFocusLocked` called `IMEStart`/`IMEStop`
   on *any* focus change to a focusable widget, buttons and sliders included.

## The fix

**gui — the input method activates only for an editable text widget.** The
arranged tree is the only place that says whether the focused widget is
editable, so the decision is made once per frame in the render pass
(`gui/ime_context.go`) rather than at focus time. `IMEStart`/`IMEStop` now mean
what the Metal, X11 and Win32 backends already documented them to mean; the
contract is written down in `gui/backend/CLAUDE.md` so a backend does not widen
it again.

Moving between two text fields still cycles the context. That is deliberate and
tested: `IMEStop` is what cancels a composition still live inside the engine
(ibus `FocusOut`, the IMM detach, the web hidden input), so without the cycle a
half-typed word would commit into the field that just took focus. The #156
invariant — re-focusing the same ID must not restart the context mid-composition
— is preserved and still covered.

**metal — `keyDown:` honours a declined key.** `doCommandBySelector:` is the
input source handing a key back rather than consuming it, so that key belongs to
the widget even mid-composition. Because the commit is queued before the key
returns, a declined key that queued text is deferred one poll, so the text lands
in the field being left rather than the one taking focus. A preedit that appears
with no edit context is an unwanted dead key: it is unmarked, discarded, and an
empty composition is pushed so Go's preedit clears.

No Carbon/TIS input-source query is needed — focus, not layout type, is the
discriminator, so `-framework Carbon` stays unlinked.

## Behaviour

Inside a focused text field native macOS composition still wins: Option+e, e
types é, and CJK input is unchanged. Everywhere else Option+printable arrives as
`EventKeyDown` with `ModAlt`. This leaves macOS stricter than X11 inside a text
field (X11 delivers the key-down and suppresses only the character) — deliberate,
and recorded in the spec.

## Tests

- `gui/ime_context_test.go` — the predicate table, the non-text widget case, blur,
  field→field cycling, and three cases driven through a real frame with a real
  `Input` / read-only `Input` / `Button`, plus one under an ID scope.
- `gui/backend/metal` — `metalTestIMEDeadKeyDeliveredWithoutTextContext`,
  `metalTestContentViewIsFirstResponder`, and a rewritten
  `metalTestIMEKeySuppressedWhileComposing` asserting all three outcomes
  (consumed → claimed, declined → reaches the widget, idle → delivered).

`make prepush` is green.

## Verified on device

- Option+e in an input prints the accent; a following `e` completes `é`.
- Option+I with a button focused fires the app shortcut.
- Option+e then Tab no longer strands `´` in the field.

One gap, stated plainly: the tab-out-of-a-field behaviour could **not** be
confirmed end to end on screen, because Tab hangs the app for an unrelated,
pre-existing reason now tracked in #394 (it reproduces identically on `main` at
80f11dba). The event pipeline is proven correct by an instrumented trace; what
happens on screen afterwards is not. The field→field IME cycling only bites on
X11/Windows/web, so a macOS run cannot exercise it either — it is covered by
test only.

Spec: `docs/specs/ime-text-context.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
