### PR TITLE
fix: tab out of a text input no longer freezes the app (#394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ### Fixed
 
+- **Tab out of a text input no longer freezes the app** (#394) — the Input's
+  blur commit fired from its `AmendLayout` hook, which `layoutArrange` runs
+  while `Update` holds the window mutex. An `OnTextCommit`/`OnBlur` handler that
+  called back into `SetFocus` — the natural thing to do from a commit handler,
+  and what `examples/todo` did — deadlocked the main thread against itself: a
+  frozen window, no panic, no CPU burn. App callbacks reached from the frame
+  pass are now raised and run after the lock is released
+  (`gui/window_deferred.go`).
 - **macOS Option+printable shortcuts reach the app** (#393) — `keyDown:` routed
   every key through `interpretKeyEvents:` and treated any resulting preedit as
   an input-method claim, so on the US layout Option+I (the circumflex dead key)
@@ -25,8 +33,32 @@ and this project adheres to
   composition it committed to arrive first, so the text lands in the field being
   left rather than the one taking focus.
 
+### Added
+
+- **`InputCommitEnter` and `InputCommitBlur`** are exported. `OnTextCommit`'s
+  second parameter is an `InputCommitReason`, but its values were unexported, so
+  an app could receive the reason and not branch on it — the whole point of
+  distinguishing "the user pressed Enter" from "focus moved on".
+- **`DebugCallbacks`** joins `DebugAll`. It reports app callbacks the frame pass
+  dropped because they kept re-queueing themselves round after round.
+
 ### Changed
 
+- **A window API called while the frame lock is held now panics instead of
+  hanging** (#394). `SetFocus`, `ClearFocus`, `UpdateView`,
+  `ClearDrawCanvasCache` and `Window.Lock` probe with `TryLock` and, when a
+  frame pass owns the mutex, panic naming the API and the remedy
+  (`QueueCommand`). This is the case an app's own `ContainerCfg.AmendLayout` /
+  `ButtonCfg.AmendLayout` hook can still reach — the hook exists to mutate the
+  tree in place, so it cannot be deferred. A crash that says what to fix beats a
+  freeze that says nothing.
+- **`ctx.Layout` is nil in a blur-triggered `OnTextCommit`, `OnBlur` and
+  `OnTextChanged`.** These now run after the arrange pass, and the tree they
+  were raised from is rebuilt from pooled arenas before then, so the pointer
+  would dangle. `ctx.Window` and the text argument are unchanged. The Enter
+  commit path is untouched and still carries a live `ctx.Layout`.
+- **`examples/todo` adds a task on Enter only**, not on blur. Tabbing out of a
+  half-typed task left the draft as a silently created todo.
 - **The platform input method is activated only for editable text widgets**
   (#393). `IMEStart`/`IMEStop` used to fire on any focus change to any focusable
   widget; they now follow the focused widget's edit context, decided each frame

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,20 @@ Backend injects at startup. Nil in tests:
   coords. Moving parent in `AmendLayout` does NOT move children. Use float
   system (`FloatAnchor`/`FloatTieOff`/`FloatOffsetX`/`FloatOffsetY`) to position
   elements with children.
+- **`AmendLayout` runs under the frame lock (`w.mu`), so no callback reached
+  from it may call a window-mutating API.** `SetFocus`, `ClearFocus`,
+  `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take `w.mu`, which
+  is not reentrant, and the frame thread is the platform event loop — the app
+  froze permanently (issue #394). Since the fix those APIs panic naming
+  themselves instead of hanging; the remedy is `ctx.Window.QueueCommand`.
+  Library code that reaches app code from the pass raises it with
+  `deferCallback` and the pass runs it after unlocking
+  (`gui/window_deferred.go`), which is how the Input's blur commit works:
+  `OnTextCommit` with `InputCommitBlur`, `OnBlur` and a normalize-driven
+  `OnTextChanged` therefore get a **nil `ctx.Layout`** — the tree is rebuilt
+  from pooled arenas before they run. The Enter commit path dispatches from
+  `EventFn` with no lock held and is unchanged. See
+  `docs/specs/frame-lock-callback-deferral.md`.
 - **One event rule (since v0.55.0): nothing is marked handled for you. A
   callback that acts on an event calls `ctx.Consume()`; one that does not, lets
   the event travel on.** This holds for every callback — `OnClick` and `OnChar`

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -77,6 +77,30 @@ over it.
 does not move its children. To move an element with its children, use the float
 fields: `FloatAnchor`, `FloatTieOff`, `FloatOffsetX`, `FloatOffsetY`.
 
+### Do not call window APIs from a hook
+
+The hook runs inside the frame pass, which holds the window mutex. `SetFocus`,
+`ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take
+that mutex, and it is not reentrant, so calling one from a hook used to freeze
+the app outright (issue #394). It now panics naming the API. Queue the work
+instead:
+
+```go
+AmendLayout: func(ctx gui.EventCtx) {
+    ctx.Layout.Shape.X += 4              // fine: this is what the hook is for
+    ctx.Window.QueueCommand(func(w *gui.Window) {
+        w.SetFocus("next-field")         // runs next frame, no lock held
+    })
+},
+```
+
+The same applies to callbacks the library raises from the pass. A blur-triggered
+`OnTextCommit` (`InputCommitBlur`), `OnBlur`, or an `OnTextChanged` fired by
+`PostCommitNormalize` on blur now runs after the pass unlocks, so it is free to
+call `SetFocus` — but its `ctx.Layout` is **nil**, because that tree has already
+been recycled. Read `ctx.Window` and the arguments instead. The Enter commit
+path is unaffected and still carries a live `ctx.Layout`.
+
 ## Group-box titles
 
 `ContainerCfg.Title` draws a label in the top border, like an HTML fieldset. Set

--- a/docs/specs/frame-lock-callback-deferral.md
+++ b/docs/specs/frame-lock-callback-deferral.md
@@ -1,0 +1,123 @@
+# Frame-lock callback deferral
+
+Status: implemented (issue #394)
+
+## The invariant
+
+**No app callback runs while the frame lock (`w.mu`) is held.**
+
+Library code that reaches app code from inside the frame pass raises the
+callback with `deferCallback` instead of calling it. `Update` and
+`updateRenderOnly` run the raised callbacks through `flushDeferredCallbacks`
+after releasing the lock. Both live in `gui/window_deferred.go`.
+
+## Why
+
+`Update` releases `w.mu` for View generation and re-takes it for `layoutArrange`
+and `buildRenderers` (`gui/window_update.go`). Two things inside that locked
+region reach app code:
+
+- `layoutAmend` (`gui/layout_pipeline.go`) invokes every shape's `AmendLayout`
+  hook.
+- `buildRenderers` runs the render pass, which reports the caret rect and syncs
+  the platform input method.
+
+`w.mu` is a plain `sync.Mutex`. It is not reentrant, and the main goroutine _is_
+the platform event loop (`runtime.LockOSThread` in
+`gui/backend/metal/mainthread.go`). So an app callback reached from that region
+that calls `SetFocus`, `ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` or
+`Window.Lock` blocks the main thread on a lock it already owns: the window
+freezes permanently, with no panic and no CPU burn.
+
+Issue #394 was exactly this. The Input's blur commit fired from
+`inputAmendLayout`; `examples/todo` called `w.SetFocus` from `OnTextCommit` to
+put the caret back in the field. Pressing <kbd>Tab</kbd> after typing froze the
+app.
+
+The defect was the contract, not the example. Calling `SetFocus` from a commit
+handler is a reasonable thing to do, and nothing said not to.
+
+## What is deferred and what is not
+
+Deferred (app code):
+
+- `OnTextCommit` with `InputCommitBlur`
+- `OnBlur`
+- `OnTextChanged` raised by `PostCommitNormalize` on the blur path
+  (`fireTextChangedDeferred`, `gui/view_input.go`)
+
+Not deferred (gui-internal, and needs the live tree):
+
+- the layout echo in `fireTextChangedDeferred` — the arrange pass is still
+  reading that tree
+- `normalizeOnCommit`, `spellCheckClear`, the selection propagation to the inner
+  text shape
+
+A deferred callback receives `EventCtx{nil, nil, w}`. **`ctx.Layout` is nil and
+a `*Layout` must never be captured**: the tree is rebuilt from pooled arenas
+(`layoutChildrenArena`) before the callback runs, so the pointer would dangle
+into reused memory. `ctx.Window` and the value arguments are unchanged.
+
+The Enter commit path (`gui/view_input_keys.go`) is dispatched from `EventFn`,
+which holds no lock, so it is untouched and still carries a live `ctx.Layout`.
+
+## Audit
+
+Two routes lead from an `AmendLayout` hook into app code across `gui/`:
+
+1. the input blur block — deferred, as above;
+2. the app's own hook — `ContainerCfg.AmendLayout` (`gui/view_container.go`) and
+   `ButtonCfg.AmendLayout`, reached as `bc.OnAmend` from `buttonAmendLayout`
+   (`gui/view_button.go`).
+
+The second cannot be deferred. The hook exists to mutate the arranged tree in
+place, so it must run in the pass. It is covered by the fail-fast below instead.
+
+Everything else that sets `AmendLayout` is geometry, focus-ring, hover or
+window-state work.
+
+## Fail fast, do not hang
+
+`updateLocked` and `renderOnlyLocked` set `w.inFramePass` for the duration of
+the locked region. The `w.mu`-taking window APIs go through `lockForAPI`, which
+probes with `TryLock` and, when the lock is held during a frame pass, panics
+naming the API and the remedy (`QueueCommand`) rather than blocking forever.
+
+The probe cannot distinguish "this goroutine self-deadlocked" from "another
+goroutine is mid-`Update`". It does not need to: calling these APIs off the
+frame thread is already outside the contract — `QueueCommand` is the documented
+route — so the message covers both.
+
+`PumpFrame` already used the same `TryLock` technique to decline a re-entrant
+frame, so this is the established instinct in this codebase, not a new one.
+
+## Flush shape
+
+`flushDeferredCallbacks` swaps the slice out before running it, so a callback
+that raises another (an `OnBlur` moving focus, blurring a second field) lands in
+the next round rather than mutating the slice being ranged. Rounds are bounded
+by `maxDeferredCallbackBatches`; past the bound the remainder is dropped and
+reported through `DebugCallbacks`.
+
+`FrameFn` re-runs the refresh pass once after any pass whose flush ran a
+deferred callback. Those callbacks run after the renderers were built, and a
+callback that writes state or moves focus marks no refresh flag — `SetFocus`
+and plain state writes are silent — so `flushDeferredCallbacks`'s own report
+(does anything run?) is what re-arms the loop. Without it the frame would
+render the pre-callback state and keep it until the next event. Two passes, not
+a loop: a view that dirties itself every pass is a bug the frame loop must not
+amplify into a spin, and the next `FrameFn` picks it up anyway.
+
+## Rejected: a reentrancy flag
+
+The obvious smaller fix is a `Window.inFrameLock` bool that makes `SetFocus`
+skip the mutex when the frame pass already owns it.
+
+It does not make the lock reentrant — it makes callers _bypass_ it based on a
+flag that is only meaningful on the owning goroutine. Any other goroutine
+calling `SetFocus` during a frame pass would read `true` and walk into
+unsynchronized state, turning a benign lock wait into a silent data race one
+arrange pass wide. It also covers only the methods someone remembers to
+annotate, and cannot cover the exported `Window.Lock` at all.
+
+Do not re-propose it.

--- a/docs/specs/frame-lock-callback-deferral.md
+++ b/docs/specs/frame-lock-callback-deferral.md
@@ -101,12 +101,12 @@ reported through `DebugCallbacks`.
 
 `FrameFn` re-runs the refresh pass once after any pass whose flush ran a
 deferred callback. Those callbacks run after the renderers were built, and a
-callback that writes state or moves focus marks no refresh flag — `SetFocus`
-and plain state writes are silent — so `flushDeferredCallbacks`'s own report
-(does anything run?) is what re-arms the loop. Without it the frame would
-render the pre-callback state and keep it until the next event. Two passes, not
-a loop: a view that dirties itself every pass is a bug the frame loop must not
-amplify into a spin, and the next `FrameFn` picks it up anyway.
+callback that writes state or moves focus marks no refresh flag — `SetFocus` and
+plain state writes are silent — so `flushDeferredCallbacks`'s own report (does
+anything run?) is what re-arms the loop. Without it the frame would render the
+pre-callback state and keep it until the next event. Two passes, not a loop: a
+view that dirties itself every pass is a bug the frame loop must not amplify
+into a spin, and the next `FrameFn` picks it up anyway.
 
 ## Rejected: a reentrancy flag
 

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -149,7 +149,17 @@ func composerView(w *gui.Window) gui.View {
 					// Keep the input fully controlled by app state.
 					gui.State[appState](ctx.Window).Draft = text
 				},
-				OnTextCommit: func(text string, _ gui.InputCommitReason, ctx gui.EventCtx) {
+				OnTextCommit: func(
+					text string, reason gui.InputCommitReason,
+					ctx gui.EventCtx,
+				) {
+					// Enter means "add this"; a commit fired by blur
+					// only means focus moved on. Tabbing out of a
+					// half-typed task should leave the draft alone,
+					// not silently create a todo.
+					if reason != gui.InputCommitEnter {
+						return
+					}
 					addTodo(ctx.Window, text)
 				},
 			}),

--- a/examples/todo/main_test.go
+++ b/examples/todo/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-gui-org/go-gui/gui"
 )
@@ -61,5 +62,53 @@ func TestDeleteTodoRemovesItem(t *testing.T) {
 		if it.ID == 1 {
 			t.Fatal("item 1 still present after delete")
 		}
+	}
+}
+
+// Tab out of a composer holding text must not freeze the app.
+//
+// Issue #394: the blur commit fired from the Input's AmendLayout hook,
+// which layoutArrange runs while Update holds the window mutex, so
+// addTodo's SetFocus wedged the main thread. Only the real repro steps
+// expose it — addTodo returns early on an empty title, so text has to
+// be typed first, and only a real focus change fires a blur commit.
+//
+// Driven behind a timeout because the failure mode is a hang, not a
+// wrong value: without the goroutine this blocks the whole package.
+// Not t.Parallel: see TestAddTodoAppendsItem (SetTheme is not race-safe).
+func TestTabOutOfComposerDoesNotHang(t *testing.T) {
+	gui.SetTheme(gui.ThemeLight.WithPadding(false))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app := newAppState()
+		before := len(app.Items)
+		w := gui.NewTestWindow(gui.WindowCfg{State: app, Width: 540, Height: 640})
+		w.TestRender(mainView)
+		if err := w.TestType("todo-input", "abc"); err != nil {
+			t.Errorf("TestType: %v", err)
+			return
+		}
+		w.EventFn(&gui.Event{Type: gui.EventKeyDown, KeyCode: gui.KeyTab})
+		w.Update()
+		if got := w.FocusID(); got != "add-todo" {
+			t.Errorf("focus after Tab = %q, want %q", got, "add-todo")
+		}
+		// The reason guard, not just the missing freeze: a blur commit
+		// must not silently create a todo or eat the draft.
+		if len(app.Items) != before {
+			t.Errorf("Tab added %d todos, want 0", len(app.Items)-before)
+		}
+		if app.Draft != "abc" {
+			t.Errorf("draft after Tab = %q, want %q (blur must not "+
+				"clear or commit it)", app.Draft, "abc")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Tab out of the composer deadlocked (issue #394)")
 	}
 }

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -85,6 +85,13 @@ const (
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugWrapOverflow
 
+	// DebugCallbacks reports an app callback the frame pass could not
+	// run: deferred callbacks that kept re-queueing themselves round
+	// after round, so the frame bounded the loop and dropped the rest
+	// rather than spin forever.
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugCallbacks
+
 	// DebugUnscopedIDs reports a focusable or scrollable shape whose ID
 	// resolves to itself — no ID-bearing ancestor above it — so its
 	// identity competes in the window-global namespace and cannot be
@@ -102,7 +109,8 @@ const (
 	// would fire on most widgets in a small app.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
-		DebugListBoxNoHeight | DebugGradientResampled | DebugWrapOverflow
+		DebugListBoxNoHeight | DebugGradientResampled | DebugWrapOverflow |
+		DebugCallbacks
 )
 
 func init() {
@@ -232,6 +240,9 @@ const (
 	// debugCheckWrapOverflow fires from layoutOverflow when a container
 	// sets both Wrap and Overflow; wrap wins and overflow is ignored.
 	debugCheckWrapOverflow
+	// debugCheckDeferredLoop fires from flushDeferredCallbacks when
+	// deferred app callbacks keep re-queueing past the batch bound.
+	debugCheckDeferredLoop
 )
 
 // checkCategory maps an internal check to the public category that
@@ -254,6 +265,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugGradientResampled
 	case debugCheckWrapOverflow:
 		return DebugWrapOverflow
+	case debugCheckDeferredLoop:
+		return DebugCallbacks
 	}
 	return 0
 }

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -256,6 +256,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckUnscopedID, DebugUnscopedIDs},
 		{debugCheckGradientResampled, DebugGradientResampled},
 		{debugCheckWrapOverflow, DebugWrapOverflow},
+		{debugCheckDeferredLoop, DebugCallbacks},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
@@ -265,7 +266,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 	// DebugAll covers every category Debug(true) turns on.
 	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
 	// a design property, not a defect.
-	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow {
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow|DebugCallbacks {
 		t.Fatal("DebugAll must cover every category Debug(true) enables")
 	}
 	if DebugAll&DebugUnscopedIDs != 0 {

--- a/gui/input_state.go
+++ b/gui/input_state.go
@@ -39,10 +39,19 @@ const (
 // InputCommitReason identifies why text was committed.
 type InputCommitReason uint8
 
-// InputCommitReason constants.
+// InputCommitReason constants. Exported because the reason is the
+// second parameter of OnTextCommit: without them an app can receive
+// the value but cannot branch on it, which is the whole point of
+// distinguishing "the user pressed Enter" from "focus moved on".
 const (
-	commitEnter InputCommitReason = iota
-	commitBlur
+	// InputCommitEnter is the user finalizing the text: Enter on a
+	// single-line field, or an IME finalize.
+	// exportaudit:keep — OnTextCommit parameter value for app authors
+	InputCommitEnter InputCommitReason = iota
+	// InputCommitBlur is the field losing focus with the text as it
+	// stands. Not an edit and not necessarily an intent to submit.
+	// exportaudit:keep — OnTextCommit parameter value for app authors
+	InputCommitBlur
 )
 
 const undoMaxSize = 50

--- a/gui/time_travel.go
+++ b/gui/time_travel.go
@@ -511,7 +511,9 @@ func (w *Window) restoreLocked(idx int) {
 	if !ok {
 		return
 	}
-	w.mu.Lock()
+	// Same probe as every other w.mu-taking entry point: a restore
+	// raised from inside a frame pass would hang rather than fail.
+	w.lockForAPI("restore")
 	s.Restore(entry.snap)
 	restoreWhitelistedNamespaces(w, entry.namespaces)
 	w.mu.Unlock()

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -403,6 +403,28 @@ func (h *inputHandlerCfg) fireTextChanged(
 	h.OnTextChanged(text, EventCtx{layout, nil, w})
 }
 
+// fireTextChangedDeferred is fireTextChanged for the one caller that
+// runs under the frame lock: the blur block in inputAmendLayout.
+//
+// The layout echo happens now — it must, the arrange pass is still
+// reading this tree — but the app callback is deferred, because
+// OnTextChanged is app code and calling SetFocus from it under w.mu
+// hangs the main thread (issue #394). The deferred ctx carries no
+// *Layout: this tree is rebuilt from pooled arenas before the callback
+// runs, so the pointer would dangle.
+func (h *inputHandlerCfg) fireTextChangedDeferred(
+	layout *Layout, text string, w *Window,
+) {
+	inputSetTextInLayout(layout, text)
+	if h.ReadOnly || h.OnTextChanged == nil {
+		return
+	}
+	changed := h.OnTextChanged
+	w.deferCallback(func(w *Window) {
+		changed(text, EventCtx{nil, nil, w})
+	})
+}
+
 // normalizeOnCommit applies PostCommitNormalize, which transforms the
 // text and is therefore an edit: read-only fields skip it and commit
 // the text unchanged.
@@ -597,19 +619,32 @@ func inputAmendLayout(
 		if wasFocused && !focused {
 			text := inputTextFromLayout(ctx.Layout)
 			if normalized := hcfg.normalizeOnCommit(
-				text, commitBlur,
+				text, InputCommitBlur,
 			); normalized != text {
 				text = normalized
-				hcfg.fireTextChanged(ctx.Layout, text, ctx.Window)
+				hcfg.fireTextChangedDeferred(ctx.Layout, text, ctx.Window)
 			}
-			if hcfg.OnTextCommit != nil {
-				hcfg.OnTextCommit(text, commitBlur, ctx)
+			// This hook runs from layoutArrange, which holds w.mu, so
+			// app callbacks are raised rather than called: OnTextCommit
+			// on a blur reasonably calls SetFocus, and doing that under
+			// the frame lock froze the app (issue #394). gui-internal
+			// work below stays inline — it touches only window state.
+			// The deferred ctx has no *Layout; see deferCallback.
+			commit, blur := hcfg.OnTextCommit, onBlur
+			if commit != nil || blur != nil {
+				committed := text
+				ctx.Window.deferCallback(func(w *Window) {
+					c := EventCtx{nil, nil, w}
+					if commit != nil {
+						commit(committed, InputCommitBlur, c)
+					}
+					if blur != nil {
+						blur(c)
+					}
+				})
 			}
 			if spellChk {
 				spellCheckClear(key, ctx.Window)
-			}
-			if onBlur != nil {
-				onBlur(ctx)
 			}
 		}
 

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -250,13 +250,13 @@ func inputCommitEnter(
 ) {
 	commitText := text
 	if normalized := hcfg.normalizeOnCommit(
-		text, commitEnter,
+		text, InputCommitEnter,
 	); normalized != text {
 		commitText = normalized
 		hcfg.fireTextChanged(layout, commitText, w)
 	}
 	if hcfg.OnTextCommit != nil {
-		hcfg.OnTextCommit(commitText, commitEnter, EventCtx{layout, nil, w})
+		hcfg.OnTextCommit(commitText, InputCommitEnter, EventCtx{layout, nil, w})
 	}
 	if hcfg.OnEnter != nil {
 		hcfg.OnEnter(EventCtx{layout, e, w})

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/go-gui-org/go-glyph"
@@ -388,7 +389,7 @@ func TestInputKeyDownEnterSingleLine(t *testing.T) {
 		ID:   "f600",
 		OnTextCommit: func(_ string, reason InputCommitReason, ctx EventCtx) {
 			committed = true
-			if reason != commitEnter {
+			if reason != InputCommitEnter {
 				t.Fatalf("got reason %d, want CommitEnter", reason)
 			}
 		},
@@ -1632,10 +1633,13 @@ func TestInputReadOnlyBlurDoesNotNormalize(t *testing.T) {
 	l1 := generateViewLayout(Input(cfg), w)
 	l1.Shape.events.AmendLayout(EventCtx{&l1, nil, w})
 
-	// Frame 2: focus moved away -> blur commit path runs.
+	// Frame 2: focus moved away -> blur commit path runs. The hook only
+	// raises the app callbacks; Update runs them once w.mu is released
+	// (window_deferred.go), so a direct hook call must flush too.
 	w.SetFocus("elsewhere")
 	l2 := generateViewLayout(Input(cfg), w)
 	l2.Shape.events.AmendLayout(EventCtx{&l2, nil, w})
+	w.flushDeferredCallbacks()
 
 	if changed != "" {
 		t.Errorf("OnTextChanged fired with %q on blur of a read-only field",
@@ -2229,5 +2233,100 @@ func TestInputOpticalCenterIsOptIn(t *testing.T) {
 	opted := inputTextShapeY(t, InputCfg{Text: "128", opticalDigitCenter: true})
 	if opted <= plain {
 		t.Errorf("opted-in text y = %v, want below plain %v", opted, plain)
+	}
+}
+
+// The editable blur path with PostCommitNormalize defers its
+// OnTextChanged: the tree already echoes the normalized text — the
+// arrange pass is still reading it — but the callback runs after the
+// pass with a nil ctx.Layout, because that tree is recycled before the
+// callback runs. The contract is documented in CLAUDE.md; this pins it.
+func TestInputBlurNormalizeDefersOnTextChanged(t *testing.T) {
+	w := newTestWindow()
+	changed := ""
+	cfg := InputCfg{
+		ID: "bn_defer", Text: "  hi  ",
+		PostCommitNormalize: func(_ string, _ InputCommitReason) string {
+			return "NORMALIZED"
+		},
+		OnTextChanged: func(nt string, ctx EventCtx) {
+			if ctx.Layout != nil {
+				t.Errorf("deferred OnTextChanged got a live ctx.Layout")
+			}
+			changed = nt
+		},
+	}
+
+	w.SetFocus("bn_defer")
+	l1 := generateViewLayout(Input(cfg), w)
+	l1.Shape.events.AmendLayout(EventCtx{&l1, nil, w})
+
+	w.SetFocus("elsewhere")
+	l2 := generateViewLayout(Input(cfg), w)
+	l2.Shape.events.AmendLayout(EventCtx{&l2, nil, w})
+
+	// The echo is inline, the callback is not.
+	if got := inputTextFromLayout(&l2); got != "NORMALIZED" {
+		t.Errorf("layout text after blur = %q, want the normalized %q",
+			got, "NORMALIZED")
+	}
+	if changed != "" {
+		t.Fatalf("OnTextChanged ran before the flush: %q", changed)
+	}
+	w.flushDeferredCallbacks()
+	if changed != "NORMALIZED" {
+		t.Errorf("OnTextChanged after flush = %q, want NORMALIZED", changed)
+	}
+}
+
+// A blur-triggered OnTextCommit that calls back into a w.mu-taking
+// Window API must not deadlock. Issue #394: the blur block ran from
+// inputAmendLayout, which layoutArrange invokes while Update holds
+// w.mu, so an app calling SetFocus from the commit wedged the main
+// thread — a frozen window with no CPU burn and no panic.
+//
+// Driven behind a timeout because the failure mode is a hang: without
+// the goroutine the whole package would block until the test binary's
+// deadline instead of naming the defect.
+func TestInputBlurCommitMaySetFocus(t *testing.T) {
+	done := make(chan string, 1)
+	go func() {
+		w := NewTestWindow(WindowCfg{})
+		view := func(w *Window) View {
+			return Column(ContainerCfg{
+				Content: []View{
+					Input(InputCfg{
+						ID:   "f394",
+						Text: "abc",
+						OnTextCommit: func(
+							_ string, reason InputCommitReason,
+							ctx EventCtx,
+						) {
+							if reason != InputCommitBlur {
+								return
+							}
+							// The natural thing to do from a commit
+							// handler, and the exact call that hung.
+							ctx.Window.SetFocus("f394")
+						},
+					}),
+					Button(ButtonCfg{
+						ID:      "b394",
+						Content: []View{Text(TextCfg{Text: "b"})},
+					}),
+				},
+			})
+		}
+		w.TestRender(view)
+		w.SetFocus("f394")
+		w.TestRender(nil)
+		next, _ := w.testTab(tabForward)
+		done <- next
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blur commit calling SetFocus deadlocked (issue #394)")
 	}
 }

--- a/gui/window.go
+++ b/gui/window.go
@@ -235,6 +235,19 @@ type Window struct {
 	// runloop, for instance). Main-thread only — no atomic needed.
 	pumping bool
 
+	// deferredCallbacks holds app callbacks raised during the frame
+	// pass and run by flushDeferredCallbacks once w.mu is released.
+	// Main-thread only, like the pass that fills it; the slice is
+	// reused across frames. See window_deferred.go.
+	deferredCallbacks []func(*Window)
+
+	// inFramePass reports that some goroutine is inside the locked
+	// region of the frame pass. Read by lockForAPI to tell a caller
+	// re-entering from a frame-pass callback — which would otherwise
+	// deadlock on the non-reentrant w.mu — from ordinary contention.
+	// Atomic because lockForAPI may run on any goroutine.
+	inFramePass atomic.Bool
+
 	// Window focus state — backend sets false on unfocus event.
 	focused bool
 

--- a/gui/window_deferred.go
+++ b/gui/window_deferred.go
@@ -1,0 +1,110 @@
+package gui
+
+// window_deferred.go — running app callbacks outside the frame lock.
+//
+// layoutArrange and buildRenderers run under w.mu (window_update.go),
+// and both reach code that fires app callbacks: an AmendLayout hook
+// detecting blur, a render pass reporting a caret rect. w.mu is a
+// plain sync.Mutex, so a callback that calls back into SetFocus,
+// UpdateView or any other w.mu-taking API deadlocks the main thread —
+// a frozen window with no panic and no CPU burn (issue #394).
+//
+// The invariant this file restores: no app callback runs while the
+// frame lock is held. Library code raises the callback with
+// deferCallback and the frame pass runs it afterwards, with nothing
+// held. Anything that must touch the live *Layout stays inline — the
+// tree is rebuilt from pooled arenas every frame, so a captured
+// *Layout dangles by the time the deferred call runs.
+
+// deferCallback queues fn to run after the current frame pass releases
+// w.mu. Nil-safe in both directions: a nil fn is dropped, and a call
+// from outside a frame pass still works — flushDeferredCallbacks is
+// what drains it.
+//
+// Main-thread only. The frame pass is the sole producer, and it runs
+// on the goroutine that owns w.mu, so the append needs no lock. Use
+// QueueCommand from any other goroutine.
+func (w *Window) deferCallback(fn func(*Window)) {
+	if fn == nil {
+		return
+	}
+	w.deferredCallbacks = append(w.deferredCallbacks, fn)
+}
+
+// flushDeferredCallbacks runs everything deferCallback collected during
+// the frame pass and reports whether any ran. Called with no lock held,
+// so a callback is free to call SetFocus, UpdateWindow or any other
+// window API.
+//
+// The bool is the "the frame is stale" signal: a deferred callback runs
+// after the renderers were built, so anything it changes (state, focus)
+// is absent from this frame's output. FrameFn re-runs the pass when the
+// flush reports true — see the two-pass loop in window_update.go.
+//
+// The slice is swapped out before the loop so a callback that defers
+// another callback (an OnBlur that moves focus into a second field,
+// which blurs a third) lands in the next batch rather than mutating the
+// slice being ranged. The batch loop is bounded: a pair of callbacks
+// that re-raise each other would otherwise spin the frame forever.
+func (w *Window) flushDeferredCallbacks() bool {
+	ran := false
+	for batch := 0; len(w.deferredCallbacks) > 0; batch++ {
+		if batch >= maxDeferredCallbackBatches {
+			w.debugWarn(debugCheckDeferredLoop, "flush",
+				"deferred callbacks still re-queueing after %d rounds; "+
+					"dropping %d — an app callback is cycling",
+				maxDeferredCallbackBatches, len(w.deferredCallbacks))
+			w.deferredCallbacks = w.deferredCallbacks[:0]
+			// Earlier batches already ran, so the frame is stale.
+			return true
+		}
+		pending := w.deferredCallbacks
+		w.deferredCallbacks = nil
+		for _, fn := range pending {
+			fn(w)
+			ran = true
+		}
+		// Reuse the batch's backing array when nothing re-queued, so a
+		// steady stream of blur commits does not allocate per frame.
+		if w.deferredCallbacks == nil {
+			w.deferredCallbacks = pending[:0]
+		}
+	}
+	return ran
+}
+
+// maxDeferredCallbackBatches bounds flushDeferredCallbacks. Two rounds
+// cover the legitimate case (a callback that moves focus, blurring a
+// second widget); beyond that the app is cycling.
+const maxDeferredCallbackBatches = 8
+
+// lockForAPI acquires w.mu for an exported window API, naming the
+// caller if the acquisition would deadlock.
+//
+// The probe is TryLock, the same technique PumpFrame uses: on success
+// nothing was held and the caller owns the lock. On failure the lock is
+// held by someone, and if that someone is a frame pass the overwhelmingly
+// likely explanation is this very goroutine — an app callback reached
+// from an AmendLayout hook or the render pass calling back into the
+// window. Blocking there never returns, so panic with the API's name
+// instead. A crash that says what to fix beats a freeze that says
+// nothing.
+//
+// Calling these APIs from a goroutine other than the frame thread is
+// already outside the contract (QueueCommand is the documented route),
+// so the message covers both readings rather than trying to tell them
+// apart — which TryLock cannot do.
+func (w *Window) lockForAPI(api string) {
+	if w.mu.TryLock() {
+		return
+	}
+	if w.inFramePass.Load() {
+		panic("gui: " + api + " called while the frame lock is held. " +
+			"An AmendLayout hook, or an app callback reached from one " +
+			"(OnTextCommit with InputCommitBlur, OnBlur, OnTextChanged), " +
+			"must not call window APIs directly — use " +
+			"ctx.Window.QueueCommand. If this call is from another " +
+			"goroutine, use QueueCommand there too.")
+	}
+	w.mu.Lock()
+}

--- a/gui/window_deferred_test.go
+++ b/gui/window_deferred_test.go
@@ -1,0 +1,217 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Deferred callbacks run in the order they were raised, and they run
+// with no lock held — the whole point, so SetFocus is legal in one.
+func TestFlushDeferredCallbacksRunsInOrder(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	var order []string
+	w.deferCallback(func(*Window) { order = append(order, "first") })
+	w.deferCallback(func(w *Window) {
+		order = append(order, "second")
+		w.SetFocus("somewhere")
+	})
+	w.deferCallback(nil) // dropped, not queued
+	w.flushDeferredCallbacks()
+
+	if strings.Join(order, ",") != "first,second" {
+		t.Fatalf("order = %v, want [first second]", order)
+	}
+	if w.FocusID() != "somewhere" {
+		t.Fatalf("focus = %q, want %q", w.FocusID(), "somewhere")
+	}
+}
+
+// A callback that defers another is legitimate — an OnBlur that moves
+// focus blurs the next field — so the flush keeps draining rather than
+// leaving the second one for the following frame.
+func TestFlushDeferredCallbacksDrainsCascade(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	ran := 0
+	w.deferCallback(func(w *Window) {
+		ran++
+		w.deferCallback(func(*Window) { ran++ })
+	})
+	w.flushDeferredCallbacks()
+	if ran != 2 {
+		t.Fatalf("ran = %d, want 2 (the cascade must drain)", ran)
+	}
+}
+
+// A pair of callbacks that re-raise each other must not spin the frame
+// forever. The flush bounds the rounds, drops the rest and says so.
+func TestFlushDeferredCallbacksBoundsRunaway(t *testing.T) {
+	buf := captureDebugMask(t, DebugCallbacks)
+	w := NewTestWindow(WindowCfg{})
+	ran := 0
+	var again func(*Window)
+	again = func(w *Window) {
+		ran++
+		w.deferCallback(again)
+	}
+	w.deferCallback(again)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.flushDeferredCallbacks()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a self-requeueing callback spun the flush forever")
+	}
+
+	if ran != maxDeferredCallbackBatches {
+		t.Fatalf("ran = %d, want %d rounds before the bound",
+			ran, maxDeferredCallbackBatches)
+	}
+	if len(w.deferredCallbacks) != 0 {
+		t.Fatalf("%d callbacks left queued, want the batch dropped",
+			len(w.deferredCallbacks))
+	}
+	if !strings.Contains(buf.String(), "re-queueing") {
+		t.Fatalf("no runaway diagnostic reported, got %q", buf.String())
+	}
+}
+
+// The fail-fast probe: a window API called while the frame lock is held
+// panics with the API's name instead of blocking forever. This is the
+// path an app takes when it calls SetFocus from its own AmendLayout
+// hook, which cannot be deferred — the hook exists to mutate the tree.
+func TestLockForAPIPanicsUnderFrameLock(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.mu.Lock()
+	w.inFramePass.Store(true)
+	defer func() {
+		w.inFramePass.Store(false)
+		w.mu.Unlock()
+		r := recover()
+		if r == nil {
+			t.Fatal("SetFocus under the frame lock did not panic")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "SetFocus") {
+			t.Fatalf("panic = %v, want the API name in the message", r)
+		}
+		if !strings.Contains(msg, "QueueCommand") {
+			t.Fatalf("panic = %v, want the remedy in the message", r)
+		}
+	}()
+	w.SetFocus("boom")
+}
+
+// An app AmendLayout hook is the one route into app code the frame pass
+// cannot defer, so it is the case the probe has to catch end to end.
+func TestAppAmendLayoutHookCallingSetFocusPanics(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("SetFocus from an app AmendLayout hook did not panic")
+		}
+		if msg, ok := r.(string); !ok ||
+			!strings.Contains(msg, "AmendLayout") {
+			t.Fatalf("panic = %v, want AmendLayout named", r)
+		}
+	}()
+	w.TestRender(func(*Window) View {
+		return Column(ContainerCfg{
+			ID: "amender",
+			AmendLayout: func(ctx EventCtx) {
+				ctx.Window.SetFocus("elsewhere")
+			},
+		})
+	})
+}
+
+// A flush that ran callbacks reports it, an empty one does not.
+func TestFlushDeferredCallbacksReports(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	if w.flushDeferredCallbacks() {
+		t.Fatal("an empty flush reported callbacks")
+	}
+	w.deferCallback(func(*Window) {})
+	if !w.flushDeferredCallbacks() {
+		t.Fatal("a flush that ran a callback reported nothing")
+	}
+	if w.flushDeferredCallbacks() {
+		t.Fatal("a second empty flush reported callbacks")
+	}
+}
+
+// A deferred callback that writes app state sets no refresh flag
+// (SetFocus and plain state writes are silent), so only the flush
+// report can make FrameFn re-run. Without the re-run the frame shows
+// the pre-callback text until the next event.
+func TestFrameFnRerunsPassAfterDeferredCallbacks(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	label := "before"
+	w.UpdateView(func(*Window) View {
+		return Text(TextCfg{ID: "label", Text: label})
+	})
+	w.deferCallback(func(*Window) { label = "after" })
+	w.markLayoutRefresh()
+
+	if !w.FrameFn() {
+		t.Fatal("FrameFn did not report a rebuild")
+	}
+	ly, ok := w.layout.FindByID("label")
+	if !ok {
+		t.Fatal("label shape missing after FrameFn")
+	}
+	if got := ly.Shape.TC.Text; got != "after" {
+		t.Fatalf("frame shows %q, want %q — the deferred callback's "+
+			"state change needs the re-run pass", got, "after")
+	}
+}
+
+// The flip side of the re-run: a frame with nothing deferred must not
+// pay for it — one pass, one view generation.
+func TestFrameFnSinglePassWithoutDeferredCallbacks(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	gens := 0
+	w.UpdateView(func(*Window) View {
+		gens++
+		return Text(TextCfg{ID: "t"})
+	})
+	w.markLayoutRefresh()
+	w.FrameFn()
+	if gens != 1 {
+		t.Fatalf("view generated %d times, want 1", gens)
+	}
+}
+
+// The re-run is bounded: a view that dirties itself every pass must
+// not make FrameFn spin — two passes and out. Driven behind a timeout
+// because the failure mode (an unbounded loop) would otherwise hang
+// the whole package.
+func TestFrameFnStopsAfterTwoPasses(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	gens := 0
+	w.UpdateView(func(w *Window) View {
+		gens++
+		w.UpdateWindow() // dirty the window from inside the pass
+		return Text(TextCfg{ID: "t"})
+	})
+	w.markLayoutRefresh()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.FrameFn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a self-dirtying view made FrameFn spin")
+	}
+	if gens != 2 {
+		t.Fatalf("view generated %d times, want 2 (bounded)", gens)
+	}
+}

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -14,7 +14,7 @@ func (w *Window) FocusID() string {
 // that already holds focus leaves selections alone. Acquires both w.mu
 // (focusID) and w.animMu (animations). Use ClearFocus to remove focus.
 func (w *Window) SetFocus(id string) {
-	w.mu.Lock()
+	w.lockForAPI("SetFocus")
 	w.animMu.Lock()
 	defer w.animMu.Unlock()
 	defer w.mu.Unlock()

--- a/gui/window_state.go
+++ b/gui/window_state.go
@@ -152,7 +152,7 @@ func (w *Window) Ctx() context.Context {
 
 // clearViewState resets all view state.
 func (w *Window) clearViewState() {
-	w.mu.Lock()
+	w.lockForAPI("clearViewState")
 	defer w.mu.Unlock()
 	w.clearViewStateLocked()
 }
@@ -167,14 +167,15 @@ func (w *Window) clearViewStateLocked() {
 // ClearDrawCanvasCache drops all cached tessellation data,
 // forcing every DrawCanvas widget to re-render next frame.
 func (w *Window) ClearDrawCanvasCache() {
-	w.mu.Lock()
+	w.lockForAPI("ClearDrawCanvasCache")
 	defer w.mu.Unlock()
 	w.viewState.registry.clearNamespace(nsDrawCanvas)
 }
 
-// Lock locks the window's mutex.
+// Lock locks the window's mutex. Panics rather than hanging when the
+// frame lock is already held — see lockForAPI.
 func (w *Window) Lock() {
-	w.mu.Lock()
+	w.lockForAPI("Lock")
 }
 
 // Unlock unlocks the window's mutex.

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -147,7 +147,7 @@ func (w *Window) RequestRedraw() {
 
 // UpdateView sets the view generator and triggers a full refresh.
 func (w *Window) UpdateView(gen func(*Window) View) {
-	w.mu.Lock()
+	w.lockForAPI("UpdateView")
 	defer w.mu.Unlock()
 	w.viewState.registry.Clear()
 	w.viewGenerator = gen
@@ -166,11 +166,26 @@ func (w *Window) FrameFn() bool {
 	w.installTheme()
 	w.flushCommands()
 	var rebuilt bool
-	if w.refreshLayout {
-		w.Update()
-		rebuilt = true
-	} else if w.refreshRenderOnly {
-		w.updateRenderOnly()
+	// Two passes, not one: Update ends by running the callbacks the
+	// frame pass deferred (window_deferred.go). A blur commit that
+	// writes state or moves focus changes what the frame must show,
+	// and neither marks a refresh flag, so the flush's own report is
+	// what re-arms the loop — the pass re-runs whenever any callback
+	// ran. A callback-driven re-run is a full Update, never a
+	// render-only pass: the callback may have changed state the layout
+	// tree encodes. ran doubles as the re-run's trigger: it holds the
+	// previous pass's flush report until the pass overwrites it.
+	// Bounded at two — a view that dirties itself every pass is a bug
+	// the frame loop must not amplify into a spin; the next FrameFn
+	// picks it up anyway.
+	ran := false
+	for pass := 0; pass < 2 &&
+		(ran || w.refreshLayout || w.refreshRenderOnly); pass++ {
+		if w.refreshLayout || ran {
+			ran = w.Update()
+		} else {
+			ran = w.updateRenderOnly()
+		}
 		rebuilt = true
 	}
 	w.initA11y()
@@ -210,12 +225,33 @@ func (w *Window) PumpFrame() bool {
 	return w.FrameFn()
 }
 
-// Update performs a full layout rebuild and re-renders.
-func (w *Window) Update() {
+// Update performs a full layout rebuild and re-renders, then runs the
+// app callbacks the pass deferred. It reports whether any deferred
+// callback ran.
+//
+// The split is load-bearing, not cosmetic: updateLocked holds w.mu
+// across layoutArrange and buildRenderers, and both reach app code.
+// Running that code inside the lock deadlocks the main thread the
+// moment it calls back into the window (issue #394), so library code
+// raises it with deferCallback and it runs here, with nothing held.
+// See window_deferred.go.
+//
+// The bool matters because those callbacks run after the renderers were
+// built: a callback that writes state or moves focus is absent from
+// this pass's output, so the caller must re-run (FrameFn re-checks
+// after each pass) or the frame stays stale until the next event.
+func (w *Window) Update() bool {
+	w.updateLocked()
+	return w.flushDeferredCallbacks()
+}
+
+func (w *Window) updateLocked() {
 	// Repeated from FrameFn because tests drive Update directly.
 	// Idempotent: a no-op when this window's theme is already installed.
 	w.installTheme()
 	w.mu.Lock()
+	w.inFramePass.Store(true)
+	defer w.inFramePass.Store(false)
 	w.refreshLayout = false
 	w.refreshRenderOnly = false
 
@@ -298,9 +334,20 @@ func (w *Window) Update() {
 	}
 }
 
-// updateRenderOnly rebuilds renderers from the existing layout.
-func (w *Window) updateRenderOnly() {
+// updateRenderOnly rebuilds renderers from the existing layout, then
+// runs whatever the render pass deferred. Reports whether any deferred
+// callback ran — same contract as Update. buildRenderers reaches app
+// code the same way the full pass does (syncIMEEditContext, the caret
+// rect report), so it needs the same treatment — see Update.
+func (w *Window) updateRenderOnly() bool {
+	w.renderOnlyLocked()
+	return w.flushDeferredCallbacks()
+}
+
+func (w *Window) renderOnlyLocked() {
 	w.mu.Lock()
+	w.inFramePass.Store(true)
+	defer w.inFramePass.Store(false)
 	defer w.mu.Unlock()
 	w.refreshRenderOnly = false
 	w.buildRenderers(w.Config.BgColor, w.windowRect())


### PR DESCRIPTION
## What

App callbacks reached from the frame pass — the Input's blur commit in
`inputAmendLayout`, which `layoutArrange` runs while `Update` holds `w.mu` —
are now raised with `deferCallback` and run after the lock is released
(`gui/window_deferred.go`). Previously an `OnTextCommit`/`OnBlur` handler that
called back into `SetFocus` deadlocked the main thread against itself: a frozen
window, no panic, no CPU burn. `examples/todo` did exactly this on Tab.

## The invariant

**No app callback runs while the frame lock is held.**

- `SetFocus`, `ClearFocus`, `UpdateView`, `ClearDrawCanvasCache`, `Window.Lock`
  probe with `TryLock` and panic naming the API and the remedy (`QueueCommand`)
  when a frame pass owns the mutex — the case an app's own `AmendLayout` hook
  can still reach (it must run in the pass).
- The Input's blur commit defers `OnTextCommit` (`InputCommitBlur`), `OnBlur`
  and a normalize-driven `OnTextChanged`; they now run with a nil `ctx.Layout`
  (the tree is recycled) but a live `ctx.Window`. The Enter commit path is
  untouched.
- `FrameFn` re-runs the pass once when a flush ran callbacks — a deferred
  callback that writes state or moves focus sets no refresh flag, so the flush
  report is the trigger, and a state write needs a full `Update`, not a
  render-only pass. Bounded at two passes.
- `InputCommitEnter`/`InputCommitBlur` are exported (an app could receive the
  reason but not branch on it).
- `DebugCallbacks` joins `DebugAll`, reporting a flush that keeps re-queueing
  past the batch bound.
- `examples/todo` adds a task on Enter only, not on blur.

Spec: `docs/specs/frame-lock-callback-deferral.md`.

## Tests

- Deadlock repros behind timeouts: `TestInputBlurCommitMaySetFocus`,
  `TestTabOutOfComposerDoesNotHang`
- Fail-fast probe: `TestLockForAPIPanicsUnderFrameLock`,
  `TestAppAmendLayoutHookCallingSetFocusPanics`
- Flush order / cascade drain / runaway bound / report bool
- FrameFn re-run on flush report, single-pass cost guard, two-pass anti-spin cap
- Blur-normalize defers `OnTextChanged` with nil `ctx.Layout`
- Todo: Tab adds no todo and preserves the draft