### PR TITLE
feat(canvas): gradient fills on DrawContext (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,44 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Gradient fills on `DrawContext`** (#398) — a canvas fill can take a
+  `gui.CanvasGradient` in place of a flat `Color`: `FilledRectGradient`,
+  `FilledCircleGradient`, `FilledArcGradient`, `FilledPolygonGradient`,
+  `FilledRoundedRectGradient`, and `FillTrianglesGradient` for caller-supplied
+  geometry. Linear and radial, with pad/reflect/repeat spread and no stop-count
+  limit. Geometry left at zero is derived from the shape being filled, so a
+  centered glow needs only its stops.
+
+  This replaces the stacked-geometry workaround a non-flat canvas fill used to
+  require. `examples/solar_system` drew its sun halo as up to 140 concentric
+  discs, where ring count was the smoothness knob and seams showed when it was
+  turned down; it is now one fill.
+
+  There is no new shader and no backend change. A gradient batch carries one
+  color per vertex on the existing `RenderSvg` command, a channel Metal, GL,
+  web, software, iOS and Android already consume — and so does PDF export. A
+  `DrawRecorder` that does not implement the new optional `DrawGradientRecorder`
+  receives the equivalent flat primitive shaded with the ramp's midpoint, so an
+  export path never drops a gradient fill.
+
 ### Fixed
+
+- **A fade to transparent no longer fades to black** — `SampleGradientStopColor`
+  interpolates in premultiplied space, where zero alpha carries no hue, and
+  returned transparent black. Any consumer that interpolates in straight-alpha
+  space — a vertex-colored triangle mesh, on every backend — read that as a real
+  color, so a white glow darkened as it faded. The nearer stop's hue is now
+  kept.
+- **Software backend: a vertex-colored mesh no longer shades from a neighbour's
+  extrapolation** — `shadeTriangle` writes a half-pixel skirt past each
+  triangle's edge so the mesh's outer edge does not thin, but the write was
+  unconditional, so the last triangle painted won even where another one
+  actually contained the pixel. A fan of narrow wedges — a glow struck from its
+  own center — had its whole inner region shaded from extrapolated weights. A
+  triangle may now only overwrite a pixel it fits better than the one already
+  there.
 
 - **Tab out of a text input no longer freezes the app** (#394) — the Input's
   blur commit fired from its `AmendLayout` hook, which `layoutArrange` runs

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -195,6 +195,35 @@ within and keeps the single-row sum — that combination behaves as a `Row`, not
 wrap. When the wrap should always fill its parent, use Fill width, which is what
 every example in this repo does.
 
+## Canvas gradients
+
+A `DrawContext` fill takes a `*gui.CanvasGradient` in place of a flat `Color`:
+`FilledRectGradient`, `FilledCircleGradient`, `FilledArcGradient`,
+`FilledPolygonGradient`, `FilledRoundedRectGradient`, and
+`FillTrianglesGradient` for geometry you tessellate yourself. Strokes stay flat.
+
+**Geometry left at zero is derived from the shape being filled.** A radial
+gradient with `R <= 0` centers on the fill's bounding box and matches its larger
+extent; a linear one whose endpoints coincide runs top to bottom. So a glow is
+its stops and nothing else:
+
+```go
+dc.FilledCircleGradient(cx, cy, r, &gui.CanvasGradient{
+	Radial: true,
+	Stops: []gui.GradientStop{
+		{Color: core, Pos: 0},
+		{Color: core.WithOpacity(0), Pos: 1},
+	},
+})
+```
+
+There is no stop-count limit — the shader's five-stop cap belongs to the shape
+gradient path (`ContainerCfg`), not this one. Do not stack concentric discs to
+fake a falloff; that is what this replaces.
+
+A gradient fill always starts its own batch and never merges with the flat fill
+before it, so interleaving the two keeps painter's order.
+
 ## The one-event rule
 
 Nothing is marked handled for you. A callback that acts on an event calls

--- a/examples/draw_canvas/main.go
+++ b/examples/draw_canvas/main.go
@@ -1,8 +1,10 @@
-// This example demonstrates the DrawCanvas widget with a line chart.
-// Draw_canvas demonstrates the DrawCanvas widget with a line chart.
+// Draw_canvas demonstrates the DrawCanvas widget: a line chart, and
+// the gradient fills DrawContext offers alongside its flat ones.
 package main
 
 import (
+	"math"
+
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend"
 )
@@ -45,6 +47,20 @@ func mainView(w *gui.Window) gui.View {
 				Radius:  8,
 				Padding: gui.NewPadding(30, 40, 40, 50),
 				OnDraw:  drawChart,
+			}),
+			gui.Text(gui.TextCfg{
+				Text:      "Gradient Fills",
+				TextStyle: gui.CurrentTheme().B1,
+			}),
+			gui.DrawCanvas(gui.DrawCanvasCfg{
+				ID:      "gradients",
+				Version: 1,
+				Width:   560,
+				Height:  140,
+				Color:   gui.RGBA(30, 30, 40, 255),
+				Radius:  8,
+				Padding: gui.PadAll(16),
+				OnDraw:  drawGradients,
 			}),
 		},
 	})
@@ -108,4 +124,79 @@ func drawChart(dc *gui.DrawContext) {
 	for i := 0; i < len(pts); i += 2 {
 		dc.FilledCircle(pts[i], pts[i+1], 4, gui.RGBA(220, 220, 255, 255))
 	}
+}
+
+// drawGradients shows the six gradient fills. Each takes a
+// *gui.CanvasGradient in place of the flat Color its plain twin takes;
+// geometry left at zero is derived from the shape being filled, so the
+// radial cases below name only their stops.
+func drawGradients(dc *gui.DrawContext) {
+	const (
+		size = 96
+		gap  = 16
+	)
+	y := (dc.Height - size) / 2
+	x := float32(0)
+	next := func() float32 {
+		v := x
+		x += size + gap
+		return v
+	}
+
+	warm := []gui.GradientStop{
+		{Color: gui.RGB(240, 120, 60), Pos: 0},
+		{Color: gui.RGB(250, 210, 90), Pos: 0.5},
+		{Color: gui.RGB(90, 150, 240), Pos: 1},
+	}
+	// A glow: opaque at the center, fading to nothing at the rim. This
+	// is the case that used to need a stack of concentric discs.
+	glow := []gui.GradientStop{
+		{Color: gui.RGBA(255, 220, 140, 255), Pos: 0},
+		{Color: gui.RGBA(255, 160, 60, 120), Pos: 0.55},
+		{Color: gui.RGBA(255, 120, 40, 0), Pos: 1},
+	}
+
+	// Linear, explicit endpoints: left to right across the square.
+	r := next()
+	dc.FilledRectGradient(r, y, size, size, &gui.CanvasGradient{
+		X1: r, Y1: y, X2: r + size, Y2: y, Stops: warm,
+	})
+
+	// Rounded rect, endpoints left unset: runs top to bottom.
+	r = next()
+	dc.FilledRoundedRectGradient(r, y, size, size, 14,
+		&gui.CanvasGradient{Stops: warm})
+
+	// Radial with no geometry at all: centered on the circle, its
+	// radius matched to it.
+	r = next()
+	dc.FilledCircleGradient(r+size/2, y+size/2, size/2,
+		&gui.CanvasGradient{Radial: true, Stops: glow})
+
+	// A pie slice.
+	r = next()
+	dc.FilledArcGradient(r+size/2, y+size/2, size/2, size/2,
+		-math.Pi/2, 1.6*math.Pi,
+		&gui.CanvasGradient{Radial: true, Stops: warm})
+
+	// A convex polygon: a hexagon.
+	r = next()
+	hex := make([]float32, 0, 12)
+	for i := range 6 {
+		a := float64(i)*math.Pi/3 - math.Pi/2
+		hex = append(hex,
+			r+size/2+size/2*float32(math.Cos(a)),
+			y+size/2+size/2*float32(math.Sin(a)))
+	}
+	dc.FilledPolygonGradient(hex, &gui.CanvasGradient{Stops: warm})
+
+	// Caller-supplied geometry, the escape hatch the five above are
+	// built on. Repeat tiles the ramp across the shape.
+	r = next()
+	dc.FillTrianglesGradient([]float32{
+		r, y + size, r + size/2, y, r + size, y + size,
+	}, &gui.CanvasGradient{
+		X1: r, Y1: 0, X2: r + size/3, Y2: 0,
+		Spread: gui.SpreadRepeat, Stops: warm,
+	})
 }

--- a/examples/solar_system/README.md
+++ b/examples/solar_system/README.md
@@ -60,14 +60,29 @@ go run ./examples/solar_system/
 
 ## Notes on technique
 
-`DrawContext` has no gradient fill: a batch carries one flat color. Everything
-here that looks like a gradient is flat shapes standing in for one.
+`DrawContext` fills come in two forms, and this example uses both.
 
-- The sun's halo is a ring of concentric circles with a **cubic** alpha falloff.
-  Linear reads as a hard-edged disc, and even quadratic leaves a visible
-  shoulder at this radius.
+The two glows are real gradients (`FilledCircleGradient`, issue #398). Each is
+one fill:
+
+- The sun's halo keeps its **cubic** alpha falloff. Linear reads as a hard-edged
+  disc, and even quadratic leaves a visible shoulder at this radius.
+- A hovered planet's halo is the same shape at planet scale.
+
+Both used to be stacks of concentric translucent discs — up to 140 of them for
+the sun — where the ring count was the smoothness knob and seams showed when it
+was turned down. `haloStops` (`draw.go`) samples the opacity those stacks
+accumulated to, so the appearance is the one they had, at one fill each and with
+nothing left to tune.
+
+Everything else that looks like a gradient is still flat shapes standing in for
+one, and deliberately so:
+
+- The planet shading is elliptical bands in a light-aligned frame. Circles
+  cannot make a crescent, so no radial gradient can express it.
 - Three translucent rings just outside each planet's silhouette feather the
-  polygon edge into something that reads as anti-aliased.
+  polygon edge into something that reads as anti-aliased. Three is few enough
+  that a gradient would not pay for itself.
 
 ### Painting a star
 
@@ -165,8 +180,10 @@ black, on the grounds that a planet you cannot see is a planet you cannot click.
 
 Level and segment counts scale with pixel radius, never a constant. A fixed
 count bands the moment the thing gets big — it showed up first on a planet
-zoomed to fill the view, and again on the sun's halo, which is 500px across when
-Jupiter is focused and banded at 17px per ring.
+zoomed to fill the view, and again on the sun's halo back when that was a ring
+stack, 500px across with Jupiter focused and banded at 17px per ring. The halo
+is a gradient now and no longer has a count to get wrong; the shading bands
+still do.
 
 A band is one flat color and its quads are emitted consecutively, so each band
 costs a single batch. The full-system view emits about 245 triangle batches a

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -331,18 +331,19 @@ func drawSun(a *App, dc *gui.DrawContext) {
 		outer *= 1.1
 	}
 
+	// One radial fill. The cubic falloff is the shape the ring stack
+	// was approximating — linear reads as a hard-edged disc and even
+	// quadratic leaves a visible shoulder at this extent, while the
+	// cube puts most of the opacity in the innermost third, which is
+	// what a real halo looks like. rings no longer sets the smoothness,
+	// only the depth the stack would have accumulated to.
 	rings := int(clamp32(outer*glowRingsPerPx, glowRingsMin, glowRingsMax))
-	for i := rings; i > 0; i-- {
-		t := float32(i) / float32(rings) // 1 at the outer edge
-		ringR := lerp(r, outer, t)
-		// Cubic falloff. Linear reads as a hard-edged disc and even
-		// quadratic leaves a visible shoulder at this extent; the cube
-		// puts most of the opacity in the innermost third, which is
-		// what a real halo looks like.
-		f := 1 - t
-		alpha := f * f * f * glowAlpha
-		dc.FilledCircle(cx, cy, ringR, colorSunGlow.WithOpacity(alpha))
-	}
+	a.glowStops = haloStops(colorSunGlow, r, outer, glowAlpha, 3, rings,
+		a.glowStops)
+	dc.FilledCircleGradient(cx, cy, outer, &gui.CanvasGradient{
+		Radial: true,
+		Stops:  a.glowStops,
+	})
 
 	// The disc: shells from the gold limb through cream to a white
 	// core. Three stops for the same reason the planets use three —
@@ -513,11 +514,12 @@ func drawPlanet(a *App, dc *gui.DrawContext, i int) {
 		// planet zoomed to fill the view, a purely proportional halo
 		// washes the whole canvas in its own color.
 		reach := min(r*1.1, 42)
-		for h := hoverHalos; h > 0; h-- {
-			t := float32(h) / hoverHalos
-			alpha := (1 - t) * (1 - t) * 0.42
-			dc.FilledCircle(cx, cy, r+reach*t, p.Color.WithOpacity(alpha))
-		}
+		a.haloStops = haloStops(p.Color, r, r+reach, 0.42, 2, hoverHalos,
+			a.haloStops)
+		dc.FilledCircleGradient(cx, cy, r+reach, &gui.CanvasGradient{
+			Radial: true,
+			Stops:  a.haloStops,
+		})
 	}
 
 	// One vector carries both facts the shading needs: which way the
@@ -865,4 +867,57 @@ func drawTooltip(a *App, dc *gui.DrawContext) {
 	dc.FilledRoundedRect(x, y, bw, bh, 5, colorTipBG)
 	dc.RoundedRect(x, y, bw, bh, 5, colorTipBorder, 1)
 	dc.Text(x+tipPadX, y+tipPadY, name, a.TipStyle)
+}
+
+// haloStops samples an accumulated-ring glow profile into gradient
+// stops, for a fill that runs from the body's edge out to reach.
+//
+// Every glow on this canvas used to be a stack of translucent discs of
+// decreasing radius. Painted back to front, their composite opacity at
+// radius rho was 1 - product(1 - a_i) over the rings outside it — and
+// with each a_i small that product is exp(-sum a_i), which integrates
+// in closed form. Sampling that curve keeps exactly the look the stack
+// had while emitting one fill instead of up to 140, and drops the
+// banding that made ring count a tuning knob in the first place: the
+// gradient interpolates between stops instead of stepping.
+//
+// falloff is the exponent the old per-ring alpha used ((1-t)^falloff),
+// peak its scale, and rings the count it would have drawn — the three
+// numbers that set the curve's shape and depth.
+func haloStops(c gui.Color, inner, outer float32,
+	peak float32, falloff int, rings int,
+	dst []gui.GradientStop,
+) []gui.GradientStop {
+	dst = dst[:0]
+	if outer <= 0 || inner < 0 || inner >= outer {
+		return dst
+	}
+	// Integrating (1-u)^falloff over [u,1] raises the exponent by one.
+	e := float64(falloff + 1)
+	k := float64(float32(rings)*peak) / e
+	alphaAt := func(u float32) float32 {
+		f := math.Pow(float64(1-u), e)
+		return float32(1 - math.Exp(-k*f))
+	}
+
+	// The glow is flat across the body it surrounds: the disc covers
+	// that region anyway, and a stop at 0 keeps the ramp from starting
+	// at the center.
+	core := alphaAt(0)
+	inFrac := inner / outer
+	dst = append(dst,
+		gui.GradientStop{Color: c.WithOpacity(core), Pos: 0},
+		gui.GradientStop{Color: c.WithOpacity(core), Pos: inFrac})
+
+	// Eight samples across the falloff. The curve is smooth and the
+	// renderer interpolates between stops, so this is well past the
+	// point where more of them change anything.
+	const samples = 8
+	for i := 1; i <= samples; i++ {
+		u := float32(i) / samples
+		pos := inFrac + (1-inFrac)*u
+		dst = append(dst,
+			gui.GradientStop{Color: c.WithOpacity(alphaAt(u)), Pos: pos})
+	}
+	return dst
 }

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -57,6 +57,12 @@ type App struct {
 
 	Stars []Star
 
+	// glowStops and haloStops back the two radial glow fills. They are
+	// reused across frames because the draw runs on every tick and a
+	// fresh slice per glow would allocate for the whole session.
+	glowStops []gui.GradientStop
+	haloStops []gui.GradientStop
+
 	// Selected and Hovered are a planet index, selSun for the sun, or
 	// -1 for the full-system view / nothing under the cursor.
 	Selected int

--- a/gui/backend/soft/draw.go
+++ b/gui/backend/soft/draw.go
@@ -27,6 +27,10 @@ type renderer struct {
 	// instead of spamming stderr every frame.
 	textErrLogged bool
 
+	// meshScoreBuf backs fillTriangleMesh's per-pixel fit scores; it is
+	// grown, never freed, so a per-frame gradient does not allocate.
+	meshScoreBuf []float32
+
 	// images caches decoded sources by the RenderCmd.Resource string.
 	images map[string]*image.NRGBA
 

--- a/gui/backend/soft/draw_canvas_gradient_test.go
+++ b/gui/backend/soft/draw_canvas_gradient_test.go
@@ -1,0 +1,161 @@
+package soft
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// canvasGradientCmd tessellates a canvas gradient fill through the real
+// DrawContext and returns it as the RenderSvg command the render path
+// would emit. This is the end of the seam: geometry and per-vertex
+// colors produced in gui/, rasterized by a backend, asserted as pixels.
+func canvasGradientCmd(t *testing.T,
+	draw func(dc *gui.DrawContext)) gui.RenderCmd {
+	t.Helper()
+	dc := gui.NewDrawContext(40, 40, nil)
+	draw(dc)
+	batches := dc.Batches()
+	if len(batches) != 1 {
+		t.Fatalf("got %d batches, want 1", len(batches))
+	}
+	b := batches[0]
+	if len(b.VertexColors)*2 != len(b.Triangles) {
+		t.Fatalf("VertexColors=%d, Triangles=%d",
+			len(b.VertexColors), len(b.Triangles))
+	}
+	return gui.RenderCmd{
+		Kind:         gui.RenderSvg,
+		Scale:        1,
+		Color:        b.Color,
+		Triangles:    b.Triangles,
+		VertexColors: b.VertexColors,
+	}
+}
+
+// TestCanvasLinearGradientRasterizes checks the ramp actually appears
+// in pixels, and in the right direction.
+func TestCanvasLinearGradientRasterizes(t *testing.T) {
+	cmd := canvasGradientCmd(t, func(dc *gui.DrawContext) {
+		dc.FilledRectGradient(4, 4, 32, 32, &gui.CanvasGradient{
+			X1: 4, Y1: 4, X2: 36, Y2: 4,
+			Stops: []gui.GradientStop{
+				{Color: gui.RGB(255, 0, 0), Pos: 0},
+				{Color: gui.RGB(0, 0, 255), Pos: 1},
+			},
+		})
+	})
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	leftR, _, leftB, _ := at(r.buf.img, 6, 20)
+	rightR, _, rightB, _ := at(r.buf.img, 34, 20)
+	if leftR <= rightR {
+		t.Errorf("red %d→%d across the ramp, want it falling",
+			leftR, rightR)
+	}
+	if leftB >= rightB {
+		t.Errorf("blue %d→%d across the ramp, want it rising",
+			leftB, rightB)
+	}
+	// A gradient perpendicular to the ramp axis must not vary.
+	topR, _, _, _ := at(r.buf.img, 20, 8)
+	botR, _, _, _ := at(r.buf.img, 20, 32)
+	if diff(int(topR), int(botR)) > 2 {
+		t.Errorf("red varies %d→%d along the constant axis", topR, botR)
+	}
+}
+
+// TestCanvasRadialGradientRasterizes is the case the concentric-ring
+// workaround existed for: a glow whose falloff is smooth and whose
+// interior carries no seams.
+func TestCanvasRadialGradientRasterizes(t *testing.T) {
+	cmd := canvasGradientCmd(t, func(dc *gui.DrawContext) {
+		dc.FilledCircleGradient(20, 20, 16, &gui.CanvasGradient{
+			Radial: true,
+			Stops: []gui.GradientStop{
+				{Color: gui.RGBA(255, 255, 255, 255), Pos: 0},
+				{Color: gui.RGBA(255, 255, 255, 0), Pos: 1},
+			},
+		})
+	})
+	r := newRenderer(40, 40, 1)
+	r.drawAll([]gui.RenderCmd{cmd})
+
+	// The buffer starts opaque black, so a white-to-transparent ramp
+	// reads as brightness rather than alpha.
+	centerV, _, _, _ := at(r.buf.img, 20, 20)
+	midV, _, _, _ := at(r.buf.img, 28, 20)
+	rimV, _, _, _ := at(r.buf.img, 35, 20)
+	if centerV <= midV || midV <= rimV {
+		t.Errorf("brightness %d→%d→%d from center to rim, want it "+
+			"falling monotonically", centerV, midV, rimV)
+	}
+	// Not a full 255: the pixel's center sits half a pixel off the
+	// fan's hub vertex, so it samples the ramp just past t=0.
+	if centerV < 200 {
+		t.Errorf("center brightness = %d, want near the t=0 stop", centerV)
+	}
+
+	// Scan a radius for a seam: the fan's triangle edges must not show
+	// as a bright ridge or a dark dip, which is exactly what the
+	// stacked-ring workaround left behind at low ring counts.
+	prev := -1
+	for x := 20; x <= 34; x++ {
+		v8, _, _, _ := at(r.buf.img, x, 20)
+		v := int(v8)
+		if prev >= 0 && v > prev+2 {
+			t.Errorf("brightness rises %d→%d at x=%d: a seam in the "+
+				"falloff", prev, v, x)
+		}
+		prev = v
+	}
+}
+
+func diff(a, b int) int {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+// TestVertexColorsLengthMismatchFallsBackToFlat pins the guard that
+// decides whether a command is a mesh. shadeTriangle indexes cols by
+// triangle, so a short list would read past the end; drawSvg's length
+// equality is the only thing standing between a malformed command and
+// that read. A mismatch must paint the flat color, not panic and not
+// vanish.
+func TestVertexColorsLengthMismatchFallsBackToFlat(t *testing.T) {
+	full := canvasGradientCmd(t, func(dc *gui.DrawContext) {
+		dc.FilledRectGradient(4, 4, 32, 32, &gui.CanvasGradient{
+			X1: 4, Y1: 4, X2: 36, Y2: 4,
+			Stops: []gui.GradientStop{
+				{Color: gui.RGB(255, 0, 0), Pos: 0},
+				{Color: gui.RGB(0, 0, 255), Pos: 1},
+			},
+		})
+	})
+	for _, tc := range []struct {
+		name string
+		cols []gui.Color
+	}{
+		{"short", full.VertexColors[:len(full.VertexColors)-1]},
+		{"empty", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := full
+			cmd.VertexColors = tc.cols
+			cmd.Color = gui.RGB(0, 255, 0)
+			r := newRenderer(40, 40, 1)
+			r.drawAll([]gui.RenderCmd{cmd})
+			// Flat green everywhere inside, no ramp.
+			for _, x := range []int{6, 20, 34} {
+				cr, cg, cb, _ := at(r.buf.img, x, 20)
+				if cg < 200 || cr > 40 || cb > 40 {
+					t.Errorf("x=%d is %d,%d,%d, want flat green",
+						x, cr, cg, cb)
+				}
+			}
+		})
+	}
+}

--- a/gui/backend/soft/draw_svg.go
+++ b/gui/backend/soft/draw_svg.go
@@ -87,9 +87,22 @@ func (r *renderer) fillTriangleMesh(verts []float32, cols []gui.Color,
 		return
 	}
 
+	// score records, per pixel, how well the triangle that shaded it
+	// actually contained it: the minimum of its barycentric weights,
+	// which is >= 0 inside the triangle and negative out in its skirt.
+	// A triangle may only overwrite a pixel it fits better than the one
+	// already there.
+	//
+	// Without this the last triangle painted simply wins, skirt or not,
+	// and a fan of narrow wedges — a glow struck from its own center,
+	// where the wedges are sub-pixel wide near the hub — has its whole
+	// inner region painted from extrapolated weights. The mesh's outer
+	// edge still gets its skirt, because no interior sample competes
+	// for those pixels.
+	score := r.meshScore(region)
 	layer := r.acquireLayer()
 	for t := range numTris {
-		shadeTriangle(layer, region, verts[t*6:t*6+6],
+		shadeTriangle(layer, region, score, verts[t*6:t*6+6],
 			scaleAlpha(cols[t*3], vAlpha),
 			scaleAlpha(cols[t*3+1], vAlpha),
 			scaleAlpha(cols[t*3+2], vAlpha))
@@ -107,8 +120,8 @@ func (r *renderer) fillTriangleMesh(verts []float32, cols []gui.Color,
 // triangle, and with no color written there the antialiased edge would
 // fade to nothing. Interior pixels are unaffected — the triangles tile,
 // so every centre inside the mesh is already claimed.
-func shadeTriangle(dst *buffer, region image.Rectangle, p []float32,
-	c0, c1, c2 gui.Color) {
+func shadeTriangle(dst *buffer, region image.Rectangle, score []float32,
+	p []float32, c0, c1, c2 gui.Color) {
 
 	src := newTriSrc(p, c0, c1, c2)
 	if src == nil {
@@ -122,12 +135,26 @@ func shadeTriangle(dst *buffer, region image.Rectangle, p []float32,
 	}
 	t0, t1, t2 := src.skirt()
 
+	stride := region.Dx()
 	for y := rect.Min.Y; y < rect.Max.Y; y++ {
 		i := dst.img.PixOffset(rect.Min.X, y)
+		si := (y-region.Min.Y)*stride + (rect.Min.X - region.Min.X)
 		for x := rect.Min.X; x < rect.Max.X; x++ {
 			w0, w1, w2 := src.weights(x, y)
 			if w0 < -t0 || w1 < -t1 || w2 < -t2 {
 				i += 4
+				si++
+				continue
+			}
+			// An interior sample (min weight >= 0) always beats a skirt
+			// sample, and among interior samples the containing
+			// triangle wins. Equal scores keep the earlier write: that
+			// happens on a shared edge, where both colors agree.
+			if fit := min(w0, w1, w2); fit > score[si] {
+				score[si] = fit
+			} else {
+				i += 4
+				si++
 				continue
 			}
 			cr, cg, cb, ca := premul(src.mix(w0, w1, w2))
@@ -136,8 +163,24 @@ func shadeTriangle(dst *buffer, region image.Rectangle, p []float32,
 			dst.img.Pix[i+2] = cb
 			dst.img.Pix[i+3] = ca
 			i += 4
+			si++
 		}
 	}
+}
+
+// meshScore returns a per-pixel scratch buffer for region, reset to a
+// value below any weight a skirt sample can produce so the first write
+// to a pixel always takes.
+func (r *renderer) meshScore(region image.Rectangle) []float32 {
+	n := region.Dx() * region.Dy()
+	if cap(r.meshScoreBuf) < n {
+		r.meshScoreBuf = make([]float32, n)
+	}
+	s := r.meshScoreBuf[:n]
+	for i := range s {
+		s[i] = -math.MaxFloat32
+	}
+	return s
 }
 
 // svgVertices transforms every vertex into device space, reusing the

--- a/gui/canvas_curve.go
+++ b/gui/canvas_curve.go
@@ -2,23 +2,26 @@ package gui
 
 import "math"
 
-// appendQuad appends two triangles forming a quad.
-func appendQuad(b *DrawCanvasTriBatch,
+// appendQuad appends a quad as two triangles. It writes into a plain
+// slice rather than a batch so gradient fills, which tessellate into a
+// scratch buffer before they know their vertex colors, share the same
+// geometry as flat fills.
+func appendQuad(dst *[]float32,
 	x0, y0, x1, y1, x2, y2, x3, y3 float32) {
-	b.Triangles = append(b.Triangles,
+	*dst = append(*dst,
 		x0, y0, x1, y1, x2, y2,
 		x0, y0, x2, y2, x3, y3,
 	)
 }
 
 // appendCornerFan appends a 90-degree filled arc fan.
-func appendCornerFan(b *DrawCanvasTriBatch,
+func appendCornerFan(dst *[]float32,
 	cx, cy, r, startAngle float32, segs int) {
 	step := float32(math.Pi/2) / float32(segs)
 	for i := range segs {
 		a0 := float64(startAngle + step*float32(i))
 		a1 := float64(startAngle + step*float32(i+1))
-		b.Triangles = append(b.Triangles,
+		*dst = append(*dst,
 			cx, cy,
 			cx+r*float32(math.Cos(a0)), cy+r*float32(math.Sin(a0)),
 			cx+r*float32(math.Cos(a1)), cy+r*float32(math.Sin(a1)),
@@ -105,4 +108,46 @@ func flattenCubicBezier(
 		tol, depth+1)
 	flattenCubicBezier(buf, midx, midy, bex, bey, ex, ey, x1, y1,
 		tol, depth+1)
+}
+
+// appendRoundedRectTris appends the fill geometry for a rounded rect:
+// a center cross of three strips plus a fan per corner. radius must
+// already be clamped to at most half the smaller dimension and be > 0.
+//
+// Shared by FilledRoundedRect and FilledRoundedRectGradient so the two
+// tessellate identically — a gradient fill differs only in how its
+// vertices are colored, never in where they are.
+func appendRoundedRectTris(dst *[]float32, x, y, w, h, r float32) {
+	// Center cross (vertical strip).
+	appendQuad(dst, x+r, y, x+w-r, y, x+w-r, y+h, x+r, y+h)
+	// Left strip.
+	appendQuad(dst, x, y+r, x+r, y+r, x+r, y+h-r, x, y+h-r)
+	// Right strip.
+	appendQuad(dst, x+w-r, y+r, x+w, y+r, x+w, y+h-r, x+w-r, y+h-r)
+
+	const segs = 8
+	appendCornerFan(dst, x+r, y+r, r, math.Pi, segs)       // TL
+	appendCornerFan(dst, x+w-r, y+r, r, 3*math.Pi/2, segs) // TR
+	appendCornerFan(dst, x+w-r, y+h-r, r, 0, segs)         // BR
+	appendCornerFan(dst, x+r, y+h-r, r, math.Pi/2, segs)   // BL
+}
+
+// appendArcFanTris appends a triangle fan from (cx, cy) to consecutive
+// pairs in an arc polyline. Shared by FilledArc and FilledArcGradient.
+func appendArcFanTris(dst *[]float32, cx, cy float32, pts []float32) {
+	for i := 0; i+3 < len(pts); i += 2 {
+		*dst = append(*dst, cx, cy, pts[i], pts[i+1], pts[i+2], pts[i+3])
+	}
+}
+
+// appendPolygonFanTris appends a convex polygon as a fan from its
+// first vertex. Shared by FilledPolygon and FilledPolygonGradient.
+func appendPolygonFanTris(dst *[]float32, points []float32) {
+	n := len(points) / 2
+	x0, y0 := points[0], points[1]
+	for i := 1; i < n-1; i++ {
+		*dst = append(*dst, x0, y0,
+			points[i*2], points[i*2+1],
+			points[(i+1)*2], points[(i+1)*2+1])
+	}
 }

--- a/gui/canvas_draw.go
+++ b/gui/canvas_draw.go
@@ -14,6 +14,11 @@ type DrawContext struct {
 	images          []DrawCanvasImageEntry
 	arcBuf          []float32
 	bezierBuf       []float32
+	gradTriBuf      []float32
+	gradSplitBuf    []float32
+	gradRadialBuf   []float32
+	gradIsolineBuf  []float32
+	gradStopBuf     []GradientStop
 	currentBatchIdx int
 	Width           float32
 	Height          float32
@@ -23,6 +28,11 @@ type DrawContext struct {
 	Scale float32
 
 	lastColor Color
+	// batchIsGradient marks the current batch as vertex-colored, which
+	// blocks the run-length merge below: a flat fill must never append
+	// its triangles to a batch carrying per-vertex colors, or the
+	// batch's two lengths stop agreeing.
+	batchIsGradient bool
 }
 
 // SetRecorder attaches a DrawRecorder that receives high-level
@@ -30,7 +40,8 @@ type DrawContext struct {
 func (dc *DrawContext) SetRecorder(r DrawRecorder) { dc.recorder = r }
 
 func (dc *DrawContext) getBatch(color Color) *DrawCanvasTriBatch {
-	if len(dc.batches) > 0 && dc.lastColor == color {
+	if len(dc.batches) > 0 && !dc.batchIsGradient &&
+		dc.lastColor == color {
 		return &dc.batches[dc.currentBatchIdx]
 	}
 	dc.batches = append(dc.batches, DrawCanvasTriBatch{
@@ -38,6 +49,7 @@ func (dc *DrawContext) getBatch(color Color) *DrawCanvasTriBatch {
 		Triangles: make([]float32, 0, 128),
 	})
 	dc.lastColor = color
+	dc.batchIsGradient = false
 	dc.currentBatchIdx = len(dc.batches) - 1
 	return &dc.batches[dc.currentBatchIdx]
 }
@@ -152,16 +164,8 @@ func (dc *DrawContext) FilledPolygon(points []float32, color Color) {
 		dc.recorder.FilledPolygon(points, color)
 		return
 	}
-	n := len(points) / 2
 	b := dc.getBatch(color)
-	x0, y0 := points[0], points[1]
-	for i := 1; i < n-1; i++ {
-		b.Triangles = append(b.Triangles,
-			x0, y0,
-			points[i*2], points[i*2+1],
-			points[(i+1)*2], points[(i+1)*2+1],
-		)
-	}
+	appendPolygonFanTris(&b.Triangles, points)
 }
 
 // FilledCircle draws a filled circle.
@@ -210,13 +214,7 @@ func (dc *DrawContext) FilledArc(cx, cy, rx, ry, start, sweep float32, color Col
 		return
 	}
 	b := dc.getBatch(color)
-	for i := 0; i+3 < len(pts); i += 2 {
-		b.Triangles = append(b.Triangles,
-			cx, cy,
-			pts[i], pts[i+1],
-			pts[i+2], pts[i+3],
-		)
-	}
+	appendArcFanTris(&b.Triangles, cx, cy, pts)
 }
 
 // arcPoints is the buffer-reusing version of arcToPolyline.
@@ -262,21 +260,7 @@ func (dc *DrawContext) FilledRoundedRect(x, y, w, h, radius float32, color Color
 		return
 	}
 	b := dc.getBatch(color)
-	r := radius
-
-	// Center cross (vertical strip).
-	appendQuad(b, x+r, y, x+w-r, y, x+w-r, y+h, x+r, y+h)
-	// Left strip.
-	appendQuad(b, x, y+r, x+r, y+r, x+r, y+h-r, x, y+h-r)
-	// Right strip.
-	appendQuad(b, x+w-r, y+r, x+w, y+r, x+w, y+h-r, x+w-r, y+h-r)
-
-	// Corner arcs (filled fans).
-	const segs = 8
-	appendCornerFan(b, x+r, y+r, r, math.Pi, segs)       // TL
-	appendCornerFan(b, x+w-r, y+r, r, 3*math.Pi/2, segs) // TR
-	appendCornerFan(b, x+w-r, y+h-r, r, 0, segs)         // BR
-	appendCornerFan(b, x+r, y+h-r, r, math.Pi/2, segs)   // BL
+	appendRoundedRectTris(&b.Triangles, x, y, w, h, radius)
 }
 
 // RoundedRect draws a stroked rectangle with rounded corners.

--- a/gui/canvas_draw_gradient.go
+++ b/gui/canvas_draw_gradient.go
@@ -1,0 +1,225 @@
+package gui
+
+import "math"
+
+// canvas_draw_gradient.go — the DrawContext gradient fills.
+//
+// Each method tessellates through the same helpers its flat twin uses,
+// so a gradient fill and a flat fill of the same shape produce the same
+// vertices; only the coloring differs. The geometry lands in a scratch
+// buffer first, because the vertex colors cannot be assigned until the
+// subdivision pass has decided how many vertices there are.
+
+// FillTrianglesGradient fills caller-supplied geometry with a gradient.
+// tris is a flat x,y triangle list — 6 floats per triangle, the same
+// layout DrawCanvasTriBatch.Triangles uses.
+//
+// This is the escape hatch the shape-specific gradient fills are built
+// on; reach for it when the geometry is not one of them.
+//
+// A nil gradient, one with no stops, or a malformed triangle list is a
+// no-op, matching how the flat fills treat a degenerate rectangle.
+func (dc *DrawContext) FillTrianglesGradient(tris []float32,
+	g *CanvasGradient) {
+	if g == nil || len(g.Stops) == 0 ||
+		len(tris) == 0 || len(tris)%6 != 0 {
+		return
+	}
+	if dc.recorder != nil {
+		if gr, ok := dc.recorder.(DrawGradientRecorder); ok {
+			gr.FillTrianglesGradient(tris, g)
+			return
+		}
+		// The recorder cannot express a gradient. Record the geometry
+		// flat at the ramp's midpoint rather than dropping it: an SVG
+		// or PDF export of a glow should be a disc, not a hole.
+		dc.recordFlatTriangles(tris, g)
+		return
+	}
+
+	// Normalize once: clamp and sort the stops, and resolve any
+	// geometry the caller left degenerate against the fill's bounds.
+	dc.gradStopBuf = dc.gradStopBuf[:0]
+	stops := NormalizeGradientStops(g.Stops, &dc.gradStopBuf)
+	if len(stops) == 0 {
+		return
+	}
+	minX, minY, maxX, maxY := triBounds(tris)
+	res := resolveCanvasGradient(*g, minX, minY, maxX, maxY)
+	res.Stops = stops
+
+	out := subdivideCanvasGradientTris(tris, &res,
+		&dc.gradSplitBuf, &dc.gradRadialBuf, &dc.gradIsolineBuf)
+	if len(out) == 0 || len(out)%6 != 0 {
+		return
+	}
+
+	numVerts := len(out) / 2
+	b := dc.gradientBatch(SampleGradientStopColor(stops, 0.5), numVerts)
+	b.Triangles = append(b.Triangles, out...)
+	for i := range numVerts {
+		t := applyCanvasSpread(
+			canvasGradientT(out[i*2], out[i*2+1], &res), res.Spread)
+		b.VertexColors = append(b.VertexColors,
+			SampleGradientStopColor(stops, t))
+	}
+}
+
+// gradientBatch starts a fresh vertex-colored batch. A gradient fill
+// never merges with the batch before it — not with a flat one, whose
+// triangles carry no colors, and not with another gradient, whose
+// colors are already assigned — so the batch's two lengths always
+// agree and validSvgCmd can enforce the relation downstream.
+func (dc *DrawContext) gradientBatch(mid Color,
+	numVerts int) *DrawCanvasTriBatch {
+	dc.batches = append(dc.batches, DrawCanvasTriBatch{
+		Color:        mid,
+		Triangles:    make([]float32, 0, numVerts*2),
+		VertexColors: make([]Color, 0, numVerts),
+	})
+	dc.lastColor = mid
+	dc.batchIsGradient = true
+	dc.currentBatchIdx = len(dc.batches) - 1
+	return &dc.batches[dc.currentBatchIdx]
+}
+
+// recordFlatTriangles forwards geometry to a recorder that cannot
+// express gradients, one triangle at a time, shaded with the ramp's
+// midpoint.
+func (dc *DrawContext) recordFlatTriangles(tris []float32,
+	g *CanvasGradient) {
+	mid, ok := dc.midGradientColor(g)
+	if !ok {
+		return
+	}
+	var tri [6]float32
+	for i := 0; i+5 < len(tris); i += 6 {
+		copy(tri[:], tris[i:i+6])
+		dc.recorder.FilledPolygon(tri[:], mid)
+	}
+}
+
+// midGradientColor samples the gradient's midpoint, for the flat
+// fallback the shape-specific fills hand to a plain recorder.
+func (dc *DrawContext) midGradientColor(g *CanvasGradient) (Color, bool) {
+	if g == nil || len(g.Stops) == 0 {
+		return Color{}, false
+	}
+	dc.gradStopBuf = dc.gradStopBuf[:0]
+	stops := NormalizeGradientStops(g.Stops, &dc.gradStopBuf)
+	if len(stops) == 0 {
+		return Color{}, false
+	}
+	return SampleGradientStopColor(stops, 0.5), true
+}
+
+// gradientRecorderFallback reports whether a shape-specific gradient
+// fill should record itself as its flat twin instead of tessellating.
+// Returns the midpoint color to record with.
+func (dc *DrawContext) gradientRecorderFallback(
+	g *CanvasGradient) (Color, bool) {
+	if dc.recorder == nil {
+		return Color{}, false
+	}
+	if _, ok := dc.recorder.(DrawGradientRecorder); ok {
+		// The recorder handles gradients; let the shape tessellate and
+		// hand the geometry over in FillTrianglesGradient.
+		return Color{}, false
+	}
+	return dc.midGradientColor(g)
+}
+
+// gradScratch resets and returns the shared geometry scratch buffer.
+func (dc *DrawContext) gradScratch() *[]float32 {
+	dc.gradTriBuf = dc.gradTriBuf[:0]
+	return &dc.gradTriBuf
+}
+
+// FilledRectGradient fills a rectangle with a gradient. A gradient
+// whose endpoints coincide runs top-to-bottom across the rect.
+func (dc *DrawContext) FilledRectGradient(x, y, w, h float32,
+	g *CanvasGradient) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	if mid, ok := dc.gradientRecorderFallback(g); ok {
+		dc.recorder.FilledRect(x, y, w, h, mid)
+		return
+	}
+	dst := dc.gradScratch()
+	*dst = append(*dst,
+		x, y, x+w, y, x+w, y+h,
+		x, y, x+w, y+h, x, y+h,
+	)
+	dc.FillTrianglesGradient(*dst, g)
+}
+
+// FilledCircleGradient fills a circle with a gradient. A radial
+// gradient with R <= 0 centers on the circle and matches its radius,
+// which makes the common glow a one-liner:
+//
+//	dc.FilledCircleGradient(cx, cy, r, &gui.CanvasGradient{
+//		Radial: true,
+//		Stops: []gui.GradientStop{
+//			{Color: core, Pos: 0},
+//			{Color: core.WithOpacity(0), Pos: 1},
+//		},
+//	})
+func (dc *DrawContext) FilledCircleGradient(cx, cy, radius float32,
+	g *CanvasGradient) {
+	dc.FilledArcGradient(cx, cy, radius, radius, 0, 2*math.Pi, g)
+}
+
+// FilledArcGradient fills an elliptical arc (a pie slice) with a
+// gradient.
+func (dc *DrawContext) FilledArcGradient(cx, cy, rx, ry, start,
+	sweep float32, g *CanvasGradient) {
+	if mid, ok := dc.gradientRecorderFallback(g); ok {
+		dc.recorder.FilledArc(cx, cy, rx, ry, start, sweep, mid)
+		return
+	}
+	pts := dc.arcPoints(cx, cy, rx, ry, start, sweep)
+	if len(pts) < 4 {
+		return
+	}
+	dst := dc.gradScratch()
+	appendArcFanTris(dst, cx, cy, pts)
+	dc.FillTrianglesGradient(*dst, g)
+}
+
+// FilledPolygonGradient fills a convex polygon with a gradient.
+// points is a flat x,y list.
+func (dc *DrawContext) FilledPolygonGradient(points []float32,
+	g *CanvasGradient) {
+	if len(points) < 6 {
+		return
+	}
+	if mid, ok := dc.gradientRecorderFallback(g); ok {
+		dc.recorder.FilledPolygon(points, mid)
+		return
+	}
+	dst := dc.gradScratch()
+	appendPolygonFanTris(dst, points)
+	dc.FillTrianglesGradient(*dst, g)
+}
+
+// FilledRoundedRectGradient fills a rounded rectangle with a gradient.
+// Radius is clamped to half the smaller dimension.
+func (dc *DrawContext) FilledRoundedRectGradient(x, y, w, h,
+	radius float32, g *CanvasGradient) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	if mid, ok := dc.gradientRecorderFallback(g); ok {
+		dc.recorder.FilledRoundedRect(x, y, w, h, radius, mid)
+		return
+	}
+	radius = min(radius, w/2, h/2)
+	if radius <= 0 {
+		dc.FilledRectGradient(x, y, w, h, g)
+		return
+	}
+	dst := dc.gradScratch()
+	appendRoundedRectTris(dst, x, y, w, h, radius)
+	dc.FillTrianglesGradient(*dst, g)
+}

--- a/gui/canvas_draw_types.go
+++ b/gui/canvas_draw_types.go
@@ -19,10 +19,22 @@ type DrawCanvasTextEntry struct {
 	X, Y  float32
 }
 
-// DrawCanvasTriBatch is one flat-color triangle batch.
+// DrawCanvasTriBatch is one triangle batch.
+//
+// A flat batch leaves VertexColors nil and paints every triangle in
+// Color. A gradient batch carries one color per vertex — exactly
+// len(Triangles)/2 of them — which every backend already consumes
+// through RenderCmd.VertexColors; its Color is then the gradient
+// sampled at its midpoint, kept only so a flat-only consumer degrades
+// to something reasonable rather than to nothing.
+//
+// The two never mix inside one batch: a gradient fill always starts a
+// fresh batch, so the length relation above holds per batch and
+// validSvgCmd can enforce it.
 type DrawCanvasTriBatch struct {
-	Triangles []float32
-	Color     Color
+	Triangles    []float32
+	VertexColors []Color
+	Color        Color
 }
 
 // DrawCanvasImageEntry stores a deferred image drawing command.
@@ -78,4 +90,19 @@ type DrawRecorder interface {
 	QuadBezier(x0, y0, cx, cy, x1, y1 float32, color Color, width float32)
 	CubicBezier(x0, y0, c1x, c1y, c2x, c2y, x1, y1 float32, color Color, width float32)
 	Text(x, y float32, text string, style TextStyle)
+}
+
+// DrawGradientRecorder is an optional extension to DrawRecorder: a
+// recorder implementing it receives gradient fills as tessellated
+// geometry plus the gradient that shades it.
+//
+// It is a separate interface rather than more methods on DrawRecorder
+// because DrawRecorder is exported and implemented outside this repo;
+// widening it would break every existing implementer. A recorder that
+// does not implement this still receives the fill, as the equivalent
+// flat primitive shaded with the gradient's midpoint color, so an
+// export path never silently drops a gradient fill.
+// exportaudit:keep — reachable from an exported signature
+type DrawGradientRecorder interface {
+	FillTrianglesGradient(tris []float32, g *CanvasGradient)
 }

--- a/gui/canvas_gradient.go
+++ b/gui/canvas_gradient.go
@@ -1,0 +1,608 @@
+package gui
+
+import "math"
+
+// canvas_gradient.go — gradient fills for DrawContext.
+//
+// A canvas gradient is baked on the CPU into per-vertex colors on the
+// batch's triangles, riding the existing RenderSvg command's
+// VertexColors channel. Every backend already consumes that channel
+// (metal, gl, web, soft, ios, android), and so does PDF export, so a
+// canvas gradient needs no shader and no backend change.
+//
+// The projection and subdivision below deliberately mirror
+// gui/svg/tessellate_gradient.go, which does the same job for SVG
+// gradients. They are not shared code: gui/svg imports gui, so the
+// dependency cannot run the other way, and routing SVG's SvgColor
+// stops through Color would move existing SVG golden output for no
+// gain here. Keep the two in sync by hand — a change to the falloff
+// math in one almost certainly wants the same change in the other.
+
+// GradientSpread selects how a canvas gradient handles parameter
+// values outside [0,1]. Pad clamps (the zero value), Reflect mirrors,
+// Repeat wraps.
+// exportaudit:keep — the enum a CanvasGradient's Spread field takes
+type GradientSpread uint8
+
+// GradientSpread values.
+const (
+	// exportaudit:keep — the zero value, named for callers that set it
+	// explicitly rather than relying on it
+	SpreadPad GradientSpread = iota
+	// exportaudit:keep — a member of an exported enum
+	SpreadReflect
+	SpreadRepeat
+)
+
+// CanvasGradient describes a gradient fill for DrawContext, in the
+// canvas's own coordinate space (the same coordinates the drawing
+// methods take).
+//
+// Geometry left degenerate is derived from the bounds of the geometry
+// being filled, so the minimum useful value is a Stops list:
+//
+//   - a linear gradient whose endpoints coincide runs top-to-bottom
+//     across the fill's bounding box
+//   - a radial gradient with R <= 0 is centered on the fill's bounding
+//     box with R set to half its larger extent
+//
+// FX/FY default to CX/CY when both are zero, matching SVG's default
+// for fx/fy. A focal point genuinely at the origin, with a center
+// elsewhere, must be nudged off it.
+//
+// Stops need not be sorted or in range; they are normalized on use.
+// There is no stop-count limit — the GPU shader's five-stop cap
+// applies to the uniform-packed shape gradient path, not to this one.
+type CanvasGradient struct {
+	Stops     []GradientStop
+	X1, Y1    float32 // linear: start point
+	X2, Y2    float32 // linear: end point
+	CX, CY, R float32 // radial: center and radius
+	FX, FY    float32 // radial: focal point
+	Radial    bool
+	Spread    GradientSpread
+}
+
+// maxCanvasStopIsolines caps how many parameter-space breakpoints a
+// linear subdivision may split at. Reflect and Repeat generate one set
+// of breakpoints per period the geometry spans, so a gradient whose
+// endpoints are tiny relative to the fill would otherwise produce an
+// unbounded split list.
+const maxCanvasStopIsolines = 256
+
+// maxCanvasIsolinePeriods bounds how many gradient periods a Repeat or
+// Reflect fill may enumerate breakpoints for.
+const maxCanvasIsolinePeriods = 64
+
+// maxCanvasSplitDepth bounds the linear stop-isoline recursion, and
+// maxCanvasRadialDepth the radial edge-length recursion. Both mirror
+// gui/svg.
+const (
+	maxCanvasSplitDepth  = 8
+	maxCanvasRadialDepth = 6
+)
+
+// maxCanvasSplitFloats caps the geometry one gradient fill may expand
+// to, and maxCanvasRadialTris the triangle count the radial pass may
+// quadruple its way to. Both are ceilings for hostile or careless
+// input — hundreds of stops over a large mesh — not tuning knobs: the
+// glow that motivated this file lands three orders of magnitude below
+// either.
+const (
+	maxCanvasSplitFloats = 1 << 20 // ~175k triangles, 4 MB
+	maxCanvasRadialTris  = 1 << 16
+)
+
+// triBounds returns the bounding box of a flat x,y triangle list.
+func triBounds(tris []float32) (minX, minY, maxX, maxY float32) {
+	if len(tris) < 2 {
+		return 0, 0, 0, 0
+	}
+	minX, minY = tris[0], tris[1]
+	maxX, maxY = minX, minY
+	for i := 2; i+1 < len(tris); i += 2 {
+		x, y := tris[i], tris[i+1]
+		minX = min(minX, x)
+		maxX = max(maxX, x)
+		minY = min(minY, y)
+		maxY = max(maxY, y)
+	}
+	return minX, minY, maxX, maxY
+}
+
+// resolveCanvasGradient fills in geometry the caller left degenerate
+// from the bounds of the geometry being filled. See CanvasGradient for
+// the defaulting rules.
+func resolveCanvasGradient(g CanvasGradient,
+	minX, minY, maxX, maxY float32) CanvasGradient {
+	if g.Radial {
+		if !(g.R > 0) { // negated > also rejects NaN
+			g.CX = (minX + maxX) * 0.5
+			g.CY = (minY + maxY) * 0.5
+			g.R = max(maxX-minX, maxY-minY) * 0.5
+			g.FX, g.FY = 0, 0
+		}
+		if g.FX == 0 && g.FY == 0 {
+			g.FX, g.FY = g.CX, g.CY
+		}
+		return g
+	}
+	if g.X1 == g.X2 && g.Y1 == g.Y2 {
+		// Top-to-bottom, matching the CSS default direction.
+		g.X1, g.Y1 = (minX+maxX)*0.5, minY
+		g.X2, g.Y2 = (minX+maxX)*0.5, maxY
+	}
+	return g
+}
+
+// canvasGradientT projects a vertex onto the gradient, returning the
+// raw (unclamped, unspread) parameter.
+func canvasGradientT(vx, vy float32, g *CanvasGradient) float32 {
+	if g.Radial {
+		r64 := float64(g.R)
+		if !(g.R > 0) || math.IsInf(r64, 0) {
+			return 0
+		}
+		dx := vx - g.FX
+		dy := vy - g.FY
+		t := float32(math.Sqrt(float64(dx*dx+dy*dy))) / g.R
+		if t != t { // NaN
+			return 0
+		}
+		return t
+	}
+	dx := g.X2 - g.X1
+	dy := g.Y2 - g.Y1
+	lenSq := dx*dx + dy*dy
+	if lenSq == 0 {
+		return 0
+	}
+	t := ((vx-g.X1)*dx + (vy-g.Y1)*dy) / lenSq
+	if t != t {
+		return 0
+	}
+	return t
+}
+
+// applyCanvasSpread maps a raw gradient parameter through the spread
+// method. Pad clamps, Reflect is a triangle wave, Repeat a sawtooth.
+// Non-finite input folds to 0.
+func applyCanvasSpread(t float32, spread GradientSpread) float32 {
+	t64 := float64(t)
+	if math.IsNaN(t64) || math.IsInf(t64, 0) {
+		return 0
+	}
+	// Clamp to a range int64 conversion handles, so the reflect parity
+	// test cannot hit implementation-defined overflow on hostile input.
+	const spreadLimit = float64(1 << 31)
+	t64 = max(-spreadLimit, min(t64, spreadLimit))
+	switch spread {
+	case SpreadReflect:
+		n := math.Floor(t64)
+		frac := float32(t64 - n)
+		if int64(n)&1 != 0 {
+			return 1 - frac
+		}
+		return frac
+	case SpreadRepeat:
+		n := math.Floor(t64)
+		return float32(t64 - n)
+	}
+	return clampUnit(float32(t64))
+}
+
+// canvasStopIsolines lists the parameter values where the gradient's
+// color ramp changes slope, over the raw-t range the geometry spans.
+// Splitting a triangle at each of these is what makes per-vertex
+// coloring exact for a linear gradient: t is affine in position, and
+// between two breakpoints the color is linear in t, so Gouraud
+// interpolation reproduces the ramp with no error.
+func canvasStopIsolines(stops []GradientStop, spread GradientSpread,
+	tMin, tMax float32, out []float32) []float32 {
+	out = out[:0]
+	if !isFiniteF(tMin) || !isFiniteF(tMax) || tMax < tMin {
+		return out
+	}
+	// Pad is constant outside [0,1], so only the two clamp boundaries
+	// and the interior stops break the ramp.
+	if spread == SpreadPad {
+		if tMin < 0 && tMax > 0 {
+			out = append(out, 0)
+		}
+		for _, s := range stops {
+			// Same ceiling the tiling branch keeps. The split pass
+			// scans this list at every node of its recursion, so an
+			// absurd stop count costs there, not just here.
+			if len(out) >= maxCanvasStopIsolines {
+				break
+			}
+			// A stop sitting on 0 or 1 is already covered by the clamp
+			// boundary above; re-adding it would only make the split
+			// pass rescan the same cut.
+			if s.Pos <= 0.001 || s.Pos >= 0.999 {
+				continue
+			}
+			if s.Pos > tMin+1e-4 && s.Pos < tMax-1e-4 {
+				out = append(out, s.Pos)
+			}
+		}
+		if tMin < 1 && tMax > 1 {
+			out = append(out, 1)
+		}
+		return out
+	}
+	// Reflect and Repeat tile the ramp, so every period the geometry
+	// spans contributes its own copy of the breakpoints. A period
+	// boundary is itself a break (the sawtooth's step, the triangle
+	// wave's fold).
+	lo := math.Floor(float64(tMin))
+	// Past 2^53 a float64 no longer holds consecutive integers, so a
+	// float loop counter would stop advancing and never reach its
+	// bound. A gradient period that small relative to the geometry has
+	// no visible structure left, so there is nothing to split at.
+	const maxIsolineBase = 1 << 53
+	if lo < -maxIsolineBase || lo > maxIsolineBase {
+		return out
+	}
+	// Count the periods as an int, clamped before the conversion: the
+	// span can be arbitrarily large, and converting an out-of-range
+	// float64 to int is undefined.
+	periods := int(min(math.Ceil(float64(tMax))-lo,
+		float64(maxCanvasIsolinePeriods)))
+	for i := 0; i <= periods; i++ {
+		k := int64(lo) + int64(i)
+		base := float32(k)
+		if len(out) >= maxCanvasStopIsolines {
+			break
+		}
+		if base > tMin+1e-4 && base < tMax-1e-4 {
+			out = append(out, base)
+		}
+		for _, s := range stops {
+			if len(out) >= maxCanvasStopIsolines {
+				break
+			}
+			// A stop on a period boundary is the boundary breakpoint
+			// already emitted above.
+			if s.Pos <= 0.001 || s.Pos >= 0.999 {
+				continue
+			}
+			// Reflect mirrors on odd periods, so a stop at Pos sits at
+			// 1-Pos there.
+			pos := s.Pos
+			if spread == SpreadReflect && k&1 != 0 {
+				pos = 1 - pos
+			}
+			v := base + pos
+			if v > tMin+1e-4 && v < tMax-1e-4 {
+				out = append(out, v)
+			}
+		}
+	}
+	return out
+}
+
+// cutFraction returns where along the segment (x0,y0)-(x1,y1) the
+// gradient reaches parameter tS, as a fraction in [0,1]. t0 and t1 are
+// the segment's endpoint parameters.
+//
+// It must be a pure function of the segment — never of the triangle the
+// segment belongs to — because that is what keeps the split watertight.
+// Two triangles sharing an edge each decide independently whether to
+// cut it and where; they agree only because both compute the same
+// answer from the same two endpoints. Disagree and the mesh gets a
+// T-junction, which renders as a hairline crack along the seam.
+//
+// For a linear gradient the parameter is affine along the segment, so
+// the fraction is the obvious ratio. For a radial one it is a distance,
+// and the ratio is merely close — close enough that the cut vertex does
+// not land on the isoline, so the recursion cuts it again, and again,
+// and neighbours diverge. Solving the quadratic puts the vertex exactly
+// on the isoline instead.
+func cutFraction(x0, y0, x1, y1, t0, t1, tS float32,
+	g *CanvasGradient) float32 {
+	if !g.Radial {
+		if t1-t0 > 1e-6 || t0-t1 > 1e-6 {
+			return clampUnit((tS - t0) / (t1 - t0))
+		}
+		return 0.5
+	}
+	// |A + s*(B-A) - F| = tS*R, expanded to a quadratic in s.
+	ux, uy := x0-g.FX, y0-g.FY
+	vx, vy := x1-x0, y1-y0
+	a := vx*vx + vy*vy
+	if a <= 1e-12 {
+		return 0.5
+	}
+	d := tS * g.R
+	b := 2 * (ux*vx + uy*vy)
+	c := ux*ux + uy*uy - d*d
+	disc := b*b - 4*a*c
+	if disc < 0 {
+		// The isoline misses the segment; the caller only asks when the
+		// endpoints straddle it, so this is float noise, not a case.
+		return clampUnit((tS - t0) / (t1 - t0 + 1e-9))
+	}
+	sq := float32(math.Sqrt(float64(disc)))
+	s0 := (-b - sq) / (2 * a)
+	s1 := (-b + sq) / (2 * a)
+	// Prefer the root inside the segment. Both can be, when the segment
+	// is a chord of the isoline circle; the endpoints straddle tS, so
+	// exactly one root separates them, and it is the one nearer the end
+	// whose parameter is on the far side.
+	switch {
+	case s0 >= 0 && s0 <= 1:
+		return s0
+	case s1 >= 0 && s1 <= 1:
+		return s1
+	}
+	return clampUnit((tS - t0) / (t1 - t0 + 1e-9))
+}
+
+// splitCanvasTriAtStops recursively cuts a triangle along the gradient
+// isolines in stopTs, appending the resulting triangles to result.
+func splitCanvasTriAtStops(ax, ay, bx, by, cx, cy float32,
+	g *CanvasGradient, stopTs []float32, depth int, result *[]float32) {
+	// The depth cap alone bounds each triangle's own expansion, not the
+	// batch's: a cut makes up to three pieces and every piece is
+	// rescanned, so a large mesh crossed by many isolines composes the
+	// two counts. Stop splitting once the batch has produced more
+	// geometry than any fill can use. Past that point neighbours can
+	// disagree about whether to cut a shared edge, which shows as a
+	// hairline — a far better failure than exhausting memory, and one
+	// no realistic fill reaches.
+	if depth >= maxCanvasSplitDepth || len(*result) >= maxCanvasSplitFloats {
+		*result = append(*result, ax, ay, bx, by, cx, cy)
+		return
+	}
+	ta := canvasGradientT(ax, ay, g)
+	tb := canvasGradientT(bx, by, g)
+	tc := canvasGradientT(cx, cy, g)
+	tMin := min(ta, tb, tc)
+	tMax := max(ta, tb, tc)
+
+	// Cut at the isoline nearest the middle of the triangle's own range
+	// rather than the first one that applies. Each cut makes up to three
+	// pieces and every piece is rescanned, so an unbalanced choice —
+	// shaving one thin band off the end, over and over — compounds into
+	// several times the triangles a balanced one produces.
+	mid := (tMin + tMax) * 0.5
+	best := -1
+	var bestDist float32
+	for i, tS := range stopTs {
+		if tS <= tMin+1e-4 || tS >= tMax-1e-4 {
+			continue
+		}
+		d := tS - mid
+		if d < 0 {
+			d = -d
+		}
+		if best < 0 || d < bestDist {
+			best, bestDist = i, d
+		}
+	}
+	if best >= 0 {
+		tS := stopTs[best]
+		// Sort the vertices by t so the cut is described in one
+		// orientation: the isoline always crosses edge p0-p2.
+		//
+		// Sorting permutes the triangle, and an odd permutation
+		// reverses its winding. That must not reach the output: the
+		// software rasterizer takes a whole batch as one path and
+		// accumulates *signed* coverage, so a mesh of mixed winding
+		// cancels itself and a glow renders as spokes radiating from
+		// its hub. flip tracks the parity so every emitted triangle
+		// carries the winding the caller handed in.
+		flip := false
+		p0x, p0y, t0 := ax, ay, ta
+		p1x, p1y, t1 := bx, by, tb
+		p2x, p2y, t2 := cx, cy, tc
+		if t0 > t1 {
+			p0x, p0y, t0, p1x, p1y, t1 = p1x, p1y, t1, p0x, p0y, t0
+			flip = !flip
+		}
+		if t1 > t2 {
+			p1x, p1y, t1, p2x, p2y, t2 = p2x, p2y, t2, p1x, p1y, t1
+			flip = !flip
+		}
+		if t0 > t1 {
+			p0x, p0y, t0, p1x, p1y, t1 = p1x, p1y, t1, p0x, p0y, t0
+			flip = !flip
+		}
+		// emit hands one sub-triangle to the recursion, undoing the
+		// sort's winding flip when there was one.
+		emit := func(x0, y0, x1, y1, x2, y2 float32) {
+			if flip {
+				x1, y1, x2, y2 = x2, y2, x1, y1
+			}
+			splitCanvasTriAtStops(x0, y0, x1, y1, x2, y2,
+				g, stopTs, depth+1, result)
+		}
+
+		f02 := cutFraction(p0x, p0y, p2x, p2y, t0, t2, tS, g)
+		i1x := p0x + f02*(p2x-p0x)
+		i1y := p0y + f02*(p2y-p0y)
+
+		switch {
+		case tS < t1-1e-4:
+			// Cut also crosses p0-p1: one triangle below, two above.
+			f01 := cutFraction(p0x, p0y, p1x, p1y, t0, t1, tS, g)
+			i2x := p0x + f01*(p1x-p0x)
+			i2y := p0y + f01*(p1y-p0y)
+			emit(p0x, p0y, i2x, i2y, i1x, i1y)
+			emit(i2x, i2y, p1x, p1y, i1x, i1y)
+			emit(p1x, p1y, p2x, p2y, i1x, i1y)
+		case tS > t1+1e-4:
+			// Cut also crosses p1-p2.
+			f12 := cutFraction(p1x, p1y, p2x, p2y, t1, t2, tS, g)
+			i2x := p1x + f12*(p2x-p1x)
+			i2y := p1y + f12*(p2y-p1y)
+			emit(p0x, p0y, p1x, p1y, i1x, i1y)
+			emit(p1x, p1y, i2x, i2y, i1x, i1y)
+			emit(i1x, i1y, i2x, i2y, p2x, p2y)
+		default:
+			// Cut passes through p1: a clean two-way split.
+			emit(p0x, p0y, p1x, p1y, i1x, i1y)
+			emit(p1x, p1y, p2x, p2y, i1x, i1y)
+		}
+		return
+	}
+	*result = append(*result, ax, ay, bx, by, cx, cy)
+}
+
+// radialTolerance is the largest error, in gradient-parameter units,
+// that a triangle may carry before the radial pass splits it. 1/256 of
+// the ramp is below one step of an 8-bit channel, so the split stops as
+// soon as the remaining error cannot be seen.
+const radialTolerance = 1.0 / 256.0
+
+// radialDeviation measures how far a triangle's distance field departs
+// from the linear interpolation Gouraud shading will apply, in
+// parameter units.
+//
+// Choosing the split criterion this way, rather than by absolute edge
+// length, is what keeps a glow cheap. A triangle fan struck from the
+// gradient's own center is already radially aligned: distance is exactly
+// linear along each spoke, so the deviation is ~0 and the fan is left
+// alone. A rectangle filled radially is not aligned at all — its two
+// triangles bulge badly — and it subdivides until they are. An
+// edge-length rule cannot tell the two apart and splits the fan into
+// thousands of triangles it did not need.
+//
+// The measure is the error at each edge's midpoint: the true parameter
+// there against the average of the edge's endpoints. That is the
+// quadratic term the linear interpolation drops.
+func radialDeviation(ax, ay, bx, by, cx, cy float32,
+	g *CanvasGradient) float32 {
+	dev := edgeDeviation(ax, ay, bx, by, g)
+	dev = max(dev, edgeDeviation(bx, by, cx, cy, g))
+	return max(dev, edgeDeviation(cx, cy, ax, ay, g))
+}
+
+func edgeDeviation(x0, y0, x1, y1 float32, g *CanvasGradient) float32 {
+	t0 := canvasGradientT(x0, y0, g)
+	t1 := canvasGradientT(x1, y1, g)
+	tm := canvasGradientT((x0+x1)*0.5, (y0+y1)*0.5, g)
+	d := tm - (t0+t1)*0.5
+	if d < 0 {
+		d = -d
+	}
+	return d
+}
+
+// splitCanvasRadialTri splits a triangle four ways to a fixed depth,
+// appending the leaves to result.
+//
+// The depth is fixed for the whole batch rather than decided per
+// triangle, and that is the point: midpoint subdivision is watertight
+// only while neighbours split the same number of times. Let one
+// triangle stop early because it happens to be flat enough and its
+// neighbour's extra vertex lands in the middle of their shared edge —
+// a T-junction, which renders as a hairline crack along the seam. A
+// glow is 74 wedges around one hub, so cracks would radiate from it
+// like spokes.
+func splitCanvasRadialTri(ax, ay, bx, by, cx, cy float32,
+	depth int, result *[]float32) {
+	if depth <= 0 {
+		*result = append(*result, ax, ay, bx, by, cx, cy)
+		return
+	}
+	mabx, maby := (ax+bx)*0.5, (ay+by)*0.5
+	mbcx, mbcy := (bx+cx)*0.5, (by+cy)*0.5
+	mcax, mcay := (cx+ax)*0.5, (cy+ay)*0.5
+	splitCanvasRadialTri(ax, ay, mabx, maby, mcax, mcay, depth-1, result)
+	splitCanvasRadialTri(mabx, maby, bx, by, mbcx, mbcy, depth-1, result)
+	splitCanvasRadialTri(mcax, mcay, mbcx, mbcy, cx, cy, depth-1, result)
+	splitCanvasRadialTri(mabx, maby, mbcx, mbcy, mcax, mcay, depth-1, result)
+}
+
+// radialSplitDepth picks how many times to halve every triangle in the
+// batch so the worst of them carries no visible curvature error.
+//
+// Each level quarters the deviation, since it is a quadratic term, so
+// the depth is the log4 of how far the worst triangle overshoots the
+// tolerance. A fan struck from the gradient's own center is already
+// radially aligned — distance is exactly linear along every spoke — so
+// it measures ~0 and pays nothing. A rectangle filled radially bulges
+// badly and refines until it does not.
+func radialSplitDepth(tris []float32, g *CanvasGradient) int {
+	var worst float32
+	for i := 0; i+5 < len(tris); i += 6 {
+		worst = max(worst, radialDeviation(tris[i], tris[i+1], tris[i+2],
+			tris[i+3], tris[i+4], tris[i+5], g))
+	}
+	depth := 0
+	for worst > radialTolerance && depth < maxCanvasRadialDepth {
+		worst *= 0.25
+		depth++
+	}
+	// Each level quadruples the whole batch, so the per-triangle depth
+	// has to answer for how many triangles there are. Back it off until
+	// the batch's total fits the budget; a fan or a rect is nowhere
+	// near it, so this only bites on geometry already dense enough that
+	// another level would not be visible anyway.
+	srcTris := len(tris) / 6
+	for depth > 0 && srcTris > maxCanvasRadialTris>>(2*depth) {
+		depth--
+	}
+	return depth
+}
+
+// subdivideCanvasGradientTris splits tris so per-vertex coloring can
+// represent the gradient. Returns tris unchanged when no split is
+// needed, so a two-stop linear fill costs nothing.
+func subdivideCanvasGradientTris(tris []float32, g *CanvasGradient,
+	scratch, radialScratch, isolines *[]float32) []float32 {
+	// Geometric refinement first, and only for a radial gradient: its
+	// parameter is a distance, so it is not affine in position, and a
+	// triangle spanning a wide angle would have its falloff flattened
+	// into a wash. Doing it before the isoline pass keeps it cheap —
+	// it refines a handful of source triangles rather than the hundreds
+	// the isoline pass produces.
+	in := tris
+	if g.Radial {
+		r64 := float64(g.R)
+		if !(g.R > 0) || math.IsInf(r64, 0) {
+			return tris
+		}
+		if depth := radialSplitDepth(tris, g); depth > 0 {
+			*radialScratch = (*radialScratch)[:0]
+			for i := 0; i+5 < len(tris); i += 6 {
+				splitCanvasRadialTri(tris[i], tris[i+1], tris[i+2],
+					tris[i+3], tris[i+4], tris[i+5], depth, radialScratch)
+			}
+			in = *radialScratch
+		}
+	}
+
+	// Then cut where the ramp changes slope. For a linear gradient this
+	// is the whole job and it is exact: the parameter is affine in
+	// position, so between two stops vertex interpolation reproduces
+	// the ramp perfectly and a two-stop fill costs nothing at all.
+	tMin, tMax := canvasTRange(in, g)
+	*isolines = canvasStopIsolines(g.Stops, g.Spread, tMin, tMax, *isolines)
+	if len(*isolines) == 0 {
+		return in
+	}
+	*scratch = (*scratch)[:0]
+	for i := 0; i+5 < len(in); i += 6 {
+		splitCanvasTriAtStops(in[i], in[i+1], in[i+2], in[i+3],
+			in[i+4], in[i+5], g, *isolines, 0, scratch)
+	}
+	return *scratch
+}
+
+// canvasTRange returns the raw parameter range the geometry spans.
+func canvasTRange(tris []float32, g *CanvasGradient) (float32, float32) {
+	if len(tris) < 2 {
+		return 0, 0
+	}
+	t := canvasGradientT(tris[0], tris[1], g)
+	tMin, tMax := t, t
+	for i := 2; i+1 < len(tris); i += 2 {
+		t = canvasGradientT(tris[i], tris[i+1], g)
+		tMin = min(tMin, t)
+		tMax = max(tMax, t)
+	}
+	return tMin, tMax
+}

--- a/gui/canvas_gradient_test.go
+++ b/gui/canvas_gradient_test.go
@@ -1,0 +1,893 @@
+package gui
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func gradStops() []GradientStop {
+	return []GradientStop{
+		{Color: RGBA(255, 0, 0, 255), Pos: 0},
+		{Color: RGBA(0, 0, 255, 255), Pos: 1},
+	}
+}
+
+func almostEqF(a, b, eps float32) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= eps
+}
+
+func TestCanvasGradientTLinear(t *testing.T) {
+	g := &CanvasGradient{X1: 0, Y1: 0, X2: 100, Y2: 0}
+	cases := []struct {
+		x, y float32
+		want float32
+	}{
+		{0, 0, 0},
+		{50, 0, 0.5},
+		{100, 0, 1},
+		{150, 0, 1.5},  // raw t is unclamped; spread decides
+		{-50, 0, -0.5}, //
+		{50, 999, 0.5}, // perpendicular offset does not move t
+	}
+	for _, c := range cases {
+		if got := canvasGradientT(c.x, c.y, g); !almostEqF(got, c.want, 1e-5) {
+			t.Errorf("canvasGradientT(%v,%v) = %v, want %v",
+				c.x, c.y, got, c.want)
+		}
+	}
+}
+
+func TestCanvasGradientTDegenerateLinear(t *testing.T) {
+	// Coincident endpoints have no direction; t must fold to 0 rather
+	// than produce a NaN that would poison every vertex color.
+	g := &CanvasGradient{X1: 5, Y1: 5, X2: 5, Y2: 5}
+	if got := canvasGradientT(99, 99, g); got != 0 {
+		t.Errorf("degenerate linear t = %v, want 0", got)
+	}
+}
+
+func TestCanvasGradientTRadial(t *testing.T) {
+	g := &CanvasGradient{Radial: true, CX: 10, CY: 10, FX: 10, FY: 10, R: 20}
+	if got := canvasGradientT(10, 10, g); got != 0 {
+		t.Errorf("center t = %v, want 0", got)
+	}
+	if got := canvasGradientT(30, 10, g); !almostEqF(got, 1, 1e-5) {
+		t.Errorf("rim t = %v, want 1", got)
+	}
+	if got := canvasGradientT(50, 10, g); !almostEqF(got, 2, 1e-5) {
+		t.Errorf("outside t = %v, want 2 (raw, unclamped)", got)
+	}
+}
+
+func TestCanvasGradientTRadialFocal(t *testing.T) {
+	// The focal point, not the center, is where t == 0.
+	g := &CanvasGradient{Radial: true, CX: 0, CY: 0, FX: 5, FY: 0, R: 10}
+	if got := canvasGradientT(5, 0, g); got != 0 {
+		t.Errorf("focal t = %v, want 0", got)
+	}
+	if got := canvasGradientT(0, 0, g); !almostEqF(got, 0.5, 1e-5) {
+		t.Errorf("center t = %v, want 0.5", got)
+	}
+}
+
+func TestCanvasGradientTBadRadius(t *testing.T) {
+	for _, r := range []float32{0, -1,
+		float32(math.NaN()), float32(math.Inf(1))} {
+		g := &CanvasGradient{Radial: true, R: r}
+		if got := canvasGradientT(3, 4, g); got != 0 {
+			t.Errorf("R=%v: t = %v, want 0", r, got)
+		}
+	}
+}
+
+func TestApplyCanvasSpread(t *testing.T) {
+	cases := []struct {
+		name   string
+		spread GradientSpread
+		in     float32
+		want   float32
+	}{
+		{"pad below", SpreadPad, -0.5, 0},
+		{"pad inside", SpreadPad, 0.25, 0.25},
+		{"pad above", SpreadPad, 2, 1},
+		{"repeat wraps", SpreadRepeat, 1.25, 0.25},
+		{"repeat negative", SpreadRepeat, -0.25, 0.75},
+		{"reflect even period", SpreadReflect, 0.25, 0.25},
+		{"reflect odd period", SpreadReflect, 1.25, 0.75},
+		// Reflect is an even function: -0.25 folds onto +0.25.
+		{"reflect negative", SpreadReflect, -0.25, 0.25},
+	}
+	for _, c := range cases {
+		got := applyCanvasSpread(c.in, c.spread)
+		if !almostEqF(got, c.want, 1e-5) {
+			t.Errorf("%s: applyCanvasSpread(%v) = %v, want %v",
+				c.name, c.in, got, c.want)
+		}
+	}
+	for _, bad := range []float32{
+		float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
+		if got := applyCanvasSpread(bad, SpreadReflect); got != 0 {
+			t.Errorf("non-finite %v: got %v, want 0", bad, got)
+		}
+	}
+}
+
+func TestResolveCanvasGradientDefaults(t *testing.T) {
+	// A radial with no radius fits the bounds: centered, R = half the
+	// larger extent, focal collapsed onto the center.
+	g := resolveCanvasGradient(CanvasGradient{Radial: true},
+		0, 0, 100, 40)
+	if g.CX != 50 || g.CY != 20 {
+		t.Errorf("center = (%v,%v), want (50,20)", g.CX, g.CY)
+	}
+	if g.R != 50 {
+		t.Errorf("R = %v, want 50", g.R)
+	}
+	if g.FX != g.CX || g.FY != g.CY {
+		t.Errorf("focal = (%v,%v), want center", g.FX, g.FY)
+	}
+
+	// A linear with coincident endpoints runs top to bottom.
+	l := resolveCanvasGradient(CanvasGradient{}, 10, 20, 30, 60)
+	if l.Y1 != 20 || l.Y2 != 60 || l.X1 != l.X2 {
+		t.Errorf("linear default = (%v,%v)-(%v,%v), want vertical 20..60",
+			l.X1, l.Y1, l.X2, l.Y2)
+	}
+
+	// Explicit geometry is left alone.
+	e := resolveCanvasGradient(
+		CanvasGradient{X1: 1, Y1: 2, X2: 3, Y2: 4}, 0, 0, 100, 100)
+	if e.X1 != 1 || e.Y1 != 2 || e.X2 != 3 || e.Y2 != 4 {
+		t.Error("explicit linear geometry was overwritten")
+	}
+}
+
+func TestCanvasStopIsolinesPad(t *testing.T) {
+	stops := []GradientStop{
+		{Pos: 0}, {Pos: 0.3}, {Pos: 0.7}, {Pos: 1},
+	}
+	// Geometry entirely inside [0,1]: only the interior stops break.
+	got := canvasStopIsolines(stops, SpreadPad, 0, 1, nil)
+	if len(got) != 2 || !almostEqF(got[0], 0.3, 1e-6) ||
+		!almostEqF(got[1], 0.7, 1e-6) {
+		t.Errorf("inside range isolines = %v, want [0.3 0.7]", got)
+	}
+	// Geometry overhanging both ends adds the two clamp boundaries,
+	// which are real slope changes for pad.
+	got = canvasStopIsolines(stops, SpreadPad, -1, 2, nil)
+	if len(got) != 4 || got[0] != 0 || got[3] != 1 {
+		t.Errorf("overhanging isolines = %v, want [0 0.3 0.7 1]", got)
+	}
+}
+
+func TestCanvasStopIsolinesRepeatTilesPeriods(t *testing.T) {
+	stops := []GradientStop{{Pos: 0}, {Pos: 0.5}, {Pos: 1}}
+	got := canvasStopIsolines(stops, SpreadRepeat, 0, 3, nil)
+	// Each period contributes its own breakpoints: the sawtooth's step
+	// at every integer, plus the mid stop inside each period.
+	want := []float32{0.5, 1, 1.5, 2, 2.5}
+	if len(got) != len(want) {
+		t.Fatalf("repeat isolines = %v, want %v", got, want)
+	}
+	for i := range want {
+		if !almostEqF(got[i], want[i], 1e-6) {
+			t.Fatalf("repeat isolines = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestCanvasStopIsolinesBounded(t *testing.T) {
+	stops := make([]GradientStop, 16)
+	for i := range stops {
+		stops[i].Pos = float32(i) / 15
+	}
+	got := canvasStopIsolines(stops, SpreadRepeat, 0, 1e6, nil)
+	if len(got) > maxCanvasStopIsolines {
+		t.Errorf("isolines = %d, want at most %d",
+			len(got), maxCanvasStopIsolines)
+	}
+}
+
+func TestSubdivideCanvasGradientRadialSplits(t *testing.T) {
+	// One big triangle against a small radius must come back split:
+	// a radial ramp is not affine, so long edges would linearize it.
+	tris := []float32{0, 0, 100, 0, 0, 100}
+	g := &CanvasGradient{Radial: true, CX: 50, CY: 50, FX: 50, FY: 50, R: 50}
+	var scratch, radial, iso []float32
+	out := subdivideCanvasGradientTris(tris, g, &scratch, &radial, &iso)
+	if len(out) <= len(tris) {
+		t.Fatalf("radial subdivision produced %d floats, want > %d",
+			len(out), len(tris))
+	}
+	if len(out)%6 != 0 {
+		t.Errorf("subdivided length %d is not a whole number of triangles",
+			len(out))
+	}
+	// The depth cap bounds the split: 4^6 leaves per source triangle.
+	maxTris := 1
+	for range maxCanvasRadialDepth {
+		maxTris *= 4
+	}
+	if len(out)/6 > maxTris {
+		t.Errorf("produced %d triangles, above the depth cap of %d",
+			len(out)/6, maxTris)
+	}
+}
+
+func TestSubdivideCanvasGradientLinearTwoStopsIsNoop(t *testing.T) {
+	// Between two stops a linear ramp is exactly reproduced by vertex
+	// interpolation, so there is nothing to split and nothing to pay.
+	tris := []float32{0, 0, 100, 0, 0, 100}
+	g := &CanvasGradient{X1: 0, Y1: 0, X2: 100, Y2: 0,
+		Stops: gradStops()}
+	var scratch, radial, iso []float32
+	out := subdivideCanvasGradientTris(tris, g, &scratch, &radial, &iso)
+	if len(out) != len(tris) {
+		t.Errorf("two-stop linear split to %d floats, want %d",
+			len(out), len(tris))
+	}
+}
+
+func TestSubdivideCanvasGradientLinearSplitsAtStops(t *testing.T) {
+	tris := []float32{0, 0, 100, 0, 0, 100}
+	g := &CanvasGradient{X1: 0, Y1: 0, X2: 100, Y2: 0, Stops: []GradientStop{
+		{Color: RGB(255, 0, 0), Pos: 0},
+		{Color: RGB(0, 255, 0), Pos: 0.5},
+		{Color: RGB(0, 0, 255), Pos: 1},
+	}}
+	var scratch, radial, iso []float32
+	out := subdivideCanvasGradientTris(tris, g, &scratch, &radial, &iso)
+	if len(out) <= len(tris) {
+		t.Errorf("three-stop linear did not split: %d floats", len(out))
+	}
+}
+
+func TestFillTrianglesGradientProducesVertexColors(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	tris := []float32{0, 0, 100, 0, 0, 100}
+	dc.FillTrianglesGradient(tris, &CanvasGradient{
+		X1: 0, Y1: 0, X2: 100, Y2: 0, Stops: gradStops(),
+	})
+	if len(dc.batches) != 1 {
+		t.Fatalf("got %d batches, want 1", len(dc.batches))
+	}
+	b := dc.batches[0]
+	if len(b.VertexColors)*2 != len(b.Triangles) {
+		t.Fatalf("VertexColors=%d, Triangles=%d: lengths must agree",
+			len(b.VertexColors), len(b.Triangles))
+	}
+	// The vertex at t=0 takes the first stop, the one at t=1 the last.
+	if b.VertexColors[0] != (gradStops()[0].Color) {
+		t.Errorf("vertex 0 = %v, want the t=0 stop", b.VertexColors[0])
+	}
+	if b.VertexColors[1] != (gradStops()[1].Color) {
+		t.Errorf("vertex 1 = %v, want the t=1 stop", b.VertexColors[1])
+	}
+}
+
+func TestFillTrianglesGradientNoops(t *testing.T) {
+	cases := []struct {
+		name string
+		tris []float32
+		g    *CanvasGradient
+	}{
+		{"nil gradient", []float32{0, 0, 1, 0, 0, 1}, nil},
+		{"no stops", []float32{0, 0, 1, 0, 0, 1}, &CanvasGradient{}},
+		{"empty tris", nil, &CanvasGradient{Stops: gradStops()}},
+		{"partial triangle", []float32{0, 0, 1, 0},
+			&CanvasGradient{Stops: gradStops()}},
+	}
+	for _, c := range cases {
+		dc := NewDrawContext(100, 100, nil)
+		dc.FillTrianglesGradient(c.tris, c.g)
+		if len(dc.batches) != 0 {
+			t.Errorf("%s: got %d batches, want 0", c.name, len(dc.batches))
+		}
+	}
+}
+
+// TestGradientBatchNeverMergesWithFlat is the invariant the whole
+// design rests on: a batch is flat or gradient, never both, so the
+// per-batch relation len(VertexColors)*2 == len(Triangles) holds and
+// validSvgCmd can enforce it downstream.
+func TestGradientBatchNeverMergesWithFlat(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	red := RGB(255, 0, 0)
+	g := &CanvasGradient{X1: 0, Y1: 0, X2: 10, Y2: 0, Stops: gradStops()}
+
+	dc.FilledRect(0, 0, 10, 10, red)
+	dc.FilledRectGradient(0, 0, 10, 10, g)
+	dc.FilledRect(20, 0, 10, 10, red) // same color as the first flat fill
+	dc.FilledRectGradient(0, 0, 10, 10, g)
+
+	if len(dc.batches) != 4 {
+		t.Fatalf("got %d batches, want 4 (no merging across a gradient)",
+			len(dc.batches))
+	}
+	wantGradient := []bool{false, true, false, true}
+	for i, b := range dc.batches {
+		isGrad := len(b.VertexColors) > 0
+		if isGrad != wantGradient[i] {
+			t.Errorf("batch %d gradient=%v, want %v", i, isGrad,
+				wantGradient[i])
+		}
+		if isGrad && len(b.VertexColors)*2 != len(b.Triangles) {
+			t.Errorf("batch %d: VertexColors=%d, Triangles=%d",
+				i, len(b.VertexColors), len(b.Triangles))
+		}
+		if !isGrad && b.VertexColors != nil {
+			t.Errorf("batch %d: flat batch carries vertex colors", i)
+		}
+	}
+}
+
+// TestFlatFillAfterGradientStartsNewBatch guards the merge test
+// specifically: without the batchIsGradient gate the flat fill would
+// append into the gradient batch and break its length relation.
+func TestFlatFillAfterGradientStartsNewBatch(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	g := &CanvasGradient{X1: 0, Y1: 0, X2: 10, Y2: 0, Stops: gradStops()}
+	dc.FilledRectGradient(0, 0, 10, 10, g)
+	mid := dc.batches[0].Color
+	// Draw flat in exactly the color the gradient batch recorded, which
+	// is what a naive lastColor comparison would merge on.
+	dc.FilledRect(0, 0, 10, 10, mid)
+	if len(dc.batches) != 2 {
+		t.Fatalf("got %d batches, want 2", len(dc.batches))
+	}
+	b := dc.batches[0]
+	if len(b.VertexColors)*2 != len(b.Triangles) {
+		t.Errorf("gradient batch corrupted: VertexColors=%d, Triangles=%d",
+			len(b.VertexColors), len(b.Triangles))
+	}
+}
+
+func TestGradientFillsProduceGeometry(t *testing.T) {
+	g := &CanvasGradient{Radial: true, Stops: gradStops()}
+	cases := []struct {
+		name string
+		draw func(dc *DrawContext)
+	}{
+		{"rect", func(dc *DrawContext) {
+			dc.FilledRectGradient(0, 0, 40, 40, g)
+		}},
+		{"circle", func(dc *DrawContext) {
+			dc.FilledCircleGradient(20, 20, 20, g)
+		}},
+		{"arc", func(dc *DrawContext) {
+			dc.FilledArcGradient(20, 20, 20, 10, 0, 1, g)
+		}},
+		{"polygon", func(dc *DrawContext) {
+			dc.FilledPolygonGradient([]float32{0, 0, 40, 0, 40, 40, 0, 40}, g)
+		}},
+		{"rounded rect", func(dc *DrawContext) {
+			dc.FilledRoundedRectGradient(0, 0, 40, 40, 8, g)
+		}},
+		{"rounded rect, zero radius", func(dc *DrawContext) {
+			dc.FilledRoundedRectGradient(0, 0, 40, 40, 0, g)
+		}},
+	}
+	for _, c := range cases {
+		dc := NewDrawContext(100, 100, nil)
+		c.draw(dc)
+		if len(dc.batches) != 1 {
+			t.Errorf("%s: got %d batches, want 1", c.name, len(dc.batches))
+			continue
+		}
+		b := dc.batches[0]
+		if len(b.Triangles) == 0 || len(b.Triangles)%6 != 0 {
+			t.Errorf("%s: %d triangle floats", c.name, len(b.Triangles))
+		}
+		if len(b.VertexColors)*2 != len(b.Triangles) {
+			t.Errorf("%s: VertexColors=%d, Triangles=%d", c.name,
+				len(b.VertexColors), len(b.Triangles))
+		}
+	}
+}
+
+func TestGradientFillsRejectDegenerateSize(t *testing.T) {
+	g := &CanvasGradient{Stops: gradStops()}
+	dc := NewDrawContext(100, 100, nil)
+	dc.FilledRectGradient(0, 0, 0, 10, g)
+	dc.FilledRectGradient(0, 0, 10, -1, g)
+	dc.FilledRoundedRectGradient(0, 0, 0, 10, 4, g)
+	dc.FilledPolygonGradient([]float32{0, 0, 1, 1}, g)
+	if len(dc.batches) != 0 {
+		t.Errorf("got %d batches, want 0", len(dc.batches))
+	}
+}
+
+// gradientRecorderStub implements the optional extension.
+type gradientRecorderStub struct {
+	nopRecorder
+	calls int
+	tris  int
+}
+
+func (r *gradientRecorderStub) FillTrianglesGradient(
+	tris []float32, _ *CanvasGradient) {
+	r.calls++
+	r.tris = len(tris)
+}
+
+func TestGradientRecorderExtensionReceivesGeometry(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	rec := &gradientRecorderStub{}
+	dc.SetRecorder(rec)
+	dc.FilledCircleGradient(20, 20, 10,
+		&CanvasGradient{Radial: true, Stops: gradStops()})
+	if rec.calls != 1 {
+		t.Fatalf("FillTrianglesGradient called %d times, want 1", rec.calls)
+	}
+	if rec.tris == 0 || rec.tris%6 != 0 {
+		t.Errorf("recorder got %d triangle floats", rec.tris)
+	}
+	if len(dc.batches) != 0 {
+		t.Error("a recorded fill must not also tessellate into a batch")
+	}
+}
+
+// flatRecorderStub implements only DrawRecorder, so gradient fills must
+// degrade to the equivalent flat primitive rather than vanish.
+type flatRecorderStub struct {
+	nopRecorder
+	arcs   int
+	rects  int
+	polys  int
+	rounds int
+	color  Color
+}
+
+func (r *flatRecorderStub) FilledArc(_, _, _, _, _, _ float32, c Color) {
+	r.arcs++
+	r.color = c
+}
+func (r *flatRecorderStub) FilledRect(_, _, _, _ float32, c Color) {
+	r.rects++
+	r.color = c
+}
+func (r *flatRecorderStub) FilledPolygon(_ []float32, c Color) {
+	r.polys++
+	r.color = c
+}
+func (r *flatRecorderStub) FilledRoundedRect(_, _, _, _, _ float32, c Color) {
+	r.rounds++
+	r.color = c
+}
+
+func TestGradientFallsBackToFlatRecorder(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	rec := &flatRecorderStub{}
+	dc.SetRecorder(rec)
+	g := &CanvasGradient{Radial: true, Stops: gradStops()}
+
+	dc.FilledCircleGradient(20, 20, 10, g)
+	dc.FilledRectGradient(0, 0, 10, 10, g)
+	dc.FilledPolygonGradient([]float32{0, 0, 10, 0, 10, 10}, g)
+	dc.FilledRoundedRectGradient(0, 0, 10, 10, 2, g)
+
+	if rec.arcs != 1 || rec.rects != 1 || rec.polys != 1 || rec.rounds != 1 {
+		t.Errorf("flat fallback counts: arc=%d rect=%d poly=%d round=%d, "+
+			"want 1 each", rec.arcs, rec.rects, rec.polys, rec.rounds)
+	}
+	if len(dc.batches) != 0 {
+		t.Error("a recorded fill must not also tessellate into a batch")
+	}
+	// The fallback shade is the ramp midpoint, not either endpoint.
+	mid := SampleGradientStopColor(gradStops(), 0.5)
+	if rec.color != mid {
+		t.Errorf("fallback color = %v, want the midpoint %v", rec.color, mid)
+	}
+}
+
+func TestFillTrianglesGradientFlatRecorderFallback(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	rec := &flatRecorderStub{}
+	dc.SetRecorder(rec)
+	dc.FillTrianglesGradient([]float32{
+		0, 0, 10, 0, 0, 10,
+		0, 0, 10, 0, 10, 10,
+	}, &CanvasGradient{Stops: gradStops()})
+	if rec.polys != 2 {
+		t.Errorf("recorded %d polygons, want 2 (one per triangle)", rec.polys)
+	}
+}
+
+// triWinding reports how many triangles in a flat list wind each way.
+func triWinding(tris []float32) (ccw, cw int) {
+	for i := 0; i+5 < len(tris); i += 6 {
+		d := (tris[i+2]-tris[i])*(tris[i+5]-tris[i+1]) -
+			(tris[i+4]-tris[i])*(tris[i+3]-tris[i+1])
+		if d < 0 {
+			cw++
+		} else {
+			ccw++
+		}
+	}
+	return ccw, cw
+}
+
+// TestGradientSubdivisionPreservesWinding is the regression test for
+// the defect that made a glow render as spokes radiating from its hub.
+//
+// The isoline splitter sorts a triangle's vertices by gradient
+// parameter, and an odd permutation reverses the winding. The software
+// rasterizer takes a whole batch as one path and accumulates *signed*
+// coverage, so a mesh of mixed winding cancels itself out along every
+// seam. Uniform winding in, uniform winding out.
+func TestGradientSubdivisionPreservesWinding(t *testing.T) {
+	// Many stops, so every triangle is cut repeatedly.
+	stops := make([]GradientStop, 10)
+	for i := range stops {
+		stops[i] = GradientStop{
+			Color: RGBA(255, 200, 80, uint8(255-i*25)),
+			Pos:   float32(i) / 9,
+		}
+	}
+	cases := []struct {
+		name string
+		draw func(dc *DrawContext)
+	}{
+		{"radial circle", func(dc *DrawContext) {
+			dc.FilledCircleGradient(130, 130, 114,
+				&CanvasGradient{Radial: true, Stops: stops})
+		}},
+		{"radial rect", func(dc *DrawContext) {
+			dc.FilledRectGradient(16, 16, 228, 228, &CanvasGradient{
+				Radial: true, CX: 130, CY: 130, FX: 130, FY: 130, R: 114,
+				Stops: stops,
+			})
+		}},
+		{"linear rect", func(dc *DrawContext) {
+			dc.FilledRectGradient(16, 16, 228, 228, &CanvasGradient{
+				X1: 16, Y1: 16, X2: 244, Y2: 244, Stops: stops,
+			})
+		}},
+		{"reflect spread", func(dc *DrawContext) {
+			dc.FilledRectGradient(16, 16, 228, 228, &CanvasGradient{
+				X1: 100, Y1: 0, X2: 160, Y2: 0,
+				Spread: SpreadReflect, Stops: stops,
+			})
+		}},
+	}
+	for _, c := range cases {
+		dc := NewDrawContext(260, 260, nil)
+		// Every source primitive here tessellates counter-clockwise,
+		// so the whole output must.
+		c.draw(dc)
+		tris := dc.Batches()[0].Triangles
+		ccw, cw := triWinding(tris)
+		if cw != 0 {
+			t.Errorf("%s: %d of %d triangles wound the wrong way",
+				c.name, cw, ccw+cw)
+		}
+	}
+}
+
+// TestRadialFanCostsNoExtraSubdivision pins the reason the split
+// criterion measures curvature rather than edge length: a fan struck
+// from the gradient's own center is already radially aligned, and an
+// edge-length rule would shatter it into thousands of triangles it
+// gains nothing from.
+func TestRadialFanCostsNoExtraSubdivision(t *testing.T) {
+	g := &CanvasGradient{Radial: true, Stops: gradStops()}
+	dcFlat := NewDrawContext(260, 260, nil)
+	dcFlat.FilledCircle(130, 130, 114, RGB(255, 255, 255))
+	fanTris := len(dcFlat.Batches()[0].Triangles) / 6
+
+	dc := NewDrawContext(260, 260, nil)
+	dc.FilledCircleGradient(130, 130, 114, g)
+	got := len(dc.Batches()[0].Triangles) / 6
+
+	// Two stops means no isolines either, so this must be the bare fan.
+	if got != fanTris {
+		t.Errorf("two-stop radial fan = %d triangles, want the flat fan's "+
+			"%d", got, fanTris)
+	}
+}
+
+// TestCanvasStopIsolinesHugeParameterTerminates pins the guard on the
+// tiling loop. Before it the loop counted periods in a float64, and
+// past 2^53 that cannot hold consecutive integers: k++ stopped
+// advancing and the loop never reached its bound. A gradient whose
+// endpoints are a hair apart against geometry of ordinary size reaches
+// those parameters — 100 units across a 1e-14 gradient is 1e16.
+//
+// The test hangs rather than fails if the guard regresses, so it runs
+// under a deadline.
+func TestCanvasStopIsolinesHugeParameterTerminates(t *testing.T) {
+	done := make(chan int, 1)
+	go func() {
+		got := canvasStopIsolines(gradStops(), SpreadRepeat,
+			1e16, 1e16+10, nil)
+		done <- len(got)
+	}()
+	select {
+	case n := <-done:
+		if n > maxCanvasStopIsolines {
+			t.Errorf("isolines = %d, want at most %d",
+				n, maxCanvasStopIsolines)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("canvasStopIsolines did not terminate at 1e16")
+	}
+}
+
+// TestCanvasStopIsolinesPadCapped covers the Pad branch's ceiling. It
+// emits one breakpoint per interior stop, and the split pass rescans
+// the whole list at every node of its recursion, so an unbounded stop
+// count costs there and not only here.
+func TestCanvasStopIsolinesPadCapped(t *testing.T) {
+	stops := make([]GradientStop, 4000)
+	for i := range stops {
+		stops[i].Pos = float32(i+1) / float32(len(stops)+2)
+	}
+	got := canvasStopIsolines(stops, SpreadPad, 0, 1, nil)
+	if len(got) > maxCanvasStopIsolines {
+		t.Errorf("pad isolines = %d, want at most %d",
+			len(got), maxCanvasStopIsolines)
+	}
+	if len(got) == 0 {
+		t.Error("pad isolines = 0, want the cap's worth")
+	}
+}
+
+// TestSplitCanvasTriAtStopsStopsAtBudget exercises the budget itself:
+// once the batch has produced more geometry than any fill can use, the
+// triangle in flight is emitted whole rather than split further.
+func TestSplitCanvasTriAtStopsStopsAtBudget(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGBA(255, 0, 0, 255), Pos: 0},
+		{Color: RGBA(0, 255, 0, 255), Pos: 0.5},
+		{Color: RGBA(0, 0, 255, 255), Pos: 1},
+	}
+	g := &CanvasGradient{X1: 0, Y1: 0, X2: 100, Y2: 0, Stops: stops}
+	iso := canvasStopIsolines(stops, SpreadPad, 0, 1, nil)
+	if len(iso) == 0 {
+		t.Fatal("no isolines; the triangle below would not split anyway")
+	}
+	// Below the budget the triangle splits.
+	var fresh []float32
+	splitCanvasTriAtStops(0, 0, 100, 0, 0, 100, g, iso, 0, &fresh)
+	if len(fresh) <= 6 {
+		t.Fatalf("split below budget produced %d floats, want > 6",
+			len(fresh))
+	}
+	// At the budget the same triangle comes through whole.
+	full := make([]float32, maxCanvasSplitFloats)
+	splitCanvasTriAtStops(0, 0, 100, 0, 0, 100, g, iso, 0, &full)
+	if got := len(full) - maxCanvasSplitFloats; got != 6 {
+		t.Errorf("split at budget appended %d floats, want 6 (unsplit)",
+			got)
+	}
+}
+
+// TestSubdivideCanvasGradientComposesBounded is the composition guard:
+// the radial pass quadruples the batch per level and the isoline pass
+// then splits every leaf up to three ways per cut. Each cap alone
+// bounds one factor, and this pins their product for the worst input a
+// real fill produces — a large rect, filled radially, with a stop list
+// far past anything a designer would write.
+func TestSubdivideCanvasGradientComposesBounded(t *testing.T) {
+	// A rect filled radially is the worst geometry for the radial pass
+	// (its two triangles bulge right across the isolines), and 200
+	// stops give the isoline pass the most cuts it will take.
+	tris := []float32{
+		0, 0, 400, 0, 400, 400,
+		0, 0, 400, 400, 0, 400,
+	}
+	stops := make([]GradientStop, 200)
+	for i := range stops {
+		stops[i] = GradientStop{
+			Color: RGBA(uint8(i), 0, 0, 255),
+			Pos:   float32(i) / float32(len(stops)-1),
+		}
+	}
+	g := &CanvasGradient{Radial: true, CX: 200, CY: 200,
+		FX: 200, FY: 200, R: 200, Stops: stops}
+	var scratch, radial, iso []float32
+	out := subdivideCanvasGradientTris(tris, g, &scratch, &radial, &iso)
+	if len(out)%6 != 0 {
+		t.Errorf("subdivided length %d is not a whole number of triangles",
+			len(out))
+	}
+	// Comfortably inside the budget, which is the claim: the two passes
+	// compose to something bounded on their own for realistic input,
+	// and the budget is the backstop for input that is not.
+	if len(out) > maxCanvasSplitFloats {
+		t.Errorf("subdivision produced %d floats, above the budget %d",
+			len(out), maxCanvasSplitFloats)
+	}
+	if len(out) <= len(tris) {
+		t.Errorf("subdivision produced %d floats, want a real split",
+			len(out))
+	}
+}
+
+// TestRadialSplitDepthBacksOffOnLargeMeshes covers the other half of
+// the budget. Depth is chosen from the worst triangle's curvature, but
+// every level quadruples the *whole* batch, so a mesh that is already
+// dense must not take the depth a single triangle would earn.
+func TestRadialSplitDepthBacksOffOnLargeMeshes(t *testing.T) {
+	g := &CanvasGradient{Radial: true, CX: 0, CY: 0, FX: 0, FY: 0, R: 10}
+	// One badly-aligned triangle, repeated until the batch is large.
+	// Each copy is offset so none of them is degenerate.
+	var tris []float32
+	const copies = 5000
+	for i := range copies {
+		o := float32(i) * 0.001
+		tris = append(tris, -100+o, -100, 100+o, -100, 0+o, 100)
+	}
+	depth := radialSplitDepth(tris, g)
+	if got := copies << (2 * depth); got > maxCanvasRadialTris {
+		t.Errorf("depth %d on %d triangles expands to %d, above %d",
+			depth, copies, got, maxCanvasRadialTris)
+	}
+	// The same triangle on its own earns a real depth, so the backoff
+	// above is the mesh size talking and not a broken criterion.
+	if solo := radialSplitDepth(tris[:6], g); solo <= depth {
+		t.Errorf("single triangle depth %d, batch depth %d: want the "+
+			"single triangle to earn more", solo, depth)
+	}
+}
+
+// TestCutFractionRadialLandsOnIsoline is why the radial cut solves a
+// quadratic instead of interpolating. The parameter is a distance, so
+// it is not affine along an edge: an interpolated cut misses the
+// isoline, the recursion sees the piece still straddling it and cuts
+// again, and neighbours that cut at different places leave a seam.
+func TestCutFractionRadialLandsOnIsoline(t *testing.T) {
+	g := &CanvasGradient{Radial: true, CX: 0, CY: 0, FX: 0, FY: 0, R: 100}
+	// A chord well off-center, where distance is at its least linear.
+	x0, y0 := float32(-80), float32(60)
+	x1, y1 := float32(80), float32(60)
+	t0 := canvasGradientT(x0, y0, g)
+	t1 := canvasGradientT(x1, y1, g)
+	const tS = 0.7
+	f := cutFraction(x0, y0, x1, y1, t0, t1, tS, g)
+	cx := x0 + f*(x1-x0)
+	cy := y0 + f*(y1-y0)
+	if got := canvasGradientT(cx, cy, g); !almostEqF(got, tS, 1e-4) {
+		t.Errorf("cut at f=%v has t=%v, want %v", f, got, tS)
+	}
+}
+
+// TestCutFractionLinearIsExact is the other half: for a linear gradient
+// the parameter is affine, so the plain ratio is already exact and the
+// quadratic path must not be taken.
+func TestCutFractionLinearIsExact(t *testing.T) {
+	g := &CanvasGradient{X1: 0, Y1: 0, X2: 100, Y2: 0}
+	f := cutFraction(0, 0, 100, 0, 0, 1, 0.25, g)
+	if !almostEqF(f, 0.25, 1e-6) {
+		t.Errorf("linear cut fraction = %v, want 0.25", f)
+	}
+	// A zero-length segment has no answer; the midpoint is the
+	// convention, and it must not divide by zero.
+	if f = cutFraction(5, 5, 5, 5, 0.3, 0.3, 0.5, g); f != 0.5 {
+		t.Errorf("degenerate segment cut fraction = %v, want 0.5", f)
+	}
+}
+
+// TestGradientAndFlatFillsShareGeometry is why appendRoundedRectTris
+// and its siblings exist: a gradient fill must put its vertices exactly
+// where its flat twin does, so switching a fill to a gradient changes
+// only how it is colored and never its silhouette. Two tessellations
+// that merely look alike drift the first time one is tuned.
+func TestGradientAndFlatFillsShareGeometry(t *testing.T) {
+	cases := []struct {
+		name string
+		flat func(*DrawContext)
+		grad func(*DrawContext)
+	}{
+		{
+			name: "rect",
+			flat: func(dc *DrawContext) {
+				dc.FilledRect(5, 7, 40, 30, RGBA(1, 2, 3, 255))
+			},
+			grad: func(dc *DrawContext) {
+				dc.FilledRectGradient(5, 7, 40, 30,
+					&CanvasGradient{Stops: gradStops()})
+			},
+		},
+		{
+			name: "circle",
+			flat: func(dc *DrawContext) {
+				dc.FilledCircle(30, 30, 20, RGBA(1, 2, 3, 255))
+			},
+			grad: func(dc *DrawContext) {
+				dc.FilledCircleGradient(30, 30, 20,
+					&CanvasGradient{Stops: gradStops()})
+			},
+		},
+		{
+			name: "rounded-rect",
+			flat: func(dc *DrawContext) {
+				dc.FilledRoundedRect(5, 7, 40, 30, 8, RGBA(1, 2, 3, 255))
+			},
+			grad: func(dc *DrawContext) {
+				dc.FilledRoundedRectGradient(5, 7, 40, 30, 8,
+					&CanvasGradient{Stops: gradStops()})
+			},
+		},
+		{
+			name: "polygon",
+			flat: func(dc *DrawContext) {
+				dc.FilledPolygon([]float32{0, 0, 30, 0, 30, 20, 0, 20},
+					RGBA(1, 2, 3, 255))
+			},
+			grad: func(dc *DrawContext) {
+				dc.FilledPolygonGradient(
+					[]float32{0, 0, 30, 0, 30, 20, 0, 20},
+					&CanvasGradient{Stops: gradStops()})
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flatDC := NewDrawContext(100, 100, nil)
+			tc.flat(flatDC)
+			gradDC := NewDrawContext(100, 100, nil)
+			tc.grad(gradDC)
+
+			flatTris := flatDC.Batches()[0].Triangles
+			gradTris := gradDC.Batches()[0].Triangles
+			// A two-stop linear gradient over a flat ramp needs no
+			// split, so the vertex lists must match exactly.
+			if len(flatTris) != len(gradTris) {
+				t.Fatalf("flat has %d floats, gradient %d",
+					len(flatTris), len(gradTris))
+			}
+			for i := range flatTris {
+				if flatTris[i] != gradTris[i] {
+					t.Fatalf("vertex float %d: flat %v, gradient %v",
+						i, flatTris[i], gradTris[i])
+				}
+			}
+		})
+	}
+}
+
+// TestFilledRoundedRectGradientZeroRadiusIsARect covers the delegation
+// branch: a radius clamped away leaves a plain rectangle, and it must
+// still be a gradient fill rather than falling through to nothing.
+func TestFilledRoundedRectGradientZeroRadiusIsARect(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	dc.FilledRoundedRectGradient(5, 5, 40, 30, 0,
+		&CanvasGradient{Stops: gradStops()})
+	rect := NewDrawContext(100, 100, nil)
+	rect.FilledRectGradient(5, 5, 40, 30, &CanvasGradient{Stops: gradStops()})
+
+	got := dc.Batches()
+	want := rect.Batches()
+	if len(got) != 1 || len(want) != 1 {
+		t.Fatalf("batches: rounded %d, rect %d", len(got), len(want))
+	}
+	if len(got[0].VertexColors) == 0 {
+		t.Error("zero-radius rounded rect lost its vertex colors")
+	}
+	if len(got[0].Triangles) != len(want[0].Triangles) {
+		t.Errorf("rounded produced %d floats, plain rect %d",
+			len(got[0].Triangles), len(want[0].Triangles))
+	}
+}
+
+// TestTriBoundsDegenerate pins the empty and single-vertex paths, which
+// resolveCanvasGradient divides by when it defaults a radius.
+func TestTriBoundsDegenerate(t *testing.T) {
+	if x0, y0, x1, y1 := triBounds(nil); x0 != 0 || y0 != 0 ||
+		x1 != 0 || y1 != 0 {
+		t.Errorf("triBounds(nil) = %v,%v,%v,%v, want zeros",
+			x0, y0, x1, y1)
+	}
+	// An odd trailing float is ignored rather than read past.
+	x0, y0, x1, y1 := triBounds([]float32{3, 4, 9})
+	if x0 != 3 || y0 != 4 || x1 != 3 || y1 != 4 {
+		t.Errorf("triBounds(short) = %v,%v,%v,%v, want 3,4,3,4",
+			x0, y0, x1, y1)
+	}
+}

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -855,7 +855,48 @@ func goldenCases() []goldenCase {
 			focusID: "bv_primary",
 			build:   buildButtonVariants,
 		},
+		{
+			// Canvas gradient fills (issue #398). Records both the
+			// linear and the radial path, because the two tessellate
+			// differently: the linear splits at stop isolines and the
+			// radial by edge length. The golden pins the vertex count
+			// each pass settles on and both ends of each ramp, so a
+			// change to the subdivision heuristics shows as a diff
+			// rather than as a screenshot nobody re-takes.
+			name:  "canvas_gradient",
+			build: buildCanvasGradient,
+		},
 	}
+}
+
+// buildCanvasGradient draws one linear and one radial gradient fill.
+// Colors are fixed literals rather than theme colors: this case exists
+// to pin the gradient math, and a theme-derived color would make the
+// dark and light recordings differ for a reason unrelated to it.
+func buildCanvasGradient(_ *Window) View {
+	return DrawCanvas(DrawCanvasCfg{
+		ID:      "canvas_gradient",
+		Sizing:  FixedFixed,
+		Width:   120,
+		Height:  60,
+		Version: 1,
+		OnDraw: func(dc *DrawContext) {
+			dc.FilledRectGradient(0, 0, 60, 60, &CanvasGradient{
+				Stops: []GradientStop{
+					{Color: RGB(255, 0, 0), Pos: 0},
+					{Color: RGB(0, 255, 0), Pos: 0.5},
+					{Color: RGB(0, 0, 255), Pos: 1},
+				},
+			})
+			dc.FilledCircleGradient(90, 30, 25, &CanvasGradient{
+				Radial: true,
+				Stops: []GradientStop{
+					{Color: RGBA(255, 255, 255, 255), Pos: 0},
+					{Color: RGBA(255, 255, 255, 0), Pos: 1},
+				},
+			})
+		},
+	})
 }
 
 // buildButtonVariants is the shared build for the two variant golden

--- a/gui/golden_test.go
+++ b/gui/golden_test.go
@@ -147,6 +147,17 @@ func serializeCmd(c RenderCmd) string {
 		fmt.Fprintf(&b, " res=%q", c.Resource)
 	case RenderSvg:
 		fmt.Fprintf(&b, " tris=%d", len(c.Triangles))
+		// A vertex-colored batch is a gradient fill. Record the count
+		// and both ends of the ramp: the count pins the tessellation
+		// the subdivision pass chose, and the endpoint colors pin the
+		// shading, which is the part a reader would otherwise have to
+		// take on trust.
+		if len(c.VertexColors) > 0 {
+			fmt.Fprintf(&b, " vcols=%d first=%s last=%s",
+				len(c.VertexColors),
+				colorStr(c.VertexColors[0]),
+				colorStr(c.VertexColors[len(c.VertexColors)-1]))
+		}
 	case RenderLine:
 		fmt.Fprintf(&b, " from=%s,%s", f2(c.OffsetX), f2(c.OffsetY))
 	case RenderShadow:

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -97,14 +97,19 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	// text were meant as backgrounds — which no in-tree consumer wants.
 	emitDrawCanvasImages(cached.Images, ox, oy, effClip, w)
 
+	// A gradient batch differs only by its VertexColors; every backend
+	// that consumes RenderSvg already reads that channel for SVG
+	// gradients, so a canvas gradient needs nothing below this line.
+	// validSvgCmd rejects a batch whose two lengths disagree.
 	for _, batch := range cached.Batches {
 		emitRenderer(RenderCmd{
-			Kind:      RenderSvg,
-			Triangles: batch.Triangles,
-			Color:     batch.Color,
-			X:         ox,
-			Y:         oy,
-			Scale:     1.0,
+			Kind:         RenderSvg,
+			Triangles:    batch.Triangles,
+			VertexColors: batch.VertexColors,
+			Color:        batch.Color,
+			X:            ox,
+			Y:            oy,
+			Scale:        1.0,
 		}, w)
 	}
 

--- a/gui/render_draw_canvas_test.go
+++ b/gui/render_draw_canvas_test.go
@@ -495,3 +495,76 @@ func TestRenderDrawCanvasClipStaysInsideViewport(t *testing.T) {
 			got.X, got.Y, got.W, got.H, want)
 	}
 }
+
+// TestRenderDrawCanvasEmitsVertexColors covers the whole seam a canvas
+// gradient rides on: the batch's per-vertex colors must reach the
+// RenderSvg command, and must survive validSvgCmd, which rejects a
+// command whose color count does not match its vertex count.
+func TestRenderDrawCanvasEmitsVertexColors(t *testing.T) {
+	w := makeWindowWithScratch()
+	shape := &Shape{
+		shapeType: shapeDrawCanvas,
+		Width:     100, Height: 100,
+		Color: RGB(100, 100, 100),
+		events: &eventHandlers{
+			OnDraw: func(dc *DrawContext) {
+				dc.FilledRectGradient(0, 0, 50, 50, &CanvasGradient{
+					Stops: []GradientStop{
+						{Color: RGB(255, 0, 0), Pos: 0},
+						{Color: RGB(0, 0, 255), Pos: 1},
+					},
+				})
+			},
+		},
+	}
+
+	renderDrawCanvas(shape, makeClip(0, 0, 200, 200), w)
+
+	var found bool
+	for i := range w.renderers {
+		r := &w.renderers[i]
+		if r.Kind != RenderSvg {
+			continue
+		}
+		found = true
+		if len(r.VertexColors) == 0 {
+			t.Fatal("RenderSvg carries no VertexColors")
+		}
+		if len(r.VertexColors)*2 != len(r.Triangles) {
+			t.Fatalf("VertexColors=%d, Triangles=%d",
+				len(r.VertexColors), len(r.Triangles))
+		}
+		if r.VertexColors[0] == r.VertexColors[len(r.VertexColors)-1] {
+			t.Error("first and last vertex share a color; " +
+				"the ramp was not applied")
+		}
+	}
+	if !found {
+		t.Fatal("expected a RenderSvg command for the gradient batch")
+	}
+}
+
+// TestRenderDrawCanvasFlatBatchHasNoVertexColors guards the other half
+// of the invariant: an ordinary flat fill must not start carrying a
+// colors slice, or every existing canvas would change how it renders.
+func TestRenderDrawCanvasFlatBatchHasNoVertexColors(t *testing.T) {
+	w := makeWindowWithScratch()
+	shape := &Shape{
+		shapeType: shapeDrawCanvas,
+		Width:     100, Height: 100,
+		events: &eventHandlers{
+			OnDraw: func(dc *DrawContext) {
+				dc.FilledRect(0, 0, 50, 50, RGB(255, 0, 0))
+			},
+		},
+	}
+
+	renderDrawCanvas(shape, makeClip(0, 0, 200, 200), w)
+
+	for i := range w.renderers {
+		r := &w.renderers[i]
+		if r.Kind == RenderSvg && r.VertexColors != nil {
+			t.Error("flat canvas batch emitted VertexColors")
+		}
+	}
+}

--- a/gui/render_gradient.go
+++ b/gui/render_gradient.go
@@ -102,7 +102,18 @@ func lerpColorPremultiplied(a, b Color, t float32) Color {
 	pG := aG + (bG-aG)*ct
 	pB := aB + (bB-aB)*ct
 	if alpha <= 0.0001 {
-		return RGBA(0, 0, 0, 0)
+		// Both ends are fully transparent, so the premultiplied RGB
+		// holds no hue to divide back out. Black would be the easy
+		// answer and is wrong: any consumer that interpolates in
+		// straight-alpha space — a vertex-colored triangle mesh, on
+		// every backend — reads that black as a real color, and a fade
+		// to transparent white darkens as it fades instead of just
+		// thinning. Carry the nearer end's hue at zero alpha.
+		hue := a
+		if ct >= 0.5 {
+			hue = b
+		}
+		return RGBA(hue.R, hue.G, hue.B, 0)
 	}
 	r := (pR / alpha) * 255.0
 	g := (pG / alpha) * 255.0

--- a/gui/render_gradient_test.go
+++ b/gui/render_gradient_test.go
@@ -147,6 +147,33 @@ func TestLerpColorPremultipliedZeroAlpha(t *testing.T) {
 	}
 }
 
+// TestLerpColorPremultipliedKeepsHueAtZeroAlpha pins the rule that a
+// fade to transparent must not fade to black. Premultiplied space has
+// no hue left at zero alpha, but the color is handed to consumers that
+// interpolate in straight-alpha space — every vertex-colored triangle
+// mesh does — where a transparent black reads as a real color and the
+// fade darkens instead of thinning.
+func TestLerpColorPremultipliedKeepsHueAtZeroAlpha(t *testing.T) {
+	white := RGBA(255, 255, 255, 255)
+	clear := RGBA(255, 255, 255, 0)
+	c := lerpColorPremultiplied(white, clear, 1)
+	if c.A != 0 {
+		t.Errorf("A = %d, want 0", c.A)
+	}
+	if c.R != 255 || c.G != 255 || c.B != 255 {
+		t.Errorf("rgb = (%d,%d,%d), want white kept", c.R, c.G, c.B)
+	}
+	// The nearer end supplies the hue, so a fade from red keeps red.
+	red := RGBA(255, 0, 0, 0)
+	blue := RGBA(0, 0, 255, 0)
+	if got := lerpColorPremultiplied(red, blue, 0.25); got.R != 255 {
+		t.Errorf("t=0.25 hue = %v, want the red end", got)
+	}
+	if got := lerpColorPremultiplied(red, blue, 0.75); got.B != 255 {
+		t.Errorf("t=0.75 hue = %v, want the blue end", got)
+	}
+}
+
 func TestSampleGradientStopColorEmpty(t *testing.T) {
 	c := SampleGradientStopColor(nil, 0.5)
 	if c.A != 0 {

--- a/gui/testdata/canvas_gradient.dark.golden
+++ b/gui/testdata/canvas_gradient.dark.golden
@@ -1,0 +1,2 @@
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#ffffff80 tris=1026 vcols=513 first=#ffffffff last=#ffffff00

--- a/gui/testdata/canvas_gradient.light.golden
+++ b/gui/testdata/canvas_gradient.light.golden
@@ -1,0 +1,2 @@
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#ffffff80 tris=1026 vcols=513 first=#ffffffff last=#ffffff00


### PR DESCRIPTION
Closes #398.

## What

A `DrawContext` fill takes a `*gui.CanvasGradient` in place of a flat `Color`. Six methods:

```go
FillTrianglesGradient(tris []float32, g *CanvasGradient)
FilledRectGradient(x, y, w, h float32, g *CanvasGradient)
FilledCircleGradient(cx, cy, r float32, g *CanvasGradient)
FilledArcGradient(cx, cy, rx, ry, start, sweep float32, g *CanvasGradient)
FilledPolygonGradient(points []float32, g *CanvasGradient)
FilledRoundedRectGradient(x, y, w, h, radius float32, g *CanvasGradient)
```

Strokes stay flat — a gradient stroke is a separate feature.

## Why it needed no backend work

The issue frames this as a missing seam to the GPU gradient shader. That framing turned out to be wrong in a useful way: the shader is quad-only (both Metal and GL upload a fixed 4-vertex quad, and the fragment applies a hardcoded rounded-rect SDF), so reaching it would have meant new pipelines in five backends.

But `RenderCmd.VertexColors []Color` already exists, is already validated by `validSvgCmd`, and is already consumed by every backend — Metal, GL, web, iOS, Android, soft — and by PDF export. So a canvas gradient becomes per-vertex colors on the existing `RenderSvg` command. **No shader, no pipeline, no backend file changes.** It also means there is no five-stop limit here; that cap is a shader-uniform constraint on the `ContainerCfg` path.

## Fidelity

Gouraud interpolation is bounded by tessellation, so each triangle is subdivided at the gradient's stop isolines — parallel lines for linear, concentric circles for radial — before sampling. For linear gradients the split is exact, since `t` is affine in position. That subdivision is what the 140-ring stacked-circle workaround in `examples/solar_system` was buying.

Zero geometry derives from the shape being filled: a radial gradient with `R <= 0` centres on the fill's bounding box and matches its larger extent. A glow is then its stops and nothing else:

```go
dc.FilledCircleGradient(cx, cy, r, &gui.CanvasGradient{
	Radial: true,
	Stops: []gui.GradientStop{
		{Color: core, Pos: 0},
		{Color: core.WithOpacity(0), Pos: 1},
	},
})
```

## Batching

A gradient fill always starts its own batch and never merges with an adjacent flat one, which keeps painter's order correct when the two interleave and keeps `len(VertexColors)*2 == len(Triangles)` true per batch.

`DrawRecorder` is exported, so gradient support is an optional `DrawGradientRecorder` extension asserted at the call site. A recorder that does not implement it gets the equivalent flat primitive sampled at `t=0.5`, so SVG/PDF export degrades rather than dropping the fill.

## Deliberate duplication

The tessellation math duplicates `gui/svg/tessellate_gradient.go` rather than sharing it: `gui/svg` imports `gui`, so the dependency cannot run the other way, and hoisting it would force every vertex through an `SvgColor` ⇄ `Color` conversion that risks moving SVG golden output for no benefit here. #399 tracks unification, and the latent triangle-winding defect in the SVG copy.

## Verification

- Golden cases recorded in both `ThemeDark` and `ThemeLight`
- Soft-backend raster tests assert actual pixels — centre/rim differ, no interior seam lattice, and a `VertexColors` length mismatch falls back to flat rather than reading out of range
- A test asserts flat and gradient fills of rect/circle/rounded-rect/polygon produce byte-identical vertex lists, which is what makes the `canvas_curve.go` refactor safe
- `make prepush` green: race tests, lint, cross-GOOS lint, cross-compiles, coverage, export audit

Pre-existing hazards found during review and deliberately left out of scope, since `FilledArcGradient` shares the helper with the flat path: #401 (`arcPoints` unbounded segment count and NaN handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)