### PR TITLE
fix: caret blink animation runs only for caret-bearing focus (#403)

### DIFF
--- a/gui/animation_loop.go
+++ b/gui/animation_loop.go
@@ -17,7 +17,7 @@ func (w *Window) AnimationAdd(a Animation) {
 }
 
 // animationAddLocked is the lock-free core of AnimationAdd. Callers
-// must already hold w.animMu (e.g. setFocusLocked).
+// must already hold w.animMu (e.g. syncBlinkCursor).
 func (w *Window) animationAddLocked(a Animation) {
 	a.SetStart(time.Now())
 	if w.animations == nil {

--- a/gui/ime_context.go
+++ b/gui/ime_context.go
@@ -1,6 +1,7 @@
 package gui
 
-// ime_context.go — deciding when the platform input method is live.
+// ime_context.go — deciding when the platform input method is live,
+// and when the caret-blink animation runs.
 //
 // The input method must be active only while an editable text widget
 // holds focus. It is not a "something is focused" signal: on macOS an
@@ -11,6 +12,11 @@ package gui
 // ("composition only becomes possible once a text widget takes
 // focus", gui/backend/gl/ime_win32.go), and on X11 IMEStart is an
 // ibus FocusIn that a button has no business claiming.
+//
+// The caret-blink animation is gated the same way (issue #403): it
+// must run only while a widget that renders a framework caret holds
+// focus, or the window re-renders every 600 ms for a caret nobody
+// draws.
 
 // shapeIsIMEEditTarget reports whether shape is the editable text
 // context an input method would write into — the shape that hosts the
@@ -34,24 +40,56 @@ func shapeIsIMEEditTarget(s *Shape) bool {
 	return s.TC != nil && s.focusOwner != "" && !s.TC.textReadOnly
 }
 
-// findIMEEditTarget reports whether the focused widget's edit target
-// is somewhere in this subtree. The walk short-circuits on the first
-// match and is skipped entirely when nothing is focused, so the cost
-// is one partial tree walk per frame with a focused widget.
-func findIMEEditTarget(layout *Layout, w *Window) bool {
-	if layout.Shape == nil {
-		return false
+// shapeDrawsCaret reports whether shape can render the framework's
+// input caret (renderInputCursor): a text-like shape that renders
+// focus state for itself or for a widget it belongs to. It is wider
+// than shapeIsIMEEditTarget on purpose (issue #403):
+//
+//   - a read-only input stays focusable for its caret and selection,
+//     so its caret blinks; only the IME gate excludes it.
+//   - a selection-only focusable Text draws a caret at its cursor,
+//     so it blinks like an input.
+//   - a terminal grid is NOT a caret target: its cursor is the
+//     consumer's own TermCursor.Visible flag, which the blink
+//     animation does not drive.
+func shapeDrawsCaret(s *Shape) bool {
+	return s != nil && s.TC != nil && s.rendersFocusState()
+}
+
+// findEditTargets reports both focus signals — whether the focused
+// widget draws a framework caret (the blink gate) and whether it is
+// an editable IME context — in one walk. The walk short-circuits as
+// soon as both are found and is skipped entirely when nothing is
+// focused, so each of its two callers (syncIMEEditContext and
+// syncBlinkCursor) pays one shallow probe per frame with a focused
+// widget, and nothing when nothing is focused. A focused widget can
+// match through two shapes (Input's container and its inner text
+// shape), so once one signal is found the walk keeps going for the
+// other.
+func findEditTargets(layout *Layout, w *Window) (caret, ime bool) {
+	if layout.Shape == nil || w.viewState.focusID == "" {
+		return false, false
 	}
-	if shapeIsIMEEditTarget(layout.Shape) &&
-		w.IsFocus(layout.Shape.focusKey()) {
-		return true
-	}
-	for i := range layout.Children {
-		if findIMEEditTarget(&layout.Children[i], w) {
-			return true
+	if w.IsFocus(layout.Shape.focusKey()) {
+		if shapeDrawsCaret(layout.Shape) {
+			caret = true
+		}
+		if shapeIsIMEEditTarget(layout.Shape) {
+			ime = true
+		}
+		if caret && ime {
+			return true, true
 		}
 	}
-	return false
+	for i := range layout.Children {
+		c, e := findEditTargets(&layout.Children[i], w)
+		caret = caret || c
+		ime = ime || e
+		if caret && ime {
+			return true, true
+		}
+	}
+	return caret, ime
 }
 
 // syncIMEEditContext starts or stops the platform input method as the
@@ -72,7 +110,8 @@ func findIMEEditTarget(layout *Layout, w *Window) bool {
 // FocusOut, the IMM context detach, the web hidden input being
 // removed.
 func (w *Window) syncIMEEditContext() {
-	editing := w.viewState.focusID != "" && findIMEEditTarget(&w.layout, w)
+	_, ime := findEditTargets(&w.layout, w)
+	editing := w.viewState.focusID != "" && ime
 	id := ""
 	if editing {
 		id = w.viewState.focusID
@@ -94,5 +133,36 @@ func (w *Window) syncIMEEditContext() {
 	}
 	if editing {
 		np.IMEStart()
+	}
+}
+
+// syncBlinkCursor starts or stops the caret-blink animation as the
+// focused widget gains or loses a framework caret (issue #403).
+//
+// Called from the render pass for the same reason syncIMEEditContext
+// is: setFocusLocked only sees an ID, which cannot say whether the
+// widget draws a caret, and SetFocus is legitimately called from
+// inside a View function, where the tree in hand is the previous
+// frame's and a newly created input is not in it yet. Registering
+// here also stops consumers re-asserting focus from View — the
+// pattern setFocusLocked's old code re-armed on every layout build —
+// from keeping a perpetual blink animation for a widget that draws
+// no caret.
+//
+// A Pulsar registers the blink animation itself and toggles on the
+// same inputCursorOn state, so its registration is never removed
+// here: it blinks without any focused input.
+func (w *Window) syncBlinkCursor() {
+	caret, _ := findEditTargets(&w.layout, w)
+	w.animMu.Lock()
+	defer w.animMu.Unlock()
+	_, present := w.animations[blinkCursorAnimationID]
+	if caret && !present {
+		w.animationAddLocked(newBlinkCursorAnimation())
+		return
+	}
+	if !caret && present && !w.hasAnimationLocked(pulsarAnimationID) {
+		delete(w.animations, blinkCursorAnimationID)
+		delete(w.animViewBound, blinkCursorAnimationID)
 	}
 }

--- a/gui/ime_context_test.go
+++ b/gui/ime_context_test.go
@@ -226,3 +226,174 @@ func TestIMECycledBetweenTextFields(t *testing.T) {
 			spy.starts, spy.stops)
 	}
 }
+
+// shapeDrawsCaret covers exactly the shapes renderInputCursor will
+// draw for. It is wider than shapeIsIMEEditTarget: a read-only input
+// keeps its caret (only the IME gate excludes it), and a
+// selection-only focusable Text draws one too. A terminal grid is not
+// a caret target — its cursor is the consumer's own TermCursor.Visible
+// flag, which the blink animation does not drive (issue #403).
+func TestShapeDrawsCaret(t *testing.T) {
+	cases := []struct {
+		name  string
+		shape *Shape
+		want  bool
+	}{
+		{"nil", nil, false},
+		{
+			"input text shape",
+			&Shape{
+				shapeType:  shapeText,
+				focusOwner: "in",
+				TC:         &shapeTextConfig{},
+			},
+			true,
+		},
+		{
+			"read-only input keeps a caret",
+			&Shape{
+				shapeType:  shapeText,
+				focusOwner: "in",
+				TC:         &shapeTextConfig{textReadOnly: true},
+			},
+			true,
+		},
+		{
+			"selection-only text draws a caret",
+			&Shape{
+				shapeType: shapeText,
+				Focusable: true,
+				ID:        "label",
+				TC:        &shapeTextConfig{},
+			},
+			true,
+		},
+		{
+			"term grid owns its own cursor",
+			&Shape{shapeType: shapeTermGrid, Focusable: true},
+			false,
+		},
+		{"button", &Shape{Focusable: true, ID: "b"}, false},
+		{
+			"plain text renders no caret",
+			&Shape{shapeType: shapeText, ID: "t", TC: &shapeTextConfig{}},
+			false,
+		},
+	}
+	for _, c := range cases {
+		if got := shapeDrawsCaret(c.shape); got != c.want {
+			t.Errorf("%s: shapeDrawsCaret = %v, want %v",
+				c.name, got, c.want)
+		}
+	}
+}
+
+// Focusing a non-text widget must not start the caret-blink
+// animation: every 600 ms tick queues a window-wide render-only
+// refresh for a caret no widget draws (issue #403).
+func TestBlinkCursorNotAddedForNonTextWidget(t *testing.T) {
+	w := newTestWindow()
+	w.layout = Layout{
+		Shape:    &Shape{},
+		Children: []Layout{{Shape: &Shape{ID: "btn", Focusable: true}}},
+	}
+
+	w.SetFocus("btn")
+	w.syncBlinkCursor()
+	if w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation active for a focused button")
+	}
+}
+
+// The blink animation follows the caret target: registered while an
+// input holds focus, removed when focus leaves it.
+func TestBlinkCursorAddedAndRemovedWithCaretTarget(t *testing.T) {
+	w := newTestWindow()
+	w.layout = imeEditTargetLayout("in")
+
+	w.SetFocus("in")
+	w.syncBlinkCursor()
+	if !w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation missing for a focused input")
+	}
+
+	w.ClearFocus()
+	w.syncBlinkCursor()
+	if w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation still active after blur")
+	}
+}
+
+// A Pulsar blinks on the same inputCursorOn state with no focused
+// input at all; its blink registration must survive syncBlinkCursor.
+func TestBlinkCursorKeptWhilePulsarActive(t *testing.T) {
+	w := newTestWindow()
+	w.layout = Layout{
+		Shape:    &Shape{},
+		Children: []Layout{{Shape: &Shape{ID: "btn", Focusable: true}}},
+	}
+	w.AnimationAdd(newBlinkCursorAnimation())
+	w.animationAddViewBound(&Animate{
+		AnimID: pulsarAnimationID,
+		Delay:  blinkCursorAnimationDelay,
+		Repeat: true,
+	})
+
+	w.SetFocus("btn")
+	w.syncBlinkCursor()
+	if !w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation removed while a Pulsar is active")
+	}
+}
+
+// End-to-end through the real widgets and a real frame: the blink
+// gate must match the caret each widget actually draws.
+func TestBlinkCursorThroughRealFrame(t *testing.T) {
+	cases := []struct {
+		name    string
+		build   func() View
+		focusID string
+		want    bool
+	}{
+		{
+			"input",
+			func() View { return Input(InputCfg{ID: "field"}) },
+			"field",
+			true,
+		},
+		{
+			"read-only input keeps its caret",
+			func() View {
+				return Input(InputCfg{ID: "field", ReadOnly: true})
+			},
+			"field",
+			true,
+		},
+		{
+			"button",
+			func() View { return Button(ButtonCfg{ID: "btn", Label: "go"}) },
+			"btn",
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := NewWindow(WindowCfg{
+				State: new(int), Width: 200, Height: 100,
+			})
+			w.viewGenerator = func(_ *Window) View {
+				return Column(ContainerCfg{
+					Sizing:  FillFill,
+					Content: []View{c.build()},
+				})
+			}
+			w.SetFocus(c.focusID)
+			w.refreshLayout = true
+			w.FrameFn()
+
+			if got := w.HasAnimation(blinkCursorAnimationID); got != c.want {
+				t.Fatalf("blink animation present = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -359,7 +359,7 @@ func (w *Window) DialogIsVisible() bool {
 // own SetFocus with DialogIsVisible.
 //
 // dialog is the dialog's layout for this frame. Called from layoutArrange
-// under w.mu; acquires w.animMu only when a reassert is needed.
+// under w.mu.
 func (w *Window) retainDialogFocus(dialog *Layout) {
 	// A malformed/empty dialog layer has no focusable target; leave focus
 	// untouched rather than blindly reasserting (which could steal it).
@@ -373,7 +373,5 @@ func (w *Window) retainDialogFocus(dialog *Layout) {
 			return
 		}
 	}
-	w.animMu.Lock()
 	w.setFocusLocked(dialogFocusID(w.dialogCfg))
-	w.animMu.Unlock()
 }

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -11,12 +11,12 @@ func (w *Window) FocusID() string {
 
 // SetFocus sets the focused widget by its string ID. A real focus
 // change clears input selections window-wide; re-asserting the widget
-// that already holds focus leaves selections alone. Acquires both w.mu
-// (focusID) and w.animMu (animations). Use ClearFocus to remove focus.
+// that already holds focus leaves selections alone. Acquires w.mu
+// (focusID); the caret-blink animation is managed from the render
+// pass, not here (see syncBlinkCursor). Use ClearFocus to remove
+// focus.
 func (w *Window) SetFocus(id string) {
 	w.lockForAPI("SetFocus")
-	w.animMu.Lock()
-	defer w.animMu.Unlock()
 	defer w.mu.Unlock()
 	w.setFocusLocked(id)
 }
@@ -42,17 +42,19 @@ func (w *Window) setFocusLocked(id string) {
 	w.viewState.focusID = id
 	if id != "" {
 		w.viewState.inputCursorOn.Store(true)
-		if !w.hasAnimationLocked(blinkCursorAnimationID) {
-			w.animationAddLocked(newBlinkCursorAnimation())
-		}
 	}
-	// The platform IME is not switched here. Whether the new widget is
-	// an *editable text* context — the only thing an input method may
-	// be activated for — cannot be answered from an ID, and SetFocus is
-	// legitimately called from inside a View function, where w.layout
-	// still holds the previous frame and a newly created input is not
-	// in it yet. syncIMEEditContext decides it from the arranged tree
-	// each frame instead (gui/ime_context.go, issue #393).
+	// The caret-blink animation is not started here. Whether the new
+	// widget draws a caret cannot be answered from an ID, and SetFocus
+	// is legitimately called from inside a View function, where
+	// w.layout still holds the previous frame and a newly created
+	// input is not in it yet. syncBlinkCursor decides it from the
+	// arranged tree each frame instead (gui/ime_context.go, issue
+	// #403).
+	// The platform IME is not switched here either, for the same
+	// reason: only an *editable text* context — the only thing an
+	// input method may be activated for — may claim it. syncIMEEditContext
+	// decides that from the arranged tree each frame (gui/ime_context.go,
+	// issue #393).
 }
 
 // resetBlinkCursorVisible resets the blink timer so the cursor

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -371,7 +371,10 @@ func (w *Window) buildRenderers(bgColor Color, clip drawClip) {
 	// The arranged tree is the only place that says whether the
 	// focused widget is editable, so the platform input method is
 	// switched here rather than at focus time (gui/ime_context.go).
+	// The caret-blink animation is gated on the same tree — an ID
+	// alone cannot say whether a widget draws a caret (issue #403).
 	w.syncIMEEditContext()
+	w.syncBlinkCursor()
 	renderLayout(&w.layout, bgColor, clip, w)
 	if inspectorSupported && w.inspectorEnabled {
 		inspectorInjectWireframe(w)


### PR DESCRIPTION
Fixes #403.

`setFocusLocked` started `BlinkCursorAnimation` for any non-empty focus id, so a consumer keeping focus on a non-input widget ran the caret-blink animation forever, queueing a window-wide render-only refresh every 600 ms (measured ~2.5–4% idle CPU in go-term's `examples/falcon`).

Blink is now gated on the focus target actually drawing a framework caret, decided from the arranged tree each frame — the same signal `syncIMEEditContext` already derives:

- `findEditTargets` replaces `findIMEEditTarget`, returning both the caret and IME signals in one walk (one shallow probe per frame).
- `syncBlinkCursor` (new, from the render pass in `buildRenderers`) adds/removes the blink animation from `findEditTargets`'s caret signal.
- `shapeDrawsCaret` is deliberately wider than `shapeIsIMEEditTarget`: a read-only input keeps its caret (only the IME gate excludes it) and a selection-only focusable `Text` draws one; a terminal grid is not a caret target (its cursor is the consumer's own `TermCursor.Visible`).
- `SetFocus` no longer touches `animMu`; `retainDialogFocus` drops its lock pair.
- A `Pulsar`'s own blink registration survives `syncBlinkCursor` (it blinks on the same `inputCursorOn` state with no focused input).

Tests: unit cases for `shapeDrawsCaret`, add/remove with focus change, Pulsar coexistence, and an end-to-end frame test through real widgets.