### PR TITLE
fix: block idle event loops instead of polling at 100ms (#405)

### DIFF
--- a/gui/app.go
+++ b/gui/app.go
@@ -26,6 +26,11 @@ type App struct {
 	ExitMode exitMode
 	mu       sync.Mutex
 	mainID   uint32
+	// wakeMainFn unblocks the backend's idle event loop when OpenWindow
+	// queues a window from another goroutine. Set by backends whose
+	// idle wait cannot select on pending itself (metal, win32); nil
+	// elsewhere (x11 selects on the pending channel directly).
+	wakeMainFn func()
 }
 
 // NewApp creates an App with an empty window registry.
@@ -122,7 +127,21 @@ func (a *App) OpenWindow(cfg WindowCfg) {
 	default:
 		log.Println("gui: App.OpenWindow: pending buffer full, " +
 			"window request dropped")
+		return
 	}
+	// The backend event loop may be blocked in an idle wait that
+	// cannot observe the pending channel (issue #405) — wake it so
+	// the window is created promptly instead of at the next event.
+	if fn := a.wakeMainFn; fn != nil {
+		fn()
+	}
+}
+
+// SetWakeMainFn sets the function called to wake the main event loop
+// when OpenWindow queues a window from another goroutine. The backend
+// sets this at init time.
+func (a *App) SetWakeMainFn(fn func()) {
+	a.wakeMainFn = fn
 }
 
 // PendingOpen returns the channel of window configs to create.

--- a/gui/app_test.go
+++ b/gui/app_test.go
@@ -103,6 +103,39 @@ func TestAppOpenWindow(t *testing.T) {
 	}
 }
 
+func TestAppOpenWindowWakes(t *testing.T) {
+	// A queued window must wake the backend's idle event loop, which
+	// cannot select on the pending channel (issue #405).
+	app := NewApp()
+	wakes := 0
+	app.SetWakeMainFn(func() { wakes++ })
+	app.OpenWindow(WindowCfg{Title: "new"})
+	if wakes != 1 {
+		t.Fatalf("wakes = %d, want 1", wakes)
+	}
+
+	// Buffer full: the request is dropped, so no wake.
+	for range 16 {
+		app.OpenWindow(WindowCfg{Title: "ok"})
+	}
+	app.OpenWindow(WindowCfg{Title: "dropped"})
+	// 15 of the 16 fit (one slot is still taken); the dropped 17th
+	// must not wake.
+	if wakes != 16 {
+		t.Fatalf("wakes = %d, want 16 (no wake on dropped request)", wakes)
+	}
+}
+
+func TestAppOpenWindowNoWakeFn(t *testing.T) {
+	// No wake fn (or one cleared with nil): OpenWindow must queue and
+	// return without panicking. Backends that select on the pending
+	// channel directly (x11) never set one.
+	app := NewApp()
+	app.SetWakeMainFn(func() { t.Error("wake called after clear") })
+	app.SetWakeMainFn(nil)
+	app.OpenWindow(WindowCfg{Title: "new"})
+}
+
 func TestEventWindowID(t *testing.T) {
 	e := Event{WindowID: 42, Type: EventMouseDown}
 	if e.WindowID != 42 {

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -86,6 +86,12 @@ const (
 	qsAllInput         = 0x04FF
 	mwmoInputAvailable = 0x0004
 
+	// waitInfinite is INFINITE for MsgWaitForMultipleObjectsEx: block
+	// until a message arrives. Real window messages and the wake
+	// message (PostMessage wmApp) end the wait; nothing periodic does
+	// (issue #405).
+	waitInfinite = 0xFFFFFFFF
+
 	gmemMoveable  = 0x0002
 	cfUnicodeText = 13
 
@@ -227,6 +233,7 @@ func pumpMessages(msg *msgW) {
 }
 
 // waitMessage blocks until a message arrives or the timeout elapses.
+// waitInfinite blocks indefinitely; the wake message ends the wait.
 func waitMessage(ms uintptr) {
 	pMsgWaitForMulti.Call(0, 0, ms, qsAllInput, mwmoInputAvailable)
 }
@@ -536,7 +543,9 @@ func (b *Backend) Run(w *gui.Window) {
 		}
 		b.plat.setCursor(w.MouseCursorState())
 		if !rendered {
-			waitMessage(100)
+			// Idle: block until a message arrives instead of polling
+			// (issue #405).
+			waitMessage(waitInfinite)
 		}
 	}
 }
@@ -595,6 +604,10 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		b.plat.w = w
 		register(b, w)
 		w.SetWakeMainFn(b.plat.wake)
+		// App-level wake: OpenWindow from another goroutine must
+		// unblock the idle wait, which cannot observe the pending
+		// channel (issue #405).
+		app.SetWakeMainFn(b.plat.wake)
 		if w.Config.OnInit != nil {
 			w.Config.OnInit(w)
 		}
@@ -645,6 +658,15 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 			return nil
 		}
 
+		// The app-level wake posts to a specific hwnd, and a
+		// destroyed hwnd silently drops the message. Re-point it at
+		// a surviving window so OpenWindow still wakes the idle wait
+		// after a close (issue #405).
+		for _, b := range backends {
+			app.SetWakeMainFn(b.plat.wake)
+			break
+		}
+
 		// Frame + render each window.
 		rendered := false
 		for _, b := range backends {
@@ -657,7 +679,9 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		}
 
 		if !rendered {
-			waitMessage(100)
+			// Idle: block until a message arrives instead of polling
+			// (issue #405).
+			waitMessage(waitInfinite)
 		}
 	}
 }

--- a/gui/backend/gl/runapp_x11.go
+++ b/gui/backend/gl/runapp_x11.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"runtime"
-	"time"
 
 	"github.com/jezek/xgb"
 
@@ -60,14 +59,14 @@ func (b *Backend) Run(w *gui.Window) {
 		}
 		b.plat.setCursor(w.MouseCursorState())
 		if !rendered {
-			select {
-			case ev, ok := <-events:
-				if !ok {
-					running = false
-				} else {
-					b.handleXEvent(ev)
-				}
-			case <-time.After(100 * time.Millisecond):
+			// Idle: block until an event or a wake arrives instead of
+			// polling (issue #405). wake() posts a ClientMessage that
+			// pumpEvents forwards onto this channel.
+			ev, ok := <-events
+			if !ok {
+				running = false
+			} else {
+				b.handleXEvent(ev)
 			}
 		}
 	}
@@ -215,6 +214,8 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		}
 
 		if !rendered {
+			// Idle: block until an event, a wake, or a pending window
+			// arrives instead of polling (issue #405).
 			select {
 			case te := <-events:
 				if !te.closed {
@@ -224,7 +225,6 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 				if err := open(gui.NewWindow(cfg)); err != nil {
 					log.Printf("gl: open window: %v", err)
 				}
-			case <-time.After(100 * time.Millisecond):
 			}
 		}
 	}

--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -51,6 +51,26 @@ const (
 
 const maxCustomPipelines = 32
 
+// idleWaitMs returns the poll timeout for one event-loop iteration.
+// -1 blocks until an event ([NSDate distantFuture]); 0 drains without
+// waiting. The loop blocks when the previous frame rendered nothing
+// (idle) — every path that dirties state wakes it: QueueCommand and
+// the animation loop via metalPostEmptyEvent, App.OpenWindow via the
+// app wake fn, and the focus/file-drop callbacks in callbacks.go
+// (issue #405).
+func idleWaitMs(rendered bool) C.int {
+	if !rendered {
+		return -1
+	}
+	return 0
+}
+
+// wakeUp posts an empty event so the idle poll returns and the loop
+// can repaint. Shared by the per-window and app-level wake fns.
+func wakeUp() {
+	C.metalPostEmptyEvent()
+}
+
 // Backend is the Metal backend for go-gui (single-window mode).
 // Embeds windowState so all draw methods are shared with
 // multi-window mode.
@@ -93,20 +113,15 @@ func (b *Backend) Run(w *gui.Window) {
 	// Activate now that windows exist on screen.
 	C.metalAppFinishLaunch()
 
-	wakeUp := func() {
-		C.metalPostEmptyEvent()
-	}
 	w.SetWakeMainFn(wakeUp)
 
 	running := true
 	rendered := true
 	evt := new(gui.Event)
 	for running {
-		waitMs := 0
-		if !rendered {
-			waitMs = 100
-		}
-		ev := C.metalPollEvent(C.int(waitMs))
+		// Idle: block until an event wakes us instead of polling.
+		// Every path that dirties state wakes the loop (issue #405).
+		ev := C.metalPollEvent(C.int(idleWaitMs(rendered)))
 		for ev != 0 {
 			mapped, cont := mapMetalEvent()
 			*evt = mapped
@@ -220,11 +235,12 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 		}
 	}()
 
-	wakeUp := func() {
-		C.metalPostEmptyEvent()
-	}
 	setWakeFn := func(w *gui.Window) {
 		w.SetWakeMainFn(wakeUp)
+		// App-level wake: OpenWindow from another goroutine must
+		// unblock the idle loop even though it cannot select on the
+		// pending channel (issue #405).
+		app.SetWakeMainFn(wakeUp)
 	}
 	for _, w := range initialWindows {
 		setWakeFn(w)
@@ -264,12 +280,9 @@ func runAppE(app *gui.App, initialWindows ...*gui.Window) error {
 			}
 		}
 
-		// Poll events. When idle, wait up to 100ms.
-		waitMs := 0
-		if !rendered {
-			waitMs = 100
-		}
-		ev := C.metalPollEvent(C.int(waitMs))
+		// Poll events. Idle: block until an event wakes us instead of
+		// polling (issue #405).
+		ev := C.metalPollEvent(C.int(idleWaitMs(rendered)))
 		for ev != 0 {
 			wid := uint32(C.metalEventWindowID())
 			mapped, cont := mapMetalEvent()

--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -19,6 +19,7 @@ void metalTestInjectQuitEvent(void);
 int metalTestQuitActionSetsQuitEvent(void);
 int metalTestAppShouldTerminateCorrect(void);
 int metalTestPollReturnsOnQuitRequested(void);
+int metalTestPollIdleWake(void);
 int metalTestCursorBoundsCheck(float mouseX, float mouseY,
                                float width, float height);
 int metalTestMenuAboutExists(void);
@@ -279,6 +280,13 @@ func testPollReturnsOnQuitRequested() bool {
 	return C.metalTestPollReturnsOnQuitRequested() != 0
 }
 
+// testPollIdleWake verifies metalPollEvent(-1) blocks until a wake
+// event arrives (issue #405). 0 on success, non-zero on failure.
+// Main-thread only: it runs the real blocking poll.
+func testPollIdleWake() int {
+	return int(C.metalTestPollIdleWake())
+}
+
 func testCursorBoundsCheck(mouseX, mouseY, width, height float32) bool {
 	return C.metalTestCursorBoundsCheck(C.float(mouseX), C.float(mouseY),
 		C.float(width), C.float(height)) != 0
@@ -370,6 +378,12 @@ func goMetalWindowFocusChanged(wid C.uint, focused C.int) {
 		et = gui.EventFocused
 	}
 	ws.attachedWindow.EventFn(&gui.Event{Type: et})
+	// windowDidBecomeKey:/windowDidResignKey: are notifications, not
+	// NSEvents — the idle loop blocks in metalPollEvent(-1) on their
+	// own, so the frame reflecting the focus change would wait for
+	// the next real event. Post an empty event to bring the loop
+	// round for the repaint (issue #405).
+	C.metalPostEmptyEvent()
 }
 
 //export goMetalFileDrop
@@ -385,4 +399,8 @@ func goMetalFileDrop(wid C.uint, cpath *C.char) {
 		Type:     gui.EventFileDropped,
 		FilePath: path,
 	})
+	// performDragOperation: is delivered by the drag session, not an
+	// NSEvent — wake the idle loop so the drop's repaint happens
+	// promptly (issue #405).
+	C.metalPostEmptyEvent()
 }

--- a/gui/backend/metal/events_test.go
+++ b/gui/backend/metal/events_test.go
@@ -11,6 +11,17 @@ import (
 
 // ─── mapMetalModifiers ────────────────────────────────────────
 
+func TestIdleWaitMs(t *testing.T) {
+	// The idle branch of the event loop must block indefinitely
+	// (issue #405); a frame that rendered keeps the drain-only poll.
+	if got := idleWaitMs(false); got != -1 {
+		t.Fatalf("idleWaitMs(false) = %d, want -1", got)
+	}
+	if got := idleWaitMs(true); got != 0 {
+		t.Fatalf("idleWaitMs(true) = %d, want 0", got)
+	}
+}
+
 func TestMapMetalModifiers_Zero(t *testing.T) {
 	if m := mapMetalModifiers(0); m != 0 {
 		t.Fatalf("zero flags → 0, got %v", m)

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -3,6 +3,7 @@
 package metal
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -185,4 +186,13 @@ func runMainThreadTests() {
 	//     latching into per-frame main-thread blocking after its first
 	//     resize.
 	runLiveResizePresentationTests()
+
+	// 12. The idle poll must block and wake: metalPollEvent(-1) sleeps
+	//     until a posted event arrives. Regression for issue #405 —
+	//     the idle loop no longer polls at 100ms, so every path that
+	//     dirties state must wake it with a posted event.
+	if rc := testPollIdleWake(); rc != 0 {
+		panic(fmt.Sprintf("metalPollEvent(-1): idle wait did not wake "+
+			"on posted event (rc %d)", rc))
+	}
 }

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -1981,6 +1981,44 @@ int metalTestPollReturnsOnQuitRequested(void) {
             _quitRequested == 0) ? 1 : 0;
 }
 
+// Verify the indefinite idle wait actually blocks and wakes: schedule
+// a run-loop timer that posts a wake event, then metalPollEvent(-1)
+// must sleep until the timer fires and return the consumed event.
+// Regression test for issue #405 — the idle loop stopped polling at
+// 100ms, so every path that dirties state must wake it with a posted
+// event.
+// Returns 0 on success; 1 if the poll returned without an event; 2 if
+// the poll did not block (returned before the timer could fire).
+int metalTestPollIdleWake(void) {
+    // Drain anything left over from earlier tests so the wait below
+    // is the wait under test.
+    while (metalPollEvent(0)) {}
+
+    // addTimer:forMode: retains the timer and schedules it in the
+    // default mode — the same mode the poll waits in.
+    NSTimer *timer = [NSTimer timerWithTimeInterval:0.1
+                                            repeats:NO
+                                              block:^(NSTimer *t) {
+        [NSApp postEvent:metalWakeEvent() atStart:NO];
+    }];
+    [[NSRunLoop currentRunLoop] addTimer:timer
+                                 forMode:NSDefaultRunLoopMode];
+
+    NSDate *t0 = [NSDate date];
+    int r = metalPollEvent(-1);
+    NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:t0];
+
+    if (r != 1) {
+        [timer invalidate];  // still scheduled — don't leak its wake
+        return 1;
+    }
+    if (elapsed < 0.05) {
+        [timer invalidate];
+        return 2;
+    }
+    return 0;
+}
+
 // Delegates to the shared metalCursorInContentBounds helper so the
 // 10 Go tests exercise the exact same logic as production code.
 int metalTestCursorBoundsCheck(float mouseX, float mouseY,


### PR DESCRIPTION
Closes #405.

## Problem

The Metal, X11, and Win32 event loops polled with a 100 ms timeout while
idle, flooring idle CPU on every platform. Nothing periodic needs the
poll — every path that dirties state can wake the loop directly.

## Change

- **Metal** — idle poll is now `metalPollEvent(-1)`, which blocks on
  `[NSDate distantFuture]`. Wake paths: `QueueCommand`/animation (posted
  empty event, existing), `App.OpenWindow` from another goroutine (new
  app-level wake fn), and the `windowDidBecomeKey:`/drag-drop
  notification callbacks, which never surface as NSEvents and would
  otherwise delay the repaint until the next real event.
- **X11** — both idle `time.After(100ms)` cases removed; the loop blocks
  on the events channel (a `_GOGUI_WAKE` ClientMessage ends the wait and
  drains as a no-op). No app-level wake needed: `runAppE`'s idle select
  already includes `PendingOpen`.
- **Win32** — `waitMessage(100)` → `waitMessage(INFINITE)` in both loops;
  `runAppE` wires the app-level wake and re-points it to a surviving
  window after a close (a destroyed hwnd silently drops the posted
  wake).

## Tests

- `TestAppOpenWindowWakes` — wake on queued window, none on dropped
  (buffer full) request; `TestAppOpenWindowNoWakeFn` — nil fn safe.
- `TestIdleWaitMs` — idleWaitMs(false) == -1, idleWaitMs(true) == 0.
- `metalTestPollIdleWake` (main-thread suite) — proves
  `metalPollEvent(-1)` genuinely blocks (~100 ms) and returns on a
  posted wake event.

## Verification

`make prepush` green (race, lint, cross-GOOS lint, cross-compiles,
coverage, export audit); CGO-free cross-build of linux+windows GL.