### PR TITLE
fix: arm the nested-runloop frame pump only while a nested mode is active (#406)

### DIFF
--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -29,6 +29,7 @@ int metalTestApplicationDidBecomeActive(void);
 void metalTestRunModalMode(int ms);
 void metalTestRunDefaultMode(int ms);
 int metalTestFramePumpActive(void);
+int metalTestNestedModesPumpStaysArmed(void);
 int metalTestPressAndHoldRegistered(void);
 void metalTestPushIMECommit(const char *utf8);
 void metalTestPushIMEComposition(const char *utf8, int start, int len);
@@ -311,6 +312,12 @@ func testApplicationDidBecomeActive() bool {
 // testFramePumpActive reports whether the nested-runloop frame-pump
 // timer is currently installed.
 func testFramePumpActive() bool { return C.metalTestFramePumpActive() != 0 }
+
+// testNestedModesPumpStaysArmed reports whether the pump timer was
+// found disarmed while a second nested mode ran inside the first.
+func testNestedModesPumpStaysArmed() bool {
+	return C.metalTestNestedModesPumpStaysArmed() != 0
+}
 
 // testPressAndHoldRegistered reports ApplePressAndHoldEnabled as
 // registered by metalAppInit: 0 off, 1 on, -1 never registered.

--- a/gui/backend/metal/frame_pump_test.go
+++ b/gui/backend/metal/frame_pump_test.go
@@ -19,13 +19,16 @@ func TestFramePumpNestedMode(t *testing.T) {
 }
 
 // runFramePumpMainThreadTests verifies the nested-runloop frame pump:
-// the timer must fire (and reach Go) while the main runloop runs in a
-// nested mode, and must stay silent in NSDefaultRunLoopMode where the
-// backend's own event loop owns frame timing.
+// the timer must be armed only while the main runloop runs in a nested
+// mode — it must fire (and reach Go) there, must not exist at all in
+// NSDefaultRunLoopMode where the backend's own event loop owns frame
+// timing, and must be retired by Destroy.
 //
 // Regression test for windows freezing — no repaint, no command flush,
 // no terminal reflow on resize — for as long as a modal dialog or open
-// menu keeps a nested AppKit runloop on the main thread.
+// menu keeps a nested AppKit runloop on the main thread. Also guards
+// issue #406: the 60 Hz timer must not wake the run loop in the default
+// mode, where its only act used to be an early return.
 //
 // Panics on failure, matching runMainThreadTests.
 func runFramePumpMainThreadTests() {
@@ -46,10 +49,10 @@ func runFramePumpMainThreadTests() {
 		panic("frame pump: metal.New: " + err.Error())
 	}
 
-	// metalAppFinishLaunch arms the pump.
+	// metalAppFinishLaunch registers the mode observer, not a timer.
 	testActivateNow()
-	if !testFramePumpActive() {
-		panic("frame pump: timer not installed after metalAppFinishLaunch")
+	if testFramePumpActive() {
+		panic("frame pump: timer armed outside a nested mode (issue #406)")
 	}
 
 	// Nested mode: the pump must run. 200 ms is ~12 ticks at 60 Hz, so
@@ -60,16 +63,25 @@ func runFramePumpMainThreadTests() {
 		panic("frame pump: no frames pumped in NSModalPanelRunLoopMode")
 	}
 
-	// Default mode: the pump must stay out of the way. The timer still
-	// fires here (it is installed in common modes) but the handler must
-	// return before calling into Go.
+	// A second nested mode over the first (menu over a modal dialog)
+	// must keep the pump armed — only the exit of the last nested mode
+	// may retire the timer.
+	if testNestedModesPumpStaysArmed() {
+		panic("frame pump: timer disarmed while a nested mode was still active")
+	}
+
+	// Default mode: the pump must not exist, let alone pump. Frames
+	// doubled here would double every frame the Go loop renders.
 	before = framePumpCount.Load()
 	testRunDefaultMode(200)
 	if got := framePumpCount.Load(); got != before {
 		panic("frame pump: pumped in NSDefaultRunLoopMode — frames doubled")
 	}
+	if testFramePumpActive() {
+		panic("frame pump: timer left armed after returning to the default mode")
+	}
 
-	// Destroy must retire the timer; a live one would keep pumping
+	// Destroy must retire the observer; a live pump would keep pumping
 	// frames for windows that no longer exist.
 	b.Destroy()
 	if testFramePumpActive() {

--- a/gui/backend/metal/metal_window.h
+++ b/gui/backend/metal/metal_window.h
@@ -198,17 +198,22 @@ void metalSetDockIcon(const void *data, int len);
 // and no frames are produced: queued commands never flush and the
 // window stops repainting until the nested loop exits.
 //
-// metalStartFramePump installs a repeating timer in
-// NSRunLoopCommonModes that renders a frame per window while such a
-// nested loop runs. It does nothing in NSDefaultRunLoopMode, where the
-// Go loop owns frame timing.
+// metalStartFramePump registers a mode-entry/exit observer on the main
+// run loop. It arms a repeating timer (in NSRunLoopCommonModes, so it
+// fires in NSEventTrackingRunLoopMode and NSModalPanelRunLoopMode) when
+// a nested mode begins and invalidates it when the last one ends, so
+// the timer exists only while such a loop runs (issue #406). In
+// NSDefaultRunLoopMode — the Go loop owns frame timing — there is no
+// timer at all: an idle app costs the run loop nothing and stays
+// eligible for App Nap.
 //
 // This cannot help when the main thread blocks with no runloop running
 // at all (e.g. a synchronous system API that puts up a TCC permission
 // prompt) — no timer fires in that state.
 void metalStartFramePump(void);
 
-// Stop and release the frame-pump timer. Idempotent.
+// Stop and release the frame-pump timer and its mode observer.
+// Idempotent.
 void metalStopFramePump(void);
 
 #endif // METAL_WINDOW_H

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -1475,9 +1475,9 @@ void metalAppFinishLaunch(void) {
 // Rationale lives in metal_window.h. The short version: the Go event loop
 // only pumps NSDefaultRunLoopMode, so a nested AppKit runloop (modal
 // dialog, menu tracking, live resize) starves every window of frames.
-// This timer is scheduled in NSRunLoopCommonModes, which includes
-// NSEventTrackingRunLoopMode and NSModalPanelRunLoopMode, so it keeps
-// firing exactly when the Go loop cannot.
+// A repeating timer is armed ONLY while such a nested mode is active
+// (issue #406); in the default mode no timer exists at all, so an idle
+// app costs the run loop nothing and stays eligible for App Nap.
 
 // Timer interval — 60 Hz. Frames are cheap when nothing is dirty:
 // Window.PumpFrame flushes commands and returns false without rendering
@@ -1486,27 +1486,78 @@ static const NSTimeInterval kFramePumpInterval = 1.0 / 60.0;
 
 static NSTimer *_framePumpTimer;
 
-void metalStartFramePump(void) {
+// Nesting depth of non-default run loop modes. The pump timer is armed
+// while this is > 0 (a menu over a modal dialog is depth 2) and
+// invalidated when it returns to 0.
+static CFIndex _framePumpNestedDepth;
+
+static CFRunLoopObserverRef _framePumpModeObserver;
+
+// Arm the timer. It is scheduled in NSRunLoopCommonModes, which includes
+// NSEventTrackingRunLoopMode and NSModalPanelRunLoopMode, so it fires
+// exactly while the current mode is a nested one.
+static void metalFramePumpArm(void) {
     if (_framePumpTimer) return;
     _framePumpTimer = [NSTimer timerWithTimeInterval:kFramePumpInterval
                                              repeats:YES
                                                block:^(NSTimer *timer) {
-        // In the default mode the Go event loop is running and owns frame
-        // timing; pumping here too would double every frame. Only the
-        // nested modes — where that loop is blocked — need this timer.
-        NSString *mode = [[NSRunLoop currentRunLoop] currentMode];
-        if (!mode || [mode isEqualToString:NSDefaultRunLoopMode]) return;
+        // Only reached while a nested mode is current — the mode check
+        // used to live here, moved to the run-loop observer below so no
+        // timer wakes in the default mode to make it.
         goMetalPumpFrames();
     }];
-    // Common modes, not the default mode: see above.
     [[NSRunLoop mainRunLoop] addTimer:_framePumpTimer
                               forMode:NSRunLoopCommonModes];
 }
 
-void metalStopFramePump(void) {
+static void metalFramePumpDisarm(void) {
     if (!_framePumpTimer) return;
     [_framePumpTimer invalidate];
     _framePumpTimer = nil;
+}
+
+// Mode-entry/exit observer on the main run loop: arm the pump when a
+// nested mode begins, invalidate it when the last one ends. Runs on the
+// main thread inside the run loop, so timer mutation here is safe.
+static void metalFramePumpModeObserver(CFRunLoopObserverRef observer,
+                                       CFRunLoopActivity activity,
+                                       void *info) {
+    NSString *mode = [[NSRunLoop currentRunLoop] currentMode];
+    BOOL nested = mode != nil && ![mode isEqualToString:NSDefaultRunLoopMode];
+    if (activity == kCFRunLoopEntry) {
+        if (nested && ++_framePumpNestedDepth == 1) {
+            metalFramePumpArm();
+        }
+    } else if (activity == kCFRunLoopExit) {
+        // Exit may be observed for a mode whose entry predates our
+        // registration — never decrement below zero.
+        if (nested && _framePumpNestedDepth > 0 &&
+            --_framePumpNestedDepth == 0) {
+            metalFramePumpDisarm();
+        }
+    }
+}
+
+void metalStartFramePump(void) {
+    if (_framePumpModeObserver) return;
+    _framePumpModeObserver =
+        CFRunLoopObserverCreate(kCFAllocatorDefault,
+                                kCFRunLoopEntry | kCFRunLoopExit,
+                                YES, 0, metalFramePumpModeObserver, NULL);
+    CFRunLoopAddObserver(CFRunLoopGetMain(), _framePumpModeObserver,
+                         kCFRunLoopCommonModes);
+    // Keep our own retain until stop, so the static is never dangling.
+}
+
+void metalStopFramePump(void) {
+    if (_framePumpModeObserver) {
+        CFRunLoopRemoveObserver(CFRunLoopGetMain(), _framePumpModeObserver,
+                                kCFRunLoopCommonModes);
+        CFRelease(_framePumpModeObserver);
+        _framePumpModeObserver = NULL;
+    }
+    metalFramePumpDisarm();
+    _framePumpNestedDepth = 0;
 }
 
 // ─── Test helpers (called from Go tests via cgo) ─────────────────
@@ -1928,6 +1979,32 @@ int metalTestPressAndHoldRegistered(void) {
 // Report whether the frame-pump timer is currently installed.
 int metalTestFramePumpActive(void) {
     return (_framePumpTimer && [_framePumpTimer isValid]) ? 1 : 0;
+}
+
+// Exercise the depth counter: while a nested mode is active, a second
+// nested mode (menu over a modal dialog) must keep the pump armed —
+// only the exit of the LAST nested mode may invalidate the timer.
+// Runs the modal mode; 60 ms in, a one-shot timer enters the tracking
+// mode for 30 ms and checks the timer on both sides of that transition.
+// Returns 1 if the timer was ever found disarmed mid-nesting.
+int metalTestNestedModesPumpStaysArmed(void) {
+    __block int disarmed = 0;
+    NSTimer *inner = [NSTimer timerWithTimeInterval:0.06
+                                            repeats:NO
+                                              block:^(NSTimer *timer) {
+        if (!metalTestFramePumpActive()) disarmed = 1;
+        // Enter the tracking mode while the modal mode is still active
+        // (depth 1→2), then let it exit (2→1): the pump must stay armed.
+        NSDate *until = [NSDate dateWithTimeIntervalSinceNow:0.03];
+        [[NSRunLoop mainRunLoop] runMode:NSEventTrackingRunLoopMode
+                              beforeDate:until];
+        if (!metalTestFramePumpActive()) disarmed = 1;
+    }];
+    // Fires only inside the modal mode — the mode under test.
+    [[NSRunLoop mainRunLoop] addTimer:inner
+                              forMode:NSModalPanelRunLoopMode];
+    metalTestRunMode(NSModalPanelRunLoopMode, 150);
+    return disarmed;
 }
 
 // Inject a synthetic quit event so Go tests can verify mapMetalEvent


### PR DESCRIPTION
Closes #406.

## Summary

The frame-pump `NSTimer` was scheduled at 60 Hz in `NSRunLoopCommonModes` for the whole life of the app. In the default run loop mode — the common case — every firing copied the current mode string and early-returned, so an idle process took 60 timer wakeups per second to do nothing, keeping the main run loop from ever going quiet (App Nap, timer coalescing).

The pump is now armed **only while a nested run loop is actually active**:

- A `CFRunLoopObserver` on the main run loop tracks mode entries/exits and maintains a nesting depth of non-default modes (modal panels, menu tracking, live resize, popovers).
- The 60 Hz timer is created when the depth goes 0→1 and invalidated when it returns to 0 — a menu over a modal dialog (depth 2) keeps it armed.
- The timer block's `currentMode` early-return is gone; the observer guarantees the timer only exists while nested, which also removes the per-fire mode-string copy.
- Idle default-mode operation carries **no timer at all**.

## Tests

`frame_pump_test.go` now asserts the #406 regression directly (timer absent after launch and after returning to the default mode), plus a new nested-mode test (`metalTestNestedModesPumpStaysArmed`) that enters `NSEventTrackingRunLoopMode` inside `NSModalPanelRunLoopMode` and verifies the pump stays armed across the depth 1→2→1 transitions. Modal-mode pumping and Destroy retirement assertions retained.

Verified with `GO_GUI_MAIN_THREAD_TESTS=1 go test -count=1 ./gui/backend/metal/` (real Cocoa path on the main thread) and `make prepush` (race, lint, cross-compile, coverage, export audit).