### PR TITLE
fix: skip a11y tree sync when nothing changed (#407)

### DIFF
--- a/gui/a11y_tree.go
+++ b/gui/a11y_tree.go
@@ -47,8 +47,15 @@ type a11y struct {
 	prevLiveValues map[string]string
 	nodes          []A11yNode // reused across frames
 	liveNodes      []liveNode // reused across frames
-	prevFocusID    string
-	initialized    bool
+	// dirty is set by updateLocked (any layout rebuild) and
+	// setFocusLocked (a real focus change — the focused index is part
+	// of the pushed snapshot but no layout rebuild accompanies it).
+	// syncA11y clears it only when it actually pushes, so a dirty tree
+	// that hits the throttle retries the next frame. An idle window
+	// with a clean tree never walks the tree or touches cgo (issue
+	// #407).
+	dirty       bool
+	initialized bool
 }
 
 // initA11y lazily creates the native accessibility container.
@@ -58,6 +65,9 @@ func (w *Window) initA11y() {
 		return
 	}
 	w.a11y.initialized = true
+	// The first sync must always run; the zero value of dirty is
+	// false, so mark it here rather than in the struct literal.
+	w.a11y.dirty = true
 
 	if w.nativePlatform != nil {
 		w.nativePlatform.A11yInit(func(action, index int) {
@@ -69,7 +79,9 @@ func (w *Window) initA11y() {
 // syncA11y walks the layout tree, builds a flat node array,
 // and pushes it to the native accessibility backend.
 // Throttled to a11ySyncInterval to avoid expensive per-frame
-// CGo calls.
+// CGo calls. When the tree is clean — no layout rebuild and no
+// focus change since the last push — the walk and the cgo call
+// are skipped entirely (issue #407).
 func (w *Window) syncA11y() {
 	if w.nativePlatform == nil || !w.a11y.initialized {
 		return
@@ -77,11 +89,17 @@ func (w *Window) syncA11y() {
 	if w.layout.Shape == nil {
 		return
 	}
+	// A dirty tree that hits the throttle keeps its dirty flag and
+	// retries on the next frame.
+	if !w.a11y.dirty {
+		return
+	}
 	now := time.Now()
 	if now.Sub(w.a11y.lastSync) < a11ySyncInterval {
 		return
 	}
 	w.a11y.lastSync = now
+	w.a11y.dirty = false
 
 	// Reuse slices across frames.
 	w.a11y.nodes = w.a11y.nodes[:0]
@@ -116,7 +134,6 @@ func (w *Window) syncA11y() {
 	for _, ln := range w.a11y.liveNodes {
 		w.a11y.prevLiveValues[ln.label] = ln.value
 	}
-	w.a11y.prevFocusID = w.viewState.focusID
 }
 
 // a11yCollect recursively walks the layout tree and appends

--- a/gui/a11y_tree_test.go
+++ b/gui/a11y_tree_test.go
@@ -585,7 +585,7 @@ func TestSyncA11yNotInitialized(t *testing.T) {
 
 func TestSyncA11yNilShape(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.layout = Layout{} // Shape is nil
 	w.syncA11y()
 	if mp := w.nativePlatform.(*mockA11yPlatform); mp.syncCnt != 0 {
@@ -595,7 +595,7 @@ func TestSyncA11yNilShape(t *testing.T) {
 
 func TestSyncA11yEmptyNodes(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.layout = Layout{
 		Shape: &Shape{A11YRole: AccessRoleNone},
 	}
@@ -607,7 +607,7 @@ func TestSyncA11yEmptyNodes(t *testing.T) {
 
 func TestSyncA11yBuildsAndSyncsTree(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.layout = Layout{
 		Shape: &Shape{A11YRole: AccessRoleGroup},
 		Children: []Layout{
@@ -664,7 +664,7 @@ func TestSyncA11yBuildsAndSyncsTree(t *testing.T) {
 
 func TestSyncA11yTrackedFocus(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.viewState.focusID = "f2"
 	w.layout = Layout{
 		Shape: &Shape{A11YRole: AccessRoleGroup},
@@ -690,24 +690,100 @@ func TestSyncA11yTrackedFocus(t *testing.T) {
 
 func TestSyncA11yThrottle(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.layout = Layout{
 		Shape: &Shape{A11YRole: AccessRoleButton},
 	}
 	w.a11y.lastSync = time.Time{}
 	w.syncA11y()
 
-	// Second call within throttle window should no-op.
+	// Second call within throttle window should no-op. Mark dirty again
+	// so the test exercises the throttle, not the clean-tree skip.
+	w.a11y.dirty = true
 	w.syncA11y()
 	mp := w.nativePlatform.(*mockA11yPlatform)
 	if mp.syncCnt != 1 {
 		t.Errorf("throttle failed: %d calls, want 1", mp.syncCnt)
 	}
+	// The blocked push must retain the dirty flag for the next frame.
+	if !w.a11y.dirty {
+		t.Error("throttled sync cleared the dirty flag")
+	}
+}
+
+func TestSyncA11ySkipsCleanTree(t *testing.T) {
+	w := newA11yWindow()
+	w.initA11y()
+	w.layout = Layout{
+		Shape: &Shape{
+			A11YRole:  AccessRoleStaticText,
+			A11YState: AccessStateLive,
+			a11Y:      &accessInfo{Label: "status", ValueNum: 100},
+		},
+	}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y()
+
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if mp.syncCnt != 1 {
+		t.Fatalf("first sync: %d calls, want 1", mp.syncCnt)
+	}
+
+	// Nothing changed: even with the throttle defeated, a clean tree
+	// must not walk or push (issue #407).
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y()
+	if mp.syncCnt != 1 {
+		t.Errorf("clean tree synced again: %d calls, want 1", mp.syncCnt)
+	}
+	if len(mp.announce) != 0 {
+		t.Errorf("clean tree announced: %v", mp.announce)
+	}
+}
+
+func TestSyncA11yFocusChangeMarksDirty(t *testing.T) {
+	w := newA11yWindow()
+	w.initA11y()
+	w.layout = Layout{
+		Shape: &Shape{A11YRole: AccessRoleGroup},
+		Children: []Layout{
+			{Shape: &Shape{
+				A11YRole:  AccessRoleButton,
+				Focusable: true, ID: "f1",
+			}},
+			{Shape: &Shape{
+				A11YRole:  AccessRoleButton,
+				Focusable: true, ID: "f2",
+			}},
+		},
+	}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y()
+
+	// A real focus change marks the tree dirty even though no layout
+	// rebuild follows, so the pushed focused index updates.
+	w.SetFocus("f2")
+	if !w.a11y.dirty {
+		t.Fatal("SetFocus should mark the a11y tree dirty")
+	}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y()
+
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if mp.focusIdx != 2 {
+		t.Errorf("focusIdx after SetFocus: got %d, want 2", mp.focusIdx)
+	}
+	// Re-asserting the same focus is not a change and must not dirty.
+	w.a11y.dirty = false
+	w.SetFocus("f2")
+	if w.a11y.dirty {
+		t.Error("re-asserting focus should not mark dirty")
+	}
 }
 
 func TestSyncA11yLiveRegionAnnounce(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.layout = Layout{
 		Shape: &Shape{
 			A11YRole:  AccessRoleStaticText,
@@ -722,6 +798,7 @@ func TestSyncA11yLiveRegionAnnounce(t *testing.T) {
 	// Change the live region value.
 	w.layout.Shape.a11Y.ValueNum = 200
 	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
 	w.syncA11y()
 
 	mp := w.nativePlatform.(*mockA11yPlatform)
@@ -736,7 +813,7 @@ func TestSyncA11yLiveRegionAnnounce(t *testing.T) {
 
 func TestSyncA11yLiveRegionNoChange(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.layout = Layout{
 		Shape: &Shape{
 			A11YRole:  AccessRoleStaticText,
@@ -748,8 +825,9 @@ func TestSyncA11yLiveRegionNoChange(t *testing.T) {
 	// First sync sets baseline.
 	w.syncA11y()
 
-	// Same value — no announce.
+	// Same value — no announce. Mark dirty so the second sync runs.
 	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
 	w.syncA11y()
 
 	mp := w.nativePlatform.(*mockA11yPlatform)
@@ -764,10 +842,14 @@ func TestSyncA11yInitLazy(t *testing.T) {
 	w.layout = Layout{
 		Shape: &Shape{A11YRole: AccessRoleButton},
 	}
-	// initA11y should set initialized=true.
+	// initA11y should set initialized=true and seed the dirty flag so
+	// the first sync always runs.
 	w.initA11y()
 	if !w.a11y.initialized {
 		t.Fatal("expected initialized after initA11y")
+	}
+	if !w.a11y.dirty {
+		t.Fatal("expected dirty after initA11y")
 	}
 	// Second call is idempotent.
 	w.initA11y()
@@ -776,9 +858,30 @@ func TestSyncA11yInitLazy(t *testing.T) {
 	}
 }
 
+// TestSyncA11yLayoutRebuildMarksDirty drives the real frame path: a
+// layout rebuild through updateLocked must dirty the tree, and the next
+// sync (once the throttle allows) must push.
+func TestSyncA11yLayoutRebuildMarksDirty(t *testing.T) {
+	w := newA11yWindow()
+	w.initA11y()
+	w.viewGenerator = func(_ *Window) View {
+		return Button(ButtonCfg{ID: "b1"})
+	}
+	w.Update()
+	if !w.a11y.dirty {
+		t.Fatal("layout rebuild should mark the a11y tree dirty")
+	}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y()
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if mp.syncCnt == 0 {
+		t.Fatal("dirty tree after rebuild should sync")
+	}
+}
+
 func TestSyncA11yNodesReused(t *testing.T) {
 	w := newA11yWindow()
-	w.a11y.initialized = true
+	w.initA11y()
 	w.layout = Layout{
 		Shape: &Shape{A11YRole: AccessRoleButton},
 	}
@@ -791,6 +894,7 @@ func TestSyncA11yNodesReused(t *testing.T) {
 
 	// Second sync should reuse the slice.
 	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
 	w.syncA11y()
 	if cap(w.a11y.nodes) != oldCap {
 		t.Error("node slice cap changed — expected reuse")

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -38,6 +38,10 @@ func (w *Window) setFocusLocked(id string) {
 	if id != prev {
 		w.clearInputSelections()
 		w.imeClear()
+		// The a11y snapshot carries the focused index but no layout
+		// rebuild accompanies a focus change, so mark the tree dirty
+		// here or syncA11y would skip the push (issue #407).
+		w.a11y.dirty = true
 	}
 	w.viewState.focusID = id
 	if id != "" {

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -259,6 +259,10 @@ func (w *Window) updateLocked() {
 	defer w.inFramePass.Store(false)
 	w.refreshLayout = false
 	w.refreshRenderOnly = false
+	// Every full layout rebuild may have changed a11y-visible state
+	// (labels, geometry, roles, live values). Mark the tree dirty so
+	// syncA11y pushes once the throttle allows (issue #407).
+	w.a11y.dirty = true
 
 	if w.viewGenerator == nil {
 		w.mu.Unlock()


### PR DESCRIPTION
## Summary

`syncA11y` ran unconditionally at 10 Hz from `FrameFn`: every 100 ms it walked the whole layout tree, converted every node's `Label`/`Value`/`Description` with `C.CString` (one malloc per non-empty string per node), pushed the array through cgo (an `NSString` per field + children-array rebuild per element), then freed everything — even for a completely idle, unchanged tree.

## Fix

A dirty flag on the window's a11y state. The tree is marked dirty from the two places that can change a11y-visible state:

- `updateLocked` — every full layout rebuild (covers events, queued commands, resize, smooth scroll, `AmendLayout` repositioning; geometry only mutates inside the arrange pass).
- `setFocusLocked` — a real focus change alters the pushed focused index with no accompanying layout rebuild.

`syncA11y` returns before the walk when clean, and clears the flag only when it actually pushes, so a dirty tree that hits the throttle retries next frame. `initA11y` seeds the flag so the first sync always runs. An idle app now pays zero tree walks and zero cgo pushes until its tree or focus changes.

Also removed the dead `prevFocusID` field (written, never read; the ObjC side tracks focus via its own `_prevFocusedIdx`).

## Tests

- `TestSyncA11ySkipsCleanTree` — clean tree never re-syncs or re-announces.
- `TestSyncA11yFocusChangeMarksDirty` — real focus change pushes the updated index; re-asserting same focus does not dirty.
- `TestSyncA11yLayoutRebuildMarksDirty` — drives the real `Update()` path and asserts the rebuild dirty + push.
- `TestSyncA11yThrottle` — asserts a throttled push retains the dirty flag.
- `TestSyncA11yInitLazy` — asserts `initA11y` seeds dirty (first sync always runs).
- All direct-sync tests now go through the real `initA11y()` path instead of poking `w.a11y.initialized` directly.

Closes #407.