### PR TITLE
feat: per-vertex color fills on DrawContext (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ and this project adheres to
 
 ### Added
 
+- **Per-vertex color fills on `DrawContext`** (#400) —
+  `FillTrianglesColors(tris, colors)` takes caller-supplied geometry and one
+  color per vertex. Nothing is evaluated on the way through: no projection, no
+  stop isolines, no subdivision. It is the primitive the gradient fills are
+  built on, exposed for shading a gradient cannot express.
+
+  A gradient's level sets are conic curves, nested and stepped linearly, so a
+  shading whose isolines are not nested, or which varies around a center rather
+  than away from it, or which stops at a silhouette, is out of reach however the
+  stops are arranged. A Lambert-shaded sphere is all three at once: the isophote
+  at `N·L = k` is an ellipse of semi-axis `√(1−k²)`, a point at `k = −1`, the
+  full limb at the terminator, a point again at `k = 1`.
+
+  `examples/solar_system` is ported to it. A planet body was 20–48 flat bands,
+  one batch each, with visible quantization at large radii; it is now a single
+  watertight mesh in one batch with a continuous ramp, and the ring count that
+  used to hide the quantization came down by more than half. A full-system frame
+  went from 232 triangle batches and 40.6k triangles to 79 and 30.2k.
+  `examples/draw_canvas` gains a per-vertex panel: a bilinear corner blend and a
+  hue sweep, neither of which any gradient emits.
+
+  No backend change — the batch rides the same `RenderCmd.VertexColors` channel
+  a gradient fill does. A `DrawRecorder` that does not implement the new
+  optional `DrawVertexColorRecorder` receives one flat polygon per triangle at
+  that triangle's mean color, so an export path never drops a shaded mesh.
+
+  Callers own one invariant the gradient path handled for them: every triangle
+  in a mesh must wind the same way. `gui/backend/soft` rasterizes the batch as
+  one path with signed coverage accumulation, so a reversed triangle cancels
+  against its neighbours and cuts a hairline seam.
+
 - **Gradient fills on `DrawContext`** (#398) — a canvas fill can take a
   `gui.CanvasGradient` in place of a flat `Color`: `FilledRectGradient`,
   `FilledCircleGradient`, `FilledArcGradient`, `FilledPolygonGradient`,

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -224,6 +224,29 @@ fake a falloff; that is what this replaces.
 A gradient fill always starts its own batch and never merges with the flat fill
 before it, so interleaving the two keeps painter's order.
 
+### When a gradient cannot express the shading
+
+`FillTrianglesColors(tris, colors)` is the primitive underneath all six. You
+supply the geometry and one color per vertex — `len(colors)*2 == len(tris)` —
+and nothing is evaluated on the way through: no projection, no stop isolines, no
+subdivision. A mismatched color count is a no-op, and the fill starts its own
+batch under the same rule a gradient does.
+
+Reach for it when the shading is not a gradient and cannot be made into one. A
+gradient's level sets are conic curves, nested inside one another, stepped
+linearly along the ramp. A shading whose isolines are not nested (a Lambert
+sphere, whose isophotes open to the terminator and close again on both sides),
+or which varies around a center rather than away from it (a hue sweep), or which
+stops at a silhouette, is out of reach however the stops are arranged.
+`examples/solar_system` is the worked case; `examples/draw_canvas` shows the two
+short ones.
+
+**Wind every triangle the same way.** `gui/backend/soft` rasterizes a
+vertex-colored batch as a single path and accumulates _signed_ coverage, so a
+triangle wound against its neighbours cancels along their shared edge and cuts a
+hairline through the mesh. Share vertices between adjacent triangles rather than
+overlapping them: with per-vertex color, an overlap paints twice and shows.
+
 ## The one-event rule
 
 Nothing is marked handled for you. A callback that acts on an event calls

--- a/examples/draw_canvas/main.go
+++ b/examples/draw_canvas/main.go
@@ -29,8 +29,13 @@ func main() {
 func mainView(w *gui.Window) gui.View {
 
 	return gui.Column(gui.ContainerCfg{
-		Sizing:  gui.FillFill,
-		Padding: gui.CurrentTheme().PaddingLarge,
+		// The three canvases are taller than the window, so the column
+		// scrolls. A scrollable container needs an ID: the scroll offset
+		// is stored against it.
+		ID:         "canvases",
+		Scrollable: true,
+		Sizing:     gui.FillFill,
+		Padding:    gui.CurrentTheme().PaddingLarge,
 
 		Spacing: gui.SomeF(16),
 		Content: []gui.View{
@@ -61,6 +66,20 @@ func mainView(w *gui.Window) gui.View {
 				Radius:  8,
 				Padding: gui.PadAll(16),
 				OnDraw:  drawGradients,
+			}),
+			gui.Text(gui.TextCfg{
+				Text:      "Per-Vertex Colors",
+				TextStyle: gui.CurrentTheme().B1,
+			}),
+			gui.DrawCanvas(gui.DrawCanvasCfg{
+				ID:      "vertex_colors",
+				Version: 1,
+				Width:   560,
+				Height:  140,
+				Color:   gui.RGBA(30, 30, 40, 255),
+				Radius:  8,
+				Padding: gui.PadAll(16),
+				OnDraw:  drawVertexColors,
 			}),
 		},
 	})
@@ -199,4 +218,65 @@ func drawGradients(dc *gui.DrawContext) {
 		X1: r, Y1: 0, X2: r + size/3, Y2: 0,
 		Spread: gui.SpreadRepeat, Stops: warm,
 	})
+}
+
+// drawVertexColors shows FillTrianglesColors, the primitive underneath
+// the gradient fills. The caller supplies the geometry and one color
+// per vertex; nothing is evaluated on the way through.
+//
+// Both tiles are shadings a gradient cannot express. A gradient's level
+// sets are conic curves nested inside one another and stepped linearly,
+// so a sweep around a center and a bilinear corner blend are both out
+// of reach however the stops are arranged.
+func drawVertexColors(dc *gui.DrawContext) {
+	const (
+		size = 96
+		gap  = 24
+	)
+	y := (dc.Height - size) / 2
+
+	// A bilinear blend: four corners, four colors, two triangles. The
+	// shared diagonal is why the colors have to be per vertex — the two
+	// triangles meet along it and their vertex colors agree there, so
+	// there is no seam.
+	x := float32(0)
+	tl := gui.RGB(240, 120, 60)
+	tr := gui.RGB(250, 210, 90)
+	br := gui.RGB(90, 150, 240)
+	bl := gui.RGB(150, 80, 220)
+	dc.FillTrianglesColors([]float32{
+		x, y, x + size, y, x + size, y + size,
+		x, y, x + size, y + size, x, y + size,
+	}, []gui.Color{tl, tr, br, tl, br, bl})
+
+	// A sweep: hue as a function of angle around the center, laid down
+	// as a triangle fan. The color varies *along* every circle centered
+	// here and is constant along every radius, which is the opposite of
+	// what a radial gradient does.
+	const seg = 64
+	x += size + gap
+	cx, cy := x+size/2, y+size/2
+	tris := make([]float32, 0, seg*6)
+	cols := make([]gui.Color, 0, seg*3)
+	white := gui.RGB(250, 250, 255)
+	for i := range seg {
+		a0 := float64(i) * 2 * math.Pi / seg
+		a1 := float64(i+1) * 2 * math.Pi / seg
+		tris = append(tris,
+			cx, cy,
+			cx+size/2*float32(math.Cos(a0)), cy+size/2*float32(math.Sin(a0)),
+			cx+size/2*float32(math.Cos(a1)), cy+size/2*float32(math.Sin(a1)))
+		cols = append(cols, white, sweepColor(a0), sweepColor(a1))
+	}
+	dc.FillTrianglesColors(tris, cols)
+}
+
+// sweepColor is the hue wheel: three primaries 120° apart, each fading
+// linearly to nothing over the 120° on either side of it.
+func sweepColor(a float64) gui.Color {
+	ramp := func(offset float64) uint8 {
+		d := math.Abs(math.Mod(a-offset+3*math.Pi, 2*math.Pi) - math.Pi)
+		return uint8(255 * max(0, 1-d/(2*math.Pi/3)))
+	}
+	return gui.RGB(ramp(0), ramp(2*math.Pi/3), ramp(4*math.Pi/3))
 }

--- a/examples/solar_system/README.md
+++ b/examples/solar_system/README.md
@@ -47,8 +47,9 @@ go run ./examples/solar_system/
   to a panel appearing.
 - **Batch-aware drawing.** `DrawContext` merges only _consecutive_ same-color
   triangles, so the starfield quantizes its twinkle to eight brightness levels
-  and draws one level at a time — eight batches per frame instead of 220, and
-  each band of a shaded sphere costs exactly one batch.
+  and draws one level at a time — eight batches per frame instead of 220. A
+  shaded sphere goes the other way: it is one mesh carrying a color per vertex,
+  so the whole body is a single batch however fine its ramp.
 
 - **One encoding for "which body".** Selection and hover are a planet index,
   `selSun` for the sun, or `-1` for nothing. The sun gets a value outside the
@@ -60,7 +61,7 @@ go run ./examples/solar_system/
 
 ## Notes on technique
 
-`DrawContext` fills come in two forms, and this example uses both.
+`DrawContext` fills come in three forms, and this example uses all of them.
 
 The two glows are real gradients (`FilledCircleGradient`, issue #398). Each is
 one fill:
@@ -75,14 +76,15 @@ was turned down. `haloStops` (`draw.go`) samples the opacity those stacks
 accumulated to, so the appearance is the one they had, at one fill each and with
 nothing left to tune.
 
-Everything else that looks like a gradient is still flat shapes standing in for
-one, and deliberately so:
+The planet shading is the third form: `FillTrianglesColors` (issue #400), where
+the caller evaluates its own shading model and hands over geometry plus one
+color per vertex. A gradient cannot stand in for it — circles cannot make a
+crescent, and neither can any other conic isoline; the argument is below.
 
-- The planet shading is elliptical bands in a light-aligned frame. Circles
-  cannot make a crescent, so no radial gradient can express it.
-- Three translucent rings just outside each planet's silhouette feather the
-  polygon edge into something that reads as anti-aliased. Three is few enough
-  that a gradient would not pay for itself.
+What is left is flat shapes standing in for a gradient, deliberately: three
+translucent rings just outside each planet's silhouette feather the polygon edge
+into something that reads as anti-aliased. Three is few enough that a gradient
+would not pay for itself.
 
 ### Painting a star
 
@@ -119,13 +121,14 @@ from one shared inner radius, which accumulated alpha there and painted a hard
 bright ring inside the limb — a worse artifact than the soft edge it was meant
 to give.
 
-### Shading a sphere out of flat polygons
+### Shading a sphere the renderer cannot express
 
 A planet is a real Lambert sphere, not an approximation of one. On a sphere lit
 by a distant source the brightness at a surface point is `N·L`, so the lines of
-equal brightness are the circles of constant angle from the light. Each band of
-brightness is the strip of surface between two of those circles, traced in a
-frame with the light as its pole and projected to screen.
+equal brightness are the circles of constant angle from the light. The body is a
+mesh of exactly those circles — one ring of vertices per intensity, traced in a
+frame with the light as its pole, projected to screen, and handed to
+`FillTrianglesColors` with the intensity carried as a color on every vertex.
 
 The light vector is built once, in screen coordinates, and carries everything
 the shading needs. `diskTilt` is the sine of the camera's elevation above the
@@ -139,7 +142,7 @@ rather than `[0, 1]`, because a camera 29° above the plane never sees a pure ne
 or full phase. Most orreries skip phase entirely and paint every planet fully
 lit.
 
-Four things about this are worth knowing if you copy it.
+Five things about this are worth knowing if you copy it.
 
 **Circles cannot make a crescent.** The first version built the body from a
 focal radial gradient — the `fx`/`fy` construction an SVG `radialGradient` uses,
@@ -149,27 +152,61 @@ disc, which reads as a second small sphere sitting inside the planet. The
 terminator is an ellipse; no amount of softening the blob's edge turns one into
 the other.
 
+**Nor can any other gradient.** The isophotes _are_ ellipses, which makes an
+elliptical gradient look like the answer, and it is not. For an orthographic
+unit sphere lit by `l`, the locus `N·L = k` projects to an ellipse centered at
+`|l₂d|·k` along the screen light direction, with semi-axis `√(1−k²)` across the
+light and `√(1−k²)·|lz|` along it. The aspect ratio is constant in `k`, so a
+gradient could match that part. Two things defeat it. The radius law is
+`√(1−k²)`, not linear: the isoline is a point at `k = −1`, opens to the full
+limb at the terminator, and closes to a point again at `k = 1`, so the isophotes
+at 30° and 150° are two small disjoint ellipses on opposite sides of the disc,
+neither containing the other. Gradient level sets are nested by construction, so
+no gradient emits that family. And each isophote is clipped at the silhouette,
+which a gradient has no notion of. That is what `FillTrianglesColors` exists
+for: the shading model is solved here and handed over already evaluated.
+
 **Hidden points get pushed onto the limb.** A band's boundary circle usually
 runs off the back of the sphere. Projecting the hidden part radially out to
 radius `r` lands it on the silhouette — exactly where the band's boundary
 belongs, and exactly where it already is at the crossing — so nothing needs
 clipping.
 
-**Bands are spaced evenly in intensity, not in angle.** Even angular spacing
-looks fine across the middle of the lit side and stripes badly at the
-terminator, because `cos` is flat at the poles and steepest at 90°: the same
-slice of angle is a much bigger slice of brightness there. Stepping `cos`
-directly makes every band the same color distance from its neighbour and spends
-angular resolution where the eye is looking. The night half still has to be
-subdivided even though every band there comes out the same color: at `cos = -1`
-the boundary circle has collapsed to the antisolar point, and a strip run from a
-single point fans out as a wedge instead of covering the region.
+**Where the rings go is decided by the limb, not by the ramp.** Even steps in
+intensity are the obvious spacing and they make the silhouette go polygonal,
+because the mesh boundary _is_ the limb: a ring only partly on the near side
+ends on the silhouette, and the mesh edge between two such rings is a chord of
+it. A limb point's intensity is `m·cos(delta)` — `delta` the angle around the
+limb from the light's screen direction, `m` the light's screen-plane length — so
+even steps in intensity are wildly uneven steps in `delta`, growing as a square
+root near `delta = 0` until a single chord spans 20°. With the light in the
+screen plane that lands on the disc's own edge, which is why the facets showed
+on planets drawn beside the sun and nowhere else.
 
-**Quads that merely touch leave hairlines.** Adjacent triangles sharing an edge
-do not tile cleanly — the rasterizer antialiases each one on its own, so both
-sides come out at partial coverage and the background shows through as a seam.
-The bands are opaque, so growing every quad a fraction of a step past its own
-share costs nothing and closes it.
+So the rings that reach the limb are spaced evenly in `delta` instead, which
+makes every limb chord the same length. Those are the rings with
+`|cos(phi)| < m`; outside that band a ring is either wholly visible — a closed
+curve around the pole the light points at — or wholly hidden. The visible cap
+gets rings spaced evenly in `phi` and the hidden one gets none, which is also a
+saving: even spacing spent nearly half its rings on the far side only for
+`appendTri` to drop them.
+
+**The mesh must be watertight and consistently wound.** Both follow from how a
+vertex-colored batch is rasterized: `gui/backend/soft` treats it as one path and
+accumulates _signed_ coverage. Adjacent triangles that merely touch antialias
+independently and leak the background through as a hairline, so consecutive
+rings share their vertices rather than being drawn as separate strips — the same
+array, used as the outer edge of one strip and the inner edge of the next. And a
+triangle wound against its neighbours subtracts from them, cutting a seam
+through the body; the limb clamp can reorder a quad's corners, so `appendTri`
+measures the signed area and emits the vertices in a consistent order rather
+than assuming one. It drops the zero-area case in the same step, which is what
+removes the rings lying entirely on the far side.
+
+The flat-band version this replaced needed a fifth trick: every quad was grown a
+fraction of a step past its own share, so opaque neighbours overlapped instead
+of merely touching. With a per-vertex ramp that overlap would itself show as
+banding, and a shared-vertex mesh has no seam left to close.
 
 **The color ramp needs the base color as a middle stop.** Interpolating straight
 from night to light passes through the midpoint of those two, which is a
@@ -178,18 +215,17 @@ its own color across most of the lit side — Uranus stays cyan and Mars stays
 red. The unlit side bottoms out at a fraction of the body's color rather than
 black, on the grounds that a planet you cannot see is a planet you cannot click.
 
-Level and segment counts scale with pixel radius, never a constant. A fixed
-count bands the moment the thing gets big — it showed up first on a planet
-zoomed to fill the view, and again on the sun's halo back when that was a ring
-stack, 500px across with Jupiter focused and banded at 17px per ring. The halo
-is a gradient now and no longer has a count to get wrong; the shading bands
-still do.
+Ring and segment counts scale with pixel radius, never a constant, but they buy
+much less than they used to. They now resolve only the _geometry_ — the
+curvature of the elliptical rings and the chord error where the mesh boundary
+meets the limb, both of which fall off as the square of the spacing. The ramp
+itself is continuous however coarse the mesh is, so the counts came down by more
+than half when the color moved onto the vertices: a full-system frame went from
+232 triangle batches and 40.6k triangles to 79 and 30.2k, and a Jupiter-focused
+frame from 137 and 52.6k to 89 and 42.7k.
 
-A band is one flat color and its quads are emitted consecutively, so each band
-costs a single batch. The full-system view emits about 245 triangle batches a
-frame and a focused planet about 270. Off-screen bodies are culled: without
-that, the seven planets outside the viewport at a focused zoom each still built
-a full-resolution sphere.
+Off-screen bodies are still culled: without that, the seven planets outside the
+viewport at a focused zoom each built a full-resolution sphere anyway.
 
 Orbit ellipses are drawn with `Arc`, the ellipse primitive, with the vertical
 radius squashed to tilt the plane. Each ellipse's center is offset by `a·e`

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -93,20 +93,24 @@ const (
 	sunShellsMin   = 14
 	sunShellsMax   = 96
 
-	// shadeLevels is how many flat-colored bands the sphere shading is
-	// quantized into, and shadeArc how many segments each band's curved
-	// boundary is traced with. Both scale with the body's pixel radius,
-	// bounded by their Min/Max: a fixed count bands badly once a planet
-	// is zoomed to fill the view, and is wasted on a 4px Mercury.
+	// shadeRows is how many rings of constant Lambert intensity the
+	// sphere mesh is built from, and shadeArc how many segments each
+	// ring is traced with. Both scale with the body's pixel radius,
+	// bounded by their Min/Max, and are wasted on a 4px Mercury.
 	//
-	// The level count is also the batch count for the body, since a band
-	// is one flat color and its quads are emitted consecutively.
-	shadeLevelsPerPx = 1.4
-	shadeLevelsMin   = 20
-	shadeLevelsMax   = 48
-	shadeArcPerPx    = 1.2
-	shadeArcMin      = 20
-	shadeArcMax      = 72
+	// These counts buy *geometry*, not color steps. The mesh carries a
+	// color per vertex, so the intensity ramp is continuous however
+	// coarse the rows are; what the rows have to resolve is the
+	// curvature of the elliptical rings and the chord error where the
+	// mesh boundary meets the limb. Both fall off as the square of the
+	// spacing, which is why far fewer rows suffice here than the flat
+	// bands this replaced needed to hide their quantization.
+	shadeRowsPerPx = 0.5
+	shadeRowsMin   = 12
+	shadeRowsMax   = 36
+	shadeArcPerPx  = 0.7
+	shadeArcMin    = 16
+	shadeArcMax    = 64
 
 	// nightScale is the unlit hemisphere's brightness, as a fraction of
 	// the body's own color. Not zero on purpose: a planet you cannot see
@@ -118,11 +122,6 @@ const (
 	// Well past the middle, so most of the lit side carries the planet's
 	// hue and the bright end stays tight.
 	baseStop = 0.72
-
-	// seamOverlap is how far past its own share each shading quad is
-	// grown, as a fraction of a step, so neighbours overlap instead of
-	// merely touching. See the comment at its use.
-	seamOverlap = 0.2
 
 	// ringNightAlpha is how much of their opacity Saturn's rings keep on
 	// the night side. They are lit by the same sun the body is.
@@ -498,10 +497,10 @@ func drawPlanet(a *App, dc *gui.DrawContext, i int) {
 	cx, cy := a.ScreenX[i], a.ScreenY[i]
 	r := max(a.ScreenR[i], 1.5)
 
-	// Cull off-screen bodies. The shading ramp's step count scales with
+	// Cull off-screen bodies. The shading mesh's ring count scales with
 	// pixel radius, so at a planet-focused zoom the seven planets that
-	// are nowhere near the viewport were still each emitting a
-	// full-resolution ramp — 537 batches a frame instead of ~120.
+	// are nowhere near the viewport were each still building a
+	// full-resolution sphere, thousands of triangles apiece.
 	// The margin covers Saturn's rings, which reach about 2r.
 	if m := r * 2.5; cx+m < 0 || cx-m > dc.Width ||
 		cy+m < 0 || cy-m > dc.Height {
@@ -531,11 +530,11 @@ func drawPlanet(a *App, dc *gui.DrawContext, i int) {
 		// half — which is what makes the rings pass behind Saturn.
 		k := a.litFraction(i)
 		drawRings(dc, cx, cy, r, math.Pi, math.Pi, k)
-		drawBody(dc, cx, cy, r, p.Color, lx, ly, lz)
+		drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz)
 		drawRings(dc, cx, cy, r, 0, math.Pi, k)
 		return
 	}
-	drawBody(dc, cx, cy, r, p.Color, lx, ly, lz)
+	drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz)
 }
 
 // lightBasis is an orthonormal frame with the light direction as its
@@ -617,14 +616,130 @@ func (b lightBasis) visibleAzimuth(cosPhi, sinPhi float32) float32 {
 	}
 }
 
-// drawBody paints one shaded sphere: a feathered rim, then a Lambert
-// intensity ramp laid down as flat-colored bands.
+// ringPlan lays out the rings drawBody walks, in cos(phi) — the Lambert
+// intensity itself.
 //
-// The bands are the real thing rather than a stand-in. On a sphere lit
-// by a distant source the brightness at a surface point is N·L, so the
+// Even steps in intensity are the obvious choice, and they are what
+// made the silhouette go polygonal. The mesh boundary *is* the limb: a
+// ring only partly on the near side ends on the silhouette, and the
+// mesh edge between two such rings is a chord of it. A limb point's
+// intensity is m*cos(delta) — delta the angle around the limb from the
+// light's screen direction, m the light's screen-plane length — so even
+// steps in intensity are wildly uneven steps in delta. Near delta = 0
+// the step grows as a square root and one chord can span 20 degrees.
+// With the light in the screen plane that lands on the disc's own edge,
+// which is exactly where the facets showed: the sun-facing and anti-sun
+// edges of a planet beside the sun.
+//
+// So the rings that reach the limb are spaced evenly in delta instead,
+// which makes every limb chord the same length. Those are the rings
+// with |cos(phi)| < m; outside that band a ring is either wholly
+// visible — a closed curve around the pole the light points at — or
+// wholly hidden. The visible cap gets rings spaced evenly in phi, the
+// hidden one gets none: it covers no visible surface, and even spacing
+// spent nearly half its rings there only for appendTri to drop them.
+//
+// Rows are split between cap and band by the share of phi each spans.
+// That gives them all to the band when the light lies in the screen
+// plane (there is no visible cap) and about half to the cap when it
+// points nearly at the camera (the band is then a sliver around the
+// terminator, which is all the limb it can touch).
+type ringPlan struct {
+	capPhi float32 // polar angle the visible cap spans
+	m      float32 // screen-plane length of the light vector
+	sgn    float32 // -1 when the visible cap is the unlit pole
+	nCap   int
+	nBand  int
+}
+
+func newRingPlan(b lightBasis, rows int) ringPlan {
+	p := ringPlan{m: min(b.m, 1), sgn: 1}
+	if b.lz < 0 {
+		p.sgn = -1
+	}
+	p.capPhi = acos32(p.m)
+	// The cap gets at least one ring even when it is tiny or empty. The
+	// ring at the visible pole is what turns the cap lens into a
+	// triangle fan, and without it the lens on the light side of the
+	// limb shows background — a small body's ring budget can leave
+	// zero cap rings while the lens is still a visible patch. When the
+	// light lies in the screen plane the cap is empty and this ring is
+	// the pole point itself, which is also the ring the band would
+	// have started with.
+	p.nCap = max(int(float32(rows)*p.capPhi/math.Pi), 1)
+	// A band of four rings is a coarse crescent, but it is still a
+	// crescent; the cap has taken the rest because the light is nearly
+	// head-on, and then there is barely any terminator to resolve.
+	p.nBand = max(rows-p.nCap, 4)
+	return p
+}
+
+// count is how many rings the plan holds.
+func (p ringPlan) count() int { return p.nCap + p.nBand + 1 }
+
+// cosPhi is ring i's Lambert intensity. The sequence is monotone, from
+// the visible pole through the band to the far side of the terminator,
+// so consecutive rings always bound a strip.
+func (p ringPlan) cosPhi(i int) float32 {
+	if i < p.nCap {
+		return p.sgn * cos32(p.capPhi*float32(i)/float32(p.nCap))
+	}
+	d := float32(math.Pi) * float32(i-p.nCap) / float32(p.nBand)
+	return p.sgn * p.m * cos32(d)
+}
+
+// bodyMesh is drawBody's reusable scratch. It holds the mesh handed to
+// FillTrianglesColors plus the two rings of screen positions the sphere
+// is walked with, so a frame that shades nine planets builds all their
+// geometry without allocating — the per-fill batch copy
+// FillTrianglesColors makes is all that is left.
+//
+// prev and cur are one ring each, x,y interleaved. Every ring is
+// evaluated once and used twice: as the outer edge of one strip and the
+// inner edge of the next. That sharing is what makes the mesh
+// watertight — adjacent strips do not merely meet along a boundary,
+// they are built from the same vertices.
+type bodyMesh struct {
+	tris      []float32
+	cols      []gui.Color
+	prev, cur []float32
+}
+
+// appendTri adds one triangle, wound consistently with every other
+// triangle in the mesh, and drops it if it has no area.
+//
+// Winding is not cosmetic. gui/backend/soft rasterizes a vertex-colored
+// batch as a single path and accumulates *signed* coverage, so a
+// triangle wound against its neighbours subtracts from them and carves
+// a seam through the body. lightBasis.point pushes hidden vertices out
+// onto the limb, which can reorder a quad's corners, so the sign is
+// measured rather than assumed.
+//
+// Dropping the zero-area case is also what removes the rings that lie
+// entirely on the far side: every one of their points is pushed to the
+// same limb position, so their strips collapse.
+func (m *bodyMesh) appendTri(x0, y0 float32, c0 gui.Color,
+	x1, y1 float32, c1 gui.Color, x2, y2 float32, c2 gui.Color,
+) {
+	switch area := (x1-x0)*(y2-y0) - (x2-x0)*(y1-y0); {
+	case area > 0:
+		m.tris = append(m.tris, x0, y0, x1, y1, x2, y2)
+		m.cols = append(m.cols, c0, c1, c2)
+	case area < 0:
+		m.tris = append(m.tris, x0, y0, x2, y2, x1, y1)
+		m.cols = append(m.cols, c0, c2, c1)
+	}
+}
+
+// drawBody paints one shaded sphere: a feathered rim, then a Lambert
+// intensity ramp laid down as a single vertex-colored mesh.
+//
+// The mesh is the real thing rather than a stand-in. On a sphere lit by
+// a distant source the brightness at a surface point is N·L, so the
 // lines of equal brightness are the circles of constant angle from the
-// light — and each band is the strip of surface between two of them,
-// traced directly in the light-aligned frame and projected to screen.
+// light. The mesh is those circles: one ring of vertices per intensity,
+// traced in the light-aligned frame and projected to screen, with the
+// intensity carried as a color on every vertex.
 //
 // That geometry is the whole point, because it is what a crescent *is*.
 // An earlier version built the body from a focal radial gradient, the
@@ -635,13 +750,25 @@ func (b lightBasis) visibleAzimuth(cosPhi, sinPhi float32) float32 {
 // terminator is an ellipse, not a circle, and no amount of softening
 // the blob's edge turns one into the other.
 //
-// Each band is emitted as a strip of quads sharing one flat color, so
-// it costs one batch: the color only changes between bands, and
-// getBatch merges consecutive same-color triangles. Adjacent bands
-// trace the same boundary curve from both sides, so there are no seams.
-func drawBody(dc *gui.DrawContext, cx, cy, r float32, base gui.Color,
-	lx, ly, lz float32,
+// Nor can any other gradient. The isophote at N·L = k projects to an
+// ellipse whose semi-axis is sqrt(1-k²): a point at k = -1, the full
+// limb at the terminator, a point again at k = 1. Gradient level sets
+// are nested by construction and grow linearly, so no gradient
+// primitive of any kind emits that family — and none of them knows to
+// stop at the silhouette. Hence FillTrianglesColors (issue #400): the
+// shading model is evaluated here, per vertex, and handed over already
+// solved.
+//
+// The whole body is one batch.
+func drawBody(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32,
+	base gui.Color, lx, ly, lz float32,
 ) {
+	// The frame, the visibility test and ringPlan's tangency all read
+	// the light as a unit vector; normalizing once here is cheaper than
+	// each of them defending itself.
+	if d := sqrt32(lx*lx + ly*ly + lz*lz); d > 0 {
+		lx, ly, lz = lx/d, ly/d, lz/d
+	}
 	night := scaleColor(base, nightScale)
 	lit := lightenColor(base, 0.26)
 	// The disc's average tone, used where there is no room to shade.
@@ -663,87 +790,74 @@ func drawBody(dc *gui.DrawContext, cx, cy, r float32, base gui.Color,
 	degenerate := sqrt32(lx*lx+ly*ly) < 1e-4
 
 	if r < flatBodyRadius || degenerate {
-		// Too small for the ramp to be visible (it would only cost
-		// batches), or nothing to orient it by. Draw the average tone
-		// flat — which for a head-on light is the fully lit tone.
+		// Too small for the ramp to be visible, or nothing to orient it
+		// by. Draw the average tone flat — which for a head-on light is
+		// the fully lit tone.
 		dc.FilledCircle(cx, cy, r, flat)
 		return
 	}
 
 	b := newLightBasis(lx, ly, lz)
-	levels := int(clamp32(r*shadeLevelsPerPx, shadeLevelsMin, shadeLevelsMax))
+	rows := int(clamp32(r*shadeRowsPerPx, shadeRowsMin, shadeRowsMax))
 	arc := int(clamp32(r*shadeArcPerPx, shadeArcMin, shadeArcMax))
+	p := newRingPlan(b, rows)
 
-	// One reused quad, so the strips do not allocate per segment.
-	var quad [8]float32
+	m.tris, m.cols = m.tris[:0], m.cols[:0]
 
-	// Bands are spaced evenly in *intensity*, not in angle. Even
-	// angular spacing looks fine over the middle of the lit side and
-	// stripes badly at the terminator, because cos is flat at the poles
-	// and steepest at 90°: the same slice of angle is a much bigger
-	// slice of brightness there. Stepping cos directly makes every band
-	// the same color distance from its neighbour, and spends angular
-	// resolution where the eye is actually looking.
-	//
-	// Darkest first, so the brighter band's seam overlap lands on top.
-	//
-	// The night half is subdivided too, even though every band there
-	// comes out the same color and merges into one batch. It cannot be
-	// one band: at cos = -1 the boundary circle has collapsed to the
-	// antisolar point, and a strip run from a single point does not
-	// cover the region — it fans out as a wedge with the rest of the
-	// night side left unpainted.
-	bands := levels * 2
-	for j := range bands {
-		c0 := -1 + 2*float32(j)/float32(bands)
-		c1 := -1 + 2*float32(j+1)/float32(bands)
-		shadeBand(dc, cx, cy, r, b, &quad,
-			c0-2*seamOverlap/float32(bands), c1,
-			sphereTone(night, base, lit, clamp32((c0+c1)/2, 0, 1)), arc)
+	// Where the rings go is ringPlan's decision, and not the obvious
+	// one; see it for why even steps in intensity make the silhouette
+	// go polygonal.
+	var prevCol gui.Color
+	for i := range p.count() {
+		c := p.cosPhi(i)
+		s := sqrt32(max(0, 1-c*c))
+		col := sphereTone(night, base, lit, clamp32(c, 0, 1))
+		m.cur = appendRing(m.cur[:0], b, r, cx, cy, c, s, arc)
+		if i > 0 {
+			m.appendStrip(prevCol, col, arc)
+		}
+		m.prev, m.cur = m.cur, m.prev
+		prevCol = col
 	}
+	dc.FillTrianglesColors(m.tris, m.cols)
 }
 
-// shadeBand fills the strip of sphere surface whose Lambert intensity
-// lies between cOut and cIn, as a run of quads sharing one flat color —
-// so the whole band costs a single batch.
-func shadeBand(dc *gui.DrawContext, cx, cy, r float32, b lightBasis,
-	quad *[8]float32, cOut, cIn float32, col gui.Color, arc int,
-) {
-	cOut = clamp32(cOut, -1, 1)
-	s0, s1 := sqrt32(1-cOut*cOut), sqrt32(1-cIn*cIn)
-
-	tMax := max(b.visibleAzimuth(cOut, s0), b.visibleAzimuth(cIn, s1))
-	if tMax <= 0 {
-		return // this band is entirely on the far side
-	}
-
+// appendRing evaluates one circle of constant Lambert intensity into
+// dst as arc+1 screen x,y pairs, spanning that circle's *own* visible
+// azimuth range.
+//
+// Each ring gets its own range rather than a shared one, so a ring that
+// is only partly on the near side ends exactly at the silhouette and
+// its two end points land on the limb. The mesh boundary is then a
+// chord of the limb per row, and lightBasis.point has already pushed
+// any hidden interior point out onto the limb as well. A ring entirely
+// on the far side collapses to a single point; it covers no visible
+// surface, and appendTri drops the strips it takes part in.
+func appendRing(dst []float32, b lightBasis, r, cx, cy, cosPhi,
+	sinPhi float32, arc int,
+) []float32 {
+	tMax := b.visibleAzimuth(cosPhi, sinPhi)
 	step := 2 * tMax / float32(arc)
-	over := step * seamOverlap
+	for k := 0; k <= arc; k++ {
+		t := -tMax + step*float32(k)
+		x, y := b.point(r, cosPhi, sinPhi, cos32(t), sin32(t))
+		dst = append(dst, cx+x, cy+y)
+	}
+	return dst
+}
+
+// appendStrip tiles the surface between the two rings currently held in
+// prev and cur with quads, two triangles apiece. Both rings carry a
+// flat color of their own and the vertex colors interpolate between
+// them, which is the ramp.
+func (m *bodyMesh) appendStrip(outer, inner gui.Color, arc int) {
 	for k := range arc {
-		// Every quad is grown slightly past its own share of the
-		// surface. Adjacent triangles that merely *share* an edge do
-		// not tile cleanly: the rasterizer antialiases each one on its
-		// own, so both sides come out at partial coverage and the
-		// background shows through as a hairline. The bands are
-		// opaque, so overlapping them costs nothing and closes the
-		// seam.
-		ta := -tMax + step*float32(k) - over
-		tb := ta + step + 2*over
-		cta, sta := cos32(ta), sin32(ta)
-		ctb, stb := cos32(tb), sin32(tb)
-
-		ax0, ay0 := b.point(r, cOut, s0, cta, sta)
-		bx0, by0 := b.point(r, cOut, s0, ctb, stb)
-		ax1, ay1 := b.point(r, cIn, s1, cta, sta)
-		bx1, by1 := b.point(r, cIn, s1, ctb, stb)
-
-		*quad = [8]float32{
-			cx + ax0, cy + ay0,
-			cx + bx0, cy + by0,
-			cx + bx1, cy + by1,
-			cx + ax1, cy + ay1,
-		}
-		dc.FilledPolygon(quad[:], col)
+		ax0, ay0 := m.prev[k*2], m.prev[k*2+1]
+		bx0, by0 := m.prev[k*2+2], m.prev[k*2+3]
+		ax1, ay1 := m.cur[k*2], m.cur[k*2+1]
+		bx1, by1 := m.cur[k*2+2], m.cur[k*2+3]
+		m.appendTri(ax0, ay0, outer, bx0, by0, outer, bx1, by1, inner)
+		m.appendTri(ax0, ay0, outer, bx1, by1, inner, ax1, ay1, inner)
 	}
 }
 

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -63,6 +63,10 @@ type App struct {
 	glowStops []gui.GradientStop
 	haloStops []gui.GradientStop
 
+	// body is drawBody's mesh scratch, reused for the same reason: nine
+	// planets a tick, each rebuilding a few thousand vertices.
+	body bodyMesh
+
 	// Selected and Hovered are a planet index, selSun for the sun, or
 	// -1 for the full-system view / nothing under the cursor.
 	Selected int

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -822,3 +822,226 @@ func TestDrawBodyDegenerateLight(t *testing.T) {
 	tick(a)
 	assertFinite(t, drawInto(a), "planet on the sun")
 }
+
+// bodyBatches draws one shaded sphere in isolation and returns the
+// context it landed in.
+func bodyBatches(t *testing.T, r float32, lx, ly, lz float32) *gui.DrawContext {
+	t.Helper()
+	dc := gui.NewDrawContext(200, 200, nil)
+	var m bodyMesh
+	drawBody(dc, &m, 100, 100, r, gui.RGB(180, 140, 90), lx, ly, lz)
+	return dc
+}
+
+// TestBodyIsOneVertexColoredBatch pins the payoff of issue #400: the
+// whole intensity ramp is one batch of interpolated vertices, where the
+// flat-band version it replaced cost one batch per band.
+func TestBodyIsOneVertexColoredBatch(t *testing.T) {
+	dc := bodyBatches(t, 60, 0.6, 0.2, -0.77)
+	meshes := 0
+	for _, b := range dc.Batches() {
+		if len(b.VertexColors) == 0 {
+			continue // the rim feather, which is flat by design
+		}
+		meshes++
+		if len(b.VertexColors)*2 != len(b.Triangles) {
+			t.Fatalf("VertexColors=%d, Triangles=%d: lengths must agree",
+				len(b.VertexColors), len(b.Triangles))
+		}
+		if len(b.Triangles) == 0 {
+			t.Fatal("the shading mesh is empty")
+		}
+	}
+	if meshes != 1 {
+		t.Errorf("body emitted %d vertex-colored batches, want 1", meshes)
+	}
+}
+
+// TestBodyMeshWindingIsConsistent guards the hazard that makes a single
+// batch possible in the first place. gui/backend/soft rasterizes a
+// vertex-colored batch as one path and accumulates signed coverage, so
+// a triangle wound against its neighbours subtracts from them and cuts
+// a seam through the body. Every light direction is worth checking:
+// the limb clamp in lightBasis.point is what can reorder a quad, and
+// which quads it reaches depends on where the light is.
+func TestBodyMeshWindingIsConsistent(t *testing.T) {
+	lights := []struct {
+		name       string
+		lx, ly, lz float32
+	}{
+		{"full face", 0.02, 0, 0.999},
+		{"quarter", 0.7, 0, 0.71},
+		{"terminator", 1, 0, 0},
+		{"crescent", 0.6, 0.2, -0.77},
+		{"near eclipse", 0.05, 0.02, -0.998},
+	}
+	for _, l := range lights {
+		dc := bodyBatches(t, 60, l.lx, l.ly, l.lz)
+		for _, b := range dc.Batches() {
+			if len(b.VertexColors) == 0 {
+				continue
+			}
+			for i := 0; i+5 < len(b.Triangles); i += 6 {
+				v := b.Triangles[i : i+6]
+				area := (v[2]-v[0])*(v[5]-v[1]) - (v[4]-v[0])*(v[3]-v[1])
+				// The bound is not zero. appendTri sorts on its own
+				// float32 evaluation of the same cross product, and a
+				// sliver whose true area is a millionth of a pixel can
+				// come out either side of zero here — Go may fuse the
+				// multiply-subtract in one function and not the other.
+				// Coverage cancellation needs area to cancel with, so
+				// the thing worth failing on is a triangle that is
+				// visibly reversed, not one at the noise floor.
+				if area < -1e-4 {
+					t.Fatalf("%s: triangle %d has signed area %v; every "+
+						"triangle in the mesh must wind the same way",
+						l.name, i/6, area)
+				}
+			}
+		}
+	}
+}
+
+// TestBodyMeshStaysInsideDisc checks the mesh boundary against the
+// silhouette. Every vertex is a surface point of the sphere or a hidden
+// point pushed onto the limb, so none of them may escape the disc.
+func TestBodyMeshStaysInsideDisc(t *testing.T) {
+	const cx, cy, r = 100, 100, 60
+	dc := bodyBatches(t, 60, 0.6, 0.2, -0.77)
+	for _, b := range dc.Batches() {
+		if len(b.VertexColors) == 0 {
+			continue
+		}
+		for i := 0; i+1 < len(b.Triangles); i += 2 {
+			dx := float64(b.Triangles[i] - cx)
+			dy := float64(b.Triangles[i+1] - cy)
+			if d := math.Sqrt(dx*dx + dy*dy); d > r+0.01 {
+				t.Fatalf("vertex %d is %v from the center, outside r=%v",
+					i/2, d, float32(r))
+			}
+		}
+	}
+}
+
+// TestBodyMeshDoesNotAllocatePerFrame pins the scratch reuse. drawBody
+// runs nine times a tick; a mesh rebuilt from a fresh slice each time
+// would allocate for the whole session.
+func TestBodyMeshDoesNotAllocatePerFrame(t *testing.T) {
+	var m bodyMesh
+	dc := gui.NewDrawContext(200, 200, nil)
+	drawBody(dc, &m, 100, 100, 60, gui.RGB(180, 140, 90), 0.6, 0.2, -0.77)
+
+	got := testing.AllocsPerRun(20, func() {
+		// A fresh context each run would allocate for its own batches,
+		// which is not what this measures; the mesh scratch is.
+		m.tris = m.tris[:0]
+		m.cols = m.cols[:0]
+		m.cur = appendRing(m.cur[:0], newLightBasis(0.6, 0.2, -0.77),
+			60, 100, 100, 0.3, 0.95, 32)
+		m.prev = m.prev[:0]
+		m.prev = appendRing(m.prev[:0], newLightBasis(0.6, 0.2, -0.77),
+			60, 100, 100, 0.2, 0.98, 32)
+		m.appendStrip(gui.RGB(1, 2, 3), gui.RGB(4, 5, 6), 32)
+	})
+	if got != 0 {
+		t.Errorf("mesh rebuild allocated %v times per run, want 0", got)
+	}
+}
+
+// pointInMesh reports whether (px,py) lies in some triangle of the
+// vertex-colored batches. The mesh is wound consistently, so a point is
+// inside a triangle when all three edge cross products share a sign;
+// the epsilon lets a point sitting exactly on a shared edge count.
+func pointInMesh(dc *gui.DrawContext, px, py float32) bool {
+	const eps = 1e-4
+	for _, b := range dc.Batches() {
+		if len(b.VertexColors) == 0 {
+			continue
+		}
+		for i := 0; i+5 < len(b.Triangles); i += 6 {
+			v := b.Triangles[i : i+6]
+			a := (v[2]-v[0])*(py-v[1]) - (px-v[0])*(v[3]-v[1])
+			c := (v[4]-v[2])*(py-v[3]) - (px-v[2])*(v[5]-v[3])
+			d := (v[0]-v[4])*(py-v[5]) - (px-v[4])*(v[1]-v[5])
+			if a >= -eps && c >= -eps && d >= -eps {
+				return true
+			}
+			if a <= eps && c <= eps && d <= eps {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestBodyMeshCoversTheLimb guards the silhouette against the facets
+// ringPlan exists to remove.
+//
+// The mesh boundary is the limb, drawn as one chord per ring that ends
+// there, so a ring spacing that samples the limb unevenly leaves wide
+// chords and the disc's edge goes visibly polygonal — background
+// showing through where the sphere should be. Sampling just inside the
+// limb all the way around is the direct test: with even steps in
+// intensity these points fall outside the chord near the light's own
+// screen direction, which is on the disc edge whenever a planet sits
+// beside the sun.
+//
+// The small-body case is the other failure mode of the same sampling:
+// a small body's ring budget can leave zero rings for the visible
+// polar cap, whose lens sits right on the light side of the limb — a
+// bare patch of background at the point where the planet meets the
+// sun. The plan floors the cap at one ring, which turns the whole lens
+// into a fan from the pole.
+func TestBodyMeshCoversTheLimb(t *testing.T) {
+	const cx, cy = 100, 100
+	lights := []struct {
+		name       string
+		lx, ly, lz float32
+		r          float32
+	}{
+		{"terminator", 1, 0, 0, 60},
+		{"beside the sun", 0.999, 0.045, 0, 60},
+		{"quarter", 0.7, 0, 0.71, 60},
+		{"crescent", 0.6, 0.2, -0.77, 60},
+		{"full face", 0.02, 0, 0.999, 60},
+	}
+	for _, l := range lights {
+		dc := bodyBatches(t, l.r, l.lx, l.ly, l.lz)
+		for k := range 256 {
+			a := 2 * math.Pi * float64(k) / 256
+			px := cx + 0.99*l.r*float32(math.Cos(a))
+			py := cy + 0.99*l.r*float32(math.Sin(a))
+			if !pointInMesh(dc, px, py) {
+				t.Fatalf("%s: the mesh leaves a gap at %.0f° around the "+
+					"limb; the silhouette is faceted there",
+					l.name, a*180/math.Pi)
+			}
+		}
+	}
+}
+
+// TestBodyMeshSmallBodyCoversTheLightSide pins the cap's floor of one
+// ring. A small body's ring budget can leave zero rings for the
+// visible polar cap, and without the floor the cap lens on the light
+// side of the limb is painted by nothing — a bare patch of background
+// where the planet meets the sun.
+//
+// The samples stay a hair off the light axis: the fan from the pole
+// ring closes with a sub-pixel float32 wedge along it, and the point
+// here is the unpainted lens, not that sliver.
+func TestBodyMeshSmallBodyCoversTheLightSide(t *testing.T) {
+	const cx, cy = 100, 100
+	const r float32 = 20
+	// The light 14.5° out of the screen plane leaves the cap lens
+	// spanning about 17.5..20 px from the center along the light axis.
+	dc := bodyBatches(t, r, 0.97, 0, 0.25)
+	for _, a := range []float64{math.Pi / 16, -math.Pi / 16} {
+		px := cx + 0.97*r*float32(math.Cos(a))
+		py := cy + 0.97*r*float32(math.Sin(a))
+		if !pointInMesh(dc, px, py) {
+			t.Fatalf("the mesh leaves a gap at %.0f° on the light side "+
+				"of the limb; the visible polar cap is unpainted",
+				a*180/math.Pi)
+		}
+	}
+}

--- a/gui/backend/soft/draw_canvas_gradient_test.go
+++ b/gui/backend/soft/draw_canvas_gradient_test.go
@@ -159,3 +159,70 @@ func TestVertexColorsLengthMismatchFallsBackToFlat(t *testing.T) {
 		})
 	}
 }
+
+// vcolCmd wraps a hand-built mesh as the RenderSvg command the canvas
+// path emits for FillTrianglesColors.
+func vcolCmd(tris []float32, cols []gui.Color) gui.RenderCmd {
+	return gui.RenderCmd{
+		Kind:         gui.RenderSvg,
+		Scale:        1,
+		Color:        gui.RGB(255, 255, 255),
+		Triangles:    tris,
+		VertexColors: cols,
+	}
+}
+
+// TestMeshWindingMustBeConsistent pins the contract a caller of
+// FillTrianglesColors takes on. The mesh is rasterized as one path with
+// *signed* coverage accumulation, so two triangles sharing an edge but
+// wound against each other contribute +0.5 and -0.5 along it: the sum
+// is zero and the background shows through as a hairline. Wound the
+// same way they sum to full coverage and the seam disappears.
+//
+// The check is a diagonal pixel, which is on the shared edge, against
+// an interior pixel of the same triangle.
+func TestMeshWindingMustBeConsistent(t *testing.T) {
+	white := gui.RGB(255, 255, 255)
+	cols := []gui.Color{white, white, white, white, white, white}
+
+	// A square split along its top-left/bottom-right diagonal.
+	same := []float32{
+		4, 4, 36, 4, 36, 36,
+		4, 4, 36, 36, 4, 36,
+	}
+	// The same square, second triangle reversed.
+	mixed := []float32{
+		4, 4, 36, 4, 36, 36,
+		4, 4, 4, 36, 36, 36,
+	}
+
+	seam := func(tris []float32) (onEdge, inside uint8) {
+		r := newRenderer(40, 40, 1)
+		r.drawAll([]gui.RenderCmd{vcolCmd(tris, cols)})
+		e, _, _, _ := at(r.buf.img, 20, 20)
+		i, _, _, _ := at(r.buf.img, 30, 12)
+		return e, i
+	}
+
+	edge, inside := seam(same)
+	if inside < 250 {
+		t.Fatalf("interior painted %d, want the mesh solid", inside)
+	}
+	if diff(int(edge), int(inside)) > 4 {
+		t.Errorf("consistent winding painted %d on the shared edge "+
+			"against %d inside: that is a seam", edge, inside)
+	}
+
+	edge, inside = seam(mixed)
+	if inside < 250 {
+		t.Fatalf("interior painted %d, want the mesh solid", inside)
+	}
+	// The cancellation is total, not marginal: the shared edge comes
+	// out at zero coverage against a solid interior.
+	if edge > 8 {
+		t.Errorf("mixed winding painted %d on the shared edge against "+
+			"%d inside; the signed accumulation is supposed to cancel "+
+			"there, and this test is what documents why a mesh must "+
+			"not do it", edge, inside)
+	}
+}

--- a/gui/canvas_colors_test.go
+++ b/gui/canvas_colors_test.go
@@ -1,0 +1,202 @@
+package gui
+
+import "testing"
+
+// vcolTris is a two-triangle quad, the smallest mesh that has an
+// interior edge.
+func vcolTris() []float32 {
+	return []float32{
+		0, 0, 10, 0, 10, 10,
+		0, 0, 10, 10, 0, 10,
+	}
+}
+
+// vcolColors is one color per vertex of vcolTris.
+func vcolColors() []Color {
+	return []Color{
+		RGB(255, 0, 0), RGB(0, 255, 0), RGB(0, 0, 255),
+		RGB(255, 0, 0), RGB(0, 0, 255), RGB(255, 255, 255),
+	}
+}
+
+func TestFillTrianglesColorsProducesVertexColors(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	tris, cols := vcolTris(), vcolColors()
+	dc.FillTrianglesColors(tris, cols)
+
+	if len(dc.batches) != 1 {
+		t.Fatalf("got %d batches, want 1", len(dc.batches))
+	}
+	b := dc.batches[0]
+	if len(b.VertexColors)*2 != len(b.Triangles) {
+		t.Fatalf("VertexColors=%d, Triangles=%d: lengths must agree",
+			len(b.VertexColors), len(b.Triangles))
+	}
+	// Nothing is evaluated: the caller's geometry and colors go through
+	// verbatim, in order.
+	for i := range tris {
+		if b.Triangles[i] != tris[i] {
+			t.Fatalf("triangle float %d = %v, want %v",
+				i, b.Triangles[i], tris[i])
+		}
+	}
+	for i := range cols {
+		if b.VertexColors[i] != cols[i] {
+			t.Fatalf("vertex color %d = %v, want %v",
+				i, b.VertexColors[i], cols[i])
+		}
+	}
+	if b.Color != meanColor(cols) {
+		t.Errorf("batch color = %v, want the mesh mean %v",
+			b.Color, meanColor(cols))
+	}
+}
+
+func TestFillTrianglesColorsNoops(t *testing.T) {
+	cases := []struct {
+		name   string
+		tris   []float32
+		colors []Color
+	}{
+		{"empty tris", nil, nil},
+		{"partial triangle", []float32{0, 0, 1, 0}, make([]Color, 2)},
+		{"too few colors", vcolTris(), make([]Color, 5)},
+		{"too many colors", vcolTris(), make([]Color, 7)},
+		{"no colors", vcolTris(), nil},
+	}
+	for _, c := range cases {
+		dc := NewDrawContext(100, 100, nil)
+		dc.FillTrianglesColors(c.tris, c.colors)
+		if len(dc.batches) != 0 {
+			t.Errorf("%s: got %d batches, want 0", c.name, len(dc.batches))
+		}
+	}
+}
+
+// TestFlatFillAfterVertexColorsStartsNewBatch is the same invariant the
+// gradient path rests on: a batch is flat or vertex-colored, never
+// both, so the per-batch length relation holds and validSvgCmd can
+// enforce it downstream.
+func TestFlatFillAfterVertexColorsStartsNewBatch(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	dc.FillTrianglesColors(vcolTris(), vcolColors())
+	// Draw flat in exactly the color the mesh batch recorded, which is
+	// what a naive lastColor comparison would merge on.
+	dc.FilledRect(0, 0, 10, 10, dc.batches[0].Color)
+	if len(dc.batches) != 2 {
+		t.Fatalf("got %d batches, want 2", len(dc.batches))
+	}
+	b := dc.batches[0]
+	if len(b.VertexColors)*2 != len(b.Triangles) {
+		t.Errorf("mesh batch corrupted: VertexColors=%d, Triangles=%d",
+			len(b.VertexColors), len(b.Triangles))
+	}
+	if dc.batches[1].VertexColors != nil {
+		t.Error("flat batch carries vertex colors")
+	}
+}
+
+// TestVertexColorFillSurvivesValidation walks the emitted batch through
+// the same validator the render path applies.
+func TestVertexColorFillSurvivesValidation(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	dc.FillTrianglesColors(vcolTris(), vcolColors())
+	b := dc.batches[0]
+	cmd := RenderCmd{
+		Kind:         RenderSvg,
+		Scale:        1,
+		Color:        b.Color,
+		Triangles:    b.Triangles,
+		VertexColors: b.VertexColors,
+	}
+	if !validSvgCmd(cmd) {
+		t.Error("a vertex-colored canvas batch failed validSvgCmd")
+	}
+}
+
+// vertexColorRecorderStub implements the optional extension.
+type vertexColorRecorderStub struct {
+	nopRecorder
+	calls  int
+	tris   int
+	colors int
+}
+
+func (r *vertexColorRecorderStub) FillTrianglesColors(
+	tris []float32, colors []Color) {
+	r.calls++
+	r.tris = len(tris)
+	r.colors = len(colors)
+}
+
+func TestVertexColorRecorderExtensionReceivesGeometry(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	rec := &vertexColorRecorderStub{}
+	dc.SetRecorder(rec)
+	dc.FillTrianglesColors(vcolTris(), vcolColors())
+
+	if rec.calls != 1 {
+		t.Fatalf("FillTrianglesColors called %d times, want 1", rec.calls)
+	}
+	if rec.tris != 12 || rec.colors != 6 {
+		t.Errorf("recorder got %d floats and %d colors, want 12 and 6",
+			rec.tris, rec.colors)
+	}
+	if len(dc.batches) != 0 {
+		t.Error("a recorded fill must not also tessellate into a batch")
+	}
+}
+
+// TestVertexColorFlatRecorderFallback pins the degrade path: a recorder
+// that cannot take per-vertex color still gets every triangle, each at
+// its own mean rather than at one color for the whole mesh.
+func TestVertexColorFlatRecorderFallback(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	rec := &meanPolyRecorder{}
+	dc.SetRecorder(rec)
+	cols := vcolColors()
+	dc.FillTrianglesColors(vcolTris(), cols)
+
+	if len(rec.colors) != 2 {
+		t.Fatalf("recorded %d polygons, want 2 (one per triangle)",
+			len(rec.colors))
+	}
+	for i := range rec.colors {
+		want := meanColor(cols[i*3 : i*3+3])
+		if rec.colors[i] != want {
+			t.Errorf("triangle %d recorded %v, want its own mean %v",
+				i, rec.colors[i], want)
+		}
+	}
+	if rec.colors[0] == rec.colors[1] {
+		t.Error("both triangles recorded the same color; the fallback " +
+			"is per-triangle, not per-mesh")
+	}
+	if len(dc.batches) != 0 {
+		t.Error("a recorded fill must not also tessellate into a batch")
+	}
+}
+
+// meanPolyRecorder keeps every polygon color it is handed, so the
+// per-triangle fallback can be checked entry by entry.
+type meanPolyRecorder struct {
+	nopRecorder
+	colors []Color
+}
+
+func (r *meanPolyRecorder) FilledPolygon(_ []float32, c Color) {
+	r.colors = append(r.colors, c)
+}
+
+func TestMeanColor(t *testing.T) {
+	if got := meanColor(nil); got != (Color{}) {
+		t.Errorf("meanColor(nil) = %v, want the unset color", got)
+	}
+	got := meanColor([]Color{
+		RGBA(0, 0, 0, 0), RGBA(100, 200, 40, 200),
+	})
+	want := RGBA(50, 100, 20, 100)
+	if got != want {
+		t.Errorf("meanColor = %v, want %v", got, want)
+	}
+}

--- a/gui/canvas_draw_colors.go
+++ b/gui/canvas_draw_colors.go
@@ -1,0 +1,77 @@
+package gui
+
+// canvas_draw_colors.go — the DrawContext per-vertex color fill.
+//
+// A gradient shades geometry by evaluating a ramp at every vertex, and
+// its level sets are conic curves nested by construction. Some shading
+// models do not produce that family: a Lambert-shaded sphere's isophotes
+// are ellipses whose radius grows as sqrt(1-k^2), non-monotonic in the
+// ramp parameter and clipped at the silhouette, so no gradient of any
+// kind emits them. FillTrianglesColors is the primitive underneath the
+// gradient fills, for a caller that has already evaluated its own
+// shading model per vertex.
+
+// FillTrianglesColors fills caller-supplied geometry with caller-supplied
+// per-vertex colors. tris is a flat x,y triangle list — 6 floats per
+// triangle, the same layout DrawCanvasTriBatch.Triangles uses — and
+// colors holds exactly one entry per vertex, so len(colors)*2 ==
+// len(tris).
+//
+// Nothing is evaluated here: no projection, no stop isolines, no
+// subdivision. The caller's colors are the shading, interpolated across
+// each triangle by the backend.
+//
+// A malformed triangle list, or a color count that does not match the
+// vertex count, is a no-op — matching how FillTrianglesGradient treats a
+// degenerate input rather than painting something the caller did not
+// ask for.
+func (dc *DrawContext) FillTrianglesColors(tris []float32,
+	colors []Color) {
+	if len(tris) == 0 || len(tris)%6 != 0 ||
+		len(colors)*2 != len(tris) {
+		return
+	}
+	if dc.recorder != nil {
+		if vr, ok := dc.recorder.(DrawVertexColorRecorder); ok {
+			vr.FillTrianglesColors(tris, colors)
+			return
+		}
+		// The recorder cannot express per-vertex color. Record each
+		// triangle flat at its own mean rather than dropping the
+		// geometry: an SVG or PDF export of a shaded sphere should be
+		// a disc, not a hole.
+		dc.recordTriangles(tris, colors, Color{})
+		return
+	}
+
+	// The batch's flat Color is the mesh's mean, playing the part the
+	// gradient's midpoint plays: it is what a flat-only consumer sees,
+	// and it is never read when VertexColors is honored.
+	b := dc.gradientBatch(meanColor(colors), len(colors))
+	b.Triangles = append(b.Triangles, tris...)
+	b.VertexColors = append(b.VertexColors, colors...)
+}
+
+// meanColor averages a color slice channel by channel, alpha included.
+// The average is unweighted — a translucent vertex pulls the mean's hue
+// as hard as an opaque one. That is only ever seen by a consumer that
+// cannot read per-vertex colors at all, where a cheap stand-in beats a
+// correct one nobody looks at.
+//
+// Accumulation is uint64 so a fill large enough to overflow a uint32
+// channel sum (a mesh of roughly sixteen million vertices) still gets
+// a mean rather than a wrap.
+func meanColor(colors []Color) Color {
+	if len(colors) == 0 {
+		return Color{}
+	}
+	var r, g, b, a uint64
+	for i := range colors {
+		r += uint64(colors[i].R)
+		g += uint64(colors[i].G)
+		b += uint64(colors[i].B)
+		a += uint64(colors[i].A)
+	}
+	n := uint64(len(colors))
+	return RGBA(uint8(r/n), uint8(g/n), uint8(b/n), uint8(a/n))
+}

--- a/gui/canvas_draw_gradient.go
+++ b/gui/canvas_draw_gradient.go
@@ -92,10 +92,27 @@ func (dc *DrawContext) recordFlatTriangles(tris []float32,
 	if !ok {
 		return
 	}
+	dc.recordTriangles(tris, nil, mid)
+}
+
+// recordTriangles hands geometry to a recorder that can only take flat
+// primitives, one triangle at a time.
+//
+// cols, when non-nil, holds one color per vertex and each triangle is
+// recorded at the mean of its own three, which is the closest a flat
+// primitive gets to interpolated shading. Otherwise every triangle
+// takes flat.
+func (dc *DrawContext) recordTriangles(tris []float32, cols []Color,
+	flat Color) {
 	var tri [6]float32
 	for i := 0; i+5 < len(tris); i += 6 {
 		copy(tri[:], tris[i:i+6])
-		dc.recorder.FilledPolygon(tri[:], mid)
+		col := flat
+		if cols != nil {
+			v := i / 2
+			col = meanColor(cols[v : v+3])
+		}
+		dc.recorder.FilledPolygon(tri[:], col)
 	}
 }
 

--- a/gui/canvas_draw_types.go
+++ b/gui/canvas_draw_types.go
@@ -106,3 +106,20 @@ type DrawRecorder interface {
 type DrawGradientRecorder interface {
 	FillTrianglesGradient(tris []float32, g *CanvasGradient)
 }
+
+// DrawVertexColorRecorder is the per-vertex-color sibling of
+// DrawGradientRecorder: a recorder implementing it receives a
+// FillTrianglesColors fill as the caller's geometry plus the caller's
+// one-color-per-vertex slice.
+//
+// It is separate from DrawGradientRecorder rather than a second method
+// on it for the same reason DrawGradientRecorder is separate from
+// DrawRecorder — both are exported and implemented outside this repo —
+// and because a per-vertex fill has no CanvasGradient to hand over.
+// A recorder that does not implement this still receives the fill, one
+// flat polygon per triangle shaded with that triangle's mean color, so
+// an export path never silently drops a shaded mesh.
+// exportaudit:keep — reachable from an exported signature
+type DrawVertexColorRecorder interface {
+	FillTrianglesColors(tris []float32, colors []Color)
+}

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -866,7 +866,43 @@ func goldenCases() []goldenCase {
 			name:  "canvas_gradient",
 			build: buildCanvasGradient,
 		},
+		{
+			// Caller-supplied per-vertex color (issue #400). The
+			// counterpart to canvas_gradient: nothing here is
+			// evaluated, so what the golden pins is that the caller's
+			// geometry and colors reach the render command untouched
+			// and in order, as one batch that never merges with the
+			// flat fill drawn after it.
+			name:  "canvas_vertex_colors",
+			build: buildCanvasVertexColors,
+		},
 	}
+}
+
+// buildCanvasVertexColors draws a hand-colored two-triangle mesh, then
+// a flat rect in the mesh's own mean color — the color a naive batch
+// merge would fold the two together on. Colors are fixed literals for
+// the same reason buildCanvasGradient's are.
+func buildCanvasVertexColors(_ *Window) View {
+	return DrawCanvas(DrawCanvasCfg{
+		ID:      "canvas_vertex_colors",
+		Sizing:  FixedFixed,
+		Width:   120,
+		Height:  60,
+		Version: 1,
+		OnDraw: func(dc *DrawContext) {
+			red, green := RGB(255, 0, 0), RGB(0, 255, 0)
+			blue, white := RGB(0, 0, 255), RGB(255, 255, 255)
+			dc.FillTrianglesColors([]float32{
+				0, 0, 60, 0, 60, 60,
+				0, 0, 60, 60, 0, 60,
+			}, []Color{
+				red, green, blue,
+				red, blue, white,
+			})
+			dc.FilledRect(70, 10, 40, 40, RGB(127, 85, 127))
+		},
+	})
 }
 
 // buildCanvasGradient draws one linear and one radial gradient fill.

--- a/gui/testdata/canvas_vertex_colors.dark.golden
+++ b/gui/testdata/canvas_vertex_colors.dark.golden
@@ -1,0 +1,2 @@
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#7f557fff tris=12 vcols=6 first=#ff0000ff last=#ffffffff
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#7f557fff tris=12

--- a/gui/testdata/canvas_vertex_colors.light.golden
+++ b/gui/testdata/canvas_vertex_colors.light.golden
@@ -1,0 +1,2 @@
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#7f557fff tris=12 vcols=6 first=#ff0000ff last=#ffffffff
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#7f557fff tris=12


### PR DESCRIPTION
## What

Adds `DrawContext.FillTrianglesColors(tris, colors)` — caller-supplied geometry plus one color per vertex, with nothing evaluated on the way through. It is the primitive underneath the gradient fills (#398), exposed for shading a gradient cannot express (non-nested isolines, sweep shadings, silhouette-clipped ramps).

## Why

A Lambert-shaded sphere's isophotes are ellipses of semi-axis √(1−k²) — non-nested, non-linear, clipped at the silhouette — so no gradient of any kind emits them. `examples/solar_system` is ported to it: the body was 20–48 flat bands (one batch each, visible quantization); it is now a single watertight mesh in one batch with a continuous ramp. Full-system frame: 232 → 79 triangle batches, 40.6k → 30.2k triangles.

## Backend / recorder story

- No backend change: the batch rides the existing `RenderCmd.VertexColors` channel.
- New optional `DrawVertexColorRecorder` extension interface; a recorder that does not implement it receives one flat polygon per triangle at that triangle's mean color, so an export path never drops a shaded mesh.
- A mismatched color count is a no-op, matching `FillTrianglesGradient`.

## Tests

- `gui/canvas_colors_test.go`: batch emission, no-op cases, batch separation from flat fills, validator survival, recorder extension + per-triangle fallback, mean color.
- `gui/golden_cases_test.go`: new `canvas_vertex_colors` case (dark + light).
- `gui/backend/soft`: `TestMeshWindingMustBeConsistent` pins the signed-coverage contract the mesh relies on.
- `examples/solar_system`: one-batch assertion, winding consistency across 5 light directions, disc containment, zero-allocation mesh rebuild, 360° limb coverage, small-body light-side cap coverage.
- Docs: CHANGELOG, `docs/dx-cheat-sheet.md`, `examples/solar_system/README.md`, `examples/draw_canvas` panel.

Closes #400