### PR TITLE
fix: park caret blink while window is unfocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@ and this project adheres to
 
 ### Fixed
 
+- **Caret blink no longer wakes an unfocused window** — the blink animation was
+  gated only on which widget held focus _inside_ the window, not on whether the
+  window held OS focus. A backgrounded app with a focused text field therefore
+  kept the 16 ms animation ticker alive and woke the main thread out of its
+  blocking event wait twice a second, forever, to blink a caret nobody could
+  type into.
+
+  `syncBlinkCursor` now folds `Window.focused` into the gate. Losing focus
+  retires the animation, which empties the animation map and parks the ticker
+  outright; regaining it re-registers the animation with the caret solid and a
+  fresh 600 ms phase. The caret is not drawn while the window is unfocused,
+  matching native macOS and Windows text fields — the rect is still emitted,
+  transparent, so the render list keeps one shape across focus states and the
+  in-place blink patch (#404) stays valid. Only the caret blink is gated: other
+  animations keep running so a background window's in-flight motion does not
+  stall and jump.
+
 - **SVG gradients: seams, spread and a 32x tessellation cost** (#399) — the SVG
   gradient tessellator now carries the fixes that landed on the canvas one in
   #398, and one bug found in the porting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,17 +6,15 @@ Guidance for Claude Code (claude.ai/code) in this repo.
 
 ```
 go run ./examples/get_started/  # run the example app
-make prepush                    # full pre-push gate (race, cross-lint, cross-compile, coverage, export audit)
-make check-all                  # test + lint + vet gates (what .githooks/pre-push runs)
-make check                      # fast subset (vet, deps-doc, large-files, generate-check, tidy-check, fmt-md-check)
-make fmt-md                     # format every tracked .md with Prettier (.prettierrc holds the flags)
-git config core.hooksPath .githooks  # enable tracked pre-commit/pre-push hooks
-make test                       # tests only
-make lint                       # golangci-lint (pinned version)
-make vet                        # go vet + requiredid analyzer
-make ergonomics-audit                 # focus/callbacks inventory + ID/a11y/theme/visual gates
+make prepush                    # full gate (race, cross-lint, cross-compile, coverage, export audit)
+make check-all                  # test + lint + vet (what .githooks/pre-push runs)
+make check                      # fast subset (vet, deps-doc, large-files, generate/tidy/fmt-md checks)
+make test / lint / vet          # individually
+make fmt-md                     # Prettier over tracked .md (.prettierrc holds the flags)
+make ergonomics-audit           # focus/callbacks inventory + ID/a11y/theme/visual/literals gates
 make export-audit               # exported surface (advisory in-repo)
-./scripts/large-files.sh        # report Go files >800 lines in gui/
+./scripts/large-files.sh        # Go files >800 lines in gui/
+git config core.hooksPath .githooks  # enable tracked hooks
 ```
 
 ## Architecture
@@ -32,16 +30,16 @@ View fn → generateViewLayout() → Layout tree
 
 ### Packages
 
-- **Keep flat: only leaf subsystems (svg/, datagrid/, markdown/, backend/, etc.)
-  in subpackages.** `gui/` itself holds the core: widget factories, layout
-  engine, theme, animation, event dispatch, state mgmt.
-- (no test backend package; tests run with nil injected interfaces)
+**Keep flat: only leaf subsystems (svg/, datagrid/, markdown/, backend/, etc.)
+in subpackages.** `gui/` itself holds the core: widget factories, layout engine,
+theme, animation, event dispatch, state mgmt. No test backend package; tests run
+with nil injected interfaces.
 
 ### Core Types
 
-- `View` — interface (`Content() []View`, `GenerateLayout(*Window) Layout`).
-  Widget factories return `View`, not `*Layout`; `*Layout` does NOT implement
-  it. In tests, reach a widget's shape via `v.GenerateLayout(w).Shape`
+`View` — interface (`Content() []View`, `GenerateLayout(*Window) Layout`).
+Widget factories return `View`, not `*Layout`; `*Layout` does NOT implement it.
+In tests, reach a widget's shape via `v.GenerateLayout(w).Shape`.
 
 ### State Management
 
@@ -61,43 +59,36 @@ All widgets take `*Cfg` struct (zero-initializable). Event callbacks share sig
 Focus requires **both** `Focusable` **and** a non-empty `ID` (`isFocusedTarget`,
 `gui/event_traversal.go`); tab order additionally needs
 `!FocusSkip && !Disabled` (`layout_query.go`). `Focusable` without an `ID` is a
-silent no-op — the widget renders and clicks but never joins the tab order. The
-`requiredid` analyzer flags this, and `gui.Debug` reports it at runtime.
+silent no-op. The `requiredid` analyzer flags it; `gui.Debug` reports it at
+runtime.
 
-**Input controls are focusable by default (v0.36.0); opt out with
-`FocusDisabled`, never with `Focusable: false`.** Sixteen Cfgs default on:
-`Button`, `ColorPicker`, `Combobox`, `DatePicker`, `Input`, `InputDate`,
-`ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`, `Slider`,
-`Switch`, `Toggle`, `Tree`, `VirtualList`. Everything else is opt-in via
-`Focusable: true`. See `docs/specs/focusable-default-input.md`; run
-`ergonomics-audit -mode focus` for the current inventory.
+**Input controls are focusable by default; opt out with `FocusDisabled`, never
+with `Focusable: false`.** Sixteen input Cfgs default on (Button, Input, Select,
+Slider, Tree, …); everything else is opt-in via `Focusable: true`. Current
+inventory: `ergonomics-audit -mode focus`. See
+`docs/specs/focusable-default-input.md`.
 
 **`Shape.ID` is a leaf; identity is the effective ID.** `resolveShapeIDs`
 (`gui/id_resolve.go`, run from `layoutArrange`) stamps `Shape.effID` = the leaf
-joined to the IDs of its **ID-bearing ancestors**, and every ID-keyed store and
-lookup uses that — read `shape.idKey()`, never `shape.ID`, at a keying site.
-Only explicit IDs join (never position, never child index); an ID-less container
-adds no scope, and its children collide as loudly as before. A leaf already
-containing `:` is **absolute** and is not joined again. Effective IDs must be
-unique per window.
+joined to the IDs of its **ID-bearing ancestors**. Read `shape.idKey()`, never
+`shape.ID`, at a keying site. Only explicit IDs join (never position, never
+child index); an ID-less container adds no scope. A leaf already containing `:`
+is **absolute** and is not joined again. Effective IDs must be unique per
+window.
 
 Public APIs (`SetFocus`, `FindByID`, `IsFocus`, `ScrollVerticalTo`, `Test*`)
-take the **effective** ID. Two seams exist for widget code: `w.EffID(cfg.ID)`
-for state read during `GenerateLayout` (the read decides the subtree, so it
-cannot wait for the pass), and `ctx.EffID(leaf)` for handlers in factories that
-build eagerly with no `Window`. Both go through `resolveLeaf`, so they cannot
-drift from the pass. `gui/datagrid` is the documented exception — its child IDs
-are absolute by design (reverse-parsed) and stay window-global. See
+take the **effective** ID. Two seams for widget code: `w.EffID(cfg.ID)` for
+state read during `GenerateLayout`, and `ctx.EffID(leaf)` for handlers in
+factories that build eagerly with no `Window`. `gui/datagrid` is the documented
+exception — its child IDs are absolute by design and stay window-global. See
 `docs/specs/widget-id-per-scope-uniqueness.md`.
 
 **Compose inner IDs with `gui.ScopeID` / `gui.ScopeIDN`, never by hand.** An ID
-is a `:`-joined path (`grid:header:name:resize`); the owner may itself be
-composed, and composition is associative. `ScopeIDN` appends a numeric segment
-without allocating for the number — use it for loop-derived identity. Both cost
-exactly one allocation; `gui/id_scope_test.go` asserts that. A **part** (a row
-key, a heading slug — a leaf value fed _into_ a composition) must not contain
-`:` and keeps its own spelling; rebuilding an ID at a lookup site is how
-producers and consumers drift. `make ergonomics-audit` (mode `ids`) fails on any
+is a `:`-joined path (`grid:header:name:resize`); composition is associative.
+`ScopeIDN` appends a numeric segment without allocating for the number — use it
+for loop-derived identity. A **part** (a row key, a heading slug — a leaf value
+fed _into_ a composition) must not contain `:` and keeps its own spelling; never
+rebuild an ID at a lookup site. `ergonomics-audit` mode `ids` fails on
 hand-rolled composition; see `docs/specs/widget-id-scoping.md`.
 
 Uniqueness is strict, including within one widget: a composite widget's inner
@@ -109,86 +100,64 @@ asserts a rendered window is clean.
 #### Accessibility fields
 
 **`A11YLabel` and `A11YDescription` live on the embedded `A11YCfg`
-(`gui/a11y_cfg.go`); never redeclare them on a Cfg.** They are a perfect
-co-occurrence group — every Cfg that carries one carries the other — so they are
-declared once and embedded in all 35. Promotion keeps reads spelled unchanged
-(`cfg.A11YLabel`), but Go has no promoted-field key in a composite literal, so
-**construction names the embed**:
+(`gui/a11y_cfg.go`); never redeclare them on a Cfg.** Reads stay spelled
+`cfg.A11YLabel`, but construction must name the embed:
 
 ```go
 gui.ButtonCfg{ID: "save", A11YCfg: gui.A11YCfg{A11YLabel: "Save"}}
 ```
 
-`A11YCfg.a11yInfo(fallback)` builds the shape's `accessInfo` — it is the
-`makeA11YInfo(a11yLabel(cfg.A11YLabel, X), cfg.A11YDescription)` pairing, and
-staticcheck elides the embedded selector, so the call reads `cfg.a11yInfo(X)`.
-Pass `""` where the widget has no content to derive a name from. `A11YRole` and
-`A11YState` stay plain fields — only `ButtonCfg` and `ContainerCfg` carry them.
+`cfg.a11yInfo(fallback)` builds the shape's `accessInfo`; pass `""` where the
+widget has no content to derive a name from. `A11YRole` and `A11YState` stay
+plain fields — only `ButtonCfg` and `ContainerCfg` carry them.
 
 #### `Opt[T]` vs plain fields
 
 **Rule: types the repo owns self-flag; only primitives get `Opt`.** `Opt[T]` is
-for when the zero value is a legitimate user choice that must be distinguishable
-from "unset" — and only when the type cannot carry that distinction itself.
-`SizeBorder` is the canonical case: `0` is a border width a caller means, so a
-plain `float32` cannot tell "no border" from "not specified". Where zero is not
-meaningful — most widths, heights, counts, and indices — `Opt` costs a wrapper
-call and buys nothing.
+for a primitive whose zero value is a legitimate user choice that must be
+distinguishable from "unset" — `SizeBorder` is the canonical case. Where zero is
+not meaningful (most widths, heights, counts, indices) `Opt` buys nothing.
 
-Owned struct types self-flag instead of wrapping: `Color` (`gui/color.go`),
-`Padding` (`gui/padding.go`) and `Sizing` (`gui/sizing.go`) carry a `set` field,
-so they are plain fields with `IsSet()`/`Or()` rather than `Opt[T]`. `Sizing`'s
-zero value (FitFit) is a real combination, which is exactly why it flags: build
-sizings with the predefined vars (`FitFit`…`FillFixed`), never a raw
-`Sizing{...}` literal — that reads as unset (ergoaudit mode `literals` gates
-this). Build `Padding` values with `NewPadding`/`PadAll`/`PaddingNone`; a raw
-`Padding{...}` literal reads as unset (ergoaudit mode `literals` gates this).
+`Color` (`gui/color.go`), `Padding` (`gui/padding.go`) and `Sizing`
+(`gui/sizing.go`) carry a `set` field, so they are plain fields with
+`IsSet()`/`Or()`. Build them with the constructors — predefined sizing vars
+(`FitFit`…`FillFixed`), `NewPadding`/`PadAll`/`PaddingNone`, `RGBA`/`RGB`/`Hex`.
+A raw `Sizing{...}` / `Padding{...}` / `Color{...}` literal reads as unset
+(ergoaudit mode `literals` gates this; the empty `Color{}` sentinel is exempt).
 
 Decide this when authoring the field, not by copying whichever neighbor was
 nearest.
 
 #### Colors on `Cfg` structs
 
-Use plain `Color`, never `Opt[Color]`. `Color` carries its own `set` flag
-(`gui/color.go`), so `Color{}` is unset and `ColorTransparent` is an explicit
-fully-transparent choice — wrapping would give the field two notions of unset.
-Build colors with `RGBA`/`RGB`/`Hex`; a raw `Color{...}` literal reads as unset
-(ergoaudit mode `literals` gates this; the empty `Color{}` sentinel is exempt).
-
-`ColorSet` (`gui/color_set.go`) groups the per-state colors; `Flat(c)` is the
-"keep one appearance" case. **Precedence: an assigned flat `Color*` field wins
-over the `ColorSet`**, so existing code keeps its appearance when a set arrives.
+Plain `Color`, never `Opt[Color]`: `Color{}` is unset and `ColorTransparent` is
+an explicit fully-transparent choice. `ColorSet` (`gui/color_set.go`) groups the
+per-state colors; `Flat(c)` is the "keep one appearance" case. **Precedence: an
+assigned flat `Color*` field wins over the `ColorSet`.**
 
 #### Visual roles and tiers
 
 **Never spell a de-emphasis alpha, a label's size step, or a form control's text
-inset at a call site.** Each has one named source; a literal there is the
-divergence issue #335 measured and removed
-(`docs/specs/widget-visual-consistency-audit.md`). The _when_ — which role each
-decision takes, and when a deviation may carry the marker — is
-`docs/style-guide.md`, enforced by `ergonomics-audit -mode visual`.
+inset at a call site.** Each has one named source. Which role each decision
+takes is `docs/style-guide.md`, enforced by `ergonomics-audit -mode visual`;
+background in `docs/specs/widget-visual-consistency-audit.md`.
 
 - **Quiet text** takes one of four `Theme` roles — `TextStyleSecondary`,
   `TextStyleLabel`, `TextStyleDisabled`, `TextStylePlaceholder`
   (`gui/theme_text_roles.go`). Use the role style directly where the text color
-  is the theme's; use `withRoleAlpha(base, role)` where it is caller-supplied,
-  which shares the _amount_ of de-emphasis without taking the hue. If none of
-  the four fits, add a fifth role — not a local number.
-- **Role values are per-theme and contrast-matched.** Alpha blends toward the
-  background, so one multiplier cannot mean the same thing on a dark and a light
-  ground. `textRolesFor` picks the ladder from the theme's own polarity;
-  `ThemeCfg.ColorText*` overrides it.
+  is the theme's; use `withRoleAlpha(base, role)` where it is caller-supplied.
+  If none of the four fits, add a fifth role — not a local number.
+- **Role values are per-theme and contrast-matched.** `textRolesFor` picks the
+  ladder from the theme's own polarity; `ThemeCfg.ColorText*` overrides it.
 - **`TextStyle.disabledRole`** marks a style that already expresses the disabled
-  state so `renderText` skips `dimAlpha`. It is set only by `themeTextRoles` and
-  must not be spelled at a call site. Without it, `layoutDisables`
-  (`gui/layout.go`) — which stamps `Disabled` onto _every descendant_ of a
-  disabled shape — halves a color the theme already quieted.
+  state so `renderText` skips `dimAlpha`. Set only by `themeTextRoles`; never at
+  a call site — `layoutDisables` stamps `Disabled` onto _every descendant_ of a
+  disabled shape and would halve a color the theme already quieted.
 - **A form control's text inset** is `Theme.PaddingField`, so controls in one
   row share a height. Not the Small/Medium/Large ladder: those size the gap
   between things, this sizes a control.
 - **A field's label** goes through `labelledField` (`gui/field_label.go`); a
-  boolean control's through `trailingLabel`. Both exist so the placement is
-  decided once.
+  boolean control's through `trailingLabel`.
 
 A container reserves space for its border whether or not it paints one, so a
 structural wrapper must set `SizeBorder: NoBorder` — an unset one inherits the
@@ -196,10 +165,10 @@ theme's container border and silently adds height.
 
 ### External Dependencies
 
-- `glyph` — text shaping/rendering lib. Consumed as versioned module; a
-  `go.work` (`use (. ../go-glyph)`) points the local build at the working copy
-  in `~/Documents/github/go-glyph`. No `replace` directive. For text work, check
-  glyph first. Only add new text routines when glyph lacks them.
+`glyph` — text shaping/rendering lib. Consumed as a versioned module; a
+`go.work` (`use (. ../go-glyph)`) points the local build at
+`~/Documents/github/go-glyph`. No `replace` directive. For text work, check
+glyph first; only add new text routines when glyph lacks them.
 
 ### Injected Interfaces
 
@@ -220,114 +189,98 @@ Backend injects at startup. Nil in tests:
 - `Children []Layout` = values. Parents = pointers. Avoids cycles
 - `StateMap` (keyed by namespace consts like `nsOverflow`, `nsSvgCache`) =
   per-window typed kv store for widget internal state
+
+#### Theme
+
 - **Theme is window-owned; `guiTheme` and the `default*Style` mirrors are a
   frame-scoped cache, not app state.** `FrameFn` calls `w.installTheme()` before
-  anything reads them, so a factory-time read resolves to the window being
-  generated — that works only because every window's frame pass runs on the one
-  main OS thread. `w.Theme()` reads, `w.SetTheme` pins that window, package
-  `SetTheme` sets the app default for windows that never pinned one.
-  `Themed(t, build)` scopes a theme to one subtree; its builder must run at
-  generation time because factories resolve defaults when called. Anything keyed
-  on a theme keys on `Theme.id`, never `Theme.Name` — names are not unique. See
+  anything reads them. `w.Theme()` reads, `w.SetTheme` pins that window, package
+  `SetTheme` sets the app default. `Themed(t, build)` scopes a theme to one
+  subtree; its builder must run at generation time. Key anything theme-dependent
+  on `Theme.id`, never `Theme.Name` — names are not unique. See
   `docs/specs/per-window-theme.md`.
 - **Theme reads split by phase, not by reachability. Code running _outside_
   generation with a `*Window` in hand calls `w.Theme()`; factories and
-  `GenerateLayout` keep the bare `guiTheme` / `default*Style` read.** Outside
-  generation the frame cache holds whichever window generated last — wrong as
-  soon as there are two windows (issue #301 migrated 13 such sites). Inside
-  generation the bare read is required, not tolerated: `Themed` scopes a theme
-  by push/pop of the _installed_ theme, so `w.Theme()` there would ignore the
-  scope. `make ergonomics-audit` mode `theme` gates the post-generation paths
+  `GenerateLayout` keep the bare `guiTheme` / `default*Style` read** — `Themed`
+  scopes by push/pop of the _installed_ theme, so `w.Theme()` there would ignore
+  the scope. `ergonomics-audit` mode `theme` gates the post-generation paths
   (`gui/backend/**`, `gui/scroll*.go`, `gui/event*.go`, `gui/native_*.go`,
   `gui/window_*.go`); mark a deliberate exception
   `ergonomics-audit:theme-global`.
 - **`ThemeMaker` is the only source of default styling. The `default*Style`
-  package vars have no initializers — never add one.** They are mirrors: `init`
-  fills them with `applyTheme(ThemeDark)` and `installTheme` refills them per
-  theme change. A literal there is a second source of truth that silently drifts
-  (issue #300 removed ~30 of them; `ThemeDark` is bordered since 2026-08 — 90 of
-  104 examples call `WithBorders(true)` explicitly — use
-  `Theme.WithBorders(false)` for the old borderless look). The two exceptions
-  are `DefaultTextStyle` and `defaultInspectorStyle`, which are ThemeMaker
-  _inputs_. `TestDefaultStylesMirrorThemeDark` is the gate. See
+  package vars have no initializers — never add one.** They are mirrors filled
+  by `init`/`installTheme`. Exceptions: `DefaultTextStyle` and
+  `defaultInspectorStyle` are ThemeMaker _inputs_. `ThemeDark` is bordered; use
+  `Theme.WithBorders(false)` for the borderless look.
+  `TestDefaultStylesMirrorThemeDark` is the gate. See
   `docs/specs/theme-style-single-source.md`.
-- `AmendLayout` hook on shapes runs after sizing to reposition overlays (color
-  picker circles, splitter handles, etc.) or manage hover. Layout uses absolute
-  coords. Moving parent in `AmendLayout` does NOT move children. Use float
-  system (`FloatAnchor`/`FloatTieOff`/`FloatOffsetX`/`FloatOffsetY`) to position
+
+#### Layout hooks and the frame lock
+
+- `AmendLayout` runs after sizing to reposition overlays (color picker circles,
+  splitter handles) or manage hover. Layout uses absolute coords. Moving a
+  parent in `AmendLayout` does NOT move children — use the float system
+  (`FloatAnchor`/`FloatTieOff`/`FloatOffsetX`/`FloatOffsetY`) to position
   elements with children.
 - **`AmendLayout` runs under the frame lock (`w.mu`), so no callback reached
   from it may call a window-mutating API.** `SetFocus`, `ClearFocus`,
   `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take `w.mu`, which
-  is not reentrant, and the frame thread is the platform event loop — the app
-  froze permanently (issue #394). Since the fix those APIs panic naming
-  themselves instead of hanging; the remedy is `ctx.Window.QueueCommand`.
-  Library code that reaches app code from the pass raises it with
-  `deferCallback` and the pass runs it after unlocking
-  (`gui/window_deferred.go`), which is how the Input's blur commit works:
-  `OnTextCommit` with `InputCommitBlur`, `OnBlur` and a normalize-driven
-  `OnTextChanged` therefore get a **nil `ctx.Layout`** — the tree is rebuilt
-  from pooled arenas before they run. The Enter commit path dispatches from
-  `EventFn` with no lock held and is unchanged. See
+  is not reentrant; they panic naming themselves. The remedy is
+  `ctx.Window.QueueCommand`. Library code reaching app code from the pass raises
+  it with `deferCallback` (`gui/window_deferred.go`), which is how Input's blur
+  commit works — so `OnTextCommit` with `InputCommitBlur`, `OnBlur` and a
+  normalize-driven `OnTextChanged` get a **nil `ctx.Layout`**. The Enter commit
+  path dispatches from `EventFn` with no lock held. See
   `docs/specs/frame-lock-callback-deferral.md`.
-- **One event rule (since v0.55.0): nothing is marked handled for you. A
-  callback that acts on an event calls `ctx.Consume()`; one that does not, lets
-  the event travel on.** This holds for every callback — `OnClick` and `OnChar`
-  no differently from `OnKeyDown` and `OnHover`. There is no `ctx.Bubble()`:
-  declining is what silence already means. Before v0.55.0 the five hit-tested
-  callbacks were "consume-class" and dispatch pre-marked their events, so an
-  empty `OnClick` was a working click-blocker; such a handler now blocks nothing
-  unless it consumes. `ctx.Event` is nil in `AmendLayout` and `OnScroll`; both
-  `EventCtx` methods are nil-safe. `gui.Debug(true)` reports handlers that act
-  without consuming while an ancestor also handles;
-  `(*Window).TestUnconsumedEvents` sweeps a whole window for them (see Dev-mode
-  diagnostics below)
+
+#### Event consumption
+
+**Nothing is marked handled for you. A callback that acts on an event calls
+`ctx.Consume()`; one that does not, lets the event travel on.** This holds for
+every callback — `OnClick` and `OnChar` no differently from `OnKeyDown` and
+`OnHover`. There is no `ctx.Bubble()`: declining is what silence already means.
+An empty `OnClick` blocks nothing. `ctx.Event` is nil in `AmendLayout` and
+`OnScroll`; both `EventCtx` methods are nil-safe.
 
 ### Dev-mode diagnostics
 
 **Most identity mistakes in this repo are already detected at runtime — turn the
-gate on before hand-auditing a layout.** `gui.Debug(true)`, or `GOGUI_DEBUG=1`
-in the environment, walks the composed tree every frame from
-`updateLayoutLocked` and reports to stderr (`gui/debug.go`):
+gate on before hand-auditing a layout.** `gui.Debug(true)`, or `GOGUI_DEBUG=1`,
+walks the composed tree every frame and reports to stderr (`gui/debug.go`):
 
 - duplicate **effective** ID — names the key and both claim sites
 - focusable shape with no `ID` (never joins the tab order)
 - scrollable shape with no `ID` (shares one offset with every other)
 - `OnMouseLeave` with no `ID` (callback never fires)
 - a scrollable listbox that resolved to height 0
-- a container setting both `Wrap` and `Overflow` (wrap wins; issue #380)
+- a container setting both `Wrap` and `Overflow` (wrap wins)
 - a callback that acted without `ctx.Consume()` while an ancestor also handles
 
-Findings are warn-once per window, so a real defect does not scroll past at
-frame rate. The gate allocates and walks the whole tree — dev only, never
-production.
+Findings are warn-once per window. The gate allocates and walks the whole tree —
+dev only, never production. Categories gate independently via
+`gui.DebugCategories(mask)`; `gui.DebugEnabled()` queries the gate.
 
-Categories gate independently via `gui.DebugCategories(mask)`;
-`gui.DebugEnabled()` queries the gate. `Debug(true)` is
-`DebugCategories(gui.DebugAll)`.
-
-**`DebugUnscopedIDs` is not in `DebugAll` and `Debug(true)` does not turn it
-on.** It reports an `ID` with no ID-bearing ancestor — still a window-global
-name, so the widget cannot be dropped into a second panel as it stands. That is
-a design property rather than a bug and fires on most widgets in a small app, so
-ask for it explicitly when auditing a screen for reusability:
+**`DebugUnscopedIDs` is not in `DebugAll`.** It reports an `ID` with no
+ID-bearing ancestor — a window-global name, so the widget cannot be dropped into
+a second panel as it stands. A design property rather than a bug, so ask for it
+explicitly when auditing a screen for reusability:
 
 ```go
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
 ```
 
-Assertable forms for tests, which return findings as data instead of printing:
+Assertable forms for tests, which return findings as data:
 `(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.
 
 ## Coding Conventions
 
-- **No variable shadowing.** Never `:=` redeclare var from outer scope. Use `=`
-  to assign existing var, or pick distinct name.
-- Committed code must pass `golangci-lint run ./...` and `gofmt`. PostToolUse
+- **No variable shadowing.** Never `:=` redeclare a var from an outer scope. Use
+  `=`, or pick a distinct name.
+- Committed code must pass `golangci-lint run ./...` and `gofmt`. A PostToolUse
   hook auto-runs lint-fix + tests on every .go edit.
 - **Minimal scoped diffs.** Touch only what the request needs. No cosmetic
-  comment/formatting churn, no drive-by edits to unrelated code. Rename/regex
-  passes must not alter comment prose (e.g. apostrophes in possessives).
+  comment/formatting churn, no drive-by edits. Rename/regex passes must not
+  alter comment prose (e.g. apostrophes in possessives).
 
 ## Verification
 
@@ -338,34 +291,30 @@ Assertable forms for tests, which return findings as data instead of printing:
   widget, drives the real frame pipeline and diffs the emitted `[]RenderCmd`
   against `gui/testdata/`, in both `ThemeDark` and `ThemeLight`. Re-record with
   `go test ./gui/ -run TestGolden -update` **after reading the diff**. Reading
-  source is not equivalent: a widget's `GenerateLayout` output is taken before
+  source is not equivalent: `GenerateLayout` output is taken before
   `layoutDisables` and before arrange, so it shows neither inherited `Disabled`
-  nor resolved geometry. Both mistakes were made and caught this way (issue
-  #335). Add a case for any widget whose appearance a change can move; set
-  `focusID` on it to record a focus state.
-- After touching the exported surface of `gui/`, run `make export-audit`
-  (tools/exportaudit): every export must be referenced from outside gui/ or
-  carry a `// exportaudit:keep` marker. The consumer scan is authoritative; the
-  in-repo run is advisory. `internal`-class exports (shared between gui/
-  packages) are accepted by policy, not hard failures; the deferred list is in
-  the gate advisory. See `docs/specs/exportaudit-surface-policy.md`.
+  nor resolved geometry. Add a case for any widget whose appearance a change can
+  move; set `focusID` on it to record a focus state.
+- After touching the exported surface of `gui/`, run `make export-audit`: every
+  export must be referenced from outside gui/ or carry a `// exportaudit:keep`
+  marker. The consumer scan is authoritative; the in-repo run is advisory.
+  `internal`-class exports are accepted by policy. See
+  `docs/specs/exportaudit-surface-policy.md`.
 - Native/CGo or focus/activation bugs: confirm root cause with instrumented
   logging (evidence) before editing. Reproduce before, verify symptom gone
   after. Never leave the app non-launching. See `gui/backend/CLAUDE.md` for the
   two-sided logging technique.
 - Verify factual / root-cause claims against the code before asserting them.
-  Don't state "go-glyph has a pure-Go path", "X is a table-version difference",
-  etc. as fact without checking.
 
 ## CI signals
 
-- Distinguish CI runner noise (CPU variance, ns/op jitter) from real
-  regressions. Keep alloc gates hard; treat timing gates as advisory.
+Distinguish CI runner noise (CPU variance, ns/op jitter) from real regressions.
+Keep alloc gates hard; treat timing gates as advisory.
 
 ## Git Workflow
 
-- Before reviewing or editing a branch, confirm it is rebased on the current
-  base branch. If stale, update first — do not build work on a stale base.
+Before reviewing or editing a branch, confirm it is rebased on the current base
+branch. If stale, update first — do not build work on a stale base.
 
 ## context-mode
 
@@ -375,19 +324,15 @@ git/mkdir/rm/ls output. `ctx_fetch_and_index` instead of curl/wget/WebFetch.
 
 ## Rejected Approaches
 
-- **WebGPU backend** — explored and rejected; superseded by issue #137. Don't
-  re-propose it. `gui/backend/gl/` already has no cgo (X11 via xgb, EGL via
-  purego, Win32 via syscall), so purego bindings got CGo-free Linux+Windows for
-  ~600 lines, where wgpu would have added 10–40 MB of runtime libs, supplied
-  none of `NativePlatform`, and left macOS untouched.
+- **WebGPU backend** — explored and rejected. Don't re-propose it.
+  `gui/backend/gl/` already has no cgo (X11 via xgb, EGL via purego, Win32 via
+  syscall).
 - **Current CGo state:** `CGO_ENABLED=0 go build ./...` is green on Linux and
   Windows for the whole module. macOS (5.9k lines ObjC) stays cgo **by
-  decision** (2026-08-12) — the value argument inverts there; do not re-open
-  without a trigger. See `docs/specs/cgo-free-backend-feasibility.md` § Phase 2.
+  decision** (2026-08-12); do not re-open without a trigger.
 
-Full history and rationale — WebGPU, the go-gl→glbind swap, the `gui/audio`
-de-cgo — in `docs/specs/cgo-free-backend-feasibility.md`.
+Full history and rationale in `docs/specs/cgo-free-backend-feasibility.md`.
 
 ## Specs
 
-- Specs should be written to docs/specs folder.
+Specs go in `docs/specs/`.

--- a/docs/specs/caret-blink-local-repaint.md
+++ b/docs/specs/caret-blink-local-repaint.md
@@ -66,6 +66,28 @@ probing, and every shape's draw code are untouched.
 - A `Pulsar` (which toggles text in the view function) still promotes blink
   ticks to a layout refresh via its own `Animate` — unchanged behavior.
 
+## Window focus
+
+The blink is gated on the window holding OS focus as well as on the focused
+widget drawing a caret. A background window receives no key events, so its caret
+marks an insertion point nobody can type into — and the blink is not free: it
+holds the 16 ms animation ticker open and calls `wakeMain` twice a second for
+the whole time the app sits idle.
+
+`syncBlinkCursor` (`gui/ime_context.go`) folds `Window.focused` into the caret
+signal. Losing focus retires the animation, which empties `w.animations` and
+parks the ticker in `animationLoop`; `handleFocusedEvent` calls
+`resetBlinkCursorVisible` on the way back, so the caret returns solid with a
+fresh phase rather than mid-blink, and the rebuild `EventFn` queues re-registers
+the animation.
+
+`renderInputCursor` paints the caret transparent while the window is unfocused,
+and `commandToggleCaretBlink` carries the same gate — a `Pulsar` keeps the blink
+animation registered in a background window, and its toggles must not paint the
+caret back in. The caret rect is still emitted, so the invariant above holds:
+the render list has one shape across focus states and the recorded slot stays
+valid.
+
 ## Files
 
 - `gui/render_text.go` — `renderInputCursor` always emits; `caretCmdState`,
@@ -73,5 +95,7 @@ probing, and every shape's draw code are untouched.
 - `gui/window.go` — `caretCmd`, `renderersDirty` fields.
 - `gui/window_update.go` — `buildRenderers` resets `caretCmd`; `FrameFn`
   presents and clears `renderersDirty`.
+- `gui/ime_context.go` — `syncBlinkCursor` window-focus gate.
+- `gui/window_event.go` — `handleFocusedEvent` resets the blink phase.
 - `gui/animation.go` / `gui/animation_loop.go` — `RefreshKind` none; the toggle
   command is enqueued per tick.

--- a/gui/ime_context.go
+++ b/gui/ime_context.go
@@ -17,6 +17,12 @@ package gui
 // must run only while a widget that renders a framework caret holds
 // focus, or the window re-renders every 600 ms for a caret nobody
 // draws.
+//
+// It is gated on the *window* holding OS focus as well. A background
+// window receives no key events, so its caret marks an insertion point
+// nobody can type into — and the blink is not free: it keeps the 16 ms
+// animation ticker alive and wakes the main thread out of its blocking
+// event wait twice a second for the whole time the app sits idle.
 
 // shapeIsIMEEditTarget reports whether shape is the editable text
 // context an input method would write into — the shape that hosts the
@@ -154,6 +160,12 @@ func (w *Window) syncIMEEditContext() {
 // here: it blinks without any focused input.
 func (w *Window) syncBlinkCursor() {
 	caret, _ := findEditTargets(&w.layout, w)
+	// An unfocused window gets no key events, so a blinking caret is a
+	// pure idle wakeup — a 16 ms ticker plus a wakeMain twice a second
+	// for a caret the user cannot type into. Dropping the animation
+	// empties w.animations, which parks the animation ticker outright
+	// (animationLoop). renderInputCursor hides the caret to match.
+	caret = caret && w.hasFocus()
 	w.animMu.Lock()
 	defer w.animMu.Unlock()
 	_, present := w.animations[blinkCursorAnimationID]

--- a/gui/ime_context_test.go
+++ b/gui/ime_context_test.go
@@ -397,3 +397,86 @@ func TestBlinkCursorThroughRealFrame(t *testing.T) {
 		})
 	}
 }
+
+// A background window blinks nothing: the animation is retired while
+// the window is unfocused so the animation ticker can park, and comes
+// back when the OS returns focus.
+func TestBlinkCursorSuspendedWhileWindowUnfocused(t *testing.T) {
+	w := newTestWindow()
+	w.layout = imeEditTargetLayout("in")
+
+	w.SetFocus("in")
+	w.syncBlinkCursor()
+	if !w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation missing for a focused input")
+	}
+
+	w.handleUnfocusedEvent()
+	w.syncBlinkCursor()
+	if w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation still active while window unfocused")
+	}
+	// A blink tick may have left the caret off at the moment focus was
+	// lost; the animation is gone, so nothing will turn it back on.
+	// Refocus must restore it solid regardless of the phase.
+	w.viewState.inputCursorOn.Store(false)
+
+	w.handleFocusedEvent()
+	w.syncBlinkCursor()
+	if !w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation not restored when window refocused")
+	}
+	if !w.inputCursorOn() {
+		t.Fatal("caret not made visible again on window refocus")
+	}
+}
+
+// The Pulsar exemption still holds while the window is unfocused: the
+// blink registration is the Pulsar's, not the caret's.
+func TestBlinkCursorKeptWhilePulsarActiveUnfocused(t *testing.T) {
+	w := newTestWindow()
+	w.layout = imeEditTargetLayout("in")
+	w.AnimationAdd(newBlinkCursorAnimation())
+	w.animationAddViewBound(&Animate{
+		AnimID: pulsarAnimationID,
+		Delay:  blinkCursorAnimationDelay,
+		Repeat: true,
+	})
+
+	w.SetFocus("in")
+	w.handleUnfocusedEvent()
+	w.syncBlinkCursor()
+	if !w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation removed while a Pulsar is active")
+	}
+}
+
+// End-to-end through a real frame: losing OS focus retires the blink
+// animation, which is what lets animationLoop park its ticker.
+func TestBlinkCursorWindowFocusThroughRealFrame(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int), Width: 200, Height: 100})
+	w.viewGenerator = func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing:  FillFill,
+			Content: []View{Input(InputCfg{ID: "field"})},
+		})
+	}
+	w.SetFocus("field")
+	w.refreshLayout = true
+	w.FrameFn()
+	if !w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation missing for a focused input")
+	}
+
+	w.EventFn(&Event{Type: EventUnfocused})
+	w.FrameFn()
+	if w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation survived the window losing focus")
+	}
+
+	w.EventFn(&Event{Type: EventFocused})
+	w.FrameFn()
+	if !w.HasAnimation(blinkCursorAnimationID) {
+		t.Fatal("blink animation not restored when the window refocused")
+	}
+}

--- a/gui/input_state_test.go
+++ b/gui/input_state_test.go
@@ -8,8 +8,9 @@ func inputHasSelection(focusID string, w *Window) bool {
 	return is.selectBeg != is.selectEnd
 }
 
+// Mirrors NewWindow's resting state — see makeWindow in render_test.go.
 func newTestWindow() *Window {
-	return &Window{}
+	return &Window{focused: true}
 }
 
 func setInputState(w *Window, focusID string, is inputState) {

--- a/gui/render_layout_test.go
+++ b/gui/render_layout_test.go
@@ -497,6 +497,45 @@ func TestRenderInputCursorBlinkOffEmitsTransparent(t *testing.T) {
 	}
 }
 
+// A background window draws no caret, but still emits the rect so the
+// render list keeps one shape across focus states (issue #404).
+func TestRenderInputCursorWindowUnfocusedEmitsTransparent(t *testing.T) {
+	w := makeWindow()
+	w.focused = false
+	w.viewState.focusID = "f100"
+	w.viewState.inputCursorOn.Store(true)
+	style := DefaultTextStyle
+	shape := &Shape{
+		Focusable: true, ID: "f100",
+		TC: &shapeTextConfig{TextStyle: &style},
+	}
+
+	renderInputCursor(shape, "hello", 0, 0, glyph.Layout{}, false, w)
+
+	if len(w.renderers) != 1 {
+		t.Fatalf("cursor should emit one transparent rect, got %d", len(w.renderers))
+	}
+	if w.renderers[0].Color != ColorTransparent {
+		t.Error("cursor should be transparent while the window is unfocused")
+	}
+}
+
+// The in-place blink toggle honours the same gate — a Pulsar keeps the
+// blink animation alive in a background window.
+func TestCommandToggleCaretBlinkWindowUnfocused(t *testing.T) {
+	w := makeWindow()
+	w.focused = false
+	w.viewState.inputCursorOn.Store(true)
+	w.caretCmd = caretCmdState{idx: 0, color: RGB(0, 255, 0), ok: true}
+	w.renderers = []RenderCmd{{Kind: RenderRect, Color: RGB(1, 2, 3)}}
+
+	commandToggleCaretBlink(w)
+
+	if w.renderers[0].Color != ColorTransparent {
+		t.Error("toggle must not paint the caret in an unfocused window")
+	}
+}
+
 func TestRenderInputCursorFallbackPosition(t *testing.T) {
 	w := makeWindow()
 	w.viewState.focusID = "f100"

--- a/gui/render_test.go
+++ b/gui/render_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 )
 
+// The raw-struct test windows mirror NewWindow's resting state: a
+// freshly created window holds OS focus (window_cfg.go). The caret
+// render gate reads it, so a zero-value false would hide every caret
+// under test (issue #422).
 func makeWindow() *Window {
-	return &Window{}
+	return &Window{focused: true}
 }
 
 func makeWindowWithScratch() *Window {
-	return &Window{scratch: newScratchPools()}
+	return &Window{focused: true, scratch: newScratchPools()}
 }
 
 func makeClip(x, y, w, h float32) drawClip {

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -230,7 +230,12 @@ func renderInputCursor(shape *Shape, text string, baseX, baseY float32,
 		layout, ok = inputGlyphLayoutResolved(text, shape, style, w, shape.TC != nil && shape.TC.textIsPassword)
 	}
 	color := style.Color
-	if !w.inputCursorOn() {
+	// A background window draws no caret (native macOS/Windows
+	// behaviour) — syncBlinkCursor retires the blink animation for the
+	// same reason. The rect is still emitted, transparent, so the
+	// render list keeps one shape across focus states and the recorded
+	// caretCmd slot stays valid (issue #404).
+	if !w.inputCursorOn() || !w.hasFocus() {
 		color = ColorTransparent
 	}
 	if ok {
@@ -317,7 +322,10 @@ func commandToggleCaretBlink(w *Window) {
 		return
 	}
 	cmd := &w.renderers[w.caretCmd.idx]
-	if w.inputCursorOn() {
+	// Same gate as renderInputCursor: a Pulsar keeps the blink
+	// animation registered while the window is unfocused, and its
+	// toggles must not paint the caret back in.
+	if w.inputCursorOn() && w.hasFocus() {
 		cmd.Color = w.caretCmd.color
 	} else {
 		cmd.Color = ColorTransparent

--- a/gui/window_event.go
+++ b/gui/window_event.go
@@ -115,6 +115,11 @@ func (w *Window) handleIMECompositionEvent(layout *Layout, e *Event) {
 
 func (w *Window) handleFocusedEvent() {
 	w.focused = true
+	// The blink animation was retired while the window sat in the
+	// background (syncBlinkCursor). Come back with the caret solid and
+	// a fresh 600 ms phase rather than resuming mid-blink; the rebuild
+	// EventFn queues re-registers the animation.
+	resetBlinkCursorVisible(w)
 }
 
 func (w *Window) handleUnfocusedEvent() {


### PR DESCRIPTION
## What

A backgrounded window with a focused text field kept the 16 ms animation ticker alive and woke the main thread out of its blocking event wait twice a second, forever, to blink a caret nobody could type into. The blink animation was gated only on which widget held focus *inside* the window, not on whether the window held OS focus.

## Changes

- `syncBlinkCursor` (`gui/ime_context.go`) folds `Window.focused` into the caret signal. Losing focus retires the animation, which empties `w.animations` and parks the ticker in `animationLoop`; `handleFocusedEvent` calls `resetBlinkCursorVisible` on the way back, so the caret returns solid with a fresh 600 ms phase rather than mid-blink, and the rebuild `EventFn` queues re-registers the animation.
- `renderInputCursor` paints the caret transparent while the window is unfocused; `commandToggleCaretBlink` carries the same gate so a Pulsar's surviving blink toggles cannot paint the caret back in. The rect is still emitted, so the render list keeps one shape across focus states and the in-place blink patch (#404) stays valid.
- Only the caret blink is gated — other animations keep running so a background window's in-flight motion does not stall.
- Test windows (`makeWindow`, `newTestWindow`) now mirror `NewWindow`'s focused resting state (issue #422); the new tests pin the suspend/restore path, the Pulsar exemption while unfocused, and the end-to-end behavior through a real frame.
- Also includes a CLAUDE.md guidance refresh (prose trim, dropped stale issue references).

## Tests

`make prepush` green (race, lint, gate checks, cross-lint, cross-compile, coverage, export audit).