### PR TITLE
feat: procedural planet surfaces and axial spin in solar_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ and this project adheres to
 
 ### Added
 
+- **Procedural planet surfaces and axial spin in `examples/solar_system`** —
+  each planet now carries a generated surface texture and turns on a tilted
+  axis: Jupiter's belts drift past, Earth shows continents and ice caps, Venus
+  turns retrograde, and Uranus rolls rather than spins. Rotation periods are
+  compressed like the orbital ones (`|realHours|^0.45`); axial tilts are real.
+
+  No engine change was involved, and that is the interesting part. There is no
+  textured-triangle path in go-gui — `FillTrianglesColors` carries per-vertex
+  colors and no UVs anywhere — so the surface is sampled on the CPU once per
+  mesh vertex and folded into the color that vertex already had. Sampling costs
+  no new transcendental per vertex: the body axes are pre-transformed into
+  camera space once, the sampling direction linearizes over each ring in the
+  `cos`/`sin` the mesh had already computed, and the shading ramp folds to an
+  affine `channel*k + w`. Textures are generated at init from 3D noise on the
+  sphere direction, which is seamless in longitude by construction, and each
+  one's mean is normalized back onto its `Planet.Color` so nav dots, labels and
+  small-body tone are unchanged. Still zero allocations per frame.
+
+  Mesh ceilings rise from 36x64 to 72x128 to carry the extra detail, which is
+  invisible at ordinary zoom (a full-system frame is 79 batches and 31.6k
+  triangles either way) and costs 99.6k triangles against 85.9k at maximum zoom,
+  where both ceilings actually bind.
+
 - **Per-vertex color fills on `DrawContext`** (#400) —
   `FillTrianglesColors(tris, colors)` takes caller-supplied geometry and one
   color per vertex. Nothing is evaluated on the way through: no projection, no

--- a/examples/solar_system/README.md
+++ b/examples/solar_system/README.md
@@ -1,19 +1,22 @@
 # Solar System
 
 An interactive orrery. Eight planets travel tilted elliptical orbits around a
-glowing sun, over a starfield that twinkles. Mercury laps the sun in about six
-seconds; Neptune takes nearly two minutes.
+glowing sun, over a starfield that twinkles. Mercury laps the sun in about seven
+and a half seconds; Neptune takes a little over two and a half minutes.
 
 Planets are shaded spheres lit from the sun, each labelled under its disc, and
 they show phases — a planet on the near side of its orbit turns its night side
-toward you and reads as a crescent. Hover a body and it glows, with a tooltip
-that follows the cursor. Click one and the camera zooms and pans to it, keeps
-following it as it orbits, and opens a fact sheet with six stat cards and a fun
-fact. The sun is a body like any other here: it hit-tests, it has its own fact
-sheet, and it takes the first navigation dot. Navigation dots along the bottom
-jump straight to any body, and the left and right arrow keys step through them
-with wraparound. Scroll, pinch, or the `+` and `−` controls zoom in and out.
-Escape, or a click on empty space, returns to the full system.
+toward you and reads as a crescent. Each one carries a procedural surface and
+turns on a tilted axis: Jupiter's belts drift past, Earth shows continents and
+ice caps, Venus turns backwards, and Uranus rolls along its orbit rather than
+spinning upright. Hover a body and it glows, with a tooltip that follows the
+cursor. Click one and the camera zooms and pans to it, keeps following it as it
+orbits, and opens a fact sheet with six stat cards and a fun fact. The sun is a
+body like any other here: it hit-tests, it has its own fact sheet, and it takes
+the first navigation dot. Navigation dots along the bottom jump straight to any
+body, and the left and right arrow keys step through them with wraparound.
+Scroll, pinch, or the `+` and `−` controls zoom in and out. Escape, or a click
+on empty space, returns to the full system.
 
 ## Run
 
@@ -50,6 +53,12 @@ go run ./examples/solar_system/
   and draws one level at a time — eight batches per frame instead of 220. A
   shaded sphere goes the other way: it is one mesh carrying a color per vertex,
   so the whole body is a single batch however fine its ramp.
+
+- **Texturing without a texture path.** The renderer has no UV coordinates
+  anywhere — `FillTrianglesColors` carries per-vertex colors and nothing else —
+  so planet surfaces are sampled on the CPU, once per mesh vertex, and folded
+  into the color that vertex already had. No engine change, and every backend
+  keeps working.
 
 - **One encoding for "which body".** Selection and hover are a planet index,
   `selSun` for the sun, or `-1` for nothing. The sun gets a value outside the
@@ -215,17 +224,97 @@ its own color across most of the lit side — Uranus stays cyan and Mars stays
 red. The unlit side bottoms out at a fraction of the body's color rather than
 black, on the grounds that a planet you cannot see is a planet you cannot click.
 
-Ring and segment counts scale with pixel radius, never a constant, but they buy
-much less than they used to. They now resolve only the _geometry_ — the
-curvature of the elliptical rings and the chord error where the mesh boundary
-meets the limb, both of which fall off as the square of the spacing. The ramp
-itself is continuous however coarse the mesh is, so the counts came down by more
-than half when the color moved onto the vertices: a full-system frame went from
-232 triangle batches and 40.6k triangles to 79 and 30.2k, and a Jupiter-focused
-frame from 137 and 52.6k to 89 and 42.7k.
+Ring and segment counts scale with pixel radius, never a constant. Moving color
+onto the vertices cut them by more than half, because the ramp is then
+continuous however coarse the mesh is and the counts have only the _geometry_
+left to resolve — the curvature of the elliptical rings and the chord error
+where the mesh boundary meets the limb, both falling off as the square of the
+spacing. A full-system frame went from 232 triangle batches and 40.6k triangles
+to 79 and about 31k.
+
+Surface texture then gave those counts a second job and reversed that argument
+in part. Albedo is sampled per vertex and interpolated between vertices, so
+detail is now bounded by mesh density in a way intensity never was: the ceilings
+are 72 rings and 128 segments, matched to the 128x64 textures, where before they
+were 36 and 64. The rates that approach them are unchanged, so this is invisible
+at ordinary zoom — a full-system frame is 79 batches and 31.6k triangles either
+way, and a selected Jupiter 105 and 47.0k against 46.8k before. It is only at
+maximum zoom, where a planet is hundreds of pixels across and both ceilings
+actually bind, that the raise costs anything: 99.6k triangles against 85.9k.
 
 Off-screen bodies are still culled: without that, the seven planets outside the
 viewport at a focused zoom each built a full-resolution sphere anyway.
+
+### Texturing a renderer that has no textures
+
+There is no textured-triangle path in go-gui, and adding one was out of scope.
+`DrawContext` offers flat fills, gradients, an axis-aligned `Image`, and
+`FillTrianglesColors` — per-vertex colors with no UVs. The `RenderSvg` command
+that carries arbitrary triangles explicitly zeroes its texcoords, and the Metal
+image pipeline derives UVs from a hardcoded quad rather than reading them. Real
+UV support would mean a new render command, a new sampling pipeline, and edits
+to six backends.
+
+Pre-baking a sphere image per frame is the obvious alternative and it is a trap.
+`gui.UseImage` does hand a CPU pixel buffer to the GPU, but it is content-keyed
+with **no invalidation API**, by explicit design, and the Metal texture cache is
+a 128-entry LRU. A per-frame key for nine spinning planets thrashes it with nine
+texture creates and destroys every frame.
+
+So the surface is sampled on the CPU, once per mesh vertex, and folded into the
+vertex color the mesh already carries. The accepted cost is that detail is
+bounded by vertex density and Gouraud-interpolated between vertices; the raised
+tessellation ceilings above are what pays for it.
+
+**Sampling turned out to be nearly free, because the mesh had already computed
+what it needs.** Two facts do the work. The light basis stores its third axis as
+2D because its `z` is exactly zero by construction, and `lightBasis.point`
+already computes the depth term for its own visibility test — which _is_ the
+normal's `z`. A vertex at `(cosPhi, sinPhi, ct, st)` has camera-space direction
+`n = cosPhi*l + sinPhi*(ct*u + st*v)`, and three things then collapse:
+
+1. **The body axes are pre-transformed into camera space, once.** Axial tilt and
+   camera elevation are both constants, so the world-to-camera rotation is
+   applied when the surface is built and never again. `n_world · a` becomes
+   `n · A` and the world transform disappears.
+2. **The ring linearizes it.** For any fixed axis `W`,
+   `n·W = cosPhi*(l·W) + sinPhi*(ct*(u·W) + st*(v·W))`. That is nine dot
+   products per body per frame, folded into nine scalars per ring, and per
+   vertex it reuses the `ct`/`st` that `appendRing` already had.
+3. **The shading ramp folds to an affine map.** `sphereTone` mixes three colors
+   all derived from one base, so at a fixed intensity it collapses to
+   `channel*k + w` — two scalars per ring instead of three color operations per
+   vertex.
+
+The result is **no new transcendental per vertex**: about fifteen multiply-adds,
+one polynomial `atan2`, a texel fetch, and the ramp. Spin is applied as a
+longitude offset rather than as a rotation of the basis — algebraically
+identical and much cheaper.
+
+The `atan2` is a polynomial with a worst case of 0.0102 rad. That is not
+sloppiness: one texel of a 128-wide texture spans 0.049 rad, so the entire error
+budget is about a fifth of the smallest thing the result can address.
+
+**Noise is evaluated on the 3D direction, not on the `(u,v)` grid.** One extra
+multiply, and it buys both seamlessness in longitude — the direction at `u=0`
+and `u=1` is literally the same point — and freedom from polar pinching. The
+test for this compares the step across the wrap column against the worst step
+anywhere else in the same texture rather than against a fixed threshold, because
+a coastline is allowed to be a sharp edge; what is not allowed is for the seam
+to be sharper than everything else.
+
+**Every texture's mean is normalized back onto its `Planet.Color`.** That is
+what makes texturing safe to add at all rather than a change to every other part
+of the app: the nav dots, the labels, the tooltip and the flat tone a body under
+`flatBodyRadius` draws all still read from that one color, and a planet too
+small to show any texture still looks like the planet it did before. The shift
+is additive so contrast survives, and iterated, because clamping at the byte
+range pulls the mean back a little when a texture has ice caps or a dark spot.
+
+Rows are uniform in `sin(latitude)` rather than in latitude. Every row band then
+covers the same area of the sphere, so texel density is even instead of crowding
+the poles — and since sampling arrives holding `sin(latitude)` already, it
+removes an `asin` from the per-vertex path.
 
 Orbit ellipses are drawn with `Arc`, the ellipse primitive, with the vertical
 radius squashed to tilt the plane. Each ellipse's center is offset by `a·e`
@@ -241,6 +330,19 @@ to 60,190 days — 684x, which nobody can watch. Periods are `realDays^0.45`,
 which preserves the ordering exactly while keeping every gap visible. Orbit
 radii use a milder `realAU^0.38`, because a stronger exponent packs the inner
 four planets inside the sun's halo.
+
+Rotation is compressed the same way and for the same reason: real periods run
+from 9.9 h to 5,832 h, a 590x range, so `RotS` is `|realHours|^0.45 x 1.07`.
+Axial tilts are the real values in radians, and Venus carries its retrograde
+spin as a negative `RotS` rather than as the equivalent 177.4° tilt — identical
+physics, more legible in a table.
+
+Worth being honest about one consequence: rotation and orbit are compressed on
+_separate_ scales, so the ratio between a planet's day and its year is not
+preserved. Mercury's real sidereal day is 0.67 of its year; here it is 4.65. The
+distortion happens to run in the direction that makes Mercury's and Venus's "a
+day lasts longer than a year" fact sheets read as true on screen, but that is a
+coincidence of the scaling rather than a property the model keeps.
 
 ## Provenance
 

--- a/examples/solar_system/camera.go
+++ b/examples/solar_system/camera.go
@@ -218,8 +218,8 @@ func (a *App) recompute() {
 // whichever happens to be first in the table.
 //
 // Only the sun's disc is a target, not its halo — the glow reaches
-// 2.2x the disc and would swallow the inner planets whenever they pass
-// in front of it.
+// 1.7x the disc (up to ~2x with the pulse and the hover stretch) and
+// would swallow the inner planets whenever they pass in front of it.
 func (a *App) hitTest(x, y float32) int {
 	best, bestD := -1, float32(math.MaxFloat32)
 	test := func(idx int, sx, sy, r float32) {

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -45,13 +45,22 @@ const (
 	// The halo and the disc both take their step count from their pixel
 	// size, for the same reason the planet ramp does: a fixed count
 	// bands visibly once the sun is close to the camera. Focusing
-	// Jupiter puts a 500px halo on screen, where 30 rings is a 17px
+	// Jupiter puts a ~380px halo on screen, where 30 rings is a 13px
 	// band apiece.
 	glowRingsPerPx = 0.22
 	glowRingsMin   = 24
 	glowRingsMax   = 140
 
-	glowExtent  = 2.2 // outer glow radius, in multiples of sunRadius
+	// glowExtent is the outer glow radius in multiples of sunRadius.
+	// Worth knowing where Mercury is: its closest *projected* approach
+	// is at the semi-minor ends of its orbit, where the world offset
+	// is (-a*e, +/-b) = (-28, +/-133) and the vertical axis is
+	// squashed by diskTilt, giving a screen distance of
+	// sqrt(28^2 + (133*0.48)^2) ~= 70 world units, or 1.34 sun radii.
+	// So 1.7 does put Mercury inside the glow twice per orbit; the low
+	// alpha and the cubic falloff are what keep that from reading as
+	// flying through a cloud. Clearing the pass outright needs 1.2.
+	glowExtent  = 1.7
 	glowPulseHz = 0.28
 
 	// The disc ramp's two hand-over points, as a fraction of the radius
@@ -105,12 +114,22 @@ const (
 	// mesh boundary meets the limb. Both fall off as the square of the
 	// spacing, which is why far fewer rows suffice here than the flat
 	// bands this replaced needed to hide their quantization.
+	// The Max ends are set by *texture* resolution rather than by
+	// silhouette smoothness, which the far lower ceilings this
+	// replaced already handled. A body's albedo is sampled per vertex
+	// and interpolated between vertices, so at a selected planet's
+	// zoom — up to roughly 640 px of radius — an arc of 64 puts one
+	// quad across 30-60 px and the surface reads as coarse blobs. 72
+	// x 128 is matched to the 128x64 texture. The PerPx rates are
+	// unchanged, so these ceilings are only reached past 144 px and
+	// 183 px of radius: a zoomed selection, never the eight small
+	// bodies of the full-system view.
 	shadeRowsPerPx = 0.5
 	shadeRowsMin   = 12
-	shadeRowsMax   = 36
+	shadeRowsMax   = 72
 	shadeArcPerPx  = 0.7
 	shadeArcMin    = 16
-	shadeArcMax    = 64
+	shadeArcMax    = 128
 
 	// nightScale is the unlit hemisphere's brightness, as a fraction of
 	// the body's own color. Not zero on purpose: a planet you cannot see
@@ -324,9 +343,13 @@ func drawSun(a *App, dc *gui.DrawContext) {
 	// Hovering brightens the halo rather than adding a ring of its own:
 	// the sun is already the brightest thing on the canvas, so a halo
 	// drawn on top of this one would not be visible as a change.
-	glowAlpha := float32(0.38)
+	// Alpha comes down with the extent. The cubic falloff piles most
+	// of the opacity into the innermost third, so a halo squeezed from
+	// 2.2 to 1.2 radii concentrates what is left into a much smaller
+	// area and would read *brighter* at the limb if the alpha stayed.
+	glowAlpha := float32(0.30)
 	if a.Hovered == selSun {
-		glowAlpha = 0.58
+		glowAlpha = 0.46
 		outer *= 1.1
 	}
 
@@ -525,16 +548,195 @@ func drawPlanet(a *App, dc *gui.DrawContext, i int) {
 	// sun lies on screen, and how far around behind the planet it is.
 	lx, ly, lz := a.lightVec(i)
 
+	// Stack-allocated: initSurface fills it, and drawBody does not let
+	// the pointer escape.
+	var sf surface
+	var sp *surface
+	if initSurface(&sf, i, a.Time) {
+		sp = &sf
+	}
+
 	if i == saturnIndex {
 		// Back half of the rings first, then the body, then the front
 		// half — which is what makes the rings pass behind Saturn.
 		k := a.litFraction(i)
 		drawRings(dc, cx, cy, r, math.Pi, math.Pi, k)
-		drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz)
+		drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz, sp)
 		drawRings(dc, cx, cy, r, 0, math.Pi, k)
 		return
 	}
-	drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz)
+	drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz, sp)
+}
+
+// bodyLitLift is how far the brightest point of a body is pushed
+// toward white. Named because the textured path has to reproduce the
+// same ramp arithmetically rather than by calling sphereTone.
+const bodyLitLift = 0.26
+
+// surface is the texture half of a body's appearance: its albedo map
+// and the orientation of the body-fixed frame that map is pinned to.
+// A nil *surface means no texture, and the flat per-ring ramp that
+// drawBody has always drawn.
+//
+// The axes are already in *camera* coordinates. Both the axial tilt
+// and the camera's elevation are constants, so the world-to-camera
+// rotation can be applied once when the surface is built and never
+// again — which is what removes the world transform from the
+// per-vertex path entirely.
+type surface struct {
+	tex           *bodyTexture
+	ax, ay, az    float32 // spin axis
+	e1x, e1y, e1z float32 // equator reference direction
+	e2x, e2y, e2z float32 // completes the right-handed frame
+	spin          float32 // rotation so far, in turns
+}
+
+// initSurface resolves planet i's body frame into camera coordinates
+// at time t.
+//
+// The orbital plane is the world xy-plane, so the orbital north pole
+// is world +z and a tilt of theta leans the spin axis that far off it.
+// Which way it leans is a free choice, taken as world +x. The camera's
+// basis in world coordinates is right (1,0,0), screen-down
+// (0, sinE, -cosE) and to-viewer (0, cosE, sinE) — see lightVec, which
+// is where those come from — and projecting the three body axes onto
+// it gives the vectors below.
+//
+// e1 x e2 == a, so the frame is right-handed and longitude increases
+// in one consistent direction for every planet.
+// It fills a caller-provided surface and reports whether the body has
+// one, rather than returning a pointer, because returning one would
+// put a heap allocation on the frame path: this runs per planet per
+// tick, and nine escaping values a frame is the whole session's worth
+// of garbage that drawBody's scratch reuse exists to avoid.
+func initSurface(s *surface, i int, t float32) bool {
+	p := &planets[i]
+	if p.RotS == 0 || planetTextures[i] == nil {
+		return false
+	}
+	sa, ca := sin32(p.Tilt), cos32(p.Tilt)
+	// diskTilt is an untyped constant; name it float32 once here so
+	// the six products below stay in one type.
+	sinE, cosE := float32(diskTilt), cosElev
+	*s = surface{
+		tex: planetTextures[i],
+		ax:  sa, ay: -ca * cosE, az: ca * sinE,
+		e1x: ca, e1y: sa * cosE, e1z: -sa * sinE,
+		e2x: 0, e2y: sinE, e2z: cosE,
+		// Phase doubles as the starting meridian so the eight bodies
+		// do not all begin with the same face toward the sun.
+		spin: t/p.RotS + p.Phase*(1/(2*math.Pi)),
+	}
+	return true
+}
+
+// surfaceProj is the body frame resolved against the light basis:
+// nine dot products, constant for a whole body.
+//
+// This is the step that makes per-vertex texturing affordable. A
+// vertex normal is n = cosPhi*l + sinPhi*(ct*u + st*v), so for any
+// fixed axis W the quantity n.W is linear in ct and st with
+// coefficients that depend only on the ring. Sampling a vertex is then
+// three multiply-adds per axis on values the ring already has, and no
+// transcendental at all.
+//
+// v contributes only two terms because its z is zero by construction
+// (see lightBasis).
+type surfaceProj struct {
+	la, ua, va float32
+	l1, u1, v1 float32
+	l2, u2, v2 float32
+}
+
+func (s *surface) project(b lightBasis) surfaceProj {
+	return surfaceProj{
+		la: b.lx*s.ax + b.ly*s.ay + b.lz*s.az,
+		ua: b.ux*s.ax + b.uy*s.ay + b.uz*s.az,
+		va: b.vx*s.ax + b.vy*s.ay,
+
+		l1: b.lx*s.e1x + b.ly*s.e1y + b.lz*s.e1z,
+		u1: b.ux*s.e1x + b.uy*s.e1y + b.uz*s.e1z,
+		v1: b.vx*s.e1x + b.vy*s.e1y,
+
+		l2: b.lx*s.e2x + b.ly*s.e2y + b.lz*s.e2z,
+		u2: b.ux*s.e2x + b.uy*s.e2y + b.uz*s.e2z,
+		v2: b.vx*s.e2x + b.vy*s.e2y,
+	}
+}
+
+// ringTex is one ring's slice of all that: the linear coefficients for
+// the three body axes, the spin offset, and the shading ramp folded to
+// an affine (k, w) on each color channel. A nil tex means the ring
+// takes its flat color instead.
+type ringTex struct {
+	tex        *bodyTexture
+	a0, a1, a2 float32 // sin(latitude)
+	b0, b1, b2 float32 // equator reference component
+	c0, c1, c2 float32 // quadrature component
+	spin       float32
+	k, w       float32
+}
+
+// ringTexFor folds the per-body projection and the per-ring geometry
+// into the coefficients appendRing consumes.
+func (p surfaceProj) ringTexFor(s *surface, cosPhi, sinPhi, k, w float32) ringTex {
+	return ringTex{
+		tex: s.tex,
+		a0:  cosPhi * p.la, a1: sinPhi * p.ua, a2: sinPhi * p.va,
+		b0: cosPhi * p.l1, b1: sinPhi * p.u1, b2: sinPhi * p.v1,
+		c0: cosPhi * p.l2, c1: sinPhi * p.u2, c2: sinPhi * p.v2,
+		spin: s.spin,
+		k:    k, w: w,
+	}
+}
+
+// ringRamp is sphereTone rewritten as the affine map it already is.
+//
+// sphereTone mixes three colors that are all derived from one base, so
+// for a fixed intensity the whole ramp collapses to channel*k + w. The
+// textured path needs exactly that, because there the "base" is a
+// different albedo at every vertex and calling sphereTone per vertex
+// would redo the same interpolation thousands of times.
+//
+// This is not bit-identical to sphereTone: that function quantizes the
+// night and lit tones to bytes before mixing, and this one does not.
+// The difference is at most one count in a channel, and the untextured
+// path still goes through sphereTone unchanged.
+func ringRamp(intensity float32) (k, w float32) {
+	if intensity < baseStop {
+		t := intensity / baseStop
+		return nightScale*(1-t) + t, 0
+	}
+	t := (intensity - baseStop) / (1 - baseStop)
+	return 1 - bodyLitLift*t, 255 * bodyLitLift * t
+}
+
+// atan2Turns is atan2(y, x) scaled to turns, in [-0.5, 0.5].
+//
+// A polynomial stand-in for the real thing, with a measured worst
+// case of 0.0102 rad (see TestAtan2TurnsMatchesLibrary). That sounds
+// sloppy and is not: one texel of a 128-wide texture spans 0.049 rad,
+// so the whole error budget is about a fifth of the smallest thing
+// the result can address, and it costs no library call on a path that
+// runs once per vertex.
+func atan2Turns(y, x float32) float32 {
+	const (
+		quarter = float32(math.Pi / 4)
+		toTurns = float32(1 / (2 * math.Pi))
+	)
+	ay := abs32(y) + 1e-10
+	var a float32
+	if x >= 0 {
+		r := (x - ay) / (x + ay)
+		a = (0.1963*r*r-0.9817)*r + quarter
+	} else {
+		r := (x + ay) / (ay - x)
+		a = (0.1963*r*r-0.9817)*r + 3*quarter
+	}
+	if y < 0 {
+		a = -a
+	}
+	return a * toTurns
 }
 
 // lightBasis is an orthonormal frame with the light direction as its
@@ -703,6 +905,13 @@ type bodyMesh struct {
 	tris      []float32
 	cols      []gui.Color
 	prev, cur []float32
+
+	// prevCol and curCol are the vertex colors of those same two
+	// rings, one per position. Color is per vertex rather than per
+	// ring so the albedo can vary along a ring while the Lambert term
+	// stays constant on it; with a flat color they hold arc+1 copies
+	// of one value and the mesh is identical to a per-ring ramp.
+	prevCol, curCol []gui.Color
 }
 
 // appendTri adds one triangle, wound consistently with every other
@@ -760,8 +969,12 @@ func (m *bodyMesh) appendTri(x0, y0 float32, c0 gui.Color,
 // solved.
 //
 // The whole body is one batch.
+// s carries the body's surface texture and orientation, or is nil for
+// an untextured body — in which case every vertex on a ring takes the
+// ring's flat tone and the mesh is exactly what it was before
+// textures existed.
 func drawBody(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32,
-	base gui.Color, lx, ly, lz float32,
+	base gui.Color, lx, ly, lz float32, s *surface,
 ) {
 	// The frame, the visibility test and ringPlan's tangency all read
 	// the light as a unit vector; normalizing once here is cheaper than
@@ -770,7 +983,7 @@ func drawBody(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32,
 		lx, ly, lz = lx/d, ly/d, lz/d
 	}
 	night := scaleColor(base, nightScale)
-	lit := lightenColor(base, 0.26)
+	lit := lightenColor(base, bodyLitLift)
 	// The disc's average tone, used where there is no room to shade.
 	flat := sphereTone(night, base, lit, clamp32((1+lz)/2, 0, 1))
 
@@ -804,20 +1017,36 @@ func drawBody(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32,
 
 	m.tris, m.cols = m.tris[:0], m.cols[:0]
 
+	// Nine dot products for the whole body; the per-ring and
+	// per-vertex work below is all multiply-adds on top of them.
+	var proj surfaceProj
+	if s != nil {
+		proj = s.project(b)
+	}
+
 	// Where the rings go is ringPlan's decision, and not the obvious
 	// one; see it for why even steps in intensity make the silhouette
 	// go polygonal.
-	var prevCol gui.Color
 	for i := range p.count() {
 		c := p.cosPhi(i)
-		s := sqrt32(max(0, 1-c*c))
-		col := sphereTone(night, base, lit, clamp32(c, 0, 1))
-		m.cur = appendRing(m.cur[:0], b, r, cx, cy, c, s, arc)
-		if i > 0 {
-			m.appendStrip(prevCol, col, arc)
+		sn := sqrt32(max(0, 1-c*c))
+		intensity := clamp32(c, 0, 1)
+		col := sphereTone(night, base, lit, intensity)
+		var rt ringTex
+		if s != nil {
+			k, w := ringRamp(intensity)
+			rt = proj.ringTexFor(s, c, sn, k, w)
 		}
+		m.cur, m.curCol = appendRing(m.cur[:0], m.curCol[:0],
+			b, r, cx, cy, c, sn, arc, col, rt)
+		if i > 0 {
+			m.appendStrip(arc)
+		}
+		// Positions and colors are two halves of one ring and must be
+		// swapped together, or a strip would pair ring i's vertices
+		// with ring i-1's colors.
 		m.prev, m.cur = m.cur, m.prev
-		prevCol = col
+		m.prevCol, m.curCol = m.curCol, m.prevCol
 	}
 	dc.FillTrianglesColors(m.tris, m.cols)
 }
@@ -833,31 +1062,62 @@ func drawBody(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32,
 // any hidden interior point out onto the limb as well. A ring entirely
 // on the far side collapses to a single point; it covers no visible
 // surface, and appendTri drops the strips it takes part in.
-func appendRing(dst []float32, b lightBasis, r, cx, cy, cosPhi,
-	sinPhi float32, arc int,
-) []float32 {
+// Colors are written to cdst in step with the positions, one per
+// vertex. With rt.tex nil every vertex on the ring takes col, since
+// the Lambert term is constant along a ring by construction. With a
+// texture the Lambert term is still constant and only the albedo
+// varies, which is what keeps the sampling cheap.
+//
+// The direction sampled is the true surface normal, not the position
+// b.point returns: point pushes hidden vertices out onto the limb, and
+// the linearization deliberately does not model that clamp. It does
+// not need to. Each ring spans its own visible azimuth, so interior
+// vertices are genuinely visible and the two end points sit where
+// z is about 0 and the clamp does nothing. The clamp only really acts
+// on rings that are wholly hidden, whose strips have no area and are
+// dropped by appendTri.
+func appendRing(dst []float32, cdst []gui.Color, b lightBasis,
+	r, cx, cy, cosPhi, sinPhi float32, arc int, col gui.Color,
+	rt ringTex,
+) ([]float32, []gui.Color) {
 	tMax := b.visibleAzimuth(cosPhi, sinPhi)
 	step := 2 * tMax / float32(arc)
 	for k := 0; k <= arc; k++ {
 		t := -tMax + step*float32(k)
-		x, y := b.point(r, cosPhi, sinPhi, cos32(t), sin32(t))
+		ct, st := cos32(t), sin32(t)
+		x, y := b.point(r, cosPhi, sinPhi, ct, st)
 		dst = append(dst, cx+x, cy+y)
+		if rt.tex == nil {
+			cdst = append(cdst, col)
+			continue
+		}
+		sinLat := rt.a0 + ct*rt.a1 + st*rt.a2
+		p1 := rt.b0 + ct*rt.b1 + st*rt.b2
+		p2 := rt.c0 + ct*rt.c1 + st*rt.c2
+		texel := rt.tex.at(sinLat, atan2Turns(p2, p1)-rt.spin)
+		cdst = append(cdst, gui.RGBA(
+			chan8(float32(texel.R)*rt.k+rt.w),
+			chan8(float32(texel.G)*rt.k+rt.w),
+			chan8(float32(texel.B)*rt.k+rt.w),
+			col.A))
 	}
-	return dst
+	return dst, cdst
 }
 
 // appendStrip tiles the surface between the two rings currently held in
-// prev and cur with quads, two triangles apiece. Both rings carry a
-// flat color of their own and the vertex colors interpolate between
-// them, which is the ramp.
-func (m *bodyMesh) appendStrip(outer, inner gui.Color, arc int) {
+// prev and cur with quads, two triangles apiece. Each vertex carries
+// the color its own ring assigned it, and the rasterizer interpolates
+// across the quad — which is the ramp.
+func (m *bodyMesh) appendStrip(arc int) {
 	for k := range arc {
 		ax0, ay0 := m.prev[k*2], m.prev[k*2+1]
 		bx0, by0 := m.prev[k*2+2], m.prev[k*2+3]
 		ax1, ay1 := m.cur[k*2], m.cur[k*2+1]
 		bx1, by1 := m.cur[k*2+2], m.cur[k*2+3]
-		m.appendTri(ax0, ay0, outer, bx0, by0, outer, bx1, by1, inner)
-		m.appendTri(ax0, ay0, outer, bx1, by1, inner, ax1, ay1, inner)
+		ac0, bc0 := m.prevCol[k], m.prevCol[k+1]
+		ac1, bc1 := m.curCol[k], m.curCol[k+1]
+		m.appendTri(ax0, ay0, ac0, bx0, by0, bc0, bx1, by1, bc1)
+		m.appendTri(ax0, ay0, ac0, bx1, by1, bc1, ax1, ay1, ac1)
 	}
 }
 

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -23,7 +23,16 @@ const (
 
 	tickAnim  = "solar_tick"
 	tickDelay = 16 * time.Millisecond
-	tickSecs  = float32(0.016)
+
+	// tickSecs is how much *simulated* time one tick advances, and it
+	// is deliberately not tickDelay. The animation still fires every
+	// 16 ms of wall clock, but advances 12.96 ms of simulation, so the
+	// whole model — orbits, axial spin, the camera tween and the star
+	// twinkle alike — runs at 81% speed (two successive 10% cuts off
+	// the original 16 ms). One number rather than a factor spread
+	// across the tables, because everything here is a function of
+	// App.Time.
+	tickSecs = float32(0.01296)
 
 	canvasID = "solar_canvas"
 

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -17,7 +17,7 @@ func TestMain(m *testing.M) {
 }
 
 // tweenTicks is the number of ticks one camera transition takes.
-const tweenTicks = 38 // camTweenSecs / tickSecs, rounded up
+const tweenTicks = 47 // camTweenSecs / tickSecs, rounded up
 
 // newTestApp is a fully seeded app with a known canvas size, so camera
 // and hit-test math is exercised without a real frame pass.
@@ -829,7 +829,7 @@ func bodyBatches(t *testing.T, r float32, lx, ly, lz float32) *gui.DrawContext {
 	t.Helper()
 	dc := gui.NewDrawContext(200, 200, nil)
 	var m bodyMesh
-	drawBody(dc, &m, 100, 100, r, gui.RGB(180, 140, 90), lx, ly, lz)
+	drawBody(dc, &m, 100, 100, r, gui.RGB(180, 140, 90), lx, ly, lz, nil)
 	return dc
 }
 
@@ -929,19 +929,22 @@ func TestBodyMeshStaysInsideDisc(t *testing.T) {
 func TestBodyMeshDoesNotAllocatePerFrame(t *testing.T) {
 	var m bodyMesh
 	dc := gui.NewDrawContext(200, 200, nil)
-	drawBody(dc, &m, 100, 100, 60, gui.RGB(180, 140, 90), 0.6, 0.2, -0.77)
+	drawBody(dc, &m, 100, 100, 60, gui.RGB(180, 140, 90), 0.6, 0.2, -0.77, nil)
 
 	got := testing.AllocsPerRun(20, func() {
 		// A fresh context each run would allocate for its own batches,
 		// which is not what this measures; the mesh scratch is.
 		m.tris = m.tris[:0]
 		m.cols = m.cols[:0]
-		m.cur = appendRing(m.cur[:0], newLightBasis(0.6, 0.2, -0.77),
-			60, 100, 100, 0.3, 0.95, 32)
-		m.prev = m.prev[:0]
-		m.prev = appendRing(m.prev[:0], newLightBasis(0.6, 0.2, -0.77),
-			60, 100, 100, 0.2, 0.98, 32)
-		m.appendStrip(gui.RGB(1, 2, 3), gui.RGB(4, 5, 6), 32)
+		// The color rings are scratch on the same footing as the
+		// position rings: reused with [:0], never reallocated.
+		m.cur, m.curCol = appendRing(m.cur[:0], m.curCol[:0],
+			newLightBasis(0.6, 0.2, -0.77),
+			60, 100, 100, 0.3, 0.95, 32, gui.RGB(1, 2, 3), ringTex{})
+		m.prev, m.prevCol = appendRing(m.prev[:0], m.prevCol[:0],
+			newLightBasis(0.6, 0.2, -0.77),
+			60, 100, 100, 0.2, 0.98, 32, gui.RGB(4, 5, 6), ringTex{})
+		m.appendStrip(32)
 	})
 	if got != 0 {
 		t.Errorf("mesh rebuild allocated %v times per run, want 0", got)

--- a/examples/solar_system/planets.go
+++ b/examples/solar_system/planets.go
@@ -37,6 +37,28 @@ type Planet struct {
 
 	Color gui.Color
 
+	// RotS is seconds for one rotation on its axis and Tilt the axial
+	// tilt in radians. A negative RotS is retrograde.
+	//
+	// Compressed like PeriodS, and for the same reason: real rotation
+	// periods run from 9.9 h (Jupiter) to 5832 h (Venus), a 590x range
+	// that would leave Jupiter a blur while Venus sat still. These are
+	// |realHours|^0.45 x 1.07, the same exponent the orbital periods
+	// use, so the ordering is exact and every planet visibly turns.
+	//
+	// Note that rotation and orbit are compressed on separate scales,
+	// so the *ratio* between a planet's day and its year is not
+	// preserved — see the README.
+	//
+	// Venus carries its retrograde spin as a negative RotS with its
+	// real 2.64 degree tilt, rather than as the equivalent 177.4
+	// degree tilt with a positive one. The two encode identical
+	// physics; this one reads at a glance. Uranus needs no sign: a
+	// tilt past 90 degrees is retrograde already, and it rolls along
+	// its orbit rather than spinning upright.
+	RotS float32
+	Tilt float32
+
 	// Fact-sheet copy, shown in the info panel.
 	Diameter    string
 	Mass        string
@@ -53,6 +75,7 @@ var planets = [...]Planet{
 	{
 		Name: "Mercury", OrbitA: 136, PeriodS: 6.0, Ecc: 0.206, Phase: 0.4,
 		Radius: 7, Color: gui.RGB(168, 158, 148),
+		RotS: 27.9, Tilt: 0.000593, // 0.034 deg, the real value
 		Diameter: "4,879 km", Mass: "0.055 Earths", Distance: "0.39 AU",
 		DayLength: "1,408 h", Gravity: "3.7 m/s²", Temperature: "-173 to 427 °C",
 		FunFact: "A day on Mercury lasts longer than its year — it spins " +
@@ -61,6 +84,7 @@ var planets = [...]Planet{
 	{
 		Name: "Venus", OrbitA: 172, PeriodS: 9.2, Ecc: 0.007, Phase: 2.1,
 		Radius: 11, Color: gui.RGB(222, 184, 135),
+		RotS: -53.0, Tilt: 0.046,
 		Diameter: "12,104 km", Mass: "0.815 Earths", Distance: "0.72 AU",
 		DayLength: "5,832 h", Gravity: "8.9 m/s²", Temperature: "464 °C",
 		FunFact: "Venus turns backwards, so the Sun there rises in the " +
@@ -69,6 +93,7 @@ var planets = [...]Planet{
 	{
 		Name: "Earth", OrbitA: 195, PeriodS: 11.4, Ecc: 0.017, Phase: 4.3,
 		Radius: 12, Color: gui.RGB(76, 140, 214),
+		RotS: 4.46, Tilt: 0.409,
 		Diameter: "12,742 km", Mass: "1 Earth", Distance: "1.00 AU",
 		DayLength: "24 h", Gravity: "9.8 m/s²", Temperature: "-88 to 58 °C",
 		FunFact: "The only world known to have liquid water on its " +
@@ -77,6 +102,7 @@ var planets = [...]Planet{
 	{
 		Name: "Mars", OrbitA: 229, PeriodS: 15.1, Ecc: 0.093, Phase: 0.9,
 		Radius: 9, Color: gui.RGB(193, 91, 58),
+		RotS: 4.53, Tilt: 0.440,
 		Diameter: "6,779 km", Mass: "0.107 Earths", Distance: "1.52 AU",
 		DayLength: "24.7 h", Gravity: "3.7 m/s²", Temperature: "-153 to 20 °C",
 		FunFact: "Olympus Mons is the tallest volcano in the solar system " +
@@ -85,6 +111,7 @@ var planets = [...]Planet{
 	{
 		Name: "Jupiter", OrbitA: 365, PeriodS: 34.6, Ecc: 0.049, Phase: 3.4,
 		Radius: 32, Color: gui.RGB(201, 156, 111),
+		RotS: 3.01, Tilt: 0.055,
 		Diameter: "139,820 km", Mass: "318 Earths", Distance: "5.20 AU",
 		DayLength: "9.9 h", Gravity: "24.8 m/s²", Temperature: "-108 °C",
 		FunFact: "The Great Red Spot is a storm wider than Earth that has " +
@@ -93,6 +120,7 @@ var planets = [...]Planet{
 	{
 		Name: "Saturn", OrbitA: 459, PeriodS: 52.2, Ecc: 0.057, Phase: 5.6,
 		Radius: 28, Color: gui.RGB(224, 202, 148),
+		RotS: 3.10, Tilt: 0.466,
 		Diameter: "116,460 km", Mass: "95 Earths", Distance: "9.54 AU",
 		DayLength: "10.7 h", Gravity: "10.4 m/s²", Temperature: "-138 °C",
 		FunFact: "Saturn is less dense than water — given a bathtub big " +
@@ -101,6 +129,7 @@ var planets = [...]Planet{
 	{
 		Name: "Uranus", OrbitA: 599, PeriodS: 83.6, Ecc: 0.046, Phase: 1.7,
 		Radius: 20, Color: gui.RGB(140, 209, 216),
+		RotS: 3.85, Tilt: 1.706,
 		Diameter: "50,724 km", Mass: "14.5 Earths", Distance: "19.2 AU",
 		DayLength: "17.2 h", Gravity: "8.7 m/s²", Temperature: "-195 °C",
 		FunFact: "Uranus orbits on its side, so each pole spends 42 years " +
@@ -109,6 +138,7 @@ var planets = [...]Planet{
 	{
 		Name: "Neptune", OrbitA: 711, PeriodS: 113.2, Ecc: 0.011, Phase: 3.9,
 		Radius: 19, Color: gui.RGB(62, 102, 209),
+		RotS: 3.73, Tilt: 0.494,
 		Diameter: "49,244 km", Mass: "17.1 Earths", Distance: "30.1 AU",
 		DayLength: "16.1 h", Gravity: "11.2 m/s²", Temperature: "-201 °C",
 		FunFact: "Neptune's winds reach 2,100 km/h — the fastest measured " +

--- a/examples/solar_system/texture.go
+++ b/examples/solar_system/texture.go
@@ -1,0 +1,448 @@
+package main
+
+import (
+	"math"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// Procedural surface textures for the planets.
+//
+// The renderer has no textured-triangle path: DrawContext offers flat
+// fills, gradients, an axis-aligned Image, and FillTrianglesColors —
+// per-vertex colors with no texture coordinates anywhere in the
+// pipeline. Pre-baking a sphere image per frame is worse than it
+// sounds, because gui.UseImage is content-keyed with no invalidation
+// and the backend texture cache is a small LRU; nine spinning planets
+// would evict it every frame.
+//
+// So the surface is sampled on the CPU, once per mesh vertex, and
+// folded into the vertex color the mesh already carries (see
+// appendRing). Nothing in gui/ changes and every backend keeps
+// working. The price is that detail is bounded by vertex density and
+// Gouraud-interpolated between vertices, which is why drawBody's
+// tessellation caps are set where they are.
+//
+// Generation runs once at init and may use whatever math it likes;
+// only sampling is on the frame path, and sampling is a clamp, a
+// multiply and an array index.
+
+const (
+	// texW and texH are longitude and latitude resolution. 128x64 is
+	// matched to the mesh's own ceiling — more texels than a body can
+	// resolve at maximum tessellation would be detail nothing samples.
+	texW = 128
+	texH = 64
+)
+
+// bodyTexture is one planet's surface albedo on a lat/lon grid.
+//
+// Rows are uniform in sin(latitude), not in latitude. That makes every
+// row band cover the same area of the sphere, so texel density is even
+// instead of crowding the poles — and, because the mesh hands sampling
+// a direction whose sin(latitude) it already has, it removes an asin
+// from the per-vertex path entirely.
+type bodyTexture struct {
+	w, h  int
+	texel []gui.Color
+}
+
+// at samples the surface at a latitude given as its sine and a
+// longitude given in turns. turn is wrapped, so a caller may add spin
+// to it without normalizing; sinLat is clamped, which only matters for
+// float error at the poles.
+func (t *bodyTexture) at(sinLat, turn float32) gui.Color {
+	// Clamp before the float-to-int below, not after: NaN compares
+	// false against both bounds, so a clamp on the integer row would
+	// let it slip through with an unspecified value. Catch it with a
+	// self-comparison and fold it to the north pole — any defined row
+	// satisfies the contract, and the sampling path cannot produce
+	// NaN in the first place. Overshoot folds to the nearest pole.
+	if sinLat > 1 {
+		sinLat = 1
+	} else if sinLat < -1 {
+		sinLat = -1
+	} else if sinLat != sinLat {
+		sinLat = 1
+	}
+	row := int((1 - sinLat) * 0.5 * float32(t.h))
+	if row < 0 {
+		row = 0
+	} else if row >= t.h {
+		row = t.h - 1
+	}
+	// Wrap into [0,1) without math.Floor: the truncation toward zero
+	// is corrected by the negative branch.
+	f := turn - float32(int(turn))
+	if f < 0 {
+		f++
+	}
+	col := int(f * float32(t.w))
+	if col < 0 {
+		col = 0
+	} else if col >= t.w {
+		col = t.w - 1
+	}
+	return t.texel[row*t.w+col]
+}
+
+// planetTextures is built once for the process, not once per App:
+// newApp runs in nearly every test, and the tables below are the same
+// every time. This follows sunGranules exactly, and for the reason
+// stated there — a surface regenerated per frame would boil.
+var planetTextures = makeTextures()
+
+// rgbF is a texel under construction. Generation works in unclamped
+// floats so a chain of tints and darkenings does not quantize at every
+// step, and only the final write clamps to bytes.
+type rgbF struct{ r, g, b float32 }
+
+func rgbOf(c gui.Color) rgbF {
+	return rgbF{float32(c.R), float32(c.G), float32(c.B)}
+}
+
+func (c rgbF) scale(f float32) rgbF {
+	return rgbF{c.r * f, c.g * f, c.b * f}
+}
+
+func (c rgbF) add(o rgbF) rgbF {
+	return rgbF{c.r + o.r, c.g + o.g, c.b + o.b}
+}
+
+func (c rgbF) mix(o rgbF, t float32) rgbF {
+	return rgbF{lerp(c.r, o.r, t), lerp(c.g, o.g, t), lerp(c.b, o.b, t)}
+}
+
+func (c rgbF) color() gui.Color {
+	return gui.RGB(chan8(c.r), chan8(c.g), chan8(c.b))
+}
+
+// --- noise kernel ---
+//
+// Noise is evaluated on the 3D direction vector rather than on the
+// (u,v) grid. That costs one extra multiply and buys two things no 2D
+// scheme gets for free: the field is seamless in longitude because
+// the direction at u=0 and u=1 is literally the same point, and there
+// is no polar pinch, because the sphere has no distinguished axis in
+// the noise's coordinates.
+
+// hash3 hashes an integer lattice point to [0,1).
+func hash3(x, y, z int32, seed uint32) float32 {
+	h := uint32(x)*0x8DA6B343 ^ uint32(y)*0xD8163841 ^ uint32(z)*0xCB1AB31F
+	h += seed * 0x9E3779B1
+	h ^= h >> 15
+	h *= 0x2C1B3C6D
+	h ^= h >> 12
+	h *= 0x297A2D39
+	h ^= h >> 15
+	return float32(h&0xFFFFFF) / float32(0x1000000)
+}
+
+func ifloor(v float32) int32 { return int32(floor32(v)) }
+
+// valueNoise3 is trilinear value noise with a smoothstep fade, so the
+// field is continuous and has a continuous first derivative — enough
+// for fbm, and cheaper than gradient noise to state.
+func valueNoise3(x, y, z float32, seed uint32) float32 {
+	xi, yi, zi := ifloor(x), ifloor(y), ifloor(z)
+	fx, fy, fz := x-float32(xi), y-float32(yi), z-float32(zi)
+	ux := fx * fx * (3 - 2*fx)
+	uy := fy * fy * (3 - 2*fy)
+	uz := fz * fz * (3 - 2*fz)
+
+	c00 := lerp(hash3(xi, yi, zi, seed), hash3(xi+1, yi, zi, seed), ux)
+	c10 := lerp(hash3(xi, yi+1, zi, seed), hash3(xi+1, yi+1, zi, seed), ux)
+	c01 := lerp(hash3(xi, yi, zi+1, seed), hash3(xi+1, yi, zi+1, seed), ux)
+	c11 := lerp(hash3(xi, yi+1, zi+1, seed), hash3(xi+1, yi+1, zi+1, seed), ux)
+
+	return lerp(lerp(c00, c10, uy), lerp(c01, c11, uy), uz)
+}
+
+// fbm3 sums octaves at doubling frequency and halving amplitude, and
+// normalizes back to roughly [0,1].
+func fbm3(x, y, z float32, oct int, seed uint32) float32 {
+	amp, freq := float32(0.5), float32(1)
+	var sum, norm float32
+	for range oct {
+		sum += amp * valueNoise3(x*freq, y*freq, z*freq, seed)
+		norm += amp
+		amp *= 0.5
+		freq *= 2
+	}
+	return sum / norm
+}
+
+// warp3 displaces a sample point by a vector-valued noise field.
+// Domain warping is what turns the smooth blobs of plain fbm into
+// something that reads as flow, and it is the whole of Venus.
+func warp3(x, y, z, amt float32, seed uint32) (float32, float32, float32) {
+	dx := fbm3(x+11.3, y+7.1, z+3.7, 3, seed^0x1234) - 0.5
+	dy := fbm3(x+5.9, y+19.2, z+13.1, 3, seed^0x5678) - 0.5
+	dz := fbm3(x+2.3, y+31.7, z+23.9, 3, seed^0x9ABC) - 0.5
+	return x + amt*2*dx, y + amt*2*dy, z + amt*2*dz
+}
+
+// spot is an elliptical feature — a storm — placed by latitude and
+// longitude, returning 1 at its center and falling to 0 at its edge.
+// wLon and wLat are its half-widths in radians.
+func spot(lat, lon, atLat, atLon, wLon, wLat float32) float32 {
+	dLon := lon - atLon
+	for dLon > math.Pi {
+		dLon -= 2 * math.Pi
+	}
+	for dLon < -math.Pi {
+		dLon += 2 * math.Pi
+	}
+	// Longitude degrees converge toward the poles; scaling by cos(lat)
+	// keeps the storm round on the globe rather than in the table.
+	dLon *= cos32(lat)
+	dx, dy := dLon/wLon, (lat-atLat)/wLat
+	d := dx*dx + dy*dy
+	if d >= 1 {
+		return 0
+	}
+	return 1 - d
+}
+
+// --- per-body surfaces ---
+//
+// Each takes the planet's own base color and the sample direction, and
+// returns an albedo near that base. Staying near the base is not
+// decoration: the same color drives the nav dots, the labels and the
+// flat tone a sub-flatBodyRadius body draws, and a texture that
+// wandered off it would make a zoomed-out planet a different planet.
+
+type texFn func(base rgbF, x, y, z, sinLat, lat, lon float32) rgbF
+
+const (
+	seedMercury = 0x4D4552
+	seedVenus   = 0x56454E
+	seedEarth   = 0x454152
+	seedMars    = 0x4D4152
+	seedJupiter = 0x4A5550
+	seedSaturn  = 0x534154
+	seedUranus  = 0x555241
+	seedNeptune = 0x4E4550
+)
+
+// texMercury: battered grey rock. The craters are a proxy, not a
+// simulation — a high-frequency band of the same noise, darkened in
+// its floors and lifted just outside them, which reads as rims at the
+// size these ever get drawn.
+func texMercury(base rgbF, x, y, z, _, _, _ float32) rgbF {
+	w := fbm3(x*3.1, y*3.1, z*3.1, 5, seedMercury)
+	c := base.scale(0.84 + 0.32*w)
+	switch k := fbm3(x*8, y*8, z*8, 2, seedMercury^0x77); {
+	case k > 0.62:
+		c = c.scale(0.80)
+	case k > 0.55:
+		c = c.scale(1.12)
+	}
+	return c
+}
+
+// texVenus: a featureless sulphuric overcast. Heavy domain warp on a
+// field stretched along longitude gives the smeared banding the real
+// cloud deck shows, and the contrast stays tiny (+/-8%) because Venus
+// genuinely has almost none.
+func texVenus(base rgbF, x, y, z, _, _, _ float32) rgbF {
+	wx, wy, wz := warp3(x*2.0, y*6.0, z*2.0, 0.5, seedVenus)
+	w := fbm3(wx, wy, wz, 4, seedVenus)
+	return base.scale(0.92 + 0.16*w)
+}
+
+// texEarth: continents by threshold, then tinted by a second field
+// standing in for aridity and modulated by latitude, so deserts sit in
+// the subtropics and tundra near the poles. Ice caps are a hard cut in
+// sin(latitude), which is where they read best at this size.
+func texEarth(base rgbF, x, y, z, sinLat, lat, _ float32) rgbF {
+	var (
+		deepSea = rgbF{28, 62, 128}
+		shallow = rgbF{74, 138, 206}
+		forest  = rgbF{58, 112, 62}
+		desert  = rgbF{176, 154, 96}
+		tundra  = rgbF{150, 158, 150}
+		ice     = rgbF{238, 244, 248}
+	)
+	wx, wy, wz := warp3(x*1.8, y*1.8, z*1.8, 0.35, seedEarth)
+	m := fbm3(wx, wy, wz, 5, seedEarth)
+
+	var c rgbF
+	if m > 0.52 {
+		// Aridity drives forest->desert; |lat| pulls the high
+		// latitudes toward tundra whatever the aridity says.
+		arid := fbm3(x*2.6+40, y*2.6, z*2.6, 4, seedEarth^0x3131)
+		c = forest.mix(desert, clamp32(arid*1.5-0.25, 0, 1))
+		if a := abs32(lat); a > 0.9 {
+			c = c.mix(tundra, clamp32((a-0.9)*2.4, 0, 1))
+		}
+		// Shade the interior so the land is not a flat cutout.
+		c = c.scale(0.90 + 0.20*fbm3(x*5, y*5, z*5, 3, seedEarth^0x9))
+	} else {
+		c = deepSea.mix(shallow, clamp32((m-0.30)*3.2, 0, 1))
+	}
+	if a := abs32(sinLat); a > 0.86 {
+		c = c.mix(ice, clamp32((a-0.86)*7, 0, 1))
+	}
+	// Pull the whole thing toward the table's blue so the drawn planet
+	// still matches its dot and its label.
+	return c.mix(base, 0.30)
+}
+
+// texMars: rusty mottling with dark maria where the field runs low,
+// and small bright polar caps.
+func texMars(base rgbF, x, y, z, sinLat, _, _ float32) rgbF {
+	w := fbm3(x*2.4, y*2.4, z*2.4, 5, seedMars)
+	c := base.scale(0.86 + 0.30*w)
+	if w < 0.45 {
+		c = c.mix(rgbF{112, 62, 48}, clamp32((0.45-w)*3.4, 0, 1))
+	}
+	if a := abs32(sinLat); a > 0.93 {
+		c = c.mix(rgbF{236, 238, 234}, clamp32((a-0.93)*11, 0, 1))
+	}
+	return c
+}
+
+// texJupiter: the bands are the planet. A sine in latitude sets the
+// belts and zones; a field stretched 4:1 along longitude pushes their
+// edges around so they are turbulent rather than ruled. The Great Red
+// Spot sits where it belongs, in the South Equatorial Belt.
+func texJupiter(base rgbF, x, y, z, _, lat, lon float32) rgbF {
+	turb := fbm3(x*1.6, y*6.4, z*1.6, 3, seedJupiter) - 0.5
+	b := float32(math.Sin(float64(lat*9 + 1.2*turb)))
+	c := base.scale(1 + 0.17*b)
+	// Belts (the dark half) get a brown cast, zones a cream one.
+	if b < 0 {
+		c = c.mix(rgbF{150, 108, 74}, -b*0.35)
+	} else {
+		c = c.mix(rgbF{232, 210, 176}, b*0.25)
+	}
+	if s := spot(lat, lon, -0.35, 2.2, 0.42, 0.13); s > 0 {
+		c = c.mix(rgbF{198, 104, 72}, s*0.85)
+	}
+	return c
+}
+
+// texSaturn: the same construction as Jupiter with fewer bands, half
+// the contrast and a brighter polar zone — which is most of what
+// separates the two by eye.
+func texSaturn(base rgbF, x, y, z, sinLat, lat, _ float32) rgbF {
+	turb := fbm3(x*1.4, y*5.6, z*1.4, 3, seedSaturn) - 0.5
+	b := float32(math.Sin(float64(lat*6 + 1.0*turb)))
+	c := base.scale(1 + 0.09*b)
+	c = c.mix(rgbF{236, 220, 176}, clamp32(abs32(sinLat)-0.55, 0, 1)*0.5)
+	return c
+}
+
+// texUranus: nearly featureless is the correct look, so this is two
+// faint bands and a mild polar brightening. Anything stronger would be
+// a prettier planet and the wrong one.
+func texUranus(base rgbF, x, y, z, sinLat, lat, _ float32) rgbF {
+	turb := fbm3(x*1.2, y*4.0, z*1.2, 2, seedUranus) - 0.5
+	b := float32(math.Sin(float64(lat*3 + 0.8*turb)))
+	c := base.add(rgbF{6 * b, 6 * b, 5 * b})
+	return c.scale(1 + 0.05*clamp32(abs32(sinLat)-0.5, 0, 1))
+}
+
+// texNeptune: three soft bands, white cirrus streaks pulled out of a
+// stretched high-frequency field, and the Great Dark Spot.
+func texNeptune(base rgbF, x, y, z, _, lat, lon float32) rgbF {
+	turb := fbm3(x*1.5, y*5.0, z*1.5, 3, seedNeptune) - 0.5
+	b := float32(math.Sin(float64(lat*4 + 1.0*turb)))
+	c := base.add(rgbF{10 * b, 10 * b, 8 * b})
+	if k := fbm3(x*2.2, y*9.0, z*2.2, 3, seedNeptune^0x5A); k > 0.70 {
+		c = c.mix(rgbF{226, 236, 248}, clamp32((k-0.70)*2.6, 0, 1))
+	}
+	if s := spot(lat, lon, -0.38, 4.1, 0.40, 0.12); s > 0 {
+		c = c.mix(rgbF{28, 48, 116}, s*0.75)
+	}
+	return c
+}
+
+// texFns is indexed like planets.
+var texFns = [len(planets)]texFn{
+	texMercury, texVenus, texEarth, texMars,
+	texJupiter, texSaturn, texUranus, texNeptune,
+}
+
+// makeTextures builds every planet's surface.
+func makeTextures() [len(planets)]*bodyTexture {
+	var out [len(planets)]*bodyTexture
+	for i := range planets {
+		out[i] = makeTexture(rgbOf(planets[i].Color), texFns[i])
+	}
+	return out
+}
+
+// makeTexture rasterizes one surface function over the lat/lon grid
+// and then normalizes its mean back onto the planet's table color.
+//
+// The normalization is what makes textures safe to add at all. Every
+// other use of Planet.Color — the nav dot, the label, the flat tone
+// below flatBodyRadius, the tooltip swatch — stays exactly as it was,
+// and a planet too small to show any texture still reads as the same
+// planet it did before.
+func makeTexture(base rgbF, fn texFn) *bodyTexture {
+	t := &bodyTexture{w: texW, h: texH}
+	buf := make([]rgbF, texW*texH)
+
+	for row := range texH {
+		// The row's own band, sampled at its center: sin(lat) uniform,
+		// matching what at() inverts.
+		sinLat := 1 - 2*(float32(row)+0.5)/float32(texH)
+		lat := float32(math.Asin(float64(clamp32(sinLat, -1, 1))))
+		cosLat := sqrt32(max(0, 1-sinLat*sinLat))
+		for col := range texW {
+			lon := 2 * math.Pi * (float32(col) + 0.5) / float32(texW)
+			x := cosLat * cos32(lon)
+			y := sinLat
+			z := cosLat * sin32(lon)
+			buf[row*texW+col] = fn(base, x, y, z, sinLat, lat, lon)
+		}
+	}
+
+	normalizeMean(buf, base)
+
+	t.texel = make([]gui.Color, len(buf))
+	for i, c := range buf {
+		t.texel[i] = c.color()
+	}
+	return t
+}
+
+// normalizeMean shifts the field so its mean lands on want.
+//
+// The shift is additive, which preserves contrast where a multiply
+// would stretch it, and it is iterated because clamping at the byte
+// range moves the mean back a little — a texture with ice caps or a
+// dark spot has texels sitting against a limit. Four passes is well
+// past where this stops moving.
+func normalizeMean(buf []rgbF, want rgbF) {
+	for range 4 {
+		var sr, sg, sb float32
+		for _, c := range buf {
+			sr += clamp32(c.r, 0, 255)
+			sg += clamp32(c.g, 0, 255)
+			sb += clamp32(c.b, 0, 255)
+		}
+		n := float32(len(buf))
+		d := rgbF{want.r - sr/n, want.g - sg/n, want.b - sb/n}
+		for i := range buf {
+			buf[i] = buf[i].add(d)
+		}
+	}
+	for i := range buf {
+		buf[i] = rgbF{
+			clamp32(buf[i].r, 0, 255),
+			clamp32(buf[i].g, 0, 255),
+			clamp32(buf[i].b, 0, 255),
+		}
+	}
+}
+
+func abs32(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/examples/solar_system/texture_test.go
+++ b/examples/solar_system/texture_test.go
@@ -1,0 +1,592 @@
+package main
+
+import (
+	"math"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// --- the sampling geometry ---
+
+// testSurface is initSurface in the shape the tests want. The
+// production call site keeps the value on its own stack to stay off
+// the frame path's allocation budget; a test does not care.
+func testSurface(i int, t float32) *surface {
+	var s surface
+	if !initSurface(&s, i, t) {
+		return nil
+	}
+	return &s
+}
+
+// worldAxes returns planet i's spin axis and equator frame in *world*
+// coordinates, built independently of newSurface so the camera
+// projection there is checked against something rather than restated.
+func worldAxes(tilt float32) (a, e1, e2 [3]float32) {
+	sa, ca := sin32(tilt), cos32(tilt)
+	return [3]float32{sa, 0, ca},
+		[3]float32{ca, 0, -sa},
+		[3]float32{0, 1, 0}
+}
+
+func dot3(a, b [3]float32) float32 {
+	return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
+}
+
+// camToWorld maps a camera-space vector back to world coordinates,
+// inverting the basis lightVec documents. The basis is orthonormal, so
+// the inverse is the transpose.
+func camToWorld(x, y, z float32) [3]float32 {
+	sinE, cosE := float32(diskTilt), cosElev
+	return [3]float32{
+		x,
+		y*sinE + z*cosE,
+		-y*cosE + z*sinE,
+	}
+}
+
+// TestSurfaceAxesAreOrthonormal pins the frame newSurface builds: unit
+// length, mutually perpendicular, and right-handed, for every tilt in
+// the table. A left-handed frame would run longitude backwards on some
+// planets and not others.
+func TestSurfaceAxesAreOrthonormal(t *testing.T) {
+	const eps = 1e-5
+	for i := range planets {
+		s := testSurface(i, 3.5)
+		if s == nil {
+			t.Fatalf("%s: no surface", planets[i].Name)
+		}
+		a := [3]float32{s.ax, s.ay, s.az}
+		e1 := [3]float32{s.e1x, s.e1y, s.e1z}
+		e2 := [3]float32{s.e2x, s.e2y, s.e2z}
+		for _, v := range []struct {
+			name string
+			v    [3]float32
+		}{{"a", a}, {"e1", e1}, {"e2", e2}} {
+			if d := abs32(dot3(v.v, v.v) - 1); d > eps {
+				t.Errorf("%s: %s is not unit (err %v)",
+					planets[i].Name, v.name, d)
+			}
+		}
+		for _, pr := range []struct {
+			name string
+			x, y [3]float32
+		}{{"a.e1", a, e1}, {"a.e2", a, e2}, {"e1.e2", e1, e2}} {
+			if d := abs32(dot3(pr.x, pr.y)); d > eps {
+				t.Errorf("%s: %s = %v, want 0",
+					planets[i].Name, pr.name, d)
+			}
+		}
+		// e1 x e2 == a is what makes longitude increase the same way
+		// for every planet.
+		cross := [3]float32{
+			e1[1]*e2[2] - e1[2]*e2[1],
+			e1[2]*e2[0] - e1[0]*e2[2],
+			e1[0]*e2[1] - e1[1]*e2[0],
+		}
+		for k := range 3 {
+			if d := abs32(cross[k] - a[k]); d > eps {
+				t.Errorf("%s: e1 x e2 component %d is %v, want %v",
+					planets[i].Name, k, cross[k], a[k])
+			}
+		}
+	}
+}
+
+// TestInitSurfaceSkipsWithoutRotation pins the RotS == 0 guard: with
+// no rotation there is no texture and no body frame, and the spin term
+// t/RotS would divide by zero. Every table planet has a rotation, so
+// the branch is only reachable here, by construction. None of the
+// tests that read RotS run in parallel, so mutating the table with
+// restore is safe.
+func TestInitSurfaceSkipsWithoutRotation(t *testing.T) {
+	orig := planets[0].RotS
+	planets[0].RotS = 0
+	defer func() { planets[0].RotS = orig }()
+	var s surface
+	if initSurface(&s, 0, 5) {
+		t.Fatal("initSurface reported a surface for a body with RotS 0")
+	}
+}
+
+// TestRingLinearizationMatchesWorldNormal is the headline check on the
+// whole texturing scheme. appendRing never forms a normal vector: it
+// evaluates three linear functions of cos(t) and sin(t) whose
+// coefficients were folded per ring. This recomputes the same three
+// quantities the long way — build the camera-space normal, rotate it
+// into world coordinates, dot it against the world axes — and requires
+// they agree.
+func TestRingLinearizationMatchesWorldNormal(t *testing.T) {
+	const eps = 1e-5
+	for i := range planets {
+		s := testSurface(i, 2.25)
+		wa, we1, we2 := worldAxes(planets[i].Tilt)
+
+		for _, l := range [][3]float32{
+			{0.6, 0.2, -0.77}, {-0.3, 0.9, 0.31}, {0.1, 0.05, 0.99},
+		} {
+			b := newLightBasis(l[0], l[1], l[2])
+			proj := s.project(b)
+
+			for pi := range 9 {
+				phi := float32(pi) * math.Pi / 8
+				cosPhi, sinPhi := cos32(phi), sin32(phi)
+				rt := proj.ringTexFor(s, cosPhi, sinPhi, 1, 0)
+
+				for ti := range 12 {
+					tt := float32(ti) * 2 * math.Pi / 12
+					ct, st := cos32(tt), sin32(tt)
+
+					// The long way: the camera-space normal, then the
+					// world dot products.
+					nx := cosPhi*b.lx + sinPhi*(ct*b.ux+st*b.vx)
+					ny := cosPhi*b.ly + sinPhi*(ct*b.uy+st*b.vy)
+					nz := cosPhi*b.lz + sinPhi*ct*b.uz
+					n := camToWorld(nx, ny, nz)
+
+					got := [3]float32{
+						rt.a0 + ct*rt.a1 + st*rt.a2,
+						rt.b0 + ct*rt.b1 + st*rt.b2,
+						rt.c0 + ct*rt.c1 + st*rt.c2,
+					}
+					want := [3]float32{
+						dot3(n, wa), dot3(n, we1), dot3(n, we2),
+					}
+					for k := range 3 {
+						if d := abs32(got[k] - want[k]); d > eps {
+							t.Fatalf("%s l=%v phi=%v t=%v axis %d: "+
+								"linearized %v, direct %v",
+								planets[i].Name, l, phi, tt, k,
+								got[k], want[k])
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestAtan2TurnsMatchesLibrary bounds the polynomial stand-in. The
+// bound that matters is texels, not radians: one texel of a 128-wide
+// texture spans 1/128 of a turn, and the approximation's worst case is
+// under a quarter of that, so no sample can land in the wrong texel by
+// more than a fraction of one.
+func TestAtan2TurnsMatchesLibrary(t *testing.T) {
+	const tol = 0.25 / texW
+	for i := range 720 {
+		ang := float64(i)*2*math.Pi/720 - math.Pi
+		x, y := float32(math.Cos(ang)), float32(math.Sin(ang))
+		want := float32(ang / (2 * math.Pi))
+		got := atan2Turns(y, x)
+		d := abs32(got - want)
+		if d > 0.5 {
+			d = abs32(d - 1) // the +/-0.5 wrap point
+		}
+		if d > tol {
+			t.Fatalf("atan2Turns(%v,%v) = %v, want %v (err %v turns)",
+				y, x, got, want, d)
+		}
+	}
+}
+
+// TestAtan2TurnsAtOrigin pins the zero guard: atan2 of (0,0) is
+// undefined, so the polynomial must return *some* defined value rather
+// than NaN or Inf — the 1e-10 term exists for exactly this call.
+func TestAtan2TurnsAtOrigin(t *testing.T) {
+	got := atan2Turns(0, 0)
+	if got != got {
+		t.Fatalf("atan2Turns(0,0) = NaN")
+	}
+	if got < -0.5 || got > 0.5 {
+		t.Fatalf("atan2Turns(0,0) = %v, outside the turn range", got)
+	}
+}
+
+// TestRingRampMatchesSphereTone pins the folded ramp against the
+// function it replaces, across the whole intensity range. The
+// end-to-end uniform-texture test only reaches the night branch: its
+// light lies mostly along the view axis, so no ring's intensity
+// exceeds baseStop. This one walks both branches directly, with the
+// same at-most-one-count allowance the end-to-end test uses.
+func TestRingRampMatchesSphereTone(t *testing.T) {
+	base := gui.RGB(180, 140, 90)
+	night := scaleColor(base, nightScale)
+	lit := lightenColor(base, bodyLitLift)
+	for i := 0; i <= 200; i++ {
+		it := float32(i) / 200
+		k, w := ringRamp(it)
+		got := gui.RGBA(
+			chan8(float32(base.R)*k+w),
+			chan8(float32(base.G)*k+w),
+			chan8(float32(base.B)*k+w),
+			base.A)
+		want := sphereTone(night, base, lit, it)
+		for _, ch := range []struct {
+			name string
+			x, y uint8
+		}{{"R", got.R, want.R}, {"G", got.G, want.G},
+			{"B", got.B, want.B}} {
+			d := int(ch.x) - int(ch.y)
+			if d < 0 {
+				d = -d
+			}
+			if d > 1 {
+				t.Fatalf("intensity %v channel %s: ramp %d, sphereTone %d",
+					it, ch.name, ch.x, ch.y)
+			}
+		}
+	}
+}
+
+// TestTextureAtClampsAndWraps walks the index math of at() directly:
+// the row mapping at the poles, the turn wrap for negative and
+// overshooting values, and the NaN contract (a defined in-bounds texel
+// rather than an out-of-range index).
+func TestTextureAtClampsAndWraps(t *testing.T) {
+	tex := &bodyTexture{w: 128, h: 64}
+	tex.texel = make([]gui.Color, 128*64)
+	for i := range tex.texel {
+		tex.texel[i] = gui.RGB(uint8(i%128), uint8(i/128), 0)
+	}
+	at := func(sinLat, turn float32) gui.Color { return tex.at(sinLat, turn) }
+	if got := at(1, 0); got != tex.texel[0] {
+		t.Errorf("north pole sampled row %v, want row 0", got)
+	}
+	if got := at(-1, 0); got != tex.texel[63*128] {
+		t.Errorf("south pole sampled row %v, want row 63", got)
+	}
+	if got := at(1.5, 0); got != tex.texel[0] {
+		t.Errorf("overshoot at +1.5 sampled %v, want row 0", got)
+	}
+	if got := at(-1.5, 0); got != tex.texel[63*128] {
+		t.Errorf("overshoot at -1.5 sampled %v, want row 63", got)
+	}
+	// Longitude: f = 0.25 and 0.75 are exactly representable, so the
+	// wrapped sample must land on a known column.
+	mid := 32 * 128 // row 32, the equator
+	if got := at(0, 0.25); got != tex.texel[mid+32] {
+		t.Errorf("turn 0.25 sampled %v, want column 32", got)
+	}
+	if got := at(0, -0.75); got != tex.texel[mid+32] {
+		t.Errorf("turn -0.75 sampled %v, want column 32", got)
+	}
+	if got := at(0, 1.25); got != tex.texel[mid+32] {
+		t.Errorf("turn 1.25 sampled %v, want column 32", got)
+	}
+	if got := at(0, 1); got != tex.texel[mid] {
+		t.Errorf("turn 1 sampled %v, want column 0", got)
+	}
+	// NaN must not panic or produce an out-of-range index.
+	got := at(float32(math.NaN()), 0)
+	if int(got.R) >= tex.w || int(got.G) >= tex.h {
+		t.Errorf("NaN sinLat sampled (%d,%d), an out-of-range texel",
+			got.R, got.G)
+	}
+}
+
+// TestUVCoordsStayInRange walks every planet over a spread of times and
+// light directions and requires the sampled row and column to land
+// inside the texture. at() clamps and wraps, so a failure here would be
+// silent smearing rather than a panic.
+func TestUVCoordsStayInRange(t *testing.T) {
+	for i := range planets {
+		for step := range 90 {
+			s := testSurface(i, float32(step)*0.7)
+			b := newLightBasis(0.6, 0.2, -0.77)
+			proj := s.project(b)
+			for pi := range 12 {
+				phi := float32(pi) * math.Pi / 11
+				cosPhi, sinPhi := cos32(phi), sin32(phi)
+				rt := proj.ringTexFor(s, cosPhi, sinPhi, 1, 0)
+				for ti := range 16 {
+					tt := float32(ti) * 2 * math.Pi / 16
+					ct, st := cos32(tt), sin32(tt)
+					sinLat := rt.a0 + ct*rt.a1 + st*rt.a2
+					if sinLat < -1.001 || sinLat > 1.001 {
+						t.Fatalf("%s: sin(lat) = %v, outside [-1,1]",
+							planets[i].Name, sinLat)
+					}
+					p1 := rt.b0 + ct*rt.b1 + st*rt.b2
+					p2 := rt.c0 + ct*rt.c1 + st*rt.c2
+					if turn := atan2Turns(p2, p1); turn < -0.501 || turn > 0.501 {
+						t.Fatalf("%s: turn = %v, outside [-0.5,0.5]",
+							planets[i].Name, turn)
+					}
+				}
+			}
+		}
+	}
+}
+
+// --- spin ---
+
+// subViewerTurn is the texture longitude, in turns, currently facing
+// the given camera-space direction.
+func subViewerTurn(s *surface, x, y, z float32) float32 {
+	p1 := x*s.e1x + y*s.e1y + z*s.e1z
+	p2 := x*s.e2x + y*s.e2y + z*s.e2z
+	return atan2Turns(p2, p1) - s.spin
+}
+
+// TestSpinAdvancesLongitude requires the face presented to the camera
+// to walk steadily around the body, and to walk the *other* way for
+// Venus — which is the whole content of its negative RotS.
+//
+// The expected sign is negative for a prograde planet, which is right
+// rather than a fudge. e1 and e2 are inertial, so a body-fixed feature
+// at body longitude L appears at inertial longitude L + spin; the
+// texture is indexed by body longitude, so sampling subtracts spin.
+// As a prograde planet turns, the feature facing the camera is one
+// with a progressively *smaller* body longitude.
+func TestSpinAdvancesLongitude(t *testing.T) {
+	for i := range planets {
+		var prev float32
+		var total float32
+		for step := range 24 {
+			s := testSurface(i, float32(step)*abs32(planets[i].RotS)/24)
+			turn := subViewerTurn(s, 0, 0, 1)
+			if step > 0 {
+				d := turn - prev
+				// Unwrap across the +/-0.5 seam.
+				for d > 0.5 {
+					d--
+				}
+				for d < -0.5 {
+					d++
+				}
+				total += d
+			}
+			prev = turn
+		}
+		// A full rotation was sampled, so the unwrapped travel should
+		// be close to one turn, negative for a prograde planet.
+		want := float32(-1)
+		if planets[i].RotS < 0 {
+			want = 1
+		}
+		// 23/24 of the way round: the loop takes 24 samples spanning
+		// one period, so it accumulates one step short of a full turn.
+		if d := abs32(total - want*23.0/24.0); d > 0.02 {
+			t.Errorf("%s: longitude travelled %v turns, want about %v",
+				planets[i].Name, total, want*23.0/24.0)
+		}
+	}
+}
+
+// TestRotationTableIsSane guards the compressed periods the same way
+// the orbit table is guarded: ordering and bounds, not exact values.
+func TestRotationTableIsSane(t *testing.T) {
+	for i := range planets {
+		p := planets[i]
+		if r := abs32(p.RotS); r < 2 || r > 60 {
+			t.Errorf("%s: |RotS| = %v, outside the compressed range",
+				p.Name, r)
+		}
+		if p.Tilt < 0 || p.Tilt > math.Pi {
+			t.Errorf("%s: Tilt = %v, outside [0,pi]", p.Name, p.Tilt)
+		}
+	}
+	// Venus is the only retrograde spinner in the table, and Uranus
+	// the only one tipped past a right angle.
+	for i := range planets {
+		retro := planets[i].RotS < 0
+		if want := planets[i].Name == "Venus"; retro != want {
+			t.Errorf("%s: retrograde = %v, want %v",
+				planets[i].Name, retro, want)
+		}
+		if tipped := planets[i].Tilt > math.Pi/2; tipped !=
+			(planets[i].Name == "Uranus") {
+			t.Errorf("%s: tilt past 90 deg = %v", planets[i].Name, tipped)
+		}
+	}
+}
+
+// --- the textures themselves ---
+
+// TestTextureMeanMatchesPlanetColor pins the normalization that makes
+// texturing safe to add: the nav dot, the label, the tooltip and the
+// flat tone a tiny body draws all still use Planet.Color, so a
+// textured planet has to average out to it.
+func TestTextureMeanMatchesPlanetColor(t *testing.T) {
+	for i := range planets {
+		tex := planetTextures[i]
+		var sr, sg, sb float64
+		for _, c := range tex.texel {
+			sr += float64(c.R)
+			sg += float64(c.G)
+			sb += float64(c.B)
+		}
+		n := float64(len(tex.texel))
+		want := planets[i].Color
+		for _, ch := range []struct {
+			name string
+			got  float64
+			want uint8
+		}{
+			{"R", sr / n, want.R}, {"G", sg / n, want.G},
+			{"B", sb / n, want.B},
+		} {
+			if d := math.Abs(ch.got - float64(ch.want)); d > 2 {
+				t.Errorf("%s: mean %s = %.2f, want %d",
+					planets[i].Name, ch.name, ch.got, ch.want)
+			}
+		}
+	}
+}
+
+// TestTextureIsSeamlessInLongitude guards the choice to build noise on
+// the 3D direction rather than on the (u,v) grid. The wrap column is
+// adjacent to column 0 on the sphere, so the step across it must be no
+// worse than the largest step anywhere else in the same texture; a
+// regression to 2D noise would put a visible line down every planet.
+func TestTextureIsSeamlessInLongitude(t *testing.T) {
+	for i := range planets {
+		tex := planetTextures[i]
+		delta := func(a, b gui.Color) int {
+			d := func(x, y uint8) int {
+				if x > y {
+					return int(x) - int(y)
+				}
+				return int(y) - int(x)
+			}
+			return d(a.R, b.R) + d(a.G, b.G) + d(a.B, b.B)
+		}
+		var seam, interior int
+		for row := range tex.h {
+			r := tex.texel[row*tex.w : (row+1)*tex.w]
+			if v := delta(r[0], r[tex.w-1]); v > seam {
+				seam = v
+			}
+			for col := range tex.w - 1 {
+				if v := delta(r[col], r[col+1]); v > interior {
+					interior = v
+				}
+			}
+		}
+		if seam > interior {
+			t.Errorf("%s: worst seam step %d exceeds worst interior "+
+				"step %d — the wrap is visible", planets[i].Name,
+				seam, interior)
+		}
+	}
+}
+
+// TestTexturedBodyMatchesFlatWhenTextureIsUniform pins the folded ramp
+// against sphereTone, which is the function it replaces on the
+// textured path. Feeding a constant albedo must reproduce the flat
+// shading to within the rounding the fold gives up: sphereTone
+// quantizes its night and lit tones to bytes before mixing and
+// ringRamp does not, which is worth at most one count.
+func TestTexturedBodyMatchesFlatWhenTextureIsUniform(t *testing.T) {
+	base := gui.RGB(180, 140, 90)
+	flatTex := &bodyTexture{w: 4, h: 2, texel: make([]gui.Color, 8)}
+	for i := range flatTex.texel {
+		flatTex.texel[i] = base
+	}
+
+	s := testSurface(2, 1.0) // Earth, for a non-trivial tilt
+	s.tex = flatTex
+
+	dcFlat := gui.NewDrawContext(400, 400, nil)
+	dcTex := gui.NewDrawContext(400, 400, nil)
+	var mf, mt bodyMesh
+	drawBody(dcFlat, &mf, 200, 200, 90, base, 0.6, 0.2, -0.77, nil)
+	drawBody(dcTex, &mt, 200, 200, 90, base, 0.6, 0.2, -0.77, s)
+
+	if len(mf.cols) != len(mt.cols) {
+		t.Fatalf("vertex counts differ: flat %d, textured %d",
+			len(mf.cols), len(mt.cols))
+	}
+	for i := range mf.cols {
+		a, b := mf.cols[i], mt.cols[i]
+		for _, ch := range []struct {
+			name string
+			x, y uint8
+		}{{"R", a.R, b.R}, {"G", a.G, b.G}, {"B", a.B, b.B},
+			{"A", a.A, b.A}} {
+			d := int(ch.x) - int(ch.y)
+			if d < 0 {
+				d = -d
+			}
+			if d > 1 {
+				t.Fatalf("vertex %d channel %s: flat %d, textured %d",
+					i, ch.name, ch.x, ch.y)
+			}
+		}
+	}
+}
+
+// TestTexturedBodyDoesNotAllocatePerFrame is the end-to-end form of
+// the gate in main_test.go: sampling a surface must not allocate
+// either, or nine textured planets a tick would allocate for the
+// session.
+func TestTexturedBodyDoesNotAllocatePerFrame(t *testing.T) {
+	var m bodyMesh
+	dc := gui.NewDrawContext(400, 400, nil)
+	s := testSurface(4, 2.0) // Jupiter
+	drawBody(dc, &m, 200, 200, 120, planets[4].Color, 0.6, 0.2, -0.77, s)
+
+	got := testing.AllocsPerRun(20, func() {
+		m.tris, m.cols = m.tris[:0], m.cols[:0]
+		b := newLightBasis(0.6, 0.2, -0.77)
+		proj := s.project(b)
+		k, w := ringRamp(0.5)
+		rt := proj.ringTexFor(s, 0.3, 0.95, k, w)
+		m.cur, m.curCol = appendRing(m.cur[:0], m.curCol[:0], b,
+			120, 200, 200, 0.3, 0.95, 64, gui.RGB(1, 2, 3), rt)
+		rt = proj.ringTexFor(s, 0.2, 0.98, k, w)
+		m.prev, m.prevCol = appendRing(m.prev[:0], m.prevCol[:0], b,
+			120, 200, 200, 0.2, 0.98, 64, gui.RGB(4, 5, 6), rt)
+		m.appendStrip(64)
+	})
+	if got != 0 {
+		t.Errorf("textured mesh rebuild allocated %v times per run, want 0", got)
+	}
+}
+
+// TestTexturedBodyStaysNearPlanetColor is the end-to-end form of the
+// mean check: a mean can be right across the texture while individual
+// texels are wild, and what actually has to hold is that putting a
+// texture on a body does not change its overall tone.
+//
+// The comparison is against the *untextured* draw of the same body,
+// not against Planet.Color directly. A drawn body is much darker than
+// its table color and should be — the mesh spans the whole visible
+// hemisphere, most of whose vertices sit well down the Lambert ramp
+// toward the limb — so the table color is not the number a drawn mean
+// is supposed to match.
+func TestTexturedBodyStaysNearPlanetColor(t *testing.T) {
+	drawnMean := func(i int, s *surface) (float64, float64, float64, int) {
+		var m bodyMesh
+		dc := gui.NewDrawContext(400, 400, nil)
+		drawBody(dc, &m, 200, 200, 100, planets[i].Color,
+			0.6, 0.2, -0.77, s)
+		var sr, sg, sb float64
+		for _, c := range m.cols {
+			sr += float64(c.R)
+			sg += float64(c.G)
+			sb += float64(c.B)
+		}
+		n := float64(len(m.cols))
+		return sr / n, sg / n, sb / n, len(m.cols)
+	}
+
+	for i := range planets {
+		fr, fg, fb, nf := drawnMean(i, nil)
+		tr, tg, tb, nt := drawnMean(i, testSurface(i, 1.0))
+		if nf != nt {
+			t.Fatalf("%s: textured mesh has %d vertices, untextured %d",
+				planets[i].Name, nt, nf)
+		}
+		for _, ch := range []struct {
+			name     string
+			flat, ha float64
+		}{{"R", fr, tr}, {"G", fg, tg}, {"B", fb, tb}} {
+			if d := math.Abs(ch.flat - ch.ha); d > 8 {
+				t.Errorf("%s: textured mean %s = %.1f, untextured %.1f",
+					planets[i].Name, ch.name, ch.ha, ch.flat)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Each planet in `examples/solar_system` now carries a procedurally generated
surface texture and turns on a tilted axis: Jupiter's belts drift past, Earth
shows continents and ice caps, Venus turns retrograde, and Uranus rolls along
its orbit. Rotation periods are compressed like the orbital ones
(`|realHours|^0.45 x 1.07`); axial tilts are real.

No engine change: go-gui has no textured-triangle path, so the surface is
sampled on the CPU once per mesh vertex and folded into the vertex color the
mesh already carried (`FillTrianglesColors`). Sampling is nearly free because
the mesh had already computed what it needs — the body axes are pre-transformed
into camera space once per body, the ring geometry linearizes the normal's dot
products (`n·W = cosPhi·(l·W) + sinPhi·(ct·(u·W) + st·(v·W))`), and the shading
ramp folds to an affine `channel·k + w`. Zero new transcendentals per vertex,
still zero allocations per frame.

Textures are generated once at init from 3D value noise (seamless in longitude
by construction, no polar pinch), and each one's mean is normalized back onto
its `Planet.Color` so nav dots, labels and small-body tones are unchanged.
Mesh ceilings rise 36x64 → 72x128 to carry the detail; invisible at ordinary
zoom, ~99.6k vs 85.9k triangles only where both ceilings bind.

Also: the sun's glow extent is tightened 2.2 → 1.7 radii (with the pulse and
hover stretch it still reaches Mercury's closest projected pass, and the
comment now documents the geometry), and the whole model runs at 81% speed
(`tickSecs` 0.016 → 0.01296).

## Test coverage

- Frame orthonormality and handedness (per-tilt), the ring linearization
  against a direct world-space normal, spin direction incl. Venus retrograde,
  the atan2 polynomial against the library, texture mean = planet color,
  longitude seamlessness, UV bounds over time/light spreads.
- Textured vs flat draw equivalence (uniform texture, ≤1 count), drawn mean
  near planet color, zero-alloc gates for both paths, `at()` clamp/wrap/NaN
  contract, `ringRamp` vs `sphereTone` on both branches, `RotS == 0` guard.