### PR TITLE
perf(solar_system): replace per-vertex ring trig with an angle-addition recurrence

### DIFF
--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -1051,6 +1051,51 @@ func drawBody(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32,
 	dc.FillTrianglesColors(m.tris, m.cols)
 }
 
+// ringAngles walks (cos t, sin t) along a ring by a fixed angular
+// step, so the whole ring costs four transcendentals instead of two per
+// vertex. appendRing's step is uniform by construction, which is what
+// makes the rotation an increment rather than a fresh evaluation.
+//
+// This is the stable form of the recurrence (Numerical Recipes 5.4),
+// not the naive product one. Writing the rotation as a *correction* to
+// the current value keeps the correction small, so its rounding error
+// is small in absolute terms too; the product form rounds the full
+// value every step and its magnitude walks away from 1. Magnitude is
+// exactly what must not drift here: |c| or |s| creeping above 1 puts a
+// vertex outside the disc, which is the property
+// TestBodyMeshStaysInsideDisc pins.
+//
+// The seed and the two coefficients are computed in float64 because
+// they are paid once per ring, not once per vertex, so the wider math
+// is free and it keeps the starting error at float32 rounding instead
+// of compounding a float32 one over up to shadeArcMax steps.
+type ringAngles struct {
+	c, s        float32
+	alpha, beta float32
+}
+
+// newRingAngles seeds the walk at t0 with a per-vertex step of step
+// radians. alpha is 2*sin^2(step/2) and beta is sin(step).
+func newRingAngles(t0, step float64) ringAngles {
+	h := math.Sin(step / 2)
+	sn, cs := math.Sincos(t0)
+	return ringAngles{
+		c:     float32(cs),
+		s:     float32(sn),
+		alpha: float32(2 * h * h),
+		beta:  float32(math.Sin(step)),
+	}
+}
+
+// next advances one step. A wholly hidden ring has step 0, hence
+// alpha and beta 0, and every vertex repeats the seed — the single
+// collapsed point appendTri drops.
+func (a *ringAngles) next() {
+	c, s := a.c, a.s
+	a.c = c - (a.alpha*c + a.beta*s)
+	a.s = s - (a.alpha*s - a.beta*c)
+}
+
 // appendRing evaluates one circle of constant Lambert intensity into
 // dst as arc+1 screen x,y pairs, spanning that circle's *own* visible
 // azimuth range.
@@ -1081,10 +1126,26 @@ func appendRing(dst []float32, cdst []gui.Color, b lightBasis,
 	rt ringTex,
 ) ([]float32, []gui.Color) {
 	tMax := b.visibleAzimuth(cosPhi, sinPhi)
-	step := 2 * tMax / float32(arc)
+	step := 2 * float64(tMax) / float64(arc)
+	ang := newRingAngles(-float64(tMax), step)
+	// The two end points are the ring's limb vertices, and there
+	// lightBasis.point's z >= 0 test is a knife edge: an ulp of
+	// difference in cos t decides whether the vertex is pushed out onto
+	// the limb or left where it fell, which is a fraction of a pixel of
+	// silhouette. So neither end point is left to the walk. The first
+	// is the seed, and the last is its mirror — cos is even and sin is
+	// odd about t = 0, and the range is symmetric — which costs
+	// nothing and is no less exact than evaluating cos32(tMax) would
+	// be.
+	c0, s0 := ang.c, ang.s
 	for k := 0; k <= arc; k++ {
-		t := -tMax + step*float32(k)
-		ct, st := cos32(t), sin32(t)
+		ct, st := ang.c, ang.s
+		if k == arc {
+			ct, st = c0, -s0
+		}
+		// Advanced here rather than at the bottom of the loop, which
+		// the flat-color path leaves by continue.
+		ang.next()
 		x, y := b.point(r, cosPhi, sinPhi, ct, st)
 		dst = append(dst, cx+x, cy+y)
 		if rt.tex == nil {

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -1048,3 +1048,147 @@ func TestBodyMeshSmallBodyCoversTheLightSide(t *testing.T) {
 		}
 	}
 }
+
+// TestAppendRingMatchesDirectTrig is the guard on issue #423's
+// recurrence: every vertex of every ring, at the tessellation caps and
+// over a spread of light directions, must land where the per-vertex
+// cos32/sin32 it replaced would have put it.
+//
+// The tolerance is a hundredth of a pixel on a 200px body. That is far
+// looser than the recurrence's own error (measured at ~1e-4 px) and far
+// tighter than anything the eye or the disc tests would catch, so it
+// fails on a drift bug long before the silhouette moves.
+func TestAppendRingMatchesDirectTrig(t *testing.T) {
+	const r, cx, cy = 200, 200, 200
+	lights := [][3]float32{
+		{0.6, 0.2, -0.77}, // oblique, light behind the body
+		{0.1, 0, 0.99},    // nearly head-on: a large visible cap
+		{1, 0, 0},         // in the screen plane: no cap, all band
+		{-0.4, 0.7, 0.6},
+		{0.3, -0.3, -0.9},
+	}
+	for _, lv := range lights {
+		b := newLightBasis(lv[0], lv[1], lv[2])
+		p := newRingPlan(b, shadeRowsMax)
+		for i := range p.count() {
+			c := p.cosPhi(i)
+			sn := sqrt32(max(0, 1-c*c))
+			got, _ := appendRing(nil, nil, b, r, cx, cy, c, sn,
+				shadeArcMax, gui.RGB(180, 140, 90), ringTex{})
+			tMax := b.visibleAzimuth(c, sn)
+			step := 2 * tMax / float32(shadeArcMax)
+			for k := 0; k <= shadeArcMax; k++ {
+				tt := -tMax + step*float32(k)
+				x, y := b.point(r, c, sn, cos32(tt), sin32(tt))
+				dx := math.Abs(float64(got[k*2] - (cx + x)))
+				dy := math.Abs(float64(got[k*2+1] - (cy + y)))
+				if math.Max(dx, dy) > 0.01 {
+					t.Fatalf("light %v ring %d vertex %d: got (%v, %v), "+
+						"direct trig gives (%v, %v)", lv, i, k,
+						got[k*2], got[k*2+1], cx+x, cy+y)
+				}
+			}
+		}
+	}
+}
+
+// BenchmarkAppendRing walks a full-resolution body's worth of rings
+// through appendRing, without the strip assembly around it, so what it
+// measures is the per-vertex cost issue #423 is about: the trig each
+// vertex pays for. Both paths are covered because the textured one does
+// more per vertex and so dilutes the trig share.
+func BenchmarkAppendRing(b *testing.B) {
+	lb := newLightBasis(0.6, 0.2, -0.77)
+	p := newRingPlan(lb, shadeRowsMax)
+	const r, cx, cy = 200, 200, 200
+	col := gui.RGB(180, 140, 90)
+	// Sized so the benchmark measures the walk, not slice growth;
+	// appendRing is always handed the mesh scratch in real use.
+	dst := make([]float32, 0, 2*(shadeArcMax+1))
+	cdst := make([]gui.Color, 0, shadeArcMax+1)
+
+	var s surface
+	textured := initSurface(&s, earthIndex(b), 1234)
+	var proj surfaceProj
+	if textured {
+		proj = s.project(lb)
+	}
+
+	run := func(b *testing.B, tex bool) {
+		b.ReportAllocs()
+		for b.Loop() {
+			for i := range p.count() {
+				c := p.cosPhi(i)
+				sn := sqrt32(max(0, 1-c*c))
+				var rt ringTex
+				if tex {
+					k, w := ringRamp(clamp32(c, 0, 1))
+					rt = proj.ringTexFor(&s, c, sn, k, w)
+				}
+				dst, cdst = appendRing(dst[:0], cdst[:0], lb, r, cx, cy,
+					c, sn, shadeArcMax, col, rt)
+			}
+		}
+	}
+	b.Run("flat", func(b *testing.B) { run(b, false) })
+	if textured {
+		b.Run("textured", func(b *testing.B) { run(b, true) })
+	}
+}
+
+// earthIndex is the first planet with both a spin and a texture, so the
+// textured benchmark path is exercised on a real body rather than a
+// hand-built surface.
+func earthIndex(tb testing.TB) int {
+	tb.Helper()
+	for i := range planets {
+		if planets[i].RotS != 0 && planetTextures[i] != nil {
+			return i
+		}
+	}
+	return 0
+}
+
+// TestRingAnglesMatchLibrary pins the recurrence against the library
+// calls it replaced. The worst case is the longest walk appendRing can
+// take: a fully visible ring at the arc cap.
+//
+// Magnitude is checked as well as the two components, because that is
+// the failure mode that matters: |c| or |s| above 1 puts a vertex
+// outside the silhouette, which is the assumption the shading's missing
+// clip rests on.
+func TestRingAnglesMatchLibrary(t *testing.T) {
+	const tMax = math.Pi
+	const step = 2 * tMax / shadeArcMax
+	ang := newRingAngles(-tMax, step)
+	for k := 0; k <= shadeArcMax; k++ {
+		want := -tMax + step*float64(k)
+		wc, ws := math.Cos(want), math.Sin(want)
+		if d := math.Abs(float64(ang.c) - wc); d > 1e-5 {
+			t.Fatalf("step %d: cos is %v, want %v (off by %v)",
+				k, ang.c, wc, d)
+		}
+		if d := math.Abs(float64(ang.s) - ws); d > 1e-5 {
+			t.Fatalf("step %d: sin is %v, want %v (off by %v)",
+				k, ang.s, ws, d)
+		}
+		mag := float64(ang.c)*float64(ang.c) + float64(ang.s)*float64(ang.s)
+		if math.Abs(mag-1) > 1e-5 {
+			t.Fatalf("step %d: c^2+s^2 is %v, want 1", k, mag)
+		}
+		ang.next()
+	}
+}
+
+// TestRingAnglesDegenerateRing covers the wholly hidden ring, whose
+// visible azimuth is zero: every vertex must repeat the seed, which is
+// the collapsed single point appendTri drops the strips of.
+func TestRingAnglesDegenerateRing(t *testing.T) {
+	ang := newRingAngles(0, 0)
+	for k := range shadeArcMax + 1 {
+		if ang.c != 1 || ang.s != 0 {
+			t.Fatalf("step %d: got (%v, %v), want (1, 0)", k, ang.c, ang.s)
+		}
+		ang.next()
+	}
+}


### PR DESCRIPTION
Closes #423

## What

`appendRing` evaluated `cos32(t)`/`sin32(t)` per vertex — two transcendentals
a vertex, thousands a body. Replaced with the Numerical Recipes 5.4
angle-addition recurrence (`ringAngles`), which is exact-by-construction
for the uniform step `appendRing` already uses: four transcendentals per
ring, then multiply-adds per vertex.

## Correctness

- The recurrence is the stable *correction* form, not the naive product
  one: magnitude stays at 1, so no vertex can drift outside the disc
  (the property `TestBodyMeshStaysInsideDisc` pins).
- Both limb endpoints are exact, not walked: the seed and its mirror
  (cos is even, sin is odd about t = 0), so the z >= 0 knife edge in
  `lightBasis.point` gets the same decision direct trig would make.
- Seed and coefficients are computed in float64 (paid once per ring),
  keeping the starting error at float32 rounding.
- Degenerate (wholly hidden) rings have step 0 and collapse to the
  single point `appendTri` already drops.

## Tests

- `TestAppendRingMatchesDirectTrig`: every vertex of every ring across
  five light directions must land within 0.01 px of the per-vertex trig
  it replaced (recurrence's own error measured ~1e-4 px).
- `TestRingAnglesMatchLibrary`: pins values and c²+s² magnitude over the
  longest possible walk (arc cap, 128 steps).
- `TestRingAnglesDegenerateRing`: the step-0 ring repeats the seed.
- `BenchmarkAppendRing`: flat and textured paths, 0 allocs/op.