### PR TITLE
docs: rewrite markdown in simple English, fix stale references

### DIFF
--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -5,7 +5,7 @@ description: Review Go code for heap allocation and performance issues
 
 # Performance Reviewer
 
-Review changed Go files for performance issues, focusing on heap allocations.
+Review changed Go files for performance issues. Focus on heap allocations.
 
 ## What to Check
 
@@ -40,6 +40,6 @@ Severity: `alloc` (heap allocation), `perf` (general performance), `nit` (minor)
 
 ## Rules
 - Run `go build -gcflags='-m' ./path/...` to check escape analysis
-- Focus on code in `gui/` package (hot path)
-- Ignore test files unless specifically asked
+- Focus on code in the `gui/` package (the hot path)
+- Ignore test files unless the user asks otherwise
 - Prioritize allocations over micro-optimizations

--- a/.claude/skills/new-example/SKILL.md
+++ b/.claude/skills/new-example/SKILL.md
@@ -15,10 +15,11 @@ Create a new example app under `examples/<name>/main.go`.
 ## Template
 
 Every example follows this structure:
-1. Package comment describing the example
+1. Package comment that describes the example
 2. `App` state struct
-3. `main()` that sets theme, creates `gui.NewWindow`, calls `backend.Run`
-4. `mainView` function returning `gui.View`
+3. `main()` that sets the theme, creates `gui.NewWindow`, and calls
+   `backend.Run`
+4. `mainView` function that returns `gui.View`
 
 ## Reference Pattern
 
@@ -28,8 +29,8 @@ Use `examples/get_started/main.go` as the canonical template:
 package main
 
 import (
-    "github.com/mike-ward/go-gui/gui"
-    "github.com/mike-ward/go-gui/gui/backend"
+    "github.com/go-gui-org/go-gui/gui"
+    "github.com/go-gui-org/go-gui/gui/backend"
 )
 
 type App struct {
@@ -37,7 +38,7 @@ type App struct {
 }
 
 func main() {
-    gui.SetTheme(gui.ThemeDarkBordered)
+    gui.SetTheme(gui.ThemeDark)
 
     w := gui.NewWindow(gui.WindowCfg{
         State:  &App{},
@@ -68,6 +69,6 @@ func mainView(w *gui.Window) gui.View {
 
 ## Rules
 - Place in `examples/<name>/main.go`
-- Use `gui.ThemeDarkBordered` unless user specifies otherwise
+- Use `gui.ThemeDark` unless the user specifies otherwise
 - Use `gui.FixedFixed` sizing for the root container
 - Follow all conventions in CLAUDE.md (no variable shadowing, clean lint)

--- a/.claude/skills/widget/SKILL.md
+++ b/.claude/skills/widget/SKILL.md
@@ -6,17 +6,17 @@ disable-model-invocation: true
 
 # New Widget
 
-Create a new widget in the `gui/` package following established conventions.
+Create a new widget in the `gui/` package. Follow established conventions.
 
 ## Arguments
-- `name` (required): widget name (e.g., "Slider", "ColorPicker")
+- `name` (required): widget name (for example, "Slider" or "ColorPicker")
 
 ## Widget Structure
 
 Every widget consists of:
 1. A `*Cfg` struct (zero-initializable, exported fields)
-2. A factory function returning `View`
-3. Event callbacks using `func(EventCtx)` signature
+2. A factory function that returns `View`
+3. Event callbacks that use the `func(EventCtx)` signature
 
 ## Template
 
@@ -45,8 +45,8 @@ type <Name>Cfg struct {
 // <Name> creates a <Name> widget.
 func <Name>(cfg <Name>Cfg) View {
     // Build layout tree
-    // Wire event handlers (consume-class events are marked handled
-    // by dispatch; notify-class ones call ctx.Consume())
+    // Wire event handlers. A callback that acts on an event calls
+    // ctx.Consume(). A callback that does not act lets it travel on.
     // Return root View
 }
 ```
@@ -54,12 +54,13 @@ func <Name>(cfg <Name>Cfg) View {
 ## Rules
 - File name: `view_<lowercase_name>.go` in `gui/`
 - Cfg struct must be zero-initializable (sensible defaults)
-- Event callbacks: `func(EventCtx)`. `OnClick`/`OnChar`/`OnMouseUp`/
-  `OnGesture`/`OnFileDrop` are consumed by default — call `ctx.Bubble()`
-  to opt out. Everything else calls `ctx.Consume()` to stop propagation
+- Event callbacks use `func(EventCtx)`. A callback that acts on an event
+  calls `ctx.Consume()`. A callback that does not act lets the event travel
+  on. Nothing is consumed by default.
 - Focus needs both `Focusable` (or default-on with no `FocusDisabled`)
-  **and** a non-empty `ID`; the `requiredid` analyzer flags
+  **and** a non-empty `ID`. The `requiredid` analyzer flags
   `Focusable: true` without an `ID`
 - No variable shadowing (use `=` not `:=` for outer-scope vars)
-- Read existing widgets (e.g., `view_button.go`, `view_slider.go`) for patterns
+- Read existing widgets (for example, `view_button.go` and `view_slider.go`)
+  for patterns
 - Must pass `golangci-lint run ./gui/...`

--- a/.windsurf/workflows/README.md
+++ b/.windsurf/workflows/README.md
@@ -1,7 +1,7 @@
 # Imported Skills and Plugins
 
 This directory contains skills and workflows imported from `~/.claude/skills/`
-and configured for use in the go-gui project.
+and configured for the go-gui project.
 
 ## Available Workflows
 
@@ -92,11 +92,10 @@ installation:
 
 ## Usage
 
-These workflows are now available as slash commands in your IDE. Simply type `/`
-followed by the workflow name to invoke them.
+These workflows are available as slash commands in your IDE. Type `/` followed
+by the workflow name to invoke them.
 
 ## Configuration
 
 Plugin configurations are stored in `~/.claude/plugins/installed_plugins.json`.
-No additional setup is required for the workflows - they're ready to use
-immediately.
+The workflows need no additional setup. They are ready to use immediately.

--- a/.windsurf/workflows/antivibe.md
+++ b/.windsurf/workflows/antivibe.md
@@ -10,10 +10,11 @@ description:
 
 ## Purpose
 
-AntiVibe generates **learning-focused explanations** of AI-written code. Not
-generic summaries - actual educational content that helps developers understand:
+AntiVibe generates **learning-focused explanations** of AI-written code. It is
+not a generic summary. It creates educational content that helps developers
+understand:
 
-- **What** the code does (functionality)
+- **What** the code does (its function)
 - **Why** it was written this way (design decisions)
 - **When** to use these patterns (context)
 - **What alternatives** exist (broader knowledge)
@@ -30,7 +31,7 @@ Use AntiVibe when:
 
 ## What AntiVibe Produces
 
-Output saved to `deep-dive/` folder as markdown:
+Output is saved to the `deep-dive/` folder as markdown:
 
 ```
 deep-dive/
@@ -51,25 +52,25 @@ Each file contains:
 
 ### Step 1: Identify Code to Analyze
 
-- Check for explicit file list in user request
-- Or use git diff to find recently modified/created files
-- Or ask user which files/components they want to understand
+- Check the user request for an explicit file list
+- Use `git diff` to find recently modified or created files
+- Ask the user which files or components they want to understand
 
 ### Step 2: Analyze Code Structure
 
 For each file:
 
-- Identify main purpose and responsibilities
+- Identify the main purpose and the responsibilities
 - Note key functions, classes, modules
-- Identify design patterns used (factory, singleton, observer, etc.)
+- Identify the design patterns used (factory, singleton, observer, and more)
 - Find any complex logic or algorithms
 
 ### Step 3: Explain Concepts
 
-For each concept/pattern found:
+For each concept or pattern found:
 
 - **What**: Plain-language explanation
-- **Why**: Why this approach was chosen over alternatives
+- **Why**: Why this approach was chosen over the alternatives
 - **When**: When to use this pattern (with context)
 - **Alternatives**: Other approaches and trade-offs
 
@@ -77,18 +78,18 @@ For each concept/pattern found:
 
 Search for and include:
 
-- Official documentation for libraries/frameworks used
-- Quality tutorials or blog posts
+- Official documentation for the libraries and frameworks used
+- High-quality tutorials and blog posts
 - Video resources (if available)
 - Related concepts for further learning
 
 ### Step 5: Generate Output
 
-Create markdown file in `deep-dive/` folder:
+Create the markdown file in the `deep-dive/` folder:
 
 - Name format: `[component]-[timestamp].md`
 - Follow the template in `templates/deep-dive.md`
-- Include code snippets where helpful
+- Include code snippets where they help
 - Make it educational, not just descriptive
 
 ## Configuration
@@ -98,8 +99,8 @@ AntiVibe can be configured to auto-trigger via hooks:
 - **SubagentStop**: After a Task completes a feature
 - **Stop**: At session end
 
-To enable auto-trigger, configure hooks in your project (see
-`hooks/hooks.json`).
+To enable auto-trigger, configure the hooks in your project. See
+`hooks/hooks.json`.
 
 ## Principles
 
@@ -112,14 +113,14 @@ To enable auto-trigger, configure hooks in your project (see
 
 ## Dependencies
 
-Optional scripts in `scripts/` folder:
+Optional scripts live in the `scripts/` folder:
 
 - `capture-phase.sh` - Detect implementation phase boundaries
 - `analyze-code.sh` - Parse code structure
 - `find-resources.sh` - Search for external resources
 - `generate-deep-dive.sh` - Create markdown output
 
-These are helpers - you can also do everything via direct code analysis.
+These scripts are helpers. You can also do everything with direct code analysis.
 
 ## Examples
 

--- a/.windsurf/workflows/golang.md
+++ b/.windsurf/workflows/golang.md
@@ -6,8 +6,8 @@ description: Go language expertise for writing idiomatic, production-quality Go 
 
 ## Overview
 
-Skill guide idiomatic, efficient, production Go. Cover concurrency, error
-handling, testing, modules per Effective Go.
+This skill guides idiomatic, efficient, production Go. It covers concurrency,
+error handling, testing, and modules per Effective Go.
 
 ## Key Concepts
 

--- a/.windsurf/workflows/graphify.md
+++ b/.windsurf/workflows/graphify.md
@@ -6,7 +6,7 @@ description:
 
 # /graphify
 
-Turn any folder of files into a navigable knowledge graph with community
+Turn any folder of files into a navigable knowledge graph. It includes community
 detection, an honest audit trail, and three outputs: interactive HTML,
 GraphRAG-ready JSON, and a plain-language GRAPH_REPORT.md.
 
@@ -41,9 +41,9 @@ GraphRAG-ready JSON, and a plain-language GRAPH_REPORT.md.
 
 ## What graphify is for
 
-graphify is built around Andrej Karpathy's /raw folder workflow: drop anything
-into a folder - papers, tweets, screenshots, code, notes - and get a structured
-knowledge graph that shows you what you didn't know was connected.
+graphify is built around Andrej Karpathy's /raw folder workflow. Drop anything
+into a folder: papers, tweets, screenshots, code, notes. You get a structured
+knowledge graph that shows you what you did not know was connected.
 
 Three things it does that Claude alone cannot:
 
@@ -51,13 +51,14 @@ Three things it does that Claude alone cannot:
    and survive across sessions. Ask questions weeks later without re-reading
    everything.
 2. **Honest audit trail** - every edge is tagged EXTRACTED, INFERRED, or
-   AMBIGUOUS. You know what was found vs invented.
+   AMBIGUOUS. You know what was found and what was invented.
 3. **Cross-document surprise** - community detection finds connections between
-   concepts in different files that you would never think to ask about directly.
+   concepts in different files that you never think to ask about directly.
 
 Use it for:
 
-- A codebase you're new to (understand architecture before touching anything)
+- A codebase you are new to (understand the architecture before touching
+  anything)
 - A reading list (papers + tweets + notes → one navigable graph)
 - A research corpus (citation graph + concept graph in one)
 - Your personal /raw folder (drop everything in, let it grow, query it)
@@ -67,8 +68,8 @@ Use it for:
 If no path was given, use `.` (current directory). Do not ask the user for a
 path.
 
-If path argument starts with `https://github.com/` or `http://github.com/`,
-treat it as a GitHub URL — run Step 0 before anything else, then continue with
+If the path argument starts with `https://github.com/` or `http://github.com/`,
+treat it as a GitHub URL. Run Step 0 before anything else. Then continue with
 the resolved local path.
 
 Follow these steps in order. Do not skip steps.

--- a/.windsurf/workflows/grill-me.md
+++ b/.windsurf/workflows/grill-me.md
@@ -6,8 +6,8 @@ description:
 ---
 
 Interview me relentlessly about every aspect of this plan until we reach a
-shared understanding. Walk down each branch of the design tree, resolving
-dependencies between decisions one-by-one. For each question, provide your
+shared understanding. Walk down each branch of the design tree. Resolve the
+dependencies between decisions one by one. For each question, provide your
 recommended answer.
 
 Ask the questions one at a time.

--- a/.windsurf/workflows/harden.md
+++ b/.windsurf/workflows/harden.md
@@ -9,7 +9,7 @@ data and DoS:
 Steps:
 
 - Run `git diff` and `git diff --cached` to identify changed files and functions
-- Read surrounding context in modified files as needed
+- Read the surrounding context in modified files when you need it
 - For each public function or entry point in the diff, check for and fix:
   - **NaN/Inf floats** — clamp or replace with safe defaults (pixelMin
     convention)
@@ -19,7 +19,7 @@ Steps:
   - **Division by zero** — guard before dividing
   - **Integer overflow** — check before arithmetic on user-supplied counts
   - **Excessive allocations** — pre-check sizes before allocating large buffers
-  - **Duplicate or degenerate data** — handle gracefully, no infinite loops
+  - **Duplicate or degenerate data** — handle it without infinite loops
 - Apply fixes directly to the source files
-- Run `go build ./...` and `go vet ./...` to verify changes compile
-- Summarize what was hardened and where
+- Run `go build ./...` and `go vet ./...` to check that the changes compile
+- Summarize what you hardened and where

--- a/.windsurf/workflows/release.md
+++ b/.windsurf/workflows/release.md
@@ -8,11 +8,11 @@ Release workflow for the current project. Steps:
 2. Get changes since last tag:
    !`git log $(git describe --tags --abbrev=0)..HEAD --oneline`
 3. Determine next minor version by incrementing the minor number of the last tag
-4. Update CHANGELOG.md with a new entry for the next version, summarizing
+4. Update CHANGELOG.md with a new entry for the next version that summarizes the
    changes
 5. Commit CHANGELOG.md and any staged/modified tracked files with message:
    `changelog: add <version> (<summary>)`
-6. Create annotated tag for the new version
-7. Push commit and tag to origin
+6. Create an annotated tag for the new version
+7. Push the commit and the tag to origin
 
 If $ARGUMENTS is provided, use it as additional context for the changelog entry.

--- a/.windsurf/workflows/review-changes.md
+++ b/.windsurf/workflows/review-changes.md
@@ -8,7 +8,8 @@ Review all uncommitted changes (staged and unstaged) for:
 
 1. **Quality** — bugs, logic errors, missing error handling at boundaries, dead
    code
-2. **Consistency** — naming, patterns, style matching the rest of the codebase
+2. **Consistency** — naming, patterns, and style that match the rest of the
+   codebase
 3. **Security** — injection, unsafe input, resource leaks
 4. **Performance** — unnecessary allocations, O(n²) where O(n) suffices,
    hot-path copies
@@ -16,10 +17,10 @@ Review all uncommitted changes (staged and unstaged) for:
 Steps:
 
 - Run `git diff` and `git diff --cached` to collect all changes
-- Read surrounding context in modified files as needed
+- Read the surrounding context in modified files when you need it
 - Report findings grouped by category (Quality, Consistency, Security,
   Performance)
 - For each finding: file:line, severity (error/warning/nit), one-line
   description
-- If no issues found, say so
+- If no issues exist, say so
 - Do NOT modify any files

--- a/.windsurf/workflows/simplify.md
+++ b/.windsurf/workflows/simplify.md
@@ -10,16 +10,16 @@ codebase to improve maintainability and readability.
 ## When to Use
 
 - When code becomes complex or hard to understand
-- When functions are getting too long
-- When there are nested conditionals that could be simplified
+- When functions become too long
+- When there are nested conditionals that can be simplified
 - When duplicate code patterns emerge
-- When API design could be more intuitive
+- When API design has room to be more intuitive
 
 ## Steps
 
 ### 1. Analyze Current Changes
 
-Focus on simplifying the code you're currently working on:
+Focus on simplifying the code you are currently working on:
 
 ```bash
 # Check what files have uncommitted changes
@@ -100,7 +100,7 @@ button.Padding = ButtonPadding
 
 ### 4. Verify Simplifications
 
-Ensure changes don't break functionality:
+Make sure that the changes do not break existing features:
 
 ```bash
 # Run all tests
@@ -119,10 +119,10 @@ Update any affected documentation or examples.
 
 ## Best Practices
 
-- **One change at a time**: Don't refactor multiple things simultaneously
-- **Preserve behavior**: Simplifications should not change observable behavior
+- **One change at a time**: Do not refactor multiple things simultaneously
+- **Preserve behavior**: Simplifications must not change observable behavior
 - **Add tests**: If simplifying untested code, add tests first
-- **Use descriptive names**: Extracted functions should clearly state their
+- **Use descriptive names**: Extracted functions must clearly state their
   purpose
 - **Keep functions small**: Aim for functions under 30-40 lines
 - **Reduce nesting**: Avoid deeply nested conditionals (>3 levels)
@@ -184,7 +184,7 @@ func buildLabelInputRow() gui.View {
 ## Tools
 
 - **gocyclo**: Cyclomatic complexity analysis
-- **golangci-lint**: Comprehensive linting
+- **golangci-lint**: Full linting
 - **go test**: Test verification
 - **grep**: Pattern searching
 - **git diff**: Review changes before commit

--- a/.windsurf/workflows/test-gaps.md
+++ b/.windsurf/workflows/test-gaps.md
@@ -10,8 +10,9 @@ Steps:
 
 - Run `git diff` and `git diff --cached` to identify changed/added files and
   functions
-- For each changed file, find out corresponding `_test.go` file (if any)
-- Read the changed code and existing tests to understand current coverage
+- For each changed file, find the matching `_test.go` file (if any)
+- Read the changed code and the existing tests to understand the current
+  coverage
 - Report gaps grouped by severity:
 
 **Missing tests** (no test exists):
@@ -36,4 +37,4 @@ For each gap:
 - State the file:function and what is untested
 - Rate as **high** (crash/panic risk), **medium** (silent wrong result), or
   **low** (cosmetic)
-- Suggest a one-line test name (e.g., `TestExportSVG_EmptySeriesNoPanic`)
+- Suggest a one-line test name (for example, `TestExportSVG_EmptySeriesNoPanic`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,10 @@ View fn → generateViewLayout() → Layout tree
 
 ### Packages
 
-**Keep flat: only leaf subsystems (svg/, datagrid/, markdown/, backend/, etc.)
-in subpackages.** `gui/` itself holds the core: widget factories, layout engine,
-theme, animation, event dispatch, state mgmt. No test backend package; tests run
-with nil injected interfaces.
+**Keep flat: only leaf subsystems (svg/, datagrid/, markdown/, backend/, and
+more) in subpackages.** `gui/` itself holds the core: widget factories, layout
+engine, theme, animation, event dispatch, state mgmt. No test backend package;
+tests run with nil injected interfaces.
 
 ### Core Types
 
@@ -152,7 +152,7 @@ background in `docs/specs/widget-visual-consistency-audit.md`.
 - **`TextStyle.disabledRole`** marks a style that already expresses the disabled
   state so `renderText` skips `dimAlpha`. Set only by `themeTextRoles`; never at
   a call site — `layoutDisables` stamps `Disabled` onto _every descendant_ of a
-  disabled shape and would halve a color the theme already quieted.
+  disabled shape and halves a color the theme already quieted.
 - **A form control's text inset** is `Theme.PaddingField`, so controls in one
   row share a height. Not the Small/Medium/Large ladder: those size the gap
   between things, this sizes a control.
@@ -202,8 +202,8 @@ Backend injects at startup. Nil in tests:
 - **Theme reads split by phase, not by reachability. Code running _outside_
   generation with a `*Window` in hand calls `w.Theme()`; factories and
   `GenerateLayout` keep the bare `guiTheme` / `default*Style` read** — `Themed`
-  scopes by push/pop of the _installed_ theme, so `w.Theme()` there would ignore
-  the scope. `ergonomics-audit` mode `theme` gates the post-generation paths
+  scopes by push/pop of the _installed_ theme, so `w.Theme()` there ignores the
+  scope. `ergonomics-audit` mode `theme` gates the post-generation paths
   (`gui/backend/**`, `gui/scroll*.go`, `gui/event*.go`, `gui/native_*.go`,
   `gui/window_*.go`); mark a deliberate exception
   `ergonomics-audit:theme-global`.
@@ -223,7 +223,7 @@ Backend injects at startup. Nil in tests:
   (`FloatAnchor`/`FloatTieOff`/`FloatOffsetX`/`FloatOffsetY`) to position
   elements with children.
 - **`AmendLayout` runs under the frame lock (`w.mu`), so no callback reached
-  from it may call a window-mutating API.** `SetFocus`, `ClearFocus`,
+  from it can call a window-mutating API.** `SetFocus`, `ClearFocus`,
   `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take `w.mu`, which
   is not reentrant; they panic naming themselves. The remedy is
   `ctx.Window.QueueCommand`. Library code reaching app code from the pass raises
@@ -280,7 +280,7 @@ Assertable forms for tests, which return findings as data:
   hook auto-runs lint-fix + tests on every .go edit.
 - **Minimal scoped diffs.** Touch only what the request needs. No cosmetic
   comment/formatting churn, no drive-by edits. Rename/regex passes must not
-  alter comment prose (e.g. apostrophes in possessives).
+  alter comment prose (for example, apostrophes in possessives).
 
 ## Verification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ When only the fast gate checks are wanted, `make check` (vet, deps-doc,
 large-files, generate-check, tidy-check) is the quick subset. The tracked
 `.githooks/pre-push` hook runs `make check-all` (test + lint + check) on every
 push — enable it with `git config core.hooksPath .githooks`. Tools like
-golangci-lint and gosec must be installed; `make lint` pins the golangci-lint
+golangci-lint and gosec must be installed. `make lint` pins the golangci-lint
 version.
 
 For a tight edit → rebuild → relaunch loop while iterating on an example app,
@@ -27,11 +27,11 @@ see [docs/dev-loop.md](docs/dev-loop.md)
 (`./scripts/dev-loop.sh ./examples/get_started/`).
 
 Build artifacts never land in the repo root: `make build-examples` writes each
-example to `examples/bin/`, `make build-macos`/`build-windows`/etc. write to
-`build/`, and `scripts/dev-loop.sh` writes to `build/dev-loop/`. A bare
-`go build ./examples/<name>/` or `go build ./tools/<name>/` drops a binary in
-the repo root, so always pass `-o` with an explicit output path (e.g.
-`-o build/<name>`).
+example to `examples/bin/`. `make build-macos`, `make build-windows`, and the
+other build targets write to `build/`. `scripts/dev-loop.sh` writes to
+`build/dev-loop/`. A bare `go build ./examples/<name>/` or
+`go build ./tools/<name>/` drops a binary in the repo root, so always pass `-o`
+with an explicit output path (for example, `-o build/<name>`).
 
 `go vet` does not run the `requiredid` analyzer — it is a standalone
 framework-owned analyzer. CI runs it on every push, and `make vet` includes it.
@@ -58,14 +58,14 @@ CI also enforces race detector and benchmark regression gates. Run
 These CI checks have no local Makefile equivalent — they either need a different
 OS runner or a baseline from `main` that only CI can supply:
 
-- OS-matrix test runs (Windows, macOS runners; Windows also runs the showcase
-  smoke test with Mesa's software GL)
+- OS-matrix test runs on Windows and macOS runners. Windows also runs the
+  showcase smoke test with Mesa's software GL
 - Coverage diff on PRs and the benchmark regression gate — both compare against
   a baseline cached from `main` (`scripts/cov-diff.sh` can run them locally if
   you supply two profiles)
-- WASM build/vet/test (`GOOS=js` needs a node `wasm_exec` wrapper);
+- WASM build/vet/test (`GOOS=js` needs a node `wasm_exec` wrapper).
   `make build-wasm` covers the build half
-- iOS and Android vet+lint — need an Xcode iphoneos sysroot / Android NDK;
+- iOS and Android vet+lint — need an Xcode iphoneos sysroot / Android NDK.
   `make build-ios` and `make build-android` cover the build half
 - Release packaging (`release.yml`)
 
@@ -94,7 +94,7 @@ go mod edit -replace=github.com/go-gui-org/go-glyph=../go-glyph
 
 Code must pass `golangci-lint run ./...` and `gofmt`. No variable shadowing.
 
-Markdown must pass Prettier. Run `make fmt-md` before committing; `make check`
+Markdown must pass Prettier. Run `make fmt-md` before committing. `make check`
 runs `make fmt-md-check` and fails on drift. The wrap width lives in
 `.prettierrc`, so no flags are needed at the call site.
 
@@ -103,7 +103,7 @@ generation — event handlers, post-arrange work, backends — and has a `*Windo
 in hand calls `w.Theme()`. The bare `guiTheme` / `default*Style` read is for
 widget factories and `GenerateLayout`, which have no window at hand and where
 the bare read is also what makes `gui.Themed` subtree scoping work.
-`make ergonomics-audit` (mode `theme`) gates the post-generation paths; see
+`make ergonomics-audit` (mode `theme`) gates the post-generation paths. See
 [docs/specs/per-window-theme.md](docs/specs/per-window-theme.md).
 
 ## Submitting Changes
@@ -122,7 +122,7 @@ the bare read is also what makes `gui.Themed` subtree scoping work.
 
 ## Adding Examples
 
-Example apps live in `examples/`. Each example should be a self-contained `main`
+Example apps live in `examples/`. Each example is a self-contained `main`
 package that demonstrates a specific feature or pattern.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ func mainView(w *gui.Window) gui.View {
 
 `gui.Label(text, style)` — pass the zero `TextStyle{}` for the default theme
 style. `gui.TextButton(id, label, onClick)` and `gui.SimpleWindow` are the same
-thin forwards; the `ID` argument stays explicit because identity is
+thin forwards. The `ID` argument stays explicit because identity is
 caller-owned.
 
 ### Full control
@@ -119,19 +119,19 @@ Sibling projects:
   Embeddable terminal emulator. https://github.com/go-gui-org/go-term
 
 - **go-glyph**\
-  Text rendering engine on steroids. https://github.com/go-gui-org/go-glyph
+  Text rendering engine. https://github.com/go-gui-org/go-glyph
 
 ## Why
 
 GUI frameworks in Go target the browser and tie you to HTML/CSS and JavaScript.
 go-gui takes the opposite approach: write your UI in pure Go, render it with
 native GPU acceleration — no browser runtime, no JavaScript bridge, no DOM. Your
-data stays in Go structs; your UI stays in Go code.
+data stays in Go structs. Your UI stays in Go code.
 
-The second thesis: a GUI toolkit should be an **ecosystem of composable
-libraries**, not a monolith. go-glyph handles text. go-charts handles data.
-go-edit handles code. Each library is usable on its own or together — all
-sharing the same rendering pipeline and event system.
+The second thesis: a GUI toolkit is an **ecosystem of composable libraries**,
+not a monolith. go-glyph handles text. go-charts handles data. go-edit handles
+code. Each library is usable on its own or together — all sharing the same
+rendering pipeline and event system.
 
 ## Features
 
@@ -139,7 +139,7 @@ sharing the same rendering pipeline and event system.
   dialogs, toasts, DataGrid with virtualization (CSV/XLSX/PDF export), Markdown
   and RTF views, SVG rendering, and more
 - **Virtualized lists, uniform or not** — `ListBox`, `Table` and `Tree`
-  virtualize rows they own; `VirtualList` handles rows the app builds, of
+  virtualize rows they own. `VirtualList` handles rows the app builds, of
   heights only the layout engine knows, and `Window.ScrollToIndex` addresses a
   row that does not exist yet
 - **GPU-accelerated** — Metal (macOS), OpenGL (Linux/Windows), WebGL/WASM
@@ -149,7 +149,7 @@ sharing the same rendering pipeline and event system.
 - **Touch gesture recognition** — tap, double-tap, long-press, pan, swipe,
   pinch, rotate with automatic mouse-event synthesis
 - **Time-travel debugging** — opt-in scrubber rewinds/replays app state
-  frame-by-frame; implement `Snapshotter` on your state type and set
+  frame-by-frame. Implement `Snapshotter` on your state type and set
   `DebugTimeTravel: true`
 - **Headless testing** — all layout and widget logic runs without a display
 - **Headless rendering** — `gui/backend/soft` rasterizes a frame to a PNG on the

--- a/cmd/buildapp/README.md
+++ b/cmd/buildapp/README.md
@@ -1,8 +1,8 @@
 # buildapp
 
-Wraps a compiled go-gui binary into a macOS `.app` bundle so it can be
-double-clicked, dragged to `/Applications`, and shown in the Dock with a proper
-name and icon.
+Wraps a compiled go-gui binary into a macOS `.app` bundle. You can then
+double-click the bundle, drag it to `/Applications`, and display it in the Dock
+with a proper name and icon.
 
 ## Install
 
@@ -32,13 +32,13 @@ Positional arg: path to a compiled Mach-O executable.
 | `-icon`        | none                           | `.png` (auto-converted) or `.icns`                  |
 | `-version`     | `1.0`                          | `CFBundleVersion` / short version                   |
 | `-bundle-deps` | `false`                        | Bundle non-system dylibs into `Contents/Frameworks` |
-| `-sign`        | `$BUILDAPP_SIGN_IDENTITY`, `-` | `codesign` identity; `-` is ad-hoc                  |
+| `-sign`        | `$BUILDAPP_SIGN_IDENTITY`, `-` | `codesign` identity. `-` is ad-hoc                  |
 
 ### Signing
 
 `buildapp` always signs the bundle. An unsigned bundle makes Gatekeeper report
-the app as "damaged", even when every binary inside is individually signed, and
-an unsigned Mach-O does not load at all on Apple Silicon.
+the app as "damaged", even when every binary inside is individually signed. An
+unsigned Mach-O does not load at all on Apple Silicon.
 
 The default identity is `-`, which is **ad-hoc**: no certificate, no team
 identifier.
@@ -52,15 +52,14 @@ CDHash=6ec1c5c95e15276640294221cfd868ab6e073487
 An ad-hoc signature gives TCC (the macOS privacy database) no designated
 requirement to key a grant against, so TCC falls back to the **cdhash**. Every
 rebuild produces a new cdhash, so **every rebuild silently revokes every
-TCC-gated permission the app holds** — screen recording, microphone, camera,
-accessibility, input monitoring, full disk access.
+TCC-gated permission the app holds**. The permissions are screen recording,
+microphone, camera, accessibility, input monitoring, and full disk access.
 
-The failure is actively misleading: the System Settings row survives, because
-that list is keyed by bundle id for display, while the authorization check is
-keyed by cdhash. The permission looks granted and the API returns denied, with
-nothing in any log connecting the two. Recovery is
-`tccutil reset <service> <bundle-id>`, a relaunch, and a re-grant — after every
-build.
+The failure is actively misleading. The System Settings row survives, because
+that list is keyed by bundle id for display. The authorization check is keyed by
+cdhash. The permission looks granted and the API returns denied, with nothing in
+any log connecting the two. Recovery is `tccutil reset <service> <bundle-id>`, a
+relaunch, and a re-grant — after every build.
 
 Pass a stable identity to key the grant on the certificate instead of the hash:
 
@@ -75,9 +74,9 @@ set -Ux BUILDAPP_SIGN_IDENTITY "My Dev Cert"
 ```
 
 `-sign` wins over the environment variable. A **self-signed** code-signing
-certificate is enough; no Apple Developer account is needed. Create one in
+certificate is enough. No Apple Developer account is needed. Create one in
 Keychain Access → Certificate Assistant → Create a Certificate, with type "Code
-Signing", then confirm it is visible to `codesign`:
+Signing". Then verify that it is visible to `codesign`:
 
 ```
 security find-identity -v -p codesigning
@@ -89,39 +88,40 @@ Verify what a bundle actually carries:
 codesign -dv --verbose=4 Foo.app
 ```
 
-Ad-hoc prints `Signature=adhoc`; a real identity prints an `Authority=` line. To
-confirm the TCC fix end to end, grant the app a permission, rebuild, and check
-the permission still works without a re-grant.
+Ad-hoc prints `Signature=adhoc`. A real identity prints an `Authority=` line. To
+verify the TCC fix end to end, grant the app a permission and rebuild. Then
+verify that the permission still works without a re-grant.
 
-This was verified on macOS 26 with a self-signed certificate: Falcon
+Verified on macOS 26 with a self-signed certificate. Falcon
 (`github.com.go-gui-org.go-term`) kept its Screen Recording grant across a
-rebuild that moved the cdhash from `573a437d…` to `bfa13ddf…`, with
-`TeamIdentifier=not set` throughout. A certificate is enough; an Apple-issued
+rebuild that moved the cdhash from `573a437d…` to `bfa13ddf…`. It had
+`TeamIdentifier=not set` throughout. A certificate is enough. An Apple-issued
 one is not required.
 
 Release builds in CI have no certificate and stay ad-hoc. That is fine — freshly
 downloaded apps have no grants to lose.
 
 The bundle-level signature uses `codesign --force --deep`. Apple deprecates
-`--deep` for distribution signing; it is kept here because the bundle carries no
-entitlements and no nested code beyond `Contents/Frameworks` (already signed
-inside-out by `-bundle-deps`), so re-signing those with the same identity costs
+`--deep` for distribution signing. buildapp keeps it because the bundle carries
+no entitlements and no nested code beyond `Contents/Frameworks` (already signed
+inside-out by `-bundle-deps`). Re-signing those with the same identity costs
 nothing. Entitlements and hardened runtime are not supported — run `codesign`
 and `notarytool` separately for distribution.
 
 ### `-bundle-deps`
 
-When set, `buildapp` walks the binary's `LC_LOAD_DYLIB` entries via `otool -L`,
-copies every non-system dylib (anything outside `/usr/lib`, `/System/Library`,
-`/Library/Apple`) into `Contents/Frameworks/`, then uses `install_name_tool` to:
+When set, `buildapp` walks the binary's `LC_LOAD_DYLIB` entries via `otool -L`.
+It copies every non-system dylib (anything outside `/usr/lib`,
+`/System/Library`, `/Library/Apple`) into `Contents/Frameworks/`. Then it uses
+`install_name_tool` to:
 
 - rewrite each bundled dylib's own id to `@rpath/<basename>`
 - rewrite every reference in the executable and in bundled dylibs to
   `@rpath/<basename>`
 - add `@executable_path/../Frameworks` as an rpath on the executable
 
-Transitive dependencies are followed. `install_name_tool` invalidates each
-signature it touches, so every modified Mach-O file is re-signed with the
+It follows transitive dependencies. `install_name_tool` invalidates each
+signature it touches, so buildapp re-signs every modified Mach-O file with the
 `-sign` identity (required on Apple Silicon). Requires `otool`,
 `install_name_tool`, and `codesign` (Xcode Command Line Tools).
 
@@ -133,15 +133,15 @@ find Foo.app -type f -perm +111 -exec otool -L {} \; | grep -E '/opt/homebrew|/u
 
 Empty output means no host paths leaked into the bundle.
 
-`.png` icons are converted to `.icns` via `sips` and `iconutil` (both ship with
-macOS). Intermediate iconset files live in the system temp directory and are
-removed on exit.
+buildapp converts `.png` icons to `.icns` via `sips` and `iconutil` (both ship
+with macOS). Intermediate iconset files live in the system temp directory, and
+the tool removes them on exit.
 
 ## Example
 
 ```
 go build -o /tmp/getstarted ./examples/get_started
-buildapp -o /tmp -name GetStarted -icon assets/icon.png /tmp/getstarted
+buildapp -o /tmp -name GetStarted -icon gui/default_icon.png /tmp/getstarted
 open /tmp/GetStarted.app
 ```
 
@@ -158,8 +158,8 @@ GetStarted.app/
 ## Notes
 
 - macOS only.
-- Existing `.app` at the destination is overwritten without prompting.
-- The bundle is always signed — ad-hoc by default, see [Signing](#signing).
-  Notarization is not performed; run `notarytool` separately for distribution.
-- Shared libraries are bundled only with `-bundle-deps`. Without it the target
+- The tool overwrites an existing `.app` at the destination without prompting.
+- The bundle is always signed — ad-hoc by default, see [Signing](#signing). It
+  does not perform notarization. Run `notarytool` separately for distribution.
+- Shared libraries are bundled only with `-bundle-deps`. Without it, the target
   machine must have them installed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,8 @@
 
 ## High-Level Pipeline
 
-Immediate-mode GUI — no virtual DOM, no diffing. Each frame rebuilds the entire
-UI from the view function.
+This is an immediate-mode GUI. There is no virtual DOM and no diffing. Each
+frame rebuilds the entire UI from the view function.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -213,49 +213,49 @@ policy from code that drifts.
 - Every frame runs on the one main OS thread, in order: `generateViewLayout`
   (builds the Layout tree) → `layoutArrange` (sizing, ID resolution, float
   extraction) → `renderLayout` (emits into `w.renderers`) → backend
-  `renderersDraw` (drains read-only). All `*Window` access is main-thread-only;
-  backends wake the loop from other threads via `SetWakeMainFn`.
+  `renderersDraw` (drains read-only). All `*Window` access is main-thread-only.
+  Backends wake the loop from other threads via `SetWakeMainFn`.
 - Frame-scoped objects come from the `w.scratch` pools (`allocShape`,
   `allocEventHandlers`, `allocEffects`, layer slices). Pointers are valid only
   until the next frame's pool reset — never store them in window/app state.
-- **Where to change:** `gui/window_update.go` owns the frame pass; keep new
-  pipeline work inside `FrameFn` on the main thread, allocating from scratch
+- **Where to change:** `gui/window_update.go` owns the frame pass. Keep new
+  pipeline work inside `FrameFn` on the main thread. Allocate from the scratch
   pools.
-- **Catches:** `make test-race`; `make bench-gate` treats alloc counts as hard
-  gates; `(*Window).FrameCount()` distinguishes one frame from re-entrancy.
+- **Catches:** `make test-race` runs. `make bench-gate` treats alloc counts as
+  hard gates. `(*Window).FrameCount()` distinguishes one frame from re-entrancy.
 
 ### Event consumption (the one-event rule)
 
 - Nothing is marked handled for you. A callback that acts on an event calls
-  `ctx.Consume()`; one that does not lets the event travel to ancestors. There
-  is no `ctx.Bubble()` — declining is silence. Applies to every callback,
+  `ctx.Consume()`. One that does not lets the event travel to ancestors. There
+  is no `ctx.Bubble()` — declining is silence. It applies to every callback,
   `OnClick`/`OnChar` no differently from `OnKeyDown`/`OnHover`.
-- `ctx.Event` is nil in `AmendLayout` and `OnScroll`; both `EventCtx` methods
+- `ctx.Event` is nil in `AmendLayout` and `OnScroll`. Both `EventCtx` methods
   are nil-safe.
-- **Where to change:** any callback. Consuming for an effect, silence for a
-  pass-through — never pre-mark events handled.
+- **Where to change:** any callback. Consume for an effect. Keep silence for a
+  pass-through. Never pre-mark events handled.
 - **Catches:** `gui.Debug(true)` (category `DebugUnconsumed`) reports handlers
-  that act without consuming while an ancestor also handles;
-  `(*Window).TestUnconsumedEvents` sweeps a whole window;
+  that act without consuming while an ancestor also handles.
+  `(*Window).TestUnconsumedEvents` sweeps a whole window.
   `make ergonomics-audit` mode `callbacks` inventories signatures. Policy:
   `docs/specs/eventctx-callback-refactor.md`.
 
 ### ID scoping
 
 - `Shape.ID` is a leaf. `resolveShapeIDs` (run from `layoutArrange`) stamps
-  `Shape.effID` = the leaf joined to its ID-bearing ancestors, and every
-  ID-keyed store and lookup uses `shape.idKey()` — never bare `Shape.ID` at a
-  keying site. Effective IDs must be unique per window; a leaf containing `:` is
-  absolute and is not joined again.
-- Compose inner IDs with `gui.ScopeID`/`gui.ScopeIDN`, never by hand (a part —
-  row key, heading slug — must not contain `:`; rebuilding an ID at a lookup
-  site is how producers and consumers drift). A composite widget's inner shape
+  `Shape.effID` = the leaf joined to its ID-bearing ancestors. Every ID-keyed
+  store and lookup uses `shape.idKey()`, never bare `Shape.ID` at a keying site.
+  Effective IDs must be unique per window. A leaf containing `:` is absolute and
+  is not joined again.
+- Compose inner IDs with `gui.ScopeID`/`gui.ScopeIDN`, never by hand. A part
+  (row key, heading slug) must not contain `:`. Rebuilding an ID at a lookup
+  site is how producers and consumers drift. A composite widget's inner shape
   that needs the owner's focus state sets `Shape.focusOwner` (a reference)
   instead of repeating its ID.
-- **Where to change:** factories building IDs, any new ID-keyed store.
-- **Catches:** `(*Window).TestDuplicateIDs`; `gui.Debug` (category
-  `DebugDuplicates`); `make ergonomics-audit` mode `ids` fails hand-rolled
-  composition. Specs: `docs/specs/widget-id-scoping.md`,
+- **Where to change:** factories that build IDs, any new ID-keyed store.
+- **Catches:** `(*Window).TestDuplicateIDs` asserts a clean window. `gui.Debug`
+  (category `DebugDuplicates`) reports duplicates. `make ergonomics-audit` mode
+  `ids` fails hand-rolled composition. Specs: `docs/specs/widget-id-scoping.md`,
   `docs/specs/widget-id-per-scope-uniqueness.md`.
 
 ### Render command ownership
@@ -264,24 +264,23 @@ policy from code that drifts.
   consume it read-only via `(*Window).Renderers()` during `renderersDraw` and
   must not retain or mutate commands across frames.
 - Bracket kinds (`RenderClip`, `RenderStencilBegin/End`,
-  `RenderFilterBegin/End`, `RenderRotateBegin/End`) must stay balanced; clip
+  `RenderFilterBegin/End`, `RenderRotateBegin/End`) must stay balanced. Clip
   commands take effect immediately for subsequent commands in the stream.
-- **Where to change:** `gui/render_layout.go` to emit; `gui/backend/*/draw.go`
-  to consume. Adding a `RenderKind` touches the dispatch switch in every
-  backend.
+- **Where to change:** `gui/render_layout.go` emits. `gui/backend/*/draw.go`
+  consumes. Adding a `RenderKind` touches the dispatch switch in every backend.
 - **Catches:** `gui/render_layout_test.go`, `gui/backend/*/render*_test.go`
   (draw-order and bracket-balance coverage).
 
 ### Backend locking & threading
 
-- Backends call into gui only on the main OS thread; they lock only their own
-  state (e.g. the GL backend's own `w.Lock()` in `gui/backend/gl/backend.go`),
-  never window state.
+- Backends call into gui only on the main OS thread. They lock only their own
+  state (for example, the GL backend's own `w.Lock()` in
+  `gui/backend/gl/backend.go`), never window state.
 - Platform dispatch is by build tag per the Backend Layer diagram above. macOS
-  stays CGo by decision; `CGO_ENABLED=0 go build ./...` is green on Linux and
-  Windows — do not re-open the CGo question without a trigger.
+  stays CGo by decision. `CGO_ENABLED=0 go build ./...` is green on Linux and
+  Windows. Do not re-open the CGo question without a trigger.
 - **Where to change:** new backends must follow the injected-interface pattern
-  (below) and the build-tag table; keep `gui/` free of platform imports.
+  (below) and the build-tag table. Keep `gui/` free of platform imports.
 - **Catches:** `make cross-compile`, `make lint-cross`, `make test` (runs the GL
   backend with `CGO_ENABLED=0`). Direction:
   `docs/specs/cgo-free-backend-feasibility.md`,
@@ -293,19 +292,19 @@ policy from code that drifts.
   window holds a different type. Widget internal state lives in the per-window
   `StateMap`, keyed by namespace consts (`nsOverflow`, `nsInput`, ...). No
   globals, no closures for state.
-- Theme is window-owned; `guiTheme` and the `default*Style` package vars are a
-  frame-scoped cache, never app state — `installTheme` refills them per theme
-  change and they have no initializers (the mirrors would drift). The two
-  exceptions are `DefaultTextStyle` and `defaultInspectorStyle`, which are
-  `ThemeMaker` inputs. Key on `Theme.id`, never `Theme.Name`.
-- Theme reads split by phase: outside generation call `w.Theme()`; factories and
-  `GenerateLayout` keep the bare `guiTheme`/`default*Style` read (required for
-  `Themed` subtree scoping). Mark deliberate exceptions
+- Theme is window-owned. `guiTheme` and the `default*Style` package vars are a
+  frame-scoped cache, never app state. `installTheme` refills them per theme
+  change, and they have no initializers. An initializer makes the mirrors drift.
+  The two exceptions are `DefaultTextStyle` and `defaultInspectorStyle`, which
+  are `ThemeMaker` inputs. Key on `Theme.id`, never `Theme.Name`.
+- Theme reads split by phase. Outside generation, call `w.Theme()`. Factories
+  and `GenerateLayout` keep the bare `guiTheme`/`default*Style` read (required
+  for `Themed` subtree scoping). Mark deliberate exceptions
   `ergonomics-audit:theme-global`.
-- **Where to change:** adding widget state → new namespace const + `StateMap`;
-  adding a default style → `ThemeMaker` only.
-- **Catches:** `TestDefaultStylesMirrorThemeDark`; `make ergonomics-audit` mode
-  `theme` gates the post-generation paths. Specs:
+- **Where to change:** to add widget state, use a new namespace const and a
+  `StateMap`. To add a default style, change `ThemeMaker` only.
+- **Catches:** `TestDefaultStylesMirrorThemeDark` runs. `make ergonomics-audit`
+  mode `theme` gates the post-generation paths. Specs:
   `docs/specs/per-window-theme.md`, `docs/specs/theme-style-single-source.md`.
 
 ### Native platform boundaries
@@ -313,41 +312,42 @@ policy from code that drifts.
 - Backends inject `TextMeasurer` (glyph metrics), `SvgParser`, and
   `NativePlatform` (dialogs, notifications, print, a11y, IME, titlebar) at
   startup. All are nil in tests — test code must never require a backend.
-- `gui/` never imports backend packages; `NativePlatform` is the only seam to
+- `gui/` never imports backend packages. `NativePlatform` is the only seam to
   platform services.
 - **Where to change:** a new platform capability is a new `NativePlatform`
   method implemented per backend, not a direct call from `gui/`.
-- **Catches:** `make test` runs with nil injected interfaces; `make vet` (incl.
+- **Catches:** `make test` runs with nil injected interfaces. `make vet` (incl.
   the `requiredid` analyzer) flags structural mistakes.
 
 ### Widget Cfg invariants
 
-- **Focusable defaults:** the 15 input Cfgs (`Button`, `ColorPicker`,
-  `Combobox`, `DatePicker`, `Input`, `InputDate`, `ListBox`, `NumericInput`,
-  `RadioButtonGroup`, `Radio`, `Select`, `Slider`, `Switch`, `Toggle`, `Tree`)
-  are focusable by default; opt out with `FocusDisabled`, never
-  `Focusable: false`. `Focusable` without a non-empty `ID` is a silent no-op —
-  the widget renders and clicks but never joins the tab order. Spec:
+- **Focusable defaults:** 20 Cfgs are focusable by default. They are `Button`,
+  `ColorChannelSlider`, `ColorPicker`, `ColorPlane`, `ColorWheel`, `Combobox`,
+  `DatePicker`, `ExpandPanel`, `Input`, `InputDate`, `ListBox`, `NumericInput`,
+  `RadioButtonGroup`, `Radio`, `Select`, `Slider`, `Switch`, `Toggle`, `Tree`,
+  `VirtualList`. Opt out with `FocusDisabled`, never `Focusable: false`.
+  `Focusable` without a non-empty `ID` is a silent no-op — the widget renders
+  and clicks but never joins the tab order. Spec:
   `docs/specs/focusable-default-input.md`.
-- **A11y fields:** `A11YLabel`/`A11YDescription` live on the embedded `A11YCfg`;
-  never redeclare them on a Cfg. Construction names the embed:
+- **A11y fields:** `A11YLabel`/`A11YDescription` live on the embedded `A11YCfg`.
+  Never redeclare them on a Cfg. Construction names the embed:
   `gui.ButtonCfg{ID: "save", A11YCfg: gui.A11YCfg{A11YLabel: "Save"}}`.
 - **`Opt[T]` vs plain fields:** only primitives get `Opt` (when zero is a
-  legitimate user choice that must be distinguishable from unset, e.g.
+  legitimate user choice that must be distinguishable from unset, for example
   `SizeBorder`). Owned types self-flag instead: `Color`, `Padding`, and `Sizing`
   carry a `set` field, so they are plain fields with `IsSet()`/`Or()`. Build
   them with constructors — `RGBA`/`RGB`/`Hex`, `NewPadding`/`PadAll`, the
   predefined `Sizing` vars — never raw `Color{...}`/`Padding{...}`/`Sizing{...}`
   literals (they read as unset).
 - **Where to change:** any widget factory or Cfg struct.
-- **Catches:** `make vet` (`requiredid`), `make ergonomics-audit` modes `focus`,
-  `a11y`, `opt`, and `literals`; `gui.Debug` reports focusable shapes with no ID
-  at runtime.
+- **Catches:** `make vet` (`requiredid`) and `make ergonomics-audit` modes
+  `focus`, `a11y`, `opt`, and `literals`. `gui.Debug` reports focusable shapes
+  with no ID at runtime.
 
 ### Generated-file expectations
 
-- `gui/svg_spinner_kinds_gen.go` is produced by `go generate ./...`
-  (`gui/internal/gen/spinnerkinds/`). Commit generated output; never hand-edit
+- `go generate ./...` produces `gui/svg_spinner_kinds_gen.go` (from
+  `gui/internal/gen/spinnerkinds/`). Commit generated output. Never hand-edit
   it. Any change to the generator must be committed with its regenerated output,
   or `make generate-check` fails the push.
 - **Where to change:** `gui/internal/gen/`, then run `go generate ./...`.
@@ -374,8 +374,8 @@ policy from code that drifts.
 - **WebGPU**: Explored on the `webgpu-backend` branch (deleted) — 12 WGSL shader
   pipelines, device init, and render loop were working. Superseded: the native
   GL backend already runs cgo-free on Linux and Windows (X11 via xgb, EGL via
-  purego). WebGPU would add 10–40 MB of runtime shared libraries and still leave
-  macOS — the only real CGo backend — untouched. Full assessment:
+  purego). If adopted, WebGPU adds 10–40 MB of runtime shared libraries and
+  still leaves macOS — the only real CGo backend — untouched. Full assessment:
   `docs/specs/cgo-free-backend-feasibility.md`.
 - **Native GL on desktop**: The native GL backend is the default renderer on
   Linux and Windows. It provides direct platform windowing (X11 on Linux, Win32

--- a/docs/cookbook-add-widget.md
+++ b/docs/cookbook-add-widget.md
@@ -1,36 +1,36 @@
 # Adding a new widget
 
-Step-by-step guide for adding a widget to the `gui` package. Uses `Toggle` as
-the running example — a checkbox-style widget with focus, keyboard handling,
-accessibility, and theme defaults.
+Step-by-step guide for adding a widget to the `gui` package. It uses `Toggle` as
+the running example. `Toggle` is a checkbox-style widget with focus, keyboard
+handling, accessibility, and theme defaults.
 
 ## 1. Create the Cfg struct
 
 Every widget has a `*Cfg` struct. Conventions:
 
 - **Zero-initializable** — all fields have usable zero values. Users omit what
-  they don't need: `ToggleCfg{Label: "Accept"}`
+  they do not need: `ToggleCfg{Label: "Accept"}`
 - **Opt[T] for optional overrides** — `Opt[float32]` distinguishes "not set"
-  from an explicit zero for primitives. Owned structs self-flag instead:
-  `Padding` and `Color` carry a `set` field, so they are plain fields —
-  `Padding{}` is unset (theme default applies), build values with
-  `NewPadding`/`PadAll`/`PaddingNone`. Read with `cfg.Radius.Get(default)` /
-  `cfg.Padding.Or(default)` in the factory.
-- **Common fields** — every interactive widget includes: `ID string`,
-  `Disabled bool`, `Invisible bool`, and a focus field: either `Focusable bool`
-  (opt-in, e.g. Button) or `FocusDisabled bool` (opt-out, for controls focusable
-  by default, e.g. Input, Toggle, Slider, Select). Focus always requires a
-  non-empty `ID` — without one the control never joins the tab order.
-  Container-like widgets add `Sizing Sizing`, `Float bool`,
-  `FloatAnchor FloatAttach`, `FloatTieOff FloatAttach`, `Padding Padding`,
-  `Radius Opt[float32]`, `SizeBorder Opt[float32]`.
+  from an explicit zero for primitives. Owned structs self-flag instead.
+  `Padding` and `Color` carry a `set` field, so they are plain fields.
+  `Padding{}` is unset (theme default applies). Build values with
+  `NewPadding`/`PadAll`/`PaddingNone`. Read them with `cfg.Radius.Get(default)`
+  / `cfg.Padding.Or(default)` in the factory.
+- **Common fields** — every interactive widget includes `ID string`,
+  `Disabled bool`, `Invisible bool`, and a focus field. The focus field is
+  either `Focusable bool` (opt-in, for example Table) or `FocusDisabled bool`
+  (opt-out, for controls focusable by default, for example Input, Toggle,
+  Slider, Select). Focus always requires a non-empty `ID`. Without one, the
+  control never joins the tab order. Container-like widgets add `Sizing Sizing`,
+  `Float bool`, `FloatAnchor FloatAttach`, `FloatTieOff FloatAttach`,
+  `Padding Padding`, `Radius Opt[float32]`, `SizeBorder Opt[float32]`.
 - **Callbacks** — one func field per event. Sig: `func(EventCtx)`. One rule for
-  all of them: call `ctx.Consume()` on any path that acts on the event, and
-  nothing on any path that means "not mine". Nothing is marked handled for you,
-  so a widget that means to absorb a click has to say so.
+  all of them: call `ctx.Consume()` on any path that acts on the event. On any
+  path that means "not mine", call nothing. Nothing is marked handled for you. A
+  widget that means to absorb a click must say so.
 - **`gui:"required"` tag** — fields that must be non-empty get the tag. The
-  `requiredid` vet analyzer enforces this at `go vet` time. Only use when the
-  widget cannot function without the value (e.g. `FormCfg.ID`).
+  `requiredid` vet analyzer enforces this at `go vet` time. Use the tag only
+  when the widget cannot function without the value (for example `FormCfg.ID`).
 
 Minimal example:
 
@@ -75,8 +75,8 @@ type ToggleCfg struct {
 
 Sig: `func WidgetName(cfg WidgetCfg) View`. The function:
 
-1. **Calls applyDefaults** — fills in theme colors, sizes, text styles for any
-   field the user didn't set
+1. **Calls applyDefaults** — provides theme colors, sizes, and text styles for
+   any field the user did not set
 2. **Reads Opt[T] values** via `.Get(fallback)` to resolve "not set"
 3. **Builds a Layout tree** — returns a `ContainerCfg`-based layout (usually
    `Row`, `Column`, or `Canvas`)
@@ -178,7 +178,7 @@ ClickOnSpace: true,
 ```
 
 **Hover/focus feedback** — use `OnHover` for mouse hover, `AmendLayout` for
-keyboard focus. `AmendLayout` runs every frame after sizing — use it to update
+keyboard focus. `AmendLayout` runs every frame after sizing. Use it to update
 child colors based on `w.IsFocus(layout.Shape.ID)`.
 
 **Inner IDs** — a composite widget's inner shapes need their own IDs. Compose
@@ -186,15 +186,14 @@ them with `gui.ScopeID(cfg.ID, "part")`, or `gui.ScopeIDN(cfg.ID, "row", i)`
 when a loop index is what distinguishes siblings. Never concatenate by hand:
 `make ergonomics-audit` fails on it, and the separator zoo it replaced is
 documented in `docs/specs/widget-id-scoping.md`. If an inner shape only needs
-the owner's focus state rather than its own identity, set `Shape.focusOwner`
-instead of giving it an ID.
+the owner's focus state, set `Shape.focusOwner` instead of giving it an ID.
 
 **a11yLabel helper** — `a11yLabel(userLabel, fallback)` returns the
-user-supplied label if non-empty, otherwise the fallback. Always set on
-interactive widgets. When the widget builds a `Shape` directly rather than
-delegating to a `ContainerCfg`, use `cfg.a11yInfo(fallback)` instead — it is the
-same pairing, promoted from the embedded `A11YCfg`, and returns the
-`*accessInfo` the shape's `a11Y` field wants.
+user-supplied label if non-empty, otherwise the fallback. Set it on every
+interactive widget. When the widget builds a `Shape` directly rather than
+delegating to a `ContainerCfg`, use `cfg.a11yInfo(fallback)` instead. It is the
+same pairing, promoted from the embedded `A11YCfg`. It returns the `*accessInfo`
+the shape's `a11Y` field wants.
 
 ## 3. Theme defaults
 
@@ -223,9 +222,9 @@ var DefaultToggleStyle = ToggleStyle{...}
 ```
 
 And in the theme's `init()` or `buildTheme()` function, populate the light/dark
-variants. The factory's `applyDefaults` function fills in any field the user
-didn't set — the per-state colors resolve through `ColorSet`, with the flat
-`Color` field as the `Base` shorthand:
+variants. The factory's `applyDefaults` function provides any field the user did
+not set. The per-state colors resolve through `ColorSet`, with the flat `Color`
+field as the `Base` shorthand:
 
 ```go
 func applyToggleDefaults(cfg *ToggleCfg) {
@@ -249,15 +248,15 @@ func applyToggleDefaults(cfg *ToggleCfg) {
 }
 ```
 
-If your widget doesn't need custom theme entries, skip this step. Simple widgets
-can use `guiTheme` colors directly.
+If your widget does not need custom theme entries, skip this step. Simple
+widgets can use `guiTheme` colors directly.
 
 ## 4. Write tests
 
 Test file: `gui/view_toggle_test.go`. Test at minimum:
 
-1. **Layout structure** — assert the generated Layout has expected shape, axis,
-   children
+1. **Layout structure** — assert the generated Layout has the expected shape,
+   axis, and children
 2. **Config passthrough** — ID, Disabled, Selected flags propagate to the
    correct Shape
 3. **Property rendering** — text content, colors, sizing reflect the config

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -1,11 +1,11 @@
 # Dev loop: rebuild-and-relaunch
 
 `scripts/dev-loop.sh` runs a Go GUI app and relaunches it whenever the module
-changes, so the edit → recompile → relaunch cycle is one save away.
+changes. The edit → recompile → relaunch cycle is one save away.
 
-This is a convenience wrapper, not in-process reload: rebuilding and relaunching
-is the honest approach for a native Go GUI, and recompiling the app package
-covers its whole dependency tree (including `gui/`).
+This is a convenience wrapper, not in-process reload. Rebuilding and relaunching
+is the honest approach for a native Go GUI. Recompiling the app package covers
+its whole dependency tree (including `gui/`).
 
 ## Usage
 
@@ -13,7 +13,7 @@ covers its whole dependency tree (including `gui/`).
 ./scripts/dev-loop.sh <app path> [args...]
 ```
 
-- `<app path>` is a Go package, e.g. `./examples/get_started/`.
+- `<app path>` is a Go package, for example `./examples/get_started/`.
 - Extra args are preserved and passed to every relaunched instance.
 
 The script is bash, but you can call it directly from Fish or any other shell:
@@ -24,23 +24,23 @@ The script is bash, but you can call it directly from Fish or any other shell:
 
 ## Behavior
 
-1. **Initial build.** The app is built into `build/dev-loop/` (gitignored) and
-   launched. If the initial build fails, the script prints the error and exits —
-   there is no previous binary to keep running.
-2. **Watch.** Every 0.5 s (override with `DEV_LOOP_POLL_SECONDS`) the module is
-   scanned for changes to `*.go`, `go.mod`, or `go.sum` files. `build/`,
-   `.git/`, docs, and scripts are ignored.
-3. **On save.** The app is rebuilt. Success: the old process is killed and the
-   new binary launched with the original args. Failure: the error is printed,
-   the watcher keeps running, and the last good binary keeps running; the next
-   save retries the build.
+1. **Initial build.** The script builds the app into `build/dev-loop/`
+   (gitignored) and launches it. If the initial build fails, the script prints
+   the error and exits. There is no previous binary to keep running.
+2. **Watch.** Every 0.5 s (override with `DEV_LOOP_POLL_SECONDS`), the script
+   scans the module for changes to `*.go`, `go.mod`, or `go.sum` files. It
+   ignores `build/`, `.git/`, docs, and scripts.
+3. **On save.** The script rebuilds the app. Success: it kills the old process
+   and launches the new binary with the original args. Failure: it prints the
+   error, the watcher keeps running, and the last good binary keeps running. The
+   next save retries the build.
 4. **Ctrl-C** kills the running app and removes the temp artifacts.
 
 ## Limits
 
-- Changes are picked up only when the binary relaunches; there is no in-process
+- Changes are picked up only when the binary relaunches. There is no in-process
   reload. State in the app (windows, focused widgets, running goroutines) is
   lost on each relaunch.
 - Only Go source and module files trigger a rebuild. Assets read at runtime
-  (SVGs, images, fonts) are not watched — relaunch after replacing those, or run
-  the app with a manual asset reload.
+  (SVGs, images, fonts) are not watched. After you replace such assets,
+  relaunch, or run the app with a manual asset reload.

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -19,13 +19,14 @@ Button{Label: "Save", OnClick: save}
 Input{ID: "name", FocusDisabled: true} // not in the tab order
 ```
 
-Most input controls are focusable by default: `Button`, `ColorChannelSlider`,
-`ColorPicker`, `ColorPlane`, `ColorWheel`, `Combobox`, `DatePicker`, `Input`,
-`InputDate`, `ListBox`, `NumericInput`, `RadioButtonGroup`, `Radio`, `Select`,
-`Slider`, `Switch`, `Toggle`, `Tree`, `VirtualList`. Everything else opts in
-with `Focusable: true`. If a control never answers the keyboard, the usual cause
-is a missing `ID`. The `requiredid` analyzer and the `DebugMissingIDs` gate
-report it. See `docs/specs/focusable-default-input.md`.
+Most input controls are focusable by default. They are `Button`,
+`ColorChannelSlider`, `ColorPicker`, `ColorPlane`, `ColorWheel`, `Combobox`,
+`DatePicker`, `Input`, `InputDate`, `ListBox`, `NumericInput`,
+`RadioButtonGroup`, `Radio`, `Select`, `Slider`, `Switch`, `Toggle`, `Tree`,
+`VirtualList`. Everything else opts in with `Focusable: true`. If a control
+never answers the keyboard, the usual cause is a missing `ID`. The `requiredid`
+analyzer and the `DebugMissingIDs` gate report it. See
+`docs/specs/focusable-default-input.md`.
 
 ## ID scoping
 
@@ -81,9 +82,8 @@ fields: `FloatAnchor`, `FloatTieOff`, `FloatOffsetX`, `FloatOffsetY`.
 
 The hook runs inside the frame pass, which holds the window mutex. `SetFocus`,
 `ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take
-that mutex, and it is not reentrant, so calling one from a hook used to freeze
-the app outright (issue #394). It now panics naming the API. Queue the work
-instead:
+that mutex. It is not reentrant, so a call from a hook froze the app outright
+(issue #394). It now panics, naming the API. Queue the work instead:
 
 ```go
 AmendLayout: func(ctx gui.EventCtx) {
@@ -96,10 +96,10 @@ AmendLayout: func(ctx gui.EventCtx) {
 
 The same applies to callbacks the library raises from the pass. A blur-triggered
 `OnTextCommit` (`InputCommitBlur`), `OnBlur`, or an `OnTextChanged` fired by
-`PostCommitNormalize` on blur now runs after the pass unlocks, so it is free to
-call `SetFocus` — but its `ctx.Layout` is **nil**, because that tree has already
-been recycled. Read `ctx.Window` and the arguments instead. The Enter commit
-path is unaffected and still carries a live `ctx.Layout`.
+`PostCommitNormalize` on blur now runs after the pass unlocks. It is free to
+call `SetFocus`. Its `ctx.Layout` is **nil**, because the pass already recycled
+that tree. Read `ctx.Window` and the arguments instead. The Enter commit path is
+unaffected and still carries a live `ctx.Layout`.
 
 ## Group-box titles
 
@@ -134,9 +134,10 @@ per-shape opt-in.
 ## Virtualized lists
 
 `ListBox`, `Table`, `Tree` and `Combobox` virtualize automatically when the
-scroll container has a bounded height (`Scrollable` plus `Height`, `MaxHeight`,
-or — `ListBox` only — a height Fill sizing resolved last frame). Every row is
-the same height there, which is exact because the widget owns the row shape.
+scroll container has a bounded height. That means `Scrollable` plus `Height` or
+`MaxHeight`, or — `ListBox` only — a height Fill sizing resolved last frame.
+Every row is the same height there, which is exact because the widget owns the
+row shape.
 
 For rows the app builds, of heights only the layout engine knows, use
 `VirtualList`:
@@ -158,20 +159,19 @@ gui.VirtualList(gui.VirtualListCfg{
 ```
 
 Set `ItemHeight` when the height is cheap to compute: heights are then exact
-from the first frame and nothing is measured. Put spacing _inside_ the row — the
+from the first frame and nothing is measured. Put spacing _inside_ the row. The
 list's own spacing is fixed at zero, because a gap between rows is height the
 model does not account for.
 
 **Use `width` for decisions, never for a minimum.** A row that sets `MinWidth`
-from it asks the list for at least the width the list just reported; the row's
+from it asks the list for at least the width the list just reported. The row's
 own border pushes that further, the list widens, and the cycle repeats every
-frame — re-wrapping and re-measuring each time, so nothing settles. Rows fill
-the width they are handed through `Sizing`. `gui.Debug(true)` reports the
-ratchet.
+frame. It re-wraps and re-measures each time, so nothing settles. Rows fill the
+width they are handed through `Sizing`. `gui.Debug(true)` reports the ratchet.
 
-Scroll by index, not by ID or percentage — a row outside the viewport has no
-shape for `FindByID` to resolve, and the content height under virtualization is
-an estimate, so a percentage drifts:
+Scroll by index, not by ID or percentage. A row outside the viewport has no
+shape for `FindByID` to resolve. The content height under virtualization is an
+estimate, so a percentage drifts:
 
 ```go
 w.ScrollToIndex("feed", 4000)          // row at the viewport top
@@ -187,12 +187,12 @@ nothing detects that. See `docs/specs/virtualized-variable-height-lists.md`.
 
 ## `Wrap` with Fit width
 
-`Wrap` with a Fit width resolves as **fit-content** (issue #379): the width is
+`Wrap` with a Fit width resolves as **fit-content** (issue #379). The width is
 `min(single-row sum, nearest definite-width ancestor's available)`, so the
 container wraps within its parent instead of rendering one unwrapped row wider
 than it. A Fit chain with no Fixed/Fill width above it has no width to wrap
-within and keeps the single-row sum — that combination behaves as a `Row`, not a
-wrap. When the wrap should always fill its parent, use Fill width, which is what
+within and keeps the single-row sum. That combination behaves as a `Row`, not a
+wrap. When the wrap must always fill its parent, use Fill width, which is what
 every example in this repo does.
 
 ## Canvas gradients
@@ -204,7 +204,7 @@ A `DrawContext` fill takes a `*gui.CanvasGradient` in place of a flat `Color`:
 
 **Geometry left at zero is derived from the shape being filled.** A radial
 gradient with `R <= 0` centers on the fill's bounding box and matches its larger
-extent; a linear one whose endpoints coincide runs top to bottom. So a glow is
+extent. A linear one whose endpoints coincide runs top to bottom. So a glow is
 its stops and nothing else:
 
 ```go
@@ -219,7 +219,7 @@ dc.FilledCircleGradient(cx, cy, r, &gui.CanvasGradient{
 
 There is no stop-count limit — the shader's five-stop cap belongs to the shape
 gradient path (`ContainerCfg`), not this one. Do not stack concentric discs to
-fake a falloff; that is what this replaces.
+fake a falloff. That is what this replaces.
 
 A gradient fill always starts its own batch and never merges with the flat fill
 before it, so interleaving the two keeps painter's order.
@@ -227,25 +227,25 @@ before it, so interleaving the two keeps painter's order.
 ### When a gradient cannot express the shading
 
 `FillTrianglesColors(tris, colors)` is the primitive underneath all six. You
-supply the geometry and one color per vertex — `len(colors)*2 == len(tris)` —
-and nothing is evaluated on the way through: no projection, no stop isolines, no
+supply the geometry and one color per vertex (`len(colors)*2 == len(tris)`).
+Nothing is evaluated on the way through: no projection, no stop isolines, no
 subdivision. A mismatched color count is a no-op, and the fill starts its own
 batch under the same rule a gradient does.
 
-Reach for it when the shading is not a gradient and cannot be made into one. A
+When the shading is not a gradient and cannot be made into one, reach for it. A
 gradient's level sets are conic curves, nested inside one another, stepped
 linearly along the ramp. A shading whose isolines are not nested (a Lambert
-sphere, whose isophotes open to the terminator and close again on both sides),
-or which varies around a center rather than away from it (a hue sweep), or which
-stops at a silhouette, is out of reach however the stops are arranged.
-`examples/solar_system` is the worked case; `examples/draw_canvas` shows the two
-short ones.
+sphere, whose isophotes open to the terminator and close again on both sides) is
+out of reach. So is a shading that varies around a center rather than away from
+it (a hue sweep), or one that stops at a silhouette. This holds however the
+stops are arranged. `examples/solar_system` is the worked case.
+`examples/draw_canvas` shows the two short ones.
 
 **Wind every triangle the same way.** `gui/backend/soft` rasterizes a
-vertex-colored batch as a single path and accumulates _signed_ coverage, so a
-triangle wound against its neighbours cancels along their shared edge and cuts a
+vertex-colored batch as a single path and accumulates _signed_ coverage. A
+triangle wound against its neighbors cancels along their shared edge and cuts a
 hairline through the mesh. Share vertices between adjacent triangles rather than
-overlapping them: with per-vertex color, an overlap paints twice and shows.
+overlapping them. With per-vertex color, an overlap paints twice and shows.
 
 ## The one-event rule
 
@@ -263,7 +263,7 @@ consuming. Findings print once per window. In tests, use
 
 `DebugUnscopedIDs` is separate and opt-in: it is not part of `DebugAll`. It
 reports an ID with no ID-bearing ancestor — the widget cannot move into a second
-panel as it stands. Ask for it when you plan to reuse a screen:
+panel as it stands. When you plan to reuse a screen, ask for it:
 
 ```go
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,6 +1,6 @@
 # Profiling
 
-Practical pprof workflows for go-gui. Covers CPU, heap, and benchmark-driven
+Practical pprof workflows for go-gui. It covers CPU, heap, and benchmark-driven
 profiling.
 
 ## Quick start
@@ -73,13 +73,13 @@ go tool pprof -sample_index=inuse_space -http=:8080 mem.prof
 go test -bench='BenchmarkRenderLayout' -benchmem -count=1 ./gui/
 ```
 
-`-benchmem` prints B/op and allocs/op per benchmark. Use to spot regressions
-before diving into pprof.
+`-benchmem` prints B/op and allocs/op per benchmark. Use it to spot regressions
+before you examine the pprof output.
 
 ## Hot paths
 
-The go-gui render pipeline has well-defined hot paths. Profile these first when
-investigating performance:
+The go-gui render pipeline has well-defined hot paths. When investigating
+performance, profile these first:
 
 | Path                  | Function               | Benchmark                       |
 | --------------------- | ---------------------- | ------------------------------- |
@@ -160,12 +160,12 @@ volume.
 
 ### Reducing slice growth allocations
 
-The most common allocation source in hot paths is slice growth. Pre-size with
-`make([]T, 0, cap)` when the upper bound is known. Check `renderLayout` and
+The most common allocation source in hot paths is slice growth. When the upper
+bound is known, pre-size with `make([]T, 0, cap)`. Check `renderLayout` and
 `generateViewLayout` call trees for slice append without pre-allocation.
 
 ### Scratch pool review
 
 `scratchPools` in `gui/scratch_pools.go` holds reusable per-frame buffers for
-frequently allocated types. When adding new hot-path allocations, consider
-pooling.
+frequently allocated types. When you add new hot-path allocations, consider
+pooling them.

--- a/docs/specs/caret-blink-local-repaint.md
+++ b/docs/specs/caret-blink-local-repaint.md
@@ -4,35 +4,35 @@
 
 A caret blink invalidated every renderer in the window. Each 600 ms blink tick,
 `BlinkCursorAnimation.Update` toggled the `inputCursorOn` atomic and reported
-`animationRefreshRenderOnly`; the animation loop translated that into
-`commandMarkRenderOnlyRefresh`, which set `w.refreshRenderOnly` and made the
-next `FrameFn` run `updateRenderOnly` → `buildRenderers` → `renderLayout` over
+`animationRefreshRenderOnly`. The animation loop translated that into
+`commandMarkRenderOnlyRefresh`, which set `w.refreshRenderOnly`. The next
+`FrameFn` then ran `updateRenderOnly` → `buildRenderers` → `renderLayout` over
 the whole layout tree.
 
-That walk re-runs every shape's draw code. For a consumer with an expensive draw
-surface (go-term's grid: per-cell glyph lookups, run-key hashing, per-run slice
-allocation) an idle focused input re-rendered the entire window 1.7×/s just to
-toggle one blinking rectangle.
+That walk re-runs every shape's draw code. Some consumers have an expensive draw
+surface. go-term's grid is one: per-cell glyph lookups, run-key hashing, and
+per-run slice allocation. With an idle focused input, go-term re-rendered the
+entire window 1.7×/s to toggle one blinking rectangle.
 
 ## Root cause
 
 The caret is not a standalone renderer. `renderInputCursor` emits the caret rect
 inline during the tree walk, and its visibility is decided by reading the blink
-atomic at emit time. So the only way to change the caret's appearance was to
+atomic at emit time. The only way to change the caret's appearance was to
 re-walk the tree. Additionally, backends present a frame only when `FrameFn`
-returns true, and true implied a rebuild — there was no "present without
-rebuild" path.
+returns true, and true implied a rebuild. There was no "present without rebuild"
+path.
 
 ## Fix
 
 Scope the caret repaint to the caret by patching the single caret `RenderCmd` in
 place. The caret rect is now **always emitted** for the focused caret-drawing
-shape — transparent while the blink state is off — and its index plus true color
+shape. It is transparent while the blink state is off. Its index and true color
 are recorded in window state during `buildRenderers` (`caretCmdState` on
 `Window`). Because the render list only changes on a rebuild, and every rebuild
 re-records the caret, the recorded index is stable between frames.
 
-The blink animation then needs no refresh at all:
+The blink animation then needs no refresh:
 
 - `BlinkCursorAnimation.RefreshKind` returns `animationRefreshNone`.
 - Each toggle enqueues `commandToggleCaretBlink` (via `AnimationCommands`, run
@@ -47,42 +47,41 @@ probing, and every shape's draw code are untouched.
 
 ### Why patch-in-place rather than the alternatives
 
-- **Per-shape dirty marks / subtree rebuild** would need to replay ancestor
-  bracket context (clip, stencil, filter, rotate) — that context is carried by
-  mutable walk state (`w.clipRadius`, `w.stencilDepth`, `w.inFilter`), not per
-  node.
-- **Caret as its own shape** would need clip-context capture at emit time and
-  changes draw ordering.
+- **Per-shape dirty marks / subtree rebuild** needs to replay ancestor bracket
+  context (clip, stencil, filter, rotate). That context is carried by mutable
+  walk state (`w.clipRadius`, `w.stencilDepth`, `w.inFilter`), not per node.
+- **Caret as its own shape** needs clip-context capture at emit time and changes
+  draw ordering.
 - The patched cmd keeps its position in the flat list, so it stays inside
   exactly the brackets (scroll clip, stencil, filter) it was drawn in.
 
 ## Invariants
 
 - Caret geometry (position, size) can only change via typing, scrolling, or
-  focus — all of which rebuild and re-record.
-- Only the focused caret-drawing shape emits and records; focus is exclusive.
+  focus. All of these rebuild and re-record.
+- Only the focused caret-drawing shape emits and records. Focus is exclusive.
 - With no caret recorded (IME composing, headless render, nothing focused) the
   toggle is a no-op and does not mark the window dirty.
 - A `Pulsar` (which toggles text in the view function) still promotes blink
-  ticks to a layout refresh via its own `Animate` — unchanged behavior.
+  ticks to a layout refresh via its own `Animate`. Behavior is unchanged.
 
 ## Window focus
 
-The blink is gated on the window holding OS focus as well as on the focused
-widget drawing a caret. A background window receives no key events, so its caret
-marks an insertion point nobody can type into — and the blink is not free: it
-holds the 16 ms animation ticker open and calls `wakeMain` twice a second for
-the whole time the app sits idle.
+The blink is gated on the window holding OS focus and on the focused widget
+drawing a caret. A background window receives no key events, so its caret marks
+an insertion point nobody can type into. The blink is not free. It holds the 16
+ms animation ticker open and calls `wakeMain` twice a second for the whole time
+the app sits idle.
 
 `syncBlinkCursor` (`gui/ime_context.go`) folds `Window.focused` into the caret
 signal. Losing focus retires the animation, which empties `w.animations` and
-parks the ticker in `animationLoop`; `handleFocusedEvent` calls
+parks the ticker in `animationLoop`. `handleFocusedEvent` calls
 `resetBlinkCursorVisible` on the way back, so the caret returns solid with a
-fresh phase rather than mid-blink, and the rebuild `EventFn` queues re-registers
-the animation.
+fresh phase rather than mid-blink. The rebuild `EventFn` queues re-registers the
+animation.
 
 `renderInputCursor` paints the caret transparent while the window is unfocused,
-and `commandToggleCaretBlink` carries the same gate — a `Pulsar` keeps the blink
+and `commandToggleCaretBlink` carries the same gate. A `Pulsar` keeps the blink
 animation registered in a background window, and its toggles must not paint the
 caret back in. The caret rect is still emitted, so the invariant above holds:
 the render list has one shape across focus states and the recorded slot stays
@@ -90,12 +89,12 @@ valid.
 
 ## Files
 
-- `gui/render_text.go` — `renderInputCursor` always emits; `caretCmdState`,
-  `emitCaretCmd`, `commandToggleCaretBlink`.
+- `gui/render_text.go` — `renderInputCursor` always emits. `caretCmdState`,
+  `emitCaretCmd`, `commandToggleCaretBlink` live here.
 - `gui/window.go` — `caretCmd`, `renderersDirty` fields.
-- `gui/window_update.go` — `buildRenderers` resets `caretCmd`; `FrameFn`
+- `gui/window_update.go` — `buildRenderers` resets `caretCmd`. `FrameFn`
   presents and clears `renderersDirty`.
 - `gui/ime_context.go` — `syncBlinkCursor` window-focus gate.
 - `gui/window_event.go` — `handleFocusedEvent` resets the blink phase.
-- `gui/animation.go` / `gui/animation_loop.go` — `RefreshKind` none; the toggle
+- `gui/animation.go` / `gui/animation_loop.go` — `RefreshKind` none. The toggle
   command is enqueued per tick.

--- a/docs/specs/cgo-free-backend-feasibility.md
+++ b/docs/specs/cgo-free-backend-feasibility.md
@@ -4,15 +4,15 @@ Assessment of [issue #137](https://github.com/go-gui-org/go-gui/issues/137).
 Date: 2026-07-31. Status: **Phase 1 implemented**, and the `gui/audio` follow-up
 (§ Audio outcome) closed the remaining Linux CGo dependency. **Phase 2 (macOS)
 closed 2026-08-12 by decision: not pursued — macOS stays cgo.** See § Phase 2
-for the rationale and the conditions that would reopen it.
+for the rationale and the conditions that can reopen it.
 
 ## Phase 1 outcome (2026-07-31)
 
 `github.com/go-gl/gl` is gone. It was replaced by `gui/backend/internal/glbind`,
-a purego binding for the 55 GL entry points and 45 constants the backend uses,
-resolved through the proc-address functions that already existed (`eglProc` on
-Linux; a new `glProc` on Windows reproducing go-gl's
-wglGetProcAddress-then-opengl32 fallback). Call sites changed by import swap
+a purego binding for the 55 GL entry points and 45 constants the backend uses.
+The binding resolves through the proc-address functions that already existed:
+`eglProc` on Linux, and a new `glProc` on Windows that reproduces go-gl's
+wglGetProcAddress-then-opengl32 fallback. Call sites changed by import swap
 only.
 
 Measured result:
@@ -33,8 +33,8 @@ Two corrections to the assessment below:
   missed it because `go build` stopped at the go-gl load error. Windows is
   unaffected — oto's Windows driver is pure syscall. Full
   `CGO_ENABLED=0 GOOS=linux go build ./...` therefore still fails, on
-  `gui/audio` alone. That is a separate dependency needing its own decision
-  (gate `gui/audio` behind a build tag, or replace oto on Linux) and was left
+  `gui/audio` alone. That is a separate dependency that needs its own decision
+  (gate `gui/audio` behind a build tag, or replace oto on Linux). It was left
   out of Phase 1.
 
 32-bit was **not** dropped: purego supports 386/arm via `syscall_32bit.go`, and
@@ -59,7 +59,7 @@ Recorded here because it is the question this assessment supersedes.
 
 A WebGPU backend was explored on branch `webgpu-backend` (since deleted): 12
 WGSL shader pipelines, device init, and the render loop all worked. It was
-rejected at the time because WebGPU has no native text rendering — font
+rejected at the time because WebGPU has no native text rendering. Font
 measurement and glyph rasterization required Canvas2D, and a hybrid backend
 defeats the purpose. GPU acceleration also does not address this project's
 actual bottleneck, which is heap allocation rather than throughput.
@@ -81,7 +81,7 @@ Issue #137 proposes a CGo-free desktop backend built on goffi + wgpu-native +
 GLFW, scoped as "roughly a full backend rewrite — 4–8k lines Go + ~12 WGSL
 shaders."
 
-Both of the issue's premises verify. Its scoping does not.
+Both of the issue's premises hold. Its scoping does not.
 
 Linux and Windows are already CGo-free apart from **one** dependency
 (`github.com/go-gl/gl`), whose surface area in this repo is 55 functions and 45
@@ -130,7 +130,7 @@ package .../gui/backend
 Surface area to port: **55 distinct GL functions, 45 constants**. Crucially, the
 proc-address plumbing needed to bind them is already written and already pure Go
 — `platform_x11.go:287` calls `gl.InitWithProcAddrFunc(eglProc)`, where
-`eglProc` comes from a purego-loaded `eglGetProcAddress`; `wgl_windows.go` has
+`eglProc` comes from a purego-loaded `eglGetProcAddress`. `wgl_windows.go` has
 the Windows equivalent.
 
 Phase 1 is therefore a swap of one dispatch layer: roughly 600 lines of purego
@@ -138,7 +138,7 @@ bindings. No shader rewrite, no wgpu, no GLFW, no windowing changes.
 
 ## 3. macOS is the entire remaining problem
 
-- `gui/backend/metal/` — 7,202 lines total; 9 Go files with `import "C"`; 3,311
+- `gui/backend/metal/` — 7,202 lines total, 9 Go files with `import "C"`, 3,311
   lines of `.m`/`.h`. Across the whole tree (metal, ios, android, filedialog):
   5,924 lines of ObjC/C.
 - macOS-only CGo outside the backend: `nativemenu/menu_darwin.go`,
@@ -158,8 +158,8 @@ Nothing about the wgpu proposal touches any of this.
 printer, bookmarks, a11y, IME, spellcheck, menubar, system tray, sound, plus
 `OpenURI`, `TitlebarDark`, `SetWindowVibrancy`. wgpu-native and GLFW supply none
 of it. The issue's claim that "existing pure-Go fallbacks (Android/iOS prove the
-pattern)" does not hold: `android/native_platform.go` no-ops only menubar, tray,
-and beep, and the android/ios backends are themselves cgo (`import "C"` in
+pattern)" does not hold. `android/native_platform.go` no-ops only menubar, tray,
+and beep. The android/ios backends are themselves cgo (`import "C"` in
 `backend.go`, `draw.go`, `text.go`, `textures.go`).
 
 **CGo-free is not dependency-free.** Today's Linux/Windows build bundles no
@@ -168,11 +168,11 @@ wgpu-native + GLFW backend replaces a _build-time_ C toolchain requirement with
 a _runtime_ obligation to ship and load ~10–40 MB of platform-specific shared
 objects. That is a net regression for distribution, not an improvement.
 
-**goffi is pre-1.0.** v0.6.0 is in progress; API stability is planned for
+**goffi is pre-1.0.** v0.6.0 is in progress. API stability is planned for
 v1.0.0. It also has a documented duplicate-`_cgo_init` symbol conflict with
 purego, which go-gui already depends on (`go.mod`:
-`github.com/ebitengine/purego v0.10.1`). Adopting goffi would force
-`-tags nofakecgo` on every downstream consumer.
+`github.com/ebitengine/purego v0.10.1`). Adopting goffi forces `-tags nofakecgo`
+on every downstream consumer.
 
 **The cost is strictly larger.** 12 WGSL shaders, device/surface init, and
 windowing glue, on top of the same GL-dispatch problem — and macOS still
@@ -194,8 +194,8 @@ binding.
   `pipeline.go`, `buffers.go`, `textures.go`, `text.go`, `platform_x11.go`,
   `platform_win32.go`). Import swap only — call sites keep their signatures.
 - Watch items:
-  - `gogl.Strs` returns a free func; reimplement as a null-terminated byte-slice
-    helper.
+  - `gogl.Strs` returns a free func. Reimplement it as a null-terminated
+    byte-slice helper.
   - `VertexAttribPointerWithOffset` — offset marshaling.
   - `GetShaderiv` / `GetShaderInfoLog` / `GetProgramiv` / `GetProgramInfoLog`
     out-params need explicit pointer marshaling under purego.
@@ -224,7 +224,7 @@ Every one of those is weakest on macOS:
 
 - Cross-compiling a macOS GUI binary from another host is hollow: a GUI app must
   be run and signed/notarized on a Mac anyway.
-- Xcode CLT is universally present on macOS; there is no toolchain-friction
+- Xcode CLT is universally present on macOS. There is no toolchain-friction
   story to fix for consumers.
 - The spike's hard part was never the call ABI but ObjC the language:
   subclassing `NSView`/`CAMetalLayer` needs runtime class registration (the
@@ -234,11 +234,11 @@ Every one of those is weakest on macOS:
 - The macOS-only CGo outside the backend (`nativemenu/menu_darwin.go`,
   `filedialog/dialog_darwin.go`, `printdialog/print_darwin.go`,
   `spellcheck/spellcheck_darwin.go`, `sysbeep/sysbeep_darwin.go`,
-  `gui/locale_detect_darwin.go`) would each need a port that is strictly worse
-  than its Linux/syscall counterpart.
+  `gui/locale_detect_darwin.go`) each needs a port that is strictly worse than
+  its Linux/syscall counterpart.
 
 The Linux/Windows phase earned its keep because those hosts lack a guaranteed
-toolchain; the macOS phase inverts the argument. The issue
+toolchain. The macOS phase inverts the argument. The issue
 (go-gui-org/go-gui#137) was closed when Phase 1 shipped and stays closed.
 
 Reopening conditions (any one, evidenced, not speculative):
@@ -282,5 +282,5 @@ find gui -name '*.m' -o -name '*.h' | xargs wc -l | tail -1         # 5924
 ```
 
 Acceptance test if Phase 1 is approved: both `CGO_ENABLED=0` builds above
-succeed, `go test ./gui/...` passes, and `go run ./examples/get_started/` on
+succeed. `go test ./gui/...` passes, and `go run ./examples/get_started/` on
 Linux renders unchanged.

--- a/docs/specs/color-picker-components.md
+++ b/docs/specs/color-picker-components.md
@@ -17,7 +17,7 @@ blocked splitting it up:
    URL, or a `data:` URL. There was no way to hand the renderer bytes.
 3. **Hue is not recoverable from RGBA.** At `S=0`, `L=0` or `L=1` the hue is
    gone. The old widget hid an `H` in window state to paper over this. Four
-   independent components each hiding their own copy would drift apart.
+   independent components, each hiding its own copy, drift apart.
 
 `gradientShaderStopLimit = 5` compounded (1): the old hue strip declared seven
 stops and was silently resampled to five on every GPU backend.
@@ -27,7 +27,7 @@ stops and was silently resampled to five on every GPU backend.
 ### One value, owned by the app
 
 `HSLA` (`gui/color_hsl.go`) is a plain value the caller holds. Every component
-takes `Value HSLA` and reports `OnChange(HSLA, EventCtx)`; none keeps state. Two
+takes `Value HSLA` and reports `OnChange(HSLA, EventCtx)`. None keeps state. Two
 controls stay in sync because they read the same variable, not because they talk
 to each other.
 
@@ -49,30 +49,31 @@ gui.SetMemImageBudget(bytes)        // default 32 MiB
 ```
 
 `Src` strings starting `mem:` are resolved by every backend through
-`gui.LookupImage` before any path handling (`drawImage` in `metal`, `gl`, `ios`,
-`android`; an offscreen canvas in `web`; a PNG-encoded embed in the PDF export).
-The registry is a byte-budgeted LRU, process-global because backends resolve a
-`Src` string with no `*Window` in hand.
+`gui.LookupImage` before any path handling. `drawImage` resolves them in
+`metal`, `gl`, `ios`, and `android`. The web backend uses an offscreen canvas,
+and the PDF export receives a PNG-encoded embed. The registry is a byte-budgeted
+LRU, process-global because backends resolve a `Src` string with no `*Window` in
+hand.
 
 **Content keying is the contract.** The key names the inputs the buffer was
 generated from, so a buffer that must change is registered under a _new_ key and
 the stale variant ages out on its own. There is deliberately no invalidation
-call: backends cache uploaded textures under the same string, so an app that
-mutated a buffer in place would have no way to tell them.
+call. Backends cache uploaded textures under the same string. An app that
+mutates a buffer in place has no way to tell them.
 
 Keys quantize — hue to whole degrees, S/L/A to whole percent. A key tracking a
-float exactly would miss on every frame of a drag and rebuild the buffer each
-time, which is the failure the cache exists to prevent. A steady frame costs one
-map lookup and zero allocations: the key is built into a stack scratch buffer,
-and `memImageSrc` returns the string stored at registration.
+float exactly misses on every frame of a drag and rebuilds the buffer each time.
+That is the failure the cache exists to prevent. A steady frame costs one map
+lookup and zero allocations: the key is built into a stack scratch buffer, and
+`memImageSrc` returns the string stored at registration.
 
 Buffers are generated at `imgScale = 2` and displayed at logical size — sharp on
 HiDPI, cheaply downscaled on 1×, and the scale never enters a key.
 
 **Security.** A `mem:` buffer bypasses `AllowedImageRoots`, `MaxImageBytes` and
-`MaxImagePixels`. Those bound _untrusted_ input — a path or URL an attacker
-might steer. An in-process pixel buffer is trusted by construction; the
-registry's byte budget is its bound.
+`MaxImagePixels`. Those bound _untrusted_ input — a path or URL an attacker can
+steer. An in-process pixel buffer is trusted by construction. The registry's
+byte budget is its bound.
 
 ### What each control depends on
 
@@ -97,7 +98,7 @@ the one sweeping it.
 - `colorMarker` (`gui/view_color_marker.go`) — the ring. It floats above the
   imagery: a channel slider floats its track to centre it in a control the thumb
   makes taller, and a marker under that track is invisible.
-- Arrow keys move every control (`colorKeyDelta`); Shift takes the 10× step. A
+- Arrow keys move every control (`colorKeyDelta`). Shift takes the 10× step. A
   key a control does not handle is not consumed, so Tab still escapes.
 
 ## API
@@ -121,13 +122,13 @@ end-cap insets land on the wrong sides.
 
 `ColorFields` set `ShowSwatch` puts a `ColorSwatch` to the right of the hex
 field, under the fields' own ID scope. Both are readouts of the same color — one
-exact, one legible — so they belong on one line; a caller that wants the swatch
-anywhere else leaves the flag off and places a plain `ColorSwatch`. It is drawn
-twice as wide as `SwatchSize`, which stays its height: a square beside a text
-field reads as a button, where a wide bar reads as a sample of the value next to
-it. A flexible spacer sits between the two, so the swatch tracks the block's
-right edge — set by the wider channel row beneath it — instead of leaving dead
-space past a short hex value.
+exact, one legible — so they belong on one line. A caller that wants the swatch
+anywhere else leaves the flag off and places a plain `ColorSwatch`. The swatch
+is drawn twice as wide as `SwatchSize`, which stays its height. A square beside
+a text field reads as a button, where a wide bar reads as a sample of the value
+next to it. A flexible spacer sits between the two, so the swatch tracks the
+block's right edge — set by the wider channel row beneath it — instead of
+leaving dead space past a short hex value.
 
 `gui.ColorPicker` is now a composition of `ColorPlane`, two vertical
 `ColorChannelSlider`s standing to the right of the plane, and `ColorFields`
@@ -140,27 +141,27 @@ fields — so the plane is that width less what the two sliders and the gaps
 beside them occupy, and the two rows come out flush. Widening the gap therefore
 narrows the plane instead of widening the picker.
 
-`ShowHSV` still works and is deprecated in favour of `ShowHSL`, which names what
+`ShowHSV` still works and is deprecated in favor of `ShowHSL`, which names what
 the row contains.
 
 ## What callers see change
 
-The square is the HSL saturation × lightness plane rather than the HSV square;
-the hue and alpha sliders stand vertically to the right of it instead of
-stacking beneath it, which makes the picker squarer; the preview swatch sits
-beside the hex field rather than left of the whole numeric column; the alpha
-slider gains a real transparency checkerboard; the hue strip is exact instead of
+The square is the HSL saturation × lightness plane rather than the HSV square.
+The hue and alpha sliders stand vertically to the right of it instead of
+stacking beneath it, which makes the picker squarer. The preview swatch sits
+beside the hex field rather than left of the whole numeric column. The alpha
+slider gains a real transparency checkerboard. The hue strip is exact instead of
 resampled to five stops. No API break.
 
 ## Rejected
 
 - **Keeping the HSV square as a mode.** It is free — two gradients, no buffer —
-  but it would have forced `ColorPicker` to carry a permanent RGBA↔HSV↔HSLA
-  adapter and two plane implementations. That is the second-source-of-truth
-  pattern this repo rejects elsewhere (`ThemeMaker` vs `default*Style`).
-- **Per-vertex colored triangle meshes** instead of buffers. Would have reached
-  the wheel without a texture upload, but touches every backend's shader and is
-  far less reusable than an image source.
+  but it forces `ColorPicker` to carry a permanent RGBA↔HSV↔HSLA adapter and two
+  plane implementations. That is the second-source-of-truth pattern this repo
+  rejects elsewhere (`ThemeMaker` vs `default*Style`).
+- **Per-vertex colored triangle meshes** instead of buffers. They reach the
+  wheel without a texture upload, but touch every backend's shader and are far
+  less reusable than an image source.
 - **PNG-encoded `data:` URLs** to avoid backend work. Re-encoding a 400×400 PNG
   on every hue change is a visible hitch on drag.
 

--- a/docs/specs/developer-ergonomics.md
+++ b/docs/specs/developer-ergonomics.md
@@ -4,7 +4,7 @@ Status: **implemented** — every row of the §6.1 progress table is done: phase
 shipped v0.53.0, the §4.3 callback/event collapse v0.55.0, the §4.4/§4.5 color
 and padding work across v0.56–v0.59, and §4.8's example audit closed. All of §9
 Q1–Q8 resolved, including the Q6 nested-scroll gate
-(`gui/scroll_nested_test.go`). The §4.7 renames are part of that; the release
+(`gui/scroll_nested_test.go`). The §4.7 renames are part of that. The release
 plan below is historical, not pending. Base: `main` @ `80715d1`. Phase progress:
 §6.1.
 
@@ -28,30 +28,30 @@ figures depend on dedupe and scope choices.
 | -------------------------------------- | ----- | ----------------------------------- |
 | Widget factories taking a `*Cfg`       | ~50   | `gui/view_*.go`                     |
 | `On*` callback decls, raw              | 136   | `ergonomics-audit -mode callbacks`  |
-| — distinct (name, signature) pairs     | 70    | deduped by go/ast; see §10          |
+| — distinct (name, signature) pairs     | 70    | deduped by go/ast. See §10          |
 | — of shape `func(EventCtx)`            | 16    |                                     |
 | — of shape `func(T…, EventCtx)`        | 19    |                                     |
-| — with a trailing `*Window`            | 27    | 14 keep it; see §4.3                |
+| — with a trailing `*Window`            | 27    | 14 keep it. See §4.3                |
 | — exposing a raw `*Event`              | 6     |                                     |
 | — neither (no `Window`/`EventCtx`)     | 2     | `OnAction`, `OnDraw`                |
 | Fields on `ContainerCfg`               | 71    | `gui/view_container.go`             |
 | Fields on `ButtonCfg`                  | 38    | `gui/view_button.go`                |
-| Distinct `Color*` field names (approx) | 20+   | `gui/view_*.go`; see §10            |
-| `Opt[T]` field decls (approx)          | 110   | `gui/view_*.go`; see §10            |
+| Distinct `Color*` field names (approx) | 20+   | `gui/view_*.go`. See §10            |
+| `Opt[T]` field decls (approx)          | 110   | `gui/view_*.go`. See §10            |
 | `StateMap[string, …]` call sites       | 242   | `gui/*.go`                          |
-| `RequireFocusID` call sites            | **0** | dead; deleted by §4.2               |
+| `RequireFocusID` call sites            | **0** | dead. Deleted by §4.2               |
 | Exported symbols in `gui` (go doc)     | 953   | 228 funcs, 349 types, 376 methods   |
 | Exported event-dispatch entry points   | **0** | `Shape.events` unexported (§4.6)    |
 | Focusable-by-default `Cfg`s            | 15    | `FocusDisabled` opt-out             |
-| — of those, `ID` **not** required      | 9     | unguarded; see §4.2                 |
-| Literals of those 9, all repos         | 408   | `go/ast` walk; see §4.2, §10        |
-| — focusable but ID-less (broken)       | 126   | 12 in go-gui's own widgets; fixed   |
+| — of those, `ID` **not** required      | 9     | unguarded. See §4.2                 |
+| Literals of those 9, all repos         | 408   | `go/ast` walk. See §4.2, §10        |
+| — focusable but ID-less (broken)       | 126   | 12 in go-gui's own widgets, fixed   |
 | — using `FocusDisabled` opt-out        | **1** | decorative case is theoretical      |
 | Tests in `examples/*/main_test.go`     | 63    | 98 lines are no-panic assertions    |
 | `Cfg`s exposing `Scrollable bool`      | 7     | scroll state keyed by ID (§4.9)     |
 | — tag-guarded                          | 5     | Combobox, CmdPalette, ListBox,      |
 |                                        |       | Table, Tree                         |
-| — guarded at runtime only              | 1     | `Container`; sole `RequireScrollID` |
+| — guarded at runtime only              | 1     | `Container`. Sole `RequireScrollID` |
 | — unguarded entirely                   | 1     | **`Input`**                         |
 | Examples calling `WindowSize()`        | 45    | 50 sites, 108 arithmetic lines      |
 
@@ -71,7 +71,7 @@ Not a preamble — these are the constraints any fix must preserve.
 
 ## 3. Corrections to circulating claims
 
-Recorded because both errors have been used to justify work.
+Recorded because both errors served as justification for work.
 
 ### 3.1 "Callback signatures are consistent `func(EventCtx)`" — false
 
@@ -94,7 +94,7 @@ and stopped.
 
 Zero `StateMap` references exist in `examples/`. `nsSelect` and `capModerate`
 are unexported (`gui/layout_overflow.go:65`), so app code cannot write that
-call. The encapsulation being asked for already exists; the reviewer read an
+call. The encapsulation being asked for already exists. The reviewer read an
 internal file as public surface. **No work required.**
 
 ## 4. Proposals, prioritized
@@ -120,7 +120,7 @@ is no build tag and no dead-code elimination. If zero-cost-when-off matters,
 that is a separate `//go:build` decision, not something the current pattern
 delivers.
 
-To be precise about the cost, since it has been queried:
+To be precise about the cost, since it was queried:
 `var focusDebug = os.Getenv(...)` is evaluated **once** at package var-init.
 There is no per-frame `os.Getenv` today, and the guarded read in `focusDupWarn`
 (`gui/layout_query.go:14`) is a plain bool load.
@@ -128,10 +128,11 @@ There is no per-frame `os.Getenv` today, and the guarded read in `focusDupWarn`
 **But make the flag `atomic.Bool`.** The proposal here is `gui.Debug(b)` — a
 function, so the flag becomes _mutable_, which today's env-only value is not.
 `focusDupWarn` is called from focus-candidate collection
-(`gui/layout_query.go:109`), i.e. per candidate per frame, so a plain bool read
-racing a `Debug(true)` write from another goroutine is a data race that `-race`
-will flag. `atomic.Bool.Load` compiles to a plain load on amd64 and arm64, so
-this costs nothing measurable. The mutability, not the lookup, is the reason.
+(`gui/layout_query.go:109`), that is, per candidate per frame, so a plain bool
+read racing a `Debug(true)` write from another goroutine is a data race that
+`-race` will flag. `atomic.Bool.Load` compiles to a plain load on amd64 and
+arm64, so this costs nothing measurable. The mutability, not the lookup, is the
+reason.
 
 **Warn once per `(check, ID)` per window.** These checks run at focus-candidate
 collection — per candidate, per frame — so an undeduplicated warning for one
@@ -222,7 +223,7 @@ case is already the analyzer's, and its dynamic case is `RequireID`'s.
 
 **Row 1 is compile-time only where the analyzer runs, which today is this repo
 alone.** `gui:"required"` is an ordinary struct tag. No compiler, no `go build`,
-and no plain `go vet` reads it; only `requiredid` does, and `requiredid` is a
+and no plain `go vet` reads it. Only `requiredid` does, and `requiredid` is a
 standalone binary invoked explicitly (`Makefile:104`,
 `.github/workflows/ci.yml:155`). Importing go-gui does not run it. For an app
 author who wires up nothing, the tag is inert and row 1 collapses into row 2:
@@ -252,7 +253,7 @@ go run github.com/go-gui-org/go-gui/tools/requiredid/cmd/requiredid ./...
 ```
 
 A `go tool` directive, `go vet -vettool=`, or a golangci-lint custom plugin all
-work equally. §8 carries the doc deliverable; whether the analyzer becomes
+work equally. §8 carries the doc deliverable. Whether the analyzer becomes
 _supported_ surface rather than an internal tool is Q8 (§9), and it is the one
 question this spec does not resolve.
 
@@ -282,7 +283,7 @@ drafts of this section long:
 | Default-on (15) | **no**                   | **126**      | tag 9 + `RequireID` |
 
 So the whole fix is the default-on row: tag `ID` with `gui:"required"` on the 9
-that lack it, add `RequireID` to their factories. Focus stays default-on; the ID
+that lack it, add `RequireID` to their factories. Focus stays default-on. The ID
 that focus depends on becomes mandatory. That is phase 1, non-breaking, and it
 closes **every defect the audit found**.
 
@@ -305,8 +306,8 @@ here:
   offsets all key off `Shape.ID`. A `Focus` value that also carries an ID is a
   second way to write the same key. `ContainerCfg` is the only type that is both
   opt-in-focusable and scrollable (`Focusable` :97, `Scrollable` :102, `ID`
-  :67), so it would have had to carry `Focus: gui.Focus("panel")` for focus
-  _and_ `ID: "panel"` for scroll keying, with nothing forcing them to agree:
+  :67), so it carries `Focus: gui.Focus("panel")` for focus _and_ `ID: "panel"`
+  for scroll keying, with nothing forcing them to agree:
 
 ```go
 // Would have needed a new rule to forbid: which one keys the scroll?
@@ -338,7 +339,7 @@ reads cleanly — input controls default on, display and container elements opt 
 | `BreadcrumbCfg`  | opt-in | `KeyLeft`, `KeyRight` (`view_breadcrumb.go:294,300`)          |
 | `ThemePickerCfg` | opt-in | `OnKeyDown` (`view_theme_picker.go:114`)                      |
 
-All three are controls a user would expect to tab into, and all three **already
+All three are controls a user expects to tab into, and all three **already
 implement arrow-key navigation**. That handler is dead code unless the author
 sets both `Focusable: true` and an `ID` — so the library ships keyboard support
 that is off by default, for widgets whose whole purpose is interaction.
@@ -403,7 +404,7 @@ missing `gui:"required"` tags need no API change — adding an `ID` to
 breaks callers _inside_ this repo, which `requiredid` flags in CI. Doing both in
 phase 1 closes the live accessibility bugs immediately and turns the analyzer
 into a working gate. Phase 1 as originally written only _warns_ about these
-defects; there is no reason to wait to fix them.
+defects. There is no reason to wait to fix them.
 
 With the opt-in collapse cut, **§4.2 is entirely phase 1** and contains no
 breaking change at all. Nothing here waits for the §4.3 release.
@@ -431,8 +432,8 @@ twelve.
 
 Two more are not callbacks at all but view builders that return a value:
 `OnCellFormat func(…) GridCellFormat` and `OnDetailRowView func(…) gg.View`.
-They are misnamed rather than mis-signatured; renaming them out of the `On*`
-space would be clearer than converting them.
+They are misnamed rather than mis-signatured. Renaming them out of the `On*`
+space reads clearer than converting them.
 
 That leaves **13 genuinely event-driven** signatures to convert: `OnAction`,
 `OnChange`, `OnLayoutChange`, `OnPanelClose`, `OnPanelSelect`, both `OnReorder`
@@ -447,8 +448,8 @@ See §7.1 for how the boundary was measured.
 
 **Collapse the event model to one rule.** The consume-class / notify-class split
 plus `ctx.Bubble()` as an escape hatch is the most confusing part of the API.
-Adopt: every callback starts unhandled; call `ctx.Consume()` to stop
-propagation; delete `Bubble()` and the auto-handled class. Cost is real — 23
+Adopt: every callback starts unhandled. Call `ctx.Consume()` to stop
+propagation. Delete `Bubble()` and the auto-handled class. Cost is real — 23
 `Bubble()`/`Consume()` sites in `examples/` alone plus all sibling call sites —
 which is precisely why it bundles with the signature work rather than shipping
 separately.
@@ -456,15 +457,15 @@ separately.
 #### 4.3.1 Pre-implementation verification (2026-08-08)
 
 Phase 4 is the first breaking phase, so every concrete claim in §4.3 and §4.7
-was re-checked against the tree before any code was written. What follows is the
-result, not a plan.
+was re-verified against the tree before any code was written. What follows is
+the result, not a plan.
 
 **Verified exactly, no change needed:** the 12 out-of-scope lifecycle signatures
-including all four `OnDone` variants; `OnCellFormat` returning `GridCellFormat`
-and `OnDetailRowView` returning `gg.View`, both confined to `gui/datagrid/`;
-zero sibling references to either; `RTF(cfg RtfCfg)` at `gui/view_rtf.go:212`;
-zero sibling references to `RtfCfg` or `gui.RTF`; `OnEvent` declared twice as
-`func(*Event, *Window)`; and the 8 `Color*` sibling sites, all in go-charts. The
+including all four `OnDone` variants. `OnCellFormat` returning `GridCellFormat`
+and `OnDetailRowView` returning `gg.View`, both confined to `gui/datagrid/`.
+Zero sibling references to either. `RTF(cfg RtfCfg)` at `gui/view_rtf.go:212`.
+Zero sibling references to `RtfCfg` or `gui.RTF`. `OnEvent` declared twice as
+`func(*Event, *Window)`. And the 8 `Color*` sibling sites, all in go-charts. The
 `27` distinct `func(T..., *Window)` signatures reproduce from
 `ergonomics-audit`.
 
@@ -497,12 +498,12 @@ go-gui itself (`gui/` 15, `gui/datagrid/` 6, `tools/eventctx` 5), plus 7 in
 siblings (go-edit 5, go-term 2).
 
 But counting `Bubble()`/`Consume()` measures the wrong thing. Under the
-collapse, `Consume()` keeps working unchanged; what changes is every
+collapse, `Consume()` keeps working unchanged. What changes is every
 **consume-class callback that relies on auto-handling** — those stop being
 handled by default and begin propagating to ancestors. `examples/` has **138**
 such sites (137 `OnClick`, 1 `OnGesture`). Most sit on widgets with no clickable
 ancestor and will be unaffected, but which ones those are is not determinable
-without checking nesting at each. That is the §7.2 silent class, at 138 sites
+without verifying nesting at each. That is the §7.2 silent class, at 138 sites
 rather than 23.
 
 **No sibling pays for the signature conversion.** Zero sibling call sites touch
@@ -536,13 +537,12 @@ spec:
 3. **Classification ignored results**, so the value-returning callbacks were
    bucketed by their parameters — `OnCellFormat` and `OnDetailRowView` as
    ordinary `*Window`-tailed, `OnCopyRows` as ordinary `*Event`-leaking. The
-   audit therefore could not surface the one category that fits no target shape.
-   There is now a `returns a value` bucket, and it holds exactly those three.
+   audit therefore missed the one category that fits no target shape. There is
+   now a `returns a value` bucket, and it holds exactly those three.
 
 Corrected declaration figures for `./gui`: **69** distinct signatures (was 70),
 `func(T..., *Window)` **24** (was 27), `leaks raw *Event` **5** (was 6),
-`returns a value` **3** (new). The §4.3 partition should be restated against
-these.
+`returns a value` **3** (new). The §4.3 partition restates against these.
 
 So the sibling cost of phase 4 is **not** "every change costs five repos a
 bump". It is: 8 `Color*` sites in go-charts, 7 `Bubble()` deletions in go-edit
@@ -561,7 +561,7 @@ contributing a second distinct signature the original count folded into one. The
 `EventCtx` replaces the `*Layout`, `*Event` and `*Window` parameters and says
 nothing about results, so it is now `func([]GridRow, EventCtx) (string, bool)`.
 No third target shape and no carve-out — the two target shapes in §4.3 were
-simply stated too narrowly, since "returns nothing" was never load-bearing.
+stated too narrowly, since "returns nothing" was never load-bearing.
 
 Verified by re-running `ergonomics-audit -mode callbacks`: `func(T..., *Window)`
 24 → **12**, `leaks raw *Event` 5 → **1** (`OnEvent` alone), `func(EventCtx)` 16
@@ -580,7 +580,7 @@ the name filter was consulted in the wrong place:
 1. **Nested closures inherited the owner name**, converting every
    `w.QueueCommand(func(w *gui.Window) {…})` written inside a converted
    callback. Harmless in the old signature-driven mode, where the owner only
-   tinted the consume-class report; fatal once the owner is the gate.
+   tinted the consume-class report. Fatal once the owner is the gate.
 2. **Named declarations were filtered by their own name.** A function reaches
    the declaration pass only because the plan established it is wired to an
    included field, but the filter then tested `onShowcaseSplitterMainChange`
@@ -594,13 +594,13 @@ All three are pinned by tests in `tools/eventctx/general_test.go`.
 **Dispatch now passes the real context through.** Where a widget invokes one of
 these callbacks from inside an already-converted callback, the fold emits `ctx`
 rather than `EventCtx{nil, ctx.Event, ctx.Window}` — 29 sites. The old signature
-carried no `*Layout`, so this hands callers strictly more than before;
-synthesizing a nil layout when one is in scope would manufacture an absence.
-Where no layout genuinely exists (six internal helpers that only ever had a
-`*Window`), `EventCtx{nil, nil, w}` is emitted and is faithful.
+carried no `*Layout`, so this hands callers strictly more than before.
+Synthesizing a nil layout when one is in scope manufactures an absence. Where no
+layout genuinely exists (six internal helpers that only ever had a `*Window`),
+`EventCtx{nil, nil, w}` is emitted and is faithful.
 
-Cost: 45 files, zero rule-4 review items, and **zero sibling sites** —
-confirming §4.3.1's finding that no sibling pays for this conversion.
+Cost: 45 files, zero rule-4 review items, and **zero sibling sites** — verifying
+§4.3.1's finding that no sibling pays for this conversion.
 
 #### 4.3.3 Measuring the §4.3b collapse (2026-08-08)
 
@@ -614,10 +614,10 @@ dispatch time, so no amount of grepping answers it.
 (`gui/debug_event.go`) that runs after every consume-class callback and reports
 the site when both halves of the hazard hold: the callback relied on the
 pre-mark (it neither called `ctx.Consume()` nor `ctx.Bubble()`), **and** an
-ancestor would also have received the event. Ancestor is decided by replaying
-that event's real dispatch condition — `PointInShape` plus the `ClickButton`
-filter for `OnClick`, the centroid for `OnGesture`, focus for `OnChar` — so the
-answer is the one dispatch would actually give.
+ancestor also receives the event. Ancestor is decided by replaying that event's
+real dispatch condition — `PointInShape` plus the `ClickButton` filter for
+`OnClick`, the centroid for `OnGesture`, focus for `OnChar` — so the answer is
+the one dispatch actually gives.
 
 `(*Window).TestEventCollapse` sweeps a rendered window with the check armed: it
 fires one synthetic event per consume-class callback in the tree and returns the
@@ -645,7 +645,7 @@ the color picker's row, a text input inside its clickable container. Both sides
 of nearly every pair are go-gui's own widget internals — `view_color_picker.go`,
 `dock_layout.go`, `view_input.go` — not application code. The collapse's silent
 cost is therefore mostly go-gui's to pay, in a handful of files, and
-mechanically: add `ctx.Consume()` to the inner handler and its behaviour is
+mechanically: add `ctx.Consume()` to the inner handler and its behavior is
 pinned before the model changes at all.
 
 (The separator inconsistency visible in those IDs — `dock_close:editor` against
@@ -670,7 +670,7 @@ fixable ahead of the collapse and verifiable by re-running the sweep.
 
 #### 4.3.4 The collapse, as shipped (v0.55.0)
 
-Done. Nothing is pre-marked; every callback consumes explicitly; `ctx.Bubble()`
+Done. Nothing is pre-marked. Every callback consumes explicitly. `ctx.Bubble()`
 is gone. Landed as three PRs, because the measurement was wrong twice before it
 was right.
 
@@ -679,9 +679,9 @@ was right.
 Runtime-identical, but `Consume()` also set `explicitConsume`, the flag
 separating "the callback asked" from "dispatch pre-marked" — so every one of
 those sites looked like a decision and was a reliance. Swapping all 14 cleared
-13 of the 18. The remaining five needed real judgement: the dock close button
-(4, inside its own tab button) and the theme picker root (1, hosted as a
-menu-item `CustomView`).
+13 of the 18. The remaining five needed real judgment: the dock close button (4,
+inside its own tab button) and the theme picker root (1, hosted as a menu-item
+`CustomView`).
 
 **The check was measuring the smaller half.** §4.3.3 asked only whether an
 ancestor had a live callback for the same event. But `mouseDownHandler` takes
@@ -689,10 +689,10 @@ focus on the way past any focusable shape under the cursor and marks the event
 handled doing so, **before any callback runs** (`gui/event_handlers.go:216`). So
 an unconsumed click on a non-focusable child inside a focusable ancestor does
 not merely fail to stop — it moves focus. No `OnClick` is involved anywhere,
-which is why the original check could not see it. Widening `ancestorHandler` to
-count focus-stealing ancestors, and sweeping all 37 constructible examples
-rather than the 8, found 7 more: the colour picker's hue strip and SV area, a
-slider track press, the scrollbar gutter's mouse-locked early return, and two in
+which is why the original check missed it. Widening `ancestorHandler` to count
+focus-stealing ancestors, and sweeping all 37 constructible examples rather than
+the 8, found 7 more: the colour picker's hue strip and SV area, a slider track
+press, the scrollbar gutter's mouse-locked early return, and two in
 `gui/datagrid`.
 
 **The static population was 214** — every consume-class callback calling neither
@@ -717,7 +717,7 @@ an empty consume-class callback used to be a working click-blocker, and now
 blocks nothing.
 
 **The debug check survives, inverted.** `debugCollapse` measured reliance on a
-pre-mark that no longer exists; `debugUnconsumed` reports a handler that acted
+pre-mark that no longer exists. `debugUnconsumed` reports a handler that acted
 without consuming while an ancestor also receives the event, and
 `TestEventCollapse` is now `TestUnconsumedEvents`. It has one honest false
 positive: deliberate pass-through — a handler that inspects an event, decides it
@@ -727,7 +727,7 @@ drive to zero.
 
 Sweep across all 37 examples after the collapse: **one finding**, and it is that
 false positive — `inputOnClick`'s "no glyph layout, cannot place a cursor" path,
-reachable only with a nil `TextMeasurer`, i.e. only in tests.
+reachable only with a nil `TextMeasurer`, that is, only in tests.
 
 ### 4.4 Color-set collapse — highest per-app line savings
 
@@ -750,7 +750,7 @@ per styled widget.
 **Precedence, when both a flat `Color*` field and a `ColorSet` are set: the flat
 field wins.** This is the only rule that makes the transition safe — existing
 code sets flat fields and must keep its current appearance when a `ColorSet`
-default arrives, and a partially-migrated literal should not silently change
+default arrives, and a partially-migrated literal must not silently change
 color. The rule is unintuitive (the newer, more specific-looking API loses), so
 it goes in the doc comment on both, not only here.
 
@@ -764,7 +764,7 @@ forces:
   `ColorClick`, `ColorBorder`, `ColorBorderFocus` (`gui/view_button.go:52-61`).
   These are exactly what `ColorSet` replaces, and they are what makes the
   `examples/todo` literal six lines long. Sibling cost is **8 sites, all in
-  go-charts**; the other four siblings set none.
+  go-charts**. The other four siblings set none.
 - **Keep `Color` permanently**, as shorthand for `ColorSet.Base`. It is the
   single-color case, it is the overwhelmingly common one, and
   `ColorSet{Base: c}` is strictly worse ergonomics for it than `Color: c`.
@@ -773,7 +773,7 @@ forces:
   own name, the same relationship `Flat(c)` has to a fully-specified `ColorSet`.
 
 So the shrink claim survives, at five fields per styled `Cfg` rather than six.
-Phase 3 lands `ColorSet` plus the precedence rule; phase 4 removes the five it
+Phase 3 lands `ColorSet` plus the precedence rule. Phase 4 removes the five it
 replaced.
 
 A caution on measuring this: a naive `^\s+Color[A-Za-z]*:` grep reports 173
@@ -784,9 +784,9 @@ names.
 
 **Consider, but do not block on:** named theme-backed style presets. The
 `examples/todo` button is really asking for "the accent style", not for six
-specific colors. A small preset set (primary / secondary / chrome / danger) may
+specific colors. A small preset set (primary / secondary / chrome / danger) can
 remove more lines than `ColorSet` alone, and the two compose — `ColorSet` is the
-mechanism, presets are the vocabulary. Ship `ColorSet` first; presets are a
+mechanism, presets are the vocabulary. Ship `ColorSet` first. Presets are a
 separate additive proposal.
 
 #### 4.4.1 Corrections from the implementation (2026-08-07)
@@ -800,14 +800,14 @@ the code. `Color` carries its own unexported `set` flag (`gui/color.go:11`),
 `Opt` was proposed to add already exists, and every widget in the repo already
 branches on `Color.IsSet()`.
 
-Wrapping would have given the field two independent notions of unset, where
-`Some(Color{})` reads as "set to unset" — the same two-conventions defect §3.1
-objects to in `InputCfg`. Pinned by `TestColorSetTransparentIsNotUnset`.
+Wrapping gives the field two independent notions of unset, where `Some(Color{})`
+reads as "set to unset" — the same two-conventions defect §3.1 objects to in
+`InputCfg`. Pinned by `TestColorSetTransparentIsNotUnset`.
 
 **`Base` does not back the border fields.** §4.4 says "unset states fall back to
 `Base`". Applied literally to `Border` that produces a border the same color as
 the fill, which reads as _no_ border — not a plausible meaning for omitting the
-field. `Base` backs `Hover`, `Click` and `Focus`; `Border` and `BorderFocus`
+field. `Base` backs `Hover`, `Click` and `Focus`. `Border` and `BorderFocus`
 fall through to the theme, and `BorderFocus` falls back to `Border` first.
 `Flat(c)` still pins all six, which is what makes it the "visually inert" case
 rather than merely "uniform fill".
@@ -823,16 +823,16 @@ replacing six, which is the saving §4.4 predicted.
 
 #### 4.4.2 Deletion scope, resolved in phase 4 (2026-08-08)
 
-**Deleting only `ButtonCfg`'s five fields would have made the API bimodal.** Six
-`Cfg`s carry the identical five state-color fields: `ButtonCfg`, `SwitchCfg`,
+**Deleting only `ButtonCfg`'s five fields makes the API bimodal.** Six `Cfg`s
+carry the identical five state-color fields: `ButtonCfg`, `SwitchCfg`,
 `ToggleCfg`, `RadioCfg`, `InputDateCfg`, `DatePickerCfg`. Removing them from
 `ButtonCfg` alone — which is what §4.4 scheduled — leaves `Switch` and `Toggle`
 styled the old way beside a `Button` that uses `Colors`, inside one widget
 family. That is worse than the uniform verbosity it replaces.
 
 Resolved by extending `ColorSet` to all six and deleting the five fields on all
-six. The 24 `Cfg`s holding a partial set (four fields down to one) keep theirs;
-"carries the full five" is the line, and it is exactly where `ColorSet` fits
+six. The 24 `Cfg`s holding a partial set (four fields down to one) keep theirs.
+"Carries the full five" is the line, and it is exactly where `ColorSet` fits
 without inventing fields a widget does not have.
 
 **The shorthand must not back the interactive states.** `Base` backs `Hover`,
@@ -852,14 +852,14 @@ difference until someone tabs to the control. Pinned by
 110 `Opt[T]` fields coexist with plain-value fields under no documented rule.
 
 **Decision: `Opt[T]` where the zero value is a legitimate user choice that must
-be distinguishable from "unset"; a plain field everywhere else.** This was the
-last §4 item still phrased as an either/or, which meant phase 3 could not start
-on it. The rule is not a style preference — it is the only thing that
-distinguishes the two cases, and `SizeBorder` is the worked example already in
-`CLAUDE.md`: a border width of 0 is a thing a caller means, so a plain field
-cannot tell "no border" from "not specified" and silently applies the theme
-default. Where zero is not meaningful (most sizes, counts, and indices), `Opt`
-costs a wrapper call and buys nothing.
+be distinguishable from "unset". Use a plain field everywhere else.** This was
+the last §4 item still phrased as an either/or. It blocked phase 3's start. The
+rule is not a style preference — it is the only thing that distinguishes the two
+cases, and `SizeBorder` is the worked example already in `CLAUDE.md`: a border
+width of 0 is a thing a caller means, so a plain field cannot tell "no border"
+from "not specified" and silently applies the theme default. Where zero is not
+meaningful (most sizes, counts, and indices), `Opt` costs a wrapper call and
+buys nothing.
 
 Applying the rule is an audit of the existing 110, not a rewrite: fields that
 satisfy it stay, fields that do not become plain in phase 4 with the other
@@ -895,32 +895,32 @@ family, with counts:
 | Family                                            | Count | Verdict                                                       |
 | ------------------------------------------------- | ----- | ------------------------------------------------------------- |
 | `Padding*`, `*Padding`, `CellSpacing`             | ~45   | keep — zero padding is a real choice, `NoPadding` exists      |
-| `SizeBorder`, `Size*Border`                       | ~30   | keep — the worked example; zero means "no border"             |
+| `SizeBorder`, `Size*Border`                       | ~30   | keep — the worked example. Zero means "no border"             |
 | `Radius*`                                         | ~35   | keep — zero means square corners, theme default is not zero   |
 | `Spacing*`                                        | ~11   | keep — `NoSpacing` exists                                     |
 | `Opacity`, `BgOpacity`, `ParamA/B/D`              | 6     | keep — zero is meaningful                                     |
 | `HAlign`, `VAlign`, `Anchor`, `TieOff`, `Mode`    | 7     | keep — enum zero is a real member (`HAlignLeft == 0`)         |
 | `Value`, `Min`, `Max`, `Ratio`, `DragStep*`       | 6     | keep — zero is a legitimate slider value                      |
 | `Size` (text), `Width*`, `Height`, `Min/MaxWidth` | ~11   | **plain in phase 4** — zero is not a meaningful size          |
-| `OffsetX/Y`, `HandleSize`, `DotSize`              | 4     | borderline; zero is expressible but equals the default anyway |
+| `OffsetX/Y`, `HandleSize`, `DotSize`              | 4     | borderline. Zero is expressible but equals the default anyway |
 
 So §4.5's phase-4 work is roughly **11 fields, not 165**. That is a materially
 smaller change than the section implies, and it is the reason the rule is worth
 documenting even though almost nothing has to move: the value is in deciding new
 fields correctly, not in the cleanup.
 
-#### 4.5.2 `Padding` self-flags; `Opt[Padding]` and `SomeP` removed (2026-08-10, #243)
+#### 4.5.2 `Padding` self-flags, `Opt[Padding]` and `SomeP` removed (2026-08-10, #243)
 
-The rule now reads: **types the repo owns self-flag; only primitives get
+The rule now reads: **types the repo owns self-flag. Only primitives get
 `Opt`.** `Padding` joined `Color` in carrying a `set` field, so "unset" (zero
 value, theme default applies) is distinguishable from explicitly zero
 (`PaddingNone`) without a wrapper. The 33 `Opt[Padding]` field declarations
-became plain `Padding`; `SomeP` was deleted (use `NewPadding`); read sites moved
+became plain `Padding`. `SomeP` was deleted (use `NewPadding`). Read sites moved
 from `.Get(def)` to `.Or(def)`. Raw `Padding{...}` literals — even with nonzero
 sides — read as unset, so ergoaudit mode `literals` gates them: build with
 `NewPadding`/`PadAll`/`PaddingNone`. `ThemeMaker` stamps the flag on its
 `cfg.Padding*` copies so a resolved theme value never reads as unset on a later
-`IsSet` check. Breaking for consumers of `SomeP` and `Opt[Padding]`; the sibling
+`IsSet` check. Breaking for consumers of `SomeP` and `Opt[Padding]`. The sibling
 repos bump together.
 
 #### 4.5.3 The literal guard extends to `Color` (2026-08-10, #243 follow-up)
@@ -930,7 +930,7 @@ the package compiles and silently reads as unset, exactly like Padding did. The
 empty `Color{}` form stays exempt — it is the explicit spelling of "unset"
 (zero-sentinel comparisons, optional color parameters) and behaves like omitting
 the value. `glyph.Color{...}` (a foreign type) never flags. The sweep converted
-~99 sites to `RGBA(...)`; two of them (examples/fontviewer,
+~99 sites to `RGBA(...)`. Two of them (examples/fontviewer,
 gui/backend/internal/glyphconv) were genuine silent-unset bugs where the theme
 default was applied instead of the color the code wrote. `dimAlpha` dropped its
 set-preserving literal for an in-place `c.A /= 2`.
@@ -997,7 +997,7 @@ justifies it.
 
 `TestScroll` is not optional either — **Q6's phase gate is undischargeable
 without it.** Q6 requires writing the nested-scroll case as a test in phase 2
-and changing the propagation model against it; an API with click, key, type,
+and changing the propagation model against it. An API with click, key, type,
 focus, and tab has no way to express that test. The same pair is what pins
 §7.2's silent consume-class regressions, which by construction produce no
 compile error.
@@ -1009,8 +1009,8 @@ errors at a render site.
 Two open design points, listed in §9: whether this lives in `gui` or a
 `gui/guitest` subpackage, and whether `TestClick` runs full hit-testing from
 coordinates or targets the ID directly. Hit-testing is the more faithful
-simulation and would also catch overlay and z-order bugs; ID-targeting is
-simpler and sufficient for state-transition tests.
+simulation and also catches overlay and z-order bugs. ID-targeting is simpler
+and sufficient for state-transition tests.
 
 #### 4.6.1 Corrections from the implementation (2026-08-07)
 
@@ -1039,7 +1039,7 @@ feature, and not worth it at this stage.
 preference. The discrete-wheel path does not move the offset at all:
 `scrollSmoothBy` arms an exponential ease that lands over later frames driven by
 the animation goroutine, which no headless test runs — and `clearHotMaps` calls
-`scrollSmoothReset` on every view rebuild, so settling a frame would discard the
+`scrollSmoothReset` on every view rebuild, so settling a frame discards the
 in-flight ease regardless. Only `scrollVertical`/`scrollHorizontal`, the
 precise/trackpad path, write synchronously. Consequence for callers: a widget
 branching on `Event.ScrollPrecise` sees the trackpad branch under test.
@@ -1047,22 +1047,22 @@ branching on `Event.ScrollPrecise` sees the trackpad branch under test.
 ### 4.7 Naming: `RTF` / `RtfCfg` casing split
 
 `RTF(cfg RtfCfg)` (`gui/view_rtf.go:212`) is the only factory whose name
-disagrees with its `Cfg` in casing. Go convention initialises acronyms
-uniformly, so this should be `RTF(cfg RTFCfg)`. Breaking rename; fold into phase
-4 where consumers already migrate.
+disagrees with its `Cfg` in casing. Go convention initializes acronyms
+uniformly, so this is `RTF(cfg RTFCfg)`. Breaking rename. Fold into phase 4
+where consumers already migrate.
 
 **Also in phase 4: rename `OnCellFormat` and `OnDetailRowView` out of the `On*`
 space.** §4.3 argues they are misnamed — they are view builders that return a
-value, not event callbacks — but named no phase, which would have meant either
-another breaking release or keeping a misnomer §8 already expects the next
-reviewer to trip on. Phase 4 is the only bus it can ride. Cost is zero outside
-the declaring package: no reference to either identifier exists in any of the
-five siblings, or anywhere in go-gui outside `gui/datagrid/`. Suggested
-`CellFormat` and `DetailRowView`, matching the `Cfg`-field-as-builder convention
-rather than the callback one.
+value, not event callbacks — but named no phase, which means either another
+breaking release or keeping a misnomer §8 already expects the next reviewer to
+trip on. Phase 4 is the only bus it can ride. Cost is zero outside the declaring
+package: no reference to either identifier exists in any of the five siblings,
+or anywhere in go-gui outside `gui/datagrid/`. Suggested `CellFormat` and
+`DetailRowView`, matching the `Cfg`-field-as-builder convention rather than the
+callback one.
 
-The other twelve factory/`Cfg` name divergences are deliberate and should stay:
-the container family (`Column`, `Row`, `Wrap`, `Canvas`, `Circle`) intentionally
+The other twelve factory/`Cfg` name divergences are deliberate and stay: the
+container family (`Column`, `Row`, `Wrap`, `Canvas`, `Circle`) intentionally
 shares `ContainerCfg`, and `RadioButtonGroupColumn` / `RadioButtonGroupRow`
 follow the same axis-variant pattern.
 
@@ -1071,7 +1071,7 @@ follow the same axis-variant pattern.
 `examples/get_started/main.go:36` documents that `FillFill` removes the need for
 `WindowSize()` and manual arithmetic. **45 example files call `WindowSize()`
 anyway** — 50 call sites and 108 lines of `float32(ww)-N` arithmetic. This is
-not one contradictory pair; it is the dominant idiom in the examples, teaching
+not one contradictory pair. It is the dominant idiom in the examples, teaching
 the opposite of what the library recommends.
 
 Treat it as an audit, not a file fix:
@@ -1084,8 +1084,8 @@ Treat it as an audit, not a file fix:
 3. Once converted, the remaining `WindowSize()` calls are a signal rather than
    noise.
 
-Highest-leverage change in the plan for _perceived_ ergonomics: the examples are
-where the idiom is learned, and right now they teach manual layout.
+The highest-impact change for _perceived_ ergonomics: the examples are where the
+idiom is learned, and right now they teach manual layout.
 
 Also convert two or three example tests from no-panic assertions to real
 state-transition assertions once §4.6 lands, so the testing pattern is
@@ -1093,7 +1093,7 @@ demonstrated rather than described.
 
 #### 4.8.1 Audit result (2026-08-08)
 
-**45 files / 50 call sites → 8 files / 9 call sites.** 37 files converted; 8
+**45 files / 50 call sites → 8 files / 9 call sites.** 37 files converted. 8
 allowlisted, each with a one-line reason at the call site so the remaining calls
 read as deliberate.
 
@@ -1106,9 +1106,9 @@ set it as the root's `Width`/`Height`, and mark the root `FixedFixed`. That is
 | `todo`             | `cardView(ww-24, wh-24, w)`         | card is `FillFill` inside the page's 12px padding |
 | `listbox`          | `Height: float32(wh) - 70`          | list `FillFill` takes the column remainder        |
 | `minesweeper`      | `ww, wh` threaded into both screens | both screens `FillFill`, params dropped           |
-| `2048`             | window size in both screens         | `gameView` `FillFill`; landing still needs it     |
-| `snake`            | window size in both screens         | play screen `FillFill`; landing still needs it    |
-| `animation_stress` | window size in three places         | root `FillFill`; two spawn helpers still need it  |
+| `2048`             | window size in both screens         | `gameView` `FillFill`, landing still needs it     |
+| `snake`            | window size in both screens         | play screen `FillFill`, landing still needs it    |
+| `animation_stress` | window size in three places         | root `FillFill`, two spawn helpers still need it  |
 
 **The allowlist, with the reason each one is real:**
 
@@ -1130,7 +1130,7 @@ content" (`gui/view_container.go:454`), so a Fill child of a Canvas has nothing
 to fill against. The revert is the finding, and the comment at the call site now
 records it.
 
-Verification is by probe, not by absence of panic. Renders at 800×600 confirmed
+Verification is by probe, not by absence of panic. Renders at 800×600 verified
 the converted view roots fill exactly 800×600 (`markdown`, `context_menu`,
 `dock_layout`, `scroll_demo` — covering a scrollable root and a
 non-`ContainerCfg` root), that `todo`'s card resolves to 773×573 inside the
@@ -1140,7 +1140,7 @@ real height (534.6) from Fill rather than from `wh - 70`.
 **Test conversion.** Three examples moved from `TestMainViewNoPanic` to state
 assertions: `key_up_demo` (one `TestKey` moves both the down and up counters,
 which a no-panic render cannot distinguish), `todo` (`TestType` + `TestClick`
-grows the list, clears the draft; a second test deletes by generated per-item
+grows the list, clears the draft. A second test deletes by generated per-item
 ID), and `dialogs` (clicking `dlg_message` puts the dialog overlay in the tree).
 
 `scroll_demo` was attempted and abandoned: `TestScroll` returns
@@ -1153,7 +1153,7 @@ carries the two state assertions it was meant to have.
 
 **Found, not fixed:** `examples/scroll_demo/main.go:111` gives all five
 percentage buttons the same ID, `"scroll_demo_pct_button"`. IDs must be unique
-per window; this is a §4.2-class defect, out of scope for a sizing audit, and it
+per window. This is a §4.2-class defect, out of scope for a sizing audit, and it
 makes those buttons untargetable by ID from a test.
 
 #### 4.8.2 The headless-overflow gap, as closed
@@ -1179,7 +1179,7 @@ overflows. It is an estimate of an estimate — right for "does this overflow",
 wrong for any pixel assertion, which is already `NewTestWindow`'s documented
 contract. It walks the string with `strings.IndexByte` rather than
 `strings.Split`, because this runs once per text shape inside the layout walk
-and a `Split` would heap-allocate on every one.
+and a `Split` heap-allocates on every one.
 
 **`ErrTestNoScrollRoom` (`gui/testing.go`)** is the diagnostic half. Even with
 the estimate, a fixture whose content genuinely fits still failed with a bare
@@ -1228,10 +1228,10 @@ than deleting it. The analyzer has zero `Scrollable` references.
 here: "`gui/view_select.go:145` builds the dropdown container with
 `Scrollable: true` and no ID." That is **false**, and it was false at this
 spec's own base commit. The literal sets `ID: dropdownScrollID` (=
-`cfg.ID + ".dropdown"`) at line 130; `Scrollable: true` sits fifteen lines below
+`cfg.ID + ".dropdown"`) at line 130. `Scrollable: true` sits fifteen lines below
 it at line 145, and the original reading took the second line without the first.
 
-Re-checked every `Scrollable: true` literal in `gui/` — command palette,
+Re-verified every `Scrollable: true` literal in `gui/` — command palette,
 inspector, table, theme picker, select, datagrid body — and **all six already
 carry an ID**. There are zero live scroll defects. The rest of this section
 still stands as a guard: the contract is unenforced even though nothing
@@ -1239,7 +1239,7 @@ currently violates it.
 
 Proposed, all additive except the tag:
 
-- Tag `ID` on `ContainerCfg` and `InputCfg`; wire `RequireScrollID` into
+- Tag `ID` on `ContainerCfg` and `InputCfg`. Wire `RequireScrollID` into
   `Input`.
 - Add a `checkScrollableID` rule to `tools/requiredid`, mirroring
   `checkFocusableID` — same shape, small diff.
@@ -1258,8 +1258,8 @@ into phase 4.
 
 ### 5.1 Positional auto-generated IDs
 
-Proposed as "derive stable IDs from tree position at layout time, like React
-keys; explicit `ID` becomes an override." **Reject.**
+Proposed as deriving stable IDs from tree position at layout time, like React
+keys, with an explicit `ID` as an override. **Reject.**
 
 IDs are not merely focus tokens — they are the identity key for all cross-frame
 widget state. 242 `StateMap[string, …]` sites key off `Shape.ID`: scroll offsets
@@ -1281,8 +1281,8 @@ nothing at build time. **Reject — the claim is inverted.** Variadic interface
 parameters allocate a backing slice plus one boxing allocation per modifier, per
 widget, per frame. That is the functional- options allocation pattern the
 proposal claims to avoid. The view phase is already the sole per-frame allocator
-(pipeline, arrange, and render are zero-alloc), so this would worsen the one hot
-spot. Struct literals allocate nothing extra; keep them and add value
+(pipeline, arrange, and render are zero-alloc), so this worsens the one hot
+spot. Struct literals allocate nothing extra. Keep them and add value
 constructors (§4.5).
 
 ### 5.3 `State[T]` returning an error instead of panicking
@@ -1297,8 +1297,8 @@ type requested (§4.1).
 | Phase | Contents                         | Breaking | Notes                |
 | ----- | -------------------------------- | -------- | -------------------- |
 | 1     | §4.1 gate, §4.2 delete + tag 9 + | no\*     | closes 13 live       |
-|       | fix 12 a11y defects, §4.9 scroll |          | defects; go-gui only |
-| 2     | §4.6 test API (incl. `TestTab`,  | no       | unblocks the rest;   |
+|       | fix 12 a11y defects, §4.9 scroll |          | defects. go-gui only |
+| 2     | §4.6 test API (incl. `TestTab`,  | no       | unblocks the rest    |
 |       | `TestScroll`)                    |          | discharges Q6 gate   |
 | 3     | §4.4 `ColorSet`, §4.5 `Opt` rule | no       | additive + fallback  |
 | 4     | §4.3, §4.7, flat `Color*`        | **yes**  | sibling migration    |
@@ -1318,7 +1318,7 @@ Two errors above:
    same nine factories, and a panic in `Button` is breaking whether or not
    anyone runs the tool. Measured rather than argued: go-charts and go-map each
    had example code that panics at runtime on a routine bump — 3 sites, exactly
-   the count §7 predicted, reached by a mechanism §6 said could not reach them.
+   the count §7 predicted, reached by a mechanism §6 claimed unreachable.
 2. **v0.53.0 is consumed.** Phase 4 needs **v0.54.0**.
 
 Revised: phase 1 = v0.53.0 (breaking, shipped). Phases 2–3 additive as
@@ -1327,8 +1327,8 @@ whatever follows.
 
 The two breaking releases are not a regression against "one breaking release":
 phase 1's break is a runtime panic on a config that was already broken, and
-phase 4's is a compile-time signature change. Bundling them would have delayed
-the a11y fix behind the event refactor.
+phase 4's is a compile-time signature change. Bundling them delays the a11y fix
+behind the event refactor.
 
 §4.6 moves ahead of the cosmetic work deliberately: a color-set refactor (§4.4)
 and an event-model change (§4.3) both alter behavior that apps currently cannot
@@ -1336,7 +1336,7 @@ assert on. Landing the test API first means the later phases ship with
 regression coverage instead of hoping the examples still look right.
 
 \* **Wrong — see the correction above.** Retained because the reasoning about
-the analyzer is sound and worth keeping; the conclusion it feeds is not. Phase 1
+the analyzer is sound and worth keeping. The conclusion it feeds is not. Phase 1
 is non-breaking **for consumers**. It removes one exported symbol with zero call
 sites anywhere (pre-1.0, no compatibility promise below v1), and adding
 `gui:"required"` to the 9 `Cfg`s breaks only go-gui's own callers — 111 of them,
@@ -1344,15 +1344,15 @@ all in this repo's tests and examples, surfaced by `requiredid` in CI rather
 than at runtime. The 3 sibling sites wait for phase 4 with the rest of the
 migration.
 
-That last claim depends on siblings not running the analyzer, so it was checked
+That last claim depends on siblings not running the analyzer, so it was verified
 rather than assumed. `requiredid` is not a `go vet` plugin registered by
-importing go-gui; it is a standalone binary invoked explicitly (`Makefile:104`
+importing go-gui. It is a standalone binary invoked explicitly (`Makefile:104`
 and `.github/workflows/ci.yml:155` both run
 `go run ./tools/requiredid/cmd/requiredid ./...`). All five siblings run plain
 `go vet ./...`, which does not load it. Tagging the 9 `Cfg`s therefore cannot
-red a sibling's CI on a routine version bump — the tags are inert in any repo
-that does not invoke the tool. If a sibling later adopts `requiredid`, it adopts
-the backlog at that moment by choice.
+turn a sibling's CI red on a routine version bump — the tags are inert in any
+repo that does not invoke the tool. If a sibling later adopts `requiredid`, it
+adopts the backlog at that moment by choice.
 
 Phase 4 must be a single release. Three breaking event refactors in consecutive
 versions is worse for consumers than one larger one.
@@ -1398,8 +1398,8 @@ the nine factories. Wiring it unconditionally panics on legitimate code:
 there is a live one — the date picker's blank out-of-month cell — plus test
 cases that exercise the opt-out. The tag gained an option,
 `gui:"required,focus"`, and the runtime guard an unexported `requireFocusID`
-that honours the same exemption. This is the predicate the deleted
-`RequireFocusID` encoded, inverted for the default-on convention; keeping it at
+that honors the same exemption. This is the predicate the deleted
+`RequireFocusID` encoded, inverted for the default-on convention. Keeping it at
 the call site rather than behind an export makes the condition visible where it
 applies.
 
@@ -1413,14 +1413,14 @@ opt-out is otherwise correct.
 
 **§4.9's tag is struck, not deferred.** Two of its three items do not apply as
 written. The runtime guard already exists —
-`RequireScrollID("container", cfg.Scrollable, cfg.ID)` has been wired in
-`buildContainerShape` all along; `ergonomics-audit` listed `ContainerCfg` as
-unguarded because it judges by tag, not by call site. And tagging
-`ContainerCfg.ID` would be wrong: most containers legitimately have no ID, so a
-`required` tag on a normally-absent field inverts the default and flags the
-common case. The rule is conditional on `Scrollable: true`, which is exactly how
-`checkFocusableID` already handles `Focusable: true` — keyed on the field in the
-literal, no tag. So §4.9 reduces to the analyzer rule, which is what shipped.
+`RequireScrollID("container", cfg.Scrollable, cfg.ID)` in `buildContainerShape`,
+wired all along. `ergonomics-audit` listed `ContainerCfg` as unguarded because
+it judges by tag, not by call site. And tagging `ContainerCfg.ID` is wrong: most
+containers legitimately have no ID, so a `required` tag on a normally-absent
+field inverts the default and flags the common case. The rule is conditional on
+`Scrollable: true`, which is exactly how `checkFocusableID` already handles
+`Focusable: true` — keyed on the field in the literal, no tag. So §4.9 reduces
+to the analyzer rule, which is what shipped.
 
 `InputCfg` also dropped out of the scrollable gap on its own: phase 1 made its
 `ID` unconditionally required, which subsumes the scroll case. `ContainerCfg`
@@ -1434,7 +1434,7 @@ guard already did.
 
 ## 7. Sibling impact
 
-All five siblings pin `go-gui v0.52.0`; `main` is v0.52.1, so these counts
+All five siblings pin `go-gui v0.52.0`. `main` is v0.52.1, so these counts
 reflect the current API. Measured with `go/ast` walks over each repo
 (`scratchpad/siblingimpact.go`).
 
@@ -1454,16 +1454,16 @@ Eighteen edits across five repos, all mechanical. The cost of the whole breaking
 release is smaller than the cost of one of its parts was assumed to be.
 
 Two rows moved after review. The `ColorSet` row was `0` until the flat-field
-deletion was scheduled (§4.4); an additive-only reading scored it zero and
+deletion was scheduled (§4.4). An additive-only reading scored it zero and
 quietly deferred the real number — `Color` is retained, so only the five state
-fields count. The `gui.Focus` row was 11 until §4.2's opt-in collapse was cut;
-those 11 sites are correct as written today and now require no edit at all.
+fields count. The `gui.Focus` row was 11 until §4.2's opt-in collapse was cut.
+Those 11 sites are correct as written today and now require no edit at all.
 **Only 3 of the remaining 18 come from §4.2**, and none of those 3 is a breaking
-API change — they are IDs that should have been supplied anyway.
+API change — they are IDs that were needed regardless.
 
 ### 7.1 How the §4.3 boundary was measured
 
-§4.3 states the conclusion; this is the derivation. A naive count finds 38
+§4.3 states the conclusion. This is the derivation. A naive count finds 38
 `*Window`-tailed callback literals in the siblings. None is forced work:
 
 | Category                            | Sites | Verdict          |
@@ -1509,7 +1509,8 @@ empty bodies.
 
 ### 7.3 Reproducing these counts
 
-Every figure in this spec comes from `tools/ergonomics-audit`, checked in:
+Every figure in this spec comes from `tools/ergonomics-audit`, which is
+committed to the repo:
 
 ```
 go run ./tools/ergonomics-audit/ -mode focus     -gui . . ../go-charts ../go-edit ../go-kite ../go-term ../go-map
@@ -1524,7 +1525,7 @@ recur.
 **Sibling figures published before 2026-08-08 are not reliable.** Mode
 `callbacks` counted any `OnX: func(..., *Window)` literal regardless of which
 module declared the field, so sibling numbers included the siblings' own
-callbacks. It now splits the two; only the "go-gui fields" figure is a migration
+callbacks. It now splits the two. Only the "go-gui fields" figure is a migration
 cost. See §4.3.1 for that fix and two others in the same mode.
 
 ## 8. Doc deliverables
@@ -1535,15 +1536,15 @@ cost. See §4.3.1 for that fix and two others in the same mode.
 - `CLAUDE.md` — event-model section rewritten for the single rule (§4.3)
 - `docs/specs/eventctx-callback-refactor.md` — mark superseded by §4.3
 - `docs/specs/idfocus-to-focusable.md` — decision 3 cites `RequireID`
-  enforcement for `Focusable: true`; amend to record that the runtime guard was
-  never wired up and is now deleted in favour of the analyzer plus the debug
+  enforcement for `Focusable: true`. Amend it to record that the runtime guard
+  was never wired and is now deleted in favor of the analyzer plus the debug
   gate (§4.2)
 - **Phase-4 migration guide** (new, `docs/migration-v0.53.md` or similar). 18
   sibling sites plus ~126 ID fills are mechanical, and §7.2's silent half is not
   — a before/after for `Focus`, `Consume`, and `ColorSet` is cheap insurance.
 - **`ergonomics-audit -fix`** (new, phase 1). Not "consider" — commit to it.
   Phase 1 alone rewrites 111 internal literals to add `ID` fields, and phase 4
-  adds ~15 more; that is a week of mechanical edits done by hand, and
+  adds ~15 more. That is a week of mechanical edits done by hand, and
   hand-editing 111 literals is how a typo'd ID reaches `main` looking like
   intent. The `go/ast` `CompositeLit` walk that finds them is already written
   and tested in `tools/ergonomics-audit`, so `-fix` is an insertion pass on top
@@ -1551,12 +1552,12 @@ cost. See §4.3.1 for that fix and two others in the same mode.
   and variable name and are **written into the source literal** — this does not
   reopen §5.1, which rejects IDs _computed at runtime from tree position_. A
   generated ID in the file is an ordinary ID that a human can read, review, and
-  edit; the rejected design has no source-level existence and changes when a
+  edit. The rejected design has no source-level existence and changes when a
   sibling is inserted. If the codemod is worth shipping for siblings, it is
   worth running on the 111 first — where its output is reviewable in the same PR
   that adds the tags.
 - **Two callback families, documented as intentional** (godoc + `CLAUDE.md`).
-  Event-driven takes `EventCtx`; lifecycle, animation, and completion take
+  Event-driven takes `EventCtx`. Lifecycle, animation, and completion take
   `func(T…, *Window)`. Writing this down is what stops the next reviewer
   reopening §4.3 as "unfinished `EventCtx`".
 - **How to run `requiredid` in your own build** (new, `README.md` plus the
@@ -1579,12 +1580,12 @@ proceed. Q8 was resolved on 2026-08-07, before phase 1 shipped.
 | #   | Topic                    | Decision                             |
 | --- | ------------------------ | ------------------------------------ |
 | 1   | Test API location        | package `gui`                        |
-| 2   | Click model              | ID-targeting v1; `TestClickAt` later |
+| 2   | Click model              | ID-targeting v1, `TestClickAt` later |
 | 3   | Nested focus             | unexported `Shape` helper            |
-| 4   | Focusable without ID     | proceed; mandatory `ID`              |
-| 5   | `ColorSet` zero value    | plain `Color` (reversed; see §4.4.1) |
-| 6   | Nested `OnMouseScroll`   | gate written 2026-08-07; see below   |
-| 7   | Breaking release target  | v0.54.0 (revised; see §6)            |
+| 4   | Focusable without ID     | proceed, mandatory `ID`              |
+| 5   | `ColorSet` zero value    | plain `Color` (reversed, see §4.4.1) |
+| 6   | Nested `OnMouseScroll`   | gate written 2026-08-07, see below   |
+| 7   | Breaking release target  | v0.54.0 (revised, see §6)            |
 | 8   | `requiredid` for authors | **documented only** (2026-08-07)     |
 
 Detail where the decision carries a constraint:
@@ -1595,8 +1596,8 @@ Detail where the decision carries a constraint:
    trade.
 2. **ID-targeting for v1.** Answers the state-transition question that 63
    example tests cannot answer today. Hit-testing arrives later as a separate
-   `TestClickAt(x, y)` — never by changing `TestClick`'s meaning, which would
-   silently reinterpret existing tests.
+   `TestClickAt(x, y)` — never by changing `TestClick`'s meaning, which silently
+   reinterprets existing tests.
 3. **Nested focus via an unexported `Shape` helper.** Compound widgets that mark
    an internal child focusable get an internal path to propagate an ID derived
    from the parent's, so `Cfg.ID` stays the only public spelling.
@@ -1606,8 +1607,8 @@ Detail where the decision carries a constraint:
    'deliberately transparent' — and fallback is the entire point of the type."
    That premise is false against the code. `Color` has carried its own `set`
    flag all along, so the distinction exists without a wrapper and adding one
-   would give the field two competing notions of unset. Shipped as plain
-   `Color`; `Flat(c)` survives unchanged as the all-states shorthand.
+   gives the field two competing notions of unset. Shipped as plain `Color`.
+   `Flat(c)` survives unchanged as the all-states shorthand.
 5. **Nested scroll is the one real risk.** Under the one-rule collapse a nested
    scrollable that today relies on notify-class propagation to hand an
    unconsumed scroll to its parent changes behavior with **no compile error** —
@@ -1616,15 +1617,15 @@ Detail where the decision carries a constraint:
    writable if phase 2 ships `TestScroll` and `TestScrollOffset` (§4.6) —
    without an offset read-back the case can be injected but not asserted, and
    the gate cannot be discharged. This is also why §4.9 belongs in phase 1:
-   scroll-state keying and scroll propagation should not both be in motion at
+   scroll-state keying and scroll propagation must not both be in motion at
    once.
 
    **Written 2026-08-07** as `gui/scroll_nested_test.go`. The current contract
    holds: an inner scrollable pinned at its limit declines the scroll, and
    traversal unwinds to the enclosing container in the same gesture. Verified to
    fire by mutation — forcing `IsHandled = true` on a scrollable under the
-   cursor reds `TestNestedScrollCascadesToParentAtLimit` with a message naming
-   Q6. Phase 4 now has something concrete to break, and breaking it is a
+   cursor turns `TestNestedScrollCascadesToParentAtLimit` red with a message
+   naming Q6. Phase 4 now has something concrete to break, and breaking it is a
    decision that has to be argued here rather than a silent behavior change.
 
    One incidental finding: the cascade is not assertable after the fact. Once
@@ -1632,12 +1633,12 @@ Detail where the decision carries a constraint:
    clip to aim a follow-up scroll at, so the test must assert across the single
    gesture where the handoff happens.
 
-6. **v0.54.0** for the §4.3/§4.4/§4.7 breaking phase; phases 2–3 as `v0.53.x`.
+6. **v0.54.0** for the §4.3/§4.4/§4.7 breaking phase. Phases 2–3 as `v0.53.x`.
    Revised from the original "v0.53.0, one breaking release" — phase 1 turned
    out to be breaking and consumed that version. The 18 remaining sibling edits
-   still land in one release; see §6.
+   still land in one release. See §6.
 7. **`requiredid` for app authors — resolved 2026-08-07: documented only.** It
-   stays a `tools/` binary that authors may invoke. The README carries the
+   stays a `tools/` binary that authors can invoke. The README carries the
    one-line invocation and the `go vet -vettool=` and golangci-lint
    alternatives, plus one sentence on what an author gets without it: a
    `RequireID` panic on first render rather than a build failure. The analyzer's
@@ -1648,9 +1649,9 @@ Detail where the decision carries a constraint:
 
    The alternatives, recorded because the trade is not obvious:
 
-   - **Documented only.** It stays a `tools/` binary that authors may invoke.
+   - **Documented only.** It stays a `tools/` binary that authors can invoke.
      Its rules can tighten freely, because nothing promises they will not. Costs
-     nothing; leaves most consumers on the `RequireID`-panic path by default.
+     nothing. Leaves most consumers on the `RequireID`-panic path by default.
    - **Supported.** Named in the README as part of the recommended setup,
      versioned with the library, plausibly a `go tool` directive. Makes §4.2's
      static-enforcement claim true for everyone — and makes the analyzer's rules
@@ -1659,9 +1660,9 @@ Detail where the decision carries a constraint:
 
    Chosen "documented only" because the support commitment buys little that the
    `RequireID` panic does not already buy loudly, and costs the freedom to
-   tighten a rule without reding somebody's build on a patch bump — the failure
-   mode `deps-doc` and the alloc gates exist to avoid. Revisit if a sibling
-   adopts the analyzer and asks for a stability promise.
+   tighten a rule without turning somebody's build red on a patch bump — the
+   failure mode `deps-doc` and the alloc gates exist to avoid. Revisit if a
+   sibling adopts the analyzer and asks for a stability promise.
 
 ## 10. Counting rules
 
@@ -1674,7 +1675,7 @@ exported `On*` field whose type is a `func`, and keys the dedupe on the field
 name joined to the `go/printer` rendering of its type. So `OnDone func(*Window)`
 and `OnDone func(NativeAlertResult, *Window)` are two entries, and an identical
 shape declared under two names stays two entries. **136 raw declarations reduce
-to 70 distinct pairs.** Scope is `gui/*.go` plus `gui/*/*.go`; `_test.go`
+to 70 distinct pairs.** Scope is `gui/*.go` plus `gui/*/*.go`. `_test.go`
 excluded.
 
 Text dedupe does not reproduce this. An earlier `grep | sort -u` pass reported
@@ -1690,12 +1691,12 @@ view builders `OnCellFormat` and `OnDetailRowView` are _not_ in that last
 bucket: they end in `*gg.Window` and so count inside the 27, which is where §4.3
 excludes them. Of the 27 `*Window`-tailed, **14 are excluded** by §4.3 as
 lifecycle/dialog callbacks that have no event to carry, leaving **13 to
-convert**. §4.3 lists all 14 by name; that list, not this count, is the phase-4
+convert**. §4.3 lists all 14 by name. That list, not this count, is the phase-4
 work item.
 
 The raw-`*Event` figure is 6, not the 5 a `grep '\*Event'` finds: two are
 declared in the `datagrid` subpackage as the qualified `*gg.Event`
-(`OnColumnPinChange`, `OnCopyRows`). `baseType` strips the package qualifier;
+(`OnColumnPinChange`, `OnCopyRows`). `baseType` strips the package qualifier.
 `TestBaseType` pins it. Counted as declaration _lines_ instead of pairs the
 figure is 7 — `OnEvent func(*Event, *Window)` is declared twice
 (`gui/window_cfg.go:14`, `gui/window.go:168`) with an identical signature and
@@ -1722,8 +1723,8 @@ misclassified `ListBoxCfg` as untagged.
 
 **Literal audit (§4.2, §7).** `go/ast` `CompositeLit` walk over each repo,
 skipping `vendor/`, `.git/`, `testdata/`. `ID` counts as present unless absent
-or the literal `""`; a computed `ID` that evaluates empty at runtime counts as
-present, so 126 is a floor. Tests included and labelled separately.
+or the literal `""`. A computed `ID` that evaluates empty at runtime counts as
+present, so 126 is a floor. Tests included and labeled separately.
 
 **`WindowSize()` audit.** Call _expressions_ under `examples/`, excluding
 `_test.go` and excluding the one occurrence in prose — the comment at

--- a/docs/specs/eventctx-callback-refactor.md
+++ b/docs/specs/eventctx-callback-refactor.md
@@ -1,13 +1,13 @@
 # EventCtx: reduce event-handling ceremony
 
 Status: **implemented and superseded.** The signature collapse shipped in
-v0.52.0–v0.54.0 (`EventCtx`, `Consume()`, `tools/eventctx`); the handled-default
+v0.52.0–v0.54.0 (`EventCtx`, `Consume()`, `tools/eventctx`). The handled-default
 flip (consume-class pre-mark + `ctx.Bubble()`) shipped with it and was then
 **deliberately reversed in v0.55.0** (`fe404f6`, #206): nothing is marked
 handled for you, `ctx.Bubble()` is deleted, `ctx.Consume()` is the one rule for
 every callback. The `class` argument survived only to name events for the
 `debugUnconsumed` check (`gui/event_traversal.go`). The one-event-rule design is
-authoritative; do not re-implement the consume-class default from this spec.
+authoritative. Do not re-implement the consume-class default from this spec.
 Item 3 (typed `ctx.State`) was dropped for the documented Go reasons. Breaking
 change.
 
@@ -32,7 +32,7 @@ Intended outcome: one breaking release that collapses the callback signature to
 keyboard/hover propagation semantics intact.
 
 **Item 3 is dropped.** Go cannot give a typed `ctx.State` — methods cannot take
-type parameters, and a generic `EventCtx[T]` would force every `Cfg` struct and
+type parameters, and a generic `EventCtx[T]` forces every `Cfg` struct and
 widget factory to become generic, which the heterogeneous `Layout` callback
 storage forbids. The achievable version saves ~10 characters. Instead, document
 the one-line app-side helper:
@@ -104,7 +104,7 @@ dispatches to `OnClick` via `handleMouseDownEvent` (`gui/window_event.go:151`).
 **Consume — marked handled before the callback runs.** `OnClick`, `OnChar`,
 `OnMouseUp`, `OnGesture`, `OnFileDrop`.
 
-**Notify — unchanged; callback must consume explicitly.** `OnKeyDown`,
+**Notify — unchanged. Callback must consume explicitly.** `OnKeyDown`,
 `OnKeyUp`, `OnHover`, `OnMouseMove`, `OnMouseLeave`, `OnMouseScroll`,
 `OnScroll`, `AmendLayout`, `OnDraw`, `OnIMECommit`. Also
 `shapeButtonColors.OnHover` / `OnAmend` (`gui/shape.go:409-410`).
@@ -114,10 +114,10 @@ the change:
 
 - `OnKeyDown` receives _every_ key. A widget handling only Enter must leave Tab,
   Escape, and accelerators to bubble — which is why the `ClickOnEnter` dispatch
-  (`gui/event_handlers.go:93-101`) consumes only on match. Auto-consuming would
-  silently kill tab traversal in any widget with a key handler.
+  (`gui/event_handlers.go:93-101`) consumes only on match. Auto-consuming kills
+  tab traversal silently in any widget with a key handler.
 - Hover/move/leave are notifications, not consumption. Nested shapes
-  legitimately all want hover; auto-consuming breaks every
+  legitimately all want hover. Auto-consuming breaks every
   hover-highlight-on-container pattern and reintroduces the same boilerplate
   inverted.
 - **`OnMouseScroll` is notify, not consume.** `mouseScrollFallbackHandler`
@@ -125,9 +125,9 @@ the change:
   through to the scroll container _only if the handler left the event
   unhandled_. Cascade-on-unhandled is the designed contract, asserted by
   `TestMouseScrollUnhandledCascadesToScrollContainer`
-  (`gui/event_handlers_test.go:444`). Auto-consuming would invert it and
-  silently break nested scroll containers. Scroll chaining is to scroll what
-  bubbling is to keys — same carve-out, same reason.
+  (`gui/event_handlers_test.go:444`). Auto-consuming inverts it and silently
+  breaks nested scroll containers. Scroll chaining is to scroll what bubbling is
+  to keys — same carve-out, same reason.
 
 **`MouseLockCfg`** (`gui/window.go:282-284`) — its `MouseDown`, `MouseMove`,
 `MouseUp` convert to the new signature but get **no auto-consume**. Mouse lock
@@ -145,8 +145,8 @@ scrolls a container reaches `fireOnScroll` → `OnScroll` while the click callba
 is still on the stack, and `AmendLayout` recurses through children from
 `gui/layout_pipeline.go:49`.
 
-A single reusable `EventCtx` owned by `*Window` would therefore be corrupted by
-any nested callback overwriting `Layout` or `Event` under the outer frame. Value
+A single reusable `EventCtx` owned by `*Window` is therefore corrupted by any
+nested callback overwriting `Layout` or `Event` under the outer frame. Value
 semantics removes the failure mode: each frame gets its own copy, and there is
 no shared buffer for a user to retain past the callback.
 
@@ -156,8 +156,8 @@ no shared buffer for a user to retain past the callback.
 sites) run inside phases that are currently zero-allocation
 (`layout_pipeline_bench_test.go`, `render_layout_bench_test.go`). Passing
 `EventCtx` by value keeps them there — nothing escapes, because no pointer to
-the struct is formed. This is the reason for value semantics over `*EventCtx`;
-confirm with the alloc gates rather than assuming.
+the struct is formed. This is the reason for value semantics over `*EventCtx`.
+Verify with the alloc gates rather than assuming.
 
 ### Pre-mark ordering inside `callRelative`
 
@@ -181,10 +181,10 @@ if handled {
 }
 ```
 
-Marking before the save would copy `IsHandled = true` into `saved`, and the
-restore would then undo any `ctx.Bubble()` the callback performed — a silent,
-hard-to-trace failure. `EventCtx.Event` stays a pointer to the same `Event`, so
-the save/restore is otherwise unaffected.
+Marking before the save copies `IsHandled = true` into `saved`. The restore then
+undoes any `ctx.Bubble()` the callback performed — a silent, hard-to-trace
+failure. `EventCtx.Event` stays a pointer to the same `Event`, so the
+save/restore is otherwise unaffected.
 
 Semantics to document: **`Bubble()` opts out of _this_ callback's auto-consume
 only.** It does not un-handle an event some earlier handler already consumed,
@@ -193,7 +193,7 @@ because the restore re-applies the incoming flag.
 ### Where the pre-mark goes — class is a parameter, not a helper
 
 **The three shared traversal helpers each serve both classes.** A blanket
-pre-mark inside them would silently destroy the carve-outs this spec spends its
+pre-mark inside them silently destroys the carve-outs this spec spends its
 length defending:
 
 | Helper                 | Consume-class callers                                           | Notify-class callers                    |
@@ -202,10 +202,10 @@ length defending:
 | `executeMouseCallback` | `OnClick` (`:219`), `OnMouseUp` (`:281`), `OnFileDrop` (`:384`) | `OnMouseMove` (`:252`)                  |
 | `callRelative`         | via `executeMouseCallback`                                      | `OnMouseScroll` (`:306`)                |
 
-(Line numbers in `gui/event_handlers.go`.) Marking inside `callRelative` would
-make `if callRelative(...) { return }` at `:306` always true and kill
-focused-target scroll cascading; marking inside `executeMouseCallback` would
-auto-consume `OnMouseMove` and kill hover-on-container.
+(Line numbers in `gui/event_handlers.go`.) Marking inside `callRelative` makes
+`if callRelative(...) { return }` at `:306` always true and kills focused-target
+scroll cascading. Marking inside `executeMouseCallback` auto-consumes
+`OnMouseMove` and kills hover-on-container.
 
 **Therefore: add an explicit class argument** to `executeFocusCallback`,
 `executeMouseCallback`, and `callRelative` — `consume bool`, or a two-valued
@@ -214,16 +214,16 @@ auto-consume `OnMouseMove` and kill hover-on-container.
 flag is set. Every call site is forced to state its class, and the compiler
 catches a new dispatch path that forgets to.
 
-This **replaces** any single `invokeConsuming(...)` helper: such a helper would
-have to duplicate the coordinate translation, and the classes are not separable
-by call path.
+This **replaces** any single `invokeConsuming(...)` helper: such a helper
+duplicates the coordinate translation, and the classes are not separable by call
+path.
 
 **Direct call sites bypassing all three helpers** — each needs the class
 decision applied by hand:
 
 - `mouseScrollFallbackHandler` (`gui/event_handlers.go:329-337`) calls
   `OnMouseScroll` directly. Notify: no pre-mark, and the cascade-on-unhandled
-  behaviour must be preserved verbatim.
+  behavior must be preserved verbatim.
 - `ClickOnSpace` (`:41-50`) and `ClickOnEnter` (`:93-101`) call `OnClick`
   directly, bypassing the mouse path. Consume: both need the pre-mark.
 - `OnGesture` dispatches directly at `gui/gesture.go:520`, through none of the
@@ -237,10 +237,10 @@ last-resort hook, fired at `gui/window_event.go:69` **only when
 unchanged, and outside the signature table by design.
 
 But auto-consume changes when it fires: clicks, chars, mouse-ups, file drops and
-gestures that any widget handled will no longer reach `OnEvent`, where
-previously a widget that forgot `IsHandled = true` let them through. That is the
-intended semantics, not a regression — but it is a visible behaviour change for
-apps using `OnEvent` as a global sniffer. Call it out in the migration guide.
+gestures that any widget handled no longer reach `OnEvent`, where previously a
+widget that forgot `IsHandled = true` let them through. That is the intended
+semantics, not a regression — but it is a visible behavior change for apps using
+`OnEvent` as a global sniffer. Call it out in the migration guide.
 
 ### Signature groups
 
@@ -252,7 +252,7 @@ apps using `OnEvent` as a global sniffer. Call it out in the migration guide.
 | `func(T, *Event, *Window)`          |   ~25 | `func(T, EventCtx)`          |
 | `func(*Window)` / `func(T,*Window)` |   ~24 | **unchanged**                |
 
-† Counts are Shape/Cfg **field declarations**, not textual occurrences; the
+† Counts are Shape/Cfg **field declarations**, not textual occurrences. The
 latter are higher because of factory helpers returning these types. The
 `func(*Layout, *Window)` set is at least: `eventHandlers.OnScroll` and
 `.AmendLayout` (`gui/shape.go:388-389`), `shapeButtonColors.OnAmend` (`:410`),
@@ -264,8 +264,8 @@ match list.
 
 `OnBlur` fires from `gui/view_input.go:537` with no event in hand, so it
 converts with a nil `ctx.Event` like the other lifecycle callbacks. It is
-arguable that blur should carry the click that moved focus; that is a separate
-change and explicitly out of scope here.
+arguable that blur carries the click that moved focus. That is a separate change
+and explicitly out of scope here.
 
 Payload carriers keep their payload as a leading argument rather than being
 stuffed into `EventCtx` — a `GridRow` is not context, and hiding it in a struct
@@ -273,8 +273,8 @@ field loses type safety at the call site.
 
 Lifecycle callbacks (animation `OnDone`/`OnValue`, native dialog and
 notification `OnDone`, `NativeMenuCfg.OnAction`) are **not** converted: they
-have no `Layout` and no `Event`, so an `EventCtx` would carry two nil fields and
-dilute what the type means.
+have no `Layout` and no `Event`, so an `EventCtx` carries two nil fields and
+dilutes what the type means.
 
 `OnDraw func(*DrawContext)` is unchanged — `DrawContext` is already its own
 context type.
@@ -287,8 +287,8 @@ unrelated.
 
 ### Phase 0 — Issues
 
-- File tracking issue for the refactor; add to org Project board (`projects/1`)
-  with Kind/Area/Status set.
+- File a tracking issue for the refactor. Add it to the org Project board
+  (`projects/1`) with Kind/Area/Status set.
 - File a **separate issue to update the GitHub wiki**
   (`github.com/go-gui-org/go-gui/wiki`). The wiki is linked from `README.md` as
   the primary documentation surface and is outside the repo, so it cannot be
@@ -302,7 +302,7 @@ unrelated.
 Thread the class argument through `executeFocusCallback`,
 `executeMouseCallback`, and `callRelative`, and apply the pre-mark at the direct
 dispatch sites — see "Where the pre-mark goes" above. The blanket "pre-mark
-inside the shared helpers" shortcut is wrong; those helpers serve both classes.
+inside the shared helpers" shortcut is wrong. Those helpers serve both classes.
 
 **Keyboard-activation dispatch.** The live click-on-key semantics are the
 `eventHandlers` struct fields, not wrappers: `ClickOnSpace` fires through
@@ -323,11 +323,11 @@ Leaving them as `(layout, e, w)` keeps the diff to the public surface.
 `leftClickOnly` (the three `Deprecated:` wrappers at the end of `gui/event.go`)
 have no production call sites — only `gui/event_test.go:141-210` exercises them.
 They were superseded by the `eventHandlers` fields above to avoid per-frame
-closure allocation. Remove them and their tests rather than porting them; a
+closure allocation. Remove them and their tests rather than porting them. A
 breaking release is the right moment. Update the referring comments in
 `gui/view_container.go:33-43` and `gui/shape.go:397-399` — the latter cites
 `docs/specs/perf-optimizations.md` §6, which does not exist. Do not propagate
-that citation; drop it.
+that citation. Drop it.
 
 ### Phase 2 — Migration tool
 
@@ -341,8 +341,8 @@ parameter lists and conditionally deletes statements inside nested closures.
 
 1. **Signature.** `func(l *Layout, e *Event, w *Window)` → `func(ctx EventCtx)`.
    Rewrite body references: `l`→`ctx.Layout`, `e`→`ctx.Event`, `w`→`ctx.Window`,
-   honouring the actual parameter names and any `_` blanks. Payload carriers
-   keep the leading argument.
+   honoring the actual parameter names and any `_` blanks. Payload carriers keep
+   the leading argument.
 2. **Notify-class callbacks:** rewrite `e.IsHandled = true` → `ctx.Consume()`.
    Never delete it.
 3. **Consume-class callbacks:** delete `e.IsHandled = true` when it is the last
@@ -350,23 +350,23 @@ parameter lists and conditionally deletes statements inside nested closures.
 4. **Everything else in a consume-class callback: report, do not rewrite.**
 
 **Rule 4 is the migration's real risk and it is not automatable.** A
-consume-class callback that today returns early _without_ setting handled is
-relying on the old bubble-by-default, and after the flip it must call
-`ctx.Bubble()` on that path. The tool cannot infer whether a given early return
-meant "not mine, pass it on" or "done, nothing to do" — those are
-indistinguishable in the old encoding, because both wrote nothing.
+consume-class callback that today returns early _without_ setting handled relies
+on the old bubble-by-default, and after the flip it must call `ctx.Bubble()` on
+that path. The tool cannot infer whether a given early return meant "not mine,
+pass it on" or "done, nothing to do" — those are indistinguishable in the old
+encoding, because both wrote nothing.
 
 So the tool **emits a report** rather than guessing: for every consume-class
 callback, list each `return` (explicit or implicit fall-off-the-end) that is not
 dominated by an `IsHandled = true` assignment. Each entry is a human decision:
-insert `ctx.Bubble()` or confirm consume-by-default is correct. Expect this list
+insert `ctx.Bubble()` or verify consume-by-default is correct. Expect this list
 to be short now that `OnMouseScroll` is notify-class — the remaining consume set
 is `OnClick`, `OnChar`, `OnMouseUp`, `OnGesture`, `OnFileDrop`, where
 conditional consumption is uncommon but real. The sharpest case is **`OnChar`
 filtering**: a focused input whose `OnChar` ignores non-text characters
 previously let them fall through to container-level ancestors, and now blocks
 them by default. Hit-test subregions and disabled-state guards are the other
-recurring shapes. Budget review time for this list; do not batch-approve.
+recurring shapes. Budget review time for this list. Do not batch-approve.
 
 The report is also the tool's contract for the sibling repos, which get the same
 treatment in Phase 7 without a maintainer who knows this spec.
@@ -384,8 +384,8 @@ Work the rule-4 report to zero before moving on.
 ### Phase 4 — Non-standard signatures
 
 `OnScroll` and `AmendLayout` (`gui/shape.go:388-389`) and
-`shapeButtonColors.OnAmend` (`:410`) take an `EventCtx` with a nil `Event`;
-update `fireOnScroll` and `gui/layout_pipeline.go:49`. `OnIMECommit` becomes
+`shapeButtonColors.OnAmend` (`:410`) take an `EventCtx` with a nil `Event`.
+Update `fireOnScroll` and `gui/layout_pipeline.go:49`. `OnIMECommit` becomes
 `func(string, EventCtx)`. `MouseLockCfg`'s three fields
 (`gui/window.go:282-284`) convert with no auto-consume.
 
@@ -419,18 +419,18 @@ go-gui tags. Follow the existing `sync-siblings` skill order. Verify each with
 1. `go build ./...` and `CGO_ENABLED=0 go build ./...` (Linux/Windows parity
    must not regress).
 2. `golangci-lint run ./...`, `gofmt -l .`, `go vet ./...` (exercises the
-   `requiredid` analyzer — confirm it does not pattern-match callback types).
+   `requiredid` analyzer — verify it does not pattern-match callback types).
 3. `go test ./...` — full suite.
 4. **Alloc gates, the real risk:** `go test -run '^$' -bench . -benchmem ./gui/`
    focusing on `layout_pipeline_bench_test.go`, `render_layout_bench_test.go`,
    `event_bench_test.go`, `view_frame_bench_test.go`. Zero-alloc phases must
    stay at 0 allocs. Compare against `main` with `benchstat`.
-5. New tests: consume-class callback bubbles nothing by default; notify-class
-   callback still bubbles; `ctx.Bubble()` restores propagation; `ctx.Consume()`
-   stops it from a notify-class callback; `OnKeyDown` on a focused widget still
-   lets Tab reach the traversal handler; nested hover fires on both child and
-   ancestor; `ClickOnSpace` and `ClickOnEnter` both activate exactly once and
-   both consume; all three `EventCtx` methods are no-ops on a nil `Event`.
+5. New tests: consume-class callback bubbles nothing by default. Notify-class
+   callback still bubbles. `ctx.Bubble()` restores propagation. `ctx.Consume()`
+   stops it from a notify-class callback. `OnKeyDown` on a focused widget still
+   lets Tab reach the traversal handler. Nested hover fires on both child and
+   ancestor. `ClickOnSpace` and `ClickOnEnter` both activate exactly once and
+   both consume. All three `EventCtx` methods are no-ops on a nil `Event`.
 6. Reentrancy: an `OnClick` that triggers a synchronous `OnScroll` must leave
    the outer callback's `EventCtx` usable. `ctx.Layout` stability is trivial
    under value semantics, so assert the stronger property — after the nested
@@ -439,9 +439,9 @@ go-gui tags. Follow the existing `sync-siblings` skill order. Verify each with
    outer frame still takes effect.
 7. Class-parameter correctness — the shared helpers serve both classes, so
    assert each side explicitly: `OnMouseMove` through `executeMouseCallback`
-   does **not** auto-consume (hover-on-container survives); `OnMouseScroll`
+   does **not** auto-consume (hover-on-container survives). `OnMouseScroll`
    through `callRelative` at `event_handlers.go:306` does **not** auto-consume
-   (focused-target scroll still cascades); `OnChar` through
+   (focused-target scroll still cascades). `OnChar` through
    `executeFocusCallback` does, while `OnKeyDown`/`OnKeyUp` through the same
    helper do not.
 8. `Window.OnEvent` reachability: a click consumed by a widget no longer reaches
@@ -457,10 +457,10 @@ go-gui tags. Follow the existing `sync-siblings` skill order. Verify each with
 
 ## Decisions
 
-1. **Single PR.** Phases 1–6 land together. Split PRs would leave `main`
-   uncompilable between them, which is worse than one unbisectable commit — and
-   the repo has no external consumers to strand. Phase 0 (issues) precedes it;
-   Phase 7 (siblings) follows the go-gui tag.
-2. **Wiki rewrite is out of scope** for this PR. Phase 0 still files the issue;
-   the rewrite happens immediately after the PR merges, against the shipped API
+1. **Single PR.** Phases 1–6 land together. Split PRs leave `main` uncompilable
+   between them, which is worse than one unbisectable commit — and the repo has
+   no external consumers to strand. Phase 0 (issues) precedes it. Phase 7
+   (siblings) follows the go-gui tag.
+2. **Wiki rewrite is out of scope** for this PR. Phase 0 still files the issue.
+   The rewrite happens immediately after the PR merges, against the shipped API
    rather than a moving target.

--- a/docs/specs/exportaudit-surface-policy.md
+++ b/docs/specs/exportaudit-surface-policy.md
@@ -25,16 +25,16 @@ references it:
 |          | go-term, go-map)                            |                       |
 
 `maxClass` is the highest class with any reference. A hard failure means
-`make export-audit` exits non-zero: the symbol is internal-only and must be
-unexported or carry a `// exportaudit:keep` marker explaining why (json
-reflection, stdlib interface conformance, name collision, signature
-reachability, documented API).
+`make export-audit` exits non-zero. The symbol is internal-only and must be
+unexported or carry a `// exportaudit:keep` marker explaining why. The accepted
+reasons: json reflection, stdlib interface conformance, name collision,
+signature reachability, documented API.
 
-The consumer scan is authoritative; without the sibling repos an export used
-only there would misclassify as none/self, so the in-repo run alone can only
-report (it never hard-fails). `make export-audit` clones nothing: it uses
-`../go-*` checkouts when present, and CI shallow-clones the five sibling repos
-into `../` so the gate is authoritative there.
+The consumer scan is authoritative. Without the sibling repos, an export used
+only there misclassifies as none/self. The in-repo run alone can only report (it
+never hard-fails). `make export-audit` clones nothing. It uses `../go-*`
+checkouts when present. CI shallow-clones the five sibling repos into `../`, so
+the gate is authoritative there.
 
 ## Internal class: accepted by policy
 
@@ -42,18 +42,18 @@ into `../` so the gate is authoritative there.
 These exports are shared implementation between the root `gui` package and its
 leaf subpackages (backend, datagrid, svg, markdown, highlight, shader). The
 architecture keeps the root package as the hub that subpackages import
-(`gui/backend → gui`, `gui/svg → gui`), so unexporting them is not possible
+(`gui/backend → gui`, `gui/svg → gui`), so unexporting them is impossible
 without an `gui/internal/` package move, which the flat-leaf design rejects.
-They are reported in the gate advisory and listed fully by `-mode report`; keep
+They are reported in the gate advisory and listed fully by `-mode report`. Keep
 markers are not required for this class.
 
 ## Contract for future changes
 
 - Any new export whose references stay inside gui/ (none/self/selftest) fails
-  the gate; unexport it or keep-mark it.
+  the gate. Unexport it or keep-mark it.
 - Any export that starts being used by a sibling repo moves out of enforcement
-  automatically; the consumer scan reclassifies it.
+  automatically. The consumer scan reclassifies it.
 - Removing a consumer's export is caught by CI: the authoritative scan sees the
   sibling reference vanish and reclassifies the export down into enforcement.
 - `-mode report` output is stable (fixed section order) so two runs can be
-  diffed; use it before and after a sweep.
+  diffed. Use it before and after a sweep.

--- a/docs/specs/focusable-default-input.md
+++ b/docs/specs/focusable-default-input.md
@@ -1,54 +1,53 @@
 # Spec: `Focusable` defaults true for input controls (`FocusDisabled` opt-out)
 
 Status: **implemented** — Phase 1 shipped v0.36.0 (Input, Select, Slider,
-Toggle, Switch); Phase 2 shipped v0.37.0, dropping `Focusable bool` for
+Toggle, Switch). Phase 2 shipped v0.37.0, dropping `Focusable bool` for
 `FocusDisabled bool` on the remaining nine controls. Both phases in CHANGELOG.
 
 Base: `main` @ `8522098` Target release: go-gui `v0.36.0` (breaking)
 
 ## Motivation
 
-Nearly every interactive `InputCfg` site in-repo sets `Focusable: true`; the
+Nearly every interactive `InputCfg` site in-repo sets `Focusable: true`. The
 exceptions are not designed non-focusable inputs but the two wrapper factories
 (which pass `cfg.Focusable` through) and a couple of tests. Requiring the field
-on every input is boilerplate that adds nothing — an input the user can't tab to
-is a bug, not a design choice. Flip the default: input controls are focusable
+on every input is boilerplate that adds nothing — an input the user cannot tab
+to is a bug, not a design choice. Flip the default: input controls are focusable
 unless the caller opts out with `FocusDisabled`.
 
 **Phase 2 is an accessibility change, not just deboilerplating.** `Select`,
 `Slider`, `Toggle`, `Switch` are mostly _not_ focusable in-repo today (Slider:
 0% set `Focusable: true`), so flipping them enrolls those controls in the Tab
-order — the intended, correct behavior (a slider should be keyboard-adjustable),
-a visible behavior change, not silent cleanup. Zero `Focusable: false` anywhere
+order — the intended, correct behavior (a slider is keyboard-adjustable) — a
+visible behavior change, not silent cleanup. Zero `Focusable: false` anywhere
 (repo + all five siblings) confirms nobody relies on the opt-out, so the flip is
 safe.
 
 Scope caveat: focus still requires `s.ID != ""` (`layout_query.go:94`), so this
 benefit only reaches **ID-bearing** call sites. `Slider`'s ID is
-`gui:"required"` (always present); `Select`/`Toggle`/`Switch` IDs are optional,
+`gui:"required"` (always present). `Select`/`Toggle`/`Switch` IDs are optional,
 so an ID-less one becomes a focusable-but-inert shape (renders, never a tab
 stop) — consistent with the whole "no ID → inert" design, not a regression. The
-a11y win lands where callers supply an ID; encourage that in the field docs
-(Phase 3), do not force it.
+a11y win lands where callers supply an ID. Encourage that in the field docs
+(Phase 3). Do not force it.
 
 This is **only a default flip**, not auto-generated identity. Focus still
 requires a non-empty `ID` (`isFocusedTarget`: `Focusable && ID != ""`). A
-defaulted-focusable input with no `ID` is simply **inert** — it renders, but
-holds no focus, cursor, or state. That graceful degradation is accepted: no ID →
-no state → the control doesn't respond. No ID is ever fabricated, so the
-identity==state-key invariant (see
-[idfocus-to-focusable.md](idfocus-to-focusable.md)) is untouched and no state
-can be silently corrupted.
+defaulted-focusable input with no `ID` is **inert**: it renders, but holds no
+focus, cursor, or state. That outcome is accepted: no ID → no state → the
+control does not respond. No ID is ever fabricated, so the identity==state-key
+invariant (see [idfocus-to-focusable.md](idfocus-to-focusable.md)) is untouched
+and no state can be silently corrupted.
 
 ## Why `FocusDisabled bool`, not `Opt[bool]`
 
-`Focusable bool` cannot default true (zero value is false) and can't distinguish
-"unset" from "explicitly false." Inverting to `FocusDisabled bool` gives a
-zero-value default of _focusable_, a single obvious opt-out, and — because the
-`Focusable` field is removed from in-scope Cfgs — turns every existing
-`Focusable: true` on those Cfgs into a **compile error**, which is the migration
-guide. Preferred over `Opt[bool]`: no wrapper type, no `.Get()` at every read,
-loud break at the call site.
+`Focusable bool` cannot default true (zero value is false) and cannot
+distinguish "unset" from "explicitly false." Inverting to `FocusDisabled bool`
+gives a zero-value default of _focusable_ and a single obvious opt-out. Because
+the `Focusable` field is removed from in-scope Cfgs, the inversion turns every
+existing `Focusable: true` on those Cfgs into a **compile error**, which is the
+migration guide. It is preferred over `Opt[bool]`: no wrapper type, no `.Get()`
+at every read, loud break at the call site.
 
 ## Decisions (locked)
 
@@ -61,7 +60,7 @@ loud break at the call site.
    (Input) and stays **required** where `gui:"required"` already demands it
    (Slider, Combobox, DatePicker, Listbox — unchanged).
 4. `Disabled` still excludes from tab order (`collectFocusCandidates` already
-   gates `!Disabled`); `ReadOnly` still keeps the control focusable.
+   gates `!Disabled`). `ReadOnly` still keeps the control focusable.
    `FocusDisabled` is orthogonal to both.
 5. Out-of-scope widgets keep `Focusable bool` opt-in (Button, Container, Text,
    RTF, Markdown, DrawCanvas, TabControl, Splitter, Breadcrumb, OverflowPanel,
@@ -73,12 +72,12 @@ loud break at the call site.
    break for consumers, not two).
 8. **Composites and Input wrappers deferred** (Combobox, DatePicker, Listbox,
    RadioButtonGroup, **NumericInput, InputDate**) — each either governs focus
-   over internal children or has a focus-model defect the flip would expose (see
+   over internal children or has a focus-model defect the flip exposes (see
    [Deferred — why](#deferred--why)). Revisit in a follow-up.
 9. **Borderline widgets stay opt-in** (ColorPicker, ThemePicker, Tree) — Tree is
    navigation, the pickers are composite.
 10. **Analyzer stays silent** on an in-scope input with no `ID`. Inert is a
-    valid choice; no positive lint.
+    valid choice. No positive lint.
 11. **In-scope invariant** — a widget qualifies for the flip only if it (a)
     never fabricates a non-empty `ID` from an empty `cfg.ID`, and (b) exposes
     exactly **one** focus candidate (tab stop). Both are required so that "no ID
@@ -88,13 +87,13 @@ loud break at the call site.
 ## In-scope widget set
 
 Only widgets that satisfy the Decision-11 invariant are in scope. Audit against
-the two failure modes (fabricated ID from empty `cfg.ID`; more than one focus
-candidate):
+the two failure modes (fabricated ID from empty `cfg.ID`, and more than one
+focus candidate):
 
 | Cfg                                                                 | Focus candidates                                           | Fabricates ID? | Verdict                 |
 | ------------------------------------------------------------------- | ---------------------------------------------------------- | -------------- | ----------------------- |
-| `InputCfg`                                                          | 1 (outer `Column`; inner `Text` is `FocusSkip`, same `ID`) | no             | ✅ in — Phase 1         |
-| `SelectCfg`                                                         | 1 (`cfg.ID`; dropdown never focusable)                     | no¹            | ✅ in — Phase 2         |
+| `InputCfg`                                                          | 1 (outer `Column`, inner `Text` is `FocusSkip`, same `ID`) | no             | ✅ in — Phase 1         |
+| `SelectCfg`                                                         | 1 (`cfg.ID`, dropdown never focusable)                     | no¹            | ✅ in — Phase 2         |
 | `SliderCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2         |
 | `ToggleCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2         |
 | `SwitchCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2         |
@@ -102,12 +101,12 @@ candidate):
 | `InputDateCfg`                                                      | 1, but inner Input `ID = cfgID+".input"` **ungated**       | **yes**        | ❌ deferred             |
 | `ComboboxCfg`, `DatePickerCfg`, `ListBoxCfg`, `RadioButtonGroupCfg` | focus over internal children                               | —              | ❌ deferred (composite) |
 
-¹ `SelectCfg.ID` is optional; empty `ID` yields one _inert_ focus target but its
-open-state (`nsSelect`) is keyed on `""` and thus shared across ID-less Selects
-— a pre-existing quirk, not focus corruption. Passing an `ID` is recommended in
-practice; not required for the flip.
+¹ `SelectCfg.ID` is optional. An empty `ID` yields one _inert_ focus target but
+its open-state (`nsSelect`) is keyed on `""` and thus shared across ID-less
+Selects — a pre-existing quirk, not focus corruption. Passing an `ID` is
+recommended in practice, not required for the flip.
 
-**Phase 1:** `InputCfg` (single-line + multiline; the 96% case). **Phase 2:**
+**Phase 1:** `InputCfg` (single-line + multiline, the 96% case). **Phase 2:**
 `SelectCfg`, `SliderCfg` (`gui:"required"` ID), `ToggleCfg`, `SwitchCfg`.
 
 ### Deferred — why
@@ -116,14 +115,14 @@ The two Input **wrappers** each break the Decision-11 invariant and need a
 dedicated focus-model fix before they can flip:
 
 - **`InputDate`** — `inputDateTextField` sets the inner Input's `ID` to
-  `cfgID + ".input"` unconditionally (`view_input_date.go:233`); with an empty
-  `cfg.ID` that is `".input"`, a fabricated non-empty ID. After the flip the
-  inner Input becomes a live tab stop under `".input"`, two ID-less InputDates
-  collide, and `nsInputDateText`/`nsInputDate` state keyed on `""` is shared —
-  the exact corruption the invariant forbids. Same for `cfgID + ".picker"` (line
-  158). It also embeds the deferred `DatePicker` composite. Fix later: make
-  `InputDateCfg.ID` required (it is stateful), or gate every derived ID on
-  `cfg.ID != ""` the way `NumericInput` gates `_field`
+  `cfgID + ".input"` unconditionally (`view_input_date.go:233`). With an empty
+  `cfg.ID` that string is `".input"`, a fabricated non-empty ID. After the flip
+  the inner Input becomes a live tab stop under `".input"`, two ID-less
+  InputDates collide, and `nsInputDateText`/`nsInputDate` state keyed on `""` is
+  shared — the exact corruption the invariant forbids. Same for
+  `cfgID + ".picker"` (line 158). It also embeds the deferred `DatePicker`
+  composite. Fix later: make `InputDateCfg.ID` required (it is stateful), or
+  gate every derived ID on `cfg.ID != ""` the way `NumericInput` gates `_field`
   (`view_input_numeric.go:156`).
 - **`NumericInput`** — with step buttons, the outer Row (`cfg.ID`, focusable)
   and the inner Input (`cfg.ID+"_field"`, focusable) are two distinct tab stops
@@ -137,7 +136,7 @@ dedicated focus-model fix before they can flip:
 
 ### Per in-scope Cfg
 
-- Remove `Focusable bool`; add `FocusDisabled bool`.
+- Remove `Focusable bool`. Add `FocusDisabled bool`.
 - Factory: every `Focusable: cfg.Focusable` → `!cfg.FocusDisabled`. `InputCfg`
   sets this on both the outer `Column` (tab stop) and the inner `Text` (which
   stays `FocusSkip` under the same `ID` → still one tab stop).
@@ -154,13 +153,13 @@ rg -n 'InputCfg\{' -g '*.md' docs README.md .claude   # docs/snippets
 ```
 
 **The compiler is not a complete checklist.** Removing the field only breaks
-literals that _write_ `Focusable:`; a literal that omits it compiles fine but
-silently flips to focusable-by-default — a behavior change the build won't flag.
-And Markdown snippets never compile at all. So review **every** `InputCfg`
+literals that _write_ `Focusable:`. A literal that omits it compiles fine but
+silently flips to focusable-by-default — a behavior change the build will not
+flag. Markdown snippets never compile at all. Review **every** `InputCfg`
 literal the commands list, not just the ones that error. Each must be rewritten
 in the same phase so the repo compiles and the gate passes:
 
-- Literal `Focusable: true` → **delete the line** (now the default; these
+- Literal `Focusable: true` → **delete the line** (now the default. These
   widgets keep an `ID`, so behavior is unchanged).
 - `Focusable: <expr>` → `FocusDisabled: !<expr>`.
 
@@ -178,7 +177,7 @@ Internal `gui/` factories to migrate in Phase 1 (all currently pass
 `view_input_date.go`, `view_color_picker.go` (×2), `view_command_palette.go`,
 `view_dialog.go`, and `datagrid/` (`data_source_grid.go`,
 `view_data_grid_edit.go`, `_events.go`, `_header.go`, `_pager.go`). Internal
-Inputs that set `Focusable: true` just drop the line; the two wrappers use
+Inputs that set `Focusable: true` drop the line. The two wrappers use
 `FocusDisabled: !cfg.Focusable`.
 
 ### `view_input.go` a11y read-only clause
@@ -193,7 +192,7 @@ if cfg.ReadOnly || !cfg.Focusable {
 
 Drop the second clause → `if cfg.ReadOnly`. With focusable-by-default,
 non-focusable is now an explicit `FocusDisabled` opt-out, not the historical
-proxy for read-only; a missing ID must not announce read-only on a field nobody
+proxy for read-only. A missing ID must not announce read-only on a field nobody
 marked read-only.
 
 ### `requiredid` analyzer (`tools/requiredid/`)
@@ -202,8 +201,8 @@ No code change expected: its "Focusable: true without ID" rule keys on the
 literal field, which no longer exists on in-scope Cfgs (writing it is a compile
 error). Verify the rule is generic (not Cfg-type-named) and that
 `gui:"required"` tags on Slider/Combobox/DatePicker/Listbox IDs are retained. An
-analyzer test can assert no diagnostic on a fake Cfg with neither field, but
-note it is low value — `tools/requiredid/testdata` defines its own fake widgets,
+analyzer test can assert no diagnostic on a fake Cfg with neither field. Note
+that it is low value — `tools/requiredid/testdata` defines its own fake widgets,
 so it cannot catch regressions against the real `gui` types.
 
 ## Migration
@@ -220,7 +219,7 @@ graph.
   occurrences in-repo and across all five consumers).
 - Out-of-scope widgets: untouched.
 
-### Consumers (breaking; dependency order)
+### Consumers (breaking, dependency order)
 
 Re-verify per repo before shipping (grep `Focusable: true` on in-scope Cfg
 literals):
@@ -228,8 +227,8 @@ literals):
 1. **go-charts** — 1 `InputCfg` site.
 2. **go-kite** — `Input` literals.
 3. **go-map** — verify no in-scope literals.
-4. **go-edit** — builds `EditorCfg`, not `Input`; expected clean.
-5. **go-term** — no `gui.Input(` usage; expected clean.
+4. **go-edit** — builds `EditorCfg`, not `Input`. Expected clean.
+5. **go-term** — no `gui.Input(` usage. Expected clean.
 
 ## Tests / examples / docs
 
@@ -243,12 +242,12 @@ literals):
     stops). With `FocusDisabled: true`: zero.
   - **Optional-ID widgets only** (`Input`, `Select`, `Toggle`, `Switch`): with
     no `ID`, zero candidates (inert, still renders). Not applicable to `Slider`
-    (would panic).
+    (it panics).
 - `view_input_test.go`: existing `Focusable: true` literals → remove.
 - **Rewrite `TestInputReadOnlyWithoutFocus`** — it currently asserts
   non-focusable ⇒ `AccessStateReadOnly`, which relied on the dropped
   `!cfg.Focusable` clause. New assertions: `ReadOnly` announces
-  `AccessStateReadOnly`; `FocusDisabled` alone does **not**.
+  `AccessStateReadOnly`. `FocusDisabled` alone does **not**.
 - Docs: `shape.go` doc comment already documents `Shape.Focusable` (unchanged).
   Update per-Cfg field docs, the widget skill scaffold, README/CHANGELOG, and
   the per-example READMEs of any example app whose literals changed in Phases
@@ -260,7 +259,7 @@ literals):
   | `Shape.Focusable`     | widget participates in the focus system                  |
   | `FocusSkip`           | focusable + click/selection, but excluded from Tab order |
   | `FocusDisabled` (Cfg) | opt out of the default-on focus (in-scope Cfgs)          |
-  | `Disabled`            | non-interactive; also excluded from Tab order            |
+  | `Disabled`            | non-interactive, also excluded from Tab order            |
 
 ## Release
 
@@ -285,9 +284,9 @@ Each code phase migrates the **whole in-repo call graph** of the Cfg it changes
   `FocusDisabled`, drop the `!cfg.Focusable` a11y clause. Migrate **all
   `InputCfg` sites** (enumerate via the commands in
   [Call-site migration](#call-site-migration-mandatory-same-commit-as-the-field-removal)):
-  internal factories (wrappers via `FocusDisabled: !cfg.Focusable`; color-picker
+  internal factories (wrappers via `FocusDisabled: !cfg.Focusable`. Color-picker
   / command-palette / dialog / datagrid drop `Focusable: true`), the 8 example
-  files, and tests (incl. the one-candidate assertion and the
+  files, and tests (including the one-candidate assertion and the
   `TestInputReadOnlyWithoutFocus` rewrite). Gate, commit, pause.
 - **Phase 2** — `Select`, `Slider`, `Toggle`, `Switch`: same swap, each with its
   full call graph (factories, examples, tests). Gate, commit, pause.
@@ -302,24 +301,25 @@ No commits without explicit permission at each pause.
 
 ## Resolved
 
-- Phase 1 reduced to `Input`; the two Input wrappers (`NumericInput`,
+- Phase 1 reduced to `Input`. The two Input wrappers (`NumericInput`,
   `InputDate`) join the deferred bucket per the Decision-11 invariant and the
   audit (Findings 1–2 from review).
-- Composites deferred; borderline widgets stay opt-in; Phase 1+2 ship together
-  as `v0.36.0`; analyzer stays silent (Decisions 7–11).
-- Review round 3 folded in: wrappers/internal factories map to
-  `FocusDisabled: !cfg.Focusable` (keeps deferred bug out); each phase migrates
-  its full call graph (not "widget + own tests"); Motivation stats corrected and
-  Phase 2 reframed as an a11y change; `TestInputReadOnlyWithoutFocus` rewrite
-  named; standalone `Radio` explicitly opt-in.
-- Review round 4 folded in: Phase 2 a11y win scoped to ID-bearing sites (focus
-  still needs `ID != ""`); the "no ID → zero candidates" test split by
-  ID-requiredness (`Slider` panics without an ID, so it's excluded); hardcoded
-  `InputCfg` counts replaced with `rg` commands, with the caveat that the
+- Composites deferred. Borderline widgets stay opt-in. Phase 1+2 ship together
+  as `v0.36.0`. Analyzer stays silent (Decisions 7–11).
+- Review round 3 incorporated: wrappers/internal factories map to
+  `FocusDisabled: !cfg.Focusable` (keeps the deferred bug out). Each phase
+  migrates its full call graph (not "widget + own tests"). Motivation stats are
+  corrected, Phase 2 is reframed as an a11y change, the
+  `TestInputReadOnlyWithoutFocus` rewrite is named, and standalone `Radio` is
+  explicitly opt-in.
+- Review round 4 incorporated: Phase 2 a11y win scoped to ID-bearing sites
+  (focus still needs `ID != ""`). The "no ID → zero candidates" test is split by
+  ID-requiredness (`Slider` panics without an ID, so it is excluded). Hardcoded
+  `InputCfg` counts are replaced with `rg` commands, with the caveat that the
   compiler catches only `Focusable`-bearing literals (docs and omitted-field
   sites need manual review).
 
 ## Open questions
 
-None blocking. Confirm the exact consumer call-sites at ship time by grepping
+None blocking. Verify the exact consumer call-sites at ship time by grepping
 `Focusable: true` on in-scope Cfg literals in each repo.

--- a/docs/specs/font-viewer.md
+++ b/docs/specs/font-viewer.md
@@ -1,9 +1,9 @@
 # Font Viewer
 
 Status: **implemented** — `examples/fontviewer/` (main.go + tests). Shipped from
-this spec; see the feature table for P0 coverage.
+this spec. See the feature table for P0 coverage.
 
-Browsable system-font catalog. Type sample text; every installed font family
+Browsable system-font catalog. Type sample text. Every installed font family
 renders it in a scrollable card grid. Filter by name, adjust preview size, click
 to copy the family name.
 
@@ -12,10 +12,10 @@ to copy the family name.
 wrapping, and glyph-atlas growth _as you scroll_ (the windowing + cache-warming
 path), not simultaneous N-family layout. An optional `--shape-all` debug mode
 (P2) drops virtualization to shape **all N families in one frame** (still
-main-thread — "concurrent" would be wrong; go-glyph shaping is single-threaded).
-The default path deliberately never does. (shirei's reference prewarms
-off-thread; this port cannot — main-thread only — so scroll-windowing is the
-substitute, not a background prewarm.)
+main-thread — "concurrent" is wrong. go-glyph shaping is single-threaded). The
+default path deliberately never does. (shirei's reference prewarms off-thread.
+This port cannot — main-thread only — so scroll-windowing is the substitute, not
+a background prewarm.)
 
 Reference: `go-shirei/examples/fontviewer` — same feature set, ported to
 go-gui's widget model (immediate-mode `Layout` tree, not shirei's closure-based
@@ -40,10 +40,10 @@ DSL).
 
 **Phasing note (why #6 is P0):** go-gui's layout shapes text for _every_ card in
 the tree, with no scroll-visibility gate (`layoutWrapTextWalk`,
-`layout_pipeline.go`); scroll offset is applied later, in the positioning phase
-(`layout_position.go`). Emitting all 500–800 cards would cold-shape every family
-on the first frame — a hard stall. Virtualization emits only the visible window,
-so per-frame cost is **O(visible), not O(N)**, and it reuses go-gui's tested
+`layout_pipeline.go`). Scroll offset is applied later, in the positioning phase
+(`layout_position.go`). Emitting all 500–800 cards cold-shapes every family on
+the first frame — a hard stall. Virtualization emits only the visible window, so
+per-frame cost is **O(visible), not O(N)**, and it reuses go-gui's tested
 `listCoreVisibleRange` primitive (the same one behind `ListBox`, `Tree`, and
 `Table`). Fixed card size is the precondition it needs.
 
@@ -55,14 +55,14 @@ Explicit so the feature table is not read as a finished font browser:
   exists (WASM stub), so the web build shows the empty state permanently.
   Browser enumeration (`FontFace` / `queryLocalFonts`) is a separate future
   phase, not a v1 gap to paper over.
-- **Regular weight only.** Previews resolve the bare family key, i.e. the
-  Regular face; per-weight/italic preview is out of scope.
-- **Mouse-first.** Cards are click-to-copy; no roving tab-stop across the grid
+- **Regular weight only.** Previews resolve the bare family key — the Regular
+  face. Per-weight/italic preview is out of scope.
+- **Mouse-first.** Cards are click-to-copy. No roving tab-stop across the grid,
   and a11y is whatever the containers default to (family names are not exposed
-  to assistive tech). **v1 is intentionally inaccessible**; a keyboard-navigable
+  to assistive tech). **v1 is intentionally inaccessible**. A keyboard-navigable
   catalog with proper `AccessRole`s is a later increment.
 - **"No fonts" copy is coarse.** A nil `FontLister` (WASM / not-yet-ready
-  backend) and a genuinely empty catalog both show "no system fonts"; the view
+  backend) and a genuinely empty catalog both show "no system fonts". The view
   does not distinguish "not ready yet" from "backend has no lister." Acceptable
   given desktop-only scope — revisit if the web build ships.
 
@@ -71,16 +71,16 @@ Explicit so the feature table is not read as a finished font browser:
 | Enumeration source                  | go-glyph's discovered font catalog (system discovery + app-registered fonts), surfaced through a **clean family set captured at registration time** — **not** a parallel CTFontManager / fontconfig / DirectWrite / AWT list, and **not** a reverse-parse of the resolution map's keys                                                                                                                                                                                                                                                                                                                          |
 | App fonts                           | Families from `RegisterAppFont` / `AddFontFile` flow through the same `registerFontPath` and land in the same set. **P0 contract:** fonts registered _before the window runs_ (the normal demo flow) are listed. Fonts registered _after_ the first successful enumeration are invisible until a refresh (`s.Loaded = false`) — that refresh is P3, and this limit must be stated, not left implied                                                                                                                                                                                                             |
 | Hidden / generic keys               | Excluded **at the source**: leading-`"."` families and generic aliases (`sans-serif`, `serif`, `monospace`, …) never enter the family set                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| Style variants                      | A face's `-Regular/-Bold/-Italic/-BoldItalic` resolution keys are **not** families; the set stores only the clean display name, so `Arial` appears once, not four times                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Style variants                      | A face's `-Regular/-Bold/-Italic/-BoldItalic` resolution keys are **not** families. The set stores only the clean display name, so `Arial` appears once, not four times                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | go-gui ↔ go-glyph seam              | Optional `FontLister` capability interface + type assertion — **not** a widened mandatory `TextMeasurer` interface                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `LayoutText` concurrency            | **Not safe.** go-glyph `doc.go` documents `Context` / `Renderer` / `TextSystem` / `GlyphAtlas` as _"Not safe for concurrent use. Call all glyph methods from the main/render thread."_ All shaping stays on the main thread                                                                                                                                                                                                                                                                                                                                                                                     |
 | Scaling strategy                    | **Grid virtualization.** Read the previous frame's scroll offset (`w.ScrollY().Get(id)`), compute the visible row range, emit only those rows padded by top/bottom spacer rects. O(visible) per frame. Same pattern as `ListBox` / `Tree` / `Table`                                                                                                                                                                                                                                                                                                                                                             |
-| Visible-range primitive             | **Export `func ListVisibleRange(itemCount int, rowHeight, listHeight, scrollY float32, overscan int) (first, last int)`** from `gui`. Wraps the tested core but takes the overscan **as an argument** (the internal `listCoreVirtualBufferRows` is not stacked on top), so the caller sets one buffer number, not 2+4. The example is `package main` and cannot call the unexported original; exporting beats duplicating the arithmetic. Scope is **only** the arithmetic helper — the grid's column/spacer math stays in the example; do not let Phase 1 grow a general virtualized-grid widget               |
+| Visible-range primitive             | **Export `func ListVisibleRange(itemCount int, rowHeight, listHeight, scrollY float32, overscan int) (first, last int)`** from `gui`. Wraps the tested core but takes the overscan **as an argument** (the internal `listCoreVirtualBufferRows` is not stacked on top), so the caller sets one buffer number, not 2+4. The example is `package main` and cannot call the unexported original. Exporting beats duplicating the arithmetic. Scope is **only** the arithmetic helper — the grid's column/spacer math stays in the example. Do not let Phase 1 grow a general virtualized-grid widget               |
 | **Grid drives BOTH its dimensions** | The grid `Column` is **`Sizing: FixedFixed`** with explicit `Width: outerW` and `Height: listH` — the _same_ numbers feed the `cols`/`ListVisibleRange` math **and** the arranged box, so neither axis can disagree with layout. Height alone was not enough: width computed from `WindowSize` but arranged by `Fill` is the identical X-axis footgun (wrong `cols` → overflow / dead space). No `FindByID` width-readback API exists, so making width explicit is the fix. `listH` is clamped `>= rowH` (`listCoreVisibleRange` yields no rows at `<= 0`)                                                      |
-| Row geometry                        | The two axes carry gap **differently**: the grid `Column` sets `Spacing: SomeF(0)` (vertical spacing must be 0 or it corrupts the spacer arithmetic — `rowH` alone accounts for the vertical `gap`); each `Row` sets `Spacing: SomeF(gap)` to draw the **horizontal** gutter between cards (this is where the `(cols-1)*gap` that `cardW` subtracts actually goes — zero it and cards abut with dead space on the right). Each `Row` is **exactly `rowH` tall** (`cardH` + vertical `gap` folded in) so `top + rows + bottom == totalRows*rowH`; trailing `gap` on the last row is an intentional bottom margin |
+| Row geometry                        | The two axes carry gap **differently**: the grid `Column` sets `Spacing: SomeF(0)` (vertical spacing must be 0 or it corrupts the spacer arithmetic — `rowH` alone accounts for the vertical `gap`). Each `Row` sets `Spacing: SomeF(gap)` to draw the **horizontal** gutter between cards (this is where the `(cols-1)*gap` that `cardW` subtracts actually goes — zero it and cards abut with dead space on the right). Each `Row` is **exactly `rowH` tall** (`cardH` + vertical `gap` folded in) so `top + rows + bottom == totalRows*rowH`. Trailing `gap` on the last row is an intentional bottom margin |
 | Container chrome                    | Root and grid `Column`s set `Padding: NoPadding`, `Spacing: SomeF(0)`, **and `SizeBorder: Some(0)`** — `DefaultContainerStyle` is `PaddingMedium` + `SpacingMedium` + `SizeBorderDef` (1.5), and `paddingHeight()` counts `2·SizeBorder`, so an un-zeroed box eats `2·pad + spacing + 2·border` (~6 px of border alone across root+grid) and `listH`/`outerW` go optimistic → over-height root / wrong `cols`. `sidePad` is the grid's **real** horizontal `Padding` (right side widened to clear the overlay scrollbar), folded into `contentW`                                                                |
-| Hover under virtualization          | **Sticky-`Copy` footgun.** `layoutMouseLeave` walks only the _current_ tree and needs a non-empty `shape.ID`; a hovered card scrolled out of the window is never visited, so its `OnMouseLeave` never fires. Rule: (a) every card gets a **stable ID** `"card:"+family` (also required for click/leave identity), and (b) the retained `hoveredFam` is cleared each frame if it is **not in the emitted `[first,last]` window**. Without (b) the "Copy" affordance reappears when the family scrolls back                                                                                                       |
-| Card grid layout                    | **Manual column math over fixed-size cards.** `gui.Wrap` lays out _all_ children and can't window, so it is not usable for a virtualized grid; compute `cols` from viewport width each frame instead                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Hover under virtualization          | **Sticky-`Copy` footgun.** `layoutMouseLeave` walks only the _current_ tree and needs a non-empty `shape.ID`. A hovered card scrolled out of the window is never visited, so its `OnMouseLeave` never fires. Rule: (a) every card gets a **stable ID** `"card:"+family` (also required for click/leave identity), and (b) the retained `hoveredFam` is cleared each frame if it is **not in the emitted `[first,last]` window**. Without (b) the "Copy" affordance reappears when the family scrolls back                                                                                                       |
+| Card grid layout                    | **Manual column math over fixed-size cards.** `gui.Wrap` lays out _all_ children and cannot window, so it is not usable for a virtualized grid. Compute `cols` from viewport width each frame instead                                                                                                                                                                                                                                                                                                                                                                                                           |
 | Family de-duplication               | Fold case when building the family set (canonical first-seen display case, keyed by `strings.ToLower`) so two faces reporting `Arial` / `arial` list once — matches shirei                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 ## Architecture
@@ -125,8 +125,8 @@ system.
 Family names are just `string`s returned by `ListSystemFonts(w)`. No struct
 needed — the viewer only needs the name to pass to `TextStyle.Family`.
 `ListSystemFonts` returns **nil** before backend init (and on WASM stubs), so
-`state.Families` may be nil; `filterFontFamilies` and every `range` over it must
-be nil-safe (ranging nil is fine; the filter returns nil for a nil input).
+`state.Families` can be nil. `filterFontFamilies` and every `range` over it must
+be nil-safe (ranging nil is fine. The filter returns nil for a nil input).
 
 ### View function skeleton
 
@@ -221,7 +221,7 @@ RootView (FillFill column)
 | `Icon(SymCopy, ...)`                 | Feather has no `IconCopy` — use a text "Copy"/"Copied" badge (add a glyph to `gui/fonts.go` only if a real icon is wanted)                                                      |
 | `Icon(SymShuffle, ...)`              | `Text(TextCfg{Text: gui.IconSync, TextStyle: iconStyle})`                                                                                                                       |
 | `PressAction()`                      | `OnClick` (containers default to `ClickButton: MouseLeft`)                                                                                                                      |
-| `IsHovered()` + `ModAttrs(...)`      | `OnHover` / leave handling on `ContainerCfg`; call `w.RequestRedraw()` if needed                                                                                                |
+| `IsHovered()` + `ModAttrs(...)`      | `OnHover` / leave handling on `ContainerCfg`. Call `w.RequestRedraw()` if needed                                                                                                |
 | `RequestNextFrame()`                 | `w.QueueCommand(...)` (wakes main) or `w.UpdateWindow()` / `w.RequestRedraw()`                                                                                                  |
 
 **Callback signatures diverge — do not assume the generic
@@ -287,7 +287,7 @@ variants never enter the set, case is folded (matching shirei), and
 same `registerFontPath`.
 
 2. **go-gui** — optional capability interface + type assertion. Do **not** widen
-   the mandatory `TextMeasurer` interface (that would force a simultaneous
+   the mandatory `TextMeasurer` interface (that forces a simultaneous
    implementation across metal/gl/web/android/ios):
 
    ```go
@@ -323,15 +323,15 @@ same `registerFontPath`.
    ```
 
 **Rejected:** Android `java.awt.GraphicsEnvironment` (desktop AWT, not Android).
-go-glyph already walks `/system/fonts`, `/product/fonts`, etc.
+go-glyph already walks `/system/fonts`, `/product/fonts`, and more.
 
 **Rejected:** Linux fontconfig in go-gui — conflicts with go-glyph's
 no-fontconfig directory walk and invites dual catalogs.
 
 **Rejected:** a parallel platform enumerator in `gui/backend/` — names from
 CTFontManager / fontconfig / DirectWrite can diverge from go-glyph's family
-strings, so cards would show fonts that silently fall back to Helvetica / Roboto
-/ etc.
+strings, so cards show fonts that silently fall back to Helvetica, Roboto, and
+more.
 
 ### Rendering — virtualize the grid
 
@@ -355,7 +355,7 @@ frame's** scroll offset at generate time via `w.ScrollY().Get(id)` (exported
 `BoundedMap`), so the range is one frame stale — the overscan buffer absorbs the
 lag.
 
-**Grid adaptation (2-D).** `ListBox`/`Table` are one item per row; the font grid
+**Grid adaptation (2-D).** `ListBox`/`Table` are one item per row. The font grid
 is a wrapped grid. Fixed card size closes the gap. Each frame:
 
 1. `cols = max(1, floor((contentW + gap) / (cardMaxW + gap)))`, recomputed from
@@ -376,7 +376,7 @@ The spacers keep the total scroll range equal to the full catalog, so the
 scrollbar stays correct.
 
 **Overscan buffer.** The internal `listCoreVirtualBufferRows = 2` is tuned for
-~20–32 px list rows; at `rowH ≈ 150–200 px` that is only 300–400 px, which a
+~20–32 px list rows. At `rowH ≈ 150–200 px` that is only 300–400 px, which a
 fast flick outruns, flashing blank rows. The exported `ListVisibleRange` takes
 the buffer as an argument, so the grid passes one `overscanRows` (start ~4, tune
 against a fast scroll on a 500+ font machine) rather than stacking its own
@@ -393,13 +393,13 @@ was insufficient — a `Fill` width arranged differently from the
 `WindowSize`-derived `cols` estimate is the identical X-axis footgun: wrong
 `cols` → overflow or dead space. There is no previous-frame width-readback API,
 so explicit width is the fix.) Source from `w.WindowSize()` (callable at view
-time; its values seed the `FillFill` root, so they are already in layout units —
+time. Its values seed the `FillFill` root, so they are already in layout units —
 see open Q1):
 
 - `listH = max(rowH, winH - headerH - toolbarH)`. The **clamp is mandatory**:
-  `listCoreVisibleRange` returns no rows for `listHeight <= 0`, so a short
-  window or overshooting chrome constants would otherwise blank the grid.
-- `outerW = winW` (the grid box fills the window; root chrome is zeroed).
+  `listCoreVisibleRange` returns no rows for `listHeight <= 0`. Without it, a
+  short window or overshooting chrome constants blanks the grid.
+- `outerW = winW` (the grid box fills the window. Root chrome is zeroed).
   `contentW = outerW - 2*sidePad - scrollbarW` after the grid's real horizontal
   `Padding`, where the right inset is widened by `scrollbarW` — an **overlay
   inset**, since the vertical scrollbar is `OverDraw: true` (reserves no layout
@@ -410,24 +410,24 @@ see open Q1):
 Chrome constants (`headerH`, `toolbarH`) must equal the real rendered heights,
 which requires the root/grid columns to zero their default `PaddingMedium`,
 `SpacingMedium`, **and `SizeBorderDef` (1.5, counted twice per box via
-`paddingHeight`)**; otherwise `listH`/`outerW` are wrong on frame one.
+`paddingHeight`)**. Otherwise `listH`/`outerW` are wrong on frame one.
 Recomputing per frame keeps resize correct.
 
 **Scroll offset must be reset on content-shape changes.** The scroll store holds
 a raw pixel offset and is re-clamped only during user-scroll events — never when
 content geometry changes. So:
 
-- **FontSize change** alters `rowH`; the old pixel offset then points at the
-  wrong row (offset −1600 at `rowH` 160 shows row 10; at `rowH` 200 it shows row
+- **FontSize change** alters `rowH`. The old pixel offset then points at the
+  wrong row (offset −1600 at `rowH` 160 shows row 10. At `rowH` 200 it shows row
   8). The size slider's `OnChange` must call `w.ScrollVerticalTo(gridID, 0)`
   after updating `state.FontSize`.
-- **Filter change** alters the match set (and can empty it); the filter input's
+- **Filter change** alters the match set (and can empty it). The filter input's
   `OnTextChanged` must likewise `w.ScrollVerticalTo(gridID, 0)`.
   `listCoreVisibleRange(0, …)` already returns `(0, -1)` (no rows), so an empty
-  result is safe; the reset just keeps the stored offset honest.
+  result is safe. The reset just keeps the stored offset honest.
 - **Window resize** changes `cols`/`rows` but **not** `rowH`, so vertical depth
-  stays valid; no reset. A now-out-of-range offset self-corrects on the next
-  scroll event. (A future refinement could anchor by first-visible family index
+  stays valid. No reset. A now-out-of-range offset self-corrects on the next
+  scroll event. (A future refinement can anchor by first-visible family index
   instead of resetting, if resetting-to-top on size change feels abrupt.)
 
 **Cost.** Arrange and shaping are both O(visible), independent of catalog size.
@@ -438,7 +438,7 @@ access is required for scale.
 
 Windowing means a newly-scrolled-in row shapes its ~`cols` cards (3–5) that
 frame — trivial, and normally invisible. If fast scrolling ever janks on
-cold-cache families, a card may render fixed-size skeleton rects for the single
+cold-cache families, a card can render fixed-size skeleton rects for the single
 frame before its font is in the glyph cache. This is cosmetic polish, not a
 scaling mechanism, and carries no persistent state.
 
@@ -477,7 +477,7 @@ The card view renders the "Copied" badge at `s.CopyOpacity` when
 `s.CopiedFam == name`. Resetting `CopiedFam`/`CopyOpacity` on every click (the
 toast pattern) means a rapid click on another card is correct even though
 `AnimationAdd` replaces the same-ID tween and skips the previous `OnDone`. The
-animation loop guarantees the redraws; no manual timer.
+animation loop guarantees the redraws. No manual timer.
 
 **Refresh cost:** `TweenAnimation.RefreshKind()` is `AnimationRefreshLayout`, so
 each of the ~1.2 s of ticks rebuilds and re-shapes the layout. Virtualization
@@ -499,7 +499,7 @@ Dark accent bar with title "go-gui font viewer" and subtitle. Fixed height
   writing the new string back to state (wide, ~440–640 px)
 - "Shuffle" button → `OnClick` sets `state.Sample` to a random entry from a
   fixed pangram pool (package var), **excluding the current sample** so a
-  re-pick never silently no-ops. E.g.:
+  re-pick never silently no-ops. For example:
 
   ```go
   var pangrams = []string{
@@ -517,8 +517,8 @@ Dark accent bar with title "go-gui font viewer" and subtitle. Fixed height
 - "Filter Fonts" label → `Input` bound to `state.Filter`. `OnTextChanged`
   updates `state.Filter` **and** resets scroll: `w.ScrollVerticalTo(gridID, 0)`
   (the match set changed — see Rendering).
-- Clear control when filter is non-empty (text "×" button is fine; also resets
-  scroll).
+- Clear control when filter is non-empty (text "×" button is fine. It also
+  resets scroll).
 - Spacer
 - "Size" label → `Slider` `ID` + `Value: state.FontSize`, Min 12, Max 72,
   Step 1. `OnChange` updates `state.FontSize` **and** resets scroll:
@@ -539,7 +539,7 @@ clip box**, deliberately _not_ a per-face fit: `1.4` approximates go-gui's list
 line-height (`listCoreRowHeightEstimate`), but go-glyph's real per-face
 `LineHeight` varies, so a tall face clips at the box and a short face leaves a
 small band. That is the accepted trade — uniform declared height is what keeps
-`rowH` constant and the spacer math honest; the Latin-only note does not cover
+`rowH` constant and the spacer math honest. The Latin-only note does not cover
 this metric variance. If the clip/band looks bad, measure the box **once per
 `FontSize`** with a reference face (never per family — that reintroduces N
 measurements), not a flat multiplier.
@@ -551,7 +551,7 @@ measurements), not a flat multiplier.
 - **Preview box**: white rounded rect with light border. Sample text in the
   family's own face, `TextModeWrap` at width `cardW - 2*previewPad`, clipped
   with parent `MaxHeight` / `Clip` to `previewLines` lines of the current
-  `FontSize`. **Latin-only contract:** sample text is Latin pangrams; non-Latin
+  `FontSize`. **Latin-only contract:** sample text is Latin pangrams. Non-Latin
   runes fall back per-rune to a covering face and do **not** exercise the card's
   family — do not "fix" this with Unicode samples that silently lie.
 
@@ -565,15 +565,15 @@ Card states:
   `hoveredFam` each frame when it falls outside `[first,last]` (see hover
   decision) — otherwise the affordance sticks when the family scrolls back
 - **Copied**: green "Copied" badge at `state.CopyOpacity` (fades 1→0 over ~1.2
-  s; the tween's `OnDone` clears `state.CopiedFam`)
+  s. The tween's `OnDone` clears `state.CopiedFam`)
 
-Changing `FontSize` changes `cardH` (preview grows) → recompute `rowH`; the
+Changing `FontSize` changes `cardH` (preview grows) → recompute `rowH`. The
 virtualization math handles it, but every card must use the same height for a
 given size.
 
 ### FontGrid
 
-Virtualized `Column` — **not** `gui.Wrap` (Wrap lays out all children and can't
+Virtualized `Column` — **not** `gui.Wrap` (Wrap lays out all children and cannot
 window):
 
 ```go
@@ -653,7 +653,7 @@ func fontGrid(w *Window, s *FontViewerState, matches []string) View {
 
 - go-glyph: case-folded `Context.families` set threaded through
   `registerFontPath` — **a signature change to a free function with direct test
-  call sites**; Phase 1 owns updating both call sites (`AddFontFile` path and
+  call sites**. Phase 1 owns updating both call sites (`AddFontFile` path and
   `fontScan.consider`) and their tests. `.LastResort` still enters `fontPaths`
   as before — the new set only _excludes_ it, no discovery behavior changes.
   Then `(*TextSystem).ListFontFamilies() []string` returns display-case names
@@ -673,11 +673,11 @@ func fontGrid(w *Window, s *FontViewerState, matches []string) View {
   the `package main` example can call it (buffer as an arg — no stacked
   `listCoreVirtualBufferRows`)
 - go-gui: `FontLister` interface + `ListSystemFonts(w *Window) []string` type
-  assertion; opt in the native text backend
+  assertion. Opt in the native text backend
 - No CTFontManager / fontconfig / DirectWrite / AWT enumerator
 
 `filterFontFamilies` is **not** a `gui` export — it is example-local
-(`examples/fontviewer`, tested there); it has no shared caller and does not
+(`examples/fontviewer`, tested there). It has no shared caller and does not
 belong in the widget API.
 
 **Release coupling:** go-glyph is upstream. Landing `ListFontFamilies` requires
@@ -687,11 +687,11 @@ a go-glyph tag + a go-gui `go.mod` bump before Phase 2 can build against it.
 
 - `examples/fontviewer/main.go` with full state (init `FontSize: 28`, random
   pangram), header, toolbar, grid
-- Sample text, shuffle, filter, size slider; filter/size handlers reset scroll
+- Sample text, shuffle, filter, size slider. Filter/size handlers reset scroll
   via `w.ScrollVerticalTo(gridID, 0)`
 - **Virtualized grid**: `FixedFixed` grid with explicit `Width: outerW` +
-  `Height: listH` (both from `w.WindowSize()`, both feeding the math);
-  `Padding`/`Spacing`/`SizeBorder` zeroed on root+grid; uniform-height cards
+  `Height: listH` (both from `w.WindowSize()`, both feeding the math).
+  `Padding`/`Spacing`/`SizeBorder` zeroed on root+grid. Uniform-height cards
   (`cardHeight`), `ListVisibleRange(..., overscanRows)` over rows, `rowH`-tall
   rows, top/bottom spacers, `listH` clamped `>= rowH`
 - Click-to-copy + tween-driven "Copied" transient (`CopyOpacity`)
@@ -699,7 +699,7 @@ a go-glyph tag + a go-gui `go.mod` bump before Phase 2 can build against it.
 - Layout/state tests: empty, filtered, copied, sizing, **and the visible-range
   math** — assert emitted card count and that
   `topSpacer + rows*rowH + bottomSpacer == totalRows*rowH` for a given
-  `(N, cols, rowH, listH, scrollY)` (pure, headless; mirrors
+  `(N, cols, rowH, listH, scrollY)` (pure, headless. Mirrors
   `TestListCoreVisibleRange` / `TestTableVirtualization`)
 
 ### Phase 3: Polish (optional)
@@ -728,7 +728,7 @@ a go-glyph tag + a go-gui `go.mod` bump before Phase 2 can build against it.
    before the grid geometry is built on the assumption.
 
 2. **Tuning constants** (empirical on a 500+ font machine, not fundamental):
-   `overscanRows` (start 4 — enough to hide a fast flick at grid `rowH`);
+   `overscanRows` (start 4 — enough to hide a fast flick at grid `rowH`).
    `nameRowH` / `previewPad` / `lineFactor` so `cardHeight(FontSize)` matches
    the actually-rendered card and rows stay uniform.
 
@@ -736,12 +736,12 @@ a go-glyph tag + a go-gui `go.mod` bump before Phase 2 can build against it.
    `toolbarH`, `sidePad`, `scrollbarW`. These hold only if the root/grid columns
    zero `Padding` **and** `SizeBorder` (default `SizeBorderDef` 1.5, counted
    twice per box) — otherwise `listH` is optimistic → blank bands the overscan
-   can't cover. Bias the estimate large, and assert `headerH`/`toolbarH` against
-   the rendered heights of `header()`/`toolbar()` in a layout test so they can't
-   silently diverge.
+   cannot cover. Bias the estimate large, and assert `headerH`/`toolbarH`
+   against the rendered heights of `header()`/`toolbar()` in a layout test so
+   they cannot silently diverge.
 
 4. **Headless PNG export**: no `RenderToPNG` equivalent exists. Keep P2
-   speculative until an offscreen buffer + encode path lands; otherwise cut from
+   speculative until an offscreen buffer + encode path lands. Otherwise cut from
    v1.
 
 5. **List API surface**: `ListSystemFonts(w *Window)` matches how other

--- a/docs/specs/frame-lock-callback-deferral.md
+++ b/docs/specs/frame-lock-callback-deferral.md
@@ -26,11 +26,11 @@ region reach app code:
 the platform event loop (`runtime.LockOSThread` in
 `gui/backend/metal/mainthread.go`). So an app callback reached from that region
 that calls `SetFocus`, `ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` or
-`Window.Lock` blocks the main thread on a lock it already owns: the window
+`Window.Lock` blocks the main thread on a lock it already owns. The window
 freezes permanently, with no panic and no CPU burn.
 
 Issue #394 was exactly this. The Input's blur commit fired from
-`inputAmendLayout`; `examples/todo` called `w.SetFocus` from `OnTextCommit` to
+`inputAmendLayout`. `examples/todo` called `w.SetFocus` from `OnTextCommit` to
 put the caret back in the field. Pressing <kbd>Tab</kbd> after typing froze the
 app.
 
@@ -55,8 +55,8 @@ Not deferred (gui-internal, and needs the live tree):
 
 A deferred callback receives `EventCtx{nil, nil, w}`. **`ctx.Layout` is nil and
 a `*Layout` must never be captured**: the tree is rebuilt from pooled arenas
-(`layoutChildrenArena`) before the callback runs, so the pointer would dangle
-into reused memory. `ctx.Window` and the value arguments are unchanged.
+(`layoutChildrenArena`) before the callback runs, so the pointer dangles into
+reused memory. `ctx.Window` and the value arguments are unchanged.
 
 The Enter commit path (`gui/view_input_keys.go`) is dispatched from `EventFn`,
 which holds no lock, so it is untouched and still carries a live `ctx.Layout`.
@@ -65,7 +65,7 @@ which holds no lock, so it is untouched and still carries a live `ctx.Layout`.
 
 Two routes lead from an `AmendLayout` hook into app code across `gui/`:
 
-1. the input blur block — deferred, as above;
+1. the input blur block — deferred, as above.
 2. the app's own hook — `ContainerCfg.AmendLayout` (`gui/view_container.go`) and
    `ButtonCfg.AmendLayout`, reached as `bc.OnAmend` from `buttonAmendLayout`
    (`gui/view_button.go`).
@@ -80,8 +80,9 @@ window-state work.
 
 `updateLocked` and `renderOnlyLocked` set `w.inFramePass` for the duration of
 the locked region. The `w.mu`-taking window APIs go through `lockForAPI`, which
-probes with `TryLock` and, when the lock is held during a frame pass, panics
-naming the API and the remedy (`QueueCommand`) rather than blocking forever.
+probes with `TryLock`. When the lock is held during a frame pass, the API
+panics, naming the API and the remedy (`QueueCommand`) rather than blocking
+forever.
 
 The probe cannot distinguish "this goroutine self-deadlocked" from "another
 goroutine is mid-`Update`". It does not need to: calling these APIs off the
@@ -95,16 +96,16 @@ frame, so this is the established instinct in this codebase, not a new one.
 
 `flushDeferredCallbacks` swaps the slice out before running it, so a callback
 that raises another (an `OnBlur` moving focus, blurring a second field) lands in
-the next round rather than mutating the slice being ranged. Rounds are bounded
-by `maxDeferredCallbackBatches`; past the bound the remainder is dropped and
+the next round rather than mutating the slice it ranges over. Rounds are bounded
+by `maxDeferredCallbackBatches`. Past the bound, the remainder is dropped and
 reported through `DebugCallbacks`.
 
 `FrameFn` re-runs the refresh pass once after any pass whose flush ran a
 deferred callback. Those callbacks run after the renderers were built, and a
 callback that writes state or moves focus marks no refresh flag — `SetFocus` and
 plain state writes are silent — so `flushDeferredCallbacks`'s own report (does
-anything run?) is what re-arms the loop. Without it the frame would render the
-pre-callback state and keep it until the next event. Two passes, not a loop: a
+anything run?) is what re-arms the loop. Without it, the frame renders the
+pre-callback state and keeps it until the next event. Two passes, not a loop: a
 view that dirties itself every pass is a bug the frame loop must not amplify
 into a spin, and the next `FrameFn` picks it up anyway.
 
@@ -115,7 +116,7 @@ skip the mutex when the frame pass already owns it.
 
 It does not make the lock reentrant — it makes callers _bypass_ it based on a
 flag that is only meaningful on the owning goroutine. Any other goroutine
-calling `SetFocus` during a frame pass would read `true` and walk into
+calling `SetFocus` during a frame pass reads `true` and walks into
 unsynchronized state, turning a benign lock wait into a silent data race one
 arrange pass wide. It also covers only the methods someone remembers to
 annotate, and cannot cover the exported `Window.Lock` at all.

--- a/docs/specs/headless-software-rendering.md
+++ b/docs/specs/headless-software-rendering.md
@@ -4,10 +4,10 @@ Issue #333 (phase 1), issue #360 (phase 2). Status: complete.
 
 ## Problem
 
-go-gui could not produce a pixel image of a frame without a GPU and a window.
-Every backend under `gui/backend/` is GPU-backed or native, so there was no way
-to take a screenshot in CI, no way to write a pixel-level regression test, and
-no starting point for a software backend.
+go-gui had no way to produce a pixel image of a frame without a GPU and a
+window. Every backend under `gui/backend/` is GPU-backed or native, so there was
+no way to take a screenshot in CI, no way to write a pixel-level regression
+test, and no starting point for a software backend.
 
 ## Approach
 
@@ -25,15 +25,15 @@ with no `import "C"`, so text works on CPU.
 framebuffer (`gui/backend/soft/glyph_backend.go`) yields every text render kind
 — `RenderText`, `RenderLayout`, `RenderLayoutTransformed`, `RenderRTF`,
 `RenderTextPath`, text gradients — from the same `glyph.TextSystem` the GPU
-backends drive, and supplies a real `gui.TextMeasurer` as a side effect. This
-removes the issue's stated obstacle: headless frames are measured with true font
-metrics, not the approximate extents a nil measurer falls back to.
+backends drive. It also supplies a real `gui.TextMeasurer` as a side effect.
+This removes the issue's stated obstacle: headless frames are measured with true
+font metrics, not the approximate extents a nil measurer falls back to.
 
 ## Placement
 
 The package is `gui/backend/soft`, not package `gui` as the issue proposed.
-`gui/svg` imports `gui`, so a rasterizer inside `gui` could never call
-`SetSvgParser` and every SVG would render blank. A subpackage has everything it
+`gui/svg` imports `gui`, so a rasterizer inside `gui` can never call
+`SetSvgParser` and every SVG renders blank. A subpackage has everything it
 needs: the `Render*` constants are exported (only the `renderKind` type is not),
 `RenderCmd`'s fields are exported, and the one unexported payload — `textPath` —
 is reachable through `gui.ComputeTextPathPlacements`. `gui/backend/gl` is the
@@ -47,8 +47,8 @@ func RenderToPNG(w *gui.Window, scale float32, path string) error
 func Release(w *gui.Window)
 ```
 
-`scale` is the device pixel ratio; `scale <= 0` means 1. A window that has not
-rendered yet has its `WindowCfg.OnInit` run first, as a backend would, so the
+`scale` is the device pixel ratio. `scale <= 0` means 1. A window that has not
+rendered yet has its `WindowCfg.OnInit` run first, as a backend does, so the
 same window value passed to `backend.Run` can be passed here instead.
 
 Preparation is idempotent and keeps the warm glyph atlas, so driving state
@@ -74,7 +74,7 @@ process.
 
 go-glyph rasterizes a glyph into a staging buffer when it is first drawn but
 only hands the page to the backend at `Commit`. On screen the next frame
-corrects the sampling; a one-shot capture has no next frame. The first pass
+corrects the sampling. A one-shot capture has no next frame. The first pass
 therefore draws the text kinds with a nil target — shaping and rasterization
 run, the quads are discarded — and `Commit` uploads the atlas. Shapes, gradients
 and images are skipped on the warm pass and drawn once, for real, in the second.
@@ -83,7 +83,7 @@ and images are skipped on the warm pass and drawn once, for real, in the second.
 
 Everything reduces to one operation: composite a source through a coverage mask,
 restricted to the clip rect. The mask comes from `golang.org/x/image/vector`,
-which antialiases every edge; the source is a solid color (`image.Uniform`), a
+which antialiases every edge. The source is a solid color (`image.Uniform`), a
 gradient sampler, or a scaled image sampler. Two consequences worth naming:
 
 - A stroke rect is one path, not two draws: the outer rounded rect plus the
@@ -92,11 +92,11 @@ gradient sampler, or a scaled image sampler. Two consequences worth naming:
 - Clipping is free. The mask is allocated at the intersection of the shape's
   bounding box and the clip rect, so geometry outside it is never rasterized.
   `RenderClip` replaces the clip rather than nesting it, matching the scissor
-  semantics the GPU backends and `gui/print_pdf.go` implement; a degenerate rect
+  semantics the GPU backends and `gui/print_pdf.go` implement. A degenerate rect
   restores the full buffer.
 
 Gradients are **not** resampled to five stops. That cap is a shader uniform
-budget; a CPU sampler has none, so the full stop list is honoured — the same
+budget. A CPU sampler has none, so the full stop list is honored — the same
 choice the web backend's canvas gradients make.
 
 ## Reproducibility
@@ -134,23 +134,23 @@ render kind is a compile-visible decision. This follows the precedent in
 
 Filters, stencil clipping and rotation all scope later drawing, and all three
 use the same construction: `RenderFilterBegin` / `RenderStencilBegin` /
-`RenderRotateBegin` re-point the render target at an offscreen layer, the
+`RenderRotateBegin` re-point the render target at an offscreen layer. The
 bracketed commands draw into it unaware, and the matching end composites the
-layer back with the scoped effect applied — a coverage mask for the stencil, an
-inverse-mapped resample for the rotation, blur plus colour matrix plus repeated
-composite for the filter.
+layer back with the scoped effect applied. The effect is a coverage mask for the
+stencil, an inverse-mapped resample for the rotation, and blur plus color matrix
+plus repeated composite for the filter.
 
 The alternative — carrying a transform and a clip mask through every draw path —
-was rejected. It would have touched every phase 1 file and still not covered
-text, which goes through go-glyph's draw backend rather than this package's path
-builders. With a layer, a rotated caption and a stencil-clipped image are
-correct for free.
+was rejected. It touches every phase 1 file and still does not cover text, which
+goes through go-glyph's draw backend rather than this package's path builders.
+With a layer, a rotated caption and a stencil-clipped image are correct for
+free.
 
 Three consequences worth naming:
 
 - **Nesting needs no depth counter.** An inner bracket composites into the outer
   bracket's layer, which is already masked. `RenderCmd.StencilDepth` is what the
-  GL backend uses to unwind a shared stencil buffer; a layer stack has nothing
+  GL backend uses to unwind a shared stencil buffer. A layer stack has nothing
   to unwind, so it is read only as documentation of intent.
 - **Layers are full window size and pooled.** Full size keeps every coordinate
   in device space, so no draw path does offset bookkeeping. The cost is bounded
@@ -166,26 +166,26 @@ is ignored rather than popping a bracket it did not open.
 
 ## SVG triangles
 
-`RenderSvg` arrives as a flat triangle list with an optional colour per vertex.
+`RenderSvg` arrives as a flat triangle list with an optional color per vertex.
 Either way the coverage for a whole command comes from a **single path**, never
 one triangle at a time: the rasterizer accumulates signed coverage across a
 path, so the interior edges triangles share cancel exactly. Rasterized
-separately, a shared edge is antialiased twice — two ~50% coverages that
-composite to 75%, not 100% — and the background shows through as a lattice of
+separately, a shared edge is antialiased twice: two ~50% coverages that
+composite to 75%, not 100%. The background then shows through as a lattice of
 pale lines over every gradient.
 
-Flat geometry is therefore filled as one path in one colour. Vertex-coloured
+Flat geometry is therefore filled as one path in one color. Vertex-colored
 geometry is a mesh, and takes two passes: the same single-path coverage mask,
 plus a pooled layer holding the shading, which is composited through it. The
 shading is **written, not blended**, so a pixel two triangles both claim along a
-shared edge is painted once — their colours agree there, and blending twice
-would darken every seam of a translucent gradient. Each triangle paints every
-pixel centre inside it plus a half-pixel skirt; the skirt keeps the mesh's outer
-edge from thinning, where a pixel the mask includes at 40% can have its centre
-just outside the triangle. Interior pixels are unaffected, since the triangles
-tile and every centre inside the mesh is already claimed. Within a triangle the
-colour is the barycentric interpolation of its three vertices, the CPU
-equivalent of the GPU's varying interpolation.
+shared edge is painted once — their colors agree there, and blending twice
+darkens every seam of a translucent gradient. Each triangle paints every pixel
+centre inside it plus a half-pixel skirt. The skirt keeps the mesh's outer edge
+from thinning, where a pixel the mask includes at 40% can have its centre just
+outside the triangle. Interior pixels are unaffected, since the triangles tile
+and every centre inside the mesh is already claimed. Within a triangle the color
+is the barycentric interpolation of its three vertices, the CPU equivalent of
+the GPU's varying interpolation.
 
 The vertex transform order mirrors `gui/backend/gl`'s `drawSvg`:
 `animateTransform` scale and translate, then rotation about (`RotCX`, `RotCY`),
@@ -195,8 +195,8 @@ it is in every other backend — no render pipeline consumes it yet.
 ## Shadow and blur
 
 The GPU path is one SDF quad per command. The CPU path rasterizes the same
-rounded rect into a coverage mask, blurs the mask, and composites the colour
-through it; a shadow additionally multiplies in the complement of its caster's
+rounded rect into a coverage mask, blurs the mask, and composites the color
+through it. A shadow additionally multiplies in the complement of its caster's
 coverage, which is the shader's second SDF. The blur is three box passes — the
 standard Gaussian approximation, at a cost independent of the radius, which is
 what makes a large shadow affordable on a CPU. `sigmaPerBlur` documents how a
@@ -207,28 +207,28 @@ linearly across a band rather than convolving.
 
 A CPU rasterizer turns an unvalidated number into wall-clock time, so the phase
 2 kinds clamp what they accept rather than trusting the stream. Blur radii reach
-`soft` from widget config and from an SVG filter's `stdDev`; `clampBlur` rejects
+`soft` from widget config and from an SVG filter's `stdDev`. `clampBlur` rejects
 NaN and caps the radius at `maxBlur` device pixels, because an infinite radius
 sizes the box-blur sliding window and the failure is a hang rather than a wrong
 pixel. `blurPlanes` caps sigma again at the plane's own size, past which a box
 already averages everything. `RenderFilterBegin.Layers` is the count of
 `feMergeNode` elements in an untrusted document and each layer is a full
 composite pass, so `maxFilterLayers` caps the repeat. Corner radii and extents
-go through negated `>` comparisons, which reject NaN where `<= 0` would pass it
-on to the rasterizer as NaN control points. `maxLayerDepth` caps bracket
-nesting: past it the bracketed commands draw into the parent, which keeps the
-begin/end pairing intact and loses only the scoped effect.
+go through negated `>` comparisons, which reject NaN where `<= 0` passes it on
+to the rasterizer as NaN control points. `maxLayerDepth` caps bracket nesting:
+past it the bracketed commands draw into the parent, which keeps the begin/end
+pairing intact and loses only the scoped effect.
 
-Compositing saturates rather than wrapping. A filter's colour matrix clamps each
-channel independently, so it can leave a pixel whose colour exceeds its own
-alpha; the unclamped premultiplied sum would pass 255 and wrap a bright pixel to
+Compositing saturates rather than wrapping. A filter's color matrix clamps each
+channel independently, so it can leave a pixel whose color exceeds its own
+alpha. The unclamped premultiplied sum passes 255 and wraps a bright pixel to
 near-black. `overPremul` is the single place that blend is spelled.
 
 ## Not in either phase
 
 Pixel golden images (issue #361) are a separate decision from the renderer
 itself and landed as their own suite (`TestPixelGolden` in this package,
-`testdata/*.png`): platform font variance and antialiasing stability make the
+`testdata/*.png`). Platform font variance and antialiasing stability make the
 goldens text-free by construction, with a tolerance-based comparison instead of
 exact bytes. See `docs/specs/pixel-golden-images.md`. The tests here assert
 pixel values from constructed command streams as well, which is

--- a/docs/specs/idfocus-to-focusable.md
+++ b/docs/specs/idfocus-to-focusable.md
@@ -20,14 +20,14 @@ as the sole focus identity removes the coupling:
 - **Tab order** = layout-tree depth-first (DFS) traversal order.
 
 `IDScroll` (scroll-state key, `uint32`) has no double-duty problem and is
-explicitly **out of scope**; it stays `uint32` and keeps its `FnvSum32` string
+explicitly **out of scope**. It stays `uint32` and keeps its `FnvSum32` string
 derivation.
 
 ## Decisions (locked)
 
 1. Tab order: layout-tree DFS order. Numeric ordering retired.
 2. Window API: `SetFocus(id string)`, `FocusID() string`,
-   `IsFocus(id string) bool`, `ClearFocus()`. No public `SetFocus("")`;
+   `IsFocus(id string) bool`, `ClearFocus()`. No public `SetFocus("")`.
    `ClearFocus()` is the documented way to defocus.
 3. Opt-in: explicit `Focusable bool`. `Focusable: true` requires a non-empty
    `ID`.
@@ -53,8 +53,8 @@ derivation.
    offsets and per-widget state. It warns once per ID per window rather than
    once per frame.
 
-7. go-term: add optional `term.Cfg.ID string`; when set it is the focus
-   identity, when empty fall back to the existing generated `"term-"+seq`
+7. go-term: add optional `term.Cfg.ID string`. When set, it is the focus
+   identity. When empty, fall back to the existing generated `"term-"+seq`
    scheme.
 
 ## Core model changes
@@ -79,11 +79,11 @@ derivation.
 ### Tab traversal (`gui/layout_query.go`, `gui/window_event.go`)
 
 - `focusCandidate{shape *Shape; id string}`.
-- `collectFocusCandidates`: gate `Focusable && !FocusSkip && !Disabled`; dedup
-  by `ID` (dev-mode warn on collision); DFS order preserved.
+- `collectFocusCandidates`: gate `Focusable && !FocusSkip && !Disabled`. Dedup
+  by `ID` (dev-mode warn on collision). DFS order preserved.
 - Replace numeric `focusFindNext`/`focusFindPrevious` with **positional**
   next/previous: find current `FocusID()` index in the ordered slice, return
-  `(i±1)` with wrap; current not found → first / last.
+  `(i±1)` with wrap. Current not found → first / last.
 - `FindLayoutByIDFocus` → `FindLayoutByFocusID(layout, id string)` matching
   `Shape.ID`.
 - `handleKeyDownEvent` dialog-layer scoping is unchanged, so Tab stays trapped
@@ -92,7 +92,7 @@ derivation.
 ### Click / scroll focus (`gui/event_handlers.go`)
 
 - Click-to-focus: `Focusable && ID != "" && button != right → SetFocus(ID)`.
-- `focusedScrollTarget`: guard `FocusID() == ""`; use `FindLayoutByFocusID`.
+- `focusedScrollTarget`: guard `FocusID() == ""`. Use `FindLayoutByFocusID`.
 
 ## StateMap key retype (`gui/state_registry.go` + consumers)
 
@@ -106,7 +106,7 @@ Six namespaces flip `uint32` (IDFocus) → `string` key. `nsScrollX` / `nsScroll
 | `nsSpellCheck`       | key `uint32`→`string`                                                 |
 | `nsMdSel`            | key `uint32`→`string`                                                 |
 | `nsMdBlocks`         | key `uint32`→`string`                                                 |
-| `nsMenu`             | key `uint32`→`string`; drop `FnvSum32("menu_"+ID)`, use `ID` directly |
+| `nsMenu`             | key `uint32`→`string`, drop `FnvSum32("menu_"+ID)`, use `ID` directly |
 | `nsContextMenuFocus` | **value** `uint32`→`string` (saved prior focus)                       |
 
 Consumers threading `idFocus uint32` → `focusID string`: `input_state.go`,
@@ -118,12 +118,12 @@ Consumers threading `idFocus uint32` → `focusID string`: `input_state.go`,
 All 34 focusable `Cfg` structs already have an `ID string` field — **no new ID
 fields required**. Per Cfg:
 
-- Drop `IDFocus uint32`; add `Focusable bool`. Focus identity = `ID`.
+- Drop `IDFocus uint32`. Add `Focusable bool`. Focus identity = `ID`.
 
 Special cases:
 
 - Menus (`view_menu.go`, `view_menubar.go`, `view_context_menu.go`): drop
-  `FnvSum32` focus derivation; use `cfg.ID`.
+  `FnvSum32` focus derivation. Use `cfg.ID`.
 - `RadioButtonGroup`: `idFocus++` → per-child
   `ID = cfg.ID + "/" + strconv.Itoa(i)`.
 - `DataGrid`: focus id → `cfg.ID + ":focus"` (string). The `:scroll` IDScroll
@@ -164,16 +164,16 @@ Each: migrate → bump `go.mod` require →
 
 1. **go-charts** — 1 site (`InputCfg`, iota `focusSearch`). Trivial.
 2. **go-kite** — 4 literals (`Input`/`Button`/`Container`). Trivial.
-3. **go-map** — `mapview` Cfg `IDFocus`/`IDFocusBase uint32` → string base;
-   legend/gallery derive `ID+index` (build order == old numeric order → tab
+3. **go-map** — `mapview` Cfg `IDFocus`/`IDFocusBase uint32` → string base.
+   Legend/gallery derive `ID+index` (build order == old numeric order → tab
    order preserved). Its own string-based overlay-marker focus system is
    independent → unaffected.
-4. **go-edit** — `EditorCfg.IDFocus uint32` → `EditorCfg.ID string`; root
+4. **go-edit** — `EditorCfg.IDFocus uint32` → `EditorCfg.ID string`. Root
    container `Focusable: true`. `SetIDFocus(focusEditor)` →
    `SetFocus("editor")`. 3 prod + 114 test occurrences (mechanical).
 5. **go-term** — `Term.focusID uint32` → `string` (optional `Cfg.ID`, else
-   `"term-"+seq`); `FocusID() uint32→string`; 11 runtime
-   `SetIDFocus`→`SetFocus`; Workspace pane compares strings.
+   `"term-"+seq`). `FocusID() uint32→string`. 11 runtime
+   `SetIDFocus`→`SetFocus`. Workspace pane compares strings.
 
 ## Verification gate (every repo)
 
@@ -194,8 +194,8 @@ go build ./... && go vet ./... && golangci-lint run ./... && go test ./...
 
 - Tab order changes for any app that relied on numeric order differing from tree
   order. Inventory shows all siblings assign IDs in ascending tree order, so
-  tree order matches; low risk.
-- Focus identity must be unique per frame among focusable widgets; duplicates
+  tree order matches. Low risk.
+- Focus identity must be unique per frame among focusable widgets. Duplicates
   collapse to one tab stop (dev-mode warned).
 - Auto-focus-on-launch (`SetIDFocus` in `OnInit`, go-edit/go-term) becomes
   `SetFocus(string)`.

--- a/docs/specs/idscroll-to-scrollable.md
+++ b/docs/specs/idscroll-to-scrollable.md
@@ -1,6 +1,6 @@
 # Spec: Replace `IDScroll uint32` with `Scrollable bool` + string scroll identity
 
-Status: implemented (go-gui #78, released v0.35.0; all five siblings bumped)
+Status: implemented (go-gui #78, released v0.35.0. All five siblings bumped)
 Base: `main` @ `3c5dac7` Target release: go-gui `v0.35.0` (breaking) Precedent:
 [idfocus-to-focusable.md](idfocus-to-focusable.md) (`v0.34.0`)
 
@@ -42,7 +42,7 @@ identity is already correct in `ID`.** No new naming scheme is needed —
 ## Measured evidence
 
 Benchmarked on `main` @ `3c5dac7` (M5, go1.26.5, `benchstat`, n=8–10). All
-spikes reverted; nothing committed.
+spikes reverted. Nothing committed.
 
 **Shape size — the migration makes `Shape` smaller:**
 
@@ -55,7 +55,7 @@ spikes reverted; nothing committed.
 | **net**                                                                        | **272 → 264** |
 
 Measured with a mirror struct, not predicted. An earlier estimate of _+24 bytes_
-assumed both fields must become strings; wrong on both counts.
+assumed both fields must become strings. Wrong on both counts.
 
 **Key type:**
 
@@ -74,21 +74,21 @@ in "Out of scope" — it is borrowed, not earned.
 
 1. **Opt-in**: `Scrollable bool`. Identity = existing `Cfg.ID` (string).
 2. **`ScrollMode` stays** as the axis restriction. It cannot serve as the
-   opt-in: its zero value is `ScrollBoth`, so making it the gate would silently
-   turn every container into a scroll container.
+   opt-in: its zero value is `ScrollBoth`, so making it the gate turns every
+   container into a scroll container silently.
 3. **`IDScrollContainer` deleted outright**, not migrated (PR A).
 4. **`FindLayoutByIDScroll` → `FindLayoutByScrollID`**, parallel to #76's
    `FindLayoutByIDFocus` → `FindLayoutByFocusID`. Keep it as a separate function
    from `FindLayoutByFocusID` — near-identical, differing only in which bool
    they gate on (`Scrollable` vs `Focusable`). Predicate:
    `id != "" && layout.Shape.Scrollable && layout.Shape.ID == id` (empty id →
-   miss, same as focus). Do not leave the old name: `IDScroll` is being deleted.
+   miss, same as focus). Do not leave the old name: `IDScroll` is deleted.
 
    **This is a behavior change, not only a rename.** Today's predicate
    (`layout_query.go:61-63`) is a bare `layout.Shape.IDScroll == idScroll` — no
    opt-in gate and no zero guard, so `findScrollLayout(w, 0)` currently matches
    the root (the first shape with `IDScroll == 0`). The new predicate is
-   strictly better; it is called out here so the tightened diff does not read as
+   strictly better. It is called out here so the tightened diff does not read as
    an unexplained mismatch during review.
 
 5. **Meaningful string IDs** in examples (`"catalog"`, `"detail"`), not
@@ -135,27 +135,27 @@ in "Out of scope" — it is borrowed, not earned.
      with no `ID` — which is exactly what the 14 examples using `IDScroll: 9110`
      become if migrated carelessly. That is why it is still worth wiring.
    - A hand-rolled `&Shape{Scrollable: true}` bypasses it entirely. None exist
-     today; grep `rg -n 'Shape\{' --type go gui/` at land time to confirm none
+     today. Grep `rg -n 'Shape\{' --type go gui/` at land time to verify none
      arrived in the meantime.
 
 8. **No duplicate-ID detection. Do not build it.** #76 warns on duplicate
-   focusable IDs, and the obvious move is to mirror that here. Don't — the two
+   focusable IDs, and the obvious move is to mirror that here. Do not. The two
    failure modes are not comparable:
 
    |           | duplicate focus ID                   | duplicate scroll ID                                                |
    | --------- | ------------------------------------ | ------------------------------------------------------------------ |
    | symptom   | widget silently skipped in tab order | two containers scroll in lockstep                                  |
-   | noticed   | easy to miss                         | usually obvious when scrolling; weaker signal under virtualization |
-   | diagnosis | needs a warning to find              | usually self-evident; not worth a per-frame seen-set               |
+   | noticed   | easy to miss                         | usually obvious when scrolling. Weaker signal under virtualization |
+   | diagnosis | needs a warning to find              | usually self-evident. Not worth a per-frame seen-set               |
 
-   A warning would cost a `scrollDebug` env gate, a `scrollDupWarn` helper, and
-   a per-frame seen-set in the view-phase runtime — to detect a bug that usually
+   A warning costs a `scrollDebug` env gate, a `scrollDupWarn` helper, and a
+   per-frame seen-set in the view-phase runtime — to detect a bug that usually
    announces itself the first time anyone scrolls. Not worth it.
 
    Note decision 12 forces a deliberate near-miss here: Table's freeze path puts
    a scrollable `bodyCfg` under an outer that already holds `ID: cfg.ID`.
-   Suffixing the body `:scroll` keeps ids unique; the rejected alternative would
-   have made two shapes share one.
+   Suffixing the body `:scroll` keeps ids unique. The rejected alternative makes
+   two shapes share one id.
 
    `RequireScrollID` (decision 7) still catches the empty-`ID` case, which is
    the one that matters during this migration: it is a compile-clean mistake
@@ -164,7 +164,7 @@ in "Out of scope" — it is borrowed, not earned.
 9. **`DataGridCfg.IDScroll` override is deleted**, not migrated.
    `dataGridScrollID` collapses to `return cfg.ID + ":scroll"` with no branch,
    matching its sibling `dataGridFocusID` (`:119-121`), which has no override.
-   Breaking for any consumer setting it explicitly; grep shows none across the
+   Breaking for any consumer setting it explicitly. Grep shows none across the
    five siblings, so blast radius is zero.
 
 10. **`ScrollbarCfg.IDScroll` is renamed `ScrollID string`** — it points at
@@ -234,9 +234,9 @@ in "Out of scope" — it is borrowed, not earned.
     retype breaks any consumer reading offsets directly, not just those setting
     a Cfg field.
 
-12. **`TableCfg` has two layout paths with different scroll structure; identity
+12. **`TableCfg` has two layout paths with different scroll structure. Identity
     branches on `freeze`.** See "Table's two paths" under PR C. Non-freeze keeps
-    identity `cfg.ID` (the outer `Column` already carries it); the freeze path's
+    identity `cfg.ID` (the outer `Column` already carries it). The freeze path's
     `bodyCfg` gets `ID: cfg.ID + ":scroll"`. Add
     `tableScrollID(cfg *TableCfg, freeze bool) string` so the container and the
     virtualization read cannot drift apart:
@@ -253,28 +253,28 @@ in "Out of scope" — it is borrowed, not earned.
     **Call it once per view, into a local — do not call it per use.** On the
     freeze path each call allocates a concatenation, and there are two uses (the
     `:202` virtualization read and the `bodyCfg` literal at `:471`). `freeze` is
-    computed at `:175`; derive `scrollID` immediately below it and thread the
+    computed at `:175`. Derive `scrollID` immediately below it and thread the
     local to both. Same rule for every other suffix-derived site (see "Per-frame
     allocation" below).
 
     Rejected: giving the freeze `bodyCfg` `ID: cfg.ID` to avoid the branch.
-    Scroll would still resolve (`FindLayoutByScrollID` gates on `Scrollable`,
-    and the freeze outer is not scrollable), but two shapes in the same tree
-    would share an id and `FindByID(cfg.ID)` becomes ambiguous. Also rejected:
-    restructuring the non-freeze path to add a dedicated inner scroll container
-    so both derive `cfg.ID + ":scroll"` — correct, but it adds a layout node and
-    is outside this spec's blast radius.
+    Scroll still resolves (`FindLayoutByScrollID` gates on `Scrollable`, and the
+    freeze outer is not scrollable), but two shapes in the same tree share an id
+    and `FindByID(cfg.ID)` becomes ambiguous. Also rejected: restructuring the
+    non-freeze path to add a dedicated inner scroll container so both derive
+    `cfg.ID + ":scroll"` — correct, but it adds a layout node and is outside
+    this spec's blast radius.
 
 ## Phase 0 — branch + execution protocol (do before any edit)
 
-Work happens on one feature branch, not on `main`. Confirm the base is current
+Work happens on one feature branch, not on `main`. Verify the base is current
 first (`git fetch && git status` — rebase if stale), then:
 
 ```fish
 git switch -c idscroll-to-scrollable main
 ```
 
-The work spans six repos. Phases 1–4 are go-gui on the branch above; phases 5–9
+The work spans six repos. Phases 1–4 are go-gui on the branch above. Phases 5–9
 are the release and the sibling migration, each sibling on its own branch in its
 own repo.
 
@@ -285,7 +285,7 @@ own repo.
 | 2     | go-gui                   | PR B — `ViewFrame` benchmark                                               | `gui: add BenchmarkViewFrame to catch Shape-size regressions`           |
 | 3     | go-gui                   | PR C — `Scrollable` + string identity                                      | `gui: replace IDScroll uint32 with Scrollable + string scroll identity` |
 | 4     | go-gui                   | tests / examples / docs / CHANGELOG                                        | `docs: migrate IDScroll references to Scrollable`                       |
-| 5     | go-kite, go-charts       | **dry run** — migrate against unreleased go-gui, prove clean, do not merge | _(no commit; branches held)_                                            |
+| 5     | go-kite, go-charts       | **dry run** — migrate against unreleased go-gui, prove clean, do not merge | _(no commit, branches held)_                                            |
 | 6     | go-gui                   | release `v0.35.0` (PR A + PR C batched), await proxy                       | _(release skill)_                                                       |
 | 7     | go-kite                  | migration + `go.mod` bump, one PR                                          | `deps: migrate to go-gui v0.35.0 Scrollable API`                        |
 | 8     | go-charts                | migration + `go.mod` bump + CI `ref:` pins, one PR                         | `deps: migrate to go-gui v0.35.0 Scrollable API`                        |
@@ -295,7 +295,7 @@ Rules for every phase:
 
 1. **Run the verification gate before committing**
    (`go build ./... && go vet ./... && golangci-lint run ./... && go test ./...`).
-   A phase with a red gate is not done; do not commit past it.
+   A phase with a red gate is not done. Do not commit past it.
 2. **Commit at the end of the phase**, that phase only — no squashing phases
    together, no work from the next phase riding along.
 3. **Pause after the commit and wait for review.** Do not start the next phase
@@ -303,16 +303,16 @@ Rules for every phase:
    anything the phase surfaced that the spec did not predict.
 4. Do not push or open PRs without explicit permission.
 
-Phase 3 is the breaking one and is large; if it cannot reach a green gate as a
+Phase 3 is the breaking one and is large. If it cannot reach a green gate as a
 single commit, stop and ask rather than committing a broken tree or inventing a
 sub-split the spec does not describe.
 
 ### Why phase 5 (dry run) precedes phase 6 (release)
 
 **Module tags are immutable.** Once `v0.35.0` is pushed it cannot be corrected,
-only superseded — and a defect found while migrating go-kite or go-charts would
-burn a `v0.35.1` across all five siblings. go-kite is the canonical decision-11
-case and go-charts owns its own `idScrollHash` helper, so those two repos are
+only superseded — and a defect found while migrating go-kite or go-charts burns
+a `v0.35.1` across all five siblings. go-kite is the canonical decision-11 case
+and go-charts owns its own `idScrollHash` helper, so those two repos are
 precisely where a spec defect surfaces.
 
 Phase 5 migrates both **against the unreleased go-gui**, using a local
@@ -333,23 +333,23 @@ For go-kite and go-charts the two cannot be split, in either order:
 
 | order                     | result                                                                              |
 | ------------------------- | ----------------------------------------------------------------------------------- |
-| bump first, migrate after | `go.mod` points at `v0.35.0`; `IDScroll` is gone; repo does not compile             |
-| migrate first, bump after | migrated code needs `Scrollable`; `v0.34.x` does not have it; repo does not compile |
+| bump first, migrate after | `go.mod` points at `v0.35.0`. `IDScroll` is gone. Repo does not compile             |
+| migrate first, bump after | migrated code needs `Scrollable`. `v0.34.x` does not have it. Repo does not compile |
 
 So the bump rides in the migration PR. **`/sync-siblings` cannot drive these
 two** — its phase 3 is `go get` → `go mod tidy` → `go build`, with no step that
 edits call sites, and its red-CI triage has no category for "the upstream API
-changed." It would `go get` the breaking version and stall on compile errors. It
-drives phase 9 only, where the three zero-ref repos are pure bumps and that flow
-fits exactly.
+changed." It runs `go get` on the breaking version and stalls on compile errors.
+It drives phase 9 only, where the three zero-ref repos are pure bumps and that
+flow fits exactly.
 
 Phases 7–8 drop the phase-5 `replace`, add the real require, and gate with
-`GOWORK=off` (go-kite has a gitignored `go.work` that would otherwise mask the
+`GOWORK=off` (go-kite has a gitignored `go.work` that otherwise masks the
 published-module resolution CI uses).
 
 ### go-charts also pins go-gui in CI (easy to miss)
 
-`go-charts/.github/workflows/ci.yml:27` and `gallery.yml` check out go-gui at a
+`go-charts/.github/workflows/ci.yml:27` and `gallery.yml` pin go-gui at a
 **hardcoded `ref: v0.34.0`** and `go mod edit -replace` onto it. That pin
 overrides `go.mod`, so bumping the require alone leaves CI building the migrated
 source against a go-gui that still has `IDScroll` — red, with a confusing error.
@@ -357,8 +357,8 @@ source against a go-gui that still has `IDScroll` — red, with a confusing erro
 
 Consequence: go-charts CI cannot verify phase 5 (the workflow needs a real tag).
 Its dry run is local-only, which is why phase 5 exists rather than trusting CI
-to catch it. Note also that this pin means go-gui's `main` advancing does
-**not** red go-charts — do not expect that signal.
+to catch it. Note also that this pin means an advancing go-gui `main` does
+**not** turn go-charts red — do not expect that signal.
 
 ## PR A (phase 1) — delete `IDScrollContainer` (independent, do first)
 
@@ -390,7 +390,7 @@ regression at all** — a flat `B/op` from those benches is an artifact, not
 evidence. Without this bench, PR C's "−8 bytes" claim is unverifiable in CI.
 
 **Do not "fix" the existing benches instead.** They measure something real
-(layout generation over a stable tree); this is an additional bench, not a
+(layout generation over a stable tree). This is an additional bench, not a
 replacement.
 
 Add as `gui/view_frame_bench_test.go` and add `ViewFrame` to the `bench-gate`
@@ -460,7 +460,7 @@ func BenchmarkViewFrame(b *testing.B) {
 ```
 
 Reference numbers on `main` @ `3c5dac7` (M5): `rows_50` ≈ 16.3 µs, 54.34 KiB,
-**353 allocs**; `rows_200` ≈ 66.5 µs, 216.2 KiB, 1403 allocs. The nonzero alloc
+**353 allocs**. `rows_200` ≈ 66.5 µs, 216.2 KiB, 1403 allocs. The nonzero alloc
 count is the point — if a future edit drives `B/op` to a constant, the bench has
 regressed into the same blind spot.
 
@@ -480,7 +480,7 @@ invalidates them.
 
 ### `Shape` (`gui/shape.go`)
 
-- Remove `IDScroll uint32`; add `Scrollable bool` next to
+- Remove `IDScroll uint32`. Add `Scrollable bool` next to
   `Focusable`/`FocusSkip` (**adjacent placement matters** — that is what lets it
   land in existing padding for free).
 - Reuse existing `Shape.ID string` as scroll identity.
@@ -490,23 +490,23 @@ invalidates them.
 
 The `IDScroll` fields are **not all the same thing**. A blind `IDScroll` →
 `Scrollable: true` pass will corrupt the reference and override cases into
-self-scrolling widgets. Each is classified below; the "action" column is the
+self-scrolling widgets. Each is classified below. The "action" column is the
 whole job.
 
 | Cfg                   | file:line                        | kind                            | action                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | --------------------- | -------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ContainerCfg`        | `view_container.go:98`           | **container**                   | `Scrollable bool`; identity = `cfg.ID`                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `ListBoxCfg`          | `view_listbox.go:48`             | **container**                   | `Scrollable bool`; container already sets `ID: cfg.ID` (`:118`, `:217`) alongside `Focusable` — same shape, both identities, different namespaces, no collision                                                                                                                                                                                                                                                                                                                                          |
+| `ContainerCfg`        | `view_container.go:98`           | **container**                   | `Scrollable bool`. Identity = `cfg.ID`                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `ListBoxCfg`          | `view_listbox.go:48`             | **container**                   | `Scrollable bool`. Container already sets `ID: cfg.ID` (`:118`, `:217`) alongside `Focusable` — same shape, both identities, different namespaces, no collision                                                                                                                                                                                                                                                                                                                                          |
 | `TreeCfg`             | `view_tree.go:36`                | **container**                   | same as ListBox (`:238`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `TableCfg`            | `view_table.go:70`               | **container ×2**                | ⚠️ two paths. Non-freeze: `outerCfg` already sets `ID: cfg.ID` (`:271`), gate at `:289` becomes `if cfg.Scrollable`. Freeze: see "Table's two paths" below — the spec's earlier draft missed it entirely                                                                                                                                                                                                                                                                                                 |
-| `ComboboxCfg`         | `view_combobox.go:46`            | **container + identity handle** | dropdown already sets `ID: cfg.ID + ".dropdown"` (`:207`); `:219` becomes `Scrollable: cfg.Scrollable` — **not `true`**, see below. ⚠️ `cfg.IDScroll` is also the caller's scroll handle (decision 11) — key becomes `cfg.ID + ".dropdown"`, document it. Read at `:121` needs that string, not a bool                                                                                                                                                                                                   |
-| `CommandPaletteCfg`   | `view_command_palette.go:48`     | **container, NO ID**            | ⚠️ `IDScroll uint32` → `Scrollable bool`. The scroll `Column` at `:218` has **no `ID` field at all** — must add `ID: cfg.ID + ":scroll"`. `CommandPaletteShow` (`:234`) and `CommandPaletteToggle` (`:261`) also take `idScroll uint32`; remove the parameter, derive `id + ":scroll"` internally for the scroll-reset on show (`:243`). **Behavior change:** today Show resets scroll only when `idScroll > 0`; after the param is gone it **always** resets `id+":scroll"` to 0 on show — intentional. |
-| `InputCfg`            | `view_input.go:78`               | **container** (multiline only)  | gate at `:152` is `cfg.Mode == InputMultiline && cfg.IDScroll > 0`; becomes `&& cfg.Scrollable`. Threads to `inputHandlerCfg` (`:134`, `:222`)                                                                                                                                                                                                                                                                                                                                                           |
-| `inputHandlerCfg`     | `view_input.go:284`              | **internal plumb**              | unexported; thread `string` through `:546`, `:644` (`inputScrollCursorIntoView`)                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `ComboboxCfg`         | `view_combobox.go:46`            | **container + identity handle** | dropdown already sets `ID: cfg.ID + ".dropdown"` (`:207`). `:219` becomes `Scrollable: cfg.Scrollable` — **not `true`**, see below. ⚠️ `cfg.IDScroll` is also the caller's scroll handle (decision 11) — key becomes `cfg.ID + ".dropdown"`, document it. Read at `:121` needs that string, not a bool                                                                                                                                                                                                   |
+| `CommandPaletteCfg`   | `view_command_palette.go:48`     | **container, NO ID**            | ⚠️ `IDScroll uint32` → `Scrollable bool`. The scroll `Column` at `:218` has **no `ID` field at all** — must add `ID: cfg.ID + ":scroll"`. `CommandPaletteShow` (`:234`) and `CommandPaletteToggle` (`:261`) also take `idScroll uint32`. Remove the parameter, derive `id + ":scroll"` internally for the scroll-reset on show (`:243`). **Behavior change:** today Show resets scroll only when `idScroll > 0`. After the param is gone it **always** resets `id+":scroll"` to 0 on show — intentional. |
+| `InputCfg`            | `view_input.go:78`               | **container** (multiline only)  | gate at `:152` is `cfg.Mode == InputMultiline && cfg.IDScroll > 0`. Becomes `&& cfg.Scrollable`. Threads to `inputHandlerCfg` (`:134`, `:222`)                                                                                                                                                                                                                                                                                                                                                           |
+| `inputHandlerCfg`     | `view_input.go:284`              | **internal plumb**              | unexported. Thread `string` through `:546`, `:644` (`inputScrollCursorIntoView`)                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `DataGridCfg`         | `datagrid/view_data_grid.go:238` | **identity override**           | ⚠️ **not** a bool — **delete the field** (decision 9). See below.                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `ScrollbarCfg`        | `view_scrollbar.go:23`           | **reference**                   | ⚠️ rename to `ScrollID string` and tag with `` `gui:"required"` `` (decision 10) — points at _another_ container's state. Never becomes a bool.                                                                                                                                                                                                                                                                                                                                                          |
-| `dragReorderStartCfg` | `drag_reorder.go:210`            | **reference**                   | ⚠️ unexported; `ScrollID string` (decision 10). Never a bool.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `inspectorNodeProps`  | `inspector.go:64`                | **display copy**                | ⚠️ unexported; holds the _inspected_ shape's id for rendering (`:494`), not an opt-in                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `dragReorderStartCfg` | `drag_reorder.go:210`            | **reference**                   | ⚠️ unexported. `ScrollID string` (decision 10). Never a bool.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `inspectorNodeProps`  | `inspector.go:64`                | **display copy**                | ⚠️ unexported. Holds the _inspected_ shape's id for rendering (`:494`), not an opt-in                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 **`appendScrollbar`** (`view_container.go:436`) is the bridge that wires the
 container's ID into the scrollbar's `IDScroll` field. Post-migration, its
@@ -534,26 +534,25 @@ func dataGridScrollID(cfg *DataGridCfg) string {
 ```
 
 That is already the exact string the container's `ID` carries at
-`view_data_grid.go:584`, so the function may be inlinable at its call sites —
-check whether it still earns its keep. `Scrollable: true` goes on that same
+`view_data_grid.go:584`, so the function can be inlined at its call sites —
+verify whether it still earns its keep. `Scrollable: true` goes on that same
 container (`:585`, replacing `IDScroll: scrollID`).
 
 ### Per-frame allocation — the migration is not alloc-neutral
 
 An earlier draft claimed this migration "only removes per-frame work."
 **Wrong.** Every `cfg.ID + ":scroll"` / `cfg.ID + ".dropdown"` is a string
-concatenation, i.e. a heap allocation, evaluated in the view phase — the one
-phase that is not already zero-alloc. The ledger per scrollable widget per
-frame:
+concatenation and a heap allocation, evaluated in the view phase — the one phase
+that is not already zero-alloc. The ledger per scrollable widget per frame:
 
-| site                               | today                                            | after                                  | delta      |
-| ---------------------------------- | ------------------------------------------------ | -------------------------------------- | ---------- |
-| DataGrid                           | concat (`ID:`) + concat-and-hash (`IDScroll:`)   | one concat, reused                     | **−1**     |
-| Select / Combobox dropdown         | concat (`ID:`) + concat-and-hash / passthrough   | one concat, reused                     | **−1 / 0** |
-| CommandPalette                     | none (the scroll `Column` has **no `ID` today**) | one concat                             | **+1**     |
-| Table, freeze                      | none                                             | one concat, if hoisted; **two if not** | **+1**     |
-| Table, non-freeze                  | none                                             | none (`cfg.ID` used directly)          | 0          |
-| Container / ListBox / Tree / Input | none                                             | none (`cfg.ID` used directly)          | 0          |
+| site                               | today                                            | after                             | delta      |
+| ---------------------------------- | ------------------------------------------------ | --------------------------------- | ---------- |
+| DataGrid                           | concat (`ID:`) + concat-and-hash (`IDScroll:`)   | one concat, reused                | **−1**     |
+| Select / Combobox dropdown         | concat (`ID:`) + concat-and-hash / passthrough   | one concat, reused                | **−1 / 0** |
+| CommandPalette                     | none (the scroll `Column` has **no `ID` today**) | one concat                        | **+1**     |
+| Table, freeze                      | none                                             | one concat if hoisted, two if not | **+1**     |
+| Table, non-freeze                  | none                                             | none (`cfg.ID` used directly)     | 0          |
+| Container / ListBox / Tree / Input | none                                             | none (`cfg.ID` used directly)     | 0          |
 
 Net is close to zero and none of it is on a hot path, but the `+1` rows are real
 and the `+2` row is avoidable. **Rule: derive each scroll id once per view call
@@ -599,9 +598,9 @@ Also update `:175`, `:196`, `:290` (gates) and `:471` (`bodyCfg` literal).
 
 Deleting `IDScroll` makes **every** reference to it a compile error. The gate
 and plumbing lists below are therefore a _convenience for estimating the diff_,
-not a safety net, and they are known to be incomplete (e.g.
-`view_container.go:354`, `:387`; `view_table.go:175,196,202,471`;
-`view_listbox.go:187,300`; `view_tree.go:181,189`; `view_input.go:185`). A
+not a safety net, and they are known to be incomplete (for example
+`view_container.go:354`, `:387`, `view_table.go:175,196,202,471`,
+`view_listbox.go:187,300`, `view_tree.go:181,189`, `view_input.go:185`). A
 missed site does not ship — it fails to build. Regenerate at land time rather
 than trusting the lists.
 
@@ -611,7 +610,7 @@ swap.** Two shapes:
 1. **Bool flip next to a key read.**
    `if cfg.IDScroll > 0 { x, _ = w.scrollY().Get(cfg.IDScroll) }` → the gate
    becomes `cfg.Scrollable` _and_ the `Get` needs the derived string. Swapping
-   only the gate leaves a compile error, but swapping both without checking
+   only the gate leaves a compile error, but swapping both without verifying
    **which** string that container carries compiles and reads the wrong key.
    Sites: `view_combobox.go:120-121` (`cfg.ID + ".dropdown"`),
    `view_command_palette.go:120-121` (`cfg.ID + ":scroll"`), `view_table.go:202`
@@ -631,16 +630,16 @@ swap.** Two shapes:
    read at `:121` is gated on `cfg.Scrollable`. Gate and container then
    disagree: a combobox that did not opt in gets a scrollbar injected and scroll
    dispatch, but virtualizes against a key nothing reads. Copy the gate
-   expression; do not assume a literal.
+   expression. Do not assume a literal.
 
 ### Gates: `IDScroll > 0` → `Scrollable` (bool gate sites)
 
-`event_handlers.go:103,343`; `gesture.go:528`; `layout_overflow.go:10`;
-`layout_sizing.go:123,433`; `layout_position.go:11,68,236`;
-`scroll.go:112,190,214,243`; `scroll_smooth.go:140-141`;
-`view_container.go:308,384`; `inspector.go:432`; `view_combobox.go:121`;
-`view_command_palette.go:120`; `view_listbox.go:144,293`; `view_tree.go:175`;
-`view_input.go:152`; `view_table.go:175,196,289`.
+`event_handlers.go:103,343`, `gesture.go:528`, `layout_overflow.go:10`,
+`layout_sizing.go:123,433`, `layout_position.go:11,68,236`,
+`scroll.go:112,190,214,243`, `scroll_smooth.go:140-141`,
+`view_container.go:308,384`, `inspector.go:432`, `view_combobox.go:121`,
+`view_command_palette.go:120`, `view_listbox.go:144,293`, `view_tree.go:175`,
+`view_input.go:152`, `view_table.go:175,196,289`.
 
 Also in `view_container.go`, not gates but same file:
 
@@ -672,9 +671,9 @@ will not compile until retargeted — regenerate with
 | `view_scrollbar.go:288,299`                           | `offsetMouseChangeX/Y` map + `idScroll` params                  |
 | `drag_reorder.go:135,210,527`                         | cfg + runtime state + `dragReorderAutoScroll`                   |
 | `view_listbox.go:118,217,537`                         | `IDScroll:` literals / locals → `Scrollable` + `ID`             |
-| `view_tree.go:238`; `view_tree_rows.go:254`           | same                                                            |
-| `view_combobox.go:219`; `view_command_palette.go:218` | same                                                            |
-| `datagrid/view_data_grid.go:585` + helpers            | override deleted; string identity                               |
+| `view_tree.go:238`, `view_tree_rows.go:254`           | same                                                            |
+| `view_combobox.go:219`, `view_command_palette.go:218` | same                                                            |
+| `datagrid/view_data_grid.go:585` + helpers            | override deleted. String identity                               |
 
 ### Window API (`gui/scroll.go`, `gui/state_registry.go`, `gui/layout_query.go`)
 
@@ -682,7 +681,7 @@ All `idScroll uint32` → `id string`: `ScrollHorizontalBy/To/ToPct/Pct`
 (`:260,277,292,309`), `ScrollVerticalBy/To/ToPct/Pct` (`:324,341,356,373`),
 `ScrollX()`/`ScrollY()` → `*BoundedMap[string, float32]`
 (`state_registry.go:77,84`), `FindLayoutByIDScroll` →
-`FindLayoutByScrollID(layout, id string)` (decision 4; predicate gates on
+`FindLayoutByScrollID(layout, id string)` (decision 4. The predicate gates on
 `Scrollable`), `findScrollLayout` (`scroll.go:7`), `inputScrollCursorIntoView`
 (`scroll.go:45`, guard `idScroll == 0` → `id == ""`).
 
@@ -700,7 +699,7 @@ time-travel's snapshotable whitelist (`time_travel.go:58-59`), but
 `snapshotWhitelistedNamespaces` walks `registry.maps` — which the scroll maps
 are absent from. **Scroll offsets are therefore not captured by time-travel
 today.** Pre-existing bug, unrelated to this migration and unchanged by it (the
-whitelist stays just as inert after the retype). File it separately; do not fix
+whitelist stays just as inert after the retype). File it separately. Do not fix
 it here.
 
 ### Hash derivations to delete
@@ -709,16 +708,16 @@ it here.
 - `view_select.go:68` — `FnvSum32(cfg.ID + ".dropdown")` (feeds `:143`)
 - `view_theme_picker.go:64` — `FnvSum32(lbID)`
 
-Then check `FnvSum32` (`gui/fnv.go`) for remaining callers — #76 removed the
-focus ones. If none remain it is deletable, **but it is exported API**: grep all
-five siblings first.
+Then verify whether `FnvSum32` (`gui/fnv.go`) has remaining callers — #76
+removed the focus ones. If none remain, it is deletable, **but it is exported
+API**: grep all five siblings first.
 
 ### Inspector specifics (`gui/inspector.go`)
 
 - `:12` — `inspectorIDScrollPanel = uint32(0xFFF00001)` magic sentinel → string
-  const, e.g. `inspectorScrollPanel = "gui:inspector:panel"`. Consumed at
+  const, for example `inspectorScrollPanel = "gui:inspector:panel"`. Consumed at
   `:156`, `:676`.
-- `:435` — `strconv.Itoa(int(p.IDScroll))` displays the id; with a string it is
+- `:435` — `strconv.Itoa(int(p.IDScroll))` displays the id. With a string it is
   printed directly. Compile break, trivial fix.
 - `:494` — `IDScroll: shape.IDScroll` copies the inspected shape's id for
   display. Becomes the string.
@@ -739,7 +738,7 @@ five siblings first.
   `scrollbar`, `row`, `combobox`, `gesture`, `column`, `tree`, `data_grid`),
   plus `examples/showcase/docs/commands.md` — which is **not**
   `widget_`-prefixed and is a different file from `docs/commands.md`. Both need
-  updating. 13 files total; regenerate with `rg -l IDScroll --glob '*.md'`.
+  updating. 13 files total. Regenerate with `rg -l IDScroll --glob '*.md'`.
 - `.claude/skills/{widget,new-example}` scaffolds if they mention `IDScroll`.
 
 ## Release (phase 6)
@@ -774,13 +773,13 @@ sites and cannot drive those two.
    the opt-in and the scroll handle. The container must acquire
    `ID: timelineScrollID` (a string) with `Scrollable: true`, and the
    `ScrollVerticalTo` call must pass that same string. `RequireScrollID` catches
-   the container if its `ID` is left empty; it does **not** catch an `ID` that
-   simply disagrees with what `ScrollVerticalTo` passes. That case compiles and
-   scrolls nothing.
+   the container if its `ID` is left empty. It does **not** catch an `ID` that
+   disagrees with what `ScrollVerticalTo` passes. That case compiles and scrolls
+   nothing.
 5. **go-charts** — regenerate counts at land
    (`rg -n 'IDScroll|idScrollHash|ScrollVertical|ScrollHorizontal|scrollCatalog|scrollDetail'`).
    `chart/data_table.go:14,67` has its own `idScrollHash(id)` helper feeding
-   `gui.TableCfg.IDScroll`; **delete the helper**, pass the string.
+   `gui.TableCfg.IDScroll`. **Delete the helper**, pass the string.
    `examples/showcase` uses `scrollCatalog`/`scrollDetail` consts across
    `catalog.go:29,94-96,237-238`, `detail.go:11,32`, `main.go:9-10,51-56`.
 
@@ -815,9 +814,9 @@ it does not move at all, the bench is not wired in.
   Read the `Get` improvement correctly: PR C does not _fix_ this bug, it
   _sidesteps_ it by keying with a string. If #77 is fixed first, uint32 reads
   drop to ~2.4 ns and string keys become the slower choice by ~2.8 ns per read —
-  a handful of containers × 2.8 ns per frame against a 4–5 ms budget, i.e.
+  a handful of containers × 2.8 ns per frame against a 4–5 ms budget, that is
   irrelevant. The size (272 → 264) and consistency arguments carry this spec on
-  their own; **PR C must not be justified on the `Get` number.**
+  their own. **PR C must not be justified on the `Get` number.**
 
 - Enum reorder of `ScrollMode` to add a `ScrollNone` zero value.
 
@@ -830,11 +829,11 @@ break vs silent break" subsections, and the go-kite note incorporate the second
 2026-07-15 pass, which verified the spec's claims against `main` @ `3c5dac7`:
 
 - `IDScrollContainer` has zero readers (sole writer `layout_position.go:200`,
-  plus the two named tests). PR A confirmed.
-- `RequireFocusID` has zero call sites. Decision 7's framing confirmed.
+  plus the two named tests). PR A verified.
+- `RequireFocusID` has zero call sites. Decision 7's framing verified.
 - `Shape` is **272** bytes today, and adding `Scrollable bool` next to
   `FocusSkip` is **free** (measured 272 → 272 on a spike). The
-  padding-absorption claim holds; the net 264 follows from removing 8 bytes of
+  padding-absorption claim holds. The net 264 follows from removing 8 bytes of
   `uint32`.
 - `FnvSum32` retains only test callers once the three production sites go —
   deletable pending the sibling grep, as written.
@@ -844,28 +843,28 @@ things the second pass got wrong or oversold:
 
 - **`IDScroll` is not a StateMap key.** The motivation said it was and the
   typed-plumbing list carried a "rekey `nsScrollX`/`nsScrollY`" item. Offsets
-  live in dedicated `w.scrollXMap`/`scrollYMap`; the consts are inert. Item
+  live in dedicated `w.scrollXMap`/`scrollYMap`. The consts are inert. Item
   deleted. Surfaced a real pre-existing bug — time-travel does not snapshot
   scroll offsets — explicitly left out of scope.
-- **Combobox.** The classification table said "just `Scrollable: true`";
-  `view_combobox.go:219` is a passthrough (`IDScroll: cfg.IDScroll`), so that
-  literal would have silently forced scroll on every dropdown. Now
+- **Combobox.** The classification table said "just `Scrollable: true`".
+  `view_combobox.go:219` is a passthrough (`IDScroll: cfg.IDScroll`), so writing
+  that literal forces scroll silently on every dropdown. Now
   `Scrollable: cfg.Scrollable`, with the Select contrast written out as a third
   silent-break shape.
 - **Alloc neutrality.** "This migration only removes per-frame work" was false:
   CommandPalette and Table-freeze each gain a concat. New "Per-frame allocation"
-  subsection; decision 12 now mandates hoisting; PR B's blind spot documented
+  subsection. Decision 12 now mandates hoisting. PR B's blind spot documented
   rather than papered over.
 - **`RequireScrollID`** was framed as catching "every missed site". It catches
   one: a bare `ContainerCfg` with `Scrollable: true` and no `ID`. Every other
   scroll container either derives a never-empty suffix id or already calls
-  `RequireID`. Still worth wiring; no longer oversold.
+  `RequireID`. Still worth wiring. No longer oversold.
 - Also: `Window.ScrollX()`/`ScrollY()` added to the CHANGELOG's breaking list as
-  a third item; decision 4 flagged as a behavior change (today's predicate has
-  no opt-in gate and no zero guard); go-kite ref count corrected 3 → 2; doc file
+  a third item. Decision 4 flagged as a behavior change (today's predicate has
+  no opt-in gate and no zero guard). go-kite ref count corrected 3 → 2. Doc file
   count corrected 11 → 13 with `commands.md` miscategorization fixed.
 
-Measured this pass: `sizeof(Shape) == 272` on `main` @ `3c5dac7`, confirming the
+Measured this pass: `sizeof(Shape) == 272` on `main` @ `3c5dac7`, verifying the
 272 → 264 claim's starting point.
 
 Nothing in this spec requires a judgement call the implementer has to make alone
@@ -875,9 +874,9 @@ underspecified on Table.
 
 ## Open risks
 
-- Scroll identity must be unique per frame among scroll containers; duplicates
+- Scroll identity must be unique per frame among scroll containers. Duplicates
   share offsets. **Accepted, undetected** (decision 8) — usually obvious when
-  scrolling; weaker under virtualization, still not worth a per-frame seen-set.
+  scrolling. Weaker under virtualization, still not worth a per-frame seen-set.
 - Containers opting in with `IDScroll: 1` and no `ID` must acquire one. Wire
   `RequireScrollID` in **early** — it is the safety net that turns every missed
   site in this migration into a panic at first render rather than a silent
@@ -887,23 +886,23 @@ underspecified on Table.
 - Typed key holders (`scroll_smooth` entries, `window` maps, `view_scrollbar`
   helpers, drag-reorder runtime state) are easy to miss if the implementer only
   greps `IDScroll > 0` — use the typed-plumbing table in PR C. Missing one is a
-  **build failure**, not a silent bug; see "Compile break vs silent break".
+  **build failure**, not a silent bug. See "Compile break vs silent break".
 - **The silent failures are gate-flips next to a key read** — the four sites
   listed in "Compile break vs silent break". A swap that satisfies the compiler
   while reading a key nothing writes produces a container that renders but never
   scrolls, or virtualizes against offset 0.
 - **Table's freeze path** (`tableFreezeLayout`) puts the scroll container
   somewhere different than the non-freeze path does, and `:202` reads the key
-  for both. Decision 12 branches; forgetting the branch mis-virtualizes
+  for both. Decision 12 branches. Forgetting the branch mis-virtualizes
   frozen-header tables specifically, which is the configuration least likely to
   be in a smoke test.
 - **Consumers lose the caller-supplied scroll handle** (decision 11). The
   derived key is recoverable from the docs, but a sibling that migrates the Cfg
   field and forgets its `ScrollVerticalTo` call site compiles and silently stops
-  scrolling. go-kite is the known instance; regrep the others for
+  scrolling. go-kite is the known instance. Regrep the others for
   `ScrollVertical|ScrollHorizontal` at land time, not just for `IDScroll`.
 - `CommandPaletteCfg`'s scroll container has no `ID` today and needs one
-  invented (`cfg.ID + ":scroll"`); Show always resets that key after the API
+  invented (`cfg.ID + ":scroll"`). Show always resets that key after the API
   shrink.
 - `allocs/op` on `BenchmarkViewFrame` (PR B) must not rise after PR C. Nothing
   in this migration touches the paths that bench covers, so any movement there

--- a/docs/specs/ime-text-context.md
+++ b/docs/specs/ime-text-context.md
@@ -18,7 +18,7 @@ because arrows produce no preedit.
 
 The other backends already assumed the narrower contract. `ime_win32.go` says
 outright that "composition only becomes possible once a text widget takes
-focus"; on X11 `IMEStart` is an ibus `FocusIn`; on web it creates a hidden
+focus". On X11 `IMEStart` is an ibus `FocusIn`. On web it creates a hidden
 `<input>` and moves DOM focus into it.
 
 ## Rule
@@ -33,7 +33,7 @@ preedit is drawn:
 - a text shape whose `focusOwner` is set — only input widgets set it
   (`view_input.go`), so a selection-only focusable `Text` is excluded — and
   whose `TC.textReadOnly` is false, since a read-only input stays focusable for
-  its caret but can never commit;
+  its caret but can never commit.
 - a focusable term grid, which consumes typed text directly.
 
 `(*Window).syncIMEEditContext` runs from `buildRenderers` and pushes only
@@ -42,7 +42,7 @@ widget that already holds it does not cycle the input context.
 
 Moving between two text fields does cycle it. `IMEStop` is what cancels a
 composition still live inside the engine — an ibus `FocusOut`, the IMM context
-detach, the web hidden `<input>` being removed — so skipping it would let a
+detach, the removal of the web hidden `<input>` — so skipping it lets a
 half-typed word commit into the field that just took focus. The activation is
 therefore keyed on the focused ID as well as on the boolean.
 
@@ -59,10 +59,10 @@ through `IMESetRect` the same way.
 
 `imeSettleAfterKeyWasComposing:` decides who owns a key, in order:
 
-1. a composition already in flight owns everything, arrows and Return included;
-2. no preedit — the key is the widget's;
+1. a composition already in flight owns everything, arrows and Return included.
+2. no preedit — the key is the widget's.
 3. a preedit started **with** an edit context focused is real input (a CJK first
-   letter, or the first half of Option+e → é) and the key is claimed;
+   letter, or the first half of Option+e → é) and the key is claimed.
 4. a preedit started **without** one is an unwanted dead key: it is discarded
    (`unmarkText`, an empty `METAL_EVENT_IME_COMP` to clear Go's preedit, and
    `[self.inputContext discardMarkedText]` to drop it inside the input source),
@@ -78,8 +78,8 @@ key, declined it as text input, and returned it as a command for the widget.
 `_imeDeclinedKey` records that, and it outranks a live composition — step 1
 above applies only to keys the input source actually consumed.
 
-Without it, Tab could not leave a field that had a dead key pending. The
-observed callback order for Option+e then Tab is:
+Without it, Tab cannot leave a field that has a dead key pending. The observed
+callback order for Option+e then Tab is:
 
 ```
 insertText: ´              the accent commits
@@ -90,13 +90,13 @@ so `wasComposing` was true and the Tab was dropped, leaving focus stuck in the
 field with the accent already typed.
 
 Because the commit is queued before the key comes back, delivering the key
-immediately would move focus before the text landed, and the accent would be
-typed into the widget that just took focus. `metalPollEvent` therefore holds a
-declined key for one poll whenever the same keystroke queued text
-(`_deferredKey`), releasing it once the queue has drained.
+immediately moves focus before the text lands, and the accent is typed into the
+widget that just took focus. `metalPollEvent` therefore holds a declined key for
+one poll whenever the same keystroke queued text (`_deferredKey`), releasing it
+once the queue has drained.
 
 The consequence, deliberate: inside a focused text field macOS keeps native
-behaviour and an Option+letter shortcut does not fire, where X11 delivers the
+behavior and an Option+letter shortcut does not fire, where X11 delivers the
 key-down and suppresses only the character.
 
 ## Tests

--- a/docs/specs/macos-native-backend.md
+++ b/docs/specs/macos-native-backend.md
@@ -2,7 +2,7 @@
 
 Status: **implemented** — SDL2 eliminated from macOS (`bead449`, #11): sdl2 is
 gone from go.mod and the Metal backend speaks Cocoa/AppKit directly. macOS stays
-cgo by decision (2026-08-12); see `cgo-free-backend-feasibility.md` § Phase 2.
+cgo by decision (2026-08-12). See `cgo-free-backend-feasibility.md` § Phase 2.
 
 ## Summary
 
@@ -33,7 +33,7 @@ eliminates ALL build-toolchain C dependencies on macOS. System framework CGo
 
 SDL3 is the current SDL stable, so the shim is the right answer for Linux and
 eventually Windows. But for macOS specifically, the Metal backend already does
-native rendering — SDL is only providing window + events + clipboard + cursors
+native rendering — SDL only provides window + events + clipboard + cursors
 
 - IME. All of these have direct AppKit equivalents with smaller API surfaces.
 
@@ -68,7 +68,7 @@ Before:                              After:
 | Window title    | `win.SetTitle()`                                     | `[nsWindow setTitle:]`                                             | 1 line |
 | Window size     | `win.GetSize()`                                      | `[nsWindow frame].size`                                            | 1 line |
 | Event pump      | `sdl.WaitEventTimeout` / `sdl.PollEvent`             | `[NSApp nextEventMatchingMask:…]`                                  | ~80    |
-| Mouse events    | `sdl.MouseButtonEvent`, etc.                         | `NSEventTypeLeftMouseDown`, etc.                                   | ~100   |
+| Mouse events    | `sdl.MouseButtonEvent`, and more                     | `NSEventTypeLeftMouseDown`, and more                               | ~100   |
 | Keyboard events | `sdl.KeyboardEvent`                                  | `NSEventTypeKeyDown` + key code mapping                            | ~80    |
 | Scroll events   | `sdl.MouseWheelEvent`                                | `NSEventTypeScrollWheel`                                           | ~30    |
 | Window events   | `sdl.WindowEvent` (resize, focus, close)             | `NSWindowDelegate` callbacks                                       | ~50    |
@@ -76,7 +76,7 @@ Before:                              After:
 | Text input      | `sdl.TextInputEvent` / `sdl.TextEditingEvent`        | `NSTextInputClient` protocol                                       | ~120   |
 | Clipboard get   | `sdl.GetClipboardText()`                             | `[NSPasteboard generalPasteboard] stringForType:`                  | ~5     |
 | Clipboard set   | `sdl.SetClipboardText()`                             | `[NSPasteboard generalPasteboard] clearContents` + `setString:`    | ~8     |
-| Cursors         | `[11]*sdl.Cursor` with `CreateSystemCursor`          | `[NSCursor arrowCursor]` etc.                                      | ~15    |
+| Cursors         | `[11]*sdl.Cursor` with `CreateSystemCursor`          | `[NSCursor arrowCursor]`, and more                                 | ~15    |
 | Live resize     | `sdl.AddEventWatchFunc` + `WINDOWEVENT_SIZE_CHANGED` | `NSWindowDelegate windowDidResize:`                                | ~20    |
 | App quit        | `sdl.QuitEvent`                                      | `NSApplicationDelegate applicationShouldTerminate:`                | ~8     |
 | Wake from timer | `sdl.RegisterEvents` + `sdl.PushEvent(UserEvent)`    | `dispatch_async(dispatch_get_main_queue(), …)` or CFRunLoop source | ~15    |
@@ -152,7 +152,7 @@ gui/backend/metal/rotation.go         — screen rotation
 
 None. The Metal backend is gated by `//go:build darwin && !ios`. All SDL2 and GL
 backend files continue to serve Linux and Windows. `gui/compat_mingw.go` stays —
-it's gated `//go:build windows && cgo` and remains needed for SDL2 on Windows.
+it is gated `//go:build windows && cgo` and remains needed for SDL2 on Windows.
 
 ### Shared files (no impact)
 
@@ -165,8 +165,8 @@ continues to select the SDL2 or GL backend as before.
 
 ### 1. Event loop
 
-The SDL `WaitEventTimeout` / `PollEvent` pattern is replaced with manual NSEvent
-polling. This mirrors what SDL does internally on macOS and gives Go full
+Manual NSEvent polling replaces the SDL `WaitEventTimeout` / `PollEvent`
+pattern. This mirrors what SDL does internally on macOS and gives Go full
 control over the loop timing.
 
 ```go
@@ -197,13 +197,13 @@ fire from the window delegate during `sendEvent:`.
 
 The wake mechanism replaces `sdl.PushEvent(&sdl.UserEvent{…})` with
 `dispatch_async(dispatch_get_main_queue(), ^{ [NSApp postEvent:… atStart:NO] })`
-— or more simply, a CFRunLoop source that Go signals.
+— or a CFRunLoop source that Go signals.
 
 ### 2. Event mapping
 
-`events.go` is rewritten. The mapping NSEvent → `gui.Event` is simpler than the
-SDL path because NSEvent already carries more structured data (e.g., button
-number, click count, pressure, precise scrolling deltas):
+`events.go` carries the NSEvent → `gui.Event` mapping. It is simpler than the
+SDL path because NSEvent already carries more structured data (for example
+button number, click count, pressure, precise scrolling deltas):
 
 ```go
 func mapNSEvent(event C.NSEventRef, b *Backend) (gui.Event, bool) {
@@ -222,8 +222,8 @@ func mapNSEvent(event C.NSEventRef, b *Backend) (gui.Event, bool) {
 ```
 
 A thin C layer in `metal_window.m` extracts fields from NSEvent (location in
-window, button number, modifier flags, etc.) as simple C functions callable from
-cgo. This avoids exposing NSEvent's ObjC interface to Go.
+window, button number, modifier flags, and more) as simple C functions callable
+from cgo. This avoids exposing NSEvent's ObjC interface to Go.
 
 Key mappings:
 
@@ -289,8 +289,8 @@ var nsCursorSelectors = [11]string{
 
 Usage: `[[NSCursor className] performSelector:NSSelectorFromString(name)]`. This
 avoids pre-defining all 11 cursors. The cursor is set once per frame in the
-event loop (existing pattern unchanged). The `Backend.cursors` array field is
-removed.
+event loop (existing pattern unchanged). The change removes the
+`Backend.cursors` array field.
 
 Note: `_windowResizeNorthWestSouthEastCursor` is a private selector. If App
 Store submission is ever a goal, replace with
@@ -316,8 +316,8 @@ void metalClipboardSet(const char *text) {
 }
 ```
 
-Go side calls these via cgo. The returned string from `metalClipboardGet` is
-freed by Go via `C.free()`.
+Go calls these via cgo. Go frees the returned string from `metalClipboardGet`
+via `C.free()`.
 
 ### 5. IME (text input)
 
@@ -333,7 +333,7 @@ void metalWindowIMESetActive(GoGuiNSWindow w, int active);
 
 When IME is active and the user types, `NSTextInputClient insertText:` fires,
 which calls a Go callback. `setMarkedText:` fires for in-progress compositions
-(Chinese, Japanese, Korean). Both are bridged to `gui.EventChar` and
+(Chinese, Japanese, Korean). Both bridge to `gui.EventChar` and
 `gui.EventIMEComposition` respectively, matching the current SDL behavior.
 
 The `NSTextInputClient` implementation in `MetalContentView`:
@@ -382,9 +382,9 @@ typedef struct {
 } GoGuiWindow;
 ```
 
-The callback function pointers are set by Go via cgo and called from the
-NSWindowDelegate. This eliminates the `goFileDrop(SDL_Window*, char*)` pattern —
-all bridges use the same `GoGuiWindow` struct and its callbacks.
+Go sets the callback function pointers via cgo. The NSWindowDelegate calls them.
+This eliminates the `goFileDrop(SDL_Window*, char*)` pattern — all bridges use
+the same `GoGuiWindow` struct and its callbacks.
 
 ### 7. Multi-window support
 
@@ -400,10 +400,10 @@ the last window closes (configurable via
 
 ### Key code mapping correctness
 
-SDL's `SDLK_*` values differ from macOS virtual key codes. The mapping table
-(`nsKeyToGui`) must be exhaustively verified against all keys go-gui supports:
-letters, digits, function keys (F1–F12), navigation (Home, End, PgUp, PgDn),
-modifiers, media keys, numpad.
+SDL's `SDLK_*` values differ from macOS virtual key codes. Verify the mapping
+table (`nsKeyToGui`) exhaustively against all keys go-gui supports: letters,
+digits, function keys (F1–F12), navigation (Home, End, PgUp, PgDn), modifiers,
+media keys, numpad.
 
 Testing strategy: write a key-event echo example that displays key codes, then
 run it side-by-side with the SDL backend's keyboard output. Diff until zero.
@@ -426,7 +426,7 @@ The existing `gui.EventIMEComposition` with `IMEStart`/`IMELength` mirrors
 SDL provides `FINGERDOWN`/`FINGERMOTION`/`FINGERUP` touch events. macOS exposes
 touch via `NSTouch` on `NSTouchBar`-capable devices and via `NSEventTypeGesture`
 for trackpad gestures. Direct `NSTouch` access requires `allowedTouchTypes` on
-the NSView. Multi-touch (e.g., for a drawing canvas) is usable but maps
+the NSView. Multi-touch (for example for a drawing canvas) is usable but maps
 differently than SDL's finger abstraction.
 
 For the initial implementation, trackpad scroll (already handled via
@@ -450,7 +450,7 @@ if (dark) {
 
 SDL has `WINDOW_FULLSCREEN` / `WINDOW_FULLSCREEN_DESKTOP` flags. NSWindow has
 `toggleFullScreen:` and `NSWindowStyleMaskFullScreen`. The `WindowCfg`
-fullscreen options map to these. Not needed for v0.28 but should be noted.
+fullscreen options map to these. Not needed for v0.28 but worth noting.
 
 ### CGo framework dependencies
 

--- a/docs/specs/markdown-render-callback.md
+++ b/docs/specs/markdown-render-callback.md
@@ -2,8 +2,8 @@
 
 Status: proposed. Written 2026-08-24. Modeled on Bun's `bun:markdown`
 `renderMarkdown({ data, callback })`: the caller gets every parsed markdown
-element (heading, list, …) in a callback and can replace its output. The
-feature is additive. It is not a breaking change.
+element (heading, list, …) in a callback and can replace its output. The feature
+is additive. It is not a breaking change.
 
 ## Problem
 
@@ -14,11 +14,10 @@ calling `Markdown()`. Structure-aware extension hooks already exist per concern
 — `CodeHighlighter`, `MathFetcher`, `MermaidFetcher` — but there is no generic
 one, so the most-requested markdown feature (callouts) has no first-class path.
 
-The render pass is already a bun-style element switch:
-`markdownBuildContent` (`gui/view_markdown.go`) discriminates each
-`markdownBlock` by flags (`IsCode`, `IsTable`, `HeaderLevel`, `IsList`, …) and
-dispatches to `mdRender*`. A render callback is a new first branch of that
-switch — no new machinery.
+The render pass is already a bun-style element switch: `markdownBuildContent`
+(`gui/view_markdown.go`) discriminates each `markdownBlock` by flags (`IsCode`,
+`IsTable`, `HeaderLevel`, `IsList`, …) and dispatches to `mdRender*`. A render
+callback is a new first branch of that switch — no new machinery.
 
 ## Design
 
@@ -33,7 +32,7 @@ precedent for behavioral hooks on the Cfg.
 ### The element
 
 `MarkdownElement` is an exported, styled view of one parsed block. The hook
-receives the *styled* form so it reuses `MarkdownStyle` instead of re-styling
+receives the _styled_ form so it reuses `MarkdownStyle` instead of re-styling
 raw runs:
 
 ```go
@@ -81,20 +80,20 @@ type MarkdownElement struct {
 RenderBlock func(el MarkdownElement) []View
 ```
 
-- Consulted first in the `markdownBuildContent` loop, per block, before the
-  kind switch. `nil` return = default rendering.
+- Consulted first in the `markdownBuildContent` loop, per block, before the kind
+  switch. `nil` return = default rendering.
 - Single callback + `Kind` discriminator, not one field per kind: handling one
   kind requires twelve no-op fields. The discriminator is the bun shape.
 - **Runs every frame.** Blocks are parsed and styled once and cached
-  (`markdownCache`, keyed on source hash + theme). The callback fires per
-  frame over the cached styled blocks. It must be cheap and pure — build
-  `View` structs, do not fetch or parse. Document this in the field comment.
+  (`markdownCache`, keyed on source hash + theme). The callback fires per frame
+  over the cached styled blocks. It must be cheap and pure — build `View`
+  structs, do not fetch or parse. Document this in the field comment.
 - **Selection is unaffected.** `makeCtx` advances rune offsets from
   `block.Content`, never from rendered views, so replaced blocks keep correct
   offsets. They are not selectable text.
 - **IDs in custom views are the hook writer's responsibility.** Compose inner
-  IDs with `ScopeID(el.DocID, …)`. The `gui.Debug` gate
-  (`TestDuplicateIDs`) catches collisions at runtime.
+  IDs with `ScopeID(el.DocID, …)`. The `gui.Debug` gate (`TestDuplicateIDs`)
+  catches collisions at runtime.
 - **List caveat.** List items accumulate through `mdFlushListItems`, which
   supplies the bullet/prefix. A non-nil return for a `MarkdownKindList` block
   replaces that item wholesale and drops it from prefix processing — the hook
@@ -111,34 +110,33 @@ RenderBlock func(el MarkdownElement) []View
 go-gui itself never renders markdown internally — the in-tree consumers are
 `examples/` — so this is a demo dog-food, not a first-party consumer.
 
-- `examples/showcase/demo_text.go` (`demoMarkdown`): implement a
-  `> [!NOTE]` / `> [!WARNING]` callout convention via `RenderBlock` — a
-  tinted container per kind. This is the most-requested markdown feature and
-  exercises the hook on blockquotes, headings, and inline content.
+- `examples/showcase/demo_text.go` (`demoMarkdown`): implement a `> [!NOTE]` /
+  `> [!WARNING]` callout convention via `RenderBlock` — a tinted container per
+  kind. This is the most-requested markdown feature and exercises the hook on
+  blockquotes, headings, and inline content.
 - A heading-derived table of contents needs a document-level pass that a
   per-block callback cannot express. It is out of scope (see below).
 
 ## Testing
 
-- Unit tests (`gui/markdown_test.go`) cover each behavior: the callback
-  receives the right `Kind` and content per block. A `nil` fallback renders
-  the default. A replacement renders in place. Selection rune offsets still
-  advance. The list caveat is covered.
+- Unit tests (`gui/markdown_test.go`) cover each behavior: the callback receives
+  the right `Kind` and content per block. A `nil` fallback renders the default.
+  A replacement renders in place. Selection rune offsets still advance. The list
+  caveat is covered.
 - Golden: add a `gui/golden_test.go` case with a `RenderBlock` (callout or
   heading wrap) recorded in both `ThemeDark` and `ThemeLight`.
-- `TestDuplicateIDs` run over a hooked document with an ID collision proves
-  the debug gate covers hook-built views.
+- `TestDuplicateIDs` run over a hooked document with an ID collision proves the
+  debug gate covers hook-built views.
 - New exports need consumers or `// exportaudit:keep` (`make export-audit`).
 
 ## Out of scope
 
 - Table-of-contents widget (needs a document-level block inspection pass).
-- Caching hook output: the hook is per-frame by design; its closure identity
-  is unhashable, so a cache key is not available. Per-frame cost is a
-  documented constraint, consistent with the rest of the immediate-mode
-  pipeline.
-- `MarkdownStyle`-level hooks (parse-time) stay as-is; `CodeHighlighter`
-  keeps its place.
+- Caching hook output: the hook is per-frame by design; its closure identity is
+  unhashable, so a cache key is not available. Per-frame cost is a documented
+  constraint, consistent with the rest of the immediate-mode pipeline.
+- `MarkdownStyle`-level hooks (parse-time) stay as-is; `CodeHighlighter` keeps
+  its place.
 
 ## Phases
 
@@ -151,10 +149,10 @@ go-gui itself never renders markdown internally — the in-tree consumers are
 
 ## Unresolved questions
 
-1. Export `MarkdownTable` now, or exclude table data from `MarkdownElement`
-   in v1 (tables keep default rendering unless the hook wraps)? Leaning:
-   include — `mdRenderTable` is the one renderer that cannot be reproduced
-   from `RichText` alone.
+1. Export `MarkdownTable` now, or exclude table data from `MarkdownElement` in
+   v1 (tables keep default rendering unless the hook wraps)? Leaning: include —
+   `mdRenderTable` is the one renderer that cannot be reproduced from `RichText`
+   alone.
 2. `MarkdownElement` mirrors `markdownBlock` field-for-field, or a curated
    subset? Leaning: curated subset + the raw parser block exposed as an
    unexported-adjacent escape hatch, to keep the exported struct small.

--- a/docs/specs/markdown-render-callback.md
+++ b/docs/specs/markdown-render-callback.md
@@ -1,0 +1,160 @@
+# Markdown render callback
+
+Status: proposed. Written 2026-08-24. Modeled on Bun's `bun:markdown`
+`renderMarkdown({ data, callback })`: the caller gets every parsed markdown
+element (heading, list, …) in a callback and can replace its output. The
+feature is additive. It is not a breaking change.
+
+## Problem
+
+The `Markdown` widget cannot express new block types or per-element rendering
+overrides. An app that wants admonitions (`> [!NOTE]`), numbered headings,
+annotated paragraphs, or dropped sections must rewrite the source string before
+calling `Markdown()`. Structure-aware extension hooks already exist per concern
+— `CodeHighlighter`, `MathFetcher`, `MermaidFetcher` — but there is no generic
+one, so the most-requested markdown feature (callouts) has no first-class path.
+
+The render pass is already a bun-style element switch:
+`markdownBuildContent` (`gui/view_markdown.go`) discriminates each
+`markdownBlock` by flags (`IsCode`, `IsTable`, `HeaderLevel`, `IsList`, …) and
+dispatches to `mdRender*`. A render callback is a new first branch of that
+switch — no new machinery.
+
+## Design
+
+### Hook location: `MarkdownCfg.RenderBlock`
+
+On `MarkdownCfg`, not `MarkdownStyle`. `CodeHighlighter` lives on the style
+because it runs at parse/style time (cached). `RenderBlock` runs at generation
+time — it needs the resolved document scope and the `*Window` for building
+views, which only the render pass has. `MathFetcher`/`MermaidFetcher` set the
+precedent for behavioral hooks on the Cfg.
+
+### The element
+
+`MarkdownElement` is an exported, styled view of one parsed block. The hook
+receives the *styled* form so it reuses `MarkdownStyle` instead of re-styling
+raw runs:
+
+```go
+// MarkdownBlockKind names a parsed markdown block for MarkdownElement.Kind.
+type MarkdownBlockKind int
+
+const (
+	MarkdownKindHeading MarkdownBlockKind = iota
+	MarkdownKindParagraph
+	MarkdownKindCode
+	MarkdownKindTable
+	MarkdownKindHR
+	MarkdownKindBlockquote
+	MarkdownKindImage
+	MarkdownKindMath
+	MarkdownKindList
+	MarkdownKindDefTerm
+	MarkdownKindDefValue
+)
+
+// MarkdownElement is one parsed, styled markdown block, passed to
+// MarkdownCfg.RenderBlock. Kind is the discriminator; Kind-specific data
+// (HeaderLevel, TableData, ImageSrc, …) is zero for other kinds.
+type MarkdownElement struct {
+	Kind        MarkdownBlockKind
+	HeaderLevel int
+	Content     RichText   // styled runs
+	PlainText   string     // unstyled source text
+	TableData   *MarkdownTable // parsed+styled table; nil for non-tables
+	DocID       string     // effective markdown widget ID, for ScopeID
+	// Task flags, image dims, CodeLanguage, MathLatex, AnchorSlug and the
+	// remaining markdownBlock fields mirror the parser; see markdownBlock.
+}
+```
+
+`TableData` is an exported mirror of the internal `parsedTable`
+(headers/rows/alignments as `RichText`), since `parsedTable` itself is private.
+
+### The callback
+
+```go
+// On MarkdownCfg:
+// RenderBlock, when non-nil, is consulted for every block during layout.
+// Return nil to fall back to the default renderer.
+RenderBlock func(el MarkdownElement) []View
+```
+
+- Consulted first in the `markdownBuildContent` loop, per block, before the
+  kind switch. `nil` return = default rendering.
+- Single callback + `Kind` discriminator, not one field per kind: handling one
+  kind requires twelve no-op fields. The discriminator is the bun shape.
+- **Runs every frame.** Blocks are parsed and styled once and cached
+  (`markdownCache`, keyed on source hash + theme). The callback fires per
+  frame over the cached styled blocks. It must be cheap and pure — build
+  `View` structs, do not fetch or parse. Document this in the field comment.
+- **Selection is unaffected.** `makeCtx` advances rune offsets from
+  `block.Content`, never from rendered views, so replaced blocks keep correct
+  offsets. They are not selectable text.
+- **IDs in custom views are the hook writer's responsibility.** Compose inner
+  IDs with `ScopeID(el.DocID, …)`. The `gui.Debug` gate
+  (`TestDuplicateIDs`) catches collisions at runtime.
+- **List caveat.** List items accumulate through `mdFlushListItems`, which
+  supplies the bullet/prefix. A non-nil return for a `MarkdownKindList` block
+  replaces that item wholesale and drops it from prefix processing — the hook
+  supplies its own prefix. Mixed lists (some items hooked, some not) therefore
+  render inconsistently. Document that hooks which override list items must
+  handle every item of a list.
+- Images/math: `mdRenderImage` and the mermaid/math fetch triggers run on the
+  cached blocks regardless of the hook, so custom replacements do not disable
+  diagram fetching.
+- `markdownToRichText` (the RTF path) is a separate pipeline and is untouched.
+
+## Dog-fooding
+
+go-gui itself never renders markdown internally — the in-tree consumers are
+`examples/` — so this is a demo dog-food, not a first-party consumer.
+
+- `examples/showcase/demo_text.go` (`demoMarkdown`): implement a
+  `> [!NOTE]` / `> [!WARNING]` callout convention via `RenderBlock` — a
+  tinted container per kind. This is the most-requested markdown feature and
+  exercises the hook on blockquotes, headings, and inline content.
+- A heading-derived table of contents needs a document-level pass that a
+  per-block callback cannot express. It is out of scope (see below).
+
+## Testing
+
+- Unit tests (`gui/markdown_test.go`) cover each behavior: the callback
+  receives the right `Kind` and content per block. A `nil` fallback renders
+  the default. A replacement renders in place. Selection rune offsets still
+  advance. The list caveat is covered.
+- Golden: add a `gui/golden_test.go` case with a `RenderBlock` (callout or
+  heading wrap) recorded in both `ThemeDark` and `ThemeLight`.
+- `TestDuplicateIDs` run over a hooked document with an ID collision proves
+  the debug gate covers hook-built views.
+- New exports need consumers or `// exportaudit:keep` (`make export-audit`).
+
+## Out of scope
+
+- Table-of-contents widget (needs a document-level block inspection pass).
+- Caching hook output: the hook is per-frame by design; its closure identity
+  is unhashable, so a cache key is not available. Per-frame cost is a
+  documented constraint, consistent with the rest of the immediate-mode
+  pipeline.
+- `MarkdownStyle`-level hooks (parse-time) stay as-is; `CodeHighlighter`
+  keeps its place.
+
+## Phases
+
+1. `gui/view_markdown.go`: add `MarkdownElement`, `MarkdownBlockKind`,
+   `MarkdownTable`, `RenderBlock` field, and the dispatch branch in
+   `markdownBuildContent`.
+2. Unit tests + golden case.
+3. Dog-food: callout rendering in `examples/showcase/demo_text.go`.
+4. Gate: `make export-audit`, `make check`, `make prepush`.
+
+## Unresolved questions
+
+1. Export `MarkdownTable` now, or exclude table data from `MarkdownElement`
+   in v1 (tables keep default rendering unless the hook wraps)? Leaning:
+   include — `mdRenderTable` is the one renderer that cannot be reproduced
+   from `RichText` alone.
+2. `MarkdownElement` mirrors `markdownBlock` field-for-field, or a curated
+   subset? Leaning: curated subset + the raw parser block exposed as an
+   unexported-adjacent escape hatch, to keep the exported struct small.

--- a/docs/specs/mouse-lock-cancel.md
+++ b/docs/specs/mouse-lock-cancel.md
@@ -22,12 +22,12 @@ mouse-up AppKit swallowed), fixed separately in `metal_window_darwin.m`. X11 is
 not affected: reparenting WMs own the resize borders on the frame window, and
 X's implicit passive grab guarantees the matching `ButtonRelease`.
 
-## Why not synthesise a `MouseUp`
+## Why not synthesize a `MouseUp`
 
 `MouseUp` is the _commit_. Dock drops call `onLayoutChange`, drag-reorder calls
-`onReorder`. Feeding a fake release on capture loss would docks a panel or
-reorder a list the user never dropped — a data mutation from an event that did
-not happen. Cancellation is a distinct outcome and needs a distinct hook.
+`onReorder`. Feeding a fake release on capture loss docks a panel or reorders a
+list the user never dropped — a data mutation from an event that did not happen.
+Cancellation is a distinct outcome and needs a distinct hook.
 
 ## Design
 
@@ -53,32 +53,32 @@ Three properties the tests pin (`gui/mouse_cancel_test.go`):
   state _is_ the lock (scrollbar, splitter, markdown selection) needs no hook,
   and the default already restores it.
 - **Clears the lock before the hook runs.** The existing escape-key unwinds
-  (`dockDragCancel`, `dragReorderCancel`) call `MouseUnlock` themselves;
-  clearing first makes that a no-op instead of a race.
+  (`dockDragCancel`, `dragReorderCancel`) call `MouseUnlock` themselves.
+  Clearing first makes that a no-op instead of a race.
 - **Runs the hook at most once.** The guard makes a second cancel inert, so a
   duplicate capture-loss report cannot double-unwind.
 
 `Cancel` takes `*Window`, not `EventCtx`, unlike the other three callbacks.
 There is no event to carry, and every other lock callback reads `ctx.Event` —
-handing them a nil one would be a footgun rather than consistency.
+handing them a nil one is a footgun rather than consistency.
 
 ## Backend contract
 
 A backend calls `MouseCancel` when the platform ends a drag without a release.
 On Win32 that is `WM_CAPTURECHANGED`, with one wrinkle: our own `ReleaseCapture`
-raises it too, so an unguarded handler would cancel after every normal mouse-up.
+raises it too, so an unguarded handler cancels after every normal mouse-up.
 `platformState.capturing` tracks ownership and is cleared _before_
 `ReleaseCapture` — that call reenters the wndproc synchronously, so a flag
-cleared afterwards would still read as an involuntary loss.
+cleared afterwards still reads as an involuntary loss.
 
 ## Wired hooks
 
 | Site                         | Cancel does                                                                      |
 | ---------------------------- | -------------------------------------------------------------------------------- |
 | text / RTF / input selection | remove the edge-scroll animation, which nothing else stops once the lock is gone |
-| slider                       | clear the pressed flag; the value keeps what the last move set                   |
+| slider                       | clear the pressed flag, the value keeps what the last move set                   |
 | color picker (SV area)       | restore the cursor the drag hid                                                  |
-| datagrid column resize       | clear the active flag; the column keeps its dragged width, focus is not moved    |
+| datagrid column resize       | clear the active flag, the column keeps its dragged width, focus is not moved    |
 | dock drag                    | `dockDragCancel` — drop nothing, hide the zone overlay                           |
 | drag-reorder                 | `dragReorderCancel` — hide ghost and gap, leave the order alone                  |
 

--- a/docs/specs/per-window-theme.md
+++ b/docs/specs/per-window-theme.md
@@ -35,8 +35,8 @@ FrameFn
   (backend clear color reads CurrentTheme here)
 ```
 
-The globals stop being app state. They are a frame-scoped cache of the theme
-belonging to the window currently being generated.
+The globals stop being app state. They are a frame-scoped cache of the theme of
+the window under generation.
 
 ### Why this is correct
 
@@ -45,7 +45,7 @@ call `runtime.LockOSThread` in package `init` and drive all windows from a
 single sequential loop (`gui/backend/metal/backend.go`,
 `gui/backend/gl/runapp_x11.go`). Two windows can never generate layouts at the
 same time, and no layout is generated off that thread. A factory-time read
-therefore always resolves against the window being generated.
+therefore always resolves against the window under generation.
 
 ### Layers
 
@@ -60,7 +60,7 @@ therefore always resolves against the window being generated.
 `gui.SetTheme` sets the app default and requests a rebuild on every window that
 has not pinned one, so existing code that calls it from `main` or from a handler
 keeps working. Both setters also install eagerly, so callers outside a frame
-pass (tests, `main` before `Run`) see the change at once; the next frame
+pass (tests, `main` before `Run`) see the change at once. The next frame
 re-establishes the correct per-window theme regardless.
 
 ### Theme identity
@@ -89,7 +89,7 @@ gui.Themed(light, func(w *gui.Window) gui.View {
 ```
 
 The builder callback is required, not sugar. A signature taking ready-made child
-views would receive children the caller already built under the enclosing theme,
+views receives children the caller already built under the enclosing theme,
 because factories resolve defaults when they are called.
 
 `Themed` scopes generation only. Reads that happen after generation stay
@@ -111,10 +111,9 @@ This was not true when per-window themes landed. `init` seeded
 `installedThemeID` instead, leaving the literals in place, so an app that never
 called `SetTheme` ran on a mixture: widgets reading `guiTheme.xStyle` got
 `ThemeDark` while widgets reading the mirror got the literals. Issue #300
-removed the literals and resolved every delta in `ThemeDark`'s favour — a
-visible change to the default appearance, chiefly the loss of the 1.5px border
-on buttons, inputs and containers. See
-`docs/specs/theme-style-single-source.md`.
+removed the literals and resolved every delta in `ThemeDark`'s favor — a visible
+change to the default appearance, chiefly the loss of the 1.5px border on
+buttons, inputs and containers. See `docs/specs/theme-style-single-source.md`.
 
 ## The generation boundary (issue #301)
 
@@ -123,8 +122,8 @@ Reads split by **phase**, not by whether a window happens to be reachable.
 **During generation** — widget factories and `GenerateLayout` — the bare
 `guiTheme` / `default*Style` read stays. It is not a compromise: `Themed` scopes
 a theme by push/pop of the _installed_ theme, so a generation-time read that
-called `w.Theme()` would silently ignore the scope. The ~420 sites are also the
-hot path; deferring one means a closure plus a `Cfg` heap escape per widget per
+calls `w.Theme()` silently ignores the scope. The ~420 sites are also the hot
+path. Deferring one means a closure plus a `Cfg` heap escape per widget per
 frame.
 
 **Outside generation** — event handlers, post-arrange injection, public window
@@ -159,13 +158,13 @@ memcpy.
 
 So both stores hold a pointer to an immutable value: `Window.theme` and the
 package `defaultTheme`. A setter publishes a new value instead of writing
-through the pointer, so a reader that took the pointer under `RLock` may keep
+through the pointer, so a reader that took the pointer under `RLock` can keep
 using it after dropping the lock. `w.Theme()` is unchanged for callers — it
 dereferences — and internal hot reads call the unexported `w.themeRef()`
 (`gui/theme_install.go`), which returns the pointer and copies nothing. With
 that, the scroll benchmark is back at ~39 ns/op, 0 allocs.
 
-Per-frame readers (the backends' clear color) keep `w.Theme()`; the copy is
+Per-frame readers (the backends' clear color) keep `w.Theme()`. The copy is
 irrelevant once per frame and the value form is the safer default.
 
 ### Gate
@@ -175,7 +174,7 @@ irrelevant once per frame and the value form is the safer default.
 `*gui.Window` receiver or parameter — but only in paths that are post-generation
 by construction: `gui/backend/**`, `gui/scroll*.go`, `gui/event*.go`,
 `gui/native_*.go`, `gui/window_*.go`. The phase cannot be decided from one
-function's syntax, so the mode does not guess; handlers living in mixed-phase
+function's syntax, so the mode does not guess. Handlers living in mixed-phase
 `view_*.go` files are covered by the convention only. A deliberate exception
 carries `ergonomics-audit:theme-global` on its line.
 
@@ -186,9 +185,9 @@ Raised as #296 proposal item 5 and declined again in #301:
 1. It does not fix the phase problem. `w.Button(cfg)` still runs eagerly and
    still resolves the theme at factory time — the same error with a window name
    attached.
-2. It breaks reusability. A package factory builds window-agnostic view intent;
-   a receiver binds a fragment to a window at construction, so every sub-tree
-   helper threads `w` and closing over the wrong window becomes easy — the bug
+2. It breaks reusability. A package factory builds window-agnostic view intent.
+   A receiver binds a fragment to a window at construction, so every sub-tree
+   helper threads `w`, and closing over the wrong window becomes easy — the bug
    class per-window themes set out to close.
 3. It fights `Themed`, for the reason above: the subtree scope lives in the
    installed theme, not in the window.

--- a/docs/specs/perf-widget-factory-pools.md
+++ b/docs/specs/perf-widget-factory-pools.md
@@ -4,11 +4,11 @@ Status: **implemented 2026-07-19** (`22e1d48`, #107). Claims verified against
 code (Circle migration, benchmark correction, cached-view tradeoff added
 2026-07-18). Measured outcome on `BenchmarkViewFrame` (rows_200, per frame):
 allocs 1,403 → 802 (**−43%**), but B/op 221 KB → 318 KB and ns/op 66 µs → 94 µs
-(**+43%** each) — the struct-growth and cached-view risks materialized as
-published, and the residual allocs are user-side interface boxes +
-`make([]View)` slices, unreachable without an API break. Net: a GC-object-count
-/ coherence win, not a frame-time one. Area: performance / GC-allocation
-reduction Scope: `gui/` (examples excluded)
+(**+43%** each). The struct-growth and cached-view risks materialized as
+published. The residual allocs are user-side interface boxes + `make([]View)`
+slices, unreachable without an API break. Net: a GC-object-count / coherence
+win, not a frame-time one. Area: performance / GC-allocation reduction Scope:
+`gui/` (examples excluded)
 
 ## Context
 
@@ -52,14 +52,14 @@ factory-phase originals.
 Route allocations #2–#5 through the existing per-frame pools by **deferring
 shape construction from the factory into `GenerateLayout`** (where `w` exists).
 Expected: a container drops from ~2–4 allocs/frame to **1** (the unavoidable
-box); a button from ~4 to ~2. On a widget-dense frame (hundreds of nodes) this
-is a large drop in GC object count per frame.
+box). A button drops from ~4 to ~2. On a widget-dense frame (hundreds of nodes)
+this is a large drop in GC object count per frame.
 
 Non-goals: changing the public factory signatures (`Row`/`Column`/`Button` stay
-`func(cfg) View`); reworking the layout/render passes (already 0-alloc); the
-per-frame `make([]View, …)` in `container()`'s Scrollable branch (:390) — an
-un-pooled factory alloc, but scrollable containers are rare per frame; follow-up
-if it shows in profiles.
+`func(cfg) View`), reworking the layout/render passes (already 0-alloc), and the
+per-frame `make([]View, …)` in `container()`'s Scrollable branch (:390). That
+last one is an un-pooled factory alloc, but scrollable containers are rare per
+frame. Follow-up if it shows in profiles.
 
 ## Approach
 
@@ -74,7 +74,7 @@ pattern.
 
 Branch off the current base (`main`) before any edits:
 `git switch main && git switch -c perf-widget-factory-pools` (confirm `main` is
-up to date first; the working tree is clean). All work lands on this branch.
+up to date first, and the working tree is clean). All work lands on this branch.
 
 ### 1. Add an effects pool (mirror the existing events pool)
 
@@ -95,16 +95,16 @@ up to date first; the working tree is clean). All work lands on this branch.
   duplicate fields.
 - `container()` (:377) keeps its cheap cfg resolution (OnAnyClick→OnClick,
   ClickButton default, Scrollable content expansion) but stops calling
-  `buildContainerShape`; it stores the resolved cfg:
+  `buildContainerShape`. It stores the resolved cfg:
   `&containerView{cfg: cfg, content: content}`. Still exactly **one** heap alloc
   (the box).
 - Convert `buildContainerShape(cfg *ContainerCfg) *Shape` into a
-  **value-returning, `w`-aware** builder, e.g.
+  **value-returning, `w`-aware** builder, for example
   `buildContainerShape(cfg *ContainerCfg, w *Window) Shape`, that:
   - returns a `Shape` value (no `&Shape{}`),
   - sets `events` from `w.allocEventHandlers(...)` — nil when no handlers,
   - sets `fx` from `w.allocEffects(...)` — nil when no effects,
-  - `A11Y` unchanged (user pointer or `makeA11YInfo`; pooling it is a stretch
+  - `A11Y` unchanged (user pointer or `makeA11YInfo`. Pooling it is a stretch
     goal).
 - `containerView.GenerateLayout` (:181) becomes:
   `layout := Layout{Shape: w.allocShape(buildContainerShape(&cv.cfg, w))}` then
@@ -112,17 +112,17 @@ up to date first; the working tree is clean). All work lands on this branch.
 - **`Circle()` (:434-439) mutates the pre-built shape**
   (`cv.shape.shapeType = shapeCircle`) — impossible once the shape is deferred.
   Add an internal `shapeType shapeType` field to `ContainerCfg` (next to `axis`,
-  :147; zero value = `shapeRectangle` path preserved in `buildContainerShape`),
+  :147. Zero value = `shapeRectangle` path preserved in `buildContainerShape`),
   set by `Circle` before calling `container()`. Without this, step 2 does not
   compile.
 - **Rewrite the `containerView` doc comment (:159-169)** — it documents the
   pre-built-shape design ("Shape is pre-built at factory time…", shallow-copy
   rationale) and becomes false after this change. New comment: cfg held by
-  value, shape built per `GenerateLayout` call from pooled allocs; cached views
+  value, shape built per `GenerateLayout` call from pooled allocs. Cached views
   re-run the build each frame (see Risks).
 
 `makeContainerEvents`/`makeContainerEffects` stay as pure field-mappers but
-their results feed the pool allocators rather than heap-escaping; keep their nil
+their results feed the pool allocators rather than heap-escaping. Keep their nil
 fast-paths (no handlers/effects → nil pointer, zero alloc).
 
 ### 3. Migrate the three direct callers
@@ -130,16 +130,16 @@ fast-paths (no handlers/effects → nil pointer, zero alloc).
 `gui/view_select.go:202`, `gui/view_color_picker.go:107`,
 `gui/view_combobox.go:289` all use the identical pattern
 `&containerView{shape: buildContainerShape(&ccfg), content: content}` with **no
-post-build shape mutation** (verified). Replace each with the deferred form
+post-build shape mutation** (confirmed). Replace each with the deferred form
 `&containerView{cfg: ccfg, content: content}`. These sites already run inside a
 `GenerateLayout` with `w` in scope, so they stay correct.
 
 `invisibleContainerView()` (:457) becomes fully stateless under cfg-by-value (no
-mutable template shape; `GenerateLayout` copies into pooled shapes), so replace
-the per-call construction with a package-level singleton
+mutable template shape, since `GenerateLayout` copies into pooled shapes), so
+replace the per-call construction with a package-level singleton
 `var invisibleView = &containerView{cfg: …}` — deletes that box alloc too. Safe
 because nothing mutates a `containerView` after construction once `Circle` moves
-its `shapeType` into cfg (step 2); an invisible "circle" losing its circle
+its `shapeType` into cfg (step 2). An invisible "circle" losing its circle
 shapeType is moot (placeholder, never drawn as either).
 
 ### 4. (Same-PR, high value) collapse `buttonView` into the container path
@@ -154,15 +154,15 @@ focus/hover logic, split it into a follow-up PR and land steps 1–3 first.
 Details:
 
 - `buttonView.GenerateLayout` gates the color attach on
-  `layout.Shape.events != nil` (:93); once folded, every container with handlers
-  would match. Add an `isButton bool` discriminator on `containerView`, set by
+  `layout.Shape.events != nil` (:93). Once folded, every container with handlers
+  matches. Add an `isButton bool` discriminator on `containerView`, set by
   `Button`.
 - Cost: every `containerView` grows ~80 B (4 `Color` + 2 func ptrs) whether or
-  not it is a button. Still a net win (removes a whole heap object per button);
-  acknowledged under Struct growth below.
+  not it is a button. Still a net win (removes a whole heap object per button).
+  Acknowledged under Struct growth below.
 - Bonus correctness: today `buttonView.GenerateLayout` mutates
   `layout.Shape.events.AmendLayout/OnHover` (:107-108) through a pointer _shared
-  with the factory template_ (`allocShape` shallow-copies the Shape; `events` is
+  with the factory template_ (`allocShape` shallow-copies the Shape. `events` is
   the same heap object every frame). Idempotent today, but fragile. Per-frame
   pooled `eventHandlers` gives each frame its own copy and removes the
   cross-frame sharing.
@@ -183,7 +183,7 @@ Details:
 - **`BenchmarkViewFrame` (`gui/view_frame_bench_test.go`) already exercises the
   factory phase** — it builds the tree through public `Row`/`Column` factories
   inside `b.Loop()` (deliberately: "Shapes are allocated inside the loop") and
-  resets view pools per iter. It measures the container win directly; capture it
+  resets view pools per iter. It measures the container win directly. Capture it
   before/after. (`BenchmarkGenerateViewLayout` does _not_ — it pre-builds a
   custom `benchView` outside the loop.)
 - Add a `-benchmem` benchmark for the **uncovered widgets**: `Button` (2-box +
@@ -193,7 +193,7 @@ Details:
 - Capture before/after `allocs/op` + `B/op` via
   `go test ./gui/ -bench='ViewFrame|Factory' -benchmem -count=5` + benchstat.
   Target: measured drop in allocs/op for container- and button-heavy trees.
-  allocs are the hard gate (per CLAUDE.md); ns/op advisory — expect a small
+  allocs are the hard gate (per CLAUDE.md). ns/op is advisory — expect a small
   ns/op _rise_ for cached views (see Risks) against a large alloc drop for
   rebuilt trees.
 - `go test ./...` (headless, ~12s) and `golangci-lint run ./...` must stay
@@ -201,9 +201,9 @@ Details:
   select, color_picker) — add targeted assertions that `GenerateLayout` still
   produces the correct Shape (events/fx present when configured, nil otherwise)
   and that pooled pointers are non-nil.
-- Run a widget-dense example (e.g. `go run ./examples/showcase/`) to confirm no
-  visual/behavioral regression in containers, buttons, select, combobox, color
-  picker, group-box titles.
+- Run a widget-dense example (for example `go run ./examples/showcase/`) to
+  confirm no visual/behavioral regression in containers, buttons, select,
+  combobox, color picker, group-box titles.
 
 ## Risks / open questions
 
@@ -217,18 +217,18 @@ Details:
   trades that for a full ~70-field `buildContainerShape` per frame — pure CPU,
   zero allocs. Accepted: alloc count is the stated bottleneck (CLAUDE.md perf
   baseline), and the field-copy cost is in the same ballpark as the Shape copy
-  it replaces. Verify with `BenchmarkViewFrame` ns/op (advisory).
+  it replaces. Confirm with `BenchmarkViewFrame` ns/op (advisory).
 - **Per-frame defaults/validation**: `applyContainerDefaults` and
   `RequireScrollID` move from factory time into `GenerateLayout`. Behavior
   change: `DefaultContainerStyle` edits now take effect on cached views next
-  frame (arguably a fix); the missing-scroll-ID panic fires at layout instead of
+  frame (arguably a fix). The missing-scroll-ID panic fires at layout instead of
   build — same frame, same message.
 - **Pool lifetime**: `fx`/`events` pooled in the view phase are read during
-  render; pools reset at frame _start_ (`resetViewPools`) and are valid through
+  render. Pools reset at frame _start_ (`resetViewPools`) and are valid through
   `buildRenderers` — the same guarantee `viewShapes`/`viewEvents` already rely
   on. Safe, but assert it in a test.
-- **Step 4 scope**: fold buttonView in the same PR only if it stays clean;
-  otherwise defer to a follow-up.
+- **Step 4 scope**: fold buttonView in the same PR only if it stays clean.
+  Otherwise defer to a follow-up.
 - Pool `AccessInfo` (`makeA11YInfo`) too? Left as a stretch goal — usually nil.
 
 ## Rejected alternatives

--- a/docs/specs/pixel-golden-images.md
+++ b/docs/specs/pixel-golden-images.md
@@ -16,17 +16,17 @@ pipeline via `RenderToImage` and compares the buffer against committed PNGs in
 ## The stability problem, and the text-free gate
 
 Pixel goldens are only useful if the same input produces the same bytes on every
-machine that runs the suite. Three drift sources were identified; the harness
+machine that runs the suite. Three drift sources were identified. The harness
 eliminates all three at once by construction:
 
 1. **Host font catalog.** The repo bundles no text font, so a family resolves
    through the platform catalog and different machines shape different glyphs.
 2. **go-glyph working copy.** The repo's go.work points at a local go-glyph
-   checkout; a developer's working copy can shape differently from the version
+   checkout. A developer's working copy can shape differently from the version
    CI resolves. A recording made on one can never match on the other.
 3. **Arch-dependent antialiasing.** `x/image/vector` and `x/image/draw`
    accumulate coverage with SIMD, which can differ by a bit or two across GOARCH
-   (recordings happen on macOS arm64; CI runs amd64 Linux and Windows).
+   (recordings happen on macOS arm64. CI runs amd64 Linux and Windows).
 
 Sources 1 and 2 are text-shaped, so **every golden case must be text-free** and
 the harness enforces it: the command stream is checked for any text render kind
@@ -34,10 +34,10 @@ the harness enforces it: the command stream is checked for any text render kind
 `RenderTextPath`, `RenderTermGrid`) or `RenderCustomShader` and the case fails
 if one appears. Icons are text kinds, so a case cannot cheat with an icon glyph.
 No text kinds means go-glyph never runs and sources 1 and 2 do not exist. Source
-3 is absorbed by the tolerance below. A text golden would need a bundled test
-font (a repo-size decision) and would re-record on every go-glyph bump —
-deferred; the direct pixel assertions in `draw_test.go` / `draw_phase2_test.go`
-cover text paths platform-independently.
+3 is absorbed by the tolerance below. A text golden is deferred: it needs a
+bundled test font (a repo-size decision) and re-records on every go-glyph bump.
+The direct pixel assertions in `draw_test.go` / `draw_phase2_test.go` cover text
+paths platform-independently.
 
 ## Comparison and tolerance
 
@@ -48,12 +48,12 @@ than exact bytes:
   differing. A flat-fill color change — the common styling regression — moves
   every pixel of the shape by well over 3 and is caught.
 - `maxDiffFraction = 0.5%` — the share of pixels allowed to differ. A 320x240
-  frame has a few hundred antialiasing edge pixels; 0.5% (384 px) sits far above
+  frame has a few hundred antialiasing edge pixels. 0.5% (384 px) sits far above
   that and far below a moved or resized shape.
 
 The trade is the issue's own: a small real regression inside the tolerance is
-missed. The tolerance is a first guess pending the first cross-arch CI run — if
-the suite reds on a runner, the failure stats show the _actual_ spread and the
+missed. The tolerance is a first guess pending the first cross-arch CI run. If
+the suite reds on a runner, the failure stats show the _actual_ spread, and the
 constants are widened from evidence, never blindly.
 
 ## Recording flow
@@ -64,15 +64,15 @@ go test ./gui/backend/soft/ -run TestPixelGolden -update
 
 `-update` re-encodes every reference from the current renderer output, matching
 the command-golden convention (`go test ./gui/ -run TestGolden -update`).
-References are committed; a deliberate rendering change re-records after
-reviewing the diff, an accidental one reds the suite.
+References are committed. A deliberate rendering change re-records after
+reviewing the diff. An accidental one reds the suite.
 
 ## Failure artifacts
 
 On mismatch the test writes `actual.png`, `expected.png` and `diff.png`
 (differing pixels in magenta) under `gui/backend/soft/testdata/failures/` and
 reports the differing-pixel count, fraction and max channel delta. The directory
-is gitignored; CI uploads it as an artifact when the test job fails, so a red
+is gitignored. CI uploads it as an artifact when the test job fails, so a red
 pixel test is reviewable rather than a log line.
 
 ## Case set
@@ -83,8 +83,8 @@ masks), half-alpha compositing (`ColorSwatch`), linear and radial gradients,
 gradient borders, circles, drop shadows, SDF blur, the color-filter bracket,
 quarter-turn rotation, inline SVG (tessellation + gradient mesh), scaled memory
 images, progress fills, and the focus ring. Every case records in `ThemeDark`
-and `ThemeLight`, and the window carries no `BgColor` so the theme's background
-is part of what is pinned.
+and `ThemeLight`. The window carries no `BgColor`, so the theme's background is
+part of what is pinned.
 
 The stencil bracket (`ContainerCfg.clipContents`) has no public trigger — the
 field is unexported — so it stays covered by `draw_phase2_test.go`'s direct
@@ -93,4 +93,4 @@ pixel assertions.
 ## Related
 
 - #333 — the software rasterizer (phase 1)
-- #360 — phase 2 kinds; the reason pixel goldens were worth building
+- #360 — phase 2 kinds. The reason pixel goldens were worth building

--- a/docs/specs/process-monitor-example.md
+++ b/docs/specs/process-monitor-example.md
@@ -30,11 +30,11 @@ shirei original).
 From shirei's README + `main.go`. Port each:
 
 1. Live process list: PID, CPU%, RSS, MEM%, USER, STATE, THREADS, NAME.
-2. Click a column header to sort; click again to reverse.
+2. Click a column header to sort. Click again to reverse.
 3. Row selection → detail panel + ~60s rolling CPU and RAM bar charts.
 4. Filter box: match name, command line, user, or PID (substring,
    case-insensitive).
-5. Flat list OR parent/child tree (collapse with ▸/▾; filter keeps ancestors
+5. Flat list OR parent/child tree (collapse with ▸/▾. Filter keeps ancestors
    visible).
 6. Sample interval selector: 0.5s / 1s / 2s / 5s.
 7. Unreadable metrics render `--`, never a fake `0`.
@@ -110,10 +110,10 @@ Per-platform `collect()`:
   collected.
 - **windows** (`collect_windows.go`): `tasklist /fo csv /nh /v` → image name,
   PID, session, mem usage, status, user, CPU time. No live per-interval CPU%
-  from a single call; report `CPUPercentUnknown` in v1 (renders `--`), or
+  from a single call. Report `CPUPercentUnknown` in v1 (renders `--`), or
   compute a delta from two `tasklist` CPU-time reads if cheap. RSS from the "Mem
   Usage" column.
-- **other** (`collect_other.go`): return an error; the UI shows the sample error
+- **other** (`collect_other.go`): return an error. The UI shows the sample error
   (matches shirei's error path).
 
 CPU% decision (v1): use `ps pcpu` directly. Caveat: on Unix `pcpu` is a
@@ -124,8 +124,8 @@ keeps the collector to one `exec` per sample. A delta-based interval CPU%
 regardless — they plot whatever CPU% is reported, over time.
 
 System memory (`sysmem_*.go`): `/proc/meminfo` (`MemTotal`,
-`MemTotal-MemAvailable`) on linux; `sysctl hw.memsize` + `vm_stat` on darwin. On
-failure/other, return `(0, 0)`; the header omits the memory bar rather than
+`MemTotal-MemAvailable`) on linux. `sysctl hw.memsize` + `vm_stat` on darwin. On
+failure/other, return `(0, 0)`. The header omits the memory bar rather than
 inventing a value (shirei's "-- not fake zero" philosophy).
 
 ### Sampler goroutine + refresh model
@@ -169,10 +169,10 @@ func startSampler(w *gui.Window) {
 
 Critical detail: use `w.UpdateWindow()` (alias `markLayoutRefresh`), **NOT**
 `w.UpdateView(fn)`. `UpdateView` clears the view-state registry every call,
-which would drop input focus and scroll position on every sample.
-`RequestRedraw()` is render-only (no view re-run) so new rows would not appear —
-also wrong. `UpdateWindow` re-runs the registered view generator against fresh
-state while preserving the registry. Register the generator once in `OnInit` via
+which drops input focus and scroll position on every sample. `RequestRedraw()`
+is render-only (no view re-run) so new rows do not appear — also wrong.
+`UpdateWindow` re-runs the registered view generator against fresh state while
+preserving the registry. Register the generator once in `OnInit` via
 `w.UpdateView(rootView)`.
 
 Reads of shared state during sampling and all mutations happen under `w.Lock()`
@@ -214,14 +214,14 @@ Theme tokens (from `gui.CurrentTheme()`) replace all shirei HSL literals:
 | padding / spacing / radius | `theme.PaddingSmall`, `theme.SpacingSmall`, `theme.RadiusSmall` |
 
 Default theme: `gui.SetTheme(gui.ThemeDark.WithBorders(true))` (matches
-`data_grid_data_source`). A `ThemePicker` widget MAY be added to the toolbar to
+`data_grid_data_source`). A `ThemePicker` widget can be added to the toolbar to
 demo light/dark switching (optional, see Open Questions).
 
 ### Header (`view.go`)
 
 `gui.Row` of: title `gui.Text{TextStyle: theme.B2}`, spacer, and stat chips
 (`gui.Row`+`gui.Text` in a rounded `ColorInterior` container) for "active/kept"
-counts and last-updated time. System memory shown as a labelled `UsageBar` (see
+counts and last-updated time. System memory shown as a labeled `UsageBar` (see
 below) + "used / total" text. If `Snapshot == nil`: "Collecting…". If
 `Err != nil`: error text in `theme.ColorError`.
 
@@ -243,7 +243,7 @@ table **immediate-mode**, like shirei does, for full cell control:
 
 - A header `gui.Row` of clickable column-title cells. Each is a `gui.Button` (or
   a container with `OnClick`) that sets `app.Sort.Column` / toggles
-  `app.Sort.Desc`; show a ▲/▼ marker on the active column.
+  `app.Sort.Desc`. Show a ▲/▼ marker on the active column.
 - Body: a **scrollable** `gui.Column` (`Scrollable: true` + `ScrollbarCfgY`, per
   `scroll_demo`) containing one `gui.Row` per visible process.
 - Each row: fixed-width cells matching the header. Cells:
@@ -251,8 +251,8 @@ table **immediate-mode**, like shirei does, for full cell control:
   - CPU: `gui.Text` + a `UsageBar` (see below).
   - NAME: in tree mode, leading indent (`Width = depth*14`) + a ▸/▾ chevron
     button toggling `p.Collapsed`, then the name.
-  - Row background: alternate `ColorPanel`/`ColorInterior`; `ColorSelect` when
-    `app.Selected == p`; `ColorHover` on hover. Row `OnClick` sets
+  - Row background: alternate `ColorPanel`/`ColorInterior`, `ColorSelect` when
+    `app.Selected == p`, and `ColorHover` on hover. Row `OnClick` sets
     `app.Selected = p`. `OnClick` is consume-class, so the click is marked
     handled by dispatch.
 - Row ordering, filtering, and tree flattening are computed by the app (port
@@ -266,26 +266,26 @@ load, or a single accent for simplicity).
 
 ### Detail panel + history charts (`chart.go`)
 
-Selected-process panel: name, pid, ppid, cpu, rss, start time; "stopped …" in
-`ColorError` when not running; full command line in muted text. Then two
-`UsageChart`s (CPU, RAM) side by side.
+Selected-process panel: name, pid, ppid, cpu, rss, start time. "Stopped …" shows
+in `ColorError` when the process is not running. The full command line shows in
+muted text. Then two `UsageChart`s (CPU, RAM) sit side by side.
 
 `UsageChart` — port shirei's container-bar chart, restyled with theme tokens:
 
 - `resampleHistory(hist, 60s, 1s, valueFn)` →
-  `[]HistBucket{Value, HasData, Interpolated}`. Port verbatim (pure Go;
+  `[]HistBucket{Value, HasData, Interpolated}`. Port verbatim (pure Go,
   unit-tested).
-- Render: a fixed-size rounded panel; a `gui.Row` of per-bucket columns. Each
-  bucket is a `gui.Column` with a bottom-anchored `gui.Rectangle` whose height =
-  `ratio * chartHeight`. Empty buckets → 1px baseline. Interpolated buckets →
-  dimmer fill. A floating title label over the bars.
-- CPU chart pins the y-scale floor at 100%; RAM chart auto-scales to the max
+- Render: a fixed-size rounded panel with a `gui.Row` of per-bucket columns.
+  Each bucket is a `gui.Column` with a bottom-anchored `gui.Rectangle` whose
+  height = `ratio * chartHeight`. Empty buckets → 1px baseline. Interpolated
+  buckets → dimmer fill. A floating title label over the bars.
+- CPU chart pins the y-scale floor at 100%. RAM chart auto-scales to the max
   seen (port `ramHistoryScale`).
 
 go-gui note: verify bottom-anchoring bars. shirei uses `Filler(1)` to push the
 bar down. In go-gui, achieve the same with a spacer child (empty `FillFill`
 container) above a fixed-height bar in a `Column`, or `VAlign: VAlignBottom` on
-the bucket column. Confirm during implementation.
+the bucket column. Verify during implementation.
 
 ## CLI flags (`main.go`)
 
@@ -298,18 +298,18 @@ Keep the subset that maps cleanly:
 - `-refresh D` : GUI sample interval default (default 1s).
 
 Drop `-png` (no headless render API). Drop `-samples`/`-period` (those drive
-shirei's multi-sample burst window for interval CPU%, unused with `ps pcpu`;
-reintroduce only if the CPU-delta enhancement lands).
+shirei's multi-sample burst window for interval CPU%, unused with `ps pcpu`).
+Reintroduce only if the CPU-delta enhancement lands.
 
 ## Testing (headless, no backend)
 
 Follows CLAUDE.md: rebuild + `go test ./examples/process_monitor/...`.
 
-- `store_test.go`: `Update` adds/updates/evicts; PID-reuse produces a distinct
-  key; ring buffer caps at `maxHistoryPoints`; stopped processes linger then
-  evict; selected process is not evicted.
-- `tree_test.go`: `treeRows` builds correct depth/child-count; collapse hides
-  subtree; filter keeps matched nodes' ancestors and ignores collapse.
+- `store_test.go`: `Update` adds/updates/evicts. PID-reuse produces a distinct
+  key. Ring buffer caps at `maxHistoryPoints`. Stopped processes linger then
+  evict. Selected process is not evicted.
+- `tree_test.go`: `treeRows` builds correct depth/child-count. Collapse hides
+  subtree. Filter keeps matched nodes' ancestors and ignores collapse.
 - `chart_test.go`: `resampleHistory` — same-slot averaging, gap interpolation
   flagged `Interpolated`, pre-first-sample slots stay `HasData=false`, fixed
   wall-clock bucket boundaries (port shirei's intent).
@@ -319,7 +319,7 @@ Follows CLAUDE.md: rebuild + `go test ./examples/process_monitor/...`.
   real `ps` collector in tests (inject a synthetic snapshot).
 
 Collectors that `exec` `ps`/`tasklist` are not unit-tested (environment
-dependent); keep them thin and behind the `collect()` seam so tests use
+dependent). Keep them thin and behind the `collect()` seam so tests use
 synthetic snapshots.
 
 ## Docs deliverables
@@ -340,13 +340,13 @@ Per `feedback_doc_sync`:
    for v1, note the caveat, enhance later.
 2. **Windows fidelity**: ship a reduced `tasklist` collector (CPU% = `--`), or
    mark Windows out of scope for v1 with the `collect_other.go` stub?
-   Recommendation: ship the reduced collector; it still lists processes.
-3. **StartTime on darwin**: pull `ps -o lstart=` (extra parse cost) for robust
+   Recommendation: ship the reduced collector. It still lists processes.
+3. **StartTime on darwin**: pull `ps -o lstart=` (extra parse cost) for stronger
    PID-reuse keys, or fall back to `{PID}` only? Recommendation: `{PID}`-only
-   fallback in v1; document it.
+   fallback in v1. Document it.
 4. **ThemePicker in toolbar** to demo light/dark, or fixed `ThemeDark`?
-   Recommendation: fixed `ThemeDark.WithBorders(true)`; add picker only if it
-   doesn't crowd the toolbar.
+   Recommendation: fixed `ThemeDark.WithBorders(true)`. Add the picker only if
+   it does not crowd the toolbar.
 5. **Refresh latency**: rely on the ~100ms idle poll (simple, no wake), accept
-   up to ~100ms lag between sample-ready and repaint? Recommendation: yes;
-   imperceptible at these intervals.
+   up to ~100ms lag between sample-ready and repaint? Recommendation: yes. The
+   lag is imperceptible at these intervals.

--- a/docs/specs/quit-dispatch-unify.md
+++ b/docs/specs/quit-dispatch-unify.md
@@ -20,7 +20,7 @@ vetoed (`running = false`).
 
 The Metal backend's wid==0 handler also has a workaround in the ObjC `quit:`
 delegate method (`metal_window.m`) — `performClose:` on the key window is needed
-because the Go-side dispatch doesn't reach all windows and can't be vetoed.
+because the Go-side dispatch does not reach all windows and cannot be vetoed.
 
 ## Goal
 
@@ -59,8 +59,8 @@ sets `running` from its veto result.
 
 `backend.go:106-108` — `Run`'s `!cont` branch now calls
 `gui.DispatchCloseRequest(w)` before `running = false; break`. Previously it
-only set `running = false` without dispatching the close request, which would
-skip `OnCloseRequest` hooks.
+only set `running = false` without dispatching the close request, which skips
+`OnCloseRequest` hooks.
 
 ### 4. Remove `EventQuitRequested` handler from both `Run` and `RunAppE`
 
@@ -75,18 +75,18 @@ handles all windows.
 
 ### 6. Add `_quitRequested` flag for out-of-band quit events
 
-**Deviation from original spec.** The spec assumed menu-bar quit clicks would be
-dequeued by `metalPollEvent` like keyboard events. In practice, menu-bar
-tracking runs in `NSEventTrackingRunLoopMode`, while `metalPollEvent` only
-dequeues from `NSDefaultRunLoopMode`. Without `performClose:`, `quit:` would set
-`_evType = METAL_EVENT_QUIT` but `metalPollEvent` would return 0 (no event in
+**Deviation from original spec.** The spec assumed `metalPollEvent` dequeues
+menu-bar quit clicks like keyboard events. In practice, menu-bar tracking runs
+in `NSEventTrackingRunLoopMode`, while `metalPollEvent` only dequeues from
+`NSDefaultRunLoopMode`. Without `performClose:`, `quit:` set
+`_evType = METAL_EVENT_QUIT`, but `metalPollEvent` returned 0 (no event in
 default mode), so Go never saw the quit.
 
 Added `static int _quitRequested` to the ObjC event state, set by `quit:` and
 `applicationShouldTerminate:`. Checked at the top of `metalPollEvent` before any
 dequeue (same pattern as the IME generation check). When set, it synthesizes
 `_evType = METAL_EVENT_QUIT` and returns 1 immediately. Consumed on first read
-so vetoed quits don't re-fire.
+so vetoed quits do not re-fire.
 
 This covers both inline cases (Cmd+Q via `performKeyEquivalent:` during
 `sendEvent:`) and out-of-band cases (menu-bar click, system logout).
@@ -100,7 +100,7 @@ This covers both inline cases (Cmd+Q via `performKeyEquivalent:` during
 | `gui/backend/metal/backend.go:106-108`     | `Run` `!cont` branch now calls `DispatchCloseRequest(w)`                       |
 | `gui/backend/metal/backend.go:110-114`     | Removed `EventQuitRequested` handler from `Run`                                |
 | `gui/backend/metal/backend.go:289-303`     | Removed `EventQuitRequested` handler from `RunAppE`                            |
-| `gui/backend/metal/metal_window.m`         | Added `_quitRequested` flag + poll check; removed `performClose:` from `quit:` |
+| `gui/backend/metal/metal_window.m`         | Added `_quitRequested` flag + poll check. Removed `performClose:` from `quit:` |
 | `gui/backend/metal/events_test.go:206-222` | Updated Cmd+Q test to expect `cont=false`                                      |
 
 ## Risks
@@ -124,6 +124,6 @@ This covers both inline cases (Cmd+Q via `performKeyEquivalent:` during
 - `GO_GUI_MAIN_THREAD_TESTS=1 go test ./gui/backend/metal/...`
 - Manual: Cmd+Q quit, menu-bar click quit, system logout quit
 - Multi-window: open 2+ windows, Cmd+Q — verify all get close requests
-- Veto: window with `OnCloseRequest` that doesn't call `Close()` — verify quit
+- Veto: window with `OnCloseRequest` that does not call `Close()` — verify quit
   is blocked
 - Dialog: open dialog then Cmd+Q — verify quit is blocked (dialog veto)

--- a/docs/specs/sdl3-shim.md
+++ b/docs/specs/sdl3-shim.md
@@ -5,7 +5,7 @@ Source: [cataggar/SDL#1](https://github.com/cataggar/SDL/pull/1) +
 
 Status: **Closed 2026-08-12 by decision: not pursued — the SDL2 backend is
 retired, so there is nothing left to shim.** See § Decision for the rationale
-and the conditions that would reopen it.
+and the conditions that can reopen it.
 
 ## Summary
 
@@ -33,13 +33,13 @@ Three layers in the shim:
    `gui/backend/sdl2/`, `gui/backend/gl/`, and `sdlkey` compile unchanged.
 
 2. **`go-sdl2-sdl3/mix`** — SDL_mixer-compatible audio engine on SDL3's native
-   audio API (SDL3 doesn't bundle SDL_mixer). Per-channel `SDL_AudioStream`s
+   audio API (SDL3 does not bundle SDL_mixer). Per-channel `SDL_AudioStream`s
    auto-mixed by SDL + dedicated music stream. Looping/fades via get-callback,
-   volume via per-stream gain. WAV decoded natively; MP3/OGG via vendored dr_mp3
+   volume via per-stream gain. WAV decoded natively. MP3/OGG via vendored dr_mp3
    / stb_vorbis (public domain).
 
 3. **`gosdl3/`** — Experimental. Zig comptime bindgen emits full cgo SDL3 Go
-   bindings. Separate from the hand-written shim; useful as a generated
+   bindings. Separate from the hand-written shim. Useful as a generated
    reference surface.
 
 ## Benefits
@@ -50,7 +50,7 @@ Three layers in the shim:
   stable release (v0.27.1).
 - **Static linking.** `-tags sdl3static` produces a fully static binary with no
   SDL3.dll/dylib. The static link file enumerates Win32 system libs (kernel32,
-  user32, gdi32, etc.) that can't be carried by a static archive.
+  user32, gdi32, and more) that cannot be carried by a static archive.
 - **Audio without SDL_mixer.** Eliminates a separate build dependency.
 - **Covers go-glyph too.** go-glyph's SDL backend (3 files) works with the same
   replace directive.
@@ -63,13 +63,13 @@ Three layers in the shim:
 
 Every contributor and CI pipeline needs zig installed. zig is increasingly
 popular for C/C++ cross-compilation and the `build.zig` already exists in the
-forked repo, but it's a non-trivial addition. On the upside, it _replaces_
+forked repo, but it is a non-trivial addition. On the upside, it _replaces_
 MSYS2, not adds to it — net toolchain count stays flat or drops.
 
 ### Shim location
 
 The shim currently lives in `cataggar/SDL` (a fork of a fork of SDL's zig port).
-Long-term, the shim should be its own standalone repo (e.g.,
+Long-term, the shim belongs in its own standalone repo (for example,
 `go-gui-org/go-sdl3-shim`) with its own lifecycle, tests, and versioning. Tying
 it to a personal SDL fork creates an unclear maintenance dependency.
 
@@ -91,7 +91,7 @@ Go→cgo path through `go-sdl2/sdl`.
 
 Without updating these, macOS compilation fails under the shim. The .m file
 (`metal_darwin.m`) is unaffected — it receives a `void*` CAMetalLayer pointer
-regardless of how it's obtained.
+regardless of how it is obtained.
 
 Changes needed in the shim's `cbits.h`/`cbits.c`:
 
@@ -126,10 +126,10 @@ go-sdl2 (SDL2) as before — the shim is opt-in.
 A standalone shim repo (`go-gui-org/go-sdl3-shim`) improves the replace target
 from a local filesystem path to a versioned module URL, but does not remove the
 replace itself. The only path to truly eliminating it is changing go-gui's
-import paths (e.g., to native SDL3 bindings via the `gosdl3/` experiment), which
-is a separate, larger effort.
+import paths (for example, to native SDL3 bindings via the `gosdl3/`
+experiment), which is a separate, larger effort.
 
-Ship v0.28 with replace. Accept that it's the design, not a temporary wart.
+Ship v0.28 with replace. Accept that it is the design, not a temporary wart.
 
 ### Audio format coverage
 
@@ -137,7 +137,7 @@ Ship v0.28 with replace. Accept that it's the design, not a temporary wart.
 
 The `sound.go` doc comment lists FLAC, AIFF, and VOC as supported formats. The
 actual `Init()` default format mask is `mix.INIT_OGG | mix.INIT_MP3`
-(audio.go:65). FLAC requires `mix.INIT_FLAC`; AIFF/VOC require `mix.INIT_MOD`.
+(audio.go:65). FLAC requires `mix.INIT_FLAC`. AIFF/VOC require `mix.INIT_MOD`.
 These are never enabled by default — the comment documents SDL_mixer's
 theoretical capabilities, not go-gui's actual behavior.
 
@@ -149,21 +149,21 @@ OGG" to reflect reality.
 
 `TestBackendRenderSmoke` reads backbuffer after `Present()`. Defined in SDL2,
 undefined in SDL3 with hardware-accelerated flip-model renderers (Direct3D11).
-Passes on software renderers (CI), may read empty pixels on accelerated Windows.
+Passes on software renderers (CI), can read empty pixels on accelerated Windows.
 Production paths (blur/color-matrix filter readback to texture targets) are
 unaffected.
 
 Additional Metal-specific gap: the Metal backend sets
 `CAMetalLayer.presentsWithTransaction = YES` (metal_darwin.m:763) to eliminate
-content shift during live resize. SDL3's Metal integration may handle
+content shift during live resize. SDL3's Metal integration can handle
 presentsWithTransaction differently or expose its own controls via the
-Properties API. A macOS Metal smoke test variant should verify live resize
+Properties API. A macOS Metal smoke test variant must verify live resize
 behavior under SDL3 before shipping.
 
 ### go-glyph coordination
 
 Both repos need the same replace directive. Works with sibling-directory layout
-(`../SDL/go-sdl2-sdl3`) but doesn't compose well across independent projects. A
+(`../SDL/go-sdl2-sdl3`) but does not compose well across independent projects. A
 standalone shim repo with its own `go.mod` module path solves this.
 
 ## Build chain comparison
@@ -216,7 +216,7 @@ work:
   Windows. The purego `glbind` backend (cgo-free Phase 1, 2026-07-31) already
   builds the entire module `CGO_ENABLED=0` on both platforms — no zig, no SDL,
   no pkg-config.
-- **It would not serve the platform that still needs cgo.** macOS, the only
+- **It does not serve the platform that still needs cgo.** macOS, the only
   remaining CGo backend, is native Metal/AppKit with zero SDL dependency
   (`macos-native-backend.md`, implemented). The shim adds nothing there.
 - **The cost stays real.** zig as a mandatory build tool for every contributor
@@ -224,9 +224,9 @@ work:
   lifecycle, and downstream replace-directive leakage — all paid to feed a
   backend that no longer exists.
 
-### Conditions that would reopen it
+### Conditions that can reopen it
 
-- A platform appears where the purego `glbind` path cannot serve (e.g. an
+- A platform appears where the purego `glbind` path cannot serve (for example an
   EGL-less target for which SDL3 is the natural host), and the shim is first
   repackaged as a standalone versioned module with its own tests.
 - An SDL2 import surface is reintroduced into the tree.

--- a/docs/specs/text-optical-centring.md
+++ b/docs/specs/text-optical-centring.md
@@ -41,7 +41,7 @@ and the box's own centre moves with it.
 ## Why it cannot be applied everywhere
 
 A single toolkit-wide correction was implemented, tried and rejected on
-evidence. Badges read correct; single-line inputs read visibly low, and editable
+evidence. Badges read correct. Single-line inputs read visibly low, and editable
 text moved vertically as the user typed. Those are two distinct failures:
 
 1. **Wrong for arbitrary text.** The correction reclaims the descent on the
@@ -70,19 +70,17 @@ correction.
 ## The rule, once the widgets had all been judged
 
 Each widget was decided on its own evidence, and the same split kept coming
-back. It is worth stating as a rule, because it is what a new widget should be
-read against:
+back. It is worth stating as a rule, because a new widget is judged against it:
 
-- **A value takes its own ink.** A badge's count, a progress bar's readout: the
-  thing being centred is that string, and centring each on its own ink is what
-  keeps two of them side by side consistent. A descender is left where metric
-  centring put it.
+- **A value takes its own ink.** A badge's count, a progress bar's readout:
+  centring that string on its own ink keeps two of them side by side consistent.
+  A descender is left where metric centring put it.
 - **A label takes the face's cap band.** A button, a tab, a menu item, a select:
   the text names a control, the eye reads it by its caps, and a row or a list of
   them must agree whatever any one of them happens to say. A descender hangs
   below centre, which is how a control label is set.
 - **A glyph takes its own ink, always.** An icon or a symbol has no cap band to
-  centre on. `TextStyle.glyphRole` marks one; the theme's `Icon` rungs carry the
+  centre on. `TextStyle.glyphRole` marks one. The theme's `Icon` rungs carry the
   mark, and `glyphStyle(ts)` is the spelling for a symbol drawn in an ordinary
   text face — a numeric input's step triangles, a toast's `×`, an overflow
   panel's `⋮`. A glyph child inside a container correcting on the cap band opts
@@ -99,7 +97,7 @@ The content-free form cannot jitter: there is no way to pass it the live text.
 so do `InputDate` (a date mask: digits and separators) and `NumericInput` (its
 pre-commit transform admits digits, the locale's separators and a sign).
 
-The constrained alphabet is the entire licence, and it is the caller's to give:
+The constrained alphabet is the entire license, and it is the caller's to give:
 `InputCfg.opticalDigitCenter` is unexported and opt-in, so a plain `Input`
 cannot acquire the correction by default and an application cannot switch it on
 for text it does not control.
@@ -115,25 +113,23 @@ wrong there, for two reasons, both measured on the real render at size 16:
   clamp leaves it alone. Its **cap band** — which is what the eye reads a
   control's label by — rode 2.5 device pixels high all the same. That is the
   reported defect, and the measured form does not touch it.
-- **It would step the label on selection.** An offset taken from the run changes
-  when the run does, so picking an option with a descender after one without
-  would move the label vertically in a control that has not moved. Content-free
-  is what a re-labelling control needs, for the same reason an editable field
-  needs it.
+- **It steps the label on selection.** An offset taken from the run changes when
+  the run does, so picking an option with a descender after one without moves
+  the label vertically in a control that has not moved. Content-free is what a
+  re-labelling control needs, for the same reason an editable field needs it.
 
 So `Select` takes `opticalCenterLabelText`: the cap band, whatever the label
 says. Measured after, the cap band of "Pick a language" and of "PICK" both land
 0.5 device pixels low — level with each other, which is the property the hook
 exists for. The descender then hangs below centre instead of pulling the whole
-label up; that is how a control label is set, and it is deliberate.
+label up. That is how a control label is set, and it is deliberate.
 
 A **menu item** takes the same band, for a different reason. Its label is the
-app's and static per call site, so the ownership rule would admit the measured
-form — but items stack in a list at a regular pitch, and measuring each run
-would move a descender-free label down while leaving its descending neighbour
-where it was. The unevenness reads down the whole menu, where the same
-disagreement between two badges side by side does not. Cap band, whatever the
-item says.
+app's and static per call site, so the ownership rule admits the measured form —
+but items stack in a list at a regular pitch, and measuring each run moves a
+descender-free label down while leaving its descending neighbour where it was.
+The unevenness reads down the whole menu, where the same disagreement between
+two badges side by side does not. Cap band, whatever the item says.
 
 Two details follow from the widget rather than the rule. A menu item's label and
 its shortcut hint share one row, so the correction is attached to that row and
@@ -145,7 +141,7 @@ that goes unused is the last line's either way. Submenu items are the wrapping
 spelling, and they are exactly the ones the defect was reported on.
 
 Measured on the real render (an open submenu, device pixels): before, the
-menubar item's ink centre sat 2.0 above its highlight box's centre; after, 0.5
+menubar item's ink centre sat 2.0 above its highlight box's centre. After, 0.5
 below — the same residual an exactly centred badge records. All three submenu
 labels, descending and not, moved by the same 3 device pixels.
 
@@ -173,10 +169,10 @@ Two costs, both real and both bounded:
   the alphabet is a guarantee only the widget building the label can make, the
   same reasoning as `InputCfg.opticalDigitCenter`.
 - **An icon button needed the glyph role** to keep its arrow on its own ink.
-  Without it the cap band would have shifted the glyph by whatever the icon
-  face's `"H"` measures, or — where that face has no `H` — by the blind fallback
-  ratio. The date picker's month-nav arrows are the case in the recordings: they
-  must not move, and they do not.
+  Without it, the cap band shifts the glyph by whatever the icon face's `"H"`
+  measures, or — where that face has no `H` — by the blind fallback ratio. The
+  date picker's month-nav arrows are the case in the recordings: they must not
+  move, and they do not.
 
 The measured form is safe precisely where jitter cannot arise: a badge's label
 changes when the app changes it, not per keystroke. Measuring the run there is
@@ -195,7 +191,7 @@ rides high):
 | `gypsy`     | −5.5        | −9.0             | −5.5             |
 
 The middle column is the version that was rejected: it fixes the count and
-drives the word 3.5 px lower than leaving it alone would.
+drives the word 3.5 px lower than leaving it alone does.
 
 ## How it is measured
 
@@ -222,14 +218,14 @@ at 48pt reads 0.0 px skew.
 The result is memoized per window in `nsOpticalOffset`, keyed by family,
 typeface, size, line spacing and — for the measured form — the run. Per window,
 not per package: the measurement comes from that window's backend. The
-measurement costs a shaping pass and an outline read; the pass that consumes it
+measurement costs a shaping pass and an outline read. The pass that consumes it
 is allocation-free and runs every frame.
 
 Where the capability is absent — nil measurer in tests, WASM/canvas, an
 unreadable outline — the offset falls back to the ratio measured above for the
 band in question (`fallbackCapOffsetRatio` 0.0886 em, `fallbackDigitOffsetRatio`
 0.0708 em), applied only to a run holding none of `descenderRunes`. A rune test
-cannot know what a face does; on the fallback path it is right for Latin text
+cannot know what a face does. On the fallback path it is right for Latin text
 and its cost is a fraction of a pixel in a recording rather than a defect on
 screen.
 
@@ -238,19 +234,19 @@ screen.
 Two forms, because widgets reach the correction at two different times:
 
 - **`opticalCenterText(style, text)`** — an `AmendLayout` hook, a sibling of
-  `centerGlyphOnInk`. Moves the arranged text child; does not feed back into
+  `centerGlyphOnInk`. Moves the arranged text child. Does not feed back into
   sizing, so a control's height stays what the theme set. This is the only form
   available to eager factories such as `Badge`, which build with no `*Window`
   and therefore cannot measure.
 - **`opticalCenterFieldText`** — the same hook, content-free and on the figure
   band, for an editable field holding digits and separators. `InputDate` and
   `NumericInput` reach it by setting `opticalDigitCenter` on the `Input` they
-  wrap; `Input` puts it on the inner row that centres the text shape, and skips
+  wrap. `Input` puts it on the inner row that centres the text shape and skips
   it for multiline, which aligns to the top and has nothing to correct. A hook
   rather than padding because these widgets do not own the field's inset:
   shifting the arranged shape leaves the control's height — and its match with
   the `Input` beside it — untouched, where spending padding from `NoPadding`
-  would have grown it by twice the offset.
+  grows it by twice the offset.
 - **`colorFieldPadding`** — the padding form, for a widget that generates with a
   `*Window` in hand and sizes its row around the result. It gives the offset to
   the top and takes the same from the bottom, so the **total inset — and the
@@ -262,15 +258,15 @@ Two forms, because widgets reach the correction at two different times:
 
 `gui/golden_cases_test.go` records `badge`, `badge_capped`, `badge_descender`,
 `button`, `button_descender`, `numeric_input`, `input_date`,
-`select_placeholder_descender`, `menu_open_descender` and `progress_bar`;
+`select_placeholder_descender`, `menu_open_descender` and `progress_bar`.
 `color_fields`, `button_disabled`, `tab_control`, `datepicker_disabled`,
 `inputdate_disabled`, `numericinput_disabled` and the five `select_*` cases
 moved. `select_placeholder_descender` records level with `select_placeholder`,
-which is what a revert to the measured form would break, and `button_descender`
+which is what a revert to the measured form breaks, and `button_descender`
 records level with `button` for the same reason. `badge_descender` is the
-counter-case that must **not** move: it is the value rule, and it is what would
-catch the cap band being applied to everything. The plain `input` case is the
-second counter-case, and the one that pins the opt-in: general text must stay
+counter-case that must **not** move: it is the value rule, and it catches the
+cap band applied to everything. The plain `input` case is the second
+counter-case, and the one that pins the opt-in: general text must stay
 metrically centred. `TextMeasurer` is nil under the golden harness, so those
 files pin the fallback-ratio path: that the correction happens and by how much,
 not what a given font measures.
@@ -286,47 +282,45 @@ cap band and that `opticalDigitLabel` reaches the figure band. An icon-button
 golden was written and then dropped for exactly this reason: it recorded the
 same numbers either way. `menu_open_descender` opens a menu for one frame (menu
 selection is `nsMenu` keyed by the menubar's ID) and records `Copy` and `Paste`
-at the same offset from their own row: the measured form would move one and not
-the other, which is the pitch defect the band exists to avoid. Its shortcut-hint
+at the same offset from their own row: the measured form moves one and not the
+other, which is the pitch defect the band exists to avoid. Its shortcut-hint
 sibling is a unit test rather than a golden, because `Shortcut.String()` renders
-macOS glyphs on darwin and words elsewhere, so the recording would not be
-portable. `examples/optical_centring/` is the probe for what a golden cannot
-show.
+macOS glyphs on darwin and words elsewhere, so the recording is not portable.
+`examples/optical_centring/` is the probe for what a golden cannot show.
 
 Two goldens changed for a reason that is not the correction: the golden harness
 now pins the window clock (`setVirtualNow`) and `datePickerMonth` reads
 `w.Now()` rather than `time.Now()`. The calendar rings _today_, so
 `datepicker_disabled` recorded a different cell every day and reddened
-overnight; the same read is what a time-travel scrub needs, since a snapshot's
-calendar should ring the scrubbed day.
+overnight. The same read is what a time-travel scrub needs, since a snapshot's
+calendar must ring the scrubbed day.
 
 ## Where it is applied
 
 `Select` (cap band, via `opticalCenterLabelText` on its outer row, composed with
-the focus ring through `amendAll`; the disclosure arrow sits in its own wrapper
+the focus ring through `amendAll`. The disclosure arrow sits in its own wrapper
 and carries its own nudge, so the hook reaches the label only). A wrapping
 multi-select is excluded — its label is a block whose later lines are placed by
 the text layout, the same exclusion `Input` makes for multiline.
 
 The **menu item** (cap band as well, on the item's own column, or on the
-label+shortcut row where there is a hint; a `CustomView` item is skipped, since
+label+shortcut row where there is a hint. A `CustomView` item is skipped, since
 its content is the app's to place). `Menubar`'s top-level items and every
 submenu item are the same factory, so both take it.
 
-**`Button`** (cap band; figure band where `opticalDigitLabel` says the label is
-digits) — which is what `TabControl`, `CommandButton` and the date picker's
+**`Button`** (cap band, or figure band where `opticalDigitLabel` says the label
+is digits) — which is what `TabControl`, `CommandButton` and the date picker's
 cells are built from, so all of those inherit it. Measured on screen, a button
 label at 48pt went from 6.5 device pixels high to dead centre.
 
 `Button` corrects from `buttonAmendLayout` rather than through
 `cv.userAmendLayout`, and does it before that function's early return. Both
 details matter for one reason: the path returns early for a disabled or
-click-less button, so routing the correction through it would leave a disabled
-label sitting a pixel above the enabled one beside it. `button` and
-`button_disabled` are recorded as a pair to keep that honest. The
-`AmendLayout: opticalCenterText` still on the inner `ContainerCfg` is there only
-to guarantee the shape gets an events record, which a bubble-text `Button`
-otherwise has no reason to allocate.
+click-less button, so routing the correction through it leaves a disabled label
+sitting a pixel above the enabled one beside it. `button` and `button_disabled`
+are recorded as a pair to keep that honest. The `AmendLayout: opticalCenterText`
+still on the inner `ContainerCfg` is there only to guarantee the shape gets an
+events record, which a bubble-text `Button` otherwise has no reason to allocate.
 
 `Badge` and `ProgressBar`'s readout (their own ink — they are values, not
 labels), `ColorFields`, `InputDate`, `NumericInput`.
@@ -334,5 +328,5 @@ labels), `ColorFields`, `InputDate`, `NumericInput`.
 Still uncorrected: `Input` and every editable control whose alphabet is _not_
 constrained (by the rule above), and the widgets that centre text without going
 through `Button` or the menu item — breadcrumb, expand panel. Those are a
-straightforward extension when wanted; each needs the hook on the container that
+straightforward extension when wanted. Each needs the hook on the container that
 holds its label.

--- a/docs/specs/theme-style-single-source.md
+++ b/docs/specs/theme-style-single-source.md
@@ -13,8 +13,8 @@ Go-Gui had two sources of default widget styling, maintained by hand:
 - `ThemeDark`, built by `ThemeMaker(themeDarkCfg)`.
 
 Only `applyTheme` writes the literals, and `init` never called it — it seeded
-`installedThemeID` so the first frame's `installTheme` would be a no-op. An app
-that never called `SetTheme` therefore ran on a **mixture**: widgets that read
+`installedThemeID` so the first frame's `installTheme` was a no-op. An app that
+never called `SetTheme` therefore ran on a **mixture**: widgets that read
 `guiTheme.xStyle` directly (badge, expand panel, slider, progress bar,
 inspector) got `ThemeDark`, while widgets that read the `default*Style` mirror
 (button, input, container, listbox, tree, menubar, ...) got the literals. The
@@ -44,8 +44,8 @@ Two literals in `gui/styles.go` are **not** mirrors and keep their values:
   happens during `init` before any theme exists.
 - `defaultInspectorStyle` — `ThemeMaker` copies it into every theme.
 
-Both are still re-assigned by `applyTheme`; for `ThemeDark` that assignment is a
-no-op, and for any other theme it is the correct behaviour.
+Both are still re-assigned by `applyTheme`. For `ThemeDark` that assignment is a
+no-op, and for any other theme it is the correct behavior.
 
 ## Why `ThemeDark` carries the 1.5 border
 
@@ -57,12 +57,11 @@ never call `SetTheme`. `ThemeLight` stays borderless (its cfg comes from
 `baseCfg`, which states no `SizeBorder`) — `ThemeLight.WithBorders(true)` is the
 one call that states it. The presets that used to name these variants
 (`dark-bordered`, `light-bordered`, the no-padding pair) were removed with the
-taste presets (visual-refresh §7, phase 8); the registry now holds only dark,
+taste presets (visual-refresh §7, phase 8). The registry now holds only dark,
 light and the three platform pairs.
 
-Every other delta was a literal that had simply fallen behind: an unstyled
-`dataGrid` placeholder, a dialog with no width bounds, a badge with no text
-style.
+Every other delta was a literal that had fallen behind: an unstyled `dataGrid`
+placeholder, a dialog with no width bounds, a badge with no text style.
 
 ## Appearance changes
 
@@ -71,7 +70,7 @@ Borders, revisited 2026-08: issue #300 removed the literal borders and left
 behind issue #325 then showed the borderless default missed the audience — 90 of
 104 example files re-opted in with `Theme.WithBorders(true)` — so `baseDarkCfg`
 carries `sizeBorderDef` again. Widgets render with their 1.5 (slider 1, radio 2)
-borders under `ThemeDark` and the app default; `Theme.WithBorders(false)`
+borders under `ThemeDark` and the app default. `Theme.WithBorders(false)`
 restores the borderless look, and `light` remains borderless by omission.
 
 Everything else:
@@ -79,11 +78,11 @@ Everything else:
 | Widget          | Change                                         |
 | --------------- | ---------------------------------------------- |
 | button          | `colorClick` 104 → 94                          |
-| input           | `ColorFocus` 104 → 74; `Padding` 5 → 10        |
+| input           | `ColorFocus` 104 → 74, `Padding` 5 → 10        |
 | input           | spell-error color → the theme's error red      |
 | listbox         | `Padding` 6 → 10                               |
-| switch, toggle  | `ColorFocus` → 74; toggle `Radius` 3.5 → 5.5   |
-| badge           | `Color` blue → grey 104; gains bold white text |
+| switch, toggle  | `ColorFocus` → 74, toggle `Radius` 3.5 → 5.5   |
+| badge           | `Color` blue → grey 104, gains bold white text |
 | toast           | `TitleStyle` bold → normal                     |
 | dialog          | gains `MinWidth` 200 / `MaxWidth` 300          |
 | menubar         | `spacingSubmenu` 0 → 1                         |

--- a/docs/specs/view-single-method.md
+++ b/docs/specs/view-single-method.md
@@ -4,7 +4,7 @@
 - Area: `gui/` core pipeline
 - Blocked on: go-gui-org/go-charts#41 (before the release tag, not before
   step 1)
-- Related: #306 (resolved — Form scopes its children; see §5)
+- Related: #306 (resolved — Form scopes its children. See §5)
 
 ## Summary
 
@@ -71,7 +71,7 @@ allocates a one-element slice per node per frame to use it.
 
 ### `formView` is a third mechanism that defeats the other two
 
-Confirmed by inspection of `gui/view_form.go:194-258`. It does not merely inject
+Verified by inspection of `gui/view_form.go:194-258`. It does not merely inject
 children before returning — it opts out of the framework walk by mutating
 itself:
 
@@ -95,9 +95,8 @@ Two things follow, and only the first is documented:
 
 `inner`'s shape carries `ID: formLayoutID(formID)` — `"form:" + formID`
 (`view_form.go:138,320`), always non-empty — so on the framework path
-`childScopeID` would push, and form children would resolve as
-`form:myform:fieldname`. On this path they resolve in the form's **enclosing**
-scope instead.
+`childScopeID` pushes, and form children resolve as `form:myform:fieldname`. On
+this path they resolve in the form's **enclosing** scope instead.
 
 #### The scope suppression is accidental, and protects nothing
 
@@ -139,8 +138,8 @@ Note also that `formLayoutID(formID)` returns `"form:" + formID`, which contains
 `joinLeaf` (`:85-87`) pass it through unjoined. That is deliberate, so
 `formDecodeLayoutID` can reverse-parse it out of `Shape.ID` during
 `formFindAncestorID`'s parent walk — the same documented pattern as
-`gui/datagrid`. It means that if the scope push did run, children would resolve
-under `form:<formID>` regardless of where the form itself sits.
+`gui/datagrid`. It means that if the scope push runs, children resolve under
+`form:<formID>` regardless of where the form itself sits.
 
 #### Separately: the truncation is a latent bug
 
@@ -181,11 +180,11 @@ allocation removed is `rotatedBoxView`'s per-node slice.
 ## Non-goals
 
 Explicitly **not** proposed: eliminating `View` in favor of building `Layout`
-directly from factories. That variant was evaluated and rejected. It would
-require `w` threaded through every factory call (`gui.Column(w, ...)`,
-`gui.Text(w, ...)`), force every user theme read from `gui.CurrentTheme()` to
-`w.Theme()`, break `Themed(t, build)` — whose contract is that `build` runs at
-generation time — and unship the per-window theming landed in #296/#302. See
+directly from factories. That variant was evaluated and rejected. It requires
+`w` threaded through every factory call (`gui.Column(w, ...)`,
+`gui.Text(w, ...)`), forces every user theme read from `gui.CurrentTheme()` to
+`w.Theme()`, breaks `Themed(t, build)` — whose contract is that `build` runs at
+generation time — and unships the per-window theming landed in #296/#302. See
 "Rejected alternative" below.
 
 ## Design
@@ -307,17 +306,17 @@ than one frame up the recursion, which is the same push at the same point in the
 walk.
 
 The `scope bool` exists solely to reproduce the flat behavior `formView`
-currently obtains by self-truncation. Pushing unconditionally would prefix every
+currently obtains by self-truncation. Pushing unconditionally prefixes every
 widget inside a form with `form:<formID>` in its effective ID — a visible change
 to `SetFocus` / `FindByID` callers, though **not** to form field lookup, which
 never touches ID resolution. Keeping the flag makes this refactor
-behavior-preserving; the scoping question is issue #306.
+behavior-preserving. The scoping question is issue #306.
 
 ### Call-site changes
 
 Three production types, plus `viewFunc`:
 
-**`containerView`** — delete `Content()`; append at the end of `GenerateLayout`,
+**`containerView`** — delete `Content()`. Append at the end of `GenerateLayout`,
 after `addGroupBoxTitle`:
 
 ```go
@@ -361,15 +360,15 @@ Three things land together there:
   becomes stateless as the interface has always claimed, and a cached `formView`
   stops being a frame-2 bug waiting to happen.
 - `generateViewLayout(inner, w)` replaces the direct call, putting the node back
-  on the one path. `formView` currently skips `ensureLayoutShape`; `inner` is a
+  on the one path. `formView` currently skips `ensureLayoutShape`. `inner` is a
   `containerView` and always produces a shape, so this is a correctness tidy
   rather than a fix.
 - routing through `appendChildViewsFlat` gives form children the arena
   reservation and the `maxEventChildren` cap that the hand-rolled loop does not
   have today. **This is the only reason `appendChildViewsFlat` needs to exist**
-  — without it, 3b could simply delete the dead line and stop.
+  — without it, 3b can delete the dead line and stop.
 
-**`rotatedBoxView`** — delete `Content()`; the singular child avoids the current
+**`rotatedBoxView`** — delete `Content()`. The singular child avoids the current
 per-node slice allocation:
 
 ```go
@@ -380,7 +379,7 @@ per-node slice allocation:
 
 where `contentSlice []View` is built once in the `RotatedBox` factory rather
 than per frame. (Alternative: an `appendChildView` singular helper. Either is
-fine; the factory-side slice keeps one helper.)
+fine. The factory-side slice keeps one helper.)
 
 **`viewFunc`** — delete `Content()`. `GenerateLayout` already self-recurses.
 
@@ -388,7 +387,7 @@ fine; the factory-side slice keeps one helper.)
 `comboboxView`, `commandPaletteView`, `tabControlView`, `themePickerView`,
 `drawCanvasView`, `termGridView`, `datePickerRollerView`, `rtfView`,
 `colorPickerView`, …) — delete the one-line `Content() []View { return nil }`.
-No other change; they already self-recurse.
+No other change. They already self-recurse.
 
 ## Downstream impact
 
@@ -431,7 +430,7 @@ migrate to generating first and walking `Layout.Children`:
 Not a pure rename — the counts differ where a container sets `Title`
 (`addGroupBoxTitle` adds two children), where a child is nil (skipped), and at
 the `maxEventChildren` cap. `go-map`'s relative assertions
-(`len(withTitle.Content()) != len(without.Content())+1`) are the ones to check
+(`len(withTitle.Content()) != len(without.Content())+1`) are the ones to verify
 individually.
 
 **The two `go-charts` sites cannot migrate this way**, and this is the finding
@@ -448,7 +447,7 @@ children to `chart.Drawer` and collect them as `[]gui.View`**. `Layout.Children`
 carries `Shape`, not `View` — the View identity is gone, so the assertion is
 impossible on the generated tree.
 
-This is not a migration gap; it is a **capability the refactor removes**. After
+This is not a migration gap. It is a **capability the refactor removes**. After
 the change, a `View`'s children live in `containerView.content`, which is
 unexported, and there is no interface method to enumerate them. Nothing can walk
 a View tree without generating it, and generating it discards View identity.
@@ -458,8 +457,8 @@ Options for `go-charts`, none of which this spec can decide unilaterally:
 1. **Restructure at the build site** — `findCharts` walks a tree
    `gallery_main.go` itself just constructed, so it can record `Drawer`s while
    building instead of rediscovering them. Cleanest, and arguably what the code
-   should have done; costs go-charts a real refactor.
-2. **Hold the cfg** — `ContainerCfg.Content` stays public, so go-charts could
+   was meant to do. It costs go-charts a real refactor.
+2. **Hold the cfg** — `ContainerCfg.Content` stays public, so go-charts can
    thread its own `[]gui.View` alongside. Works, slightly redundant.
 3. ~~**Provide a replacement seam in `gui/`**~~ — **rejected**, see Unresolved
    #4. Option 1 or 2 it is.
@@ -471,12 +470,12 @@ the `Layout.Children` migration fails for them, and three suggested directions.
 
 `go-map` (18 sites) and `go-term` (1) are mechanical and can migrate with the
 bump rather than ahead of it — but note `go-map`'s relative assertions
-(`len(withTitle.Content()) != len(without.Content())+1`) need checking against
+(`len(withTitle.Content()) != len(without.Content())+1`) need verifying against
 the `addGroupBoxTitle` child-count difference rather than blind translation.
 
 `GenerateViewLayout` (exported) is called from `gui/datagrid` tests,
 `examples/showcase`, and `examples/process_monitor`. Its signature and semantics
-are unchanged; only its doc comment needs the "walks `Content()`" sentence
+are unchanged. Only its doc comment needs the "walks `Content()`" sentence
 replaced.
 
 ## Implementation order
@@ -485,7 +484,7 @@ replaced.
 
 **Decided: no enumeration accessor** (2026-08-14). `go-charts`#41 is therefore a
 blocking prerequisite rather than a follow-up, and step 2 must merge before the
-release tag. All open questions in this spec are now closed; implementation can
+release tag. All open questions in this spec are now closed. Implementation can
 start at step 1.
 
 ### 1. go-gui pre-work — no behavior change, lands independently
@@ -495,7 +494,7 @@ start at step 1.
    the before/after alloc delta measures the harness, not production.
 2. **Add the two missing assertions** — group-box child ordering, and form
    children's flat effective IDs with the companion `FormFieldState` check.
-   Green before and after; they exist so that a mistake in step 3 fails for the
+   Green before and after. They exist so that a mistake in step 3 fails for the
    right reason rather than silently.
 
 ### 2. go-charts#41 — parallel with step 1
@@ -505,16 +504,16 @@ concurrently. **Must be merged before go-gui tags a release** carrying step 3.
 
 ### 3. The refactor — two PRs, not one
 
-**3a — interface collapse.** Add `appendChildViews`; shrink
-`generateViewLayout`; delete all 27 `Content()` implementations; update
-`containerView`, `rotatedBoxView`, `viewFunc`, and the three test stubs; fix the
+**3a — interface collapse.** Add `appendChildViews`. Shrink
+`generateViewLayout`. Delete all 27 `Content()` implementations. Update
+`containerView`, `rotatedBoxView`, `viewFunc`, and the three test stubs. Fix the
 doc comments in `view.go`, `doc.go:80`, and `layout.go:4,26`.
 
-Per the Unresolved #4 decision, `gui/doc.go` should also state the new
-constraint outright: **a View tree cannot be walked without generating it, and
-generating it discards View identity — record Views at construction time if you
-need to find them by type later.** That is the one thing this change takes away
-from users, so it belongs in the docs rather than in a compile error.
+Per the Unresolved #4 decision, `gui/doc.go` also states the new constraint
+outright: **a View tree cannot be walked without generating it, and generating
+it discards View identity — record Views at construction time if you need to
+find them by type later.** That is the one thing this change takes away from
+users, so it belongs in the docs rather than in a compile error.
 
 `formView` loses only its `Content()` method here — see "Call-site changes"
 above for why that is behavior-preserving without any helper.
@@ -525,7 +524,7 @@ above for why that is behavior-preserving without any helper.
 The split exists because **3b carries all of the ID-scoping risk and 3a carries
 none**. Keeping them apart means a focus or ID regression bisects to a small,
 single-purpose PR instead of one that touched 27 files. 3a is large but
-mechanical; 3b is three lines and the whole reason to be careful.
+mechanical. 3b is three lines and the whole reason to be careful.
 
 ### 4. Release and sibling bumps
 
@@ -536,13 +535,13 @@ implementations nor call sites.
 ### 5. Issue #306 — resolved: Form scopes its children
 
 Landed 2026-08-14, after the refactor settled. `Form` now routes through the
-single `appendChildViews` path like every other container;
+single `appendChildViews` path like every other container.
 `appendChildViewsFlat` is deleted. Form children's effective IDs changed from
 the flat leaf to `form:<id>:<leaf>` (absolute prefix — a form inside an
 ID-bearing panel still scopes under `form:<id>`, never the panel's scope). That
 is a breaking change for `SetFocus` / `FindByID` callers that used the flat
-name; the field registry never participated (`FieldID` is a separate namespace)
-and is unaffected. What it fixes: two forms in one window may each hold an
+name. The field registry never participated (`FieldID` is a separate namespace)
+and is unaffected. What it fixes: two forms in one window can each hold an
 `Input{ID: "email"}` without colliding on one effective ID — the flat behavior
 made such a window fail `TestDuplicateIDs`.
 
@@ -563,7 +562,7 @@ Existing gates that must stay green unmodified in intent:
 - `BenchmarkGenerateViewLayout` (`gui/view_bench_test.go:75`) — **the baseline
   shifts under this change and the numbers are not comparable as-is.**
   `benchView.Content()` (`:13-22`) itself allocates a `[]View` per node per
-  call; moving it to `appendChildViews` drops allocations from the harness
+  call. Moving it to `appendChildViews` drops allocations from the harness
   rather than from production code. Either pin the benchmark to a
   production-shaped tree (`Column` + `Text`) before the refactor and compare
   that, or record both numbers and state which is drift. Do not report the raw
@@ -579,9 +578,9 @@ via `appendChildViews`.
 Then: `make check-all`, `make export-audit` (the `View` interface is exported
 surface), and `make ergonomics-audit`.
 
-Two behaviors currently relied on with nothing pinning them down. Both should
-gain an assertion in **step 1**, before either refactor PR, so the tests fail
-for the right reason if step 3 gets them wrong:
+Two behaviors currently relied on with nothing pinning them down. Both gain an
+assertion in **step 1**, before either refactor PR, so the tests fail for the
+right reason if step 3 gets them wrong:
 
 1. **Group-box ordering.** A container with `Title` set _and_ `Content` children
    must keep the `addGroupBoxTitle` eraser + label ahead of the content
@@ -613,9 +612,9 @@ trade against. Costs, in the smallest app in the repo
 (`examples/get_started/main.go`, 11 lines of tree):
 
 - four `w` threadings, scaling linearly with nesting depth
-- `gui.CurrentTheme()` → `w.Theme()` in every app, because factories would run
-  at call time rather than under `installTheme`'s frame cache — issue #301
-  again, but in user code instead of 13 internal sites
+- `gui.CurrentTheme()` → `w.Theme()` in every app, because factories run at call
+  time rather than under `installTheme`'s frame cache — issue #301 again, but in
+  user code instead of 13 internal sites
 - evaluation order stops being deferred: a `[]Layout` literal evaluates its
   elements before the enclosing call, so the idScope push cannot be expressed
   around it
@@ -637,8 +636,8 @@ A large API break across six repos, in exchange for a saving that measures zero.
    no — it is accidental.** The truncation predates ID scoping by two months
    (`2fda77b7`, 2026-06-08 vs `70a7a399`/#228, 2026-08-09), its comment claims
    only double-processing, and no test covers the effect. The earlier rationale
-   in this spec — that field registration would break — was wrong; field IDs are
-   a separate namespace. See "The scope suppression is accidental" above.
+   in this spec — that field registration breaks — was wrong. Field IDs are a
+   separate namespace. See "The scope suppression is accidental" above.
 
    **Decided (2026-08-14): keep flat, superseded by #306 the same day.** This
    change was behavior-preserving — `appendChildViewsFlat` reproduced today's
@@ -660,16 +659,16 @@ A large API break across six repos, in exchange for a saving that measures zero.
    Boxing a pointer into an interface allocates nothing — the pointer fits in
    the interface's data word. The per-node cost is the **view struct itself**
    (`&containerView{}` is 512 B, dominated by the embedded `ContainerCfg`), and
-   a layouts-only design would still pay a comparable cost for the `Layout` +
-   `Shape` it builds instead.
+   a layouts-only design still pays a comparable cost for the `Layout` + `Shape`
+   it builds instead.
 
    The `Content()` call remains a real **dispatch** (~2.5 ns/node/frame), which
    is why collapsing it is still worth doing — but it is not an allocation, and
-   this spec should not be sold as an allocation win. The only allocation this
+   this spec does not sell itself as an allocation win. The only allocation this
    change removes is `rotatedBoxView`'s per-node slice.
 
 4. **Reopened by the call-site survey — but the seams need separating first.**
-   The original framing ("should `appendChildViews` be exported?") conflates two
+   The original framing — whether to export `appendChildViews` — conflates two
    distinct things:
 
    - **Producer seam** — a composite widget declaring children and wanting the
@@ -680,11 +679,11 @@ A large API break across six repos, in exchange for a saving that measures zero.
      stands for this seam.
    - **Consumer seam** — code enumerating an existing View tree. This is what
      the 21 downstream call sites use, and it is what the refactor actually
-     removes. `appendChildViews` does not serve it; exporting it would not
+     removes. `appendChildViews` does not serve it. Exporting it does not
      unblock a single one of those sites.
 
-   So the live question was narrower and different: should `gui/` offer a
-   replacement for View-tree enumeration at all?
+   So the live question was narrower and different: whether `gui/` offers a
+   replacement for View-tree enumeration at all.
 
    **Decided (2026-08-14): no accessor.** `GenerateViewLayout(v, w).Children`
    covers 19 of the 21 downstream sites. The other two want View identity
@@ -703,6 +702,6 @@ A large API break across six repos, in exchange for a saving that measures zero.
      rather than learned by compile error.
 
    Rejected: an exported `ChildViews(v View) []View` backed by an unexported
-   `childViewer` interface. It would unblock `go-charts` with no restructuring,
-   but reintroduces on every `View` exactly the second mechanism this spec
-   exists to remove.
+   `childViewer` interface. It unblocks `go-charts` with no restructuring, but
+   reintroduces on every `View` exactly the second mechanism this spec exists to
+   remove.

--- a/docs/specs/virtualized-variable-height-lists.md
+++ b/docs/specs/virtualized-variable-height-lists.md
@@ -11,7 +11,7 @@ content height is faked with transparent spacer rectangles sized
 useless for rows the caller builds — a chat transcript, a feed, a log view, a
 card list.
 
-**Rows could not be addressed by index.** `scrollToView` resolves through
+**Rows were not addressable by index.** `scrollToView` resolves through
 `FindByID`, so a row virtualization never built is structurally unreachable.
 `ScrollVerticalToPct` inherits the fictional content height, so `pct = 1` lands
 near the end rather than at it and pin-to-bottom drifts with every append.
@@ -33,7 +33,7 @@ existing uniform ones.
 
 ### Why an exact tree rather than a sampled average
 
-go-shirei's `widgets.VirtualList` (zlib; design reference, not copied) samples
+go-shirei's `widgets.VirtualList` (zlib, design reference, not copied) samples
 the first N and last N rows and extrapolates an average. That is cheaper and
 stateless, and its own documentation records what it costs: a thumb that jumps
 and a false bottom on a corpus whose row heights are regionally skewed — a feed
@@ -43,7 +43,7 @@ An exact prefix-sum tree pays 12 B/item and a staleness problem in exchange for
 a scrollbar that means what it shows. Both costs are answered rather than
 accepted:
 
-- staleness — `ItemKey` (below);
+- staleness — `ItemKey` (below).
 - memory — above `listHeightMaxVariable` (~4M items) the model falls back to
   uniform and reports it under `gui.Debug` (the `DebugListBoxNoHeight`
   category).
@@ -54,20 +54,20 @@ At a million rows the running prefix reaches ~3×10⁷ px, where one float32 ULP
 ~4 px. That is visible jitter, and worse, it makes the prefix sequence
 non-monotonic — so the `IndexAt` binary-lifting search can return an index whose
 span does not contain `y`. The heights themselves stay float32 because they are
-pixel measurements; only the accumulation needs the range.
+pixel measurements. Only the accumulation needs the range.
 
 ### Why shirei's per-frame `Measure` does not port
 
 shirei measures every candidate row each frame and caches nothing. In go-gui the
 layout passes mutate ID-keyed window state (`layoutOverflow`'s overflow map,
 `resolveShapeIDs`) and draw shapes from the frame-scoped pool. Measuring N rows
-per frame would both allocate and corrupt per-window state. Measurement here is
-therefore observation of rows that were built anyway — the `listBoxAmendLayout`
-idiom — which is what makes the write-back and the re-anchor necessary.
+per frame allocates and corrupts per-window state. Measurement here is therefore
+observation of rows that were built anyway — the `listBoxAmendLayout` idiom —
+which is what makes the write-back and the re-anchor necessary.
 
 ### Heights are keyed, positions are indexed
 
-`heights`/`tree` hold the current frame's index order; `byKey` holds what was
+`heights`/`tree` hold the current frame's index order. `byKey` holds what was
 actually measured, under the caller's `ItemKey`. A count change rebuilds the
 tree by walking `ItemKey(i)` and taking `byKey[k]`, so an insert, a delete or a
 reorder keeps every measured height on its own item. Without `ItemKey` the model
@@ -108,13 +108,13 @@ hair below it and the walk answers with the row above — one ULP of error, a
 whole row of displacement, and the correction then moves the reader by that
 row's height. The tolerance is one float32 ULP of `y` plus a sub-pixel floor.
 `TestListHeightModelIndexAtMonotonic` asserts `IndexAt(Prefix(i)) == i` over a
-corpus of deliberately fractional heights; whole-pixel heights give prefixes
+corpus of deliberately fractional heights. Whole-pixel heights give prefixes
 that are exact in float32 and ask nothing.
 
 The already-positioned children are shifted by the same amount, as scroll
 anchoring shifts them. This is the part that is easy to get wrong. This frame's
 rows were laid out at their _actual_ heights above a leading spacer sized from
-the _stale_ model, so they already sit off by exactly that delta; correcting
+the _stale_ model, so they already sit off by exactly that delta. Correcting
 only the stored offset fixes the next frame and leaves this one visibly
 displaced. `TestVirtualListWriteBackHoldsTheAnchorRow` is the layout-level
 guard.
@@ -151,8 +151,8 @@ already on screen.
 | Site                          | Index space                                                          |
 | ----------------------------- | -------------------------------------------------------------------- |
 | `gui/view_listbox.go`         | `cfg.Data`, subheadings included                                     |
-| `gui/view_table.go`           | `cfg.Data`; `indexBase = dataStart`, so a frozen header sits outside |
-| `gui/view_tree_rows.go`       | the **flat** row index, not the node index; re-registered per frame  |
+| `gui/view_table.go`           | `cfg.Data`, `indexBase = dataStart`, so a frozen header sits outside |
+| `gui/view_tree_rows.go`       | the **flat** row index, not the node index, re-registered per frame  |
 | `gui/view_combobox.go`        | the **filtered** items — moves with the query                        |
 | `gui/view_command_palette.go` | the **filtered** items — moves with the query                        |
 
@@ -161,7 +161,7 @@ Known limits inherited rather than fixed here:
 - Virtualization triggers on `Scrollable && height > 0`. Only `ListBox` falls
   back to the height arrange recorded last frame, so a Fill-sized `Table` or
   `Tree` never virtualizes and therefore registers no model.
-- The table emits separator rectangles between rows that may not be inside
+- The table emits separator rectangles between rows that can lie outside
   `tableEstimateRowHeight`. The registered model inherits that error rather than
   introducing a second one.
 
@@ -170,22 +170,22 @@ Known limits inherited rather than fixed here:
 `gui/view_virtual_list.go` and `_build.go` (split for the 800-line gate).
 
 - **No `Virtualize` flag.** Virtualization turns on automatically when the
-  scroll container has a bounded height, following the existing convention;
+  scroll container has a bounded height, following the existing convention.
   `VirtualList` is scrollable by construction. Height source: `Cfg.Height` →
   `MaxHeight` → the inner height the amend hook recorded last frame.
 - **Bounded first-frame probe.** Under Fill sizing frame 1 has no height. The
-  `ListBox` precedent builds _every_ row there; at a million rows that is a
+  `ListBox` precedent builds _every_ row there. At a million rows that is a
   hang, so a `virtualListProbeRows` window is built instead — enough for arrange
   to record a height.
 - **Overscan in pixels, not rows.** A row count is meaningless when rows differ
   in height. A row count remains as a secondary cap against pathological
   corpora.
 - **Spacing fixed at zero.** A gap between rows is height the model does not
-  account for, and every position below would drift by one gap per row. Space
-  rows from inside `ItemView`.
+  account for, and every position below drifts by one gap per row. Space rows
+  from inside `ItemView`.
 - **Focus is an index, not a shape.** An unbuilt row has no effective ID, so the
   focused row lives in a `StateMap` keyed by list ID. `VirtualListFocusedIndex`
-  / `SetVirtualListFocusedIndex` read and write it; arrow keys move it and call
+  / `SetVirtualListFocusedIndex` read and write it. Arrow keys move it and call
   `ScrollIndexIntoView`, so focus lands one frame later. Tab traverses only
   built rows.
 - Row IDs are the caller's to compose, with `ScopeIDN(listID, "row", i)` — an ID
@@ -208,14 +208,14 @@ Nothing about it looks like a failure from inside the widget, so the widget
 reports it: `virtualListNoteWidth` counts consecutive frames of widening with
 the window standing still — the window moving is what separates a resize, which
 stops, from a ratchet, which does not — and warns after four under [Debug]. Rows
-fill the width they are given through `Sizing`; the argument is for decisions,
+fill the width they are given through `Sizing`. The argument is for decisions,
 not for minimums.
 
 ## Known limits
 
 1. **Without `ItemKey` the model is index-keyed** (above).
 2. **Width is one frame late.** `ItemView(i, width)` receives the inner width
-   recorded by the previous arrange; it is 0 on frame 1. After a resize the
+   recorded by the previous arrange. It is 0 on frame 1. After a resize the
    heights are stale for one frame. The width change does **not** discard them:
    a height measured for a row at a slightly different wrap predicts that row
    better than one estimate shared by the whole corpus, and the rows on screen
@@ -230,5 +230,5 @@ not for minimums.
 
 go-shirei `widgets/scroll.go` and `docs/virtual-list.md` (zlib) were read as a
 design reference for the problem shape and the failure modes worth documenting.
-No code was copied; the height model here is deliberately a different design,
+No code was copied. The height model here is deliberately a different design,
 for the reasons above.

--- a/docs/specs/visual-refresh.md
+++ b/docs/specs/visual-refresh.md
@@ -2,8 +2,8 @@
 
 - **Status:** phase 5b landed (§ 5.4 focus ring in the default presets, wired
   through every remaining focusable). Phase 5a landed earlier (§ 5.5
-  `BoxShadow.Spread` through six backends); phase 4 (§ 5.2 radius ladder, § 5.3
-  elevation); phases 1, 2, 3 (palettes, accent ramp, semantic colors, border,
+  `BoxShadow.Spread` through six backends). Phase 4 (§ 5.2 radius ladder, § 5.3
+  elevation). Phases 1, 2, 3 (palettes, accent ramp, semantic colors, border,
   type ladder, density). Phases 6, 7, 8 pending.
 - **Extends:** `docs/style-guide.md`,
   `docs/specs/widget-visual-consistency-audit.md` (issue #335)
@@ -44,8 +44,8 @@ amount of per-widget polish reaches.
 ## Non-goals
 
 - Hover/focus color transitions. The animation system (`gui/animation*.go`) is a
-  frame-driven registry of `Animation` objects keyed by ID on the `Window`;
-  nothing connects a shape's hover state to a color tween. Wiring that means
+  frame-driven registry of `Animation` objects keyed by ID on the `Window`.
+  Nothing connects a shape's hover state to a color tween. Wiring that means
   per-effective-ID hover progress in `StateMap` plus color interpolation in the
   fill resolution of ~16 widgets, in a toolkit whose stated bottleneck is
   allocation. Separate project, budgeted separately.
@@ -121,11 +121,11 @@ A `Fit`-sized empty field is a stub. Add `ThemeCfg.SizeFieldMinWidth`
 `MinWidth`.
 
 **Zero means no floor, not "derive 160."** It is a `float32` with a meaningful
-zero, and the § Opt rule says a primitive whose zero is a real choice would need
+zero, and the § Opt rule says a primitive whose zero is a real choice needs
 `Opt` — but here the two readings collapse: `baseCfg()` sets 160, so every
 preset theme carries it, and a hand-built `ThemeCfg` that leaves it zero is
 asking for today's Fit-to-content behavior. A custom theme wanting no floor sets
-nothing; one wanting a different floor states it. No `Opt` wrapper. This also
+nothing. One wanting a different floor states it. No `Opt` wrapper. This also
 retires **four** literals in `ThemeMaker`, not two: the same `MinWidth: 75` /
 `MaxWidth: 200` pair appears on `selectStyle` (`theme_maker.go:188-189`) and
 again on `ComboboxStyle` (`theme_maker.go:436-437`). They are the reason a
@@ -135,9 +135,9 @@ theme nor the caller stated.
 **`MaxWidth: 200` goes too, not just `MinWidth`.** It is the same defect from
 the other end: a `Select` given `FillFit` in a 900px row stops at 200px and the
 caller has no way to see why. With § 1's fix in place a labelled `Select` can
-finally fill its row, and the cap would silently defeat it. Drop both fields to
-0 (uncapped) on `selectStyle` and `ComboboxStyle`; a caller wanting a ceiling
-sets `MaxWidth` on the Cfg. `maxDropdownHeight: 200` is unrelated and stays — it
+finally fill its row, and the cap silently defeats it. Drop both fields to 0
+(uncapped) on `selectStyle` and `ComboboxStyle`. A caller wanting a ceiling sets
+`MaxWidth` on the Cfg. `maxDropdownHeight: 200` is unrelated and stays — it
 bounds the popup list, not the control.
 
 ---
@@ -173,7 +173,7 @@ non-HiDPI Linux or Windows display, and the toolkit's own themes ship
 everywhere. The platform themes take their platform's value, which is what they
 exist for.
 
-The current top of the ladder (`+4/+8`) is too flat to build a heading from;
+The current top of the ladder (`+4/+8`) is too flat to build a heading from.
 `+3/+8` gives one clear step for section headings (17) and one for page titles
 (22) while pulling the crowded bottom apart.
 
@@ -182,7 +182,7 @@ The current top of the ladder (`+4/+8`) is too flat to build a heading from;
 The `B1..B6` bold ladder already exists and is complete. The defect is in what
 widgets _default_ to, not in what the theme offers. Audit pass: every widget
 rendering a heading, a group-box title, a dialog title, a tab label or a table
-header takes a `B` rung; body and value text stays `N`. Section 3 of the widget
+header takes a `B` rung. Body and value text stays `N`. Section 3 of the widget
 audit (`docs/specs/widget-visual-consistency-audit.md`) is the model for how to
 record this.
 
@@ -218,7 +218,7 @@ the reference render the "Role" label appears equally attached to the control
 below it as to its own `Select`. Roughly doubling each rung makes group
 membership legible without measuring.
 
-The rung meanings in `gui/styles.go` stay exactly as documented; only the values
+The rung meanings in `gui/styles.go` stay exactly as documented. Only the values
 move.
 
 ---
@@ -250,7 +250,7 @@ separation.
 
 The wash assumes a fill behind it. A **group box** (a titled container) has a
 transparent fill, so its border and heading are its only separation from the
-page; `Theme.ColorBorder` reads as nothing there. When `ColorBorder` is left
+page. `Theme.ColorBorder` reads as nothing there. When `ColorBorder` is left
 unset on a titled container, it resolves the group-box ink — the theme's own
 body text at 60% (`groupBoxInk`, `gui/view_container.go`) — and forces the
 hairline border unless the caller states one. Caller-explicit colors win.
@@ -311,18 +311,18 @@ states one color and gets a working ramp. The derivation is pinned, because
 - **`ColorTextOnAccent`** is white when `srgbLuminance(ColorAccent) < 0.45`,
   black otherwise, using the existing `srgbLuminance`
   (`gui/theme_text_roles.go:69`). 0.45 rather than the midpoint because white
-  text on a mid-blue reads better than black at the same luminance; both default
+  text on a mid-blue reads better than black at the same luminance. Both default
   accents land well clear of it, so the threshold only matters for a custom
   theme picking a yellow or lime accent.
 
-The table values are what these rules produce from `#4D82F0` and `#2F6FE0`; a
-test should assert that, so the table and the code cannot drift.
+The table values are what these rules produce from `#4D82F0` and `#2F6FE0`. A
+test asserts that, so the table and the code cannot drift.
 
 `ColorAccentSubtle` replaces full-accent fills on selected and highlighted rows
 — `ListBox`, `Table`, `DataGrid`, and the dropdown rows of `Select`, `Combobox`
 and the command palette — where a saturated slab behind every selected row is
 the loudest thing on the screen. Selection paints the subtle tint everywhere and
-in every focus state; focus is the ring (phase 5b), not a second fill (decision
+in every focus state. Focus is the ring (phase 5b), not a second fill (decision
 2). Only the menus keep the full accent fill on their selected item, where the
 row _is_ the focus indication. A subtle row's text stays the body color — the
 accent/text pairing (`ColorTextOnSelect`) applies only where the full accent
@@ -330,8 +330,8 @@ fill still happens.
 
 ### 4.4 Semantic colors
 
-`ColorSuccess`, `ColorWarning` and `ColorError` already exist on `ThemeCfg`;
-only `ColorError` is set by the default presets. Fill all three in both
+`ColorSuccess`, `ColorWarning` and `ColorError` already exist on `ThemeCfg`.
+Only `ColorError` is set by the default presets. Fill all three in both
 polarities and give each a `*Subtle` companion on the same derivation rule as
 the accent, so a validation message and its field background are one decision.
 
@@ -341,7 +341,7 @@ the accent, so a validation message and its field background are one decision.
 
 ### 5.1 Border
 
-`sizeBorderDef 1.5 → 1`. A hairline is what every platform draws; 1.5 at 2x is a
+`sizeBorderDef 1.5 → 1`. A hairline is what every platform draws. 1.5 at 2x is a
 3-pixel stroke and is the main reason the toolkit reads boxy. The macOS theme
 already sets 1 for exactly this reason (`gui/theme_macos.go:76`).
 
@@ -360,7 +360,7 @@ the proposal (a hand-tuned platform theme already landed on these numbers) and
 means `macos`/`macos-dark` see only `RadiusLarge` move, 10 → 12, if that theme
 drops its override.
 
-An audit item: confirm which styles currently consume `RadiusLarge` and move any
+An audit item: verify which styles currently consume `RadiusLarge` and move any
 _control_-tier consumer down to `RadiusMedium` before the bump, or a slider
 track becomes a capsule by accident.
 
@@ -374,8 +374,8 @@ today. Fill them:
 | Dark  | `RGBA(0,0,0,140)`, blur 12   | `RGBA(0,0,0,170)`, blur 32   |
 | Light | `RGBA(16,24,40,40)`, blur 12 | `RGBA(16,24,40,60)`, blur 32 |
 
-Revised after the first pass shipped, when every elevated surface read as a grey
-cloud rather than as depth. The alphas above are the original table's; two other
+Revised after the first pass shipped, when every elevated surface read as a gray
+cloud rather than as depth. The alphas above are the original table's. Two other
 things were wrong.
 
 **The GPU shadow shader had the falloff off by a factor of two, in both
@@ -398,8 +398,8 @@ documented reference the GPU path matches.
 
 **Concentric, not offset.** A downward offset puts a heavy band under one edge
 and nothing above it. On a menu — anchored to a trigger it visibly drops from —
-that reads as depth; on a dialog centred in the window it reads as the surface
-sliding. `OffsetY: 0` in both tiers; the tier is expressed by blur and alpha
+that reads as depth. On a dialog centered in the window it reads as the surface
+sliding. `OffsetY: 0` in both tiers. The tier is expressed by blur and alpha
 alone.
 
 The platform themes (macOS, WinUI, GNOME) keep their offsets — those mirror the
@@ -415,7 +415,7 @@ problem.
 
 ### 5.4 Focus ring
 
-`ThemeCfg.FocusRing` is nil in both default presets; only the macOS themes set
+`ThemeCfg.FocusRing` is nil in both default presets. Only the macOS themes set
 it (`gui/theme_macos.go:93`). Set it in both:
 `BoxShadow{Color: ColorAccent at 25% alpha, BlurRadius: 2}` — a spread-free
 glow, deliberately not a spread ring.
@@ -423,13 +423,12 @@ glow, deliberately not a spread ring.
 Why no spread: the glow is drawn _outside_ the control's layout bounds, but a
 shape's clip is `shapeBounds ∩ parentClip` (`layout_position.go`), and a Fill
 control sitting against its parent's content edge has the glow scissored away on
-the sides it touches. A spread ring would lose a hard-edged band there; a
-spread-free glow loses only a faint tail and degrades gracefully, and the focus
-_border_ (`ColorBorderFocus`) remains the never-clipped indicator. The real fix
-is a draw-outset the ancestors' clips can honour — tracked in the § 10
-checklist. The alpha reads as focus, never as a second border: a spread adds a
-crisp plateau at full ring alpha, which is exactly what the spread-free glow
-avoids.
+the sides it touches. A spread ring loses a hard-edged band there. A spread-free
+glow loses only a faint tail and degrades gracefully, and the focus _border_
+(`ColorBorderFocus`) remains the never-clipped indicator. The real fix is a
+draw-outset the ancestors' clips can honor — tracked in the § 10 checklist. The
+alpha reads as focus, never as a second border: a spread adds a crisp plateau at
+full ring alpha, which is exactly what the spread-free glow avoids.
 
 Two follow-ons:
 
@@ -454,7 +453,7 @@ Two follow-ons:
 
 `BoxShadow` carries `Color`, `OffsetX`, `OffsetY`, `BlurRadius` and nothing
 else. Add `Spread float32`: the amount the shadow's own shape is grown beyond
-the caster before blurring. Zero is today's behaviour, so every existing shadow
+the caster before blurring. Zero is today's behavior, so every existing shadow
 is untouched.
 
 **This cannot be done at the emit site.** The obvious cheap implementation —
@@ -464,7 +463,7 @@ rounded rect with the **inverse coverage of the un-offset caster multiplied in**
 (`softRoundRect(cmd, offX, offY, cutCaster: true)`,
 `gui/backend/soft/draw_effects.go:63`), and the caster cut-out is derived from
 the same command rect. Inflating that rect inflates the cut-out with it and
-erases the ring exactly where it should appear.
+erases the ring exactly where it appears.
 
 So spread needs real plumbing:
 
@@ -532,12 +531,12 @@ time, but `Content: []View{Text(...)}` has already run. Left alone, an accent
 both:
 
 - **The button owns the label.** Add `ButtonCfg.Label string`, the field
-  `TextButton` already implies; when set, `Button` builds the `Text` itself and
+  `TextButton` already implies. When set, `Button` builds the `Text` itself and
   applies the variant's `ColorTextOnAccent`. This is the path every variant
-  example should use, and `TextButton` gains a variant argument or a sibling.
+  example uses, and `TextButton` gains a variant argument or a sibling.
 - **The caller owns the label.** For `Content`-built buttons, an explicitly
-  colored `Text` must keep its color — overriding it would be worse than the
-  problem. To recolor only the ones that took the default, `TextStyle` gains an
+  colored `Text` must keep its color — overriding it is worse than the problem.
+  To recolor only the ones that took the default, `TextStyle` gains an
   unexported `defaultedColor bool` set by `Text` on the `DefaultTextStyle`
   fallback, following the exact precedent of `disabledRole` and `glyphRole`
   (`gui/styles.go:96-129`): unexported, set in one place, never spelled at a
@@ -548,8 +547,8 @@ If the second half proves noisy in practice, ship only the first and document
 that a `Content`-built filled button must color its own label — but do not ship
 the variants with neither.
 
-One accent-filled primary per surface is the convention; state it in
-`docs/style-guide.md` and check it in review, not in code.
+One accent-filled primary per surface is the convention. State it in
+`docs/style-guide.md` and verify it in review, not in code.
 
 ---
 
@@ -563,7 +562,7 @@ Fourteen names are registered today. Remove six:
 | `light-bordered`     | Reachable as `ThemeLight.WithBorders(true)`.                         |
 | `dark-no-padding`    | Reachable as `ThemeDark.WithBorders(false)` plus a padding override. |
 | `light-no-padding`   | Same.                                                                |
-| `blue-dark`          | A taste preset; `ThemeMaker` is the supported way to make one.       |
+| `blue-dark`          | A taste preset. `ThemeMaker` is the supported way to make one.       |
 | `blue-dark-bordered` | Same.                                                                |
 
 Eight remain: `dark` (default), `light`, and the three platform pairs
@@ -580,7 +579,7 @@ automatically. `docs/` and per-example READMEs naming removed presets must be
 updated (see § 10).
 
 `defaultTheme = &ThemeDark` (`gui/theme_defaults.go:249`) already makes dark the
-default with no `SetTheme` call; that is kept and pinned by a test.
+default with no `SetTheme` call. That is kept and pinned by a test.
 
 ---
 
@@ -594,7 +593,7 @@ default with no `SetTheme` call; that is kept and pinned by a test.
   nothing inline separates by anything but fill value, and it still leaves the
   label's contrast depending on where the fill happens to be. Outside the bar
   the readout is legible at every percentage and the bar becomes a pure
-  indicator. `TextShow` keeps its name and meaning; only the placement changes,
+  indicator. `TextShow` keeps its name and meaning. Only the placement changes,
   and `progressBarCenterLabel` plus the `opticalCenterText` amend
   (`view_progress_bar.go:88`) are deleted with it. The fill is **already**
   radius-clipped — the fill `Row` sets `Radius: SomeF(radius)`
@@ -660,7 +659,7 @@ Mandatory before any phase is called done:
   | Focused `Input` and focused `Select` (case `focusID`) | 5b       |
   | The four button variants side by side                 | 6        |
 
-  The two phase-1 cases are the regression pins for § 1 and § 8; adding them
+  The two phase-1 cases are the regression pins for § 1 and § 8. Adding them
   first means every later phase re-records them and the diff shows the density
   and palette moves on a shape whose geometry is already correct.
 
@@ -671,7 +670,7 @@ Mandatory before any phase is called done:
   1. **Emit test** (backend-independent): a container with a `Spread`-only
      shadow — zero blur, zero offset — produces exactly one `RenderShadow`
      command carrying the spread. This is the guard-widening in § 5.5 and it
-     fails today; it is the cheapest possible pin on the whole feature.
+     fails today. It is the cheapest possible pin on the whole feature.
   2. **Validation test**: `validShadowCmd` accepts a positive `Spread`, rejects
      NaN/Inf and negative values, and range-checks against the same ceiling as
      `BlurRadius`.
@@ -687,11 +686,10 @@ Mandatory before any phase is called done:
   The bar is **equivalent geometry and coverage**, not pixel-identical output.
   The six backends do not agree pixel-for-pixel today — analytic SDF coverage in
   the GPU paths against a box-blurred alpha mask in `soft` differ at the edges
-  by construction — so "renders identically" would be a test no correct
-  implementation could pass. See the two-sided technique in
-  `gui/backend/CLAUDE.md`.
+  by construction — so "renders identically" is a test no correct implementation
+  can pass. See the two-sided technique in `gui/backend/CLAUDE.md`.
 
-- `TestDefaultStylesMirrorThemeDark` must stay green; it is the gate that stops
+- `TestDefaultStylesMirrorThemeDark` must stay green. It is the gate that stops
   a literal being reintroduced into a `default*Style` mirror.
 - `make prepush`.
 
@@ -700,28 +698,28 @@ pinned by the same § 10 cases, re-recorded and diff-read:
 
 1. **Readout outside the bar.** `progress_bar` (dark + light) re-recorded: the
    track keeps `SizeProgressBar` (20×20) and the fill is 42% of the track's own
-   box; the readout sits after the track at `SpacingSmall` in the secondary role
+   box. The readout sits after the track at `SpacingSmall` in the secondary role
    (`#e6e8eba0` dark, `#1a1d21ae` light) — no text over the fill, no
    `TextBackground` chip. `TestProgressBarFillUsesTrackBox` pins the fill math
-   to the track's box (the outer's width includes the readout and would spill
-   the fill); `TestThemeMakerProgressReadoutIsSecondary` pins the style role;
+   to the track's box (the outer's width includes the readout and spills the
+   fill). `TestThemeMakerProgressReadoutIsSecondary` pins the style role.
    `TestProgressBarReadoutTrails` pins the two-child structure.
 2. **Boolean retune.** `boolean_labels` and `boolean_labels_disabled` (both
    themes) re-recorded: switch 34×20 (knob radius 7), radio 15 (7.5), toggle
    unchanged at `ts.Size + 4`. `SizeSwitchWidth/Height` and `SizeRadio` in
-   `theme_defaults.go` are the only touched sizes; the platform overrides in
+   `theme_defaults.go` are the only touched sizes. The platform overrides in
    `theme_macos.go`, `theme_gnome.go`, `theme_winui.go` are untouched.
 3. **Pixel invariance.** `switch_focused.dark` re-recorded for the new pill and
-   knob; the light case was unchanged at its sample points and
+   knob. The light case was unchanged at its sample points and
    macos/gnome/windows were byte-identical — the override seam held. The
    re-record sweep also touched `progress_fill`/`switch_focused.light` PNGs with
-   identical pixels (encoder noise); those were restored, not kept.
+   identical pixels (encoder noise). Those were restored, not kept.
 
 Phase 8 — § 7 checklist. A removal, so the gate is that nothing else moves:
 
 1. **The registry is exactly eight.** `TestPresetThemesRegistered` names `dark`,
    `light`, `macos`, `macos-dark`, `gnome`, `gnome-dark`, `windows`,
-   `windows-dark`; `TestPresetThemesDefined` covers the same eight including the
+   `windows-dark`. `TestPresetThemesDefined` covers the same eight including the
    platform pairs, which were previously asserted only inside
    `TestPresetThemesRegistered`. `ThemeGet` on any of the six removed names
    returns nil.
@@ -735,13 +733,13 @@ Phase 8 — § 7 checklist. A removal, so the gate is that nothing else moves:
    `TestThemePresetElevationValues` pins dark/light only.
 3. **Goldens and pixels unmoved.** No registered theme changed appearance, so
    `TestGolden` and `TestPixelGolden` pass without re-recording — a regression
-   here means the removal touched a shared builder (e.g. `baseCfg`), not just
-   the deleted presets.
+   here means the removal touched a shared builder (for example `baseCfg`), not
+   just the deleted presets.
 4. **Docs say the same thing.** `docs/specs/theme-style-single-source.md` no
-   longer names `dark-bordered` or `blue-dark`; `CLAUDE.md` drops the
-   `dark-no-padding` hint; `CHANGELOG.md` carries the breaking-change entry
-   under Unreleased → Removed; `ThemePicker` screenshots and the README gallery
-   are deferred (a human at a display is required; see Deferred questions). The
+   longer names `dark-bordered` or `blue-dark`. `CLAUDE.md` drops the
+   `dark-no-padding` hint. `CHANGELOG.md` carries the breaking-change entry
+   under Unreleased → Removed. `ThemePicker` screenshots and the README gallery
+   are deferred (a human at a display is required. See Deferred questions). The
    example sweep is its own commit: 94 files call `WithBorders(true)`, which is
    a no-op since the 2026-08 default-border flip, and the two
    `WithBorders(false)` sites are kept.
@@ -758,12 +756,12 @@ the corners.
   with `rad+s`, and leaves the caster cut-out's `coverageRoundRect` at the
   un-inflated `w, h, rad`. Verified by the three recorded pixel goldens
   (`shadow-spread-ring`, `shadow-spread-blur`, `shadow-spread-rounded`), sampled
-  on all four sides and diagonally; the rounded case is the radius-divergence
+  on all four sides and diagonally. The rounded case is the radius-divergence
   pin (ring present at the corner diagonal, so the corner radius grew).
 - **metal / ios** — `drawShadow` (`metal/draw.go`, `ios/draw.go`) scales
   `spread := r.Spread * s`, adds it to `expand`, passes the inflated
   `rad+spread` to `gpu.BuildQuad`, and loads `tm[14] = spread` before
-  `metalSetTM`; `vs_shadow` forwards `tm[14]` as a `spread` varying (the
+  `metalSetTM`. `vs_shadow` forwards `tm[14]` as a `spread` varying (the
   transformed zero-vector's `.z`), and `fs_shadow` shrinks the caster field by
   it (`radius - spread`, `half_size - spread`). At `s = 0` every expression
   degenerates to the pre-5a shader, so legacy shadows are byte-identical.
@@ -771,37 +769,36 @@ the corners.
   uniform (`gl/draw.go` `drawShadow`), same `VsShadowGLSL`/`FsShadowGLSL`.
 - **android** — same construction via `glesSetTM` and the GLES 300 sources
   `vs_shadow_src`/`fs_shadow_src` (`gles_android.c`). GLES/NDK compile is
-  exercised only by `make build-android` (needs the NDK; not part of prepush),
+  exercised only by `make build-android` (needs the NDK, not part of prepush),
   so the C shader strings are validated by review and by the prepush cross-lint.
-- **web** — Canvas2D has no native shadow spread; both branches of `drawShadow`
+- **web** — Canvas2D has no native shadow spread. Both branches of `drawShadow`
   (`web/draw.go`) inflate the source shape to `(x-s, y-s, w+2s, h+2s, rad+s)`,
-  whose native shadow covers the inflated area; the container's own fill (drawn
+  whose native shadow covers the inflated area. The container's own fill (drawn
   next) covers the caster. Coverage-equivalent to the SDF paths per the § 10
-  bar; not pixel-recorded (canvas backend has no pixel harness).
+  bar. Not pixel-recorded (canvas backend has no pixel harness).
 
 Transport decision, recorded for 5b: the spread reaches the GPU shaders through
 the **existing `tm` uniform** (`tm[14]`), not through the packed vertex params
-(`PackParams`, 2 × 12 bits in one float32) — three packed slots would need 36
-bits against float32's 24-bit mantissa and cannot be exact. `tm` already carries
-the caster offset, so no new uniform or vertex attribute was added on any
-backend.
+(`PackParams`, 2 × 12 bits in one float32) — three packed slots need 36 bits
+against float32's 24-bit mantissa and cannot be exact. `tm` already carries the
+caster offset, so no new uniform or vertex attribute was added on any backend.
 
-Phase 5b — focus-ring checklist. The ring rides the 5a plumbing; nothing in a
+Phase 5b — focus-ring checklist. The ring rides the 5a plumbing. Nothing in a
 backend changed. What had to be true, and how each was pinned:
 
 1. **The defaults carry a ring.** `baseDarkCfg` and the light preset set
    `FocusRing` = accent at 25% alpha (`WithOpacity(0.25)`, so the RGB is the
    single accent decision), `BlurRadius: 2`, no spread — a spread-free glow by
-   design (§ 5.4: a spread would add a crisp plateau that reads as a second
-   border, and a scissored edge loses only a faint tail, not a hard band). The
-   derived presets (no-padding, bordered) inherit it by cfg copy; macOS keeps
-   its own ring and GNOME/Windows stay nil (border recolor only). Pinned by
+   design (§ 5.4: a spread adds a crisp plateau that reads as a second border,
+   and a scissored edge loses only a faint tail, not a hard band). The derived
+   presets (no-padding, bordered) inherit it by cfg copy. macOS keeps its own
+   ring and GNOME/Windows stay nil (border recolor only). Pinned by
    `TestThemePresetElevationValues` (per-preset ring pointer) and
    `TestFocusRingDefaultsCarryARing`.
 2. **Every focusable that has no ring gets one.** `Combobox`, `DatePicker`,
    `InputDate`, `Tree`, `NumericInput` swap their inline border-recolor
    `AmendLayout` for `focusRingAmend` (same recolor plus the ring, keyed by
-   effective ID); `Radio`, `Switch`, `Toggle`, `Slider` compose
+   effective ID). `Radio`, `Switch`, `Toggle`, `Slider` compose
    `focusRingAmend(Color{}, Color{})` after their own hooks — ring shadow on the
    focusable row, per-state pill/track colors untouched. `RadioButtonGroup` has
    no focusable shape of its own (focus governs the options), so its `Radio`s
@@ -812,21 +809,21 @@ backend changed. What had to be true, and how each was pinned:
    transparent-fill, borderless shape carrying a ring shadow (the light table
    body, whose preset resolves `Color` transparent and `SizeBorder` 0) was
    pruned before `renderContainer` ran and the ring silently vanished. The prune
-   now counts `fx.Shadow`; the focus goldens re-recorded in both themes are the
+   now counts `fx.Shadow`. The focus goldens re-recorded in both themes are the
    pin.
 4. **Focused goldens, re-recorded in both themes after reading the diff.**
    `listbox_focused`, `select_focused`, `expand_panel_focused`, `table_focused`
    (8 files) each gained exactly one `Shadow` line (`blur=2.00`, no spread,
-   `#4d82f03f` dark / `#2f6fe03f` light) with no other geometry change;
+   `#4d82f03f` dark / `#2f6fe03f` light) with no other geometry change.
    `menu_open_descender` and the unfocused cases were unchanged. New in 5b per
    the § 10 table: `input_focused` (dark + light).
 5. **Pixel golden across the platform overrides.** New `switch_focused` case
    under dark, light, macos-dark, gnome-dark and windows-dark — the switch is
    the focusable whose geometry the macOS theme also overrides (38×22). Sampled
-   pixels confirm: dark/light show the soft accent glow hugging the pill, macOS
+   pixels verify: dark/light show the soft accent glow hugging the pill, macOS
    its own soft glow, GNOME/Windows no glow and only the pill's border recolor.
 6. **The nil contract changed with intent.** `focusRingAmend` used to return nil
-   when both colors were unset; a ring-bearing theme now justifies the hook by
+   when both colors were unset. A ring-bearing theme now justifies the hook by
    itself. `focus_ring_test.go` pins both regimes (ringless theme → nil, ringed
    → ring-only hook).
 
@@ -837,8 +834,8 @@ done until the docs say the same thing:
   one-primary-per-surface convention, the new ladders.
 - `README.md` — screenshots re-taken.
 - `CHANGELOG.md` — a breaking-change entry naming the six removed preset names.
-- `examples/` — 93 files call `WithBorders(true)` (111 call sites); borders are
-  the default, so these are no-ops and should be deleted in the same sweep. Any
+- `examples/` — 93 files call `WithBorders(true)` (111 call sites). Borders are
+  the default, so these are no-ops and are deleted in the same sweep. Any
   example naming a removed preset must be repointed.
 - Per-example READMEs that show screenshots.
 
@@ -846,7 +843,7 @@ done until the docs say the same thing:
 
 - **Preset removal (§ 7, phase 8)** — the six names are unregistered and their
   builders deleted, per the § 7 table, with one table correction: `light` is
-  still borderless (`baseCfg` states no `SizeBorder`; only `baseDarkCfg` sets
+  still borderless (`baseCfg` states no `SizeBorder`. Only `baseDarkCfg` sets
   it), so `light-bordered` was **not** a duplicate — it was
   `ThemeLight.WithBorders(true)`, and that call is the migration. The registry
   holds eight: dark, light, and the three platform pairs, which stay because
@@ -857,27 +854,27 @@ done until the docs say the same thing:
   carry shadows), so `TestPresetThemesCarryNoElevation` was deleted and the
   flat-vs-elevated dropdown pair test now builds its flat subject from a bare
   `baseCfg()` — the same material the taste presets were made of. `ThemeGet` on
-  a removed name misses; the change is breaking and is called out in
+  a removed name misses. The change is breaking and is called out in
   `CHANGELOG.md` under Unreleased → Removed.
 - **Progress readout placement and boolean sizes (§ 8, phase 7)** — the readout
-  trails the bar at `SpacingSmall` in `TextStyleSecondary`, outside the fill;
+  trails the bar at `SpacingSmall` in `TextStyleSecondary`, outside the fill.
   `progressBarCenterLabel` and the readout's `opticalCenterText` amend are
   deleted. The widget restructured: the outer row owns identity, sizing and
-  a11y; the track (caller's `Width`, track color, radius) is its first child
+  a11y. The track (caller's `Width`, track color, radius) is its first child
   with the fill as the track's only child. The amend math moved with the
   structure: the fill is sized from the track's laid-out box — using the outer's
-  width would shrink the fill by the readout's share and spill it past the
-  track. The track takes `Sizing: FillFit` so a `FillFit` bar still absorbs the
-  leftover; the stated `Width` stays its floor when the outer fits content. One
+  width shrinks the fill by the readout's share and spills it past the track.
+  The track takes `Sizing: FillFit` so a `FillFit` bar still absorbs the
+  leftover. The stated `Width` stays its floor when the outer fits content. One
   seam needed a guard: in a vertical bar the column's cross-axis fill pass
   stretches the `FillFit` track to the column's width, which grows to fit the
   readout — so a vertical track whose caller did not ask for a fill-width bar is
   capped at its stated width (`MaxWidth`), keeping `Width: 12` a 12-px bar with
   the readout below it. The default readout style is now the theme's secondary
-  role (`progressBarStyle.TextStyle` moved off the body text); the caller's
+  role (`progressBarStyle.TextStyle` moved off the body text). The caller's
   `TextStyle`/`TextBackground`/`TextPadding` fields still override. The switch
   (36×22 → 34×20), radio (16 → 15) and knob radii retune against the 14px
-  ladder; `ToggleStyle.Size` was already `ts.Size + 4`, so the toggle did not
+  ladder. `ToggleStyle.Size` was already `ts.Size + 4`, so the toggle did not
   move. GNOME (40×24), Windows (40×20) and macOS (38×22) keep their switch
   overrides untouched — the platform seam § 8 exists to exercise. Pixel
   evidence: `switch_focused.dark` re-recorded for the new pill and knob, the
@@ -890,10 +887,10 @@ done until the docs say the same thing:
   the spec first specified. The redesign came from the clip pass: the glow is
   drawn outside the control's bounds but clipped to `shapeBounds ∩ parentClip`,
   so a control against its parent's content edge loses the glow tail there — a
-  spread ring would lose a hard band, a glow loses only a faint tail, and
+  spread ring loses a hard band, a glow loses only a faint tail, and
   `ColorBorderFocus` stays the never-clipped indicator (a draw-outset the
-  ancestors' clips can honour is the tracked fix). macOS keeps its hand-tuned
-  ring (accent-tinted soft glow); GNOME and Windows deliberately stay nil
+  ancestors' clips can honor is the tracked fix). macOS keeps its hand-tuned
+  ring (accent-tinted soft glow). GNOME and Windows deliberately stay nil
   (border recolor only, documented at their cfg sites). The small controls —
   `Radio`, `Switch`, `Toggle`, `Slider` — put the glow on the focusable row and
   keep their per-state pill/track colors untouched: the glow is the row's focus
@@ -901,10 +898,9 @@ done until the docs say the same thing:
   the state recolor. `RadioButtonGroup` wires nothing itself — its `Radio`
   options carry the ring. `focusRingAmend(Color{}, Color{})` is now a valid
   request under a ring-bearing theme (the hook's nil contract is "nothing
-  visible would change", not "no colors given"). The render prune fix (shadow
-  counts as FX in `renderShapeInner`) is the one non-wiring change; without it
-  the ring silently vanishes on transparent, borderless shapes (the light table
-  body).
+  visible changes", not "no colors given"). The render prune fix (shadow counts
+  as FX in `renderShapeInner`) is the one non-wiring change. Without it the ring
+  silently vanishes on transparent, borderless shapes (the light table body).
 - **Button variants (§ 6, phase 6)** — `ButtonVariant` with the zero value being
   today's button, and the variant styles `ButtonStylePrimary/Ghost/Danger`
   derived in `ThemeMaker` by copying the base `ButtonStyle` and swapping fills
@@ -914,13 +910,13 @@ done until the docs say the same thing:
   fields read at generation (like `focusRing`), not mirrors, so `applyTheme` and
   the mirror gate are untouched. Label recoloring takes both spec paths:
   `ButtonCfg.Label` builds the text inside `Button` with the variant's color
-  applied; a `Content`-built label is recolored by `buttonAmendLayout` only if
+  applied. A `Content`-built label is recolored by `buttonAmendLayout` only if
   its style carries the new `TextStyle.defaultedColor` marker (set solely by
   `Text` on its `DefaultTextStyle` fallback), which rides along through struct
   copies like `disabledRole` — an explicitly colored label is never overridden.
   The amend color is captured at generation onto `shapeButtonColors` (the
   `focusRing` precedent) because the amend is a plain func with no closure.
-  `TextButton` keeps its signature; `TextButtonVariant` is the Label-path
+  `TextButton` keeps its signature. `TextButtonVariant` is the Label-path
   sibling. Export audit: the type, the four constants and the three Theme fields
   carry `exportaudit:keep` until a sibling consumer lands. Golden coverage: the
   four variants side by side plus the same row focused on the primary — the
@@ -930,8 +926,8 @@ done until the docs say the same thing:
   covers the platform ring overrides. The light theme's borderless buttons
   (pre-existing: `baseCfg` sets no `SizeBorder`) are recorded as-is.
 - **`BoxShadow.Spread`** — add it (§ 5.5). Scope is six backend draw paths, not
-  one field; phase 5a. Transport: `tm[14]` on the existing `tm` uniform (the
-  packed-params float32 cannot hold a third 12-bit slot exactly; see the § 10
+  one field. Phase 5a. Transport: `tm[14]` on the existing `tm` uniform (the
+  packed-params float32 cannot hold a third 12-bit slot exactly. See the § 10
   checklist note). Validation class: finite and non-negative in `validShadowCmd`
   — the same class as `BlurRadius`, which has no gui-level ceiling either
   (`soft` clamps both at 512). Web: the source shape is inflated by spread
@@ -939,54 +935,54 @@ done until the docs say the same thing:
   coverage: a "Spread ring" / "Focus ring" row in the showcase graphics demo and
   a focus-ring card in `examples/shadow_demo`.
 - **Platform themes** — the six stay registered (§ 7). Eight preset names total.
-- **Tab label weight (§ 2.2)** — the selected tab takes `B3`; resting tab labels
+- **Tab label weight (§ 2.2)** — the selected tab takes `B3`. Resting tab labels
   stay `N3`. The strip keeps its quiet by default and gains hierarchy only where
   the eye already points.
 - **Pixel-harness platform coverage (§ 10)** — a per-case `themes` list, not a
   global six-theme recording: the one representative case (a form row and a
-  button row) records under dark, light and the three dark platform themes;
-  every other case keeps the dark/light pair.
+  button row) records under dark, light and the three dark platform themes.
+  Every other case keeps the dark/light pair.
 - **Body size** — phase 2 ships the spec table (dark/light 14, macOS 13, Windows
   12, GNOME 15). The 14-vs-13 check on a non-HiDPI display is still open
-  (deferred question 1); if 13 wins, the dark/light ladder shifts one step and
+  (deferred question 1). If 13 wins, the dark/light ladder shifts one step and
   phases 2–3 goldens re-record before phase 4.
 - **Markdown block gap** — `MarkdownStyle.blockSpacing` moves from
   `SpacingLarge` to `SpacingMedium`. Under the phase-2 ladder Large went 15 →
   28, and a markdown document is a stack of paragraphs, not a stack of unrelated
-  sections; at body 14 the 28px gap reads as a hole. The extra spacer emitted
+  sections. At body 14 the 28px gap reads as a hole. The extra spacer emitted
   after a closing blockquote drops to `blockSpacing / 2`, since that spacer is
   itself a child and so carries a block gap on each side (a full-height one
   totalled three gaps, ~84px).
 
 - **`colorPickerMinPlane`** — 120 → 112 (view_color_picker.go). The refreshed
   spacing ladder drops the picker's derived plane to 118, tripping the old floor
-  and breaking the picker's row-width invariant; the floor is degenerate-theme
+  and breaking the picker's row-width invariant. The floor is degenerate-theme
   protection, so it now sits under the default derivation.
 - **Body size** — 14 ships (deferred question 1, answered): the non-HiDPI check
-  stays owed but no longer blocks; a later shift re-records phases 2–3 goldens.
+  stays owed but no longer blocks. A later shift re-records phases 2–3 goldens.
 - **Selection fill (deferred question 2)** — subtle + ring: selected and
   highlighted rows paint `ColorAccentSubtle` in every focus state, and their
   text stays the body color. Focus is the ring (phase 5b), never a second fill.
   Menus keep the full accent on their selected item. No focus-state plumbing in
   row renderers.
 - **Light semantic colors** — success `#2E9E5B`, warning `#B07E1F`, error
-  `#D64545`; dark keeps its existing error and the historic toast/badge
+  `#D64545`. Dark keeps its existing error and the historic toast/badge
   success/warning values (moved from ThemeMaker literals into the preset consts,
   with the literals kept as the unset fallback so unstated themes stay
   byte-identical).
 - **Accent fallback chain** — `ColorAccent` → `ColorSelect` → legacy select
   (`colorSelectDark`). `ColorSelect` defaults to the accent. Platform and taste
-  themes keep their native select, which becomes their accent; their ramps
+  themes keep their native select, which becomes their accent. Their ramps
   derive.
 - **Accent ramp table corrected to the derivation** — the rule in § 4.3 (sRGB
   HSL `L±0.12`) does not reproduce the table's original hover/pressed values
-  (e.g. dark pressed came out `#155AEB`, not `#3A6FD8`), and no clean formula
-  reproduces that table either. The rule is the mechanism the spec chose and is
-  what a custom theme gets, so the table was corrected to what the rule produces
-  (`#85AAF5`/`#155AEB` dark, `#6494E8`/`#1B53B7` light);
+  (for example dark pressed came out `#155AEB`, not `#3A6FD8`), and no clean
+  formula reproduces that table either. The rule is the mechanism the spec chose
+  and is what a custom theme gets, so the table was corrected to what the rule
+  produces (`#85AAF5`/`#155AEB` dark, `#6494E8`/`#1B53B7` light).
   `TestThemeMakerAccentRamp` pins both.
 - **List rows drop `ColorTextOnSelect`** — with selection on the subtle tint,
-  the paired foreground no longer applies to list-like rows; the accent/text
+  the paired foreground no longer applies to list-like rows. The accent/text
   pairing survives in menus and the full-accent fills (slider fill, selected
   tab, radio, switch). The five pairing tests were updated to pin body text on
   washed rows, and the now-dead widget- and style-level `ColorTextOnSelect`
@@ -1007,14 +1003,14 @@ done until the docs say the same thing:
   when the ladder moved, so nothing needed demoting to `RadiusMedium`: the only
   derived site is the toggle's `radiusLarge * 2` pill, which clamps at
   half-height identically at 15 and 24. macOS dropped its radius override
-  entirely (Large went 10 → 12 by inheritance; the spec's "if that theme drops
+  entirely (Large went 10 → 12 by inheritance. The spec's "if that theme drops
   its override" branch was taken), GNOME's overrides were byte-identical to the
   new base and dropped as redundant, and Windows keeps its native
   `RadiusLarge = 8`. The base ladder is now one number set everywhere a platform
   does not override.
 - **Elevation in dark/light (§ 5.3)** — `darkShadowPopover`/`darkShadowDialog`
   and `lightShadowPopover`/`lightShadowDialog` follow the platform themes' const
-  pattern; `baseDarkCfg` and `themeLightCfg` wire them, so the derived presets
+  pattern. `baseDarkCfg` and `themeLightCfg` wire them, so the derived presets
   (no-padding, bordered) inherit elevation as dark/light's visual twins. The
   blue taste preset stays flat. Fan-out unchanged: popover tier on
   select/combobox/date-picker/tooltip/toast/menubar-submenu, dialog tier on
@@ -1026,7 +1022,7 @@ done until the docs say the same thing:
 ## Deferred questions
 
 1. **Body size 14 vs 13** — decided at phase 3: 14 ships (see decisions). The
-   non-HiDPI render check is still owed; if 13 wins there, the dark/light ladder
+   non-HiDPI render check is still owed. If 13 wins there, the dark/light ladder
    shifts one step and phases 2–3 goldens re-record before phase 4.
 2. **Selection fill vs `ColorAccentSubtle`** — decided at phase 3: subtle + ring
    (see decisions).
@@ -1034,5 +1030,5 @@ done until the docs say the same thing:
    `assets/showcase.png`, `assets/gallery.png`, `todo.png`, `digital-rain.png`,
    `benchmark.png`, `calculator.png`, `inspector.png` and any per-example README
    images still show pre-refresh pixels (borderless, old radii, centered
-   progress readout). Re-taking needs a human at a display running each app;
-   nothing in the repo captures them. Do it as a drive-by after phase 8 lands.
+   progress readout). Re-taking needs a human at a display running each app.
+   Nothing in the repo captures them. Do it as a drive-by after phase 8 lands.

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -1,10 +1,10 @@
 # Spec: per-scope uniqueness (framework-computed effective IDs)
 
-Status: **implemented** (phases A, B and C). Written 2026-08-09; revised after
+Status: **implemented** (phases A, B and C). Written 2026-08-09. Revised after
 review (round 2: generation-time scope for widget state, datagrid exception,
-migration-list gaps); implemented 2026-08-09. Source: "Remaining work" in
+migration-list gaps). Implemented 2026-08-09. Source: "Remaining work" in
 [`widget-id-scoping.md`](widget-id-scoping.md). Target: major version (semantic
-break; signatures unchanged).
+break, signatures unchanged).
 
 ## What shipped, and where it differs from this spec
 
@@ -17,13 +17,13 @@ implementation, and the code is the authority.
    injected overlay (toast, dialog, inspector) is resolved separately as its own
    root. Consequence: a float written inside an ID-bearing panel — a combobox
    dropdown, a popover — **keeps that panel's scope**, where the "each float is
-   its own pipeline root with an empty scope" rule would have stripped it. That
-   rule was a consequence of _where_ the pass ran, not a goal, and keeping the
-   scope is strictly better: it removes a class of cross-panel collision, and it
-   lets the generation-time scope and the pass agree with no float special case
-   (a widget cannot know its shape is a float before it builds it). Injected
-   overlays still start from an empty scope, so the spec's statement about
-   tooltips and menus injected from outside the tree holds.
+   its own pipeline root with an empty scope" rule strips it. That rule was a
+   consequence of _where_ the pass ran, not a goal, and keeping the scope is
+   strictly better: it removes a class of cross-panel collision, and it lets the
+   generation-time scope and the pass agree with no float special case (a widget
+   cannot know its shape is a float before it builds it). Injected overlays
+   still start from an empty scope, so the spec's statement about tooltips and
+   menus injected from outside the tree holds.
 2. **`EventCtx.EffID` was added.** Decision 7 assumed a stateful widget always
    has a `*Window` while it composes. Several do not: `Input`, `Slider`,
    `Splitter`, `ProgressBar`, `Skeleton` and `Scrollbar` build their trees in
@@ -39,7 +39,7 @@ implementation, and the code is the authority.
    ergonomics-audit mode.** "Has no ID-bearing ancestor" is a property of the
    composed tree, which the AST does not have. It is `gui.DebugUnscopedIDs`,
    deliberately **outside** `DebugAll` — it reports a design property, not a
-   defect, and would fire on most widgets in a small app. Enable it with
+   defect, and fires on most widgets in a small app. Enable it with
    `gui.DebugCategories(gui.DebugUnscopedIDs)`.
 
 Phase A.4 (producer simplification) was applied where a composite's own nesting
@@ -54,7 +54,7 @@ decided below.
 one allocation per ID-bearing widget per frame, measured on `BenchmarkViewFrame`
 as 202 → 252 allocs/op (rows_50) and 802 → 1002 (rows_200) — exactly +1 per row.
 `(*Window).joinLeaf` memoizes `(scope, leaf) → joined` in a bounded map shared
-by both paths, which puts every one of those numbers back on its baseline;
+by both paths, which puts every one of those numbers back on its baseline.
 `TestJoinLeafCachedIsAllocationFree` gates it. A hit is always correct and an
 eviction only recomputes, because the key is identity, not position — the
 objection to a positional cache never applied here.
@@ -63,10 +63,10 @@ One cost remains and cannot be cached away: `effID` moved `Shape` from 280 to
 296 bytes, across a size-class boundary (288 → 320), so every shape allocates 32
 bytes more. On an 11k-shape frame that is ~355 KB of extra transient garbage.
 `focusOwner` is resolved **in place** rather than in a second field to avoid
-paying that again — a second string would leave only 8 bytes of headroom before
-the next size class.
+paying that again — a second string leaves only 8 bytes of headroom before the
+next size class.
 
-One behavioural detail worth recording: `a11yLabel` now announces only the last
+One behavioral detail worth recording: `a11yLabel` now announces only the last
 segment when it falls back to an ID. The fallback is a widget ID, IDs are now
 paths, and a screen reader must hear `name`, not `settings:name`. An explicit
 `A11YLabel` is never touched.
@@ -117,7 +117,7 @@ identity:
 
 ## Invariant
 
-**Effective identity** (`effID`) is window-unique. **Leaf** `Shape.ID` may
+**Effective identity** (`effID`) is window-unique. **Leaf** `Shape.ID` can
 repeat across scopes.
 
 ```
@@ -133,7 +133,7 @@ Rules:
 
 - **ID-bearing** means non-empty `Shape.ID`. Join only on those ancestors. Never
   position, never count.
-- ID-less ancestors add no scope. Children under them stay flat; collisions stay
+- ID-less ancestors add no scope. Children under them stay flat. Collisions stay
   loud, as today.
 - An absolute ancestor still contributes its full `effID` as the join prefix:
   leaf `"name"` under `"app:settings"` → `"app:settings:name"`.
@@ -156,7 +156,7 @@ These supersede parent Decisions 1–2 for identity resolution. The `:` grammar
 and no-escaping rules stay.
 
 This is **not** a widget-side ID stack inside `GenerateLayout`. Widget factories
-still set leaf `Shape.ID` (plain or absolute); scope is the framework's job. A
+still set leaf `Shape.ID` (plain or absolute). Scope is the framework's job. A
 post-build resolve pass stamps `effID` before any ID-keyed store or match that
 runs after layout generation. Widget-internal state read **during**
 `GenerateLayout` cannot wait for that pass — Decision 7 gives widgets their
@@ -173,17 +173,17 @@ scope at generation time instead.
    after an ancestor gains an ID must pass the full path (or keep composing with
    `ScopeID` and rely on the absolute escape). This is a **semantic** API break
    on a major version.
-3. **`Shape.ID` is the leaf; `Shape.effID` is the resolved path.** New
+3. **`Shape.ID` is the leaf. `Shape.effID` is the resolved path.** New
    unexported field. Do not rewrite `ID` in the pass — that breaks debug paths
    and mid-frame reads that still mean the leaf.
 4. **No bare global leaf under an ID'd ancestor.** Answer to the opt-out
-   question: the `:` absolute form is sufficient; a separate opt-out is not.
+   question: the `:` absolute form is sufficient. A separate opt-out is not.
 5. **Hero stays identity-keyed.** Same leaf under different ancestor IDs does
    **not** hero-match across a transition. Apps that need a shared hero key must
    use the same absolute (`:`-bearing) ID on both sides, or share an ID-bearing
    ancestor path.
 6. **`focusOwner` / `focusKey` resolve to `effID`.** Today `focusOwner` is a
-   string copy of the owner's leaf ID; `focusKey()` returns that string or
+   string copy of the owner's leaf ID. `focusKey()` returns that string or
    `s.ID`. After stores key on `effID`, that leaf string is wrong under a scoped
    ancestor (`"name"` vs `"settings:name"`). The resolve pass (or `focusKey`)
    must return the **owner's `effID`**. Preferred: stamp an unexported owner
@@ -195,10 +195,10 @@ scope at generation time instead.
    select, tree / sidebar / listbox state, …) cannot wait for the resolve pass —
    their tree shape depends on the read. `generateViewLayout` maintains a
    framework-side scope: before recursing into a child it pushes the child's
-   `effID`; `w.EffID(leaf)` joins the current scope with the leaf (absolute `:`
+   `effID`. `w.EffID(leaf)` joins the current scope with the leaf (absolute `:`
    leaves pass through unchanged). Stateful widgets key every `ns*` map on
    `w.EffID(cfg.ID)`, reads and writes alike (event handlers close the key over
-   at generation; it stays valid while ancestor IDs do). The float boundary
+   at generation. It stays valid while ancestor IDs do). The float boundary
    resets scope to `""` at each float root during generation, matching the
    resolve pass. One `resolveLeaf(scope, leaf)` helper implements both paths so
    they cannot drift. Cost: one `:`-join per stateful widget per frame — Phase
@@ -211,7 +211,7 @@ scope at generation time instead.
 | `Panel{ID:"settings"}` → `Input{ID:"name"}`               | `settings`, `name` | `settings`, `settings:name`                      |
 | Two such panels (`settings` / `profile`)                  | same leaves        | `settings:name` vs `profile:name` — no collision |
 | ID-less `Column` → two `Input{ID:"name"}`                 | `name`, `name`     | both `name` — loud collision, as today           |
-| `Input{ID: ScopeID("grid","row","1")}` under any ancestor | `grid:row:1`       | `grid:row:1` (absolute; no further join)         |
+| `Input{ID: ScopeID("grid","row","1")}` under any ancestor | `grid:row:1`       | `grid:row:1` (absolute, no further join)         |
 
 ### Producer simplification is load-bearing
 
@@ -261,9 +261,9 @@ and row keys (`ScopeID(cfg.ID, "row", rowID)`) and the scroll child
 two grids with the same `cfg.ID` under different ID'd panels **still collide on
 every child ID** — the composability win does not extend to datagrid, and the
 children must stay absolute because the reverse parse requires it. The grid
-root's own leaf becomes `panel:grid`; audit its leaf-ID consumers
+root's own leaf becomes `panel:grid`. Audit its leaf-ID consumers
 (`FindByID(cfg.ID)`, `IsFocus(cfg.ID)`, reverse-parse callers) as migration
-work. A future per-grid prefix fix would parse against the grid's `effID`.
+work. A future per-grid prefix fix parses against the grid's `effID`.
 
 **Dock is the second deliberate absolute composite, for the opposite reason.** A
 dock group container takes `ScopeID(dockID, node.ID)` and a dock splitter takes
@@ -273,10 +273,10 @@ tree changes on every drop, and the group scopes the panel content inside it, so
 a position-derived group ID re-keys every widget in the panel — its scroll
 offset, its focus, its input state — whenever anything else in the dock moves
 (issue #389). The dock's own ID is resolved (`w.EffID(cfg.ID)`), so the composed
-ID still carries the surrounding scope; what it does not carry is the splitter
+ID still carries the surrounding scope. What it does not carry is the splitter
 path. Node IDs minted by `dockTreeSplitAt` / `dockTreeWrapRoot` join with `-`,
 not `IDSep`: a node ID is tree data fed into `ScopeID` as a **part**, and an
-`IDSep` in a part would make the composed leaf absolute in the wrong way —
+`IDSep` in a part makes the composed leaf absolute in the wrong way —
 window-global, outside the dock scope.
 
 ## Resolution pass
@@ -322,14 +322,14 @@ one commit each with a test:
 - **`reservedDialogID`:** keep comparing the **leaf** sentinel
   (`"___dialog_reserved_do_not_use___"`). Dialogs are separate float roots, so
   leaf and `effID` stay equal under empty scope. Do not fold this into the
-  FindByID migration; optionally make the constant absolute later if dialogs
+  FindByID migration. Optionally make the constant absolute later if dialogs
   ever nest under ID'd ancestors in the same tree.
 - **Also migrate** any widget code that compares `cfg.ID` or `Shape.ID` to the
   focus / scroll / hover / StateMap store (`IsFocus`, focus paint, input-state,
   spell-check). After the change those stores hold `effID`. "Already a full path
   string" is not enough once producers emit plain leaves. Fix `focusKey()` per
   Decision 6 so Input's inner text keeps working. Note the `AmendLayout`
-  `IsFocus` call sites that pass the leaf today — e.g. the combobox's
+  `IsFocus` call sites that pass the leaf today — for example the combobox's
   `AmendLayout` uses `ctx.Layout.Shape.ID` (`gui/view_combobox.go`) — they
   become `effID` (or `w.EffID`).
 
@@ -338,20 +338,20 @@ one commit each with a test:
 ### Phase A — per-scope uniqueness
 
 1. Land this spec (done as draft).
-2. Add `effID` + `resolveShapeIDs`; call it first in every `layoutPipeline`
+2. Add `effID` + `resolveShapeIDs`. Call it first in every `layoutPipeline`
    (main + floats). Implement Decision 6 (`focusKey` → owner `effID`) and
    Decision 7 (generation-time scope, `w.EffID`, shared `resolveLeaf`).
-3. Migrate stores/matches as above (including StateMap — post-layout keys to
-   `effID`, `GenerateLayout`-time keys to `w.EffID`; exclude `reservedDialogID`
+3. Migrate stores/matches as above (including StateMap: post-layout keys to
+   `effID`, `GenerateLayout`-time keys to `w.EffID`. Exclude `reservedDialogID`
    leaf sentinel).
 4. **Required before the composability claim:** simplify every nesting-mirroring
    `ScopeID(cfg.ID, part)` producer to a plain leaf. Leave absolute leaves that
    cannot simplify. Until this lands, two instances of the same composite under
    different ID'd panels still collide on absolute children.
-5. Ergoaudit `ids` mode: warn on state-keyed shapes (focusable / scrollable /
-   stateful) with a plain leaf and no ID-bearing ancestor (still globally
-   competing).
-6. Docs: CLAUDE.md Focus section; parent Remaining work pointer; showcase
+5. ergonomics-audit `ids` mode: warn on state-keyed shapes (focusable /
+   scrollable / stateful) with a plain leaf and no ID-bearing ancestor (still
+   globally competing).
+6. Docs: CLAUDE.md Focus section, parent Remaining work pointer, showcase
    regression. Showcase win requires ID-bearing demo/panel ancestors.
 
 ### Phase B — hero
@@ -364,14 +364,14 @@ different ancestor IDs do not match (Decision 5).
 ### Phase C — ID caching
 
 The positional-cache objection dissolves: a cross-frame memo keyed by
-**(ownerEffectiveID, leafID) → string** is identity-keyed. Eviction recomputes;
-it never hands the wrong ID to the wrong row. The memo lives on `Window` and is
+**(ownerEffectiveID, leafID) → string** is identity-keyed. Eviction recomputes.
+It never hands the wrong ID to the wrong row. The memo lives on `Window` and is
 shared with Decision 7's generation-time joins — same key, same pure function,
 so a miss recomputes identically.
 
 1. Benchmark two frames (allocs/op + ns/op): (a) today's absolute datagrid path
-   — Phase A adds nothing for `:` leaves; (b) a scoped-panel tree after Phase
-   A.4, where joins run inside `resolveShapeIDs`; (c) a stateful-widget tree
+   — Phase A adds nothing for `:` leaves. (b) A scoped-panel tree after Phase
+   A.4, where joins run inside `resolveShapeIDs`. (c) A stateful-widget tree
    (combobox-style), where Decision 7 joins run during `GenerateLayout`. Closing
    "no cache" on (a) alone is wrong once (b) and (c) exist.
 2. If (b) or (c) shows: bounded (LRU) memo in the resolve pass **and** the
@@ -382,24 +382,24 @@ so a miss recomputes identically.
 
 | Parent                                                      | This spec                                                                                                                                                         |
 | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Decision 1: helper only; containers do not push a namespace | Superseded for plain leaves under ID-bearing ancestors — via post-build resolve plus a framework-side generation-time scope (Decision 7), not a widget-side stack |
-| Decision 2: flat window-global strings; per-scope deferred  | Effective IDs stay flat strings; uniqueness is on `effID`; leaf reuse across scopes is allowed                                                                    |
-| Grammar / no escaping / `ScopeID`                           | Unchanged; absolute leaves are today's composed strings                                                                                                           |
+| Decision 1: helper only, containers do not push a namespace | Superseded for plain leaves under ID-bearing ancestors — via post-build resolve plus a framework-side generation-time scope (Decision 7), not a widget-side stack |
+| Decision 2: flat window-global strings, per-scope deferred  | Effective IDs stay flat strings. Uniqueness is on `effID`. Leaf reuse across scopes is allowed                                                                    |
+| Grammar / no escaping / `ScopeID`                           | Unchanged. Absolute leaves are today's composed strings                                                                                                           |
 
 ## Closed questions
 
 1. **Version:** major. Semantic break for callers that pass leaf IDs into public
    APIs once ancestors are ID'd.
 2. **`effID` field:** new unexported field. Do not rewrite `ID`.
-3. **Opt-out:** no separate opt-out. `:` means absolute; plain leaf under an
+3. **Opt-out:** no separate opt-out. `:` means absolute. A plain leaf under an
    ID'd ancestor always joins.
 4. **`focusOwner`:** resolve to owner's `effID` (Decision 6). Preferred stamp
-   during resolve or `*Shape` reference; bare leaf `focusKey` is invalid after
+   during resolve or `*Shape` reference. Bare leaf `focusKey` is invalid after
    stores migrate.
 5. **Widget-state keys read during `GenerateLayout`:** migrate to
    `w.EffID(cfg.ID)` (Decision 7) — the resolve pass alone cannot serve reads
    that happen before it.
-6. **Datagrid:** stays a permanent absolute-leaf exception; the composability
+6. **Datagrid:** stays a permanent absolute-leaf exception. The composability
    claim explicitly excludes it until a per-grid `effID`-based parse exists.
 7. **Joined vs absolute collision** (`"a:b"` from two spellings): allowed,
-   reported loudly by the duplicate-ID check; no escaping, per parent spec.
+   reported loudly by the duplicate-ID check. No escaping, per parent spec.

--- a/docs/specs/widget-id-scoping.md
+++ b/docs/specs/widget-id-scoping.md
@@ -1,7 +1,7 @@
 # Widget ID scoping
 
 Status: implemented. Written 2026-08-09 after a `GOGUI_DEBUG=1` run of the
-showcase reported 39 duplicate IDs; decided and implemented the same day.
+showcase reported 39 duplicate IDs. Decided and implemented the same day.
 
 ## Problem
 
@@ -18,7 +18,7 @@ rest came from the framework:
 | ----- | ------------------------------------------------------------- |
 | 32    | `Input` put `cfg.ID` on both its container and its inner text |
 | 5     | every markdown paragraph claimed the markdown widget's ID     |
-| 2     | showcase: a constant ID in a loop; a nested widget copy-paste |
+| 2     | showcase: a constant ID in a loop, a nested widget copy-paste |
 
 Both framework causes were fixed first (`Shape.focusOwner` for the first,
 container-owned ID for the second), and the check is available as
@@ -61,7 +61,7 @@ and focus. There is no warning for that, because from the framework's view
 nothing is wrong.
 
 Prior art agrees. Dear ImGui uses an explicit ID stack (`PushID`/`PopID`)
-precisely so loop iterations disambiguate; egui derives an `Id` from the parent
+precisely so loop iterations disambiguate. egui derives an `Id` from the parent
 scope plus a caller-supplied `id_salt`. Both are explicit identity plus a scope,
 not implicit identity.
 
@@ -74,15 +74,15 @@ not implicit identity.
 2. **IDs stay flat, window-global strings.** No public API changed: `SetFocus`,
    `ScrollVerticalTo`, `FindByID` and the test helpers still take the whole
    composed string. Per-scope uniqueness was considered and rejected for now —
-   it would touch `FindByID`, focus traversal, scroll keys, `StateMap` keys and
-   the debug audit, all of which assume a flat namespace.
+   it touches `FindByID`, focus traversal, scroll keys, `StateMap` keys and the
+   debug audit, all of which assume a flat namespace.
 3. **One separator: `:`.** Already dominant, already parsed by the datagrid, and
-   rare in application IDs, which favour `-` and `_`.
+   rare in application IDs, which favor `-` and `_`.
 4. **No escaping.** See below.
 
 ## The grammar
 
-An ID is a `:`-joined path. The _owner_ may itself already be composed — that is
+An ID is a `:`-joined path. The _owner_ can itself already be composed — that is
 how nesting works — and composition is associative:
 
 ```go
@@ -90,7 +90,7 @@ base := gui.ScopeID(cfg.ID, "header", col.ID) // "grid:header:name"
 gui.ScopeID(base, "resize")                   // "grid:header:name:resize"
 ```
 
-`ScopeIDN` appends a numeric last segment without materialising the number as
+`ScopeIDN` appends a numeric last segment without materializing the number as
 its own string, for loop-derived identity:
 
 ```go
@@ -102,7 +102,7 @@ inner IDs — and two of them in one window collide loudly rather than silently.
 
 Both functions cost **exactly one allocation**: the returned string. `ScopeID`
 uses single-expression concatenation for the common arities and an exactly sized
-`strings.Builder` beyond them; the variadic backing array does not escape.
+`strings.Builder` beyond them. The variadic backing array does not escape.
 `gui/id_scope_test.go` asserts this with `testing.AllocsPerRun`, and that test
 is the guard — a future edit that lets `parts` escape shows up there and nowhere
 else.
@@ -119,24 +119,22 @@ escaping, a part must not contain `:`, so parts keep their own spelling:
   (`view_data_grid_crud.go`) row keys
 
 All three flow through `dataGridRowID` into `ScopeID(cfg.ID, "row", rowID)`.
-Rewriting them as `__src:o:5` would make a part contain the separator, producing
+Rewriting them as `__src:o:5` makes a part contain the separator, producing
 `grid:row:__src:o:5` — ambiguous with a real nested scope. Underscore form is
 correct here, not a leftover.
 
 ### Why no escaping
 
-Escaping would break the datagrid's reverse parse.
-`dataGridHeaderColIDFromLayoutID` recovers a column ID by trimming
-`dataGridHeaderPrefix(gridID)` and comparing the remainder verbatim on a
-per-frame hit-test path; an unescape step would add an allocation there.
-Composed IDs are also user-facing — applications pass them to
+Escaping breaks the datagrid's reverse parse. `dataGridHeaderColIDFromLayoutID`
+recovers a column ID by trimming `dataGridHeaderPrefix(gridID)` and comparing
+the remainder verbatim on a per-frame hit-test path. An unescape step adds an
+allocation there. Composed IDs are also user-facing — applications pass them to
 `ScrollVerticalTo`, and they appear in `GOGUI_DEBUG` output and the inspector —
 and `a\:b` is worse to read and worse to type.
 
-The hazard escaping would remove is ambiguity: two different `(owner, parts)`
-tuples composing to the same string. That hazard is exactly a duplicate ID,
-which `debugCheckShape` already reports and `(*Window).TestDuplicateIDs` already
-asserts.
+Escaping removes ambiguity: two different `(owner, parts)` tuples can compose to
+the same string. That hazard is exactly a duplicate ID, which `debugCheckShape`
+already reports and `(*Window).TestDuplicateIDs` already asserts.
 
 ## Enforcement
 
@@ -147,7 +145,7 @@ concatenation or `fmt.Sprintf` that either lands in an ID position — a Cfg
 `...ID` function — or is built off something already named like an ID.
 
 That second rule is the one that earns its keep. The producers are easy to
-migrate; the **consumers** drift. `w.IsFocus(cfg.ID+"_popup")` rebuilds an ID
+migrate. The **consumers** drift. `w.IsFocus(cfg.ID+"_popup")` rebuilds an ID
 the producer has already moved, and it sits in a call argument rather than any
 position the first rule can name. Four such consumers existed, and each broke
 its widget when only the producer was migrated.
@@ -184,10 +182,10 @@ the duplicate audit rather than passing silently.
 supersedes Decisions 1–2 here for identity resolution:
 
 - **Per-scope uniqueness** (shipped) — framework-computed `effID` from
-  ID-bearing ancestors; leaf `Shape.ID` may repeat across scopes; uniqueness
+  ID-bearing ancestors. Leaf `Shape.ID` can repeat across scopes. Uniqueness
   stays on the effective key.
-- **Hero animations** (shipped) — keyed on `effID`; same leaf under different
+- **Hero animations** (shipped) — keyed on `effID`. Same leaf under different
   ancestors does not match (constraint of ID-only join).
 - **Caching composed IDs across frames** (shipped) — the benchmark showed +1
   alloc per widget per frame, so the identity-keyed memo landed
-  (`(*Window).joinLeaf`); a positional cache is still rejected.
+  (`(*Window).joinLeaf`). A positional cache is still rejected.

--- a/docs/specs/widget-visual-consistency-audit.md
+++ b/docs/specs/widget-visual-consistency-audit.md
@@ -6,7 +6,7 @@ so a later reader can check whether the finding still holds.
 
 ## Problem
 
-Nothing in the repo tells an author how a control should look. There is no named
+Nothing in the repo tells an author how a control must look. There is no named
 role for "secondary text", no tier for "the padding a field puts around its
 text", and no rule for where a field's label goes. So every visual decision was
 made independently, at each widget, by whoever wrote it — and the widgets
@@ -86,8 +86,8 @@ This is a stronger finding than the source table above, and it is only visible
 at the renderer: reading `theme_maker.go` suggests tab and breadcrumb agree at
 130, and they do not.
 
-It also means a `TextStyleDisabled` role cannot simply be dropped in. Unifying
-the themed value while `layoutDisables` still halves it leaves tab at half of
+It also means a `TextStyleDisabled` role cannot be dropped in. Unifying the
+themed value while `layoutDisables` still halves it leaves tab at half of
 whatever the role says. The role and the `Disabled` stamp have to be reconciled,
 not just deduplicated.
 
@@ -102,8 +102,8 @@ Input disabled `#2020207f`, placeholder `#20202064` — byte-identical alphas to
 the dark theme, over a base color of `#202020` instead of `#e1e1e1`.
 
 De-emphasis today is a pure alpha, applied without reference to what it is
-blending toward. Alpha 65 over `#e1e1e1` on a dark ground is faint but legible;
-alpha 65 over `#202020` on a light ground is nearly gone. This is the direct
+blending toward. Alpha 65 over `#e1e1e1` on a dark ground is faint but legible.
+Alpha 65 over `#202020` on a light ground is nearly gone. This is the direct
 evidence that a role must be a **per-theme value**, not one derived multiplier.
 
 ### 1.1.2 What the roles did and did not close
@@ -116,8 +116,8 @@ They do not reach widgets that never themed their disabled text at all. `Input`
 is the example: it carries no disabled text style, so `dimAlpha` still halves
 its base color to 127. On the dark theme that is within one step of the role's
 128 and invisible. On the light theme the role is 149, so Input's disabled text
-sits 22 alpha below where the role says it should — the light-theme contrast gap
-of §1.1.1, surviving in the widgets the roles have not reached.
+sits 22 alpha below the role's value — the light-theme contrast gap of §1.1.1,
+surviving in the widgets the roles have not reached.
 
 **Closed by issue #341 — the renderer now asks the theme.** `renderText`
 (`gui/render_text.go`) replaced `dimAlpha` with `w.Theme().disabledTextColor(c)`
@@ -126,7 +126,7 @@ amount, per theme. Every disabled text shape in the package — Input, Select,
 Combobox, ListBox, NumericInput, InputDate, DatePicker, Button, Switch, Toggle,
 Radio, Tree, menu items, plain `Text` — renders at 128 on dark and 149 on light,
 in both the direct-disabled and ancestor-disabled cases, which the per-widget
-sweep the issue originally described could not reach. The verdict on the open
+sweep the issue originally described cannot reach. The verdict on the open
 question: `TextStyleDisabled` **replaces** `dimAlpha` for text. `dimAlpha`
 survives for non-text surfaces — fills, borders, `renderText`'s Bg/Stroke
 colors, and the group-box title eraser.
@@ -164,7 +164,7 @@ The rungs derive from a per-theme body size via `textSizes` (visual-refresh
 
 Three ways to reach a size coexist:
 
-1. **Named handles** — markdown uses the full `B1..B6` ladder; `N3`/`N4`
+1. **Named handles** — markdown uses the full `B1..B6` ladder. `N3`/`N4` appears
    elsewhere. The intended path.
 2. **Raw theme constants** — `guiTheme.sizeTextXSmall` (`gui/inspector.go:161`,
    `gui/inspector_props.go:57,109`).
@@ -188,7 +188,7 @@ Two structural findings:
 
 Eight field widgets have **no `Label` field at all**: `Input`, `Select`,
 `Combobox`, `Slider`, `NumericInput`, `DatePicker`, `InputDate`, `ColorPicker`.
-An app that wants a labelled form builds the label itself, which means every app
+An app that wants a labeled form builds the label itself, which means every app
 invents its own form layout.
 
 Where labels do exist, three unrelated conventions:
@@ -226,7 +226,7 @@ at the const block and in `docs/style-guide.md`:
   giving the tier its first caller inside `gui/`.
 
 `nestIndent` (16) is a structural indent for nested blockquotes and list depths,
-not a gap between siblings; it stays off the ladder and says so in a comment.
+not a gap between siblings. It stays off the ladder and says so in a comment.
 `Theme.PaddingField` remains a separate concept: it sizes a control, the tiers
 size the gaps between them.
 
@@ -234,7 +234,7 @@ size the gaps between them.
 
 21 styles inherit `cfg.SizeBorder`. Two outliers only:
 `gui/view_date_picker_calendar.go:153` uses `SomeF(2)`, ignoring
-`sizeBorderDef = 1.5`; `gui/view_color_swatch.go:53` has its own
+`sizeBorderDef = 1.5`. `gui/view_color_swatch.go:53` has its own
 `colorSwatchBorder = 1`.
 
 Recorded for completeness. No action proposed.
@@ -273,7 +273,7 @@ in the focus system, the user can tab to it, and nothing on screen says so. That
 is an accessibility failure with a styling fix.
 
 The middle rows are a different thing. `Table` has no `Focusable`, no key
-handler and a transparent, borderless outer container; `ExpandPanel`'s header
+handler and a transparent, borderless outer container. `ExpandPanel`'s header
 row has `OnClick` and `OnChar` but never joins the tab order. Giving these a
 focus ring means first designing keyboard navigation for them — a feature, and
 out of scope for a consistency pass. Recording them here as _not focusable_
@@ -323,7 +323,7 @@ and Combobox all on the shared tier, Input still arranged 3px taller.
 The cause was invisible: Input's inner row leaves `SizeBorder` unset, so it
 inherited the theme's container border of 1.5, and a container reserves space
 for its border whether or not the border is painted. That row's border is
-transparent, so 3px of height went to a border nobody could see.
+transparent, so 3px of height went to a border nobody saw.
 
 Only the arranged geometry showed it — the configured paddings were equal and
 the source read as correct. `TestFieldControlsShareHeight` therefore asserts the
@@ -337,13 +337,13 @@ is not a field, and `gui/view_button.go:104-107` documents its choice.
 
 | §   | Axis              | State                                                                               |
 | --- | ----------------- | ----------------------------------------------------------------------------------- |
-| 1   | Dimming           | 7 source values; disabled text renders at 3, over a 2× spread                       |
-| 2   | Type steps        | 3 parallel systems; 1 theme bypass                                                  |
-| 3   | Field labels      | absent on 8 widgets; 3 conventions elsewhere                                        |
-| 4   | Spacing           | 1 tier of 3 unused; ~10 magic values                                                |
-| 5   | Borders           | healthy; 2 outliers                                                                 |
-| 6   | Interaction state | ColorSet on 17/17 interactive widgets; focus missing where a widget cannot take one |
-| 7   | Density           | 5 insets; Input's theme padding dead                                                |
+| 1   | Dimming           | 7 source values, disabled text renders at 3, over a 2× spread                       |
+| 2   | Type steps        | 3 parallel systems, 1 theme bypass                                                  |
+| 3   | Field labels      | absent on 8 widgets, 3 conventions elsewhere                                        |
+| 4   | Spacing           | 1 tier of 3 unused, ~10 magic values                                                |
+| 5   | Borders           | healthy, 2 outliers                                                                 |
+| 6   | Interaction state | ColorSet on 17/17 interactive widgets, focus missing where a widget cannot take one |
+| 7   | Density           | 5 insets, Input's theme padding dead                                                |
 
 The ordering that follows from this is: fix §6 and §7 first (a user sees them),
 then §1 and §3 (an author trips on them), and leave §5 alone.
@@ -360,21 +360,21 @@ opposite conclusion — that disabled text is dimmed once — reached by walking
 widget's `GenerateLayout` output directly. That snapshot is taken _before_
 `layoutDisables` runs, so it does not show what the renderer sees. The golden
 harness caught it. Any future claim in this document about what a widget looks
-like should be recorded, not read.
+like must be recorded, not read.
 
 ## Resolution
 
 What this branch changed, per axis. The measurements above describe the state at
-`b6adf899` and are kept as the "before"; this section is the "after".
+`b6adf899` and are kept as the "before". This section is the "after".
 
 | §   | Axis              | Outcome                                                                                                                |
 | --- | ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 1   | Dimming           | closed — four named roles, per-theme and contrast-matched; disabled text routed through the role at render (#341)      |
+| 1   | Dimming           | closed — four named roles, per-theme and contrast-matched. Disabled text routed through the role at render (#341)      |
 | 2   | Type steps        | mostly — full ladder exported, mono +1 documented, two steps tracked                                                   |
 | 3   | Field labels      | closed — `Label` on all eight, one shared convention                                                                   |
-| 4   | Spacing           | closed — four tiers with stated meanings; the tight values, toast stack, and block/radio-group defaults fold in (#344) |
+| 4   | Spacing           | closed — four tiers with stated meanings. The tight values, toast stack, and block/radio-group defaults fold in (#344) |
 | 5   | Borders           | untouched, by decision                                                                                                 |
-| 6   | Interaction state | closed — `ColorSet` on all 17 interactive widgets (#342); focus rings for the four that could take one                 |
+| 6   | Interaction state | closed — `ColorSet` on all 17 interactive widgets (#342). Focus rings for the four that can take one                   |
 | 7   | Density           | closed — one field-inset tier, two latent bugs fixed                                                                   |
 
 ### Left open

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,20 +1,20 @@
 # Style guide — the when, not the what
 
 Issue #335, steps 3–4. This document is the **when**: which named role a widget
-should read, and when a deviation is allowed. It cites roles, never values.
-Values live in exactly one place — `ThemeMaker` and the `default*Style` mirrors
-— and re-spelling one here would be the second source of truth the audit's other
+must read, and when a deviation is allowed. It cites roles, never values. Values
+live in exactly one place — `ThemeMaker` and the `default*Style` mirrors. If one
+is re-spelled here, it becomes the second source of truth the audit's other
 findings were measured against. If this guide says "secondary text" it means
 `Theme.TextStyleSecondary`, whatever it resolves to in the installed theme.
 
 The gate that enforces these decisions is `ergonomics-audit -mode visual`
-(`make ergonomics-audit`): a literal dimming alpha or type-size step in
+(`make ergonomics-audit`). A literal dimming alpha or type-size step in
 `gui/view_*.go` fails it unless the line carries the marker (§ Deviating).
 
 ## Text — pick the role by what the text _does_
 
 Four roles cover every de-emphasis. Choose by the text's job, not by how quiet
-it should look:
+it looks:
 
 | Role                   | Use when the text…                                                        |
 | ---------------------- | ------------------------------------------------------------------------- |
@@ -24,12 +24,12 @@ it should look:
 | `TextStylePlaceholder` | stands in for a value not yet entered                                     |
 
 Read the role's style directly where the text color is the theme's
-(`ts := guiTheme.TextStyleSecondary`); use `withRoleAlpha(base, role)` where the
-hue is caller-supplied — the channel label on a user-picked color keeps its hue
+(`ts := guiTheme.TextStyleSecondary`). Use `withRoleAlpha(base, role)` where the
+hue is caller-supplied. The channel label on a user-picked color keeps its hue
 and takes only the role's amount of quiet.
 
 Never spell an alpha. An opaque color (`alpha 255`) is not de-emphasis and does
-not need a role; a fade, a ramp or a fill is not text and is covered by the
+not need a role. A fade, a ramp, or a fill is not text and is covered by the
 marker (§ Deviating), not by a role.
 
 ## Type steps — size by named handle, or not at all
@@ -38,27 +38,27 @@ The size ladder is a set of named handles (`N1`..`N6`, `M1`..`M6`, `I1`..`I6`,
 `BI1`..`BI6`, `B1`..`B6`, `Icon1`..`Icon6`). Every rung is exported — an app's
 widget spells the step of the widget beside it instead of guessing. Take a step
 by reading the handle, never by arithmetic on `X.Size`. A `Size ± N` that
-produces a text style is a finding; two tracked exceptions carry the marker (§
+produces a text style is a finding. Two tracked exceptions carry the marker (§
 Deviating).
 
 Naming a step's _floor_ does not resolve the step. `f32Max(X.Size-4, N6.Size)`
-still sizes text by arithmetic; the named rung only bounds the result. The gate
+still sizes text by arithmetic. The named rung only bounds the result. The gate
 reports it either way — it keys on the arithmetic, not on how the bound is
 spelled.
 
 The mono ladder sits +1 above the roman ladder at every rung (`M4` is 13 where
-`N4` is 12): an optical compensation for the mono face, uniform because it is
-the same face at every size. Expect the step when mixing `M`-rungs with
+`N4` is 12). This is an optical compensation for the mono face, uniform because
+it is the same face at every size. Expect the step when mixing `M`-rungs with
 `N`-rungs.
 
 The ladder is derived, not stated: each theme states a **body size** and the six
-rungs come from it (`textSizes`, visual-refresh §2.1). dark/light body 14 (10,
-11, 12, 14, 17, 22); the platform themes carry their platform's native body —
-macOS 13, Windows 12, GNOME 15 — which is what they exist for. A custom theme
-states `TextStyleDef.Size` and gets a complete ladder.
+rungs come from it (`textSizes`, visual-refresh §2.1). The dark/light body
+is 14. The rungs are 10, 11, 12, 14, 17, 22. The platform themes carry their
+platform's native body — macOS 13, Windows 12, GNOME 15 — which is what they
+exist for. A custom theme states `TextStyleDef.Size` and gets a complete ladder.
 
-**Headings take B rungs.** A widget rendering a heading, a group-box title, a
-dialog title, a tab label or a table header names a bold step; body and value
+**Headings take B rungs.** A widget that renders a heading, a group-box title, a
+dialog title, a tab label, or a table header names a bold step. Body and value
 text stays N (visual-refresh §2.2):
 
 | Widget                           | Role               | Rung               |
@@ -74,8 +74,8 @@ Recorded as **staying N**: list and tree subheadings (their hierarchy comes from
 size and color, not weight), breadcrumbs, menu items, field labels, button
 labels, the progress readout.
 
-The only automatic step in the toolkit is a field label: `TextStyleLabel` steps
-its own size, so a labelled form reads correctly without the widget spelling a
+The only automatic step in the toolkit is a field label. `TextStyleLabel` steps
+its own size, so a labeled form reads correctly without the widget spelling a
 number.
 
 Distinguish a type step from geometry. A row height, icon width or splitter
@@ -98,13 +98,13 @@ neither substitutes for the other.
 ## Spacing and insets — the tiers mean relatedness
 
 `SpacingTight` is the gap inside one composite control, between parts that read
-as a single unit (calendar cells, the tab strip, submenu items); `SpacingSmall`
-binds a tightly related pair (a control and its readout); `SpacingMedium`
-separates members of one group; `SpacingLarge` separates sections. Prefer a tier
-over a magic number; a number that bypasses the ladder is a finding on the same
+as a single unit (calendar cells, the tab strip, submenu items). `SpacingSmall`
+binds a tightly related pair (a control and its readout). `SpacingMedium`
+separates members of one group. `SpacingLarge` separates sections. Prefer a tier
+over a magic number. A number that bypasses the ladder is a finding on the same
 basis as a dimming alpha. A structural indent (a nested blockquote, a list
-depth) is not a gap between siblings and stays off the ladder, but must say so
-in a comment.
+depth) is not a gap between siblings and stays off the ladder. A comment must
+say so.
 
 A form control's text inset is `Theme.PaddingField` — that is what makes
 controls in one row share a height. A structural wrapper (a container that
@@ -116,71 +116,73 @@ height.
 
 The radius ladder is `Theme.RadiusSmall` 4 (badges, scrollbar thumbs),
 `Theme.RadiusMedium` 6 (controls), `Theme.RadiusLarge` 12 (dialogs, dropdowns,
-popovers, the tab body) — one number set in the base theme, overridden by a
-platform theme only where the platform actually differs (Windows keeps its
-native large at 8). A floating surface is a style at `RadiusLarge` or higher; a
-control taking `RadiusLarge` is a finding on the same basis as a magic alpha —
-the toggle pill (`radiusLarge * 2`, clamped to a capsule) is the deliberate
-exception. Rounding is never spelled at a call site.
+popovers, the tab body). One number sets it in the base theme. A platform theme
+overrides it only where the platform actually differs (Windows keeps its native
+large at 8). A floating surface is a style at `RadiusLarge` or higher. A control
+taking `RadiusLarge` is a finding on the same basis as a magic alpha. The toggle
+pill (`radiusLarge * 2`, clamped to a capsule) is the deliberate exception.
+Rounding is never spelled at a call site.
 
 Elevation has exactly two tiers (visual-refresh § 5.3): `ShadowPopover` (menus,
 dropdowns, tooltips, toasts) and `ShadowDialog` (dialogs, the command palette),
 both resolved in `ThemeMaker` from `ThemeCfg`. **Elevation goes on floating
-surfaces only** — a panel or card that separates from its neighbours by fill
-value never gets a shadow; a shadow there is solving a contrast problem with the
-wrong tool. `Theme.RadiusLarge` and the two shadow tiers travel together: a
-floating surface carries both.
+surfaces only.** A panel or card that separates from its neighbors by fill value
+never gets a shadow. A shadow there solves a contrast problem with the wrong
+tool. `Theme.RadiusLarge` and the two shadow tiers travel together: a floating
+surface carries both.
 
 ## Vertical centring — correct the ink only where the alphabet allows
 
-A vertically-centred control centres the text's _line box_, which reserves
-descent space the ink may not use, so short descender-free text — digits above
-all — reads high. The correction is `opticalCenterText` (the `AmendLayout` form)
-or `colorFieldPadding` (the padding form); never a local number.
+A vertically-centered control centers the text's _line box_, which reserves
+descent space that the ink does not always use. So short descender-free text —
+digits above all — reads high. The correction is `opticalCenterText` (the
+`AmendLayout` form) or `colorFieldPadding` (the padding form). Never use a local
+number.
 
-Apply it only where **the widget owns the text**: a badge's count, a progress
-bar's percentage, a button or tab label — anything built on `Button` inherits it
-— **or where the widget constrains the alphabet** so nothing can descend: a
-colour channel, a date mask, a numeric field. Text the user types into an
-unconstrained control is not eligible — correcting it drops descender-bearing
-content low, and that is measured, not predicted (issue #346).
+Apply it only where **the widget owns the text**. That includes a badge's count,
+a progress bar's percentage, a button or tab label. Anything built on `Button`
+inherits it. Apply it also where **the widget constrains the alphabet** so
+nothing can descend: a color channel, a date mask, a numeric field. Text the
+user types into an unconstrained control is not eligible. Correcting it drops
+descender-bearing content low, and that is measured, not predicted (issue #346).
 
-A control that **re-labels itself** — a `Select` showing a placeholder until an
-option is chosen — takes `opticalCenterLabelText`: the cap band, whatever the
-label says. Measuring the run there both misses the defect (a descending label's
-ink band already reads low while its cap band rides high) and would step the
-label when the selection changed.
+A control that **re-labels itself** — a `Select` that shows a placeholder until
+an option is chosen — takes `opticalCenterLabelText`. It uses the cap band,
+whatever the label says. Measuring the run there both misses the defect (a
+descending label's ink band already reads low while its cap band rides high) and
+steps the label when the selection changes.
 
 A control in a **list at a regular pitch** — a menu item — takes the cap band
-for a second reason: measuring each run would move a descender-free label while
-leaving its neighbour, and uneven baselines read down the whole list. The same
+for a second reason. Measuring each run moves a descender-free label while
+leaving its neighbor. Uneven baselines read down the whole list. The same
 disagreement between two badges side by side does not.
 
 Which form depends on what the text **is**, and the split is worth learning as
 one rule:
 
-- a **value** — a badge's count, a progress readout — is centred on its own ink;
-- a **label** — a button, tab, menu item, select — on the face's cap band;
+- a **value** — a badge's count, a progress readout — is centered on its own
+  ink.
+- a **label** — a button, tab, menu item, select — on the face's cap band.
 - a **glyph** — an icon, a step triangle, a `×` — always on its own ink, and it
-  says so through its style: the theme's `Icon` rungs carry the mark, and
+  says so through its style. The theme's `Icon` rungs carry the mark, and
   `glyphStyle(ts)` applies it to a symbol drawn in a text face. A glyph child
   inside a cap-band container corrects itself, so an icon button needs nothing
-  at the call site;
+  at the call site.
 - **editable text** takes a content-free band, or none at all.
 
-A digit-only label is the one case that needs saying out loud: figures measure
-shorter than caps, so a widget that knows its label is digits opts into the
+A digit-only label is the one case that needs saying out loud. Figures measure
+shorter than caps. So a widget that knows its label is digits opts into the
 figure band (`ButtonCfg.opticalDigitLabel`, as the date picker's cells do). An
-application cannot — the alphabet is a guarantee only the widget building the
+application cannot — the alphabet is a guarantee only the widget that builds the
 label can make.
 
 Editable text takes the content-free form — `opticalCenterFieldText` as a hook,
-`colorFieldPadding` as padding — because an offset that follows the content
-moves the baseline as the user types. A widget wrapping `Input` opts in with the
-unexported `opticalDigitCenter`, which is what keeps the guarantee the caller's
-to make — and the probe must match the alphabet that guarantee names: the figure
-band for a digit field, the cap band for a hex one. Probing the taller band for
-digits overshoots by as much as leaving them alone. See
+`colorFieldPadding` as padding. An offset that follows the content moves the
+baseline as the user types. A widget that wraps `Input` opts in with the
+unexported `opticalDigitCenter`. That keeps the guarantee the caller's to make.
+The probe must match the alphabet that guarantee names: the figure band for a
+digit field, the cap band for a hex one. Probing the taller band for digits
+overshoots by as much as leaving them alone. See
 `docs/specs/text-optical-centring.md`.
 
 ## Per-state colors — ColorSet, with flat as the exception
@@ -203,27 +205,27 @@ override:
   polarity detected as `textRolesFor` does it. **This is the selection wash.**
   Selected and keyboard-highlighted rows in `ListBox`, `Table`, `DataGrid`,
   `Select`, `Combobox` and the command palette paint `ColorAccentSubtle`, never
-  the full accent — focus is the ring, not a second fill. Text on a subtle row
-  stays the body color; only the full accent fill takes the paired
+  the full accent. Focus is the ring, not a second fill. Text on a subtle row
+  stays the body color. Only the full accent fill takes the paired
   `ColorTextOnAccent` foreground.
 - `ColorTextOnAccent` — white when `srgbLuminance(accent) < 0.45`, black
   otherwise.
 
 `ColorSelect` defaults to `ColorAccent`, and an unstated accent resolves to
-`ColorSelect`, so selection, focus and accent are one decision by default and
-two when a theme needs them apart. A platform theme keeps its native accent by
-stating only its own `ColorSelect`.
+`ColorSelect`. Selection, focus, and accent are one decision by default. They
+are two when a theme needs them apart. A platform theme keeps its native accent
+by stating only its own `ColorSelect`.
 
 `ColorTextOnSelect` — the foreground over the full-accent fills (menu selection,
 the selected tab, the slider fill) — defaults to the same luminance-paired
-color, so a light theme never draws its near-black body text on its blue accent.
-An explicit `ColorTextOnSelect` still wins. The progress bar's percentage is the
-exception: it straddles fill and track, so no single color pairs with both — it
+color. A light theme never draws its near-black body text on its blue accent. An
+explicit `ColorTextOnSelect` still wins. The progress bar's percentage is the
+exception. It straddles fill and track, so no single color pairs with both. It
 keeps the body text, unboxed, and stays secondary.
 
 The semantic colors (`ColorSuccess`, `ColorWarning`, `ColorError`) and their
 `*Subtle` companions follow the same rule — fill + tint, one decision. The
-presets fill all six; a validation message and its field background are meant to
+presets fill all six. A validation message and its field background are meant to
 be one pair (the consumers land with the validation work).
 
 ## Focus rings — the shared helper, not a local stroke
@@ -235,13 +237,13 @@ the same affordance — the divergence the audit's §6 measured.
 
 ## Button variants — one primary per surface
 
-`ButtonPrimary` is the accent-filled call to action; the convention is **one per
-surface**. A row of secondaries with a single primary says where the user should
-land; two primaries compete and say nothing. This is checked in review, not in
-code. `ButtonDanger` is reserved for destructive confirmations and carries the
-same one-per-surface rule. `ButtonGhost` is for actions that must not compete
-with the secondaries beside them — toolbar overflow, a "cancel" that sits next
-to a primary.
+`ButtonPrimary` is the accent-filled call to action. The convention is **one per
+surface**. A row of secondaries with a single primary says where the user lands.
+Two primaries compete and say nothing. This is checked in review, not in code.
+`ButtonDanger` is reserved for destructive confirmations and carries the same
+one-per-surface rule. `ButtonGhost` is for actions that must not compete with
+the secondaries beside them — toolbar overflow, a "cancel" that sits next to a
+primary.
 
 ## Deviating
 
@@ -261,7 +263,7 @@ a new exemption is a decision, not a habit:
 - **Non-text fills** — an alpha that is not de-emphasized text: markdown
   code/blockquote backgrounds, the dock zone preview, a drag ghost, a selection
   highlight, the swatch edge.
-- **Tracked size steps** — two, and both for the same reason: they step from a
+- **Tracked size steps** — two, and both for the same reason. They step from a
   caller-supplied size, which lands anywhere, so no named rung is the one to
   read. The date-picker roller's center-item emphasis
   (`view_date_picker_roller.go`) and the numeric input's step triangle
@@ -269,6 +271,6 @@ a new exemption is a decision, not a habit:
   end, +5 above medium), so no fixed step equals a rung at every size. Both
   bound the result with named rungs.
 
-A new deviation carries the marker **and** a comment naming the reason; the gate
+A new deviation carries the marker **and** a comment naming the reason. The gate
 reports the line as deferred, so the exemption stays visible in every
 `make ergonomics-audit` run. Anything else fails the gate — which is the point.

--- a/docs/subpackage-analysis.md
+++ b/docs/subpackage-analysis.md
@@ -1,19 +1,19 @@
 # Subpackage analysis
 
-June 2026. Evaluated splitting large core subsystems out of the root `gui`
-package into subpackages (`gui/layout/`, `gui/animation/`, etc.).
+June 2026. This analysis evaluated splitting large core subsystems out of the
+root `gui` package into subpackages (`gui/layout/`, `gui/animation/`, and more).
 
 ## Current state
 
 - Root `gui/` package: ~200 non-test .go files at top level (~400 including
   tests)
-- 25 library packages under `gui/` (16 under `backend/`); 82 total in the module
+- 25 library packages under `gui/` (16 under `backend/`). 82 total in the module
   including examples and tools
 - Compile time: 0.28s — not a problem
 - File naming convention: `layout_*.go`, `render_*.go`, `view_*.go`,
   `animation_*.go` — provides grep-level discoverability
 - Existing subpackages: `datagrid`, `markdown`, `svg`, `svg/css`, `highlight`,
-  `audio`, `shader` — leaf subsystems that import `gui` but aren't imported by
+  `audio`, `shader` — leaf subsystems that import `gui` but are not imported by
   it
 
 ## Why core subsystems can't move
@@ -28,7 +28,7 @@ Core types are mutually dependent. Examples:
   `Window`, `Layout`, `Sizing`
 - Layout engine (`layout_arrange.go`) references `Shape`, `Layout`
 - Render engine (`render_layout.go`) walks `Layout` trees and reads shape state
-  (e.g. `Opacity`) that animations mutate
+  (for example `Opacity`) that animations mutate
 
 Moving `Window` to `gui/window` and animation to `gui/animation` creates:
 
@@ -37,8 +37,8 @@ gui/window → gui/animation  (Window embeds animation lifecycle state)
 gui/animation → gui/window  (Animation.Update takes *Window)
 ```
 
-Go forbids import cycles. The single-package design avoids this by design — it's
-not an accident, it's the architecture.
+Go forbids import cycles. The single-package design avoids this by design — it
+is not an accident, it is the architecture.
 
 ### Type coupling
 
@@ -51,9 +51,9 @@ Every subsystem references these types:
 | `Window` | all widgets, event, state, animation                  |
 | `Sizing` | layout, all container widgets, theme                  |
 
-These form the trunk of the dependency tree. Moving them out doesn't reduce
-coupling — it just moves the coupling across package boundaries, which Go
-doesn't allow.
+These form the trunk of the dependency tree. Moving them out does not reduce
+coupling. It moves the coupling across package boundaries, which Go does not
+allow.
 
 ## What could move (but shouldn't)
 
@@ -83,7 +83,7 @@ The existing approach is right:
 
 - Compile times exceed 5s (10× current) AND
 - The slow package is `gui/` (not backend or examples) AND
-- Go tooling can't mitigate (build cache, Go workspaces)
+- Go tooling cannot mitigate (build cache, Go workspaces)
 
 The file prefix convention (`layout_*.go`, `render_*.go`, `view_*.go`,
 `animation_*.go`) provides sufficient discoverability at current scale.

--- a/examples/android_demo/README.md
+++ b/examples/android_demo/README.md
@@ -1,6 +1,6 @@
 # Android Demo
 
-Demonstrates go-gui running on Android via OpenGL ES 3.0.
+Demonstrates go-gui on Android via OpenGL ES 3.0.
 
 ## Prerequisites
 
@@ -38,9 +38,10 @@ Kotlin host:
 
 ## Troubleshooting
 
-- **gomobile not found**: Ensure `$GOPATH/bin` is in `$PATH`
-- **NDK not found**: Set `ANDROID_NDK_HOME` or install via Android Studio SDK
-  Manager
-- **Linker errors**: Verify NDK includes GLES3 headers
+- **gomobile not found**: Make sure that `$GOPATH/bin` is in `$PATH`
+- **NDK not found**: Set `ANDROID_NDK_HOME`. Alternatively, install the NDK
+  through the Android Studio SDK Manager
+- **Linker errors**: Make sure that the NDK includes the GLES3 headers
   (`$NDK/toolchains/llvm/prebuilt/*/sysroot/usr/include/GLES3/`)
-- **Black screen**: Check logcat for `go-gui-gles` tag shader compilation errors
+- **Black screen**: Make sure that logcat shows no shader compilation errors
+  under the `go-gui-gles` tag

--- a/examples/headless_png/README.md
+++ b/examples/headless_png/README.md
@@ -1,6 +1,6 @@
 # headless_png
 
-Renders a window to a PNG with no GPU and no window on screen, using the
+Renders a window to a PNG with no GPU and no window on screen. It uses the
 software rasterizer in `gui/backend/soft`.
 
 ```
@@ -8,14 +8,14 @@ go run ./examples/headless_png/            # writes headless.png
 go run ./examples/headless_png/ shot.png   # writes shot.png
 ```
 
-The window is built exactly as it would be for `backend.Run` — same
-`gui.SimpleWindow`, same view function. `soft.RenderToPNG` runs `OnInit`,
-settles one frame and rasterizes it on the CPU, so the only difference from a
-real run is the last step.
+The window is built exactly as it is for `backend.Run` — the same
+`gui.SimpleWindow`, the same view function. `soft.RenderToPNG` runs `OnInit`,
+settles one frame, and rasterizes it on the CPU. The only difference from a real
+run is the last step.
 
 The `2` in `soft.RenderToPNG(w, 2, out)` is the device pixel ratio: `1` gives
 one device pixel per logical pixel, `2` captures at Retina density.
 
 Useful for CI screenshots and pixel-level regression tests. See
-`docs/specs/headless-software-rendering.md` for what the renderer covers; SVG,
+`docs/specs/headless-software-rendering.md` for what the renderer covers. SVG,
 shadow, blur and filter commands are skipped in this phase.

--- a/examples/ios_demo/ios/IOSDemo/README.md
+++ b/examples/ios_demo/ios/IOSDemo/README.md
@@ -4,7 +4,8 @@ Runs go-gui on the iOS Simulator. No Apple Developer account needed.
 
 ## Prerequisites
 
-- macOS with Xcode installed (`xcode-select -p` to verify)
+- macOS with Xcode installed (`xcode-select -p` to make sure that Xcode is
+  installed)
 - At least one iOS simulator runtime (`xcrun simctl list runtimes`)
 
 ## Run
@@ -41,14 +42,14 @@ xcrun simctl launch "iPhone 17 Pro" com.example.IOSDemo
 **"Unable to load simulator devices" or CoreSimulator version mismatch**
 
 Your Xcode and macOS simulator runtime are out of sync. Update macOS (System
-Settings → Software Update) or install a matching simulator runtime in Xcode
-(Settings → Platforms).
+Settings → Software Update). Alternatively, install a matching simulator runtime
+in Xcode (Settings → Platforms).
 
 **"The app couldn't be installed"**
 
-Make sure the simulator is booted before installing.
+Make sure that the simulator is booted before you install the app.
 
 **App launches to a black screen**
 
-The app uses Metal for rendering. Simulators on Apple Silicon support Metal;
-Intel Macs may have limited support.
+The app uses Metal for rendering. Simulators on Apple Silicon support Metal.
+Intel Macs can have limited support.

--- a/examples/markdown/markdown_source.md
+++ b/examples/markdown/markdown_source.md
@@ -6,11 +6,11 @@ for syntax or as a test file for rendering engines.
 ## Text Formatting
 
 Regular paragraph text flows naturally across multiple lines. When you write
-content in Markdown, you don't need to worry about line breaks within a
+content in Markdown, you do not need to worry about line breaks within a
 paragraph---the renderer handles text wrapping automatically. This makes it easy
 to write long-form content without constantly thinking about formatting.
 
-Here's another paragraph to show separation. Paragraphs are separated by blank
+Here is another paragraph to show separation. Paragraphs are separated by blank
 lines. You can use **bold text** for emphasis, _italic text_ for subtle
 emphasis, or _**bold and italic**_ together. You can also use ~~strikethrough~~
 for deleted content and `inline code` for technical terms or commands.
@@ -63,8 +63,7 @@ combine with bold: ++**bold underline**++.
 
 ### Task Lists
 
-- [x] Completed task that has been marked as done by placing an 'x' inside the
-      brackets.
+- [x] Completed task, marked as done with an 'x' inside the brackets.
 - [x] Another finished task demonstrating the checked state, which renders as a
       filled checkbox in most Markdown viewers and platforms that support this
       extension.
@@ -137,7 +136,7 @@ class ShoppingCart:
 
 ### Links
 
-Here's a [link to OpenAI](https://openai.com) inline in text. You can also use
+Here is a [link to OpenAI](https://openai.com) inline in text. You can also use
 [reference-style links](https://example.com "Example Website") that define the
 URL elsewhere in the document, which keeps paragraphs cleaner when you have many
 links.
@@ -198,8 +197,8 @@ The HTML specification is maintained by the W3C. HTMLX is not the same as HTML.
 
 ## Escaping Characters
 
-Use backslashes to display literal characters that would otherwise be
-interpreted as Markdown:
+Use backslashes to display literal characters. Without a backslash, the parser
+interprets them as Markdown:
 
 \*This text is surrounded by literal asterisks\*
 
@@ -296,9 +295,9 @@ done
 
 ## Conclusion
 
-This document has covered all the common Markdown elements you're likely to
-encounter or need in everyday writing. Different Markdown processors may support
-additional features or have slight variations in syntax, so always test your
+This document covers all the common Markdown elements you are likely to
+encounter or need in everyday writing. Different Markdown processors can support
+additional features or have slight variations in syntax. Always test your
 content in the target environment.
 
 For more information, consult the

--- a/examples/process_monitor/README.md
+++ b/examples/process_monitor/README.md
@@ -1,12 +1,13 @@
 # process_monitor
 
-A small live task manager: a filterable process list with flat/tree views,
-sortable columns, and per-process CPU/RAM history charts — built on go-gui's
-immediate-mode pipeline and styled entirely from the standard theme tokens.
+A small live task manager: a filterable process list, flat and tree views,
+sortable columns, and per-process CPU/RAM history charts. It runs on go-gui's
+immediate-mode pipeline and takes all its styling from the standard theme
+tokens.
 
 It is a functional port of the [go-shirei `process_monitor`][shirei] example.
-The goal is feature parity, not a pixel-for-pixel visual match: the layout takes
-cues from other go-gui examples and the colors come from `gui.ThemeDark` /
+The goal is feature parity, not a pixel-for-pixel visual match. The layout takes
+cues from other go-gui examples. The colors come from `gui.ThemeDark` /
 `gui.ThemeLight`, not hand-picked HSL values.
 
 [shirei]: https://go.hasen.dev
@@ -14,14 +15,14 @@ cues from other go-gui examples and the colors come from `gui.ThemeDark` /
 ## Features
 
 - Live process list: PID, CPU%, RSS, MEM%, USER, STATE, THREADS, NAME.
-- Click a column header to sort; click again to reverse.
+- Click a column header to sort. Click it again to reverse.
 - Select a row for a detail panel with ~60s rolling CPU and RAM charts.
-- Filter box matching name, command line, user, or PID (substring,
+- Filter box that matches name, command line, user, or PID (substring,
   case-insensitive).
-- Flat list **or** parent/child tree (collapse a subtree with ▸/▾; an active
-  filter keeps matched processes' ancestors visible).
+- Flat list **or** parent/child tree. Collapse a subtree with ▸/▾. An active
+  filter keeps the ancestors of matched processes visible.
 - Sample-interval selector: 0.5s / 1s / 2s / 5s.
-- Metrics the OS won't report render `--`, never a fake `0`.
+- Metrics that the OS does not report render `--`, never a fake `0`.
 - System memory bar in the header (shown only when the platform reports totals).
 
 ## Run it
@@ -43,17 +44,17 @@ go-gui examples share the root module, so this example pulls in no third-party
 process library. It shells out to the OS instead:
 
 - **macOS / Linux** — parse `ps` (`collect_unix.go`). Linux also reports the
-  thread count via `nlwp`; macOS `ps` has no thread column, so THREADS shows
+  thread count via `nlwp`. macOS `ps` has no thread column, so THREADS shows
   `--` there.
-- **Windows** — parse `tasklist` CSV (`collect_windows.go`). No live CPU% is
-  available from one call, so CPU shows `--`.
+- **Windows** — parse `tasklist` CSV (`collect_windows.go`). One call does not
+  provide a live CPU%, so CPU shows `--`.
 - System memory totals come from `/proc/meminfo` (Linux) or `sysctl` + `vm_stat`
-  (macOS); other platforms omit the memory bar.
+  (macOS). Other platforms omit the memory bar.
 
 **CPU% caveat:** on Unix the value is `ps`'s `%cpu`, which is a _lifetime
-average_, not an instantaneous interval rate. It is a real, useful number and
-needs only one sample; a delta-based interval CPU% (two cumulative-CPU-time
-reads) would be the enhancement.
+average_, not an instantaneous interval rate. It is a real, useful number that
+needs only one sample. A delta-based interval CPU% is the enhancement. It
+requires two cumulative-CPU-time reads.
 
 ### Background sampling, UI only reads
 
@@ -71,20 +72,21 @@ w.Unlock()
 ```
 
 `UpdateWindow` (not `UpdateView`) re-runs the registered view without clearing
-the state registry, so the filter input keeps focus and the list keeps its
-scroll position across refreshes. The backend's idle poll repaints within ~100
-ms, so no explicit wake is needed at these intervals.
+the state registry. The filter input keeps focus, and the list keeps its scroll
+position across refreshes. The backend's idle poll repaints within ~100 ms, so
+these intervals need no explicit wake.
 
 ### Stable processes + rolling history
 
 `ProcessStore` (`store.go`) keeps a stable `*Process` per identity so table rows
-and chart history survive across refreshes. Exited processes linger for 60 s (so
-their charts stay visible) and are then evicted — unless they are selected.
+and chart history survive across refreshes. Exited processes linger for 60 s, so
+their charts stay visible. The app evicts them after that, unless they are
+selected.
 
 ### Charts from plain containers
 
 Each history chart (`chart.go`) is a row of bottom-anchored `Rectangle` bars in
 fixed 2-second time buckets — no canvas widget, no chart library.
-`resampleHistory` folds the irregularly-sampled history into those fixed buckets
-(averaging within a slot, linearly interpolating gaps) so the x-axis is always
-"last 60 s," independent of the sample rate.
+`resampleHistory` folds the irregularly-sampled history into those fixed
+buckets: it averages within a slot and linearly interpolates gaps. The x-axis is
+then always "last 60 s," independent of the sample rate.

--- a/examples/showcase/docs/commands.md
+++ b/examples/showcase/docs/commands.md
@@ -42,12 +42,10 @@ Pre-combined convenience constants:
 | `ModCtrlShift`    | `ModCtrl \| ModShift`           |
 | `ModCtrlAlt`      | `ModCtrl \| ModAlt`             |
 | `ModCtrlAltShift` | `ModCtrl \| ModAlt \| ModShift` |
-| `ModCtrlSuper`    | `ModCtrl \| ModSuper`           |
 | `ModAltShift`     | `ModAlt \| ModShift`            |
-| `ModAltSuper`     | `ModAlt \| ModSuper`            |
 | `ModSuperShift`   | `ModSuper \| ModShift`          |
 
-`Modifier.Has(mod)` tests if a flag is set; `HasAny(mods...)` tests any of
+`Modifier.Has(mod)` tests if a flag is set. `HasAny(mods...)` tests any of
 several.
 
 ### Command
@@ -69,11 +67,11 @@ type Command struct {
 pipeline:
 
 - `Global: true` — fires _before_ focus dispatch. Use for app-wide shortcuts
-  (save, new, command palette toggle) that should work regardless of which
-  widget has focus.
+  (save, new, command palette toggle) that work regardless of which widget has
+  focus.
 - `Global: false` (default) — fires _after_ focus dispatch, as a fallback. Use
-  for commands that should yield to focused widgets (e.g., an undo command that
-  should not fire while a text input has focus and handles its own undo).
+  for commands that yield to focused widgets. For example, an undo command does
+  not fire while a text input has focus and handles its own undo.
 
 **`CanExecute`** — when non-nil, the command is skipped during dispatch if it
 returns false. Widgets bound to the command (buttons, menu items) auto-disable.
@@ -103,19 +101,18 @@ w.RegisterCommands(cmd1, cmd2, cmd3)
 
 **Constraints:**
 
-- Duplicate command ID → panic
-- Duplicate shortcut (same key + modifiers on two commands) → panic
+- Duplicate command ID → error
+- Duplicate shortcut (same key + modifiers on two commands) → error
 
 ### Window Methods
 
-| Method                                       | Description                                |
-| -------------------------------------------- | ------------------------------------------ |
-| `RegisterCommand(cmd)`                       | Register one command; panics on duplicates |
-| `RegisterCommands(cmds...)`                  | Register multiple commands                 |
-| `UnregisterCommand(id)`                      | Remove by ID; no-op if not found           |
-| `CommandByID(id) (Command, bool)`            | Lookup by ID                               |
-| `CommandCanExecute(id) bool`                 | Check CanExecute; false if not found       |
-| `CommandPaletteItems() []CommandPaletteItem` | Export commands with Labels for palette    |
+| Method                                       | Description                                 |
+| -------------------------------------------- | ------------------------------------------- |
+| `RegisterCommand(cmd)`                       | Register one command. Error on duplicates   |
+| `RegisterCommands(cmds...)`                  | Register multiple commands                  |
+| `UnregisterCommand(id)`                      | Remove by ID. No-op if not found            |
+| `CommandByID(id) (Command, bool)`            | Lookup by ID                                |
+| `CommandPaletteItems() []CommandPaletteItem` | Export commands with labels for the palette |
 
 ## Keyboard Dispatch Pipeline
 
@@ -128,7 +125,7 @@ When a `KeyDown` event arrives, the window processes it in this order:
 4. Non-global command dispatch  (Global=false commands as fallback)
 ```
 
-At each stage, if a handler sets `ctx.Consume()`, subsequent stages are skipped.
+If a handler sets `ctx.Consume()` at any stage, subsequent stages are skipped.
 This means:
 
 - Global commands always take priority.
@@ -142,18 +139,19 @@ This means:
 Creates a button automatically wired to a registered command.
 
 ```go
-gui.CommandButton(w, "edit.undo", gui.ButtonCfg{})
+gui.CommandButton("edit.undo", gui.ButtonCfg{})
 ```
 
 **Auto behaviors:**
 
 - **Label** — if `cfg.Content` is nil, fills from `Command.Label` + shortcut
-  hint (e.g., `"Undo  ⌘Z"`)
+  hint (for example, `"Undo  ⌘Z"`)
 - **OnClick** — wired to `Command.Execute` (re-checks `CanExecute` at click
   time)
 - **Disabled** — auto-disables when `CanExecute` returns false
 
-Panics if the command ID is not registered.
+An unregistered command ID renders the text `unknown command: <id>` instead of a
+button.
 
 ### Menu Items
 
@@ -218,12 +216,9 @@ func paletteAction(id string, e *gui.Event, w *gui.Window) {
 
 ### Visibility Functions
 
-| Function                              | Description          |
-| ------------------------------------- | -------------------- |
-| `CommandPaletteShow(id, w)`           | Show and focus input |
-| `CommandPaletteDismiss(id, w)`        | Hide and reset query |
-| `CommandPaletteToggle(id, w)`         | Toggle visibility    |
-| `CommandPaletteIsVisible(id, w) bool` | Check if showing     |
+| Function                      | Description       |
+| ----------------------------- | ----------------- |
+| `CommandPaletteToggle(id, w)` | Toggle visibility |
 
 ### Palette Keyboard Navigation
 
@@ -327,14 +322,14 @@ func registerCommands(w *gui.Window) {
 
 The `keyName()` function provides display names for all supported keys:
 
-| Category    | Keys                                                                                                                                                             |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Letters     | `KeyA` – `KeyZ` → `"A"` – `"Z"`                                                                                                                                  |
-| Numbers     | `Key0` – `Key9` → `"0"` – `"9"`                                                                                                                                  |
-| Function    | `KeyF1` – `KeyF25` → `"F1"` – `"F25"`                                                                                                                            |
-| Keypad      | `KeyKP0` – `KeyKP9` → `"KP0"` – `"KP9"`                                                                                                                          |
-| Navigation  | `KeyUp`, `KeyDown`, `KeyLeft`, `KeyRight`                                                                                                                        |
-| Page        | `KeyHome`, `KeyEnd`, `KeyPageUp`, `KeyPageDown`                                                                                                                  |
-| Editing     | `KeyBackspace`, `KeyDelete`, `KeyInsert`, `KeyTab`                                                                                                               |
-| Special     | `KeySpace`, `KeyEnter`, `KeyEscape`                                                                                                                              |
-| Punctuation | `KeyMinus`, `KeyEqual`, `KeyComma`, `KeyPeriod`, `KeySlash`, `KeyBackslash`,`KeyLeftBracket`, `KeyRightBracket`, `KeyApostrophe`, `KeySemicolon`,`KeyGraveAccen` |
+| Category    | Keys                                                                                                                                                              |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Letters     | `KeyA` – `KeyZ` → `"A"` – `"Z"`                                                                                                                                   |
+| Numbers     | `Key0` – `Key9` → `"0"` – `"9"`                                                                                                                                   |
+| Function    | `KeyF1` – `KeyF25` → `"F1"` – `"F25"`                                                                                                                             |
+| Keypad      | `KeyKP0` – `KeyKP9` → `"KP0"` – `"KP9"`                                                                                                                           |
+| Navigation  | `KeyUp`, `KeyDown`, `KeyLeft`, `KeyRight`                                                                                                                         |
+| Page        | `KeyHome`, `KeyEnd`, `KeyPageUp`, `KeyPageDown`                                                                                                                   |
+| Editing     | `KeyBackspace`, `KeyDelete`, `KeyInsert`, `KeyTab`                                                                                                                |
+| Special     | `KeySpace`, `KeyEnter`, `KeyEscape`                                                                                                                               |
+| Punctuation | `KeyMinus`, `KeyEqual`, `KeyComma`, `KeyPeriod`, `KeySlash`, `KeyBackslash`,`KeyLeftBracket`, `KeyRightBracket`, `KeyApostrophe`, `KeySemicolon`,`KeyGraveAccent` |

--- a/examples/showcase/docs/markdown_demo.md
+++ b/examples/showcase/docs/markdown_demo.md
@@ -6,11 +6,11 @@ for syntax or as a test file for rendering engines.
 ## Text Formatting
 
 Regular paragraph text flows naturally across multiple lines. When you write
-content in Markdown, you don't need to worry about line breaks within a
-paragraph---the renderer handles text wrapping automatically. This makes it easy
+content in Markdown, you do not need to worry about line breaks within a
+paragraph. The renderer handles text wrapping automatically. This makes it easy
 to write long-form content without constantly thinking about formatting.
 
-Here's another paragraph to show separation. Paragraphs are separated by blank
+Here is another paragraph to show separation. Paragraphs are separated by blank
 lines. You can use **bold text** for emphasis, _italic text_ for subtle
 emphasis, or _**bold and italic**_ together. You can also use ~~strikethrough~~
 for deleted content and `inline code` for technical terms or commands.
@@ -26,53 +26,51 @@ combine with bold: ++**bold underline**++.
 
 ### Unordered Lists
 
-- The first item in this unordered list contains enough text to demonstrate how
-  list items wrap when they exceed the typical line length of most editors and
-  viewers, which is usually around 80 to 120 characters depending on your
+- The first item in this unordered list demonstrates how list items wrap. List
+  items wrap when they exceed the typical line length of most editors and
+  viewers. That length is usually around 80 to 120 characters, depending on your
   settings.
 - Second item with a shorter description but still meaningful content.
-- Third item that also spans multiple lines when rendered in a narrow viewport,
-  showing how Markdown handles long list content gracefully without breaking the
-  visual hierarchy of the document.
-  - Nested item underneath the third item, demonstrating that you can create
-    hierarchical structures within your lists by indenting with two spaces or a
-    tab.
-  - Another nested item with substantial content to show that nested items also
-    wrap properly when they contain lengthy descriptions or explanations that
-    exceed the available width.
-    - Deeply nested item showing three levels of nesting, which is about as deep
-      as you typically want to go for readability purposes.
+- Third item that also spans multiple lines when rendered in a narrow viewport.
+  Markdown handles long list content without breaking the visual hierarchy of
+  the document.
+  - Nested item underneath the third item. You can create hierarchical
+    structures within your lists by indenting with two spaces or a tab.
+  - Another nested item with substantial content. Nested items also wrap
+    properly when they contain lengthy descriptions or explanations that exceed
+    the available width.
+    - Deeply nested item showing three levels of nesting. Three levels is about
+      as deep as you typically want to go for readability purposes.
 - Fourth item back at the root level.
 
 ### Ordered Lists
 
 1.  First ordered item with extensive explanatory text that wraps across
-    multiple lines, demonstrating that numbered lists behave the same way as
-    bulleted lists when it comes to handling long content within individual
-    items.
-2.  Second ordered item that continues the numbering sequence automatically,
-    regardless of what number you actually type in the source Markdown.
-3.  Third item with enough content to wrap, ensuring that the visual
-    presentation remains clean and readable even when individual list items
-    contain paragraph-length descriptions or instructions.
+    multiple lines. Numbered lists behave the same way as bulleted lists for
+    handling long content within individual items.
+2.  Second ordered item that continues the numbering sequence automatically. The
+    sequence continues regardless of what number you actually type in the source
+    Markdown.
+3.  Third item with enough content to wrap. The visual presentation stays clean
+    and readable even when individual list items contain paragraph-length
+    descriptions or instructions.
     1.  Nested numbered item showing that you can create sub-lists within
-        ordered lists as well, maintaining proper indentation and numbering
-        throughout the hierarchy.
+        ordered lists as well. The sub-lists maintain proper indentation and
+        numbering throughout the hierarchy.
     2.  Another nested numbered item with additional explanatory content.
 4.  Fourth item returning to the main list level.
 
 ### Task Lists
 
-- [x] Completed task that has been marked as done by placing an 'x' inside the
-      brackets.
-- [x] Another finished task demonstrating the checked state, which renders as a
-      filled checkbox in most Markdown viewers and platforms that support this
-      extension.
+- [x] Completed task. You mark it as done by placing an 'x' inside the brackets.
+- [x] Another finished task demonstrating the checked state. The checked state
+      renders as a filled checkbox in most Markdown viewers and platforms that
+      support this extension.
 - [ ] Incomplete task waiting to be done, shown with empty brackets that render
       as an unchecked checkbox in compatible viewers.
 - [ ] Another pending task with a longer description that explains what needs to
-      be accomplished, demonstrating that task list items can also contain
-      substantial amounts of text that wrap naturally.
+      be accomplished. Task list items can also contain substantial amounts of
+      text that wrap naturally.
 
 ## Blockquotes
 
@@ -86,9 +84,9 @@ combine with bold: ++**bold underline**++.
 > to use the greater-than symbol at the start of each line. This second
 > paragraph is still part of the same blockquote.
 >
-> > Nested blockquotes are also possible, allowing you to show quoted material
-> > within quoted material---useful for email threads or forum discussions where
-> > multiple levels of response exist.
+> > Nested blockquotes are also possible. They allow you to show quoted material
+> > within quoted material. This is useful for email threads or forum
+> > discussions where multiple levels of response exist.
 
 ## Code
 
@@ -137,8 +135,8 @@ class ShoppingCart:
 
 ### Links
 
-Here's a [link to OpenAI](https://openai.com) inline in text. You can also use
-[reference-style links](https://example.com "Example Website") that define the
+Here is a [link to OpenAI](https://openai.com) inline in text. You can also use
+[reference-style links](https://example.com "Example Website"). They define the
 URL elsewhere in the document, which keeps paragraphs cleaner when you have many
 links.
 
@@ -180,7 +178,7 @@ Another section after a different style of horizontal rule.
 
 ### Footnotes
 
-Here's a sentence with a footnote[^1] and here's another one[^2].
+Here is a sentence with a footnote[^1] and here is another one[^2].
 
 ### Definition Lists
 
@@ -198,8 +196,8 @@ The HTML specification is maintained by the W3C. HTMLX is not the same as HTML.
 
 ## Escaping Characters
 
-Use backslashes to display literal characters that would otherwise be
-interpreted as Markdown:
+Use backslashes to display literal characters. Without backslashes, Markdown
+interprets those characters as formatting:
 
 \*This text is surrounded by literal asterisks\*
 
@@ -296,9 +294,9 @@ done
 
 ## Conclusion
 
-This document has covered all the common Markdown elements you're likely to
-encounter or need in everyday writing. Different Markdown processors may support
-additional features or have slight variations in syntax, so always test your
+This document has covered all the common Markdown elements you are likely to
+encounter or need in everyday writing. Different Markdown processors can support
+additional features or have slight variations in syntax. Always test your
 content in the target environment.
 
 For more information, consult the

--- a/examples/showcase/docs/welcome.md
+++ b/examples/showcase/docs/welcome.md
@@ -7,7 +7,7 @@ routing.
 
 The toolkit targets real app workflows, not toy demos. It includes built-in
 theming, keyboard-first navigation, text input with IME support, and modern
-rendering features so native-feeling UI can be built quickly and maintained
+rendering features. You can build native-feeling UI quickly and maintain it
 without UI boilerplate.
 
 ## ✨ Top Features
@@ -15,7 +15,7 @@ without UI boilerplate.
 - Declarative layout primitives (`row`, `column`, fixed/fill sizing, spacing,
   padding)
 - Rich control set (inputs, selects, tables, tabs, dialogs, trees, date pickers,
-  more)
+  and more)
 - Theme system with light/dark palettes and consistent component styling
 - Rendering effects: gradients, shadows, blur, SVG, markdown, and custom shaders
 - Animation support for tween, spring, keyframe, and layout transitions

--- a/examples/showcase/docs/widget_animations.md
+++ b/examples/showcase/docs/widget_animations.md
@@ -1,6 +1,6 @@
 Tween, spring, and keyframe animation types. All implement the `Animation`
-interface and are managed via `w.AnimationAdd`, `w.AnimationRemove`, and
-`w.HasAnimation`. The animation loop ticks at ~60 fps (16ms). Each animation
+interface. The window manages them via `w.AnimationAdd`, `w.AnimationRemove`,
+and `w.HasAnimation`. The animation loop ticks at ~60 fps (16ms). Each animation
 receives an `OnValue` callback with the interpolated value and an optional
 `OnDone` callback.
 

--- a/examples/showcase/docs/widget_audio.md
+++ b/examples/showcase/docs/widget_audio.md
@@ -39,10 +39,10 @@ audio.ResumeMusic()
 audio.FadeOutMusic(1000)
 ```
 
-The showcase demo loads its music clip from the embedded asset
-`examples/showcase/assets/music.ogg` (Mozart, Eine kleine Nachtmusik K. 525, I.
-Allegro — public-domain Musopen recording) via `embeddedAssetPath`, since
-`LoadMusic` takes a file path.
+The showcase demo loads its music clip via `embeddedAssetPath`. The clip is the
+embedded asset `examples/showcase/assets/music.ogg` (Mozart, Eine kleine
+Nachtmusik K. 525, I. Allegro — a public-domain Musopen recording). `LoadMusic`
+takes a file path.
 
 ## Live Synthesis
 
@@ -86,7 +86,7 @@ gui.Column(gui.ContainerCfg{
 ```
 
 A voice plays a note-off by releasing internally and returning `(0, false)` once
-its release envelope finishes — the channel frees itself, so no per-pad channel
+its release envelope finishes. The channel frees itself, so no per-pad channel
 bookkeeping is needed.
 
 ## Volume
@@ -150,6 +150,6 @@ snd.SetVolume(0.3)         // per-sound volume
 ## Notes
 
 - Only **one music track** plays at a time (global music channel)
-- Do not Free a Sound while it is still playing
-- No external libraries required — beep is pure Go on macOS/Windows; Linux needs
+- Do not Free a Sound while it plays
+- No external libraries required — beep is pure Go on macOS/Windows. Linux needs
   `-ldl` only

--- a/examples/showcase/docs/widget_badge.md
+++ b/examples/showcase/docs/widget_badge.md
@@ -1,5 +1,5 @@
 Numeric and colored pill labels for counts and status indicators. Dot mode
-renders a small circle; labeled mode renders text inside a rounded pill.
+renders a small circle. Labeled mode renders text inside a rounded pill.
 
 ## Usage
 
@@ -26,7 +26,7 @@ gui.Badge(gui.BadgeCfg{Label: "150", Max: 99})
 | -------- | ------------ | ------------------------------------- |
 | Label    | string       | Badge text                            |
 | Variant  | BadgeVariant | Color variant preset                  |
-| Max      | int          | Cap value; shows "max+" when exceeded |
+| Max      | int          | Cap value. Shows "max+" when exceeded |
 | Dot      | bool         | Show as a small dot instead of text   |
 
 ## Appearance

--- a/examples/showcase/docs/widget_blur.md
+++ b/examples/showcase/docs/widget_blur.md
@@ -56,7 +56,7 @@ gui.Column(gui.ContainerCfg{
 
 - `BlurRadius` is a plain `float32`, not `Opt[float32]`. Zero means no blur.
 - Combine with `Radius` (corner rounding) to create orb or pill glows.
-- Blur is rendered via a GPU shader pass; large radii have minimal extra cost on
+- Blur is rendered via a GPU shader pass. Large radii have minimal extra cost on
   Metal/OpenGL backends.
 - Distinct from `BoxShadow.BlurRadius` which blurs a drop shadow, not the shape
   fill itself.

--- a/examples/showcase/docs/widget_color_filter.md
+++ b/examples/showcase/docs/widget_color_filter.md
@@ -1,8 +1,8 @@
 Post-processing color matrix transforms on container content. Set `ColorFilter`
 on `ContainerCfg` to apply a 4×4 color matrix to the container's rendered
-content. The container is captured into an FBO, the matrix is applied via a GPU
-shader pass, and the result is composited back. Works independently of or
-combined with `BlurRadius`.
+content. The container is captured into an FBO. The matrix is applied via a GPU
+shader pass. The result is composited back. Works independently of or combined
+with `BlurRadius`.
 
 ## Grayscale
 
@@ -133,9 +133,9 @@ gui.Column(gui.ContainerCfg{
 ## Notes
 
 - Containers only — not available on individual widgets.
-- No nesting. A single FBO pair is used; nested filter brackets are guarded
+- No nesting. A single FBO pair is used. Nested filter brackets are guarded
   against at the render level.
 - Operates on premultiplied-alpha pixels from the FBO.
 - Contrast and invert inject bias via the alpha column of the matrix, which is
   correct for premultiplied content.
-- Rendered via Metal and OpenGL backends. ignores the color matrix.
+- Rendered via the Metal and OpenGL backends.

--- a/examples/showcase/docs/widget_column.md
+++ b/examples/showcase/docs/widget_column.md
@@ -7,7 +7,7 @@ Column over Row when either direction works.
 ```go
 gui.Column(gui.ContainerCfg{
     Spacing: gui.SomeF(8),
-    Padding: gui.SomeP(4, 8, 4, 8),
+    Padding: gui.NewPadding(4, 8, 4, 8),
     Sizing:  gui.FillFit,
     Content: []gui.View{child1, child2},
 })

--- a/examples/showcase/docs/widget_combobox.md
+++ b/examples/showcase/docs/widget_combobox.md
@@ -1,5 +1,5 @@
-Editable dropdown with type-ahead filtering. Typing narrows the options list;
-selecting an option commits the value.
+Editable dropdown with type-ahead filtering. Typing narrows the options list.
+Selecting an option commits the value.
 
 Combobox already accepts `[]string` directly via the `Options` field.
 

--- a/examples/showcase/docs/widget_command_button.md
+++ b/examples/showcase/docs/widget_command_button.md
@@ -59,7 +59,7 @@ CommandButton accepts a standard ButtonCfg. The most relevant fields:
 ## Appearance
 
 Inherits all ButtonCfg appearance properties (Color, Radius, Padding,
-SizeBorder, etc.). See Button docs for the full list.
+SizeBorder, and more). See Button docs for the full list.
 
 ## Accessibility
 

--- a/examples/showcase/docs/widget_data_grid.md
+++ b/examples/showcase/docs/widget_data_grid.md
@@ -95,7 +95,7 @@ datagrid.New(w, datagrid.DataGridCfg{
 | FrozenTopRowIDs        | []string            | Row IDs pinned to top                                                                  |
 | DetailExpandedRowIDs   | map[string]bool     | Expanded detail row IDs                                                                |
 | QuickFilterPlaceholder | string              | Quick filter placeholder text                                                          |
-| QuickFilterDebounce    | time.Duration       | Quick filter debounce delay (200ms with DataSource, 0 otherwise; negative = immediate) |
+| QuickFilterDebounce    | time.Duration       | Quick filter debounce delay (200ms with DataSource, 0 otherwise. Negative = immediate) |
 | RowHeight              | float32             | Row height in pixels                                                                   |
 | HeaderHeight           | float32             | Header height in pixels                                                                |
 | Scrollable             | bool                | Opt into the scroll system (state keyed by ID)                                         |

--- a/examples/showcase/docs/widget_data_source.md
+++ b/examples/showcase/docs/widget_data_source.md
@@ -90,4 +90,4 @@ type DataGridDataSource interface {
 | SupportsOffset | bool                | Enable offset pagination     |
 | RowCountKnown  | bool                | Expose total row count       |
 
-Runtime stats available via `w.DataGridSourceStats(id)`.
+Get runtime stats via `w.DataGridSourceStats(id)`.

--- a/examples/showcase/docs/widget_dock_layout.md
+++ b/examples/showcase/docs/widget_dock_layout.md
@@ -67,7 +67,7 @@ root := gui.DockSplit("root", gui.DockSplitHorizontal, 0.2,
 
 | Function                  | Description                         |
 | ------------------------- | ----------------------------------- |
-| DockTreeRemovePanel       | Remove panel; collapse empty splits |
+| DockTreeRemovePanel       | Remove panel. Collapse empty splits |
 | DockTreeAddTab            | Add panel as tab in existing group  |
 | DockTreeSplitAt           | Split a group, insert panel at edge |
 | DockTreeMovePanel         | Remove + insert (drag-and-drop)     |

--- a/examples/showcase/docs/widget_drag_reorder.md
+++ b/examples/showcase/docs/widget_drag_reorder.md
@@ -61,7 +61,7 @@ gui.Tree(gui.TreeCfg{
 | movedID   | string | ID of the dragged item          |
 | beforeID  | string | ID of the item to insert before |
 
-`beforeID` is `\"\"` when dropping at the end of the list.
+`beforeID` is `\"\"` when the item drops at the end of the list.
 
 ## Helper
 

--- a/examples/showcase/docs/widget_draw_canvas.md
+++ b/examples/showcase/docs/widget_draw_canvas.md
@@ -1,7 +1,7 @@
 Procedural 2D drawing canvas with cached tessellation. Draw shapes, lines, text,
 images, and arcs via the `OnDraw` callback. Output is tessellated into triangles
-and cached by `Version` — only re-drawn when the version changes. Optional
-`Focusable` + `OnKeyDown` make the canvas keyboard-focusable.
+and cached by `Version`. The canvas re-draws only when the version changes.
+Optional `Focusable` + `OnKeyDown` make the canvas keyboard-focusable.
 
 ## Usage
 
@@ -62,7 +62,7 @@ gui.DrawCanvas(gui.DrawCanvasCfg{
 
 | Method | Signature                                                               | Description                                                |
 | ------ | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Image  | (x, y, w, h float32, src string, bgOpacity Opt[float32], bgColor Color) | Draw image inside the canvas; `src` matches `ImageCfg.Src` |
+| Image  | (x, y, w, h float32, src string, bgOpacity Opt[float32], bgColor Color) | Draw image inside the canvas. `src` matches `ImageCfg.Src` |
 
 `src` accepts the same forms as `ImageCfg.Src`:
 
@@ -70,9 +70,9 @@ gui.DrawCanvas(gui.DrawCanvasCfg{
 - `http://` / `https://` URL (cached on disk)
 - `data:` URL (base64 payload)
 
-`bgOpacity` is an `Opt[float32]` in [0, 1]; zero value = 1.0. It modulates the
-background-color alpha only; it does not fade the image texture itself.
-`bgColor` paints behind the image (useful for PNGs with transparency); zero
+`bgOpacity` is an `Opt[float32]` in [0, 1]. Zero value = 1.0. It modulates the
+background-color alpha only. It does not fade the image texture itself.
+`bgColor` paints behind the image (useful for PNGs with transparency). Zero
 value = transparent.
 
 Example:
@@ -151,7 +151,7 @@ widget ID.
 | A11YCfg  | A11YCfg | Embedded: A11YLabel, A11YDescription |
 
 A focusable canvas advertises as an interactive element (button role) to
-assistive tech; non-focusable canvases advertise as images. Provide a meaningful
+assistive tech. Non-focusable canvases advertise as images. Provide a meaningful
 `A11YLabel` on interactive canvases.
 
 Set the pair through the embed: `A11YCfg: gui.A11YCfg{A11YLabel: "Save"}`.

--- a/examples/showcase/docs/widget_forms.md
+++ b/examples/showcase/docs/widget_forms.md
@@ -19,7 +19,7 @@ gui.Form(gui.FormCfg{
 
 Register fields each frame so the form runtime tracks them. Use
 **FormRegisterFieldByID** when the form ID is known at view construction time
-(the common case). Use **FormRegisterField** when you don't know the form ID —
+(the common case). Use **FormRegisterField** when you do not know the form ID —
 it walks the layout parent chain to locate the ancestor Form.
 
 ```go
@@ -160,7 +160,7 @@ func validateEmail(
 ## Allow Submit Despite Errors or Pending
 
 By default, `FormRequestSubmit` is blocked when any field has errors or an async
-validator is running. Override per-form:
+validator runs. Override per-form:
 
 ```go
 gui.Form(gui.FormCfg{
@@ -183,7 +183,7 @@ gui.Form(gui.FormCfg{
 ```
 
 Check `FormSubmitEvent.Errors` and `FormSubmitEvent.Pending` in your submit
-handler — they carry the issues that would normally block submission.
+handler. They carry the issues that block submission by default.
 
 ## Custom Slots
 

--- a/examples/showcase/docs/widget_icons.md
+++ b/examples/showcase/docs/widget_icons.md
@@ -1,7 +1,7 @@
-256 icons from the Feather icon font. Each icon is a named constant (e.g.
-`gui.IconCheck`, `gui.IconFolder`, `gui.IconSearch`). Render with `gui.Text`
-using one of the six theme Icon styles. Icons are Unicode glyphs — no image
-files required.
+256 icons from the Feather icon font. Each icon is a named constant (for
+example, `gui.IconCheck`, `gui.IconFolder`, `gui.IconSearch`). Render with
+`gui.Text` using one of the six theme Icon styles. Icons are Unicode glyphs — no
+image files required.
 
 ## Usage
 

--- a/examples/showcase/docs/widget_image.md
+++ b/examples/showcase/docs/widget_image.md
@@ -24,7 +24,7 @@ gui.Image(gui.ImageCfg{
 ```
 
 Remote images are fetched asynchronously, cached locally, and displayed on
-completion. A placeholder rectangle is shown while downloading.
+completion. A placeholder rectangle is shown during the download.
 
 ## Key Properties
 

--- a/examples/showcase/docs/widget_input.md
+++ b/examples/showcase/docs/widget_input.md
@@ -58,19 +58,19 @@ token definitions).
 
 ## Key Properties
 
-| Property    | Type            | Description                        |
-| ----------- | --------------- | ---------------------------------- |
-| Text        | string          | Current text value                 |
-| Placeholder | string          | Hint text shown when empty         |
-| IsPassword  | bool            | Mask characters for password entry |
-| Mode        | InputMode       | InputSingleLine or InputMultiline  |
-| MaskPreset  | InputMaskPreset | Built-in mask (phone, card, etc.)  |
-| Mask        | string          | Custom mask pattern                |
-| MaskTokens  | []MaskTokenDef  | Custom token definitions for mask  |
-| Disabled    | bool            | Disable interaction                |
-| Height      | float32         | Height (useful for multiline)      |
-| MinWidth    | float32         | Minimum width                      |
-| MaxWidth    | float32         | Maximum width                      |
+| Property    | Type            | Description                           |
+| ----------- | --------------- | ------------------------------------- |
+| Text        | string          | Current text value                    |
+| Placeholder | string          | Hint text shown when empty            |
+| IsPassword  | bool            | Mask characters for password entry    |
+| Mode        | InputMode       | InputSingleLine or InputMultiline     |
+| MaskPreset  | InputMaskPreset | Built-in mask (phone, card, and more) |
+| Mask        | string          | Custom mask pattern                   |
+| MaskTokens  | []MaskTokenDef  | Custom token definitions for mask     |
+| Disabled    | bool            | Disable interaction                   |
+| Height      | float32         | Height (useful for multiline)         |
+| MinWidth    | float32         | Minimum width                         |
+| MaxWidth    | float32         | Maximum width                         |
 
 ## Appearance
 

--- a/examples/showcase/docs/widget_listbox.md
+++ b/examples/showcase/docs/widget_listbox.md
@@ -72,7 +72,7 @@ When `Items` is set, `Data` is ignored.
 | Items       | []string        | Simple string list (alt. to Data)              |
 | Data        | []ListBoxOption | Items (ID, Name, Value, IsSubhead)             |
 | Multiple    | bool            | Allow multi-select                             |
-| Height      | float32         | Fixed height (enables virtualization)          |
+| Height      | float32         | Fixed height (activates virtualization)        |
 | MinWidth    | float32         | Minimum width                                  |
 | MaxWidth    | float32         | Maximum width                                  |
 | MinHeight   | float32         | Minimum height                                 |

--- a/examples/showcase/docs/widget_locale.md
+++ b/examples/showcase/docs/widget_locale.md
@@ -1,7 +1,7 @@
 Global locale system controlling number formatting, date formatting, currency
-symbols, UI strings (OK, Cancel, etc.), weekday/month names, text direction, and
-app-level translations. Ten locales are registered by default; custom locales
-can be added via `LocaleRegister` or loaded from JSON bundles.
+symbols, UI strings (OK, Cancel, and more), weekday/month names, text direction,
+and app-level translations. Ten locales are registered by default. You can add
+custom locales via `LocaleRegister` or load them from JSON bundles.
 
 ## Set Locale
 
@@ -68,18 +68,18 @@ if err == nil {
 
 ## Locale Struct
 
-| Field         | Type              | Description                      |
-| ------------- | ----------------- | -------------------------------- |
-| ID            | string            | Locale identifier (e.g. "en-US") |
-| TextDir       | TextDirection     | TextDirLTR or TextDirRTL         |
-| Number        | NumberFormat      | Number formatting rules          |
-| Date          | DateFormat        | Date formatting rules            |
-| Currency      | CurrencyFormat    | Currency formatting rules        |
-| Translations  | map[string]string | App-level translation keys       |
-| WeekdaysShort | [7]string         | Sun..Sat short names             |
-| WeekdaysFull  | [7]string         | Sun..Sat full names              |
-| MonthsShort   | [12]string        | Jan..Dec short names             |
-| MonthsFull    | [12]string        | Jan..Dec full names              |
+| Field         | Type              | Description                              |
+| ------------- | ----------------- | ---------------------------------------- |
+| ID            | string            | Locale identifier (for example, "en-US") |
+| TextDir       | TextDirection     | TextDirLTR or TextDirRTL                 |
+| Number        | NumberFormat      | Number formatting rules                  |
+| Date          | DateFormat        | Date formatting rules                    |
+| Currency      | CurrencyFormat    | Currency formatting rules                |
+| Translations  | map[string]string | App-level translation keys               |
+| WeekdaysShort | [7]string         | Sun..Sat short names                     |
+| WeekdaysFull  | [7]string         | Sun..Sat full names                      |
+| MonthsShort   | [12]string        | Jan..Dec short names                     |
+| MonthsFull    | [12]string        | Jan..Dec full names                      |
 
 ## NumberFormat
 
@@ -93,23 +93,23 @@ if err == nil {
 
 ## DateFormat
 
-| Field          | Type   | Description                          |
-| -------------- | ------ | ------------------------------------ |
-| ShortDate      | string | Short date pattern (e.g. "M/D/YYYY") |
-| LongDate       | string | Long date pattern                    |
-| MonthYear      | string | Month-year pattern                   |
-| FirstDayOfWeek | uint8  | 0=Sunday, 1=Monday                   |
-| Use24H         | bool   | Use 24-hour time format              |
+| Field          | Type   | Description                                  |
+| -------------- | ------ | -------------------------------------------- |
+| ShortDate      | string | Short date pattern (for example, "M/D/YYYY") |
+| LongDate       | string | Long date pattern                            |
+| MonthYear      | string | Month-year pattern                           |
+| FirstDayOfWeek | uint8  | 0=Sunday, 1=Monday                           |
+| Use24H         | bool   | Use 24-hour time format                      |
 
 ## CurrencyFormat
 
-| Field    | Type                 | Description                     |
-| -------- | -------------------- | ------------------------------- |
-| Symbol   | string               | Currency symbol (e.g. "$")      |
-| Code     | string               | ISO code (e.g. "USD")           |
-| Position | NumericAffixPosition | AffixPrefix or AffixSuffix      |
-| Spacing  | bool                 | Space between symbol and number |
-| Decimals | int                  | Decimal places (default 2)      |
+| Field    | Type                 | Description                        |
+| -------- | -------------------- | ---------------------------------- |
+| Symbol   | string               | Currency symbol (for example, "$") |
+| Code     | string               | ISO code (for example, "USD")      |
+| Position | NumericAffixPosition | AffixPrefix or AffixSuffix         |
+| Spacing  | bool                 | Space between symbol and number    |
+| Decimals | int                  | Decimal places (default 2)         |
 
 ## UI Strings
 

--- a/examples/showcase/docs/widget_markdown.md
+++ b/examples/showcase/docs/widget_markdown.md
@@ -37,19 +37,19 @@ w.Markdown(gui.MarkdownCfg{
 
 ## Key Properties
 
-| Property            | Type          | Description                                             |
-| ------------------- | ------------- | ------------------------------------------------------- |
-| Source              | string        | Markdown source string                                  |
-| Style               | MarkdownStyle | Typography and color configuration                      |
-| Mode                | Opt[TextMode] | Text wrapping mode                                      |
-| Focusable           | bool          | Enables focus and text selection (needs a non-empty ID) |
-| MinWidth            | float32       | Minimum view width                                      |
-| MermaidWidth        | int           | Max mermaid diagram width (0 = 600)                     |
-| DisableExternalAPIs | bool          | Disable CodeCogs/Kroki APIs                             |
-| Disabled            | bool          | Disable interaction                                     |
-| Invisible           | bool          | Hide without removing from layout                       |
-| Clip                | bool          | Clip content to bounds                                  |
-| FocusSkip           | bool          | Skip in tab-order navigation                            |
+| Property            | Type          | Description                                               |
+| ------------------- | ------------- | --------------------------------------------------------- |
+| Source              | string        | Markdown source string                                    |
+| Style               | MarkdownStyle | Typography and color configuration                        |
+| Mode                | Opt[TextMode] | Text wrapping mode                                        |
+| Focusable           | bool          | Activates focus and text selection (needs a non-empty ID) |
+| MinWidth            | float32       | Minimum view width                                        |
+| MermaidWidth        | int           | Max mermaid diagram width (0 = 600)                       |
+| DisableExternalAPIs | bool          | Disable CodeCogs/Kroki APIs                               |
+| Disabled            | bool          | Disable interaction                                       |
+| Invisible           | bool          | Hide without removing from layout                         |
+| Clip                | bool          | Clip content to bounds                                    |
+| FocusSkip           | bool          | Skip in tab-order navigation                              |
 
 ## Appearance
 

--- a/examples/showcase/docs/widget_multi_window.md
+++ b/examples/showcase/docs/widget_multi_window.md
@@ -1,5 +1,5 @@
 Manage multiple OS windows from a single application. An App instance acts as a
-registry for all windows, enabling cross-window communication via Broadcast and
+registry for all windows. You can communicate across windows via Broadcast and
 QueueCommand.
 
 ## Setup
@@ -63,7 +63,7 @@ w.App().Broadcast(func(other *gui.Window) {
 | Method     | Signature              | Description                         |
 | ---------- | ---------------------- | ----------------------------------- |
 | Register   | (id uint32, w *Window) | Associate platform ID with window   |
-| Unregister | (id uint32) bool       | Remove window; returns exit signal  |
+| Unregister | (id uint32) bool       | Remove window. Returns exit signal  |
 | Window     | (id uint32) *Window    | Lookup by platform ID               |
 | Windows    | () []*Window           | Snapshot of all windows in order    |
 | OpenWindow | (cfg WindowCfg)        | Queue window creation (next frame)  |

--- a/examples/showcase/docs/widget_notification.md
+++ b/examples/showcase/docs/widget_notification.md
@@ -1,5 +1,6 @@
-Send native OS notifications via the platform notification center. Runs
-asynchronously; result is delivered via callback on the main thread.
+Send native OS notifications through the platform notification center. The
+notification runs asynchronously. The result arrives through the callback on the
+main thread.
 
 ## Usage
 

--- a/examples/showcase/docs/widget_numeric_input.md
+++ b/examples/showcase/docs/widget_numeric_input.md
@@ -8,8 +8,8 @@ gui.NumericInput(gui.NumericInputCfg{
     ID:          "qty",
     Placeholder: "Enter number",
     Decimals:    2,
-    Min:         gui.SomeD(0),
-    Max:         gui.SomeD(999),
+    Min:         gui.Some(0.0),
+    Max:         gui.Some(999.0),
     OnValueCommit: func(v gui.Opt[float64], s string, ctx gui.EventCtx) {
         gui.State[App](ctx.Window).Qty = v
     },
@@ -22,34 +22,31 @@ gui.NumericInput(gui.NumericInputCfg{
 gui.NumericInput(gui.NumericInputCfg{
     ID:   "price",
     Mode: gui.NumericCurrency,
-    CurrencyCfg: gui.NumericCurrencyModeCfg{Symbol: "$"},
 })
 ```
 
 ## Key Properties
 
-| Property    | Type                   | Description                       |
-| ----------- | ---------------------- | --------------------------------- |
-| Text        | string                 | Current text value                |
-| Value       | Opt[float64]           | Parsed numeric value              |
-| Placeholder | string                 | Hint text shown when empty        |
-| Decimals    | int                    | Decimal places                    |
-| Min         | Opt[float64]           | Minimum allowed value             |
-| Max         | Opt[float64]           | Maximum allowed value             |
-| Mode        | NumericInputMode       | Number, currency, or percent      |
-| StepCfg     | NumericStepCfg         | Step button configuration         |
-| CurrencyCfg | NumericCurrencyModeCfg | Currency mode settings            |
-| PercentCfg  | NumericPercentModeCfg  | Percent mode settings             |
-| Locale      | NumericLocaleCfg       | Locale formatting rules           |
-| Disabled    | bool                   | Disable interaction               |
-| Invisible   | bool                   | Hide without removing from layout |
-| Sizing      | Sizing                 | Combined axis sizing mode         |
-| Width       | float32                | Fixed width                       |
-| Height      | float32                | Fixed height                      |
-| MinWidth    | float32                | Minimum width                     |
-| MaxWidth    | float32                | Maximum width                     |
-| MinHeight   | float32                | Minimum height                    |
-| MaxHeight   | float32                | Maximum height                    |
+| Property    | Type             | Description                       |
+| ----------- | ---------------- | --------------------------------- |
+| Text        | string           | Current text value                |
+| Value       | Opt[float64]     | Parsed numeric value              |
+| Placeholder | string           | Hint text shown when empty        |
+| Decimals    | int              | Decimal places                    |
+| Min         | Opt[float64]     | Minimum allowed value             |
+| Max         | Opt[float64]     | Maximum allowed value             |
+| Mode        | NumericInputMode | Number, currency, or percent      |
+| StepCfg     | NumericStepCfg   | Step button configuration         |
+| Locale      | NumericLocaleCfg | Locale formatting rules           |
+| Disabled    | bool             | Disable interaction               |
+| Invisible   | bool             | Hide without removing from layout |
+| Sizing      | Sizing           | Combined axis sizing mode         |
+| Width       | float32          | Fixed width                       |
+| Height      | float32          | Fixed height                      |
+| MinWidth    | float32          | Minimum width                     |
+| MaxWidth    | float32          | Maximum width                     |
+| MinHeight   | float32          | Minimum height                    |
+| MaxHeight   | float32          | Maximum height                    |
 
 ## Appearance
 

--- a/examples/showcase/docs/widget_overflow_panel.md
+++ b/examples/showcase/docs/widget_overflow_panel.md
@@ -1,6 +1,6 @@
-Toolbar that hides items that don't fit and shows them in a dropdown menu.
-Useful for responsive toolbars and action bars. Items that overflow are shown
-via a trigger button that opens a dropdown Menu.
+Toolbar that hides items that do not fit and shows them in a dropdown menu. Use
+it for responsive toolbars and action bars. Items that overflow appear in a
+dropdown menu opened by a trigger button.
 
 ## Usage
 

--- a/examples/showcase/docs/widget_printing.md
+++ b/examples/showcase/docs/widget_printing.md
@@ -1,6 +1,6 @@
-Export the current window to PDF or send to the OS print dialog. Supports paper
-sizes, margins, orientation, duplex, color mode, page ranges, headers/footers,
-and DPI settings.
+Export the current window to PDF or send it to the OS print dialog. Set the
+title, output path, copies, page ranges, headers, and footers on the job.
+`NewPrintJob` provides sensible defaults.
 
 ## Export PDF
 
@@ -8,10 +8,10 @@ and DPI settings.
 job := gui.NewPrintJob()
 job.OutputPath = "/tmp/output.pdf"
 job.Title = "My Document"
-job.Paper = gui.PaperA4
-job.Orientation = gui.PrintLandscape
 r := w.ExportPrintJob(job)
-if r.IsOk() {
+if r.ErrorMessage != "" {
+    fmt.Println("Error:", r.ErrorMessage)
+} else {
     fmt.Println("Saved to", r.Path)
 }
 ```
@@ -29,33 +29,20 @@ if r.Status == gui.PrintRunOK {
 
 ## PrintJob Properties
 
-| Property    | Type                 | Description                        |
-| ----------- | -------------------- | ---------------------------------- |
-| OutputPath  | string               | PDF output path (export only)      |
-| Title       | string               | Document title                     |
-| JobName     | string               | OS print job name                  |
-| Paper       | PaperSize            | Paper size                         |
-| Orientation | PrintOrientation     | Portrait or Landscape              |
-| Margins     | PrintMargins         | Page margins in points (1/72 inch) |
-| Copies      | int                  | Number of copies (default 1)       |
-| Duplex      | PrintDuplexMode      | Simplex / LongEdge / ShortEdge     |
-| ColorMode   | PrintColorMode       | Default / Color / Grayscale        |
-| ScaleMode   | PrintScaleMode       | FitToPage or ActualSize            |
-| PageRanges  | []PrintPageRange     | Specific page ranges               |
-| Header      | PrintHeaderFooterCfg | Header text (left/center/right)    |
-| Footer      | PrintHeaderFooterCfg | Footer text (left/center/right)    |
-| Paginate    | bool                 | Enable pagination                  |
-| RasterDPI   | int                  | Raster DPI (default 300)           |
-| JPEGQuality | int                  | JPEG quality (default 85)          |
+| Property    | Type                 | Description                     |
+| ----------- | -------------------- | ------------------------------- |
+| OutputPath  | string               | PDF output path (export only)   |
+| Title       | string               | Document title                  |
+| JobName     | string               | OS print job name               |
+| Orientation | PrintOrientation     | Portrait or Landscape           |
+| Copies      | int                  | Number of copies (default 1)    |
+| PageRanges  | []PrintPageRange     | Specific page ranges            |
+| Header      | PrintHeaderFooterCfg | Header text (left/center/right) |
+| Footer      | PrintHeaderFooterCfg | Footer text (left/center/right) |
 
 ## Paper Sizes
 
-| Constant    | Size         |
-| ----------- | ------------ |
-| PaperLetter | 8.5 x 11 in  |
-| PaperLegal  | 8.5 x 14 in  |
-| PaperA4     | 210 x 297 mm |
-| PaperA3     | 297 x 420 mm |
+`NewPrintJob` defaults to A4 portrait paper.
 
 ## PrintMargins
 
@@ -66,16 +53,15 @@ if r.Status == gui.PrintRunOK {
 | Bottom | float32 | Bottom margin in points |
 | Left   | float32 | Left margin in points   |
 
-`DefaultPrintMargins()` returns 36pt (0.5 inch) on all sides.
+The default margins are 36 points (0.5 inch) on all sides.
 
 ## PrintExportResult
 
-| Field        | Type              | Description            |
-| ------------ | ----------------- | ---------------------- |
-| Status       | PrintExportStatus | PrintExportOK or Error |
-| Path         | string            | Output file path       |
-| ErrorCode    | string            | Error code if failed   |
-| ErrorMessage | string            | Human-readable error   |
+| Field        | Type   | Description          |
+| ------------ | ------ | -------------------- |
+| Path         | string | Output file path     |
+| ErrorCode    | string | Error code if failed |
+| ErrorMessage | string | Human-readable error |
 
 ## PrintRunResult
 
@@ -85,4 +71,3 @@ if r.Status == gui.PrintRunOK {
 | ErrorCode    | string         | Error code if failed  |
 | ErrorMessage | string         | Human-readable error  |
 | PDFPath      | string         | Path to generated PDF |
-| Warnings     | []PrintWarning | Non-fatal issues      |

--- a/examples/showcase/docs/widget_radio.md
+++ b/examples/showcase/docs/widget_radio.md
@@ -1,5 +1,5 @@
-Circular radio button for selecting one option. Typically used inside a
-RadioButtonGroup, but can be used standalone.
+Circular radio button for selecting one option. Typically used inside a radio
+button group, but can be used standalone.
 
 ## Usage
 

--- a/examples/showcase/docs/widget_radio_group.md
+++ b/examples/showcase/docs/widget_radio_group.md
@@ -27,8 +27,8 @@ gui.RadioButtonGroupRow(gui.RadioButtonGroupCfg{
         gui.NewRadioOption("M", "m"),
         gui.NewRadioOption("L", "l"),
     },
-    OnSelect: func(v string, w *gui.Window) {
-        gui.State[App](w).Size = v
+    OnSelect: func(v string, ctx gui.EventCtx) {
+        gui.State[App](ctx.Window).Size = v
     },
 })
 ```
@@ -78,9 +78,9 @@ When `Items` is set, `Options` is ignored.
 
 ## Events
 
-| Callback | Signature             | Fired when        |
-| -------- | --------------------- | ----------------- |
-| OnSelect | func(string, *Window) | Selection changes |
+| Callback | Signature              | Fired when        |
+| -------- | ---------------------- | ----------------- |
+| OnSelect | func(string, EventCtx) | Selection changes |
 
 ## Accessibility
 

--- a/examples/showcase/docs/widget_row.md
+++ b/examples/showcase/docs/widget_row.md
@@ -6,7 +6,7 @@ sizing, alignment, scrolling, floating, borders, and event handling.
 ```go
 gui.Row(gui.ContainerCfg{
     Spacing: gui.SomeF(8),
-    Padding: gui.SomeP(4, 8, 4, 8),
+    Padding: gui.NewPadding(4, 8, 4, 8),
     Sizing:  gui.FillFit,
     Content: []gui.View{child1, child2},
 })
@@ -18,7 +18,7 @@ gui.Row(gui.ContainerCfg{
 gui.Row(gui.ContainerCfg{
     ID:         "my-row",
     Scrollable: true,
-    ScrollMode: gui.ScrollModeX,
+    ScrollMode: gui.ScrollHorizontalOnly,
     Sizing:     gui.FillFixed,
     Height:     200,
     Content:    items,

--- a/examples/showcase/docs/widget_rtf.md
+++ b/examples/showcase/docs/widget_rtf.md
@@ -39,7 +39,6 @@ gui.RTF(gui.RTFCfg{
 | `RichRun(text, style)`             | Styled text run                          |
 | `RichLink(text, url, style)`       | Hyperlink (auto underline + theme color) |
 | `RichAbbr(text, expansion, style)` | Abbreviation with tooltip                |
-| `RichFootnote(id, content, style)` | Superscript footnote with tooltip        |
 | `RichBr()`                         | Line break                               |
 
 ## Text Decorations
@@ -55,18 +54,18 @@ gui.RichRun("underlined", gui.TextStyle{
 
 ## Key Properties
 
-| Property      | Type       | Description                                             |
-| ------------- | ---------- | ------------------------------------------------------- |
-| RichText      | RichText   | Runs of styled text                                     |
-| MinWidth      | float32    | Minimum block width                                     |
-| Mode          | TextMode   | Text wrapping mode                                      |
-| HangingIndent | float32    | Negative indent for wrapped lines                       |
-| Clip          | bool       | Clip text to bounds                                     |
-| BaseTextStyle | *TextStyle | Fallback style for runs                                 |
-| Focusable     | bool       | Enables focus and text selection (needs a non-empty ID) |
-| Disabled      | bool       | Disable interaction                                     |
-| Invisible     | bool       | Hide without removing from layout                       |
-| FocusSkip     | bool       | Skip in tab-order navigation                            |
+| Property      | Type       | Description                                              |
+| ------------- | ---------- | -------------------------------------------------------- |
+| RichText      | RichText   | Runs of styled text                                      |
+| MinWidth      | float32    | Minimum block width                                      |
+| Mode          | TextMode   | Text wrapping mode                                       |
+| HangingIndent | float32    | Negative indent for wrapped lines                        |
+| Clip          | bool       | Clip text to bounds                                      |
+| BaseTextStyle | *TextStyle | Fallback style for runs                                  |
+| Focusable     | bool       | Turns on focus and text selection (needs a non-empty ID) |
+| Disabled      | bool       | Disable interaction                                      |
+| Invisible     | bool       | Hide without removing from layout                        |
+| FocusSkip     | bool       | Skip in tab-order navigation                             |
 
 ## Accessibility
 

--- a/examples/showcase/docs/widget_scrollbar.md
+++ b/examples/showcase/docs/widget_scrollbar.md
@@ -10,7 +10,6 @@ gui.Column(gui.ContainerCfg{
     Scrollable:    true,
     ScrollbarCfgY: &gui.ScrollbarCfg{
         GapEdge:  4,
-        Overflow: gui.ScrollbarOnHover,
     },
     Content: views,
 })
@@ -31,18 +30,17 @@ gui.Column(gui.ContainerCfg{
 
 ## Key Properties
 
-| Property     | Type                 | Description                      |
-| ------------ | -------------------- | -------------------------------- |
-| ID           | string               | Unique identifier                |
-| ScrollID     | string               | Scroll container ID to attach to |
-| Orientation  | ScrollbarOrientation | Horizontal or vertical           |
-| Size         | float32              | Scrollbar thickness              |
-| MinThumbSize | float32              | Minimum thumb length             |
-| Radius       | float32              | Track corner radius              |
-| RadiusThumb  | float32              | Thumb corner radius              |
-| GapEdge      | float32              | Gap from container edge          |
-| GapEnd       | float32              | Gap from track ends              |
-| Overflow     | ScrollbarOverflow    | Visibility mode                  |
+| Property     | Type                 | Description             |
+| ------------ | -------------------- | ----------------------- |
+| ID           | string               | Unique identifier       |
+| Orientation  | ScrollbarOrientation | Horizontal or vertical  |
+| Size         | float32              | Scrollbar thickness     |
+| MinThumbSize | float32              | Minimum thumb length    |
+| Radius       | float32              | Track corner radius     |
+| RadiusThumb  | float32              | Thumb corner radius     |
+| GapEdge      | float32              | Gap from container edge |
+| GapEnd       | float32              | Gap from track ends     |
+| Overflow     | ScrollbarOverflow    | Visibility mode         |
 
 ## Appearance
 
@@ -58,4 +56,3 @@ gui.Column(gui.ContainerCfg{
 | ScrollbarAuto    | Show when content overflows (default) |
 | ScrollbarHidden  | Never show                            |
 | ScrollbarVisible | Always show                           |
-| ScrollbarOnHover | Show on mouse hover only              |

--- a/examples/showcase/docs/widget_select.md
+++ b/examples/showcase/docs/widget_select.md
@@ -1,8 +1,8 @@
 Dropdown selector with single or multi-select. Options prefixed with "---"
 render as subheadings.
 
-Select already accepts `[]string` directly via the `Options` field — the
-zero-configuration path.
+Select accepts `[]string` directly through the `Options` field. This path needs
+no configuration.
 
 ## Usage
 

--- a/examples/showcase/docs/widget_skeleton.md
+++ b/examples/showcase/docs/widget_skeleton.md
@@ -86,7 +86,6 @@ gui.Skeleton(gui.SkeletonCfg{
 
 | Variant        | Description                       |
 | -------------- | --------------------------------- |
-| SkeletonRect   | Rounded rectangle (default)       |
 | SkeletonCircle | Circle, sized by Width and Height |
 
 ## Accessibility

--- a/examples/showcase/docs/widget_svg.md
+++ b/examples/showcase/docs/widget_svg.md
@@ -1,6 +1,6 @@
 Scalable vector graphics from file or inline SVG string. Faithful rendering of
 designer-authored static and animated SVG — not a complete SVG 1.1/2
-implementation. See `docs/svg-support.md` for the authoritative feature matrix.
+implementation.
 
 ## From File
 

--- a/examples/showcase/docs/widget_svg_spinner.md
+++ b/examples/showcase/docs/widget_svg_spinner.md
@@ -2,7 +2,7 @@ One hundred six built-in animated SVG spinners drawn from the open-source
 svg-spinners collection plus extended SMIL- and CSS-driven assets. Each kind is
 embedded as raw SVG and rendered through the same pipeline as `gui.Svg`, so
 assets recolor via `fill=\"currentColor\"` and scale cleanly at any size.
-Identify a spinner by its `SvgSpinnerKind` constant; call `SvgSpinnerCount` or
+Identify a spinner by its `SvgSpinnerKind` constant. Call `SvgSpinnerCount` or
 `SvgSpinnerName` to enumerate or label them.
 
 ## Usage
@@ -67,16 +67,16 @@ for i := range gui.SvgSpinnerCount() {
 
 ## Accessibility
 
-| Property | Type    | Description                                                                            |
-| -------- | ------- | -------------------------------------------------------------------------------------- |
-| A11YCfg  | A11YCfg | Embedded: A11YLabel (short spoken name), A11YDescription (e.g. "loading, please wait") |
+| Property | Type    | Description                                                                                   |
+| -------- | ------- | --------------------------------------------------------------------------------------------- |
+| A11YCfg  | A11YCfg | Embedded: A11YLabel (short spoken name), A11YDescription (for example "loading, please wait") |
 
 ## Helpers
 
-| Function          | Description                                   |
-| ----------------- | --------------------------------------------- |
-| SvgSpinnerCount() | Returns the number of built-in kinds (106)    |
-| SvgSpinnerName(k) | Returns the asset basename (e.g. "tail-spin") |
+| Function          | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| SvgSpinnerCount() | Returns the number of built-in kinds (106)           |
+| SvgSpinnerName(k) | Returns the asset basename (for example "tail-spin") |
 
 ## Animation Pipeline
 
@@ -250,12 +250,12 @@ CSS features:
 
 ## Caveats
 
-- Assets relying on SMIL or CSS features outside the supported subset may render
+- Assets relying on SMIL or CSS features outside the supported subset can render
   as their static first frame.
-- `<set>` defaults to freeze semantics (SMIL default is remove); authors who
+- `<set>` defaults to freeze semantics (the SMIL default is remove). Authors who
   want remove must set `fill=\"remove\"` explicitly.
-- `SvgSpinnerCount` and enum values are generated from the embedded asset
-  directory, so numeric values shift when assets are added or removed — always
+- `SvgSpinnerCount` and the enum values are generated from the embedded asset
+  directory. Numeric values shift when assets are added or removed. Always
   reference kinds by their named constant.
 
 Set the pair through the embed: `A11YCfg: gui.A11YCfg{A11YLabel: "Save"}`.

--- a/examples/showcase/docs/widget_table.md
+++ b/examples/showcase/docs/widget_table.md
@@ -25,6 +25,8 @@ w.Table(cfg)
 ## Custom Rows
 
 ```go
+alignEnd := gui.HAlignEnd
+
 w.Table(gui.TableCfg{
     ID:          "custom",
     BorderStyle: gui.TableBorderAll,
@@ -35,7 +37,7 @@ w.Table(gui.TableCfg{
         }},
         {Cells: []gui.TableCellCfg{
             {Value: "Alice"},
-            {Value: "95", HAlign: gui.HAlignEndPtr()},
+            {Value: "95", HAlign: &alignEnd},
         }},
     },
 })
@@ -103,17 +105,17 @@ When `RawData` is set, `Data` is ignored.
 
 ## Appearance
 
-| Property         | Type         | Description                |
-| ---------------- | ------------ | -------------------------- |
-| ColorBorder      | Color        | Border/grid line color     |
-| ColorSelect      | Color        | Selected row background    |
-| ColorHover       | Color        | Hovered row background     |
-| ColorRowAlt      | *Color       | Alternating row background |
-| CellPadding      | Opt[Padding] | Padding inside each cell   |
-| TextStyle        | TextStyle    | Body cell text style       |
-| TextStyleHead    | TextStyle    | Header cell text style     |
-| SizeBorder       | float32      | Border line width          |
-| SizeBorderHeader | float32      | Header border line width   |
+| Property         | Type      | Description                |
+| ---------------- | --------- | -------------------------- |
+| ColorBorder      | Color     | Border/grid line color     |
+| ColorSelect      | Color     | Selected row background    |
+| ColorHover       | Color     | Hovered row background     |
+| ColorRowAlt      | *Color    | Alternating row background |
+| CellPadding      | Padding   | Padding inside each cell   |
+| TextStyle        | TextStyle | Body cell text style       |
+| TextStyleHead    | TextStyle | Header cell text style     |
+| SizeBorder       | float32   | Border line width          |
+| SizeBorderHeader | float32   | Header border line width   |
 
 ## Events
 

--- a/examples/showcase/docs/widget_text.md
+++ b/examples/showcase/docs/widget_text.md
@@ -48,23 +48,22 @@ gui.Text(gui.TextCfg{
 
 ## Key Properties
 
-| Property          | Type      | Description                                             |
-| ----------------- | --------- | ------------------------------------------------------- |
-| Text              | string    | Content to display                                      |
-| TextStyle         | TextStyle | Font, size, color, decorations                          |
-| Mode              | TextMode  | Wrapping behavior                                       |
-| Focusable         | bool      | Enables focus and text selection (needs a non-empty ID) |
-| TabSize           | uint32    | Tab width in spaces                                     |
-| MinWidth          | float32   | Minimum text width                                      |
-| Clip              | bool      | Clip text to bounds                                     |
-| Opacity           | float32   | Text opacity (0.0–1.0)                                  |
-| Hero              | bool      | Animate text transitions                                |
-| IsPassword        | bool      | Mask characters                                         |
-| PlaceholderActive | bool      | Render as placeholder style                             |
-| Sizing            | Sizing    | Override default sizing                                 |
-| Disabled          | bool      | Disable interaction                                     |
-| Invisible         | bool      | Hide without removing from layout                       |
-| FocusSkip         | bool      | Skip in tab-order navigation                            |
+| Property   | Type      | Description                                              |
+| ---------- | --------- | -------------------------------------------------------- |
+| Text       | string    | Content to display                                       |
+| TextStyle  | TextStyle | Font, size, color, decorations                           |
+| Mode       | TextMode  | Wrapping behavior                                        |
+| Focusable  | bool      | Turns on focus and text selection (needs a non-empty ID) |
+| TabSize    | uint32    | Tab width in spaces                                      |
+| MinWidth   | float32   | Minimum text width                                       |
+| Clip       | bool      | Clip text to bounds                                      |
+| Opacity    | float32   | Text opacity (0.0–1.0)                                   |
+| Hero       | bool      | Animate text transitions                                 |
+| IsPassword | bool      | Mask characters                                          |
+| Sizing     | Sizing    | Override default sizing                                  |
+| Disabled   | bool      | Disable interaction                                      |
+| Invisible  | bool      | Hide without removing from layout                        |
+| FocusSkip  | bool      | Skip in tab-order navigation                             |
 
 ## TextStyle Fields
 

--- a/examples/showcase/docs/widget_theme_gen.md
+++ b/examples/showcase/docs/widget_theme_gen.md
@@ -84,5 +84,5 @@ gui.SetTheme(gui.ThemeMaker(cfg))
 | Warm       | Warm-shifted palette     |
 | Cool       | Cool-shifted palette     |
 
-Use the tint slider to control surface saturation. Dark mode is derived
-automatically from the same seed color.
+Use the tint slider to control surface saturation. The framework derives dark
+mode automatically from the same seed color.

--- a/examples/showcase/docs/widget_toggle.md
+++ b/examples/showcase/docs/widget_toggle.md
@@ -1,5 +1,4 @@
-Checkbox-style toggle with optional label. `Checkbox()` is an alias for
-`Toggle()`.
+Checkbox-style toggle with optional label.
 
 ## Usage
 

--- a/examples/showcase/docs/widget_tooltip.md
+++ b/examples/showcase/docs/widget_tooltip.md
@@ -19,7 +19,6 @@ gui.WithTooltip(w, gui.WithTooltipCfg{
 gui.WithTooltip(w, gui.WithTooltipCfg{
     Text:   "Right side tooltip",
     Anchor: gui.Some(gui.FloatMiddleRight),
-    TieOff: gui.Some(gui.FloatMiddleLeft),
     Content: []gui.View{
         gui.Button(gui.ButtonCfg{...}),
     },
@@ -34,7 +33,6 @@ gui.WithTooltip(w, gui.WithTooltipCfg{
 | Text     | string           | Tooltip text content       |
 | Delay    | time.Duration    | Hover delay before showing |
 | Anchor   | Opt[FloatAttach] | Tooltip anchor on trigger  |
-| TieOff   | Opt[FloatAttach] | Tooltip attach point       |
 | Content  | []View           | Wrapped target views       |
 
 ## TooltipCfg Properties (Advanced)
@@ -45,7 +43,6 @@ gui.WithTooltip(w, gui.WithTooltipCfg{
 | Delay       | time.Duration    | Hover delay before showing    |
 | Content     | []View           | Custom tooltip content        |
 | Anchor      | Opt[FloatAttach] | Float anchor point            |
-| TieOff      | Opt[FloatAttach] | Float tie-off point           |
 | OffsetX     | Opt[float32]     | Horizontal offset from anchor |
 | OffsetY     | Opt[float32]     | Vertical offset from anchor   |
 | FloatZIndex | int              | Z-index for float layering    |

--- a/examples/showcase/docs/widget_tree.md
+++ b/examples/showcase/docs/widget_tree.md
@@ -76,7 +76,7 @@ When `ItemPaths` is set, `Nodes` is ignored.
 | ItemPaths   | []string      | Flat slash-separated paths (alt.)              |
 | Nodes       | []TreeNodeCfg | Root-level tree nodes                          |
 | Indent      | float32       | Indent per nesting level                       |
-| Spacing     | float32       | Vertical spacing between rows                  |
+| Spacing     | Opt[float32]  | Vertical spacing between rows                  |
 | Scrollable  | bool          | Opt into the scroll system (state keyed by ID) |
 | Reorderable | bool          | Enable drag-reorder of siblings                |
 | Disabled    | bool          | Disable interaction                            |
@@ -91,15 +91,15 @@ When `ItemPaths` is set, `Nodes` is ignored.
 
 ## TreeNodeCfg
 
-| Property      | Type          | Description                        |
-| ------------- | ------------- | ---------------------------------- |
-| ID            | string        | Node identifier (defaults to Text) |
-| Text          | string        | Display text                       |
-| Icon          | string        | Icon string (e.g. IconFolder)      |
-| Lazy          | bool          | Load children on expand            |
-| Nodes         | []TreeNodeCfg | Child nodes                        |
-| TextStyle     | TextStyle     | Text styling                       |
-| TextStyleIcon | TextStyle     | Icon text styling                  |
+| Property      | Type          | Description                          |
+| ------------- | ------------- | ------------------------------------ |
+| ID            | string        | Node identifier (defaults to Text)   |
+| Text          | string        | Display text                         |
+| Icon          | string        | Icon string (for example IconFolder) |
+| Lazy          | bool          | Load children on expand              |
+| Nodes         | []TreeNodeCfg | Child nodes                          |
+| TextStyle     | TextStyle     | Text styling                         |
+| TextStyleIcon | TextStyle     | Icon text styling                    |
 
 ## Appearance
 

--- a/examples/solar_system/README.md
+++ b/examples/solar_system/README.md
@@ -2,16 +2,16 @@
 
 An interactive orrery. Eight planets travel tilted elliptical orbits around a
 glowing sun, over a starfield that twinkles. Mercury laps the sun in about seven
-and a half seconds; Neptune takes a little over two and a half minutes.
+and a half seconds. Neptune takes a little over two and a half minutes.
 
-Planets are shaded spheres lit from the sun, each labelled under its disc, and
-they show phases — a planet on the near side of its orbit turns its night side
-toward you and reads as a crescent. Each one carries a procedural surface and
-turns on a tilted axis: Jupiter's belts drift past, Earth shows continents and
-ice caps, Venus turns backwards, and Uranus rolls along its orbit rather than
-spinning upright. Hover a body and it glows, with a tooltip that follows the
-cursor. Click one and the camera zooms and pans to it, keeps following it as it
-orbits, and opens a fact sheet with six stat cards and a fun fact. The sun is a
+Planets are shaded spheres lit from the sun, each labelled under its disc. They
+show phases. A planet on the near side of its orbit turns its night side toward
+you and reads as a crescent. Each one carries a procedural surface and turns on
+a tilted axis. Jupiter's belts drift past. Earth shows continents and ice caps.
+Venus turns backwards, and Uranus rolls along its orbit and does not spin
+upright. Hover a body and it glows, with a tooltip that follows the cursor.
+Click one and the camera zooms and pans to it. It follows the planet as it
+orbits and opens a fact sheet with six stat cards and a fun fact. The sun is a
 body like any other here: it hit-tests, it has its own fact sheet, and it takes
 the first navigation dot. Navigation dots along the bottom jump straight to any
 body, and the left and right arrow keys step through them with wraparound.
@@ -28,45 +28,45 @@ go run ./examples/solar_system/
 
 - **`DrawCanvas` as a full application surface** — the entire simulation is one
   canvas, with `Version` bumped every tick to invalidate the tessellation cache.
-  Without that bump the canvas would render frame one forever.
-- **Continuous animation** via `Animate` with `Repeat`, driving a single `tick`
-  that advances time, the camera, and hover in one place.
-- **A camera whose target moves.** A selected planet keeps orbiting, so the
-  camera's goal is re-read every tick rather than captured at click time.
-  Interrupting a transition restarts the tween from wherever the camera actually
-  is, so there is no snap back to the previous anchor.
-- **Hit-testing drawn geometry.** Screen positions are computed once per tick
-  and both the hit-test and the painting read them, which is what guarantees the
+  Without that bump, the canvas renders frame one forever.
+- **Continuous animation** via `Animate` with `Repeat`. It drives a single
+  `tick` that advances time, the camera, and hover in one place.
+- **A camera whose target moves.** A selected planet continues to orbit. The
+  code re-reads the camera's goal every tick rather than capturing it at click
+  time. Interrupting a transition restarts the tween from wherever the camera
+  actually is, so there is no snap back to the previous anchor.
+- **Hit-testing drawn geometry.** Screen positions are computed once per tick,
+  and both the hit-test and the painting read them. That is what guarantees the
   two agree. A minimum hit radius keeps sub-pixel bodies clickable.
 - **Per-callback coordinate spaces.** `OnMouseMove` and `OnClick` are
-  shape-relative; `OnHover` and `OnMouseLeave` are window-absolute. The canvas
+  shape-relative. `OnHover` and `OnMouseLeave` are window-absolute. The canvas
   takes no padding, so shape-relative coordinates are also content coordinates.
 - **Gesture and scroll input.** `GesturePinch` reports a _cumulative_ scale, so
-  the per-event delta is recovered by tracking the previous value. Scroll
+  the app recovers the per-event delta by tracking the previous value. Scroll
   arrives in lines or in points depending on `ScrollPrecise`.
 - **The float system.** The zoom controls and the info panel are ordinary
   widgets floated over the canvas. Float children are excluded from parent
   sizing, so the canvas keeps the whole window and the camera math never reacts
-  to a panel appearing.
+  when a panel appears.
 - **Batch-aware drawing.** `DrawContext` merges only _consecutive_ same-color
   triangles, so the starfield quantizes its twinkle to eight brightness levels
-  and draws one level at a time — eight batches per frame instead of 220. A
-  shaded sphere goes the other way: it is one mesh carrying a color per vertex,
-  so the whole body is a single batch however fine its ramp.
+  and draws one level at a time. That is eight batches per frame instead of 220.
+  A shaded sphere goes the other way: it is one mesh that carries a color per
+  vertex. The whole body is then a single batch, however fine its ramp.
 
 - **Texturing without a texture path.** The renderer has no UV coordinates
-  anywhere — `FillTrianglesColors` carries per-vertex colors and nothing else —
-  so planet surfaces are sampled on the CPU, once per mesh vertex, and folded
-  into the color that vertex already had. No engine change, and every backend
-  keeps working.
+  anywhere — `FillTrianglesColors` carries per-vertex colors and nothing else.
+  The app samples planet surfaces on the CPU, once per mesh vertex, and folds
+  them into the color that vertex already had. No engine change, and every
+  backend still works.
 
 - **One encoding for "which body".** Selection and hover are a planet index,
   `selSun` for the sun, or `-1` for nothing. The sun gets a value outside the
-  planet range rather than a row in the planets table: it does not orbit, so it
-  has no `orbitPos` to recompute a screen position from, and it is not drawn by
-  `drawPlanet`. `bodyAt` is the one place that encoding is decoded, and arrow
-  stepping walks a _rank_ rather than the encoded value, because `selSun` is
-  deliberately not adjacent to Mercury in arithmetic.
+  planet range rather than a row in the planets table. It does not orbit, so it
+  has no `orbitPos` to recompute a screen position from. `drawPlanet` does not
+  draw it. `bodyAt` is the one place that encoding is decoded. Arrow stepping
+  walks a _rank_ rather than the encoded value, because `selSun` is deliberately
+  not adjacent to Mercury in arithmetic.
 
 ## Notes on technique
 
@@ -79,210 +79,211 @@ one fill:
   disc, and even quadratic leaves a visible shoulder at this radius.
 - A hovered planet's halo is the same shape at planet scale.
 
-Both used to be stacks of concentric translucent discs — up to 140 of them for
-the sun — where the ring count was the smoothness knob and seams showed when it
-was turned down. `haloStops` (`draw.go`) samples the opacity those stacks
-accumulated to, so the appearance is the one they had, at one fill each and with
-nothing left to tune.
+Both used to be stacks of concentric translucent discs, up to 140 of them for
+the sun. The ring count was the smoothness knob. Seams showed when the count was
+decreased. `haloStops` (`draw.go`) samples the opacity those stacks accumulated
+to, so the appearance is the one they had. That is one fill each, with nothing
+left to tune.
 
-The planet shading is the third form: `FillTrianglesColors` (issue #400), where
-the caller evaluates its own shading model and hands over geometry plus one
-color per vertex. A gradient cannot stand in for it — circles cannot make a
-crescent, and neither can any other conic isoline; the argument is below.
+The planet shading is the third form: `FillTrianglesColors` (issue #400). The
+caller evaluates its own shading model and hands over geometry plus one color
+per vertex. A gradient cannot stand in for it — circles cannot make a crescent,
+and neither can any other conic isoline. The argument is below.
 
-What is left is flat shapes standing in for a gradient, deliberately: three
-translucent rings just outside each planet's silhouette feather the polygon edge
-into something that reads as anti-aliased. Three is few enough that a gradient
-would not pay for itself.
+The remaining approach is flat shapes in place of a gradient, deliberately.
+Three translucent rings just outside each planet's silhouette feather the
+polygon edge, so it reads as anti-aliased. Three is few enough that a gradient
+does not pay for itself.
 
 ### Painting a star
 
-A sun is not a bright disc, and four separate things have to be true before it
-reads as one.
+A sun is not a bright disc. Four separate things must be true before it reads as
+one.
 
-**The color belongs at the edge, not the middle.** Ramping the face orange all
-the way in reads as an amber lamp. The disc is near-white across most of its
+**The color belongs at the edge, not the middle.** If the face ramps orange all
+the way in, it reads as an amber lamp. The disc is near-white across most of its
 face, with gold kept to a rind at the limb and to the halo around it.
 
 **The limb is brighter than the body behind it.** The disc ramp runs bright rind
-→ slightly deeper body → white core, and the dip between the first two is the
-point: that is what limb brightening looks like. A plain center-out ramp is a
-coin lit from the front.
+→ slightly deeper body → white core. The dip between the first two is the point:
+that is what limb brightening looks like. A plain center-out ramp is a coin lit
+from the front.
 
-**The face is mottled.** Granulation is a fixed set of soft blobs, each a small
-stack of nested circles so it has a falloff instead of a hard edge. They are
-drawn tier-major with lit and dark cells in separate passes, so every circle in
-a pass shares one color and the whole texture costs `2 x tiers` batches rather
-than one per cell — drawing cell-major would cost seventy times more. Cells are
-placed by `sqrt` of a uniform so they spread over the _area_ instead of crowding
-the middle, and each one's far edge is clamped inside the limb so the texture
-needs no clipping.
+**The face is mottled.** Granulation is a fixed set of soft blobs. Each blob is
+a small stack of nested circles, so it has a falloff instead of a hard edge.
+They are drawn tier-major with lit and dark cells in separate passes. Every
+circle in a pass shares one color, so the whole texture costs `2 x tiers`
+batches rather than one per cell. A cell-major pass costs seventy times more.
+The app places cells by `sqrt` of a uniform, so they spread over the _area_
+instead of crowding the middle. It clamps each cell's far edge inside the limb,
+so the texture needs no clipping.
 
 **The rim is ragged.** A clean circular edge looks like a coin no matter how
-bright it is, so the corona is a fringe whose radius is modulated by a smoothed
-noise ring that drifts slowly with time. Raw uniform noise gives a spiky rim
-that reads as a gear, and the ring has to wrap — a seam at the join would show
-as a notch that never moves.
+bright it is. The corona is a fringe whose radius follows a smoothed noise ring
+that drifts slowly with time. Raw uniform noise gives a spiky rim that reads as
+a gear. The ring must wrap. A seam at the join shows as a notch that never
+moves.
 
-The corona's tiers are _nested_ annuli sharing boundaries, each band's inner
-edge being the previous band's outer edge. The first attempt stacked them all
-from one shared inner radius, which accumulated alpha there and painted a hard
-bright ring inside the limb — a worse artifact than the soft edge it was meant
-to give.
+The corona's tiers are _nested_ annuli that share boundaries. Each band's inner
+edge is the previous band's outer edge. The first attempt stacked them all from
+one shared inner radius. Alpha accumulated there and painted a hard bright ring
+inside the limb — a worse artifact than the soft edge the design intended.
 
 ### Shading a sphere the renderer cannot express
 
 A planet is a real Lambert sphere, not an approximation of one. On a sphere lit
-by a distant source the brightness at a surface point is `N·L`, so the lines of
+by a distant source, the brightness at a surface point is `N·L`. The lines of
 equal brightness are the circles of constant angle from the light. The body is a
-mesh of exactly those circles — one ring of vertices per intensity, traced in a
-frame with the light as its pole, projected to screen, and handed to
-`FillTrianglesColors` with the intensity carried as a color on every vertex.
+mesh of exactly those circles, one ring of vertices per intensity. The app
+traces the mesh in a frame with the light as its pole and projects it to screen.
+It hands the result to `FillTrianglesColors`, with the intensity as a color on
+every vertex.
 
 The light vector is built once, in screen coordinates, and carries everything
 the shading needs. `diskTilt` is the sine of the camera's elevation above the
-orbital plane — that is what the vertical squash in `worldToScreen` _is_ — so
-the camera's basis is `R = (1,0,0)`, `D = (0, sin e, -cos e)`,
-`V = (0, cos e, sin e)`, and projecting the world light direction onto it gives
-all three components. The `z` component falls out as `cos` of the phase angle,
-so **phase** costs no extra derivation: a planet on the near side of its orbit
-has the sun beyond it and reads as a crescent. Its range is about `[0.06, 0.94]`
-rather than `[0, 1]`, because a camera 29° above the plane never sees a pure new
-or full phase. Most orreries skip phase entirely and paint every planet fully
-lit.
+orbital plane — that is what the vertical squash in `worldToScreen` _is_. The
+camera's basis is `R = (1,0,0)`, `D = (0, sin e, -cos e)`,
+`V = (0, cos e, sin e)`. The projection of the world light direction onto this
+basis gives all three components. The `z` component falls out as `cos` of the
+phase angle, so **phase** costs no extra derivation. A planet on the near side
+of its orbit has the sun beyond it and reads as a crescent. Its range is about
+`[0.06, 0.94]` rather than `[0, 1]`, because a camera 29° above the plane never
+sees a pure new or full phase. Most orreries skip phase entirely and paint every
+planet fully lit.
 
 Five things about this are worth knowing if you copy it.
 
 **Circles cannot make a crescent.** The first version built the body from a
-focal radial gradient — the `fx`/`fy` construction an SVG `radialGradient` uses,
-which `gui/svg/xml_defs.go` parses. Its isophotes are circles. Pushing the focal
-point out to the limb to fake a crescent puts a compact bright blob on a dark
-disc, which reads as a second small sphere sitting inside the planet. The
-terminator is an ellipse; no amount of softening the blob's edge turns one into
-the other.
+focal radial gradient. That is the `fx`/`fy` construction an SVG
+`radialGradient` uses, which `gui/svg/xml_defs.go` parses. Its isophotes are
+circles. If the focal point is pushed out to the limb to fake a crescent, a
+compact bright blob appears on a dark disc. It reads as a second small sphere
+inside the planet. The terminator is an ellipse. No amount of softening the
+blob's edge turns one into the other.
 
 **Nor can any other gradient.** The isophotes _are_ ellipses, which makes an
 elliptical gradient look like the answer, and it is not. For an orthographic
-unit sphere lit by `l`, the locus `N·L = k` projects to an ellipse centered at
-`|l₂d|·k` along the screen light direction, with semi-axis `√(1−k²)` across the
-light and `√(1−k²)·|lz|` along it. The aspect ratio is constant in `k`, so a
-gradient could match that part. Two things defeat it. The radius law is
-`√(1−k²)`, not linear: the isoline is a point at `k = −1`, opens to the full
-limb at the terminator, and closes to a point again at `k = 1`, so the isophotes
-at 30° and 150° are two small disjoint ellipses on opposite sides of the disc,
-neither containing the other. Gradient level sets are nested by construction, so
-no gradient emits that family. And each isophote is clipped at the silhouette,
-which a gradient has no notion of. That is what `FillTrianglesColors` exists
-for: the shading model is solved here and handed over already evaluated.
+unit sphere lit by `l`, the locus `N·L = k` projects to an ellipse. The ellipse
+is centered at `|l₂d|·k` along the screen light direction, with semi-axis
+`√(1−k²)` across the light and `√(1−k²)·|lz|` along it. The aspect ratio is
+constant in `k`, so a gradient can match that part. Two things defeat it. The
+radius law is `√(1−k²)`, not linear. The isoline is a point at `k = −1`. It
+opens to the full limb at the terminator, and closes to a point again at
+`k = 1`. The isophotes at 30° and 150° are two small disjoint ellipses on
+opposite sides of the disc, neither containing the other. Gradient level sets
+are nested by construction, so no gradient emits that family. Each isophote is
+clipped at the silhouette, which a gradient has no notion of. That is what
+`FillTrianglesColors` exists for: the app solves the shading model here and
+hands it over already evaluated.
 
 **Hidden points get pushed onto the limb.** A band's boundary circle usually
-runs off the back of the sphere. Projecting the hidden part radially out to
-radius `r` lands it on the silhouette — exactly where the band's boundary
-belongs, and exactly where it already is at the crossing — so nothing needs
-clipping.
+runs off the back of the sphere. The hidden part, projected radially out to
+radius `r`, lands on the silhouette. That is exactly where the band's boundary
+belongs and where it already is at the crossing, so nothing needs clipping.
 
 **Where the rings go is decided by the limb, not by the ramp.** Even steps in
-intensity are the obvious spacing and they make the silhouette go polygonal,
-because the mesh boundary _is_ the limb: a ring only partly on the near side
-ends on the silhouette, and the mesh edge between two such rings is a chord of
-it. A limb point's intensity is `m·cos(delta)` — `delta` the angle around the
-limb from the light's screen direction, `m` the light's screen-plane length — so
-even steps in intensity are wildly uneven steps in `delta`, growing as a square
-root near `delta = 0` until a single chord spans 20°. With the light in the
-screen plane that lands on the disc's own edge, which is why the facets showed
+intensity are the obvious spacing. They make the silhouette go polygonal,
+because the mesh boundary _is_ the limb. A ring only partly on the near side
+ends on the silhouette. The mesh edge between two such rings is a chord of it. A
+limb point's intensity is `m·cos(delta)`, with `delta` the angle around the limb
+from the light's screen direction and `m` the light's screen-plane length. Even
+steps in intensity are wildly uneven steps in `delta`. They grow as a square
+root near `delta = 0`, until a single chord spans 20°. With the light in the
+screen plane, that lands on the disc's own edge. That is why the facets showed
 on planets drawn beside the sun and nowhere else.
 
 So the rings that reach the limb are spaced evenly in `delta` instead, which
 makes every limb chord the same length. Those are the rings with
-`|cos(phi)| < m`; outside that band a ring is either wholly visible — a closed
-curve around the pole the light points at — or wholly hidden. The visible cap
-gets rings spaced evenly in `phi` and the hidden one gets none, which is also a
-saving: even spacing spent nearly half its rings on the far side only for
-`appendTri` to drop them.
+`|cos(phi)| < m`. Outside that band, a ring is either wholly visible or wholly
+hidden. A visible ring is a closed curve around the pole the light points at.
+The visible cap gets rings spaced evenly in `phi`, and the hidden one gets none.
+This is also a saving. Even spacing spent nearly half its rings on the far side,
+only for `appendTri` to drop them.
 
 **The mesh must be watertight and consistently wound.** Both follow from how a
 vertex-colored batch is rasterized: `gui/backend/soft` treats it as one path and
 accumulates _signed_ coverage. Adjacent triangles that merely touch antialias
-independently and leak the background through as a hairline, so consecutive
-rings share their vertices rather than being drawn as separate strips — the same
-array, used as the outer edge of one strip and the inner edge of the next. And a
-triangle wound against its neighbours subtracts from them, cutting a seam
-through the body; the limb clamp can reorder a quad's corners, so `appendTri`
-measures the signed area and emits the vertices in a consistent order rather
-than assuming one. It drops the zero-area case in the same step, which is what
-removes the rings lying entirely on the far side.
+independently and leak the background through as a hairline. Consecutive rings
+share their vertices instead of separate strips. They use the same array as the
+outer edge of one strip and the inner edge of the next. A triangle wound against
+its neighbours subtracts from them and cuts a seam through the body. The limb
+clamp can reorder a quad's corners. `appendTri` measures the signed area and
+emits the vertices in a consistent order rather than assuming one. It drops the
+zero-area case in the same step. That removes the rings that lie entirely on the
+far side.
 
 The flat-band version this replaced needed a fifth trick: every quad was grown a
-fraction of a step past its own share, so opaque neighbours overlapped instead
-of merely touching. With a per-vertex ramp that overlap would itself show as
-banding, and a shared-vertex mesh has no seam left to close.
+fraction of a step past its own share. Opaque neighbours then overlapped instead
+of merely touching. With a per-vertex ramp, that overlap shows as banding. A
+shared-vertex mesh has no seam left to close.
 
-**The color ramp needs the base color as a middle stop.** Interpolating straight
-from night to light passes through the midpoint of those two, which is a
-desaturated grey, and the planet loses its hue. With three stops the disc keeps
+**The color ramp needs the base color as a middle stop.** Interpolation straight
+from night to light passes through the midpoint of those two. That midpoint is a
+desaturated grey, and the planet loses its hue. With three stops, the disc keeps
 its own color across most of the lit side — Uranus stays cyan and Mars stays
-red. The unlit side bottoms out at a fraction of the body's color rather than
-black, on the grounds that a planet you cannot see is a planet you cannot click.
+red. The unlit side stops at a fraction of the body's color rather than black. A
+planet you cannot see is a planet you cannot click.
 
 Ring and segment counts scale with pixel radius, never a constant. Moving color
-onto the vertices cut them by more than half, because the ramp is then
-continuous however coarse the mesh is and the counts have only the _geometry_
-left to resolve — the curvature of the elliptical rings and the chord error
-where the mesh boundary meets the limb, both falling off as the square of the
-spacing. A full-system frame went from 232 triangle batches and 40.6k triangles
-to 79 and about 31k.
+onto the vertices cut them by more than half. The ramp is then continuous
+however coarse the mesh is. The counts have only the _geometry_ left to resolve.
+The geometry is the curvature of the elliptical rings and the chord error where
+the mesh boundary meets the limb. Both fall off as the square of the spacing. A
+full-system frame went from 232 triangle batches and 40.6k triangles to 79 and
+about 31k.
 
 Surface texture then gave those counts a second job and reversed that argument
-in part. Albedo is sampled per vertex and interpolated between vertices, so
-detail is now bounded by mesh density in a way intensity never was: the ceilings
-are 72 rings and 128 segments, matched to the 128x64 textures, where before they
-were 36 and 64. The rates that approach them are unchanged, so this is invisible
-at ordinary zoom — a full-system frame is 79 batches and 31.6k triangles either
-way, and a selected Jupiter 105 and 47.0k against 46.8k before. It is only at
-maximum zoom, where a planet is hundreds of pixels across and both ceilings
-actually bind, that the raise costs anything: 99.6k triangles against 85.9k.
+in part. The app samples albedo per vertex and interpolates it between vertices.
+Mesh density now bounds detail in a way intensity never did. The ceilings are 72
+rings and 128 segments, matched to the 128x64 textures, where before they were
+36 and 64. The rates that approach them are unchanged, so this is invisible at
+ordinary zoom. A full-system frame is 79 batches and 31.6k triangles either way.
+A selected Jupiter is 105 batches and 47.0k triangles, against 46.8k before. It
+is only at maximum zoom, where a planet is hundreds of pixels across and both
+ceilings actually bind, that the raise costs anything. It is 99.6k triangles
+against 85.9k.
 
-Off-screen bodies are still culled: without that, the seven planets outside the
-viewport at a focused zoom each built a full-resolution sphere anyway.
+Off-screen bodies are still culled. Without that, the seven planets outside the
+viewport at a focused zoom each build a full-resolution sphere anyway.
 
 ### Texturing a renderer that has no textures
 
-There is no textured-triangle path in go-gui, and adding one was out of scope.
+There is no textured-triangle path in go-gui. Adding one is out of scope.
 `DrawContext` offers flat fills, gradients, an axis-aligned `Image`, and
 `FillTrianglesColors` — per-vertex colors with no UVs. The `RenderSvg` command
-that carries arbitrary triangles explicitly zeroes its texcoords, and the Metal
+that carries arbitrary triangles explicitly zeroes its texcoords. The Metal
 image pipeline derives UVs from a hardcoded quad rather than reading them. Real
-UV support would mean a new render command, a new sampling pipeline, and edits
-to six backends.
+UV support needs a new render command, a new sampling pipeline, and edits to six
+backends.
 
-Pre-baking a sphere image per frame is the obvious alternative and it is a trap.
-`gui.UseImage` does hand a CPU pixel buffer to the GPU, but it is content-keyed
-with **no invalidation API**, by explicit design, and the Metal texture cache is
-a 128-entry LRU. A per-frame key for nine spinning planets thrashes it with nine
-texture creates and destroys every frame.
+Pre-baking a sphere image per frame is the obvious alternative, and it is a
+trap. `gui.UseImage` does hand a CPU pixel buffer to the GPU, but it is
+content-keyed with **no invalidation API**, by explicit design. The Metal
+texture cache is a 128-entry LRU. For nine planets that spin, a per-frame key
+thrashes the cache with nine texture creates and destroys every frame.
 
-So the surface is sampled on the CPU, once per mesh vertex, and folded into the
-vertex color the mesh already carries. The accepted cost is that detail is
-bounded by vertex density and Gouraud-interpolated between vertices; the raised
-tessellation ceilings above are what pays for it.
+So the app samples the surface on the CPU, once per mesh vertex, and folds it
+into the vertex color the mesh already carries. The accepted cost is that detail
+is bounded by vertex density and Gouraud-interpolated between vertices. The
+raised tessellation ceilings above pay for it.
 
-**Sampling turned out to be nearly free, because the mesh had already computed
-what it needs.** Two facts do the work. The light basis stores its third axis as
-2D because its `z` is exactly zero by construction, and `lightBasis.point`
-already computes the depth term for its own visibility test — which _is_ the
-normal's `z`. A vertex at `(cosPhi, sinPhi, ct, st)` has camera-space direction
+**Sampling turned out to be nearly free, because the mesh already computed what
+it needs.** Two facts do the work. The light basis stores its third axis as 2D
+because its `z` is exactly zero by construction. `lightBasis.point` already
+computes the depth term for its own visibility test — which _is_ the normal's
+`z`. A vertex at `(cosPhi, sinPhi, ct, st)` has camera-space direction
 `n = cosPhi*l + sinPhi*(ct*u + st*v)`, and three things then collapse:
 
 1. **The body axes are pre-transformed into camera space, once.** Axial tilt and
-   camera elevation are both constants, so the world-to-camera rotation is
-   applied when the surface is built and never again. `n_world · a` becomes
+   camera elevation are both constants. The code applies the world-to-camera
+   rotation when it builds the surface, and never again. `n_world · a` becomes
    `n · A` and the world transform disappears.
 2. **The ring linearizes it.** For any fixed axis `W`,
    `n·W = cosPhi*(l·W) + sinPhi*(ct*(u·W) + st*(v·W))`. That is nine dot
-   products per body per frame, folded into nine scalars per ring, and per
-   vertex it reuses the `ct`/`st` that `appendRing` already had.
+   products per body per frame, folded into nine scalars per ring. Per vertex,
+   it reuses the `ct`/`st` that `appendRing` already had.
 3. **The shading ramp folds to an affine map.** `sphereTone` mixes three colors
-   all derived from one base, so at a fixed intensity it collapses to
+   all derived from one base. At a fixed intensity, it collapses to
    `channel*k + w` — two scalars per ring instead of three color operations per
    vertex.
 
@@ -292,57 +293,57 @@ longitude offset rather than as a rotation of the basis — algebraically
 identical and much cheaper.
 
 The `atan2` is a polynomial with a worst case of 0.0102 rad. That is not
-sloppiness: one texel of a 128-wide texture spans 0.049 rad, so the entire error
+sloppiness: one texel of a 128-wide texture spans 0.049 rad. The entire error
 budget is about a fifth of the smallest thing the result can address.
 
 **Noise is evaluated on the 3D direction, not on the `(u,v)` grid.** One extra
-multiply, and it buys both seamlessness in longitude — the direction at `u=0`
-and `u=1` is literally the same point — and freedom from polar pinching. The
-test for this compares the step across the wrap column against the worst step
-anywhere else in the same texture rather than against a fixed threshold, because
-a coastline is allowed to be a sharp edge; what is not allowed is for the seam
-to be sharper than everything else.
+multiply, and it buys both seamlessness in longitude and freedom from polar
+pinching. The direction at `u=0` and `u=1` is literally the same point. The test
+for this compares the step across the wrap column against the worst step
+anywhere else in the same texture. It does not use a fixed threshold. A
+coastline can be a sharp edge. The seam cannot be sharper than everything else.
 
 **Every texture's mean is normalized back onto its `Planet.Color`.** That is
-what makes texturing safe to add at all rather than a change to every other part
-of the app: the nav dots, the labels, the tooltip and the flat tone a body under
-`flatBodyRadius` draws all still read from that one color, and a planet too
-small to show any texture still looks like the planet it did before. The shift
-is additive so contrast survives, and iterated, because clamping at the byte
-range pulls the mean back a little when a texture has ice caps or a dark spot.
+what makes texturing safe to add. It is not a change to every other part of the
+app. The nav dots, the labels, the tooltip, and the flat tone a body under
+`flatBodyRadius` draws all still read from that one color. A planet too small to
+show any texture still looks like the planet it did before. The shift is
+additive, so contrast survives. It is also applied iteratively. Clamping at the
+byte range pulls the mean back a little when a texture has ice caps or a dark
+spot.
 
 Rows are uniform in `sin(latitude)` rather than in latitude. Every row band then
 covers the same area of the sphere, so texel density is even instead of crowding
-the poles — and since sampling arrives holding `sin(latitude)` already, it
-removes an `asin` from the per-vertex path.
+the poles. Since the sampler already holds `sin(latitude)`, the scheme removes
+an `asin` from the per-vertex path.
 
 Orbit ellipses are drawn with `Arc`, the ellipse primitive, with the vertical
 radius squashed to tilt the plane. Each ellipse's center is offset by `a·e`
-because the sun sits on the focus, not the center — without that offset the
-eccentricity would not be visible at all.
+because the sun sits on the focus, not the center. Without that offset, the
+eccentricity is not visible at all.
 
 Saturn's rings are drawn in three passes: the back half of the arc, then the
-body, then the front half — which is what makes them pass behind it. Planets are
+body, then the front half. That is what makes them pass behind it. Planets are
 painted in screen-Y order, so a nearer body correctly overlaps a farther one.
 
 Orbital periods and radii are compressed, not to scale. The real range spans 88
-to 60,190 days — 684x, which nobody can watch. Periods are `realDays^0.45`,
-which preserves the ordering exactly while keeping every gap visible. Orbit
-radii use a milder `realAU^0.38`, because a stronger exponent packs the inner
-four planets inside the sun's halo.
+to 60,190 days — 684x, which nobody can watch. Periods are `realDays^0.45`. This
+preserves the ordering exactly and keeps every gap visible. Orbit radii use a
+milder `realAU^0.38`, because a stronger exponent packs the inner four planets
+inside the sun's halo.
 
-Rotation is compressed the same way and for the same reason: real periods run
+Rotation is compressed the same way and for the same reason. Real periods run
 from 9.9 h to 5,832 h, a 590x range, so `RotS` is `|realHours|^0.45 x 1.07`.
-Axial tilts are the real values in radians, and Venus carries its retrograde
-spin as a negative `RotS` rather than as the equivalent 177.4° tilt — identical
-physics, more legible in a table.
+Axial tilts are the real values in radians. Venus carries its retrograde spin as
+a negative `RotS` rather than as the equivalent 177.4° tilt — identical physics,
+more legible in a table.
 
 Worth being honest about one consequence: rotation and orbit are compressed on
-_separate_ scales, so the ratio between a planet's day and its year is not
-preserved. Mercury's real sidereal day is 0.67 of its year; here it is 4.65. The
-distortion happens to run in the direction that makes Mercury's and Venus's "a
-day lasts longer than a year" fact sheets read as true on screen, but that is a
-coincidence of the scaling rather than a property the model keeps.
+_separate_ scales. The ratio between a planet's day and its year is not
+preserved. Mercury's real sidereal day is 0.67 of its year. Here it is 4.65. The
+distortion happens to run in the direction that makes Mercury's and Venus's fact
+sheets read as true on screen. The sheets claim "a day lasts longer than a
+year". That is a coincidence of the scaling, not a property the model keeps.
 
 ## Provenance
 

--- a/examples/svg_a11y/README.md
+++ b/examples/svg_a11y/README.md
@@ -10,5 +10,5 @@ side-by-side.
 go run ./examples/svg_a11y
 ```
 
-Metadata is read from `cached.Parsed.A11y` (`SvgParsed.A11y`), set by the parser
+Metadata comes from `cached.Parsed.A11y` (`SvgParsed.A11y`). The parser sets it
 after `LoadSvg`.

--- a/examples/svg_aspect/README.md
+++ b/examples/svg_aspect/README.md
@@ -1,9 +1,10 @@
 # svg_aspect
 
-3x3 grid renders the same square SVG inside wide rectangular tiles under each
-`preserveAspectRatio` alignment value. Top-row click toggles between `meet`
-(fit, leaves slack) and `slice` (fill, overflows + clips). Demonstrates that the
-alignment offset places the content correctly along the under-filled axis.
+A 3x3 grid renders the same square SVG inside wide rectangular tiles under each
+`preserveAspectRatio` alignment value. A click in the top row toggles between
+`meet` (fit, leaves slack) and `slice` (fill, overflows + clips). Demonstrates
+that the alignment offset places the content correctly along the under-filled
+axis.
 
 ## Run
 

--- a/examples/svg_css_selectors/README.md
+++ b/examples/svg_css_selectors/README.md
@@ -11,7 +11,7 @@ Six tiles demonstrate v0.14.0 CSS Selectors L4 additions:
 - **Attribute prefix (`[data-kind^=hot]`)** — picks elements whose attribute
   starts with the needle.
 - **`:not(.skip)`** — inverts a class selector (single-compound negation).
-- **Compound mix (`rect + [tag=ok]`)** — combines combinator with attribute
+- **Compound mix (`rect + [tag=ok]`)** — combines a combinator with an attribute
   selector.
 
 ## Run

--- a/examples/svg_css_states/README.md
+++ b/examples/svg_css_states/README.md
@@ -5,7 +5,7 @@ Demonstrates CSS `:hover` and `:focus` pseudo-class matching driven by
 
 The embedded `<style>` block defines hover/focus rules for two element ids
 (`#ring`, `#dot`). Buttons toggle the IDs that the SVG view forwards through
-`SvgCfg`; the cascade re-runs and the widget re-renders with the new colors
+`SvgCfg`. The cascade re-runs, and the widget re-renders with the new colors
 applied.
 
 **Status:** v0.15.0 ships the parser/cascade/cache plumbing. The widget does not
@@ -13,8 +13,8 @@ yet auto-detect mouse hover — apps drive the IDs themselves. Pointer-tracking
 hover for the `Svg` widget is the v0.16 followup.
 
 To wire it manually: hit-test the cached SVG paths via
-`TessellatedPath.ContainsPoint(px, py)` (added in v0.13.0), recover the
-corresponding element id, and feed it back through `SvgCfg` on the next View
+`TessellatedPath.ContainsPoint(px, py)` (added in v0.13.0). Then recover the
+corresponding element id. Then feed it back through `SvgCfg` on the next View
 pass.
 
 Run:

--- a/examples/svg_css_vars/README.md
+++ b/examples/svg_css_vars/README.md
@@ -2,13 +2,13 @@
 
 Demonstrates v0.14.0 custom-property additions:
 
-- **`var(--name, fallback)`** — fallback honored when the named variable is
-  undefined. The inner rect's `fill` resolves to the fallback `#f1f5f9` because
-  `--missing` is never defined.
+- **`var(--name, fallback)`** — the renderer honors the fallback when the named
+  variable is undefined. The inner rect's `fill` resolves to the fallback
+  `#f1f5f9` because `--missing` is never defined.
 - **`calc()`** — `calc(var(--base) + 1px)` computes the stroke width. The base
   value is mixed with a unit-bearing literal and resolves at parse time.
 - **Theme switching** — rebuilds the SVG source with a different `--primary` /
-  `--accent` per theme; the cascade picks the new values transparently.
+  `--accent` per theme. The cascade picks the new values.
 
 ## Run
 

--- a/examples/svg_flatness/README.md
+++ b/examples/svg_flatness/README.md
@@ -3,10 +3,10 @@
 Demonstrates `SvgCfg.FlatnessTolerance` — the tessellation tolerance floor in
 viewBox units.
 
-A curve-heavy SVG is rendered five times with increasing tolerance: default (0),
-0.5, 1.5, 4, 10. Higher values produce coarser polylines and fewer triangles,
-visible as faceting on the Bezier edges. Use this knob to trade visual fidelity
-for vertex count on icon walls or large path-heavy renders.
+The app renders a curve-heavy SVG five times with increasing tolerance: default
+(0), 0.5, 1.5, 4, 10. Higher values produce coarser polylines and fewer
+triangles, visible as faceting on the Bezier edges. Use this knob to trade
+visual fidelity for vertex count on icon walls or large path-heavy renders.
 
 Default `FlatnessTolerance=0` keeps the renderer's built-in 0.15 floor —
 fingerprint-stable with prior versions.

--- a/examples/svg_gradient_spread/README.md
+++ b/examples/svg_gradient_spread/README.md
@@ -3,15 +3,15 @@
 Demonstrates the `spreadMethod` attribute on `<linearGradient>` and
 `<radialGradient>`.
 
-For each gradient kind the same source is rendered three times, once per spread
-mode:
+For each gradient kind, the app renders the same source three times, once per
+spread mode:
 
 - `pad` — values outside [0,1] clamp to the first/last stop. Default.
 - `reflect` — triangle wave: the gradient mirrors back and forth.
 - `repeat` — sawtooth: the gradient wraps as a tile.
 
-Stops sit on a short segment (`x1=0% x2=40%`) leaving room outside the
-gradient's own range so reflect/repeat have somewhere to wrap.
+Stops sit on a short segment (`x1=0% x2=40%`). This leaves room outside the
+gradient's own range, so reflect and repeat have somewhere to wrap.
 
 Run:
 

--- a/examples/svg_hittest/README.md
+++ b/examples/svg_hittest/README.md
@@ -1,6 +1,6 @@
 # svg_hittest
 
-Click any shape in the rendered SVG; the right pane prints the matched `PathID`
+Click any shape in the rendered SVG. The right pane prints the matched `PathID`
 and viewBox coordinates. Demonstrates `TessellatedPath.ContainsPoint` with the
 typical "display→viewBox" coord conversion (divide by `cached.Scale`, add
 viewBox origin).
@@ -11,6 +11,6 @@ viewBox origin).
 go run ./examples/svg_hittest
 ```
 
-Click in the empty space between shapes to see the empty-cell readout; click on
+Click in the empty space between shapes to see the empty-cell readout. Click on
 a circle/rect/triangle to see its PathID. Note that `ContainsPoint` ignores
 stroke paths — fill triangulation is the hit target.

--- a/examples/svg_radial/README.md
+++ b/examples/svg_radial/README.md
@@ -2,7 +2,7 @@
 
 Six tiles render the same 100x100 box with linear, centered radial, off-center
 radial, large-R radial, multi-stop radial, and a shifted-focal radial gradient.
-Confirms the new `<radialGradient>` parsing + render path.
+This confirms the new `<radialGradient>` parsing and render path.
 
 ## Run
 

--- a/examples/svg_use_symbol/README.md
+++ b/examples/svg_use_symbol/README.md
@@ -2,14 +2,14 @@
 
 Demonstrates SVG `<use href="#id">` and `<symbol>` resolution.
 
-A `<symbol id="star">` block is defined once in `<defs>`; four `<use>`
+A `<symbol id="star">` block is defined once in `<defs>`. Four `<use>`
 references render the symbol at different positions, each with a per-instance
-`fill` override. The result is rendered side by side with a manually duplicated
-equivalent so any geometric or color delta is immediately visible.
+`fill` override. The example renders the result side by side with a manually
+duplicated equivalent. Any geometric or color delta is immediately visible.
 
-A second sample shows `<use>` referencing a single `<circle>` element, including
-per-instance `transform="scale(...)"` and `transform="rotate(...)"` overrides on
-the use sites.
+A second sample shows `<use>` that references a single `<circle>` element,
+including per-instance `transform="scale(...)"` and `transform="rotate(...)"`
+overrides on the use sites.
 
 Run:
 

--- a/examples/virtual_list/README.md
+++ b/examples/virtual_list/README.md
@@ -1,8 +1,8 @@
 # virtual_list
 
 A virtualized message feed of 50,000 cards whose rows differ in height. Row
-height falls out of the wrapped body text, so nothing — not the app, not the
-widget — knows a row's height until the layout engine has measured it.
+height derives from the wrapped body text. Nothing — not the app, not the widget
+— knows a row's height until the layout engine measures it.
 
 ## Run
 
@@ -12,22 +12,23 @@ go run ./examples/virtual_list
 
 ## What it demonstrates
 
-- **Variable row heights.** `VirtualList` builds only the rows near the viewport
-  and holds the rest of the space in two transparent spacers, sized from a
-  prefix-sum tree that converges on measured heights. The existing virtualized
-  widgets (`ListBox`, `Table`, `Tree`) divide by one scalar row height instead,
-  which is exact for the rows they own and useless for rows the caller builds.
+- **Variable row heights.** `VirtualList` builds only the rows near the
+  viewport. It holds the rest of the space in two transparent spacers, sized
+  from a prefix-sum tree that converges on measured heights. The existing
+  virtualized widgets (`ListBox`, `Table`, `Tree`) divide by one scalar row
+  height instead. That is exact for the rows they own and useless for rows the
+  caller builds.
 - **Index-addressed scrolling.** The Jump box calls
   `Window.ScrollToIndexAt(id, n, 0.5)`. The target row does not exist yet, so
   there is no ID to resolve and no view to find — `scrollToView` structurally
   cannot reach it.
 - **Pin to bottom.** A background goroutine appends a message every second. With
   the toggle on, `Window.ScrollToEnd` re-pins after each append.
-  `ScrollVerticalToPct(id, 1)` is the wrong tool: under virtualization the
-  content height is assembled from spacers over estimated rows, so a percentage
+  `ScrollVerticalToPct(id, 1)` is the wrong tool: under virtualization the app
+  assembles the content height from spacers over estimated rows, so a percentage
   drifts.
-- **`ItemKey`.** Heights are stored under the key, so a measured height follows
-  its message when others are inserted above it.
+- **`ItemKey`.** The store keys heights, so a measured height follows its
+  message when the app inserts others above it.
 
 ## Things worth copying
 
@@ -37,5 +38,4 @@ go run ./examples/virtual_list
   inner width the list recorded during the previous frame's arrange, which is
   what makes the measured height meaningful.
 - Spacing between rows lives _inside_ the row. The list's own spacing is fixed
-  at zero, because a gap between rows would be height the model does not account
-  for.
+  at zero, because a gap between rows is height the model does not account for.


### PR DESCRIPTION
Applies the simple-english skill (ASD-STE100 pragmatic mode) to all tracked markdown files: split over-limit sentences, ban should/would/may/could in favor of must/can/fact, remove semicolons and slop words, unify vocabulary per file. CHANGELOG.md excluded as a historical record.

Staleness fixes found while editing:
- widget_printing.md rewritten against the post-#372 print API
- widget_column.md: gui.SomeP -> gui.NewPadding (removed API)
- commands.md: wrong arities, unexported rows, KeyGraveAccent typo
- widget docs: removed nonexistent HAlignEndPtr, Checkbox alias, ThemeDarkBordered, ScrollModeX, SomeD, unexported fields
- new-example SKILL.md: wrong module path, ThemeDarkBordered
- cmd/buildapp README: nonexistent icon path
- architecture.md: 15 -> 20 default-focus input cfgs

Verified: make prepush green, make fmt-md-check green.