### PR TITLE
fix(solar_system): reset pinch baseline at gesture boundaries

### DIFF
--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -559,7 +559,12 @@ func drawPlanet(a *App, dc *gui.DrawContext, i int) {
 	if i == saturnIndex {
 		// Back half of the rings first, then the body, then the front
 		// half — which is what makes the rings pass behind Saturn.
-		k := a.litFraction(i)
+		//
+		// The phase is read off lz rather than by calling litFraction,
+		// which would redo orbitPos and the normalization for the vector
+		// already in hand. litFraction is this same expression; see it
+		// for why the z component is the cosine of the phase angle.
+		k := (1 + lz) / 2
 		drawRings(dc, cx, cy, r, math.Pi, math.Pi, k)
 		drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz, sp)
 		drawRings(dc, cx, cy, r, 0, math.Pi, k)

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -1192,3 +1192,52 @@ func TestRingAnglesDegenerateRing(t *testing.T) {
 		ang.next()
 	}
 }
+
+// TestPinchBaselinesPerSequence pins the sequence boundary. PinchScale
+// is cumulative within one gesture and restarts near 1 for the next, so
+// a baseline carried across the boundary would divide the new pinch's
+// opening scale by the old one's final — undoing the whole previous
+// pinch on its first event.
+func TestPinchBaselinesPerSequence(t *testing.T) {
+	t.Parallel()
+	a := newTestApp()
+
+	// First pinch: began, two changes, ended.
+	a.applyPinch(1.05, true)
+	a.applyPinch(1.5, false)
+	a.applyPinch(2.0, false)
+	a.applyPinch(2.0, true)
+
+	after := a.UserZoom
+	if after < 1.5 {
+		t.Fatalf("first pinch should have zoomed in; UserZoom = %v", after)
+	}
+
+	// Second pinch opens where the first left off, not scaled by it.
+	a.applyPinch(1.05, true)
+	if a.UserZoom != after {
+		t.Fatalf("began event moved the zoom: %v -> %v", after, a.UserZoom)
+	}
+	a.applyPinch(1.26, false)
+	if want := after * 1.2; !nearly(a.UserZoom, want, 1e-4) {
+		t.Fatalf("second pinch delta = %v, want %v", a.UserZoom, want)
+	}
+}
+
+// TestPinchDeltaIsRelative checks the mid-sequence ratio itself: two
+// changes compose to the cumulative scale, not to its square.
+func TestPinchDeltaIsRelative(t *testing.T) {
+	t.Parallel()
+	a := newTestApp()
+	a.applyPinch(1.0, true)
+	a.applyPinch(1.4, false)
+	a.applyPinch(2.0, false)
+	if !nearly(a.UserZoom, 2.0, 1e-4) {
+		t.Fatalf("UserZoom = %v, want 2.0", a.UserZoom)
+	}
+}
+
+func nearly(got, want, tol float32) bool {
+	d := got - want
+	return d < tol && d > -tol
+}

--- a/examples/solar_system/view.go
+++ b/examples/solar_system/view.go
@@ -109,15 +109,36 @@ func solarCanvas(a *App) gui.View {
 				a.PinchPrev = 0
 				return
 			}
-			// PinchScale is cumulative for the gesture and the phase
-			// constants are unexported, so there is no "began" to test
-			// against. Tracking the previous value recovers the
-			// per-event ratio: the first event only baselines.
-			if a.PinchPrev > 0 {
-				a.applyUserZoom(e.PinchScale / a.PinchPrev)
-			}
-			a.PinchPrev = e.PinchScale
+			// Only gesturePhaseBegan/Ended/Cancelled are unexported;
+			// GesturePhaseChanged is not, so "not a change" is how a
+			// sequence boundary is recognized.
+			a.applyPinch(e.PinchScale, e.GesturePhase != gui.GesturePhaseChanged)
 			ctx.Consume()
 		},
 	})
+}
+
+// applyPinch folds one pinch event into the manual zoom. boundary marks
+// the events that open or close a sequence — began, ended and cancelled
+// — as opposed to a mid-gesture change.
+//
+// PinchScale is cumulative *within* one gesture and restarts near 1 for
+// the next, so the previous value is what recovers a per-event ratio —
+// but only between events of the same sequence. Carrying it across a
+// boundary divides the new pinch's opening scale by the old one's final
+// and undoes the whole previous pinch in a single frame.
+//
+// Baselining on all three boundary phases is what makes that one branch:
+// on began it is the correct start value, and on ended or cancelled the
+// stale value is overwritten by the next sequence's began before any
+// delta is applied.
+func (a *App) applyPinch(scale float32, boundary bool) {
+	if boundary {
+		a.PinchPrev = scale
+		return
+	}
+	if a.PinchPrev > 0 {
+		a.applyUserZoom(scale / a.PinchPrev)
+	}
+	a.PinchPrev = scale
 }

--- a/examples/solar_system/zz_effbench_test.go
+++ b/examples/solar_system/zz_effbench_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestInitCostMeasure(t *testing.T) {
+	start := time.Now()
+	_ = makeTextures()
+	t.Logf("makeTextures: %v", time.Since(start))
+}
+
+// counter tallies every primitive drawSystem emits in one frame.
+type counter struct{ n map[string]int }
+
+func newCounter() *counter      { return &counter{n: map[string]int{}} }
+func (c *counter) hit(k string) { c.n[k]++ }
+
+func (c *counter) Line(x0, y0, x1, y1 float32, col gui.Color, w float32)        { c.hit("Line") }
+func (c *counter) Polyline(p []float32, col gui.Color, w float32)               { c.hit("Polyline") }
+func (c *counter) FilledRect(x, y, w, h float32, col gui.Color)                 { c.hit("FilledRect") }
+func (c *counter) Rect(x, y, w, h float32, col gui.Color, wd float32)           { c.hit("Rect") }
+func (c *counter) FilledCircle(cx, cy, r float32, col gui.Color)                { c.hit("FilledCircle") }
+func (c *counter) Circle(cx, cy, r float32, col gui.Color, w float32)           { c.hit("Circle") }
+func (c *counter) FilledArc(cx, cy, rx, ry, s, sw float32, col gui.Color)       { c.hit("FilledArc") }
+func (c *counter) Arc(cx, cy, rx, ry, s, sw float32, col gui.Color, w float32)  { c.hit("Arc") }
+func (c *counter) FilledPolygon(p []float32, col gui.Color)                     { c.hit("FilledPolygon") }
+func (c *counter) FilledRoundedRect(x, y, w, h, r float32, col gui.Color)       { c.hit("FilledRoundedRect") }
+func (c *counter) RoundedRect(x, y, w, h, r float32, col gui.Color, wd float32) { c.hit("RoundedRect") }
+func (c *counter) DashedLine(x0, y0, x1, y1 float32, col gui.Color, w, d, g float32) {
+	c.hit("DashedLine")
+}
+func (c *counter) DashedPolyline(p []float32, col gui.Color, w, d, g float32) {
+	c.hit("DashedPolyline")
+}
+func (c *counter) PolylineJoined(p []float32, col gui.Color, w float32) { c.hit("PolylineJoined") }
+func (c *counter) QuadBezier(a, b, cc, d, e, f float32, col gui.Color, w float32) {
+	c.hit("QuadBezier")
+}
+func (c *counter) CubicBezier(a, b, cc, d, e, f, g, h float32, col gui.Color, w float32) {
+	c.hit("CubicBezier")
+}
+func (c *counter) Text(x, y float32, s string, st gui.TextStyle) { c.hit("Text") }
+func (c *counter) FillTrianglesGradient(tris []float32, g *gui.CanvasGradient) {
+	c.hit("FillTrianglesGradient")
+}
+func (c *counter) FillTrianglesColors(tris []float32, cols []gui.Color) {
+	c.hit("FillTrianglesColors")
+	c.n["meshTris"] += len(tris) / 6
+}
+
+func countFrame(a *App) *counter {
+	dc := gui.NewDrawContext(a.CanvasW, a.CanvasH, nil)
+	c := newCounter()
+	dc.SetRecorder(c)
+	drawSystem(a, dc)
+	return c
+}
+
+func TestPrimitiveCountsPerFrame(t *testing.T) {
+	cases := []struct {
+		name string
+		sel  int
+	}{
+		{"full-system", -1},
+		{"sun-selected", selSun},
+		{"jupiter-selected", 4},
+		{"mercury-selected", 0},
+	}
+	for _, tc := range cases {
+		a := newApp()
+		a.CanvasW, a.CanvasH = 1100, 760
+		a.Selected = tc.sel
+		for range 120 { // let the tween settle
+			tick(a)
+		}
+		c := countFrame(a)
+		t.Logf("%-18s sunR=%6.1f  %v", tc.name, a.SunR, c.n)
+	}
+}
+
+func TestBatchCountPerFrame(t *testing.T) {
+	for _, sel := range []int{-1, selSun, 4} {
+		a := newApp()
+		a.CanvasW, a.CanvasH = 1100, 760
+		a.Selected = sel
+		for range 120 {
+			tick(a)
+		}
+		dc := gui.NewDrawContext(a.CanvasW, a.CanvasH, nil)
+		drawSystem(a, dc)
+		var tris int
+		for _, b := range dc.Batches() {
+			tris += len(b.Triangles) / 6
+		}
+		t.Logf("sel=%3d batches=%4d triangles=%6d", sel, len(dc.Batches()), tris)
+	}
+}
+
+func benchFrame(b *testing.B, sel int) {
+	a := newApp()
+	a.CanvasW, a.CanvasH = 1100, 760
+	a.Selected = sel
+	for range 120 {
+		tick(a)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		tick(a)
+		dc := gui.NewDrawContext(a.CanvasW, a.CanvasH, nil)
+		drawSystem(a, dc)
+	}
+}
+
+func BenchmarkFrameFullSystem(b *testing.B) { benchFrame(b, -1) }
+func BenchmarkFrameJupiter(b *testing.B)    { benchFrame(b, 4) }
+
+func BenchmarkTickOnly(b *testing.B) {
+	a := newApp()
+	a.CanvasW, a.CanvasH = 1100, 760
+	b.ReportAllocs()
+	for b.Loop() {
+		tick(a)
+	}
+}


### PR DESCRIPTION
PinchScale is cumulative within one gesture and restarts near 1 for the next. Carrying the previous value across a sequence boundary divided the new pinch's opening scale by the old one's final — undoing the whole previous pinch in a single frame.

- Baseline on began/ended/cancelled phases instead of only tracking the previous value
- Tests pin the sequence-boundary behavior and the mid-sequence ratio
- Read the ring phase off the lz already in hand instead of redoing orbitPos via litFraction
- Add effbench harness for the draw path