### PR TITLE
perf(solar_system): 1093 draw calls per frame down to 161 (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **`examples/solar_system` draws a frame in 161 calls instead of 1093** (#429),
+  with 40-60% fewer allocations behind it. No engine change; every fix is in the
+  example. The example drew each effect as a stack of primitives, one draw call
+  apiece, and each call opens or extends a batch.
+
+  Four of them collapse to one call each. The sun's disc was 14-96 opaque
+  circles faking a gradient — but opaque shells composite to nothing, and the
+  ramp they sampled is piecewise linear, so five stops and one
+  `FilledCircleGradient` reproduce it exactly and drop the banding it showed at
+  small sizes. The corona was 576 polygons and the starfield 220 rectangles;
+  both are now a single `FillTrianglesColors` mesh, which is safe because
+  neither field overlaps itself. The starfield's eight-level alpha quantization,
+  which existed only to keep the batch count down, goes with it, so the twinkle
+  is continuous. The granulation keeps its separate circles — the cells overlap
+  on purpose and merging them would change how they blend — but its count now
+  scales with the sun's pixel radius instead of drawing a canvas-filling texture
+  onto a 70px disc.
+
+  The draw path also stops recomputing orbit positions that `recompute` cached a
+  moment earlier.
+
+  Measured at 1100x760, 500 iterations x 5 runs, Apple M5:
+
+  | view        | draw calls  | batches  | allocs/frame | bytes/frame     |
+  | ----------- | ----------- | -------- | ------------ | --------------- |
+  | full-system | 1093 -> 161 | 79 -> 42 | 341 -> 208   | 3.15 -> 2.19 MB |
+  | jupiter     | 1128 -> 239 | 97 -> 22 | 488 -> 184   | 4.40 -> 3.75 MB |
+
+  Frame time moves less than the draw-call count does, because the benchmark
+  measures tessellation rather than submission: full-system 778 -> 725 us and
+  jupiter 1168 -> 1096 us, both about 6-7%. The counts above are now enforced as
+  regression budgets rather than logged and forgotten.
+
 ## [v0.65.0] - 2026-08-25
 
 Gradients and per-vertex color reach `DrawContext`, and the SVG gradient

--- a/examples/solar_system/camera.go
+++ b/examples/solar_system/camera.go
@@ -163,6 +163,19 @@ var cosElev = sqrt32(1 - diskTilt*diskTilt)
 // falls out of this for free rather than needing its own derivation.
 func (a *App) lightVec(i int) (lx, ly, lz float32) {
 	px, py := orbitPos(&planets[i], a.Time)
+	return lightVecAt(px, py)
+}
+
+// lightVecAt is lightVec with the planet's world position supplied.
+//
+// The draw path takes this door, reading the position recompute
+// already cached, so the eight planets do not repeat the orbit
+// trigonometry a second time in the same tick. lightVec keeps its own
+// orbitPos call rather than reading the cache: it is also reached from
+// litFraction and from callers that move Time on their own, and a
+// cache read there would answer with the previous position instead of
+// failing.
+func lightVecAt(px, py float32) (lx, ly, lz float32) {
 	d := sqrt32(px*px + py*py)
 	if d == 0 {
 		// Degenerate: a planet at the sun's own position. Light it
@@ -207,6 +220,10 @@ func (a *App) recompute() {
 	a.SunR = sunRadius * z
 	for i := range planets {
 		wx, wy := orbitPos(&planets[i], a.Time)
+		// Kept as well as the screen position: the shading needs the
+		// world vector to the sun, which the screen squash has already
+		// destroyed. See lightVecAt.
+		a.WorldX[i], a.WorldY[i] = wx, wy
 		a.ScreenX[i], a.ScreenY[i] = a.worldToScreen(wx, wy)
 		a.ScreenR[i] = planets[i].Radius * z
 	}

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -189,49 +189,33 @@ func drawSystem(a *App, dc *gui.DrawContext) {
 	drawTooltip(a, dc)
 }
 
-// drawStars paints the twinkling background.
+// drawStars paints the twinkling background as one vertex-colored mesh.
 //
-// Brightness is quantized to starAlphaLevels and the field is drawn one
-// level at a time. DrawContext merges only *consecutive* same-color
-// triangles, so 220 stars at 220 distinct alphas would open 220 batches
-// every frame; grouping opens 8. At star size the banding is invisible.
-// The stars are squares rather than circles for the same reason: two
-// triangles instead of ~64, and at 1-2px nobody can tell.
+// The field used to be quantized to eight alpha levels and drawn a
+// level at a time, because a flat batch merges only *consecutive*
+// same-color triangles and 220 stars at 220 distinct alphas would open
+// 220 batches. A vertex-colored batch carries a color per vertex, so
+// the grouping — and the eight-way scan over the field it needed — has
+// nothing left to buy: one pass, one batch, and each star keeps its own
+// alpha instead of the nearest eighth.
 //
-// Levels are bucketed once up front rather than re-derived inside the
-// per-level pass: the twinkle is a sine per star, and evaluating it
-// once per level instead would cost starAlphaLevels times as many.
-// The bucket array is fixed-size and does not escape, so it stays on
-// the stack and the whole pass allocates nothing.
+// The stars stay squares rather than circles: two triangles instead of
+// ~64, and at 1-2px nobody can tell.
 func drawStars(a *App, dc *gui.DrawContext) {
-	var bucket [starCount]uint8
-	n := min(len(a.Stars), starCount)
-	for i := range n {
+	m := &a.stars
+	m.tris, m.cols = m.tris[:0], m.cols[:0]
+
+	for i := range min(len(a.Stars), starCount) {
 		s := &a.Stars[i]
-		bucket[i] = uint8(starLevel(s.Base +
-			s.Amp*sin32(a.Time*s.Speed+s.Phase)))
-	}
+		b := s.Base + s.Amp*sin32(a.Time*s.Speed+s.Phase)
+		c := colorStar.WithOpacity(clamp32(b, starAlphaFloor, 1))
 
-	for level := range starAlphaLevels {
-		// Level midpoint, so the darkest bucket is not fully invisible.
-		alpha := (float32(level) + 0.5) / starAlphaLevels
-		c := colorStar.WithOpacity(alpha)
-		for i := range n {
-			if int(bucket[i]) != level {
-				continue
-			}
-			s := &a.Stars[i]
-			dc.FilledRect(s.X*dc.Width, s.Y*dc.Height, s.Size, s.Size, c)
-		}
+		x0, y0 := s.X*dc.Width, s.Y*dc.Height
+		x1, y1 := x0+s.Size, y0+s.Size
+		m.appendTri(x0, y0, c, x1, y0, c, x1, y1, c)
+		m.appendTri(x0, y0, c, x1, y1, c, x0, y1, c)
 	}
-}
-
-// starLevel buckets a brightness in [0,1] into [0, starAlphaLevels).
-func starLevel(b float32) int {
-	lvl := int(floor32(clamp32(b, 0, 0.999) * starAlphaLevels))
-	// clamp32 already bounds the input, so this only guards against a
-	// future change to the levels constant.
-	return min(max(lvl, 0), starAlphaLevels-1)
+	dc.FillTrianglesColors(m.tris, m.cols)
 }
 
 // drawOrbits traces each orbit as a full ellipse. Arc is the ellipse

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -383,7 +383,7 @@ func drawSun(a *App, dc *gui.DrawContext) {
 	})
 
 	drawGranulation(dc, cx, cy, r)
-	drawCorona(dc, cx, cy, r, a.Time)
+	drawCorona(dc, &a.corona, cx, cy, r, a.Time)
 }
 
 // sunDiscTone ramps the face from the limb (t = 0) to the core
@@ -485,8 +485,17 @@ func drawGranulation(dc *gui.DrawContext, cx, cy, r float32) {
 // The same noise modulates every boundary, so the raggedness is
 // coherent from the limb outward instead of a set of independent
 // wobbles, and its index drifts with time so the fringe crawls.
-func drawCorona(dc *gui.DrawContext, cx, cy, r, now float32) {
-	var quad [8]float32
+//
+// The whole fringe is one vertex-colored batch rather than
+// coronaTiers*coronaSteps polygons. That is safe here in a way it is
+// not for the granulation: the bands are *disjoint*, tier k's outer
+// boundary being tier k+1's inner one from the same coronaPoint call,
+// so nothing inside the mesh overlaps anything else and there is no
+// stacked translucency for the merge to flatten. Quads within a tier
+// stop double-blending at their shared edge, which is what the seam
+// note on appendTri is about.
+func drawCorona(dc *gui.DrawContext, m *bodyMesh, cx, cy, r, now float32) {
+	m.tris, m.cols = m.tris[:0], m.cols[:0]
 	drift := now * coronaDriftHz * float32(coronaSteps)
 
 	for tier := range coronaTiers {
@@ -503,16 +512,18 @@ func drawCorona(dc *gui.DrawContext, cx, cy, r, now float32) {
 			ang := 2 * math.Pi * float32(k) / coronaSteps
 			cX, cY := coronaPoint(r, ang, f0, drift)
 			dX, dY := coronaPoint(r, ang, f1, drift)
-			quad = [8]float32{
-				cx + aX, cy + aY,
-				cx + cX, cy + cY,
-				cx + dX, cy + dY,
-				cx + bX, cy + bY,
-			}
-			dc.FilledPolygon(quad[:], col)
+			// The same two triangles FilledPolygon's fan emitted,
+			// through appendTri so the winding is measured: the soft
+			// backend accumulates signed coverage over the batch and a
+			// quad wound against its neighbour would carve a seam.
+			m.appendTri(cx+aX, cy+aY, col, cx+cX, cy+cY, col,
+				cx+dX, cy+dY, col)
+			m.appendTri(cx+aX, cy+aY, col, cx+dX, cy+dY, col,
+				cx+bX, cy+bY, col)
 			aX, aY, bX, bY = cX, cY, dX, dY
 		}
 	}
+	dc.FillTrianglesColors(m.tris, m.cols)
 }
 
 // coronaPoint is a point on the fringe boundary at fraction f of the

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -96,11 +96,11 @@ const (
 	coronaRagged  = 0.72 // how much of that reach the noise modulates
 	coronaDriftHz = 0.05 // how fast the ragged edge crawls
 
-	// sunShells ramps the disc itself from a near-white core to its
-	// orange limb, which is what stops it reading as a flat coin.
-	sunShellsPerPx = 0.9
-	sunShellsMin   = 14
-	sunShellsMax   = 96
+	// sunShellSpan is how far in from the limb the disc ramp runs, as a
+	// fraction of the radius: the core tone is reached at 0.03*r and
+	// holds flat from there in. It is what stops the face reading as a
+	// flat coin.
+	sunShellSpan = 0.97
 
 	// shadeRows is how many rings of constant Lambert intensity the
 	// sphere mesh is built from, and shadeArc how many segments each
@@ -367,15 +367,15 @@ func drawSun(a *App, dc *gui.DrawContext) {
 		Stops:  a.glowStops,
 	})
 
-	// The disc: shells from the gold limb through cream to a white
-	// core. Three stops for the same reason the planets use three —
-	// two would walk the middle of the face through a washed-out
-	// midpoint of the two ends.
-	shells := int(clamp32(r*sunShellsPerPx, sunShellsMin, sunShellsMax))
-	for i := range shells {
-		t := float32(i) / float32(shells-1) // 0 at the limb, 1 at the core
-		dc.FilledCircle(cx, cy, r*(1-0.97*t), sunDiscTone(t))
-	}
+	// The disc: the gold limb through cream to a white core. Three
+	// segments for the same reason the planets use three — two would
+	// walk the middle of the face through a washed-out midpoint of the
+	// two ends.
+	a.discStops = sunDiscStops(a.discStops)
+	dc.FilledCircleGradient(cx, cy, r, &gui.CanvasGradient{
+		Radial: true,
+		Stops:  a.discStops,
+	})
 
 	drawGranulation(dc, cx, cy, r)
 	drawCorona(dc, cx, cy, r, a.Time)
@@ -395,6 +395,34 @@ func sunDiscTone(t float32) gui.Color {
 		return mixColor(colorSunBody, colorSunCore,
 			(t-discCoreStop)/(1-discCoreStop))
 	}
+}
+
+// sunDiscStops turns the disc ramp into the stops of one radial fill.
+//
+// This is not the integration haloStops does. The shell stack this
+// replaces was *opaque* — every shell hid the one before it, so the
+// visible color at radius r*(1-sunShellSpan*t) was simply
+// sunDiscTone(t), with nothing to composite. And sunDiscTone is
+// piecewise *linear* in t while the fill lerps between stops, so one
+// stop at each of its three hand-over points reproduces the ramp
+// exactly, at any size, instead of the 14-96 quantized bands the stack
+// emitted.
+//
+// The ramp runs inward, so t maps to the radius fraction
+// u = 1 - sunShellSpan*t and the stops come out in reverse order: pos
+// 0 is the core, pos 1 the limb.
+func sunDiscStops(dst []gui.GradientStop) []gui.GradientStop {
+	dst = dst[:0]
+	// The core tone held flat inside the innermost shell. Without a
+	// stop pinning pos 0 the fill would keep ramping past it.
+	dst = append(dst, gui.GradientStop{Color: sunDiscTone(1), Pos: 0})
+	for _, t := range [...]float32{1, discCoreStop, discRimStop, 0} {
+		dst = append(dst, gui.GradientStop{
+			Color: sunDiscTone(t),
+			Pos:   1 - sunShellSpan*t,
+		})
+	}
+	return dst
 }
 
 // drawGranulation lays the mottled convection texture over the disc.

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -86,6 +86,11 @@ const (
 	granuleMinRadius = 14
 	granuleInset     = 0.94
 
+	// granulesPerPx caps the cell count against the disc's pixel
+	// radius, so the default view draws about half the set and the
+	// full set arrives once the sun is 70px across.
+	granulesPerPx = 1.0
+
 	// The corona rim: a ragged band hugging the limb, drawn as
 	// coronaTiers quad strips of falling alpha. coronaSteps is how many
 	// angular segments the ragged edge is traced with, and must match
@@ -436,6 +441,14 @@ func drawGranulation(dc *gui.DrawContext, cx, cy, r float32) {
 	if r < granuleMinRadius {
 		return // the cells would be sub-pixel; they would only cost batches
 	}
+	// Level of detail. The full set is sized for a sun that fills the
+	// canvas; at the default zoom it is 70 cells over a 70px disc,
+	// where the texture reads as noise long before the last cell is
+	// placed. Taking a prefix is a fair sample because makeGranules
+	// draws every field from one RNG stream, so the cells are in no
+	// order — the prefix is as evenly spread as the whole.
+	cells := sunGranules[:min(len(sunGranules), int(r*granulesPerPx))]
+
 	for _, lit := range [2]bool{true, false} {
 		base := colorSunGranuleDark
 		if lit {
@@ -445,7 +458,7 @@ func drawGranulation(dc *gui.DrawContext, cx, cy, r float32) {
 			// Outermost tier first, so the stack builds a soft falloff
 			// rather than a hard disc.
 			scale := 1 - float32(tier)/granuleTiers
-			for _, g := range sunGranules {
+			for _, g := range cells {
 				if g.lit != lit {
 					continue
 				}

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -598,7 +598,7 @@ func drawPlanet(a *App, dc *gui.DrawContext, i int) {
 
 	// One vector carries both facts the shading needs: which way the
 	// sun lies on screen, and how far around behind the planet it is.
-	lx, ly, lz := a.lightVec(i)
+	lx, ly, lz := lightVecAt(a.WorldX[i], a.WorldY[i])
 
 	// Stack-allocated: initSurface fills it, and drawBody does not let
 	// the pointer escape.

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -72,6 +72,9 @@ type App struct {
 	glowStops []gui.GradientStop
 	haloStops []gui.GradientStop
 
+	// discStops backs the sun's disc fill, reused for the same reason.
+	discStops []gui.GradientStop
+
 	// body is drawBody's mesh scratch, reused for the same reason: nine
 	// planets a tick, each rebuilding a few thousand vertices.
 	body bodyMesh

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -36,11 +36,13 @@ const (
 
 	canvasID = "solar_canvas"
 
-	// starCount is the fixed starfield size, and starAlphaLevels the
-	// number of quantized twinkle brightnesses. See drawStars for why
-	// the quantization matters.
-	starCount       = 220
-	starAlphaLevels = 8
+	// starCount is the fixed starfield size. starAlphaFloor is the
+	// dimmest a star may go: the quantized field this replaced put its
+	// darkest bucket at the bucket's midpoint rather than at zero, and
+	// keeping that floor is what stops the faintest stars blinking out
+	// entirely at the bottom of the twinkle.
+	starCount      = 220
+	starAlphaFloor = 0.0625
 
 	// keyZoomStep is the multiplier one +/- press applies.
 	keyZoomStep = 1.15
@@ -74,6 +76,10 @@ type App struct {
 
 	// discStops backs the sun's disc fill, reused for the same reason.
 	discStops []gui.GradientStop
+
+	// stars is drawStars' mesh scratch, on the same footing as the two
+	// below.
+	stars bodyMesh
 
 	// body is drawBody's mesh scratch, reused for the same reason: nine
 	// planets a tick, each rebuilding a few thousand vertices. corona

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -76,8 +76,11 @@ type App struct {
 	discStops []gui.GradientStop
 
 	// body is drawBody's mesh scratch, reused for the same reason: nine
-	// planets a tick, each rebuilding a few thousand vertices.
-	body bodyMesh
+	// planets a tick, each rebuilding a few thousand vertices. corona
+	// is drawCorona's, kept separate so the two capacities settle
+	// independently rather than sawing against each other.
+	body   bodyMesh
+	corona bodyMesh
 
 	// Selected and Hovered are a planet index, selSun for the sun, or
 	// -1 for the full-system view / nothing under the cursor.

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -114,6 +114,13 @@ type App struct {
 	ScreenY [len(planets)]float32
 	ScreenR [len(planets)]float32
 
+	// The world positions those came from, kept because the shading
+	// works in world space and the vertical squash above is not
+	// invertible from ScreenY alone. Draw-path reads only — see
+	// lightVecAt for why lightVec does not use them.
+	WorldX [len(planets)]float32
+	WorldY [len(planets)]float32
+
 	// The sun's, kept the same way and for the same reason: hit-testing
 	// and painting must agree on where it is.
 	SunX, SunY, SunR float32

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -995,6 +995,51 @@ func TestBodyMeshDoesNotAllocatePerFrame(t *testing.T) {
 	}
 }
 
+// TestCoronaMeshDoesNotAllocatePerFrame is the same gate for the
+// fringe. It is the larger of the two meshes on the full-system view,
+// so a scratch that reallocated here would cost more than the body's.
+func TestCoronaMeshDoesNotAllocatePerFrame(t *testing.T) {
+	var m bodyMesh
+	dc := gui.NewDrawContext(400, 400, nil)
+	drawCorona(dc, &m, 200, 200, 90, 0) // settle the capacity
+
+	got := testing.AllocsPerRun(20, func() {
+		// Only the mesh append is measured. FillTrianglesColors opens a
+		// batch on the shared context, whose growth is not this test's
+		// subject, so the context is reused across runs rather than
+		// rebuilt.
+		drawCorona(dc, &m, 200, 200, 90, 0)
+	})
+	// The batch the fill opens is one allocation on the first run and
+	// none after, which AllocsPerRun averages away; anything more is
+	// the mesh regrowing.
+	if got > 2 {
+		t.Errorf("corona rebuild allocated %v times per run, want <= 2", got)
+	}
+}
+
+// TestCoronaIsOneVertexColoredBatch pins the merge. The fringe was 576
+// separate polygons; the point of the mesh is that it is one.
+func TestCoronaIsOneVertexColoredBatch(t *testing.T) {
+	t.Parallel()
+	var m bodyMesh
+	dc := gui.NewDrawContext(400, 400, nil)
+	drawCorona(dc, &m, 200, 200, 90, 0)
+
+	n := 0
+	for _, b := range dc.Batches() {
+		if len(b.VertexColors) > 0 {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("corona emitted %d vertex-colored batches, want 1", n)
+	}
+	if want := 2 * coronaTiers * coronaSteps; len(m.cols) != 3*want {
+		t.Errorf("corona emitted %d vertices, want %d", len(m.cols), 3*want)
+	}
+}
+
 // pointInMesh reports whether (px,py) lies in some triangle of the
 // vertex-colored batches. The mesh is wound consistently, so a point is
 // inside a triangle when all three edge cross products share a sign;

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -353,20 +353,53 @@ func TestTooltipClampedToCanvas(t *testing.T) {
 	}
 }
 
-// TestStarLevelsBounded guards the bucketing that keeps the starfield
-// at starAlphaLevels batches instead of one per star.
-func TestStarLevelsBounded(t *testing.T) {
+// TestStarfieldIsOneBatch guards what replaced the alpha bucketing:
+// the whole field is one vertex-colored batch, so no amount of twinkle
+// can reintroduce a batch per star. The alpha floor is checked over the
+// same sweep — a star that reaches zero has blinked out, which is what
+// the bucket midpoint used to prevent.
+func TestStarfieldIsOneBatch(t *testing.T) {
 	t.Parallel()
 	a := newApp()
 	for step := range 200 {
-		tm := float32(step) * 0.05
-		for i := range a.Stars {
-			s := &a.Stars[i]
-			b := s.Base + s.Amp*sin32(tm*s.Speed+s.Phase)
-			if lvl := starLevel(b); lvl < 0 || lvl >= starAlphaLevels {
-				t.Fatalf("starLevel(%v) = %d, out of range", b, lvl)
+		a.Time = float32(step) * 0.05
+		dc := gui.NewDrawContext(400, 300, nil)
+		drawStars(a, dc)
+
+		batches := dc.Batches()
+		if len(batches) != 1 || len(batches[0].VertexColors) == 0 {
+			t.Fatalf("t=%v: starfield emitted %d batches, want 1 colored",
+				a.Time, len(batches))
+		}
+		// Two triangles a star, three vertices a triangle.
+		if want := 6 * len(a.Stars); len(batches[0].VertexColors) != want {
+			t.Fatalf("t=%v: %d vertices, want %d",
+				a.Time, len(batches[0].VertexColors), want)
+		}
+		for _, c := range batches[0].VertexColors {
+			if c.A == 0 {
+				t.Fatalf("t=%v: a star faded to fully transparent", a.Time)
 			}
 		}
+	}
+}
+
+// TestStarfieldDoesNotAllocatePerFrame is the third of the mesh-reuse
+// gates, alongside the body's and the corona's. The field is rebuilt
+// every tick, so a scratch that regrew would allocate for the session.
+func TestStarfieldDoesNotAllocatePerFrame(t *testing.T) {
+	a := newApp()
+	dc := gui.NewDrawContext(400, 300, nil)
+	drawStars(a, dc) // settle the capacity
+
+	got := testing.AllocsPerRun(20, func() {
+		a.Time += 0.05
+		drawStars(a, dc)
+	})
+	// One for the batch FillTrianglesColors opens on the first run,
+	// which AllocsPerRun averages away; more than that is the mesh.
+	if got > 2 {
+		t.Errorf("starfield allocated %v times per run, want <= 2", got)
 	}
 }
 

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -438,6 +438,34 @@ func TestShadingFacesTheSun(t *testing.T) {
 	}
 }
 
+// TestWorldCacheMatchesOrbitPos pins the seam the draw path reads
+// through. lightVecAt is fed App.WorldX/Y instead of calling orbitPos,
+// so the two must agree after every recompute; a planet left out of
+// that loop would shade as though it were somewhere else.
+func TestWorldCacheMatchesOrbitPos(t *testing.T) {
+	t.Parallel()
+	a := newTestApp()
+	for _, tm := range []float32{0, 3.7, 91} {
+		a.Time = tm
+		a.recompute()
+		for i := range planets {
+			wx, wy := orbitPos(&planets[i], a.Time)
+			if a.WorldX[i] != wx || a.WorldY[i] != wy {
+				t.Errorf("t=%v planet %d: cached (%v,%v), live (%v,%v)",
+					tm, i, a.WorldX[i], a.WorldY[i], wx, wy)
+			}
+			// And the cached pair must reach the same light vector the
+			// index-taking form does.
+			gx, gy, gz := lightVecAt(a.WorldX[i], a.WorldY[i])
+			wx2, wy2, wz2 := a.lightVec(i)
+			if gx != wx2 || gy != wy2 || gz != wz2 {
+				t.Errorf("t=%v planet %d: lightVecAt disagrees with lightVec",
+					tm, i)
+			}
+		}
+	}
+}
+
 // TestLightVecDegenerate covers a planet sitting on the sun's own world
 // position, where the light direction is undefined. lightVec must
 // answer with the camera axis rather than dividing by zero, and the

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -724,6 +724,50 @@ func TestSunDiscToneLimbBrightening(t *testing.T) {
 	}
 }
 
+// TestSunDiscStopsMatchTheRamp is the gate on the shell stack having
+// been replaced by one gradient without a change of appearance. The
+// shells were opaque and sunDiscTone is piecewise linear, so sampling
+// the stops at any radius must return exactly the tone the shell that
+// covered that radius carried. Ordering is checked too: the stops feed
+// a fill that lerps in place, so an out-of-order pos would invert a
+// segment rather than fail loudly.
+func TestSunDiscStopsMatchTheRamp(t *testing.T) {
+	t.Parallel()
+	stops := sunDiscStops(nil)
+
+	for i := 1; i < len(stops); i++ {
+		if stops[i].Pos < stops[i-1].Pos {
+			t.Fatalf("stop %d pos %v goes backwards from %v",
+				i, stops[i].Pos, stops[i-1].Pos)
+		}
+	}
+
+	const samples = 64
+	for i := range samples + 1 {
+		tt := float32(i) / samples
+		// The radius fraction the shell at parameter tt covered.
+		u := 1 - sunShellSpan*tt
+		got := gui.SampleGradientStopColor(stops, u)
+		want := sunDiscTone(tt)
+		// One count of rounding: the stops are bytes, and the fill
+		// lerps them premultiplied, which is a no-op here only because
+		// every disc tone is fully opaque.
+		if absI(int(got.R)-int(want.R)) > 1 ||
+			absI(int(got.G)-int(want.G)) > 1 ||
+			absI(int(got.B)-int(want.B)) > 1 || got.A != want.A {
+			t.Errorf("t=%v (pos %v): gradient %v, ramp %v", tt, u, got, want)
+		}
+	}
+}
+
+// absI is |x| for ints, for the channel comparison above.
+func absI(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 // drawInto runs the full paint into a headless DrawContext and returns
 // it. A nil TextMeasurer is what tests get, and every DrawContext text
 // call is nil-safe, so the geometry is exercised end to end without a


### PR DESCRIPTION
Closes #429 (P0-P2 items 1-5).

Every fix is in the example; no engine change. The example drew each effect as
a stack of primitives, one draw call apiece, and each call opens or extends a
batch.

## What changed

| # | Fix | Effect |
|---|-----|--------|
| 1 | Sun disc: 14-96 opaque circles -> one `FilledCircleGradient` | biggest batch win |
| 2 | Granulation: cell count scales with the disc's pixel radius | full-system only |
| 3 | Corona: 576 `FilledPolygon` -> one `FillTrianglesColors` mesh | 576 calls -> 1 |
| 4 | Draw path reads the world position `recompute` cached | no measurable change |
| 5 | Starfield: 220 `FilledRect` + 8-level bucketing -> one mesh | 220 calls -> 1 |

## Results

1100x760, 500 iterations x 5 runs, Apple M5:

| view        | draw calls  | batches  | allocs    | bytes           | frame time     |
| ----------- | ----------- | -------- | --------- | --------------- | -------------- |
| full-system | 1093 -> 161 | 79 -> 42 | 341 -> 208 | 3.15 -> 2.19 MB | 778 -> 725 us |
| jupiter     | 1128 -> 239 | 97 -> 22 | 488 -> 184 | 4.40 -> 3.75 MB | 1168 -> 1096 us |

Frame *time* moves only 6-7%: the benchmark measures tessellation, not
submission, and the gradient path subdivides along isolines, trading shell fans
for split triangles. The win is draw calls and allocations.

## Two places the issue was wrong

**The sun disc needs 5 exact stops, not 8-10 samples.** The issue proposed
sampling the ramp the way `haloStops` does. `haloStops` has to integrate
because a *translucent* stack composites as `1 - exp(-sum)`. The disc shells
were opaque -- each hid the one before -- so the visible color is just
`sunDiscTone(t)`, and that function is piecewise *linear* while the fill lerps
between stops. Five stops reproduce it exactly at any size, with no sampling
error, and drop the banding the stack showed where the clamp bottomed out at
14 shells. `TestSunDiscStopsMatchTheRamp` pins this to within one count of byte
rounding across 65 sample points.

**Merging translucent overlapping fills into one batch is not
appearance-neutral.** `gui/backend/soft` rasterizes a vertex-colored batch as
one path accumulating *signed* coverage (see the `bodyMesh.appendTri` doc), so
overlapping triangles inside one batch do not double-blend the way separate
draws do. That rules the mesh rewrite out for the granulation -- 420
deliberately overlapping alpha-34 cells -- which got an LOD cap instead. The
corona and the starfield are disjoint, so both merged safely.

Two smaller corrections: `drawOrbits` never called `orbitPos` (it draws the
orbit ellipse from `OrbitA`/`Ecc`, not the planet), and `advanceCamera` runs
*before* `recompute` in `tick()`, so neither could read the cache. Only
`lightVec` was redundant, and it is split into `lightVecAt` rather than made to
read the cache: several callers move `Time` without a `recompute`, where a
cache read would quietly answer with the previous position.

## Behavior change worth a look

The starfield twinkle is now continuous rather than quantized to eight alpha
levels. The quantization existed only to keep the batch count down and has
nothing left to buy. `starAlphaFloor` preserves what the bucket midpoint was
really doing, which was stopping the faintest stars blinking out entirely.

## Verification

- `make prepush` green: race tests, lint, cross-GOOS lint, cross-compiles,
  coverage gate, export audit.
- `TestPrimitiveCountsPerFrame` and `TestBatchCountPerFrame` were
  assertion-free harnesses that could never fail. They now carry budgets ~15%
  above current; the gate was confirmed to fire by tightening one until it did.
- New: `TestSunDiscStopsMatchTheRamp`, `TestCoronaIsOneVertexColoredBatch`,
  `TestStarfieldIsOneBatch`, `TestWorldCacheMatchesOrbitPos`, plus mesh-reuse
  allocation gates for the corona and starfield alongside the existing body one.
- Visual: ran the app and checked the full-system and sun-selected views.
  Smooth disc with limb brightening, granulation at full count when zoomed,
  corona fringe intact, no banding or seams.

Not in scope (agreed up front): P3/P4 -- `gui/` batch pre-sizing or
`DrawContext` pooling, the label-width cache, and the `Pow`/`Exp`
approximations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)