### PR TITLE
perf(solar_system): granulation as a mesh, with the falloff it claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to
 
 ### Changed
 
+- **`examples/solar_system`'s granulation is a mesh, and now actually has the
+  falloff it always claimed.** Each convection cell was a stack of three nested
+  translucent circles, meant to give the blob a soft edge. Every circle in the
+  stack carried the same color, so `getBatch` merged the whole polarity into one
+  batch — and a backend takes one coverage mask per batch, which flattened the
+  stack back into a single hard-edged disc. The falloff was paid for and thrown
+  away.
+
+  A cell is now one triangle fan carrying its falloff as vertex alpha, opaque at
+  the center and transparent at the rim, with lit and dark cells in separate
+  meshes so a bright cell over a dark one still composites. The fans read their
+  offsets from a unit circle built once at startup, so placing 70 cells costs no
+  trigonometry at all — the old path went through `arcPoints`, whose per-segment
+  `math.Cos`/`math.Sin` was 8.7% of the frame on its own.
+
+  Measured at 1100x760, Apple M5, whole frame through the real pipeline:
+
+  | view        | frame time    | triangles      | FilledCircle calls |
+  | ----------- | ------------- | -------------- | ------------------ |
+  | full-system | 597 -> 532 us | 22.0k -> 15.6k | 126 -> 24          |
+  | jupiter     | 948 -> 798 us | 36.0k -> 21.4k | 219 -> 9           |
+
 - **An animated `DrawCanvas` now redraws without allocating.** Steady-state
   redraw goes from 51 allocations and 341 KB per frame to zero and zero, and
   ~40% less time with it (`BenchmarkDrawCanvasRedraw`, 300x300 canvas, Apple

--- a/examples/solar_system/README.md
+++ b/examples/solar_system/README.md
@@ -49,10 +49,10 @@ go run ./examples/solar_system/
   sizing, so the canvas keeps the whole window and the camera math never reacts
   when a panel appears.
 - **Batch-aware drawing.** `DrawContext` merges only _consecutive_ same-color
-  triangles, so the starfield quantizes its twinkle to eight brightness levels
-  and draws one level at a time. That is eight batches per frame instead of 220.
-  A shaded sphere goes the other way: it is one mesh that carries a color per
-  vertex. The whole body is then a single batch, however fine its ramp.
+  triangles, so a field of differently-tinted shapes costs one batch apiece. The
+  way out is a mesh that carries a color per vertex: the starfield is one batch
+  with every star keeping its own alpha, and a shaded sphere is one batch
+  however fine its ramp.
 
 - **Texturing without a texture path.** The renderer has no UV coordinates
   anywhere — `FillTrianglesColors` carries per-vertex colors and nothing else.
@@ -110,10 +110,16 @@ that is what limb brightening looks like. A plain center-out ramp is a coin lit
 from the front.
 
 **The face is mottled.** Granulation is a fixed set of soft blobs. Each blob is
-a small stack of nested circles, so it has a falloff instead of a hard edge.
-They are drawn tier-major with lit and dark cells in separate passes. Every
-circle in a pass shares one color, so the whole texture costs `2 x tiers`
-batches rather than one per cell. A cell-major pass costs seventy times more.
+one triangle fan that carries its falloff as vertex alpha: opaque at the center,
+transparent at the rim. Lit and dark cells go in separate meshes, so the whole
+texture is two batches and no trigonometry — the fans read their offsets from a
+unit circle built once at startup.
+
+The two meshes are not an optimization. A backend takes one coverage mask per
+batch, so anything inside a single mesh flattens where it overlaps instead of
+compositing. Two batches is what keeps a bright cell laid over a dark one
+reading as two cells.
+
 The app places cells by `sqrt` of a uniform, so they spread over the _area_
 instead of crowding the middle. It clamps each cell's far edge inside the limb,
 so the texture needs no clipping.
@@ -237,14 +243,26 @@ in part. The app samples albedo per vertex and interpolates it between vertices.
 Mesh density now bounds detail in a way intensity never did. The ceilings are 72
 rings and 128 segments, matched to the 128x64 textures, where before they were
 36 and 64. The rates that approach them are unchanged, so this is invisible at
-ordinary zoom. A full-system frame is 79 batches and 31.6k triangles either way.
-A selected Jupiter is 105 batches and 47.0k triangles, against 46.8k before. It
-is only at maximum zoom, where a planet is hundreds of pixels across and both
-ceilings actually bind, that the raise costs anything. It is 99.6k triangles
-against 85.9k.
+ordinary zoom: when that change landed, a full-system frame was 79 batches and
+31.6k triangles either way, and a selected Jupiter 105 batches and 47.0k
+triangles against 46.8k before. It is only at maximum zoom, where a planet is
+hundreds of pixels across and both ceilings actually bind, that the raise costs
+anything. It was 99.6k triangles against 85.9k.
 
 Off-screen bodies are still culled. Without that, the seven planets outside the
 viewport at a focused zoom each build a full-resolution sphere anyway.
+
+Current counts, from `TestBatchCountPerFrame` and `TestPrimitiveCountsPerFrame`
+at 1100x760:
+
+| view        | batches | triangles | draw calls |
+| ----------- | ------- | --------- | ---------- |
+| full-system | 42      | 15.6k     | 61         |
+| jupiter     | 22      | 21.4k     | 31         |
+
+The frame itself allocates almost nothing. `DrawCanvas` recycles a redraw's
+tessellation buffers, so what is left per frame is the view phase building the
+info panel, not the drawing.
 
 ### Texturing a renderer that has no textures
 

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -24,11 +24,13 @@ var (
 	colorSunLimb = gui.RGB(255, 252, 234)
 	colorSunGlow = gui.RGB(255, 186, 78)
 
-	// Granulation: the mottling across the disc. Both are laid on at
-	// low alpha and stacked, so these are much lighter in effect than
-	// they look.
-	colorSunGranuleLit  = gui.RGBA(255, 255, 250, 34)
-	colorSunGranuleDark = gui.RGBA(240, 200, 126, 34)
+	// Granulation: the mottling across the disc. Each cell is a soft
+	// blob, and these are the color at its center — the alpha the
+	// three stacked discs this replaces composited to there. It fades
+	// to nothing at the cell's rim, so the field is far lighter in
+	// effect than the numbers look.
+	colorSunGranuleLit  = gui.RGBA(255, 255, 250, 89)
+	colorSunGranuleDark = gui.RGBA(240, 200, 126, 89)
 
 	// The corona ring right at the limb, brighter than the disc it
 	// sits on.
@@ -71,14 +73,17 @@ const (
 	discRimStop  = 0.14
 	discCoreStop = 0.34
 
-	// Granulation. The cells are a fixed set of soft blobs, each drawn
-	// as granuleTiers nested circles so it has a falloff instead of a
-	// hard edge. Tiers are drawn outermost-first across *all* cells at
-	// once, and lit and dark cells in separate passes, so one tier of
-	// one polarity is a single flat color and therefore a single
-	// batch: 2*granuleTiers batches for the whole texture.
+	// Granulation. The cells are a fixed set of soft blobs, each a
+	// triangle fan carrying its falloff as vertex alpha: opaque at the
+	// center, transparent at the rim. One mesh per polarity, so the
+	// whole texture is two batches and costs no trigonometry.
 	granuleCount = 70
-	granuleTiers = 3
+
+	// granuleSegs is how many triangles a cell's fan is traced with.
+	// The cells run 10-35px across at a sun that fills the canvas,
+	// where twelve segments is under 3px of chord — well inside what
+	// the alpha falloff hides.
+	granuleSegs = 12
 
 	// granuleMinRadius is the pixel radius below which the cells are
 	// too small to see and are skipped. granuleInset is how far out a
@@ -245,11 +250,13 @@ func drawOrbits(a *App, dc *gui.DrawContext) {
 // granule is one convection cell on the sun's face: a soft blob at a
 // fixed spot, either brighter or darker than the disc under it.
 type granule struct {
-	// Polar placement inside the disc, so the field stays inside the
-	// limb at any radius without a clip.
-	ang, dist float32
-	size      float32 // blob radius, as a fraction of the sun's
-	lit       bool
+	// Placement inside the disc, so the field stays inside the limb at
+	// any radius without a clip. The angle is kept resolved rather than
+	// as an angle: it is fixed at init and the draw runs every frame.
+	cos, sin float32
+	dist     float32
+	size     float32 // blob radius, as a fraction of the sun's
+	lit      bool
 }
 
 // sunGranules and sunEdge are both built once with a fixed seed. The
@@ -271,8 +278,10 @@ func makeGranules() []granule {
 		// read as a clean hot spot, and the clamp keeps a cell's far
 		// edge inside the limb so the texture needs no clipping.
 		dist := 0.16 + sqrt32(rng.Float32())*0.60
+		ang := rng.Float32() * 2 * math.Pi
 		g[i] = granule{
-			ang:  rng.Float32() * 2 * math.Pi,
+			cos:  cos32(ang),
+			sin:  sin32(ang),
 			dist: min(dist, granuleInset-size),
 			size: size,
 			lit:  rng.Float32() < 0.55,
@@ -366,7 +375,7 @@ func drawSun(a *App, dc *gui.DrawContext) {
 		Stops:  a.discStops,
 	})
 
-	drawGranulation(dc, cx, cy, r)
+	drawGranulation(dc, &a.granules, cx, cy, r)
 	drawCorona(dc, &a.corona, cx, cy, r, a.Time)
 }
 
@@ -414,14 +423,41 @@ func sunDiscStops(dst []gui.GradientStop) []gui.GradientStop {
 	return dst
 }
 
+// granuleRim is the unit circle a cell's fan is traced with, as
+// interleaved x,y. The cells never change shape, only scale and
+// position, so the trigonometry is done once here rather than per cell
+// per frame. The ring closes on its first point, which is what lets the
+// fan loop read pairs without wrapping.
+var granuleRim = makeGranuleRim()
+
+func makeGranuleRim() []float32 {
+	p := make([]float32, 0, (granuleSegs+1)*2)
+	for i := 0; i <= granuleSegs; i++ {
+		ang := 2 * math.Pi * float32(i) / granuleSegs
+		p = append(p, cos32(ang), sin32(ang))
+	}
+	return p
+}
+
 // drawGranulation lays the mottled convection texture over the disc.
 //
-// Tier-major, and lit and dark in separate passes: every circle inside
-// one pass shares a color, and getBatch merges consecutive same-color
-// triangles, so the whole texture costs 2*granuleTiers batches instead
-// of one per cell. Drawing cell-major would cost granuleCount times
-// more.
-func drawGranulation(dc *gui.DrawContext, cx, cy, r float32) {
+// Each cell is one triangle fan: its center at full alpha, its rim at
+// zero, so the falloff is carried by the vertex colors.
+//
+// It used to be three nested translucent circles per cell, meant to
+// build that falloff by stacking. They never did. All three carried the
+// same color, so getBatch merged the whole polarity into one batch, and
+// a backend takes one coverage mask per batch — the stack flattened
+// back into the single hard-edged disc it was there to avoid. The
+// falloff was paid for and thrown away, at 228 triangles a cell
+// (arcPoints sizes its segment count by radius) against twelve here.
+//
+// Lit and dark stay in separate meshes, and that split is the part that
+// is load-bearing: two batches is what keeps a bright cell laid over a
+// dark one compositing rather than flattening. Cells of the same
+// polarity still flatten where they overlap, exactly as they did
+// before.
+func drawGranulation(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32) {
 	if r < granuleMinRadius {
 		return // the cells would be sub-pixel; they would only cost batches
 	}
@@ -434,24 +470,27 @@ func drawGranulation(dc *gui.DrawContext, cx, cy, r float32) {
 	cells := sunGranules[:min(len(sunGranules), int(r*granulesPerPx))]
 
 	for _, lit := range [2]bool{true, false} {
-		base := colorSunGranuleDark
+		center := colorSunGranuleDark
 		if lit {
-			base = colorSunGranuleLit
+			center = colorSunGranuleLit
 		}
-		for tier := range granuleTiers {
-			// Outermost tier first, so the stack builds a soft falloff
-			// rather than a hard disc.
-			scale := 1 - float32(tier)/granuleTiers
-			for _, g := range cells {
-				if g.lit != lit {
-					continue
-				}
-				dc.FilledCircle(
-					cx+cos32(g.ang)*g.dist*r,
-					cy+sin32(g.ang)*g.dist*r,
-					g.size*r*scale, base)
+		rim := center.WithOpacity(0)
+
+		m.tris, m.cols = m.tris[:0], m.cols[:0]
+		for i := range cells {
+			g := &cells[i]
+			if g.lit != lit {
+				continue
+			}
+			bx, by := cx+g.cos*g.dist*r, cy+g.sin*g.dist*r
+			br := g.size * r
+			for k := 0; k+3 < len(granuleRim); k += 2 {
+				m.appendTri(bx, by, center,
+					bx+granuleRim[k]*br, by+granuleRim[k+1]*br, rim,
+					bx+granuleRim[k+2]*br, by+granuleRim[k+3]*br, rim)
 			}
 		}
+		dc.FillTrianglesColors(m.tris, m.cols)
 	}
 }
 

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -88,6 +88,10 @@ type App struct {
 	body   bodyMesh
 	corona bodyMesh
 
+	// granules is drawGranulation's, on the same footing. It is filled
+	// and flushed twice per frame, once per cell polarity.
+	granules bodyMesh
+
 	// Selected and Hovered are a planet index, selSun for the sun, or
 	// -1 for the full-system view / nothing under the cursor.
 	Selected int

--- a/examples/solar_system/zz_effbench_test.go
+++ b/examples/solar_system/zz_effbench_test.go
@@ -127,3 +127,34 @@ func BenchmarkTickOnly(b *testing.B) {
 		tick(a)
 	}
 }
+
+// benchWholeFrame drives the frame the app actually runs: view
+// generation, layout, and the renderer build that calls OnDraw through
+// renderDrawCanvas — where the tessellation buffers are pooled. The
+// benchFrame family above measures OnDraw in isolation with a fresh
+// DrawContext, so it cannot see that pooling; this one can, and it is
+// the number that corresponds to a running window.
+func benchWholeFrame(b *testing.B, sel int) {
+	a := newApp()
+	a.CanvasW, a.CanvasH = windowW, windowH
+	a.Selected = sel
+	for range 120 {
+		tick(a)
+	}
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  a,
+		Width:  windowW,
+		Height: windowH,
+	})
+	w.TestRender(mainView)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		tick(a)
+		w.TestRender(nil)
+	}
+}
+
+func BenchmarkWholeFrameFullSystem(b *testing.B) { benchWholeFrame(b, -1) }
+func BenchmarkWholeFrameJupiter(b *testing.B)    { benchWholeFrame(b, 4) }


### PR DESCRIPTION
Stacked on #432 — review that first; this PR targets its branch.

## The bug behind the perf work

Each convection cell was three nested translucent circles, meant to give the blob a soft edge. All three carried the same color, so `getBatch` merged the whole polarity into one batch — and a backend takes one coverage mask per batch, so the stack flattened back into the single hard-edged disc it existed to avoid. The falloff was paid for on every frame and thrown away.

| before | after |
| --- | --- |
| flat discs with visible hard edges | genuine soft mottling |

Rendered headlessly through `soft.RenderToPNG` at 3x, full-system view. The before image shows the cells as overlapping circles; the after shows the convection texture the code always described.

## Change

A cell is one triangle fan carrying its falloff as vertex alpha — opaque at the center, transparent at the rim. Lit and dark cells stay in separate meshes, and that split is the load-bearing part: two batches is what keeps a bright cell laid over a dark one compositing instead of flattening. Cells of the same polarity still flatten where they overlap, exactly as before.

The fans read their offsets from a unit circle built once at startup, so placing 70 cells costs no trigonometry. The old path went through `arcPoints`, whose per-segment `math.Cos`/`math.Sin` measured 8.7% of the frame on its own, and whose radius-driven segment count made one cell 228 triangles against twelve here.

## Measurements

Whole frame through the real pipeline (view + layout + renderer build), 1100x760, Apple M5:

| view | frame time | triangles | FilledCircle calls |
| --- | --- | --- | --- |
| full-system | 597 -> 532 us | 22.0k -> 15.6k | 126 -> 24 |
| jupiter | 948 -> 798 us | 36.0k -> 21.4k | 219 -> 9 |

Also adds `BenchmarkWholeFrameFullSystem` / `BenchmarkWholeFrameJupiter`. The existing `BenchmarkFrame*` call `OnDraw` with a standalone `DrawContext`, which cannot see the buffer pooling in `renderDrawCanvas`; these go through `TestRender`, so they measure what a running window does.

## Docs

`README.md`: the granulation section described the tier stack; the "What it demonstrates" bullet still described the starfield's eight-level alpha quantization, removed back in #429. Both corrected, plus current batch/triangle counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)