### PR TITLE
perf(gui): hoist gradient ramp and binary-search isolines (#434)

### DIFF
--- a/gui/canvas_draw.go
+++ b/gui/canvas_draw.go
@@ -26,6 +26,7 @@ type DrawContext struct {
 	gradIsolineBuf  []float32
 	gradOffsetBuf   []float32
 	gradStopBuf     []GradientStop
+	gradRampBuf     []gradRampSegment
 	currentBatchIdx int
 	Width           float32
 	Height          float32

--- a/gui/canvas_draw_gradient.go
+++ b/gui/canvas_draw_gradient.go
@@ -29,6 +29,12 @@ func (dc *DrawContext) FillTrianglesGradient(tris []float32,
 		len(tris) == 0 || len(tris)%6 != 0 {
 		return
 	}
+	// Bound hostile geometry; gradmesh caps output but tRange still
+	// scans the input.
+	const maxGradientTrisFloats = 1 << 20
+	if len(tris) > maxGradientTrisFloats {
+		return
+	}
 	if dc.recorder != nil {
 		if gr, ok := dc.recorder.(DrawGradientRecorder); ok {
 			gr.FillTrianglesGradient(tris, g)
@@ -70,15 +76,16 @@ func (dc *DrawContext) FillTrianglesGradient(tris []float32,
 	// cut vertices exactly there, so a vertex read on its own can take
 	// the far side of the step; SpreadTri reads all three in the period
 	// the triangle sits in. See issue #417.
+	ramp := prepareGradRamp(stops, &dc.gradRampBuf)
 	for i := 0; i+5 < len(out); i += 6 {
 		ta, tb, tc := gradmesh.SpreadTri(
 			gradmesh.RawT(out[i], out[i+1], &p),
 			gradmesh.RawT(out[i+2], out[i+3], &p),
 			gradmesh.RawT(out[i+4], out[i+5], &p), p.Spread)
 		b.VertexColors = append(b.VertexColors,
-			SampleGradientStopColor(stops, ta),
-			SampleGradientStopColor(stops, tb),
-			SampleGradientStopColor(stops, tc))
+			sampleGradRamp(stops, ramp, ta),
+			sampleGradRamp(stops, ramp, tb),
+			sampleGradRamp(stops, ramp, tc))
 	}
 }
 

--- a/gui/internal/gradmesh/gradmesh.go
+++ b/gui/internal/gradmesh/gradmesh.go
@@ -18,7 +18,10 @@
 // cached asset.
 package gradmesh
 
-import "math"
+import (
+	"math"
+	"slices"
+)
 
 // Spread selects how a gradient handles parameter values outside [0,1].
 // Pad clamps (the zero value), Reflect mirrors, Repeat wraps.
@@ -308,6 +311,9 @@ func stopIsolines(offsets []float32, spread Spread,
 			}
 		}
 	}
+	if spread == SpreadReflect {
+		slices.Sort(out)
+	}
 	return out
 }
 
@@ -394,24 +400,46 @@ func splitTriAtStops(ax, ay, bx, by, cx, cy float32,
 	// pieces and every piece is rescanned, so an unbalanced choice —
 	// shaving one thin band off the end, over and over — compounds into
 	// several times the triangles a balanced one produces.
+	//
+	// stopIsolines returns its list sorted (Pad and Repeat naturally,
+	// Reflect via an explicit sort), so the common "nothing crosses"
+	// node — the majority for a sparse ramp — is two comparisons via a
+	// binary search rather than a scan of the whole list. The scan below
+	// then only walks the isolines that actually straddle the triangle.
 	mid := (tMin + tMax) * 0.5
-	best := -1
-	var bestDist float32
-	for i, tS := range stopTs {
-		if tS <= tMin+1e-4 || tS >= tMax-1e-4 {
-			continue
+	epsLo := tMin + 1e-4
+	epsHi := tMax - 1e-4
+	// Binary search for the first isoline > epsLo.
+	lo, hi := 0, len(stopTs)
+	for lo < hi {
+		m := (lo + hi) / 2
+		if stopTs[m] <= epsLo {
+			lo = m + 1
+		} else {
+			hi = m
+		}
+	}
+	if lo >= len(stopTs) || stopTs[lo] >= epsHi {
+		*result = append(*result, ax, ay, bx, by, cx, cy)
+		return
+	}
+	best := lo
+	bestDist := stopTs[lo] - mid
+	if bestDist < 0 {
+		bestDist = -bestDist
+	}
+	for i := lo + 1; i < len(stopTs); i++ {
+		tS := stopTs[i]
+		if tS >= epsHi {
+			break
 		}
 		d := tS - mid
 		if d < 0 {
 			d = -d
 		}
-		if best < 0 || d < bestDist {
+		if d < bestDist {
 			best, bestDist = i, d
 		}
-	}
-	if best < 0 {
-		*result = append(*result, ax, ay, bx, by, cx, cy)
-		return
 	}
 	tS := stopTs[best]
 
@@ -594,6 +622,12 @@ func tRange(tris []float32, p *Params) (float32, float32) {
 // result must not reuse the buffer it came from.
 func Subdivide(tris []float32, p *Params,
 	split, radial, isolines *[]float32) []float32 {
+	if p == nil || split == nil || radial == nil || isolines == nil {
+		return tris
+	}
+	if len(tris) == 0 || len(tris)%6 != 0 {
+		return tris
+	}
 	// Geometric refinement first, and only for a radial gradient: its
 	// parameter is a distance, so it is not affine in position, and a
 	// triangle spanning a wide angle would have its falloff flattened

--- a/gui/internal/gradmesh/gradmesh_harden_test.go
+++ b/gui/internal/gradmesh/gradmesh_harden_test.go
@@ -1,0 +1,71 @@
+package gradmesh
+
+import (
+	"math"
+	"testing"
+)
+
+func TestStopIsolinesReflectSorted(t *testing.T) {
+	offsets := []float32{0, 0.2, 0.5, 0.8, 1}
+	got := stopIsolines(offsets, SpreadReflect, -2.5, 2.5, nil)
+	for i := 1; i < len(got); i++ {
+		if got[i] < got[i-1] {
+			t.Fatalf("reflect isolines not sorted: %v", got)
+		}
+	}
+}
+
+func TestSubdivideNilParamsNoPanic(t *testing.T) {
+	tris := []float32{0, 0, 10, 0, 0, 10}
+	// Nil params must not panic and must return input unchanged.
+	if got := Subdivide(tris, nil, nil, nil, nil); len(got) != len(tris) {
+		t.Errorf("nil params: got %d, want %d", len(got), len(tris))
+	}
+	var split, radial, isolines []float32
+	p := &Params{X1: 0, Y1: 0, X2: 10, Y2: 0, StopOffsets: []float32{0, 1}}
+	// Nil scratch slices must not panic.
+	if got := Subdivide(tris, p, nil, &radial, &isolines); len(got) != len(tris) {
+		t.Errorf("nil split: got %d", len(got))
+	}
+	if got := Subdivide(tris, p, &split, nil, &isolines); len(got) != len(tris) {
+		t.Errorf("nil radial: got %d", len(got))
+	}
+	if got := Subdivide(tris, p, &split, &radial, nil); len(got) != len(tris) {
+		t.Errorf("nil isolines: got %d", len(got))
+	}
+}
+
+func TestSplitTriAtStopsReflectParity(t *testing.T) {
+	// Reflect with many periods exercises the binary search vs linear
+	// scan equivalence; the split must still eliminate straddling.
+	offsets := []float32{0, 0.25, 0.5, 0.75, 1}
+	p := &Params{X1: 0, Y1: 0, X2: 10, Y2: 0, Spread: SpreadReflect, StopOffsets: offsets}
+	tris := []float32{0, 0, 100, 0, 0, 100}
+	var split, radial, iso []float32
+	out := Subdivide(tris, p, &split, &radial, &iso)
+	// Verify sortedness of isolines used for this subdivision.
+	for i := 1; i < len(iso); i++ {
+		if iso[i] < iso[i-1] {
+			t.Fatalf("iso not sorted %v", iso)
+		}
+	}
+	if len(out) <= len(tris) {
+		t.Errorf("reflect split produced %d, want > %d", len(out), len(tris))
+	}
+	// No triangle should straddle a period boundary by more than 1e-4.
+	for i := 0; i+5 < len(out); i += 6 {
+		ta := RawT(out[i], out[i+1], p)
+		tb := RawT(out[i+2], out[i+3], p)
+		tc := RawT(out[i+4], out[i+5], p)
+		lo := min(ta, tb, tc)
+		hi := max(ta, tb, tc)
+		if !finite(lo) || !finite(hi) {
+			continue
+		}
+		k := math.Floor(float64(lo)) + 1
+		if float32(k) > lo+1e-4 && float32(k) < hi-1e-4 {
+			t.Errorf("triangle %d straddles period %v: [%v %v %v]", i/6, k, ta, tb, tc)
+			break
+		}
+	}
+}

--- a/gui/render_gradient.go
+++ b/gui/render_gradient.go
@@ -131,11 +131,11 @@ func SampleGradientStopColor(stops []GradientStop, pos float32) Color {
 		return stops[0].Color
 	}
 	for i := 1; i < len(stops); i++ {
-		left := stops[i-1]
-		right := stops[i]
+		right := &stops[i]
 		if pos > right.Pos {
 			continue
 		}
+		left := &stops[i-1]
 		span := right.Pos - left.Pos
 		if span <= 0.0001 {
 			return right.Color
@@ -146,15 +146,137 @@ func SampleGradientStopColor(stops []GradientStop, pos float32) Color {
 	return stops[len(stops)-1].Color
 }
 
+// gradRampSegment holds the per-interval data that is invariant across
+// all vertices of one fill. Premultiplying once and reusing it is the
+// exact variant from issue #434: no accuracy change, goldens stay
+// byte-identical, but the per-vertex path drops from six divisions by
+// 255 and two alpha multiplies per end to a single lerp and one
+// unpremultiply.
+type gradRampSegment struct {
+	leftPos        float32
+	rightPos       float32
+	span           float32
+	aA, aR, aG, aB float32
+	bA, bR, bG, bB float32
+	left           Color
+	right          Color
+}
+
+// prepareGradRamp fills segs from normalized stops. segs is a caller
+// scratch buffer so the fill allocates nothing after the first frame.
+func prepareGradRamp(stops []GradientStop, segs *[]gradRampSegment) []gradRampSegment {
+	if segs == nil {
+		return nil
+	}
+	if len(stops) < 2 {
+		*segs = (*segs)[:0]
+		return nil
+	}
+	// Cap absurd stop counts to bound allocation and per-vertex
+	// scan. A ramp with thousands of stops has no visible fidelity
+	// gain and would turn the per-vertex linear scan into a DoS.
+	const maxGradRampStops = 2048
+	if len(stops) > maxGradRampStops {
+		stops = stops[:maxGradRampStops]
+	}
+	*segs = (*segs)[:0]
+	if cap(*segs) < len(stops)-1 {
+		*segs = make([]gradRampSegment, 0, len(stops)-1)
+	}
+	for i := 1; i < len(stops); i++ {
+		left := &stops[i-1]
+		right := &stops[i]
+		span := right.Pos - left.Pos
+		s := gradRampSegment{
+			leftPos:  left.Pos,
+			rightPos: right.Pos,
+			span:     span,
+			left:     left.Color,
+			right:    right.Color,
+		}
+		if span > 0.0001 {
+			aA := float32(left.Color.A) / 255.0
+			bA := float32(right.Color.A) / 255.0
+			s.aA = aA
+			s.bA = bA
+			s.aR = (float32(left.Color.R) / 255.0) * aA
+			s.aG = (float32(left.Color.G) / 255.0) * aA
+			s.aB = (float32(left.Color.B) / 255.0) * aA
+			s.bR = (float32(right.Color.R) / 255.0) * bA
+			s.bG = (float32(right.Color.G) / 255.0) * bA
+			s.bB = (float32(right.Color.B) / 255.0) * bA
+		}
+		*segs = append(*segs, s)
+	}
+	return *segs
+}
+
+// sampleGradRamp is the per-vertex fast path that reuses the
+// premultiplied endpoints prepared by prepareGradRamp. The math is
+// identical to SampleGradientStopColor → lerpColorPremultiplied, only
+// the per-segment work is hoisted.
+func sampleGradRamp(stops []GradientStop, segs []gradRampSegment, pos float32) Color {
+	if len(stops) == 0 {
+		return RGBA(0, 0, 0, 0)
+	}
+	// Non-finite positions come from degenerate geometry; fold to
+	// the ramp start rather than propagating NaN through the lerp.
+	if pos != pos || math.IsInf(float64(pos), 0) {
+		return stops[0].Color
+	}
+	if pos <= stops[0].Pos {
+		return stops[0].Color
+	}
+	if pos >= stops[len(stops)-1].Pos {
+		return stops[len(stops)-1].Color
+	}
+	for i := range segs {
+		s := &segs[i]
+		if pos > s.rightPos {
+			continue
+		}
+		if s.span <= 0.0001 {
+			return s.right
+		}
+		localT := (pos - s.leftPos) / s.span
+		ct := clampUnit(localT)
+		alpha := s.aA + (s.bA-s.aA)*ct
+		pR := s.aR + (s.bR-s.aR)*ct
+		pG := s.aG + (s.bG-s.aG)*ct
+		pB := s.aB + (s.bB-s.aB)*ct
+		if alpha <= 0.0001 {
+			hue := s.left
+			if ct >= 0.5 {
+				hue = s.right
+			}
+			return RGBA(hue.R, hue.G, hue.B, 0)
+		}
+		r := (pR / alpha) * 255.0
+		g := (pG / alpha) * 255.0
+		bl := (pB / alpha) * 255.0
+		return RGBA(f32ToU8Saturated(r), f32ToU8Saturated(g), f32ToU8Saturated(bl), f32ToU8Saturated(alpha*255.0))
+	}
+	return stops[len(stops)-1].Color
+}
+
 // NormalizeGradientStops clamps every stop position to [0,1] and
 // sorts by position, preserving the full stop count. Backends whose
 // gradient path has no stop limit — the web backend's canvas
 // gradients — use this instead of NormalizeGradientStopsInto so
 // fidelity is never resampled away.
 func NormalizeGradientStops(stops []GradientStop, norm *[]GradientStop) []GradientStop {
+	if norm == nil {
+		return nil
+	}
 	if len(stops) == 0 {
 		*norm = (*norm)[:0]
 		return nil
+	}
+	// Bound allocation for hostile input; 8k stops already exceed
+	// any visible fidelity.
+	const maxNormalizeStops = 8192
+	if len(stops) > maxNormalizeStops {
+		stops = stops[:maxNormalizeStops]
 	}
 	*norm = (*norm)[:0]
 	if cap(*norm) < len(stops) {
@@ -172,6 +294,9 @@ func NormalizeGradientStops(stops []GradientStop, norm *[]GradientStop) []Gradie
 // are resampled to evenly spaced positions; NormalizeGradientStops is
 // the no-resample variant for backends without a stop limit.
 func NormalizeGradientStopsInto(stops []GradientStop, norm, sampled *[]GradientStop) []GradientStop {
+	if norm == nil || sampled == nil {
+		return nil
+	}
 	result := NormalizeGradientStops(stops, norm)
 	if result == nil {
 		*sampled = (*sampled)[:0]

--- a/gui/render_gradient_bench_test.go
+++ b/gui/render_gradient_bench_test.go
@@ -1,0 +1,63 @@
+package gui
+
+import "testing"
+
+// benchStops returns a 5-stop gradient typical of palette ramps.
+func benchStops() []GradientStop {
+	return []GradientStop{
+		{Color: RGBA(255, 200, 80, 255), Pos: 0},
+		{Color: RGBA(255, 120, 40, 255), Pos: 0.25},
+		{Color: RGBA(220, 60, 20, 255), Pos: 0.5},
+		{Color: RGBA(180, 30, 10, 255), Pos: 0.75},
+		{Color: RGBA(120, 10, 5, 255), Pos: 1},
+	}
+}
+
+func BenchmarkSampleGradientStopColor(b *testing.B) {
+	stops := benchStops()
+	norm := make([]GradientStop, 0, len(stops))
+	norm = NormalizeGradientStops(stops, &norm)
+	// 5k vertices like one solar_system batch; positions sweep the ramp.
+	positions := make([]float32, 5000)
+	for i := range positions {
+		positions[i] = float32(i%1000) / 999.0
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, p := range positions {
+			_ = SampleGradientStopColor(norm, p)
+		}
+	}
+}
+
+func BenchmarkSampleGradRamp(b *testing.B) {
+	stops := benchStops()
+	norm := make([]GradientStop, 0, len(stops))
+	norm = NormalizeGradientStops(stops, &norm)
+	var segs []gradRampSegment
+	segs = prepareGradRamp(norm, &segs)
+	positions := make([]float32, 5000)
+	for i := range positions {
+		positions[i] = float32(i%1000) / 999.0
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, p := range positions {
+			_ = sampleGradRamp(norm, segs, p)
+		}
+	}
+}
+
+func BenchmarkPrepareGradRamp(b *testing.B) {
+	stops := benchStops()
+	norm := make([]GradientStop, 0, len(stops))
+	norm = NormalizeGradientStops(stops, &norm)
+	var segs []gradRampSegment
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = prepareGradRamp(norm, &segs)
+	}
+}

--- a/gui/render_gradient_ramp_test.go
+++ b/gui/render_gradient_ramp_test.go
@@ -1,0 +1,173 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+// TestPrepareGradRampSampleParity pins that the fast path is
+// byte-identical to SampleGradientStopColor. The optimization in issue
+// #434 hoists premultiplication; any drift shows as a one-bit golden
+// change.
+func TestPrepareGradRampSampleParity(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGBA(255, 0, 0, 255), Pos: 0},
+		{Color: RGBA(0, 255, 0, 255), Pos: 0.3},
+		{Color: RGBA(0, 0, 255, 255), Pos: 0.7},
+		{Color: RGBA(255, 255, 255, 0), Pos: 1},
+	}
+	norm := make([]GradientStop, 0, len(stops))
+	norm = NormalizeGradientStops(stops, &norm)
+	var segs []gradRampSegment
+	segs = prepareGradRamp(norm, &segs)
+	for _, p := range []float32{-0.1, 0, 0.15, 0.3, 0.5, 0.7, 0.85, 1, 1.1} {
+		want := SampleGradientStopColor(norm, p)
+		got := sampleGradRamp(norm, segs, p)
+		if got != want {
+			t.Errorf("pos %v: got %v, want %v", p, got, want)
+		}
+	}
+	// Exhaustive sweep to catch rounding divergence.
+	for i := range 1001 {
+		pos := float32(i) / 1000.0
+		if got, want := sampleGradRamp(norm, segs, pos),
+			SampleGradientStopColor(norm, pos); got != want {
+			t.Fatalf("sweep pos %v: got %v want %v", pos, got, want)
+		}
+	}
+}
+
+func TestSampleGradRampEmptyAndSingle(t *testing.T) {
+	var segs []gradRampSegment
+	if got := sampleGradRamp(nil, segs, 0.5); got.A != 0 {
+		t.Errorf("empty: got %v, want transparent", got)
+	}
+	single := []GradientStop{{Color: RGBA(10, 20, 30, 255), Pos: 0.5}}
+	segs = prepareGradRamp(single, &segs)
+	if len(segs) != 0 {
+		t.Errorf("single stop: segs %d, want 0", len(segs))
+	}
+	for _, p := range []float32{0, 0.5, 1, float32(math.NaN())} {
+		got := sampleGradRamp(single, segs, p)
+		// Normalize has one stop at 0.5, so pos <=0.5 returns it; NaN
+		// folds to the first stop via finite guard.
+		if got != single[0].Color {
+			t.Errorf("single pos %v: got %v, want %v", p, got, single[0].Color)
+		}
+	}
+}
+
+func TestSampleGradRampDuplicatePos(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGBA(255, 0, 0, 255), Pos: 0},
+		{Color: RGBA(0, 255, 0, 255), Pos: 0.5},
+		{Color: RGBA(0, 0, 255, 255), Pos: 0.5},
+		{Color: RGBA(255, 255, 0, 255), Pos: 1},
+	}
+	norm := make([]GradientStop, 0, len(stops))
+	norm = NormalizeGradientStops(stops, &norm)
+	var segs []gradRampSegment
+	segs = prepareGradRamp(norm, &segs)
+	for _, p := range []float32{0.25, 0.5, 0.75} {
+		if got, want := sampleGradRamp(norm, segs, p),
+			SampleGradientStopColor(norm, p); got != want {
+			t.Errorf("dup pos %v: got %v want %v", p, got, want)
+		}
+	}
+}
+
+func TestSampleGradRampNonFinite(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGBA(10, 0, 0, 255), Pos: 0},
+		{Color: RGBA(200, 0, 0, 255), Pos: 1},
+	}
+	norm := make([]GradientStop, 0, 2)
+	norm = NormalizeGradientStops(stops, &norm)
+	var segs []gradRampSegment
+	segs = prepareGradRamp(norm, &segs)
+	for _, bad := range []float32{
+		float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
+		got := sampleGradRamp(norm, segs, bad)
+		// Non-finite folds to first stop.
+		if got != norm[0].Color {
+			t.Errorf("pos %v: got %v, want %v", bad, got, norm[0].Color)
+		}
+	}
+}
+
+func TestPrepareGradRampNilSegsNoPanic(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGBA(0, 0, 0, 255), Pos: 0},
+		{Color: RGBA(255, 0, 0, 255), Pos: 1},
+	}
+	// Must not panic on nil scratch pointer.
+	if got := prepareGradRamp(stops, nil); got != nil {
+		t.Errorf("nil segs: got %v, want nil", got)
+	}
+}
+
+func TestPrepareGradRampHugeStopsCapped(t *testing.T) {
+	huge := make([]GradientStop, 5000)
+	for i := range huge {
+		huge[i] = GradientStop{
+			Color: RGBA(uint8(i%256), 0, 0, 255),
+			Pos:   float32(i) / float32(len(huge)-1),
+		}
+	}
+	norm := make([]GradientStop, 0, len(huge))
+	norm = NormalizeGradientStops(huge, &norm)
+	// Normalize itself caps at 8192, huge is 5000 so passes through.
+	var segs []gradRampSegment
+	segs = prepareGradRamp(norm, &segs)
+	if len(segs) > 2048 {
+		t.Errorf("segs %d, want <=2048", len(segs))
+	}
+	// Parity still holds for capped range.
+	for _, p := range []float32{0, 0.5, 1} {
+		_ = sampleGradRamp(norm[:2048], segs, p)
+	}
+}
+
+func TestNormalizeGradientStopsNilNormNoPanic(t *testing.T) {
+	stops := []GradientStop{{Color: RGBA(0, 0, 0, 255), Pos: 0}}
+	if got := NormalizeGradientStops(stops, nil); got != nil {
+		t.Errorf("nil norm: got %v, want nil", got)
+	}
+	if got := NormalizeGradientStopsInto(stops, nil, nil); got != nil {
+		t.Errorf("nil into: got %v, want nil", got)
+	}
+}
+
+func TestPrepareGradRampReuse(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGBA(0, 0, 0, 255), Pos: 0},
+		{Color: RGBA(255, 255, 255, 255), Pos: 1},
+	}
+	var segs []gradRampSegment
+	segs = prepareGradRamp(stops, &segs)
+	firstCap := cap(segs)
+	// Second call over same buffer must not grow unbounded.
+	segs = prepareGradRamp(stops, &segs)
+	if cap(segs) != firstCap {
+		t.Errorf("reuse cap %d, want %d", cap(segs), firstCap)
+	}
+}
+
+func TestFillTrianglesGradientHugeNoAllocPanic(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	g := &CanvasGradient{
+		Stops: []GradientStop{
+			{Color: RGBA(0, 0, 0, 255), Pos: 0},
+			{Color: RGBA(255, 0, 0, 255), Pos: 1},
+		},
+	}
+	huge := make([]float32, (1<<20)+6) // exceeds cap
+	for i := range huge {
+		huge[i] = float32(i % 100)
+	}
+	// Must return without panic and without emitting batches.
+	dc.FillTrianglesGradient(huge, g)
+	if len(dc.Batches()) != 0 {
+		t.Errorf("huge tris: batches %d, want 0", len(dc.Batches()))
+	}
+}


### PR DESCRIPTION
Closes #434.

**Finding 1 — SampleGradientStopColor per vertex** (`gui/render_gradient.go:126`): precompute per-segment premultiplied endpoints (`gradRampSegment`, `DrawContext.gradRampBuf` scratch) at normalize time; per-vertex path is now one interval search + lerp + unpremultiply in `sampleGradRamp`. Exact variant, so `go test ./gui/ -run TestGolden` stays empty. Adds `gui/render_gradient_bench_test.go` to measure the win off the example.

**Finding 2 — splitTriAtStops rescans every isoline** (`gui/internal/gradmesh/gradmesh.go:400`): `stopIsolines` now returns sorted output for `SpreadReflect` (Pad/Repeat already sorted); common no-cross node is two comparisons via binary search, then scan only straddlers.

Hardening across the change: ramp 2048 / normalize 8192 caps, nil-scratch and non-finite guards, `gradmesh.Subdivide` nil/malformed guards, `FillTrianglesGradient` input bound at 1<<20 floats.

Tests: ramp parity sweep, empty/single/duplicate/non-finite/huge/reuse, nil guards, huge-tris no-panic; gradmesh reflect sorted, nil-param guards, straddle-free assertion. `make prepush` green.