### PR TITLE
feat(gui): canvas text honors TextStyle.AffineTransform (#436)

### DIFF
--- a/gui/backend/android/draw.go
+++ b/gui/backend/android/draw.go
@@ -13,6 +13,8 @@ import (
 	"math"
 	"unsafe"
 
+	"github.com/go-gui-org/go-glyph"
+
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
@@ -407,6 +409,22 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 
 func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
+		return
+	}
+	if gui.DrawTextTransformed(r, b.textSys,
+		guiStyleToGlyphConfig,
+		func(layout glyph.Layout, grad *glyph.GradientConfig) {
+			b.UseGlyphPipeline()
+			b.TextQueued = true
+			if grad != nil {
+				b.textSys.DrawLayoutTransformedWithGradient(
+					layout, r.X, r.Y, *r.LayoutTransform, grad)
+			} else {
+				b.textSys.DrawLayoutTransformed(
+					layout, r.X, r.Y, *r.LayoutTransform)
+			}
+			b.InvalidatePipelineState()
+		}) {
 		return
 	}
 	cfg := glyphconv.GuiTextConfigFromRender(r)

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -9,6 +9,8 @@ import (
 
 	gogl "github.com/go-gui-org/go-gui/gui/backend/internal/glbind"
 
+	"github.com/go-gui-org/go-glyph"
+
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
@@ -405,6 +407,21 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 
 func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
+		return
+	}
+	if gui.DrawTextTransformed(r, b.textSys,
+		guiStyleToGlyphConfig,
+		func(layout glyph.Layout, grad *glyph.GradientConfig) {
+			b.useGlyphPipeline()
+			if grad != nil {
+				b.textSys.DrawLayoutTransformedWithGradient(
+					layout, r.X, r.Y, *r.LayoutTransform, grad)
+			} else {
+				b.textSys.DrawLayoutTransformed(
+					layout, r.X, r.Y, *r.LayoutTransform)
+			}
+			b.restoreAfterGlyph()
+		}) {
 		return
 	}
 	cfg := glyphconv.GuiTextConfigFromRender(r)

--- a/gui/backend/ios/draw.go
+++ b/gui/backend/ios/draw.go
@@ -13,6 +13,8 @@ import (
 	"math"
 	"unsafe"
 
+	"github.com/go-gui-org/go-glyph"
+
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
@@ -407,6 +409,22 @@ func (b *Backend) drawSvg(r *gui.RenderCmd) {
 
 func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
+		return
+	}
+	if gui.DrawTextTransformed(r, b.textSys,
+		guiStyleToGlyphConfig,
+		func(layout glyph.Layout, grad *glyph.GradientConfig) {
+			b.UseGlyphPipeline()
+			b.TextQueued = true
+			if grad != nil {
+				b.textSys.DrawLayoutTransformedWithGradient(
+					layout, r.X, r.Y, *r.LayoutTransform, grad)
+			} else {
+				b.textSys.DrawLayoutTransformed(
+					layout, r.X, r.Y, *r.LayoutTransform)
+			}
+			b.InvalidatePipelineState()
+		}) {
 		return
 	}
 	cfg := glyphconv.GuiTextConfigFromRender(r)

--- a/gui/backend/metal/draw.go
+++ b/gui/backend/metal/draw.go
@@ -13,6 +13,8 @@ import (
 	"math"
 	"unsafe"
 
+	"github.com/go-gui-org/go-glyph"
+
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/gpu"
@@ -427,6 +429,20 @@ func (b *windowState) drawSvg(r *gui.RenderCmd) {
 
 func (b *windowState) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
+		return
+	}
+	if gui.DrawTextTransformed(r, b.textSys,
+		guiStyleToGlyphConfig,
+		func(layout glyph.Layout, grad *glyph.GradientConfig) {
+			b.useGlyphPipeline()
+			if grad != nil {
+				b.textSys.DrawLayoutTransformedWithGradient(
+					layout, r.X, r.Y, *r.LayoutTransform, grad)
+			} else {
+				b.textSys.DrawLayoutTransformed(
+					layout, r.X, r.Y, *r.LayoutTransform)
+			}
+		}) {
 		return
 	}
 	cfg := glyphconv.GuiTextConfigFromRender(r)

--- a/gui/backend/soft/text.go
+++ b/gui/backend/soft/text.go
@@ -100,6 +100,19 @@ func (r *renderer) drawText(cmd *gui.RenderCmd) {
 	if r.textSys == nil || cmd.Text == "" {
 		return
 	}
+	if gui.DrawTextTransformed(cmd, r.textSys,
+		guiStyleToGlyphConfig,
+		func(layout glyph.Layout, grad *glyph.GradientConfig) {
+			if grad != nil {
+				r.textSys.DrawLayoutTransformedWithGradient(
+					layout, cmd.X, cmd.Y, *cmd.LayoutTransform, grad)
+			} else {
+				r.textSys.DrawLayoutTransformed(
+					layout, cmd.X, cmd.Y, *cmd.LayoutTransform)
+			}
+		}) {
+		return
+	}
 	cfg := glyphconv.GuiTextConfigFromRender(cmd)
 	if err := r.textSys.DrawText(cmd.X, cmd.Y, cmd.Text, cfg); err != nil && !r.textErrLogged {
 		// Warn once per renderer: a persistent failure (e.g. missing

--- a/gui/backend/web/draw.go
+++ b/gui/backend/web/draw.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall/js"
 
+	"github.com/go-gui-org/go-glyph"
+
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
 )
@@ -209,6 +211,28 @@ func (b *Backend) drawStrokeRect(r *gui.RenderCmd) {
 
 func (b *Backend) drawText(r *gui.RenderCmd) {
 	if b.textSys == nil || len(r.Text) == 0 {
+		return
+	}
+	if gui.DrawTextTransformed(r, b.textSys,
+		glyphconv.GuiStyleToGlyphConfig,
+		func(layout glyph.Layout, grad *glyph.GradientConfig) {
+			// Web's glyph backend has no DrawTexturedQuadTransformed
+			// support; emulate the transform via Canvas2D like
+			// drawLayoutTransformed does.
+			t := *r.LayoutTransform
+			b.ctx2d.Call("save")
+			b.ctx2d.Call("transform",
+				float64(t.XX), float64(t.YX),
+				float64(t.XY), float64(t.YY),
+				float64(r.X)+float64(t.X0),
+				float64(r.Y)+float64(t.Y0))
+			if grad != nil {
+				b.textSys.DrawLayoutWithGradient(layout, 0, 0, grad)
+			} else {
+				b.textSys.DrawLayout(layout, 0, 0)
+			}
+			b.ctx2d.Call("restore")
+		}) {
 		return
 	}
 	cfg := glyphconv.GuiTextConfigFromRender(r)

--- a/gui/golden_test.go
+++ b/gui/golden_test.go
@@ -143,6 +143,12 @@ func serializeCmd(c RenderCmd) string {
 		if c.TextWidth != 0 {
 			b.WriteString(" tw=" + f2(c.TextWidth))
 		}
+		if c.LayoutTransform != nil {
+			t := c.LayoutTransform
+			fmt.Fprintf(&b, " affine=[%s,%s,%s,%s,%s,%s]",
+				f2(t.XX), f2(t.XY), f2(t.YX), f2(t.YY),
+				f2(t.X0), f2(t.Y0))
+		}
 	case RenderImage:
 		fmt.Fprintf(&b, " res=%q", c.Resource)
 	case RenderSvg:
@@ -178,6 +184,12 @@ func serializeCmd(c RenderCmd) string {
 	}
 	if c.LayoutPtr != nil {
 		b.WriteString(" +glyphlayout")
+	}
+	if c.LayoutTransform != nil && c.Kind != RenderText {
+		t := c.LayoutTransform
+		fmt.Fprintf(&b, " affine=[%s,%s,%s,%s,%s,%s]",
+			f2(t.XX), f2(t.XY), f2(t.YX), f2(t.YY),
+			f2(t.X0), f2(t.Y0))
 	}
 	return b.String()
 }

--- a/gui/print_pdf.go
+++ b/gui/print_pdf.go
@@ -233,6 +233,32 @@ func pdfRenderText(ctx *pdfCtx, cmd RenderCmd) {
 	ascent := float64(fa * ctx.scale)
 	lineH := size * ptToMM64() * 1.2
 	lines := strings.Split(text, "\n")
+	// Affine canvas text: apply the same transform the
+	// screen backends see. Keep the transform around the
+	// text origin so a skew around (X,Y) does not skew
+	// around the page origin. The generic matrix is
+	// sufficient; per-glyph curvature is out of scope.
+	hasXform := cmd.LayoutTransform != nil
+	if hasXform {
+		t := *cmd.LayoutTransform
+		mx := ctx.px(cmd.X)
+		my := ctx.py(cmd.Y)
+		ctx.pdf.TransformBegin()
+		// T(mx,my) * Affine * T(-mx,-my) in PDF
+		// coordinates (Y already flipped in mx/my).
+		// For the common case (XX/YY near 1, XY/YX
+		// skew), this keeps the text at its origin.
+		// X0/Y0 are in logical px; scale to mm.
+		e := mx*(1-float64(t.XX)) - my*float64(t.XY) +
+			float64(t.X0*ctx.scale)
+		f := my*(1-float64(t.YY)) - mx*float64(t.YX) +
+			float64(t.Y0*ctx.scale)
+		ctx.pdf.Transform(fpdf.TransformMatrix{
+			A: float64(t.XX), B: float64(t.YX),
+			C: float64(t.XY), D: float64(t.YY),
+			E: e, F: f,
+		})
+	}
 	for i, line := range lines {
 		ctx.pdf.Text(ctx.px(cmd.X),
 			ctx.py(cmd.Y)+ascent+float64(i)*lineH, line)
@@ -248,6 +274,9 @@ func pdfRenderText(ctx *pdfCtx, cmd RenderCmd) {
 			sy := ctx.py(cmd.Y) + ascent*0.65 + float64(i)*lineH
 			ctx.pdf.Line(ctx.px(cmd.X), sy, ctx.px(cmd.X)+lineW, sy)
 		}
+	}
+	if hasXform {
+		ctx.pdf.TransformEnd()
 	}
 	if alphaSet {
 		resetAlpha(ctx.pdf)

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -133,7 +133,16 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 
 		tx := ox + t.X
 		ty := oy + t.Y
-		rotated := t.Style.RotationRadians != 0
+		// Affine (skew/squash/arbitrary) takes precedence over
+		// rotation. Rotation keeps the GPU MVP path via
+		// RotateBegin/End; affine carries LayoutTransform on the
+		// RenderText so the backend can draw a cached layout
+		// with DrawLayoutTransformed (see #436). Identity
+		// affines are treated as unset so they do not emit a
+		// transform.
+		hasAffine := t.Style.AffineTransform != nil &&
+			!affineTransformIsIdentity(*t.Style.AffineTransform)
+		rotated := !hasAffine && t.Style.RotationRadians != 0
 
 		if rotated {
 			deg := t.Style.RotationRadians * (180 / math.Pi)
@@ -145,7 +154,7 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 			}, w)
 		}
 
-		emitRenderer(RenderCmd{
+		cmd := RenderCmd{
 			Kind:         RenderText,
 			X:            tx,
 			Y:            ty,
@@ -157,7 +166,12 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 			TextWidth:    textWidth,
 			TextStylePtr: w.scratch.renderTextStyles.alloc(t.Style),
 			TextGradient: t.Style.Gradient,
-		}, w)
+		}
+		if hasAffine {
+			cmd.LayoutTransform = w.scratch.renderAffineTransforms.alloc(
+				*t.Style.AffineTransform)
+		}
+		emitRenderer(cmd, w)
 
 		if rotated {
 			emitRenderer(RenderCmd{

--- a/gui/render_draw_common.go
+++ b/gui/render_draw_common.go
@@ -101,6 +101,64 @@ func ComputeTextPathPlacements(
 	return layout, placements, nil
 }
 
+// DrawTextTransformed draws a RenderText with an affine
+// transform via the glyph layout cache. Returns true when it
+// handled the command (including on error / empty text), so the
+// caller should not also take the DrawText fast path. The fast
+// path is left to the caller so each backend keeps its own
+// glyph-pipeline setup.
+func DrawTextTransformed(
+	r *RenderCmd,
+	textSys *glyph.TextSystem,
+	styleToCfg func(TextStyle) glyph.TextConfig,
+	drawFn func(glyph.Layout, *glyph.GradientConfig),
+) bool {
+	if r == nil || textSys == nil || r.LayoutTransform == nil {
+		return false
+	}
+	// Reject NaN/Inf transforms before touching glyph
+	// cache — render_validate also drops these, and the
+	// glyph renderer is not required to handle them.
+	t := *r.LayoutTransform
+	if !f32IsFinite(t.XX) || !f32IsFinite(t.XY) ||
+		!f32IsFinite(t.YX) || !f32IsFinite(t.YY) ||
+		!f32IsFinite(t.X0) || !f32IsFinite(t.Y0) {
+		return true
+	}
+	if len(r.Text) == 0 {
+		return true
+	}
+	var cfg glyph.TextConfig
+	if r.TextStylePtr != nil {
+		cfg = styleToCfg(*r.TextStylePtr)
+		cfg.Gradient = r.TextGradient
+	} else {
+		// Fallback for plain RenderText with no style ptr
+		// (mirrors glyphconv.GuiTextConfigFromRender).
+		cfg = glyph.TextConfig{
+			Style: glyph.TextStyle{
+				FontName: r.FontName,
+				Size:     r.FontSize,
+				Color: glyph.Color{
+					R: r.Color.R, G: r.Color.G,
+					B: r.Color.B, A: r.Color.A,
+				},
+			},
+			Block: glyph.DefaultBlockStyle(),
+		}
+	}
+	if r.W > 0 {
+		cfg.Block.Wrap = glyph.WrapWord
+		cfg.Block.Width = r.W
+	}
+	layout, err := textSys.LayoutTextCached(r.Text, cfg)
+	if err != nil {
+		return true
+	}
+	drawFn(layout, r.TextGradient)
+	return true
+}
+
 // GradientBorderRect is one edge rect with its sampled color for a
 // gradient border. Shared across all backends.
 // exportaudit:keep — reachable from an exported signature

--- a/gui/render_types.go
+++ b/gui/render_types.go
@@ -46,13 +46,18 @@ type RenderCmd struct {
 	ColorMatrix *[16]float32 // FilterBegin: color transform
 
 	// Pointer fields.
-	Shader          *Shader
-	Gradient        *GradientDef
-	TextStylePtr    *TextStyle            // full text style (typeface, etc.)
-	TextGradient    *glyph.GradientConfig // text gradient for glyph-layout draws
-	textPath        *textPathData         // SVG textPath placement data
-	TermGrid        *TermGridData         // terminal grid buffer (RenderTermGrid)
-	LayoutPtr       *glyph.Layout         // pre-shaped glyph layout
+	Shader       *Shader
+	Gradient     *GradientDef
+	TextStylePtr *TextStyle            // full text style (typeface, etc.)
+	TextGradient *glyph.GradientConfig // text gradient for glyph-layout draws
+	textPath     *textPathData         // SVG textPath placement data
+	TermGrid     *TermGridData         // terminal grid buffer (RenderTermGrid)
+	LayoutPtr    *glyph.Layout         // pre-shaped glyph layout
+	// LayoutTransform holds the affine for RenderLayoutTransformed and,
+	// when set, for RenderText (canvas affine text). The backend's
+	// drawText draws a cached layout with it; unset means the fast
+	// DrawText path. Keep the field on RenderText so the canvas can
+	// carry skew/squash without shaping in gui (see #436).
 	LayoutTransform *glyph.AffineTransform
 
 	// String data.

--- a/gui/render_validate.go
+++ b/gui/render_validate.go
@@ -69,7 +69,18 @@ func validCircleCmd(r RenderCmd) bool {
 }
 
 func validTextCmd(r RenderCmd) bool {
-	return f32AllFinite2(r.X, r.Y) && len(r.Text) > 0
+	if !f32AllFinite2(r.X, r.Y) || len(r.Text) == 0 {
+		return false
+	}
+	if r.LayoutTransform != nil {
+		t := *r.LayoutTransform
+		if !f32AllFinite2(t.XX, t.XY) ||
+			!f32AllFinite2(t.YX, t.YY) ||
+			!f32AllFinite2(t.X0, t.Y0) {
+			return false
+		}
+	}
+	return true
 }
 
 func validLayoutCmd(r RenderCmd) bool {
@@ -77,8 +88,17 @@ func validLayoutCmd(r RenderCmd) bool {
 }
 
 func validLayoutTransformedCmd(r RenderCmd) bool {
-	return f32AllFinite2(r.X, r.Y) &&
-		r.LayoutPtr != nil && r.LayoutTransform != nil
+	if !f32AllFinite2(r.X, r.Y) ||
+		r.LayoutPtr == nil || r.LayoutTransform == nil {
+		return false
+	}
+	t := *r.LayoutTransform
+	if !f32AllFinite2(t.XX, t.XY) ||
+		!f32AllFinite2(t.YX, t.YY) ||
+		!f32AllFinite2(t.X0, t.Y0) {
+		return false
+	}
+	return true
 }
 
 func validImageCmd(r RenderCmd) bool {


### PR DESCRIPTION
Fixes #436.

`TextStyle.AffineTransform` was honored on the widget path (`RenderLayoutTransformed`) but silent on `DrawCanvas`, which only checked `RotationRadians`. This carries `LayoutTransform` on `RenderText` so the canvas can render skew/squash/arbitrary affines through the cached glyph layout path with no per-frame shaping in `gui`.

- `gui/render_types.go` — `LayoutTransform` meaningful on `RenderText`.
- `gui/render_draw_canvas.go` — affine (non-identity) takes precedence over rotation; unchanged text emits identical commands.
- `gui/render_draw_common.go` — shared `DrawTextTransformed` helper (NaN/Inf guard, `TextStylePtr` fallback, `LayoutTextCached`).
- `gui/backend/{metal,gl,soft,web,ios,android}/draw.go` — `drawText` branches via the shared helper.
- `gui/render_validate.go` — accept `LayoutTransform` on `RenderText`/`LayoutTransformed`.
- `gui/print_pdf.go` — affine on canvas text via `Transform` around `(X,Y)`.
- `gui/golden_test.go` — serialize `LayoutTransform`.

Unset transforms are identical wire-format; existing goldens unaffected. Fast path for untransformed text unchanged.

Verification: `make prepush` green, `make check-all` via pre-push hook green.

Closes #436