### PR TITLE
fix(gui): export 225 icon constants accidentally unexported (#441)

### DIFF
--- a/gui/fonts.go
+++ b/gui/fonts.go
@@ -121,519 +121,520 @@ func LoadAppFonts(ts FontRegistrar, backend string) {
 }
 
 // Icon constants — Feather icon font Unicode mappings.
+// exportaudit:keep — icon font is public API; every Icon* is deliberately exported
 const (
-	iconArrowDown              = "\uf100"
-	iconArrowLeft              = "\uf101"
-	iconArrowRight             = "\uf102"
-	iconArrowUp                = "\uf103"
-	iconArtboard               = "\uf104"
-	iconBar                    = "\uf105"
-	iconBarChart               = "\uf106"
-	iconBeer                   = "\uf107"
+	IconArrowDown              = "\uf100"
+	IconArrowLeft              = "\uf101"
+	IconArrowRight             = "\uf102"
+	IconArrowUp                = "\uf103"
+	IconArtboard               = "\uf104"
+	IconBar                    = "\uf105"
+	IconBarChart               = "\uf106"
+	IconBeer                   = "\uf107"
 	IconBell                   = "\uf108"
 	IconBook                   = "\uf109"
-	iconBrowser                = "\uf10b"
-	iconBrush                  = "\uf10c"
-	iconBug                    = "\uf10d"
-	iconBuilding               = "\uf10e"
-	iconCalendar               = "\uf10f"
-	iconCamera                 = "\uf110"
-	iconCheck                  = "\uf111"
-	iconClock                  = "\uf113"
-	iconClose                  = "\uf114"
-	iconCloud                  = "\uf115"
-	iconCocktail               = "\uf116"
-	iconCode                   = "\uf117"
-	iconColumns                = "\uf118"
-	iconComment                = "\uf119"
-	iconCommenting             = "\uf11a"
-	iconComments               = "\uf11b"
-	iconDesktop                = "\uf11d"
-	iconDiamond                = "\uf11e"
-	iconDisabled               = "\uf11f"
+	IconBrowser                = "\uf10b"
+	IconBrush                  = "\uf10c"
+	IconBug                    = "\uf10d"
+	IconBuilding               = "\uf10e"
+	IconCalendar               = "\uf10f"
+	IconCamera                 = "\uf110"
+	IconCheck                  = "\uf111"
+	IconClock                  = "\uf113"
+	IconClose                  = "\uf114"
+	IconCloud                  = "\uf115"
+	IconCocktail               = "\uf116"
+	IconCode                   = "\uf117"
+	IconColumns                = "\uf118"
+	IconComment                = "\uf119"
+	IconCommenting             = "\uf11a"
+	IconComments               = "\uf11b"
+	IconDesktop                = "\uf11d"
+	IconDiamond                = "\uf11e"
+	IconDisabled               = "\uf11f"
 	IconDownload               = "\uf120"
-	iconDropDown               = "\uf121"
-	iconDropLeft               = "\uf122"
-	iconDropRight              = "\uf123"
-	iconDropUp                 = "\uf124"
-	iconElipsisH               = "\uf125"
-	iconElipsisV               = "\uf126"
-	iconEye                    = "\uf127"
-	iconFeed                   = "\uf128"
+	IconDropDown               = "\uf121"
+	IconDropLeft               = "\uf122"
+	IconDropRight              = "\uf123"
+	IconDropUp                 = "\uf124"
+	IconElipsisH               = "\uf125"
+	IconElipsisV               = "\uf126"
+	IconEye                    = "\uf127"
+	IconFeed                   = "\uf128"
 	IconFlag                   = "\uf129"
 	IconFolder                 = "\uf12a"
-	iconFork                   = "\uf12b"
-	iconGlobe                  = "\uf12c"
-	iconHash                   = "\uf12d"
+	IconFork                   = "\uf12b"
+	IconGlobe                  = "\uf12c"
+	IconHash                   = "\uf12d"
 	IconHeart                  = "\uf12e"
-	iconHome                   = "\uf12f"
-	iconInfo                   = "\uf130"
-	iconKey                    = "\uf131"
+	IconHome                   = "\uf12f"
+	IconInfo                   = "\uf130"
+	IconKey                    = "\uf131"
 	IconKeyboard               = "\uf132"
-	iconLaptop                 = "\uf133"
-	iconLayout                 = "\uf134"
-	iconLineChart              = "\uf135"
-	iconLink                   = "\uf136"
-	iconLinkExternal           = "\uf137"
-	iconLocation               = "\uf138"
-	iconLock                   = "\uf139"
-	iconLogin                  = "\uf13a"
-	iconLogout                 = "\uf13b"
-	iconMail                   = "\uf13c"
-	iconMedal                  = "\uf13d"
-	iconMegaphone              = "\uf13e"
-	iconMinus                  = "\uf140"
-	iconMobile                 = "\uf141"
-	iconMouse                  = "\uf142"
-	iconPencil                 = "\uf144"
-	iconPhone                  = "\uf145"
-	iconPieChart               = "\uf146"
-	iconPizza                  = "\uf147"
+	IconLaptop                 = "\uf133"
+	IconLayout                 = "\uf134"
+	IconLineChart              = "\uf135"
+	IconLink                   = "\uf136"
+	IconLinkExternal           = "\uf137"
+	IconLocation               = "\uf138"
+	IconLock                   = "\uf139"
+	IconLogin                  = "\uf13a"
+	IconLogout                 = "\uf13b"
+	IconMail                   = "\uf13c"
+	IconMedal                  = "\uf13d"
+	IconMegaphone              = "\uf13e"
+	IconMinus                  = "\uf140"
+	IconMobile                 = "\uf141"
+	IconMouse                  = "\uf142"
+	IconPencil                 = "\uf144"
+	IconPhone                  = "\uf145"
+	IconPieChart               = "\uf146"
+	IconPizza                  = "\uf147"
 	IconPlus                   = "\uf148"
-	iconPrototype              = "\uf149"
-	iconQuestion               = "\uf14a"
-	iconQuoteLeft              = "\uf14b"
-	iconQuoteRight             = "\uf14c"
+	IconPrototype              = "\uf149"
+	IconQuestion               = "\uf14a"
+	IconQuoteLeft              = "\uf14b"
+	IconQuoteRight             = "\uf14c"
 	IconRocket                 = "\uf14d"
 	IconSearch                 = "\uf14e"
-	iconShare                  = "\uf14f"
-	iconSitemap                = "\uf150"
+	IconShare                  = "\uf14f"
+	IconSitemap                = "\uf150"
 	IconStar                   = "\uf151"
-	iconTablet                 = "\uf152"
-	iconTag                    = "\uf153"
-	iconTerminal               = "\uf154"
-	iconTicket                 = "\uf155"
-	iconTiled                  = "\uf156"
+	IconTablet                 = "\uf152"
+	IconTag                    = "\uf153"
+	IconTerminal               = "\uf154"
+	IconTicket                 = "\uf155"
+	IconTiled                  = "\uf156"
 	IconTrash                  = "\uf157"
-	iconTrophy                 = "\uf158"
-	iconUpload                 = "\uf159"
+	IconTrophy                 = "\uf158"
+	IconUpload                 = "\uf159"
 	IconUser                   = "\uf15a"
-	iconUserPlus               = "\uf15b"
-	iconUsers                  = "\uf15c"
-	iconVector                 = "\uf15d"
-	iconVideo                  = "\uf15e"
-	iconWarning                = "\uf15f"
-	iconWineGlass              = "\uf161"
-	iconWrench                 = "\uf162"
-	iconBirthdayCake           = "\uf163"
-	iconMention                = "\uf164"
-	iconPalette                = "\uf165"
-	iconCoffee                 = "\uf166"
-	iconHeartO                 = "\uf167"
+	IconUserPlus               = "\uf15b"
+	IconUsers                  = "\uf15c"
+	IconVector                 = "\uf15d"
+	IconVideo                  = "\uf15e"
+	IconWarning                = "\uf15f"
+	IconWineGlass              = "\uf161"
+	IconWrench                 = "\uf162"
+	IconBirthdayCake           = "\uf163"
+	IconMention                = "\uf164"
+	IconPalette                = "\uf165"
+	IconCoffee                 = "\uf166"
+	IconHeartO                 = "\uf167"
 	IconStarO                  = "\uf168"
-	iconUnlock                 = "\uf169"
-	iconSearchMinus            = "\uf16a"
-	iconSearchPlus             = "\uf16b"
-	iconUserMinus              = "\uf16c"
-	iconMapIcon                = "\uf16d"
+	IconUnlock                 = "\uf169"
+	IconSearchMinus            = "\uf16a"
+	IconSearchPlus             = "\uf16b"
+	IconUserMinus              = "\uf16c"
+	IconMapIcon                = "\uf16d"
 	IconExport                 = "\uf16e"
-	iconImport                 = "\uf16f"
-	iconBookmark               = "\uf170"
+	IconImport                 = "\uf16f"
+	IconBookmark               = "\uf170"
 	IconPrint                  = "\uf171"
-	iconShield                 = "\uf172"
-	iconFilter                 = "\uf173"
-	iconFeather                = "\uf174"
-	iconMusic                  = "\uf175"
-	iconFolderOpen             = "\uf176"
-	iconMagic                  = "\uf177"
-	iconPaperPlane             = "\uf178"
-	iconBold                   = "\uf179"
-	iconItalic                 = "\uf17a"
-	iconTextSize               = "\uf17b"
-	iconListBullet             = "\uf17c"
-	iconListOrder              = "\uf17d"
+	IconShield                 = "\uf172"
+	IconFilter                 = "\uf173"
+	IconFeather                = "\uf174"
+	IconMusic                  = "\uf175"
+	IconFolderOpen             = "\uf176"
+	IconMagic                  = "\uf177"
+	IconPaperPlane             = "\uf178"
+	IconBold                   = "\uf179"
+	IconItalic                 = "\uf17a"
+	IconTextSize               = "\uf17b"
+	IconListBullet             = "\uf17c"
+	IconListOrder              = "\uf17d"
 	IconListTask               = "\uf17e"
-	iconEdit                   = "\uf17f"
-	iconBackward               = "\uf180"
-	iconCompress               = "\uf181"
-	iconEject                  = "\uf182"
-	iconExpand                 = "\uf183"
-	iconFastBackward           = "\uf184"
-	iconFastForward            = "\uf185"
-	iconForward                = "\uf186"
-	iconPause                  = "\uf187"
+	IconEdit                   = "\uf17f"
+	IconBackward               = "\uf180"
+	IconCompress               = "\uf181"
+	IconEject                  = "\uf182"
+	IconExpand                 = "\uf183"
+	IconFastBackward           = "\uf184"
+	IconFastForward            = "\uf185"
+	IconForward                = "\uf186"
+	IconPause                  = "\uf187"
 	IconPlay                   = "\uf188"
-	iconRandom                 = "\uf189"
+	IconRandom                 = "\uf189"
 	IconStop                   = "\uf18b"
-	iconLayer                  = "\uf18c"
-	iconHeadphone              = "\uf18e"
-	iconPlug                   = "\uf18f"
-	iconUsb                    = "\uf190"
+	IconLayer                  = "\uf18c"
+	IconHeadphone              = "\uf18e"
+	IconPlug                   = "\uf18f"
+	IconUsb                    = "\uf190"
 	IconGamepad                = "\uf191"
-	iconLoop                   = "\uf192"
+	IconLoop                   = "\uf192"
 	IconSync                   = "\uf194"
-	iconAlignCenter            = "\uf195"
-	iconAlignLeft              = "\uf196"
-	iconAlignRight             = "\uf197"
-	iconAppMenu                = "\uf198"
-	iconAudioPlayer            = "\uf199"
-	iconCheckCircle            = "\uf19a"
-	iconCheckCircleO           = "\uf19b"
-	iconCheckVerified          = "\uf19c"
-	iconCutlery                = "\uf19d"
-	iconDeleteLink             = "\uf19e"
-	iconDocument               = "\uf19f"
-	iconEqualizer              = "\uf1a0"
-	iconFileExcel              = "\uf1a2"
-	iconFilePowerpoint         = "\uf1a3"
-	iconFileWord               = "\uf1a4"
-	iconGear                   = "\uf1a5"
-	iconInsertLink             = "\uf1a6"
-	iconKitchenCooker          = "\uf1a7"
-	iconMoney                  = "\uf1a8"
-	iconPicture                = "\uf1a9"
-	iconPot                    = "\uf1aa"
-	iconSpeaker                = "\uf1ab"
-	iconTable                  = "\uf1ac"
-	iconTimeline               = "\uf1ad"
-	iconUnderline              = "\uf1ae"
-	iconWatch                  = "\uf1af"
-	iconWatchAlt               = "\uf1b0"
-	iconFile                   = "\uf1b1"
-	iconFileAudio              = "\uf1b2"
-	iconFileImage              = "\uf1b3"
-	iconFileMovie              = "\uf1b4"
-	iconFileZip                = "\uf1b5"
-	iconAngry                  = "\uf1b6"
-	iconCry                    = "\uf1b7"
-	iconDisappointed           = "\uf1b8"
-	iconFrowing                = "\uf1b9"
-	iconOpenMouth              = "\uf1ba"
-	iconRage                   = "\uf1bb"
+	IconAlignCenter            = "\uf195"
+	IconAlignLeft              = "\uf196"
+	IconAlignRight             = "\uf197"
+	IconAppMenu                = "\uf198"
+	IconAudioPlayer            = "\uf199"
+	IconCheckCircle            = "\uf19a"
+	IconCheckCircleO           = "\uf19b"
+	IconCheckVerified          = "\uf19c"
+	IconCutlery                = "\uf19d"
+	IconDeleteLink             = "\uf19e"
+	IconDocument               = "\uf19f"
+	IconEqualizer              = "\uf1a0"
+	IconFileExcel              = "\uf1a2"
+	IconFilePowerpoint         = "\uf1a3"
+	IconFileWord               = "\uf1a4"
+	IconGear                   = "\uf1a5"
+	IconInsertLink             = "\uf1a6"
+	IconKitchenCooker          = "\uf1a7"
+	IconMoney                  = "\uf1a8"
+	IconPicture                = "\uf1a9"
+	IconPot                    = "\uf1aa"
+	IconSpeaker                = "\uf1ab"
+	IconTable                  = "\uf1ac"
+	IconTimeline               = "\uf1ad"
+	IconUnderline              = "\uf1ae"
+	IconWatch                  = "\uf1af"
+	IconWatchAlt               = "\uf1b0"
+	IconFile                   = "\uf1b1"
+	IconFileAudio              = "\uf1b2"
+	IconFileImage              = "\uf1b3"
+	IconFileMovie              = "\uf1b4"
+	IconFileZip                = "\uf1b5"
+	IconAngry                  = "\uf1b6"
+	IconCry                    = "\uf1b7"
+	IconDisappointed           = "\uf1b8"
+	IconFrowing                = "\uf1b9"
+	IconOpenMouth              = "\uf1ba"
+	IconRage                   = "\uf1bb"
 	IconSmile                  = "\uf1bc"
 	IconSmileAlt               = "\uf1bd"
-	iconTired                  = "\uf1be"
-	iconAlignBottom            = "\uf1bf"
-	iconAlignTop               = "\uf1c0"
-	iconAlignVertically        = "\uf1c1"
-	iconCrop                   = "\uf1c2"
-	iconDifference             = "\uf1c3"
-	iconDistributeVertically   = "\uf1c5"
-	iconEraser                 = "\uf1c6"
-	iconIntersect              = "\uf1c7"
-	iconMask                   = "\uf1c8"
-	iconScale                  = "\uf1c9"
-	iconSubtract               = "\uf1ca"
-	iconTextAlignCenter        = "\uf1cb"
-	iconTextAlignLeft          = "\uf1cc"
-	iconTextAlignRight         = "\uf1cd"
-	iconUnion                  = "\uf1ce"
-	iconDistributeHorizontally = "\uf1cf"
-	iconStepBackward           = "\uf1d0"
-	iconStepForward            = "\uf1d1"
-	iconCommentO               = "\uf1d2"
-	iconCodepen                = "\uf1d3"
-	iconFacebook               = "\uf1d4"
-	iconGit                    = "\uf1d5"
-	iconGithub                 = "\uf1d6"
+	IconTired                  = "\uf1be"
+	IconAlignBottom            = "\uf1bf"
+	IconAlignTop               = "\uf1c0"
+	IconAlignVertically        = "\uf1c1"
+	IconCrop                   = "\uf1c2"
+	IconDifference             = "\uf1c3"
+	IconDistributeVertically   = "\uf1c5"
+	IconEraser                 = "\uf1c6"
+	IconIntersect              = "\uf1c7"
+	IconMask                   = "\uf1c8"
+	IconScale                  = "\uf1c9"
+	IconSubtract               = "\uf1ca"
+	IconTextAlignCenter        = "\uf1cb"
+	IconTextAlignLeft          = "\uf1cc"
+	IconTextAlignRight         = "\uf1cd"
+	IconUnion                  = "\uf1ce"
+	IconDistributeHorizontally = "\uf1cf"
+	IconStepBackward           = "\uf1d0"
+	IconStepForward            = "\uf1d1"
+	IconCommentO               = "\uf1d2"
+	IconCodepen                = "\uf1d3"
+	IconFacebook               = "\uf1d4"
+	IconGit                    = "\uf1d5"
+	IconGithub                 = "\uf1d6"
 	IconGithubAlt              = "\uf1d7"
-	iconGoogle                 = "\uf1d8"
-	iconGooglePlus             = "\uf1d9"
-	iconInstagram              = "\uf1da"
-	iconPinterest              = "\uf1db"
-	iconPocket                 = "\uf1dc"
+	IconGoogle                 = "\uf1d8"
+	IconGooglePlus             = "\uf1d9"
+	IconInstagram              = "\uf1da"
+	IconPinterest              = "\uf1db"
+	IconPocket                 = "\uf1dc"
 	IconTwitter                = "\uf1dd"
-	iconWordpress              = "\uf1de"
-	iconWordpressAlt           = "\uf1df"
-	iconYoutube                = "\uf1e0"
-	iconMessanger              = "\uf1e1"
-	iconActivity               = "\uf1e2"
-	iconBolt                   = "\uf1e3"
-	iconPictureSquare          = "\uf1e4"
-	iconTextAlignJustify       = "\uf1e5"
-	iconAddCart                = "\uf1e6"
+	IconWordpress              = "\uf1de"
+	IconWordpressAlt           = "\uf1df"
+	IconYoutube                = "\uf1e0"
+	IconMessanger              = "\uf1e1"
+	IconActivity               = "\uf1e2"
+	IconBolt                   = "\uf1e3"
+	IconPictureSquare          = "\uf1e4"
+	IconTextAlignJustify       = "\uf1e5"
+	IconAddCart                = "\uf1e6"
 	IconCage                   = "\uf1e7"
-	iconCart                   = "\uf1e8"
-	iconCreditCard             = "\uf1e9"
-	iconGift                   = "\uf1ea"
-	iconRemoveCart             = "\uf1eb"
-	iconShoppingBag            = "\uf1ec"
-	iconTruck                  = "\uf1ed"
-	iconWallet                 = "\uf1ee"
+	IconCart                   = "\uf1e8"
+	IconCreditCard             = "\uf1e9"
+	IconGift                   = "\uf1ea"
+	IconRemoveCart             = "\uf1eb"
+	IconShoppingBag            = "\uf1ec"
+	IconTruck                  = "\uf1ed"
+	IconWallet                 = "\uf1ee"
 	IconMoon                   = "\uf1ef"
 	IconSunnyO                 = "\uf1f0"
-	iconSunrise                = "\uf1f1"
-	iconUmbrella               = "\uf1f2"
+	IconSunrise                = "\uf1f1"
+	IconUmbrella               = "\uf1f2"
 	IconTarget                 = "\uf1f3"
-	iconSmilePlus              = "\uf1f5"
+	IconSmilePlus              = "\uf1f5"
 	IconSmileHeart             = "\uf1f6"
-	iconBeginner               = "\uf1f7"
-	iconTrain                  = "\uf1f8"
-	iconDonut                  = "\uf1f9"
-	iconRiceCracker            = "\uf1fa"
-	iconApron                  = "\uf1fb"
-	iconOctpus                 = "\uf1fc"
-	iconSquid                  = "\uf1fd"
-	iconBus                    = "\uf1fe"
-	iconCar                    = "\uf1ff"
-	iconNoticeActive           = "\uf200"
-	iconNoticeOff              = "\uf201"
-	iconNoticeOn               = "\uf202"
-	iconNoticePush             = "\uf203"
-	iconTaxi                   = "\uf204"
-	iconVr                     = "\uf205"
-	iconBread                  = "\uf206"
-	iconFryingPan              = "\uf207"
-	iconMitarashiDango         = "\uf208"
-	iconTumblerGlass           = "\uf209"
-	iconYakiDango              = "\uf20a"
+	IconBeginner               = "\uf1f7"
+	IconTrain                  = "\uf1f8"
+	IconDonut                  = "\uf1f9"
+	IconRiceCracker            = "\uf1fa"
+	IconApron                  = "\uf1fb"
+	IconOctpus                 = "\uf1fc"
+	IconSquid                  = "\uf1fd"
+	IconBus                    = "\uf1fe"
+	IconCar                    = "\uf1ff"
+	IconNoticeActive           = "\uf200"
+	IconNoticeOff              = "\uf201"
+	IconNoticeOn               = "\uf202"
+	IconNoticePush             = "\uf203"
+	IconTaxi                   = "\uf204"
+	IconVr                     = "\uf205"
+	IconBread                  = "\uf206"
+	IconFryingPan              = "\uf207"
+	IconMitarashiDango         = "\uf208"
+	IconTumblerGlass           = "\uf209"
+	IconYakiDango              = "\uf20a"
 )
 
 // IconLookup maps V-style snake_case icon names to Unicode values.
 var IconLookup = map[string]string{
-	"icon_arrow_down":              iconArrowDown,
-	"icon_arrow_left":              iconArrowLeft,
-	"icon_arrow_right":             iconArrowRight,
-	"icon_arrow_up":                iconArrowUp,
-	"icon_artboard":                iconArtboard,
-	"icon_bar":                     iconBar,
-	"icon_bar_chart":               iconBarChart,
-	"icon_beer":                    iconBeer,
+	"icon_arrow_down":              IconArrowDown,
+	"icon_arrow_left":              IconArrowLeft,
+	"icon_arrow_right":             IconArrowRight,
+	"icon_arrow_up":                IconArrowUp,
+	"icon_artboard":                IconArtboard,
+	"icon_bar":                     IconBar,
+	"icon_bar_chart":               IconBarChart,
+	"icon_beer":                    IconBeer,
 	"icon_bell":                    IconBell,
 	"icon_book":                    IconBook,
-	"icon_browser":                 iconBrowser,
-	"icon_brush":                   iconBrush,
-	"icon_bug":                     iconBug,
-	"icon_building":                iconBuilding,
-	"icon_calendar":                iconCalendar,
-	"icon_camera":                  iconCamera,
-	"icon_check":                   iconCheck,
-	"icon_clock":                   iconClock,
-	"icon_close":                   iconClose,
-	"icon_cloud":                   iconCloud,
-	"icon_cocktail":                iconCocktail,
-	"icon_code":                    iconCode,
-	"icon_columns":                 iconColumns,
-	"icon_comment":                 iconComment,
-	"icon_commenting":              iconCommenting,
-	"icon_comments":                iconComments,
-	"icon_desktop":                 iconDesktop,
-	"icon_diamond":                 iconDiamond,
-	"icon_disabled":                iconDisabled,
+	"icon_browser":                 IconBrowser,
+	"icon_brush":                   IconBrush,
+	"icon_bug":                     IconBug,
+	"icon_building":                IconBuilding,
+	"icon_calendar":                IconCalendar,
+	"icon_camera":                  IconCamera,
+	"icon_check":                   IconCheck,
+	"icon_clock":                   IconClock,
+	"icon_close":                   IconClose,
+	"icon_cloud":                   IconCloud,
+	"icon_cocktail":                IconCocktail,
+	"icon_code":                    IconCode,
+	"icon_columns":                 IconColumns,
+	"icon_comment":                 IconComment,
+	"icon_commenting":              IconCommenting,
+	"icon_comments":                IconComments,
+	"icon_desktop":                 IconDesktop,
+	"icon_diamond":                 IconDiamond,
+	"icon_disabled":                IconDisabled,
 	"icon_download":                IconDownload,
-	"icon_drop_down":               iconDropDown,
-	"icon_drop_left":               iconDropLeft,
-	"icon_drop_right":              iconDropRight,
-	"icon_drop_up":                 iconDropUp,
-	"icon_elipsis_h":               iconElipsisH,
-	"icon_elipsis_v":               iconElipsisV,
-	"icon_eye":                     iconEye,
-	"icon_feed":                    iconFeed,
+	"icon_drop_down":               IconDropDown,
+	"icon_drop_left":               IconDropLeft,
+	"icon_drop_right":              IconDropRight,
+	"icon_drop_up":                 IconDropUp,
+	"icon_elipsis_h":               IconElipsisH,
+	"icon_elipsis_v":               IconElipsisV,
+	"icon_eye":                     IconEye,
+	"icon_feed":                    IconFeed,
 	"icon_flag":                    IconFlag,
 	"icon_folder":                  IconFolder,
-	"icon_fork":                    iconFork,
-	"icon_globe":                   iconGlobe,
-	"icon_hash":                    iconHash,
+	"icon_fork":                    IconFork,
+	"icon_globe":                   IconGlobe,
+	"icon_hash":                    IconHash,
 	"icon_heart":                   IconHeart,
-	"icon_home":                    iconHome,
-	"icon_info":                    iconInfo,
-	"icon_key":                     iconKey,
+	"icon_home":                    IconHome,
+	"icon_info":                    IconInfo,
+	"icon_key":                     IconKey,
 	"icon_keyboard":                IconKeyboard,
-	"icon_laptop":                  iconLaptop,
-	"icon_layout":                  iconLayout,
-	"icon_line_chart":              iconLineChart,
-	"icon_link":                    iconLink,
-	"icon_link_external":           iconLinkExternal,
-	"icon_location":                iconLocation,
-	"icon_lock":                    iconLock,
-	"icon_login":                   iconLogin,
-	"icon_logout":                  iconLogout,
-	"icon_mail":                    iconMail,
-	"icon_medal":                   iconMedal,
-	"icon_megaphone":               iconMegaphone,
-	"icon_minus":                   iconMinus,
-	"icon_mobile":                  iconMobile,
-	"icon_mouse":                   iconMouse,
-	"icon_pencil":                  iconPencil,
-	"icon_phone":                   iconPhone,
-	"icon_pie_chart":               iconPieChart,
-	"icon_pizza":                   iconPizza,
+	"icon_laptop":                  IconLaptop,
+	"icon_layout":                  IconLayout,
+	"icon_line_chart":              IconLineChart,
+	"icon_link":                    IconLink,
+	"icon_link_external":           IconLinkExternal,
+	"icon_location":                IconLocation,
+	"icon_lock":                    IconLock,
+	"icon_login":                   IconLogin,
+	"icon_logout":                  IconLogout,
+	"icon_mail":                    IconMail,
+	"icon_medal":                   IconMedal,
+	"icon_megaphone":               IconMegaphone,
+	"icon_minus":                   IconMinus,
+	"icon_mobile":                  IconMobile,
+	"icon_mouse":                   IconMouse,
+	"icon_pencil":                  IconPencil,
+	"icon_phone":                   IconPhone,
+	"icon_pie_chart":               IconPieChart,
+	"icon_pizza":                   IconPizza,
 	"icon_plus":                    IconPlus,
-	"icon_prototype":               iconPrototype,
-	"icon_question":                iconQuestion,
-	"icon_quote_left":              iconQuoteLeft,
-	"icon_quote_right":             iconQuoteRight,
+	"icon_prototype":               IconPrototype,
+	"icon_question":                IconQuestion,
+	"icon_quote_left":              IconQuoteLeft,
+	"icon_quote_right":             IconQuoteRight,
 	"icon_rocket":                  IconRocket,
 	"icon_search":                  IconSearch,
-	"icon_share":                   iconShare,
-	"icon_sitemap":                 iconSitemap,
+	"icon_share":                   IconShare,
+	"icon_sitemap":                 IconSitemap,
 	"icon_star":                    IconStar,
-	"icon_tablet":                  iconTablet,
-	"icon_tag":                     iconTag,
-	"icon_terminal":                iconTerminal,
-	"icon_ticket":                  iconTicket,
-	"icon_tiled":                   iconTiled,
+	"icon_tablet":                  IconTablet,
+	"icon_tag":                     IconTag,
+	"icon_terminal":                IconTerminal,
+	"icon_ticket":                  IconTicket,
+	"icon_tiled":                   IconTiled,
 	"icon_trash":                   IconTrash,
-	"icon_trophy":                  iconTrophy,
-	"icon_upload":                  iconUpload,
+	"icon_trophy":                  IconTrophy,
+	"icon_upload":                  IconUpload,
 	"icon_user":                    IconUser,
-	"icon_user_plus":               iconUserPlus,
-	"icon_users":                   iconUsers,
-	"icon_vector":                  iconVector,
-	"icon_video":                   iconVideo,
-	"icon_warning":                 iconWarning,
-	"icon_wine_glass":              iconWineGlass,
-	"icon_wrench":                  iconWrench,
-	"icon_birthday_cake":           iconBirthdayCake,
-	"icon_mention":                 iconMention,
-	"icon_palette":                 iconPalette,
-	"icon_coffee":                  iconCoffee,
-	"icon_heart_o":                 iconHeartO,
+	"icon_user_plus":               IconUserPlus,
+	"icon_users":                   IconUsers,
+	"icon_vector":                  IconVector,
+	"icon_video":                   IconVideo,
+	"icon_warning":                 IconWarning,
+	"icon_wine_glass":              IconWineGlass,
+	"icon_wrench":                  IconWrench,
+	"icon_birthday_cake":           IconBirthdayCake,
+	"icon_mention":                 IconMention,
+	"icon_palette":                 IconPalette,
+	"icon_coffee":                  IconCoffee,
+	"icon_heart_o":                 IconHeartO,
 	"icon_star_o":                  IconStarO,
-	"icon_unlock":                  iconUnlock,
-	"icon_search_minus":            iconSearchMinus,
-	"icon_search_plus":             iconSearchPlus,
-	"icon_user_minus":              iconUserMinus,
-	"icon_map":                     iconMapIcon,
+	"icon_unlock":                  IconUnlock,
+	"icon_search_minus":            IconSearchMinus,
+	"icon_search_plus":             IconSearchPlus,
+	"icon_user_minus":              IconUserMinus,
+	"icon_map":                     IconMapIcon,
 	"icon_export":                  IconExport,
-	"icon_import":                  iconImport,
-	"icon_bookmark":                iconBookmark,
+	"icon_import":                  IconImport,
+	"icon_bookmark":                IconBookmark,
 	"icon_print":                   IconPrint,
-	"icon_shield":                  iconShield,
-	"icon_filter":                  iconFilter,
-	"icon_feather":                 iconFeather,
-	"icon_music":                   iconMusic,
-	"icon_folder_open":             iconFolderOpen,
-	"icon_magic":                   iconMagic,
-	"icon_paper_plane":             iconPaperPlane,
-	"icon_bold":                    iconBold,
-	"icon_italic":                  iconItalic,
-	"icon_text_size":               iconTextSize,
-	"icon_list_bullet":             iconListBullet,
-	"icon_list_order":              iconListOrder,
+	"icon_shield":                  IconShield,
+	"icon_filter":                  IconFilter,
+	"icon_feather":                 IconFeather,
+	"icon_music":                   IconMusic,
+	"icon_folder_open":             IconFolderOpen,
+	"icon_magic":                   IconMagic,
+	"icon_paper_plane":             IconPaperPlane,
+	"icon_bold":                    IconBold,
+	"icon_italic":                  IconItalic,
+	"icon_text_size":               IconTextSize,
+	"icon_list_bullet":             IconListBullet,
+	"icon_list_order":              IconListOrder,
 	"icon_list_task":               IconListTask,
-	"icon_edit":                    iconEdit,
-	"icon_backward":                iconBackward,
-	"icon_compress":                iconCompress,
-	"icon_eject":                   iconEject,
-	"icon_expand":                  iconExpand,
-	"icon_fast_backward":           iconFastBackward,
-	"icon_fast_forward":            iconFastForward,
-	"icon_forward":                 iconForward,
-	"icon_pause":                   iconPause,
+	"icon_edit":                    IconEdit,
+	"icon_backward":                IconBackward,
+	"icon_compress":                IconCompress,
+	"icon_eject":                   IconEject,
+	"icon_expand":                  IconExpand,
+	"icon_fast_backward":           IconFastBackward,
+	"icon_fast_forward":            IconFastForward,
+	"icon_forward":                 IconForward,
+	"icon_pause":                   IconPause,
 	"icon_play":                    IconPlay,
-	"icon_random":                  iconRandom,
+	"icon_random":                  IconRandom,
 	"icon_stop":                    IconStop,
-	"icon_layer":                   iconLayer,
-	"icon_headphone":               iconHeadphone,
-	"icon_plug":                    iconPlug,
-	"icon_usb":                     iconUsb,
+	"icon_layer":                   IconLayer,
+	"icon_headphone":               IconHeadphone,
+	"icon_plug":                    IconPlug,
+	"icon_usb":                     IconUsb,
 	"icon_gamepad":                 IconGamepad,
-	"icon_loop":                    iconLoop,
+	"icon_loop":                    IconLoop,
 	"icon_sync":                    IconSync,
-	"icon_align_center":            iconAlignCenter,
-	"icon_align_left":              iconAlignLeft,
-	"icon_align_right":             iconAlignRight,
-	"icon_app_menu":                iconAppMenu,
-	"icon_audio_player":            iconAudioPlayer,
-	"icon_check_circle":            iconCheckCircle,
-	"icon_check_circle_o":          iconCheckCircleO,
-	"icon_check_verified":          iconCheckVerified,
-	"icon_cutlery":                 iconCutlery,
-	"icon_delete_link":             iconDeleteLink,
-	"icon_document":                iconDocument,
-	"icon_equalizer":               iconEqualizer,
-	"icon_file_excel":              iconFileExcel,
-	"icon_file_powerpoint":         iconFilePowerpoint,
-	"icon_file_word":               iconFileWord,
-	"icon_gear":                    iconGear,
-	"icon_insert_link":             iconInsertLink,
-	"icon_kitchen_cooker":          iconKitchenCooker,
-	"icon_money":                   iconMoney,
-	"icon_picture":                 iconPicture,
-	"icon_pot":                     iconPot,
-	"icon_speaker":                 iconSpeaker,
-	"icon_table":                   iconTable,
-	"icon_timeline":                iconTimeline,
-	"icon_underline":               iconUnderline,
-	"icon_watch":                   iconWatch,
-	"icon_watch_alt":               iconWatchAlt,
-	"icon_file":                    iconFile,
-	"icon_file_audio":              iconFileAudio,
-	"icon_file_image":              iconFileImage,
-	"icon_file_movie":              iconFileMovie,
-	"icon_file_zip":                iconFileZip,
-	"icon_angry":                   iconAngry,
-	"icon_cry":                     iconCry,
-	"icon_disappointed":            iconDisappointed,
-	"icon_frowing":                 iconFrowing,
-	"icon_open_mouth":              iconOpenMouth,
-	"icon_rage":                    iconRage,
+	"icon_align_center":            IconAlignCenter,
+	"icon_align_left":              IconAlignLeft,
+	"icon_align_right":             IconAlignRight,
+	"icon_app_menu":                IconAppMenu,
+	"icon_audio_player":            IconAudioPlayer,
+	"icon_check_circle":            IconCheckCircle,
+	"icon_check_circle_o":          IconCheckCircleO,
+	"icon_check_verified":          IconCheckVerified,
+	"icon_cutlery":                 IconCutlery,
+	"icon_delete_link":             IconDeleteLink,
+	"icon_document":                IconDocument,
+	"icon_equalizer":               IconEqualizer,
+	"icon_file_excel":              IconFileExcel,
+	"icon_file_powerpoint":         IconFilePowerpoint,
+	"icon_file_word":               IconFileWord,
+	"icon_gear":                    IconGear,
+	"icon_insert_link":             IconInsertLink,
+	"icon_kitchen_cooker":          IconKitchenCooker,
+	"icon_money":                   IconMoney,
+	"icon_picture":                 IconPicture,
+	"icon_pot":                     IconPot,
+	"icon_speaker":                 IconSpeaker,
+	"icon_table":                   IconTable,
+	"icon_timeline":                IconTimeline,
+	"icon_underline":               IconUnderline,
+	"icon_watch":                   IconWatch,
+	"icon_watch_alt":               IconWatchAlt,
+	"icon_file":                    IconFile,
+	"icon_file_audio":              IconFileAudio,
+	"icon_file_image":              IconFileImage,
+	"icon_file_movie":              IconFileMovie,
+	"icon_file_zip":                IconFileZip,
+	"icon_angry":                   IconAngry,
+	"icon_cry":                     IconCry,
+	"icon_disappointed":            IconDisappointed,
+	"icon_frowing":                 IconFrowing,
+	"icon_open_mouth":              IconOpenMouth,
+	"icon_rage":                    IconRage,
 	"icon_smile":                   IconSmile,
 	"icon_smile_alt":               IconSmileAlt,
-	"icon_tired":                   iconTired,
-	"icon_align_bottom":            iconAlignBottom,
-	"icon_align_top":               iconAlignTop,
-	"icon_align_vertically":        iconAlignVertically,
-	"icon_crop":                    iconCrop,
-	"icon_difference":              iconDifference,
-	"icon_distribute_vertically":   iconDistributeVertically,
-	"icon_eraser":                  iconEraser,
-	"icon_intersect":               iconIntersect,
-	"icon_mask":                    iconMask,
-	"icon_scale":                   iconScale,
-	"icon_subtract":                iconSubtract,
-	"icon_text_align_center":       iconTextAlignCenter,
-	"icon_text_align_left":         iconTextAlignLeft,
-	"icon_text_align_right":        iconTextAlignRight,
-	"icon_union":                   iconUnion,
-	"icon_distribute_horizontally": iconDistributeHorizontally,
-	"icon_step_backward":           iconStepBackward,
-	"icon_step_forward":            iconStepForward,
-	"icon_comment_o":               iconCommentO,
-	"icon_codepen":                 iconCodepen,
-	"icon_facebook":                iconFacebook,
-	"icon_git":                     iconGit,
-	"icon_github":                  iconGithub,
+	"icon_tired":                   IconTired,
+	"icon_align_bottom":            IconAlignBottom,
+	"icon_align_top":               IconAlignTop,
+	"icon_align_vertically":        IconAlignVertically,
+	"icon_crop":                    IconCrop,
+	"icon_difference":              IconDifference,
+	"icon_distribute_vertically":   IconDistributeVertically,
+	"icon_eraser":                  IconEraser,
+	"icon_intersect":               IconIntersect,
+	"icon_mask":                    IconMask,
+	"icon_scale":                   IconScale,
+	"icon_subtract":                IconSubtract,
+	"icon_text_align_center":       IconTextAlignCenter,
+	"icon_text_align_left":         IconTextAlignLeft,
+	"icon_text_align_right":        IconTextAlignRight,
+	"icon_union":                   IconUnion,
+	"icon_distribute_horizontally": IconDistributeHorizontally,
+	"icon_step_backward":           IconStepBackward,
+	"icon_step_forward":            IconStepForward,
+	"icon_comment_o":               IconCommentO,
+	"icon_codepen":                 IconCodepen,
+	"icon_facebook":                IconFacebook,
+	"icon_git":                     IconGit,
+	"icon_github":                  IconGithub,
 	"icon_github_alt":              IconGithubAlt,
-	"icon_google":                  iconGoogle,
-	"icon_google_plus":             iconGooglePlus,
-	"icon_instagram":               iconInstagram,
-	"icon_pinterest":               iconPinterest,
-	"icon_pocket":                  iconPocket,
+	"icon_google":                  IconGoogle,
+	"icon_google_plus":             IconGooglePlus,
+	"icon_instagram":               IconInstagram,
+	"icon_pinterest":               IconPinterest,
+	"icon_pocket":                  IconPocket,
 	"icon_twitter":                 IconTwitter,
-	"icon_wordpress":               iconWordpress,
-	"icon_wordpress_alt":           iconWordpressAlt,
-	"icon_youtube":                 iconYoutube,
-	"icon_messanger":               iconMessanger,
-	"icon_activity":                iconActivity,
-	"icon_bolt":                    iconBolt,
-	"icon_picture_square":          iconPictureSquare,
-	"icon_text_align_justify":      iconTextAlignJustify,
-	"icon_add_cart":                iconAddCart,
+	"icon_wordpress":               IconWordpress,
+	"icon_wordpress_alt":           IconWordpressAlt,
+	"icon_youtube":                 IconYoutube,
+	"icon_messanger":               IconMessanger,
+	"icon_activity":                IconActivity,
+	"icon_bolt":                    IconBolt,
+	"icon_picture_square":          IconPictureSquare,
+	"icon_text_align_justify":      IconTextAlignJustify,
+	"icon_add_cart":                IconAddCart,
 	"icon_cage":                    IconCage,
-	"icon_cart":                    iconCart,
-	"icon_credit_card":             iconCreditCard,
-	"icon_gift":                    iconGift,
-	"icon_remove_cart":             iconRemoveCart,
-	"icon_shopping_bag":            iconShoppingBag,
-	"icon_truck":                   iconTruck,
-	"icon_wallet":                  iconWallet,
+	"icon_cart":                    IconCart,
+	"icon_credit_card":             IconCreditCard,
+	"icon_gift":                    IconGift,
+	"icon_remove_cart":             IconRemoveCart,
+	"icon_shopping_bag":            IconShoppingBag,
+	"icon_truck":                   IconTruck,
+	"icon_wallet":                  IconWallet,
 	"icon_moon":                    IconMoon,
 	"icon_sunny_o":                 IconSunnyO,
-	"icon_sunrise":                 iconSunrise,
-	"icon_umbrella":                iconUmbrella,
+	"icon_sunrise":                 IconSunrise,
+	"icon_umbrella":                IconUmbrella,
 	"icon_target":                  IconTarget,
-	"icon_smile_plus":              iconSmilePlus,
+	"icon_smile_plus":              IconSmilePlus,
 	"icon_smile_heart":             IconSmileHeart,
-	"icon_beginner":                iconBeginner,
-	"icon_train":                   iconTrain,
-	"icon_donut":                   iconDonut,
-	"icon_rice_cracker":            iconRiceCracker,
-	"icon_apron":                   iconApron,
-	"icon_octpus":                  iconOctpus,
-	"icon_squid":                   iconSquid,
-	"icon_bus":                     iconBus,
-	"icon_car":                     iconCar,
-	"icon_notice_active":           iconNoticeActive,
-	"icon_notice_off":              iconNoticeOff,
-	"icon_notice_on":               iconNoticeOn,
-	"icon_notice_push":             iconNoticePush,
-	"icon_taxi":                    iconTaxi,
-	"icon_vr":                      iconVr,
-	"icon_bread":                   iconBread,
-	"icon_frying_pan":              iconFryingPan,
-	"icon_mitarashi_dango":         iconMitarashiDango,
-	"icon_tumbler_glass":           iconTumblerGlass,
-	"icon_yaki_dango":              iconYakiDango,
+	"icon_beginner":                IconBeginner,
+	"icon_train":                   IconTrain,
+	"icon_donut":                   IconDonut,
+	"icon_rice_cracker":            IconRiceCracker,
+	"icon_apron":                   IconApron,
+	"icon_octpus":                  IconOctpus,
+	"icon_squid":                   IconSquid,
+	"icon_bus":                     IconBus,
+	"icon_car":                     IconCar,
+	"icon_notice_active":           IconNoticeActive,
+	"icon_notice_off":              IconNoticeOff,
+	"icon_notice_on":               IconNoticeOn,
+	"icon_notice_push":             IconNoticePush,
+	"icon_taxi":                    IconTaxi,
+	"icon_vr":                      IconVr,
+	"icon_bread":                   IconBread,
+	"icon_frying_pan":              IconFryingPan,
+	"icon_mitarashi_dango":         IconMitarashiDango,
+	"icon_tumbler_glass":           IconTumblerGlass,
+	"icon_yaki_dango":              IconYakiDango,
 }

--- a/gui/fonts_test.go
+++ b/gui/fonts_test.go
@@ -19,11 +19,11 @@ func TestIconLookupKnownKeys(t *testing.T) {
 		key  string
 		want string
 	}{
-		{"icon_arrow_down", iconArrowDown},
-		{"icon_check", iconCheck},
-		{"icon_home", iconHome},
+		{"icon_arrow_down", IconArrowDown},
+		{"icon_check", IconCheck},
+		{"icon_home", IconHome},
 		{"icon_star", IconStar},
-		{"icon_yaki_dango", iconYakiDango},
+		{"icon_yaki_dango", IconYakiDango},
 	}
 	for _, tt := range tests {
 		if got, ok := IconLookup[tt.key]; !ok {

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -301,7 +301,7 @@ func datePickerControls(
 				Colors:   ColorSet{Border: ColorTransparent}.resolved(ColorTransparent, themeButtonSet()),
 				OnClick:  onPrev,
 				Content: []View{Text(TextCfg{
-					Text:      iconArrowLeft,
+					Text:      IconArrowLeft,
 					TextStyle: CurrentTheme().Icon3,
 				})},
 			}),
@@ -312,7 +312,7 @@ func datePickerControls(
 				Colors:   ColorSet{Border: ColorTransparent}.resolved(ColorTransparent, themeButtonSet()),
 				OnClick:  onNext,
 				Content: []View{Text(TextCfg{
-					Text:      iconArrowRight,
+					Text:      IconArrowRight,
 					TextStyle: CurrentTheme().Icon3,
 				})},
 			}),

--- a/gui/view_markdown_blocks.go
+++ b/gui/view_markdown_blocks.go
@@ -154,11 +154,11 @@ func mdCopyButton(
 		checkStyle := iconStyle
 		checkStyle.Color = RGBA(80, 200, 80, 255)
 		btnContent = []View{
-			Text(TextCfg{Text: iconCheck, TextStyle: checkStyle}),
+			Text(TextCfg{Text: IconCheck, TextStyle: checkStyle}),
 		}
 	} else {
 		btnContent = []View{
-			Text(TextCfg{Text: iconFile, TextStyle: iconStyle}),
+			Text(TextCfg{Text: IconFile, TextStyle: iconStyle}),
 		}
 	}
 
@@ -483,12 +483,12 @@ func mdTaskCheckbox(checked bool, boxSize float32, cfg MarkdownCfg) View {
 		checkStyle.Size = boxSize * 1.1
 		checkStyle.Color = White
 		content = []View{
-			Text(TextCfg{Text: iconCheck, TextStyle: checkStyle}),
+			Text(TextCfg{Text: IconCheck, TextStyle: checkStyle}),
 		}
 		// Same defect as Toggle's check: the icon font's advance box is
 		// taller and wider than the mark, so flow centring leaves it high
 		// and off to one side inside this small fixed box.
-		amend = centerGlyphOnInk(iconCheck, checkStyle)
+		amend = centerGlyphOnInk(IconCheck, checkStyle)
 	}
 
 	return Column(ContainerCfg{

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -41,7 +41,7 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 
 	// Paint palette icon.
 	content = append(content, Text(TextCfg{
-		Text:      iconPalette,
+		Text:      IconPalette,
 		TextStyle: guiTheme.Icon3,
 	}))
 

--- a/gui/view_tree_rows.go
+++ b/gui/view_tree_rows.go
@@ -119,7 +119,7 @@ func treeIconWidth(cfg *TreeCfg, w *Window) float32 {
 	}
 	if w != nil && w.textMeasurer != nil {
 		return max(
-			w.textMeasurer.TextWidth(iconDropDown+" ", style),
+			w.textMeasurer.TextWidth(IconDropDown+" ", style),
 			style.Size+4,
 		)
 	}
@@ -131,12 +131,12 @@ func treeArrowIcon(row treeFlatRow) string {
 		return " "
 	}
 	if row.IsExpanded {
-		return iconDropDown
+		return IconDropDown
 	}
 	if ActiveLocale.TextDir == TextDirRTL {
-		return iconDropLeft
+		return IconDropLeft
 	}
-	return iconDropRight
+	return IconDropRight
 }
 
 func treeRowView(


### PR DESCRIPTION
Closes #441.

225 Feather icon mappings in `gui/fonts.go:124` were lowercased (`iconFile`, `iconHome`, etc.) after the `a80087ec` surface sweep — only 30 `Icon*` remained. Consumers could only reach most icons via `IconLookup["icon_file"]`, losing autocomplete and compile-time checking.

- Rename the 225 constants to `Icon*` (`IconArrowDown`, `IconFile`, `IconHome`, …) and update `IconLookup` + `fonts_test.go`.
- Fix the four internal consumers (`view_date_picker`, `view_markdown_blocks`, `view_theme_picker`, `view_tree_rows`).
- Mark the block `// exportaudit:keep` so the public icon API is gated as intentional (gate reports `surface clean`).

Verification: `make prepush` green, `go test ./...` / `go vet` / `golangci-lint` clean, `exportaudit` reports 256 `Icon*` consts (255 glyphs + `IconFontName`) correctly classified.