### PR TITLE
fix(gui): color channel fields size to theme font, not a fixed width

### DIFF
--- a/gui/testdata/color_fields.dark.golden
+++ b/gui/testdata/color_fields.dark.golden
@@ -3,27 +3,27 @@ StrokeRect xy=15.00,15.00 wh=115.00,31.60 color=#ffffff1c radius=6.00 thickness=
 Clip xy=26.00,22.24 wh=93.00,19.60
 Text xy=26.00,22.24 wh=0.00,0.00 color=#e6e8ebff text="#3380CC" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=27.10,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Red" size=11.00
-Rect xy=15.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=15.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=26.00,81.24 wh=22.00,19.60
+Text xy=31.10,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Red" size=11.00
+Rect xy=15.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,81.24 wh=30.00,19.60
 Text xy=26.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="51" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=70.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Green" size=11.00
-Rect xy=65.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=65.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=76.00,81.24 wh=22.00,19.60
-Text xy=76.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="128" size=14.00
+Text xy=82.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Green" size=11.00
+Rect xy=73.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=73.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=84.00,81.24 wh=30.00,19.60
+Text xy=84.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="128" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=123.80,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Blue" size=11.00
-Rect xy=115.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=115.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=126.00,81.24 wh=22.00,19.60
-Text xy=126.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="204" size=14.00
+Text xy=143.80,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Blue" size=11.00
+Rect xy=131.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=131.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=142.00,81.24 wh=30.00,19.60
+Text xy=142.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="204" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=170.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Alpha" size=11.00
-Rect xy=165.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=165.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=176.00,81.24 wh=22.00,19.60
-Text xy=176.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="255" size=14.00
+Text xy=198.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Alpha" size=11.00
+Rect xy=189.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=189.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=200.00,81.24 wh=30.00,19.60
+Text xy=200.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="255" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/color_fields.light.golden
+++ b/gui/testdata/color_fields.light.golden
@@ -2,23 +2,23 @@ Rect xy=14.00,14.00 wh=115.00,29.60 color=#ffffffff radius=6.00 fill
 Clip xy=24.00,20.24 wh=95.00,19.60
 Text xy=24.00,20.24 wh=0.00,0.00 color=#1a1d21ff text="#3380CC" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=26.10,49.60 wh=0.00,0.00 color=#1a1d21ba text="Red" size=11.00
-Rect xy=14.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=24.00,77.24 wh=24.00,19.60
+Text xy=30.10,49.60 wh=0.00,0.00 color=#1a1d21ba text="Red" size=11.00
+Rect xy=14.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,77.24 wh=32.00,19.60
 Text xy=24.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="51" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=69.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Green" size=11.00
-Rect xy=64.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=74.00,77.24 wh=24.00,19.60
-Text xy=74.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="128" size=14.00
+Text xy=81.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Green" size=11.00
+Rect xy=72.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=82.00,77.24 wh=32.00,19.60
+Text xy=82.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="128" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=122.80,49.60 wh=0.00,0.00 color=#1a1d21ba text="Blue" size=11.00
-Rect xy=114.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=124.00,77.24 wh=24.00,19.60
-Text xy=124.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="204" size=14.00
+Text xy=142.80,49.60 wh=0.00,0.00 color=#1a1d21ba text="Blue" size=11.00
+Rect xy=130.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=140.00,77.24 wh=32.00,19.60
+Text xy=140.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="204" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=169.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Alpha" size=11.00
-Rect xy=164.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=174.00,77.24 wh=24.00,19.60
-Text xy=174.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="255" size=14.00
+Text xy=197.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Alpha" size=11.00
+Rect xy=188.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=198.00,77.24 wh=32.00,19.60
+Text xy=198.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="255" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/color_fields_hsl.dark.golden
+++ b/gui/testdata/color_fields_hsl.dark.golden
@@ -3,45 +3,45 @@ StrokeRect xy=15.00,15.00 wh=115.00,31.60 color=#ffffff1c radius=6.00 thickness=
 Clip xy=26.00,22.24 wh=93.00,19.60
 Text xy=26.00,22.24 wh=0.00,0.00 color=#e6e8ebff text="#3380CC" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=27.10,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Red" size=11.00
-Rect xy=15.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=15.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=26.00,81.24 wh=22.00,19.60
+Text xy=31.10,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Red" size=11.00
+Rect xy=15.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,81.24 wh=30.00,19.60
 Text xy=26.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="51" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=70.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Green" size=11.00
-Rect xy=65.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=65.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=76.00,81.24 wh=22.00,19.60
-Text xy=76.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="128" size=14.00
+Text xy=82.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Green" size=11.00
+Rect xy=73.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=73.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=84.00,81.24 wh=30.00,19.60
+Text xy=84.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="128" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=123.80,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Blue" size=11.00
-Rect xy=115.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=115.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=126.00,81.24 wh=22.00,19.60
-Text xy=126.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="204" size=14.00
+Text xy=143.80,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Blue" size=11.00
+Rect xy=131.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=131.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=142.00,81.24 wh=30.00,19.60
+Text xy=142.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="204" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=170.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Alpha" size=11.00
-Rect xy=165.00,74.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=165.00,74.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=176.00,81.24 wh=22.00,19.60
-Text xy=176.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="255" size=14.00
+Text xy=198.50,52.60 wh=0.00,0.00 color=#e6e8ebb2 text="Alpha" size=11.00
+Rect xy=189.00,74.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=189.00,74.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=200.00,81.24 wh=30.00,19.60
+Text xy=200.00,81.24 wh=0.00,0.00 color=#e6e8ebff text="255" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=27.10,111.60 wh=0.00,0.00 color=#e6e8ebb2 text="Hue" size=11.00
-Rect xy=15.00,133.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=15.00,133.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=26.00,140.24 wh=22.00,19.60
+Text xy=31.10,111.60 wh=0.00,0.00 color=#e6e8ebb2 text="Hue" size=11.00
+Rect xy=15.00,133.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,133.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,140.24 wh=30.00,19.60
 Text xy=26.00,140.24 wh=0.00,0.00 color=#e6e8ebff text="210" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=77.10,111.60 wh=0.00,0.00 color=#e6e8ebb2 text="Sat" size=11.00
-Rect xy=65.00,133.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=65.00,133.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=76.00,140.24 wh=22.00,19.60
-Text xy=76.00,140.24 wh=0.00,0.00 color=#e6e8ebff text="60" size=14.00
+Text xy=89.10,111.60 wh=0.00,0.00 color=#e6e8ebb2 text="Sat" size=11.00
+Rect xy=73.00,133.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=73.00,133.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=84.00,140.24 wh=30.00,19.60
+Text xy=84.00,140.24 wh=0.00,0.00 color=#e6e8ebff text="60" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=115.00,111.60 wh=0.00,0.00 color=#e6e8ebb2 text="Lightness" size=11.00
-Rect xy=122.70,133.00 wh=44.00,31.60 color=#262a2fff radius=6.00 fill
-StrokeRect xy=122.70,133.00 wh=44.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
-Clip xy=133.70,140.24 wh=22.00,19.60
-Text xy=133.70,140.24 wh=0.00,0.00 color=#e6e8ebff text="50" size=14.00
+Text xy=131.00,111.60 wh=0.00,0.00 color=#e6e8ebb2 text="Lightness" size=11.00
+Rect xy=134.70,133.00 wh=52.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=134.70,133.00 wh=52.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=145.70,140.24 wh=30.00,19.60
+Text xy=145.70,140.24 wh=0.00,0.00 color=#e6e8ebff text="50" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/color_fields_hsl.light.golden
+++ b/gui/testdata/color_fields_hsl.light.golden
@@ -2,38 +2,38 @@ Rect xy=14.00,14.00 wh=115.00,29.60 color=#ffffffff radius=6.00 fill
 Clip xy=24.00,20.24 wh=95.00,19.60
 Text xy=24.00,20.24 wh=0.00,0.00 color=#1a1d21ff text="#3380CC" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=26.10,49.60 wh=0.00,0.00 color=#1a1d21ba text="Red" size=11.00
-Rect xy=14.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=24.00,77.24 wh=24.00,19.60
+Text xy=30.10,49.60 wh=0.00,0.00 color=#1a1d21ba text="Red" size=11.00
+Rect xy=14.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,77.24 wh=32.00,19.60
 Text xy=24.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="51" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=69.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Green" size=11.00
-Rect xy=64.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=74.00,77.24 wh=24.00,19.60
-Text xy=74.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="128" size=14.00
+Text xy=81.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Green" size=11.00
+Rect xy=72.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=82.00,77.24 wh=32.00,19.60
+Text xy=82.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="128" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=122.80,49.60 wh=0.00,0.00 color=#1a1d21ba text="Blue" size=11.00
-Rect xy=114.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=124.00,77.24 wh=24.00,19.60
-Text xy=124.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="204" size=14.00
+Text xy=142.80,49.60 wh=0.00,0.00 color=#1a1d21ba text="Blue" size=11.00
+Rect xy=130.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=140.00,77.24 wh=32.00,19.60
+Text xy=140.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="204" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=169.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Alpha" size=11.00
-Rect xy=164.00,71.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=174.00,77.24 wh=24.00,19.60
-Text xy=174.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="255" size=14.00
+Text xy=197.50,49.60 wh=0.00,0.00 color=#1a1d21ba text="Alpha" size=11.00
+Rect xy=188.00,71.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=198.00,77.24 wh=32.00,19.60
+Text xy=198.00,77.24 wh=0.00,0.00 color=#1a1d21ff text="255" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=26.10,106.60 wh=0.00,0.00 color=#1a1d21ba text="Hue" size=11.00
-Rect xy=14.00,128.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=24.00,134.24 wh=24.00,19.60
+Text xy=30.10,106.60 wh=0.00,0.00 color=#1a1d21ba text="Hue" size=11.00
+Rect xy=14.00,128.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,134.24 wh=32.00,19.60
 Text xy=24.00,134.24 wh=0.00,0.00 color=#1a1d21ff text="210" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=76.10,106.60 wh=0.00,0.00 color=#1a1d21ba text="Sat" size=11.00
-Rect xy=64.00,128.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=74.00,134.24 wh=24.00,19.60
-Text xy=74.00,134.24 wh=0.00,0.00 color=#1a1d21ff text="60" size=14.00
+Text xy=88.10,106.60 wh=0.00,0.00 color=#1a1d21ba text="Sat" size=11.00
+Rect xy=72.00,128.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=82.00,134.24 wh=32.00,19.60
+Text xy=82.00,134.24 wh=0.00,0.00 color=#1a1d21ff text="60" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00
-Text xy=114.00,106.60 wh=0.00,0.00 color=#1a1d21ba text="Lightness" size=11.00
-Rect xy=121.70,128.00 wh=44.00,29.60 color=#ffffffff radius=6.00 fill
-Clip xy=131.70,134.24 wh=24.00,19.60
-Text xy=131.70,134.24 wh=0.00,0.00 color=#1a1d21ff text="50" size=14.00
+Text xy=130.00,106.60 wh=0.00,0.00 color=#1a1d21ba text="Lightness" size=11.00
+Rect xy=133.70,128.00 wh=52.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=143.70,134.24 wh=32.00,19.60
+Text xy=143.70,134.24 wh=0.00,0.00 color=#1a1d21ff text="50" size=14.00
 Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/view_color_components_test.go
+++ b/gui/view_color_components_test.go
@@ -663,6 +663,38 @@ func TestColorSwatchColorLayerHasOutline(t *testing.T) {
 	}
 }
 
+// The channel field width starts at the default floor and grows only
+// when three digits at the measured glyph width need more room —
+// GNOME's 15pt body, or a caller's larger font. An explicit
+// ColorFieldsCfg.FieldWidth still wins. The picker re-derives the same
+// number so its rows stay aligned at any of these sizes.
+func TestEffectiveColorFieldWidth(t *testing.T) {
+	style := TextStyle{Size: 15}
+	pad := colorFieldPadding(nil, style)
+
+	if got := effectiveColorFieldWidth(nil, style, pad, 0); got != defaultColorFieldWidth {
+		t.Errorf("nil window = %v, want floor %v", got, defaultColorFieldWidth)
+	}
+	if got := effectiveColorFieldWidth(nil, style, pad, 70); got != 70 {
+		t.Errorf("explicit width = %v, want 70", got)
+	}
+
+	w := &Window{}
+	// Three digits at 6pt fit the floor, so no growth happens.
+	w.textMeasurer = &stubTextMeasurer{charWidth: 6, fontHeight: 16}
+	if got := effectiveColorFieldWidth(w, style, pad, 0); got != defaultColorFieldWidth {
+		t.Errorf("narrow glyphs = %v, want floor %v",
+			got, defaultColorFieldWidth)
+	}
+	// 20pt digits are the growth case the whole measured path exists
+	// for; without it the third digit clips.
+	w.textMeasurer = &stubTextMeasurer{charWidth: 20, fontHeight: 16}
+	if got := effectiveColorFieldWidth(w, style, pad, 0); got <= defaultColorFieldWidth {
+		t.Errorf("wide glyphs = %v, want growth beyond %v",
+			got, defaultColorFieldWidth)
+	}
+}
+
 // The fields correct for optical centring: an Input centres the text's
 // line box, and the descent space under a digit is empty, so metric
 // centring leaves the ink visibly high. This asserts the predicted ink

--- a/gui/view_color_fields.go
+++ b/gui/view_color_fields.go
@@ -52,9 +52,6 @@ type colorFieldsView struct {
 // ColorFields creates the hex and channel inputs for a color.
 func ColorFields(cfg ColorFieldsCfg) View {
 	RequireID("ColorFields", cfg.ID)
-	if cfg.FieldWidth <= 0 {
-		cfg.FieldWidth = defaultColorFieldWidth
-	}
 	if cfg.TextStyle == (TextStyle{}) {
 		cfg.TextStyle = defaultColorPickerStyle.TextStyle
 	}
@@ -65,12 +62,16 @@ func ColorFields(cfg ColorFieldsCfg) View {
 }
 
 const (
-	// defaultColorFieldWidth holds three digits with room for the caret,
-	// and stays just above the widest RGBA label ("Green") so the label
-	// never widens the column. It sets the whole picker's width — four
-	// of these is its widest row — so the slack here is what shows up as
-	// empty space beside the shorter rows.
-	defaultColorFieldWidth = 44
+	// defaultColorFieldWidth is the minimum channel field width. It
+	// holds three digits with room for the caret at the base body
+	// size (14) and stays just above the widest RGBA label ("Green")
+	// so the label never widens the column. It sets the whole
+	// picker's width — four of these is its widest row — so the
+	// slack here is what shows up as empty space beside the shorter
+	// rows. The effective width can grow beyond this when the theme's
+	// body size or the measured glyph width needs it (GNOME at 15,
+	// or a user-bumped font), via effectiveColorFieldWidth.
+	defaultColorFieldWidth = 52
 	// defaultHexFieldWidth holds the widest value the field ever shows
 	// — "#RRGGBBAA", which Hex() emits whenever alpha is not full — so
 	// pinning the field to it never clips.
@@ -92,14 +93,19 @@ func (fv *colorFieldsView) GenerateLayout(w *Window) Layout {
 	// One measurement for every field in the block; see
 	// colorFieldPadding.
 	pad := colorFieldPadding(w, cfg.TextStyle)
+	// Effective column width covers three digits at the
+	// theme's body size. The constant 52 holds 14pt; GNOME
+	// at 15 (and any AdjustFontSize bump) would clip the
+	// third digit without this, hence the measured growth.
+	colW := colorFieldColumnWidth(w, cfg.TextStyle, pad, cfg.FieldWidth)
 
 	rows := make([]View, 0, 3)
 	if !cfg.HideHex {
 		rows = append(rows, colorHexRow(cfg, id, v, pad))
 	}
-	rows = append(rows, colorRGBARow(cfg, id, v, pad))
+	rows = append(rows, colorRGBARow(cfg, id, v, pad, colW))
 	if cfg.ShowHSL {
-		rows = append(rows, colorHSLRow(cfg, id, v, pad))
+		rows = append(rows, colorHSLRow(cfg, id, v, pad, colW))
 	}
 
 	return generateViewLayout(&containerView{
@@ -219,12 +225,12 @@ type colorFieldSpec struct {
 // colorFieldRow lays out a row of labeled channel inputs. The RGBA and
 // HSL rows share everything except what each column edits, so the
 // difference lives in the specs, not in a second copy of the row.
-func colorFieldRow(cfg *ColorFieldsCfg, pad Padding, specs []colorFieldSpec) View {
+func colorFieldRow(cfg *ColorFieldsCfg, pad Padding, specs []colorFieldSpec, fieldWidth float32) View {
 	fields := make([]View, 0, len(specs))
 	for i := range specs {
 		s := &specs[i]
 		fields = append(fields, colorFieldColumn(cfg, pad,
-			s.label, s.val, s.id, s.apply))
+			s.label, s.val, s.id, s.apply, fieldWidth))
 	}
 	return Row(ContainerCfg{
 		Padding:    NoPadding,
@@ -239,7 +245,7 @@ func colorFieldRow(cfg *ColorFieldsCfg, pad Padding, specs []colorFieldSpec) Vie
 // where a value round-trips through RGBA, because that is exactly what
 // the user asked to edit.
 func colorRGBARow(
-	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding,
+	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding, fieldWidth float32,
 ) View {
 	c := v.Color()
 	l := ActiveLocale
@@ -278,13 +284,13 @@ func colorRGBARow(
 			},
 		})
 	}
-	return colorFieldRow(cfg, pad, specs)
+	return colorFieldRow(cfg, pad, specs, fieldWidth)
 }
 
 // colorHSLRow builds the H/S/L inputs, which edit the value directly
 // with no RGBA round-trip and so cannot lose the hue.
 func colorHSLRow(
-	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding,
+	cfg *ColorFieldsCfg, id string, v HSLA, pad Padding, fieldWidth float32,
 ) View {
 	l := ActiveLocale
 	type field struct {
@@ -324,7 +330,7 @@ func colorHSLRow(
 			},
 		})
 	}
-	return colorFieldRow(cfg, pad, specs)
+	return colorFieldRow(cfg, pad, specs, fieldWidth)
 }
 
 // centeredText centres a copy of a style, leaving the caller's
@@ -384,13 +390,91 @@ func colorFieldPadding(w *Window, style TextStyle) Padding {
 // rows of a composed picker come out the same width, and both sides
 // read one name instead of one hard-coded formula each.
 func colorFieldsBlockWidth() float32 {
-	return 4*defaultColorFieldWidth + 3*SpacingSmall
+	return colorFieldsBlockWidthFor(defaultColorFieldWidth)
+}
+
+// colorFieldsBlockWidthFor returns the block width for a given field
+// width. Used by the picker when the effective width has been
+// measured for the current theme/style.
+func colorFieldsBlockWidthFor(fieldWidth float32) float32 {
+	return 4*fieldWidth + 3*SpacingSmall
+}
+
+// colorFieldTextWidth measures the widest three-digit value ("888")
+// the field will ever hold. Only reachable with a measurer in hand:
+// effectiveColorFieldWidth stays at the default floor without one, so
+// no fallback estimate is needed here.
+func colorFieldTextWidth(w *Window, style TextStyle) float32 {
+	// "888" is the widest digit in proportional faces such as
+	// Cantarell/SF. "000" is narrower; using the max avoids an
+	// off-by-one clip when the user types 888 on GNOME at 15pt.
+	return w.textMeasurer.TextWidth("888", centeredText(style))
+}
+
+// effectiveColorFieldWidth returns the width a channel field should
+// take. An explicit FieldWidth wins; otherwise the width grows from
+// the default to hold three digits at the current style/padding/
+// border, with a small caret slack. The default 52 holds 14pt with
+// margin, but GNOME at 15 (and any AdjustFontSize bump) needs more.
+// Without a measurer we stay at the floor: the floor already covers
+// GNOME's 15pt with margin, and a fallback estimate (size*0.6) would
+// overestimate and enlarge every nil-window test beyond production
+// (where the real glyph width is narrower).
+func effectiveColorFieldWidth(
+	w *Window, style TextStyle, pad Padding, explicit float32,
+) float32 {
+	if explicit > 0 {
+		return explicit
+	}
+	if w == nil || w.textMeasurer == nil {
+		return defaultColorFieldWidth
+	}
+	// defaultInputStyle mirrors guiTheme.InputStyle (one assignment
+	// under applyTheme's lock), so there is no second source to fall
+	// back to; a zero border means a borderless theme, and the 1
+	// keeps the estimate conservative rather than exact.
+	border := defaultInputStyle.SizeBorder
+	if border == 0 {
+		border = 1
+	}
+	// Small slack for the caret and breathing room, so "255"
+	// does not kiss the field edge.
+	const caretSlack = 6
+	needed := colorFieldTextWidth(w, style) + pad.Width() + 2*border + caretSlack
+	return f32Max(needed, defaultColorFieldWidth)
+}
+
+// colorFieldColumnWidth returns the width every channel column in the
+// fields block takes: the field's own width, rounded up to the widest
+// label any row carries. A column is Fit, so a label wider than its
+// field would widen just that column and make the analytics in
+// colorFieldsBlockWidthFor under-count the block; keeping every column
+// uniform gives the picker one exact number — and an even grid, which
+// is also the better look. Without a measurer the label role is small
+// enough relative to the floor that only the field side can govern.
+func colorFieldColumnWidth(
+	w *Window, style TextStyle, pad Padding, explicit float32,
+) float32 {
+	fw := effectiveColorFieldWidth(w, style, pad, explicit)
+	if w == nil || w.textMeasurer == nil {
+		return fw
+	}
+	labelStyle := fieldLabelStyle(style)
+	l := ActiveLocale
+	labelW := float32(0)
+	for _, label := range [7]string{
+		l.strRed, l.strGreen, l.strBlue, l.strAlpha,
+		l.strHue, l.strSat, l.strLightness,
+	} {
+		labelW = f32Max(labelW, w.textMeasurer.TextWidth(label, labelStyle))
+	}
+	return f32Max(fw, labelW)
 }
 
 // colorFieldColumn builds one labeled numeric input.
 func colorFieldColumn(
 	cfg *ColorFieldsCfg, pad Padding, label string, val int,
-	inputID string, apply func(string, EventCtx),
+	inputID string, apply func(string, EventCtx), fieldWidth float32,
 ) View {
 	// Centred rather than the default left: the label is narrower than
 	// its field, and left alignment hangs it off the field's left edge
@@ -413,13 +497,13 @@ func colorFieldColumn(
 			// ragged against each other down the row.
 			TextStyle: centeredText(cfg.TextStyle),
 			Padding:   pad,
-			Width:     cfg.FieldWidth,
+			Width:     fieldWidth,
 			// Pinned both ways like the hex field: an Input is
 			// Fit-sized, so "0" and "255" would resolve to
 			// different widths and the whole column of fields
 			// would shift as the user drags a control.
-			MinWidth: cfg.FieldWidth,
-			MaxWidth: cfg.FieldWidth,
+			MinWidth: fieldWidth,
+			MaxWidth: fieldWidth,
 			A11YCfg:  A11YCfg{A11YLabel: label},
 			OnTextChanged: func(text string, ctx EventCtx) {
 				apply(text, ctx)

--- a/gui/view_color_picker.go
+++ b/gui/view_color_picker.go
@@ -98,7 +98,15 @@ func (cv *colorPickerView) GenerateLayout(w *Window) Layout {
 		}
 	}
 
-	planeSize := colorPickerPlaneSize(style)
+	// The plane row must match the fields row's width. The
+	// fields row grows with the theme's body size (GNOME at
+	// 15, or an AdjustFontSize bump), so measure the same
+	// field width here rather than using the fixed block
+	// width.
+	pad := colorFieldPadding(w, style.TextStyle)
+	colW := colorFieldColumnWidth(w, style.TextStyle, pad, 0)
+	blockWidth := colorFieldsBlockWidthFor(colW)
+	planeSize := colorPickerPlaneSizeFor(style, blockWidth)
 	content := []View{
 		// Plane first, then the two channel sliders stood on end beside
 		// it: the sliders are as tall as the plane, so the picker is
@@ -182,8 +190,8 @@ const colorPickerSwatchSize = 32
 // sliders carry their own imagery, so at small spacing they read as
 // part of the plane's edge rather than as separate controls.
 //
-// colorPickerPlaneSize subtracts it, so widening the gap narrows the
-// plane and the row's total width does not move.
+// colorPickerPlaneSizeFor subtracts it, so widening the gap narrows
+// the plane and the row's total width does not move.
 const colorPickerPlaneGap = SpacingMedium
 
 // colorPickerMinPlane floors the derived plane size. A theme with wide
@@ -196,7 +204,7 @@ const colorPickerPlaneGap = SpacingMedium
 // on width for a geometry reason, not a design one.
 const colorPickerMinPlane = 112
 
-// colorPickerPlaneSize derives the plane's edge length instead of
+// colorPickerPlaneSizeFor derives the plane's edge length instead of
 // taking the theme's sVSize directly.
 //
 // The picker is as wide as its widest row, and that row is the four
@@ -205,15 +213,14 @@ const colorPickerMinPlane = 112
 // up as dead space to the right of the alpha input. Subtract exactly
 // what the sliders occupy so the two rows come out the same width.
 //
-// It is only ever a shrink: sVSize stays the upper bound, so a theme
-// asking for a small plane is never grown to fill the row.
-func colorPickerPlaneSize(style ColorPickerStyle) float32 {
+// Row alignment is the invariant; sVSize only seeds a standalone
+// ColorPlane's default. The two do not cap one another: a theme
+// asking for a small plane is not grown to fill the row, and fields
+// widened by a measured font (GNOME at 15, an AdjustFontSize bump)
+// grow the plane past sVSize rather than reintroduce the dead space.
+func colorPickerPlaneSizeFor(style ColorPickerStyle, blockWidth float32) float32 {
 	sliderThick := f32Max(style.sliderHeight, style.indicatorSize)
-	// The fields block's own width; see colorFieldsBlockWidth.
-	size := colorFieldsBlockWidth() - 2*(sliderThick+colorPickerPlaneGap)
-	if size > style.sVSize {
-		size = style.sVSize
-	}
+	size := blockWidth - 2*(sliderThick+colorPickerPlaneGap)
 	return f32Max(size, colorPickerMinPlane)
 }
 

--- a/gui/view_color_picker_test.go
+++ b/gui/view_color_picker_test.go
@@ -179,13 +179,8 @@ func TestColorPickerPlaneFitsFields(t *testing.T) {
 	applyColorPickerDefaults(&cfg)
 	style := cfg.Style
 
-	size := colorPickerPlaneSize(style)
-	if size > style.sVSize {
-		t.Errorf("plane = %v, must not exceed sVSize %v",
-			size, style.sVSize)
-	}
-
 	thick := f32Max(style.sliderHeight, style.indicatorSize)
+	size := colorPickerPlaneSizeFor(style, colorFieldsBlockWidth())
 	top := size + 2*(thick+colorPickerPlaneGap)
 	fields := colorFieldsBlockWidth()
 	if top != fields {
@@ -200,30 +195,57 @@ func TestColorPickerPlaneFitsFields(t *testing.T) {
 // same width and start at the same x under either theme.
 func TestColorPickerRowsAlignUnderBorders(t *testing.T) {
 	for _, borders := range []bool{false, true} {
-		w := &Window{}
-		w.SetTheme(ThemeDark.WithBorders(borders))
-		// A real measurer is needed: the labels above each field are
-		// zero-width without one, so the defect would not show.
-		w.textMeasurer = &stubTextMeasurer{charWidth: 7, fontHeight: 16}
-		l := w.TestRender(func(*Window) View {
-			return ColorPicker(ColorPickerCfg{ID: "p", ShowHSL: true})
-		})
+		assertPickerRowsAligned(t, borders,
+			&stubTextMeasurer{charWidth: 7, fontHeight: 16})
+	}
+}
 
-		fields := findShapeByID(l, "p:fields")
-		plane := findShapeByID(l, "p:plane")
-		alpha := findShapeByID(l, "p:alpha")
-		if fields == nil || plane == nil || alpha == nil {
-			t.Fatalf("borders=%v: missing shapes", borders)
-		}
-		if fields.Shape.X != plane.Shape.X {
-			t.Errorf("borders=%v: fields x = %v, plane x = %v",
-				borders, fields.Shape.X, plane.Shape.X)
-		}
-		// The plane row ends at the alpha slider's right edge.
-		rowEnd := alpha.Shape.X + alpha.Shape.Width
-		if got := fields.Shape.X + fields.Shape.Width; got != rowEnd {
-			t.Errorf("borders=%v: fields right = %v, plane row = %v",
-				borders, got, rowEnd)
-		}
+// The same alignment must hold when the measured glyph width grows the
+// channel fields past the default floor — the picker's plane math has
+// to read the same measured width the fields block does.
+func TestColorPickerRowsAlignWithGrownFields(t *testing.T) {
+	for _, borders := range []bool{false, true} {
+		assertPickerRowsAligned(t, borders,
+			&stubTextMeasurer{charWidth: 20, fontHeight: 16})
+	}
+	// The wide measurer must in fact drive the growth, or the test
+	// above only re-checks the floor.
+	w := &Window{}
+	w.textMeasurer = &stubTextMeasurer{charWidth: 20, fontHeight: 16}
+	style := defaultColorPickerStyle.TextStyle
+	pad := colorFieldPadding(w, style)
+	if got := effectiveColorFieldWidth(w, style, pad, 0); got <= defaultColorFieldWidth {
+		t.Fatalf("grown-fields test needs growth: width = %v, floor %v",
+			got, defaultColorFieldWidth)
+	}
+}
+
+func assertPickerRowsAligned(
+	t *testing.T, borders bool, measurer *stubTextMeasurer,
+) {
+	w := &Window{}
+	w.SetTheme(ThemeDark.WithBorders(borders))
+	// A real measurer is needed: the labels above each field are
+	// zero-width without one, so the defect would not show.
+	w.textMeasurer = measurer
+	l := w.TestRender(func(*Window) View {
+		return ColorPicker(ColorPickerCfg{ID: "p", ShowHSL: true})
+	})
+
+	fields := findShapeByID(l, "p:fields")
+	plane := findShapeByID(l, "p:plane")
+	alpha := findShapeByID(l, "p:alpha")
+	if fields == nil || plane == nil || alpha == nil {
+		t.Fatalf("borders=%v: missing shapes", borders)
+	}
+	if fields.Shape.X != plane.Shape.X {
+		t.Errorf("borders=%v: fields x = %v, plane x = %v",
+			borders, fields.Shape.X, plane.Shape.X)
+	}
+	// The plane row ends at the alpha slider's right edge.
+	rowEnd := alpha.Shape.X + alpha.Shape.Width
+	if got := fields.Shape.X + fields.Shape.Width; got != rowEnd {
+		t.Errorf("borders=%v: fields right = %v, plane row = %v",
+			borders, got, rowEnd)
 	}
 }


### PR DESCRIPTION
## Problem

The color channel field width was a fixed 44px. At GNOME's 15pt body size (or any `AdjustFontSize` bump) the third digit of a channel value clipped.

## Change

- Raise the floor from 44 to 52 (holds 14pt with margin; covers GNOME 15pt when no measurer is available, e.g. nil-window tests).
- `effectiveColorFieldWidth`: measure the widest value (`"888"`) plus padding, border, and caret slack at the active style; grow beyond the floor only when the theme needs it. An explicit `FieldWidth` still wins.
- `colorFieldColumnWidth`: round the column up to the widest localized channel label (Red/Green/Blue/Alpha/Hue/Sat/Lightness) so the picker block width stays exact and the grid even.
- The picker plane row now derives from the measured block width (`colorFieldsBlockWidthFor` / `colorPickerPlaneSizeFor`) instead of the fixed constant, so plane and fields rows stay the same width at any font size.

## Tests

- Re-recorded `color_fields{,_hsl}` goldens (dark + light) for the 44 → 52 floor.
- New/updated cases in `view_color_components_test.go` and `view_color_picker_test.go` covering measured growth and explicit-width override.

Local gate: `make prepush` green.