### PR TITLE
perf(gui): closed-form mesh for concentric radial gradients

### DIFF
--- a/gui/animation.go
+++ b/gui/animation.go
@@ -58,9 +58,21 @@ type AnimationRefreshKind uint8
 
 // AnimationRefreshKind constants.
 const (
-	animationRefreshNone       AnimationRefreshKind = iota
-	animationRefreshRenderOnly                      // repaint only
-	AnimationRefreshLayout                          // full layout rebuild
+	animationRefreshNone AnimationRefreshKind = iota
+	// AnimationRefreshRenderOnly rebuilds the render commands from the
+	// layout already in hand: no view function runs, and nothing is
+	// re-arranged. It is the right kind for an animation whose every
+	// frame changes only what a widget paints — a canvas, a spinner —
+	// rather than what the widget tree contains.
+	//
+	// A DrawCanvas driven this way must set
+	// DrawCanvasCfg.AlwaysRedraw, because its Version never reaches
+	// the cache without a view pass. Anything that does change the
+	// tree still needs a layout refresh from its own event handler.
+	//
+	// exportaudit:keep — the refresh kind an app sets on Animate
+	AnimationRefreshRenderOnly
+	AnimationRefreshLayout // full layout rebuild
 )
 
 // maxAnimationRefreshKind returns the higher-priority refresh kind.

--- a/gui/animation_core_test.go
+++ b/gui/animation_core_test.go
@@ -46,8 +46,8 @@ func TestMaxRefreshKindDowngrade(t *testing.T) {
 }
 
 func TestMaxRefreshKindEqual(t *testing.T) {
-	got := maxAnimationRefreshKind(animationRefreshRenderOnly, animationRefreshRenderOnly)
-	if got != animationRefreshRenderOnly {
-		t.Errorf("got %d, want %d", got, animationRefreshRenderOnly)
+	got := maxAnimationRefreshKind(AnimationRefreshRenderOnly, AnimationRefreshRenderOnly)
+	if got != AnimationRefreshRenderOnly {
+		t.Errorf("got %d, want %d", got, AnimationRefreshRenderOnly)
 	}
 }

--- a/gui/animation_loop.go
+++ b/gui/animation_loop.go
@@ -170,7 +170,7 @@ func (w *Window) animationLoop() {
 		}
 
 		switch refreshKind {
-		case animationRefreshRenderOnly:
+		case AnimationRefreshRenderOnly:
 			deferred = append(deferred, queuedCommand{
 				kind:     queuedCommandWindowFn,
 				windowFn: commandMarkRenderOnlyRefresh,

--- a/gui/animation_test.go
+++ b/gui/animation_test.go
@@ -155,10 +155,10 @@ func TestAnimateRefreshKindDefault(t *testing.T) {
 }
 
 func TestAnimateRefreshKindCustom(t *testing.T) {
-	a := &Animate{AnimID: "test", Refresh: animationRefreshRenderOnly}
-	if a.RefreshKind() != animationRefreshRenderOnly {
+	a := &Animate{AnimID: "test", Refresh: AnimationRefreshRenderOnly}
+	if a.RefreshKind() != AnimationRefreshRenderOnly {
 		t.Errorf("RefreshKind = %d, want %d",
-			a.RefreshKind(), animationRefreshRenderOnly)
+			a.RefreshKind(), AnimationRefreshRenderOnly)
 	}
 }
 

--- a/gui/canvas_draw.go
+++ b/gui/canvas_draw.go
@@ -27,6 +27,8 @@ type DrawContext struct {
 	gradOffsetBuf   []float32
 	gradStopBuf     []GradientStop
 	gradRampBuf     []gradRampSegment
+	gradRingBuf     []gradRing
+	lineBuf         [4]float32
 	currentBatchIdx int
 	Width           float32
 	Height          float32
@@ -84,7 +86,12 @@ func (dc *DrawContext) Line(x0, y0, x1, y1 float32, color Color, width float32) 
 		dc.recorder.Line(x0, y0, x1, y1, color, width)
 		return
 	}
-	dc.Polyline([]float32{x0, y0, x1, y1}, color, width)
+	// Through a reused array rather than a literal: Polyline hands its
+	// points to dc.recorder, so the parameter escapes and a literal
+	// here heap-allocates on every call — even on this branch, which
+	// has already established there is no recorder.
+	dc.lineBuf = [4]float32{x0, y0, x1, y1}
+	dc.Polyline(dc.lineBuf[:], color, width)
 }
 
 // Polyline draws a stroked open polyline using simple

--- a/gui/canvas_draw_batch.go
+++ b/gui/canvas_draw_batch.go
@@ -96,4 +96,5 @@ func (dc *DrawContext) resetFor(w, h, scale float32, tm TextMeasurer,
 	dc.gradIsolineBuf = keepScratch(dc.gradIsolineBuf)
 	dc.gradOffsetBuf = keepScratch(dc.gradOffsetBuf)
 	dc.gradStopBuf = keepScratch(dc.gradStopBuf)
+	dc.gradRingBuf = keepScratch(dc.gradRingBuf)
 }

--- a/gui/canvas_draw_gradient.go
+++ b/gui/canvas_draw_gradient.go
@@ -203,7 +203,181 @@ func (dc *DrawContext) FilledRectGradient(x, y, w, h float32,
 //	})
 func (dc *DrawContext) FilledCircleGradient(cx, cy, radius float32,
 	g *CanvasGradient) {
+	if dc.fillConcentricRings(cx, cy, radius, g) {
+		return
+	}
 	dc.FilledArcGradient(cx, cy, radius, radius, 0, 2*math.Pi, g)
+}
+
+// concentricMinSegs is the angular resolution the ring mesh needs
+// before its own interpolation error is invisible.
+//
+// A ring band's vertices sit on its two isolines, but Gouraud shading
+// interpolates across the chord between them, so a point near the
+// middle of a segment reads the color of a radius up to the sagitta
+// r*(1-cos(pi/n)) away. Below 1/256 of the ramp — the same tolerance
+// the general path's radial pass refines to — that is under one step
+// of an 8-bit channel, and 1-cos(pi/36) is 0.0038.
+//
+// A full circle's segment count starts at 64 and climbs with radius,
+// so this never rejects one in practice; it is the invariant stated
+// rather than inherited from arcPoints' formula.
+const concentricMinSegs = 36
+
+// gradRing is one boundary of the concentric ring mesh: the radius the
+// ramp reaches a given color at.
+type gradRing struct {
+	radius float32
+	color  Color
+}
+
+// fillConcentricRings is the closed-form fill for the most common
+// radial gradient there is: a ramp centered on the circle it fills.
+// Reports whether it handled the fill.
+//
+// The general path has to *find* the ramp's isolines. It refines the
+// fan until no triangle's radial error is visible, then cuts every
+// triangle at every stop, then projects each resulting vertex back
+// through a square root to recover the parameter it was cut at. For a
+// concentric ramp all of that is answering a question with a known
+// answer: the isolines are circles about the center, at radius
+// stop.Pos * r.
+//
+// So the mesh is emitted as one quad strip per pair of adjacent stops,
+// and the vertex colors are the stops themselves — no subdivision
+// search, no per-vertex projection, and no ramp sampling. It is also
+// exact where the general path approximates: interpolating a distance
+// field linearly across a split triangle is only as good as the split
+// was fine, while a ring boundary lies exactly on its isoline.
+//
+// Bails out to the general path for anything else: an ellipse, an
+// off-center or offset-focal ramp, a non-pad spread (whose isolines
+// repeat past the rim), or an active recorder, whose gradient contract
+// is the raw geometry plus the gradient.
+func (dc *DrawContext) fillConcentricRings(cx, cy, r float32,
+	g *CanvasGradient) bool {
+	if dc.recorder != nil || g == nil || len(g.Stops) == 0 {
+		return false
+	}
+	if !g.Radial || g.Spread != SpreadPad || !(r > 0) {
+		return false
+	}
+	// Two ways to be concentric, tested against what the caller wrote
+	// rather than against a resolved copy. Resolving first and
+	// comparing the result would mean comparing cx to
+	// ((cx-r)+(cx+r))*0.5, which float32 does not always round back to
+	// cx — a fill would fall off the fast path for no reason a caller
+	// could see.
+	if !(g.R > 0) {
+		// Left to default. resolveCanvasGradient centers a degenerate
+		// radial on the fill's bounds with R at half its larger
+		// extent, which for a full circle's fan is this circle.
+	} else if g.R != r || g.CX != cx || g.CY != cy {
+		return false
+	} else if !(g.FX == 0 && g.FY == 0) &&
+		!(g.FX == cx && g.FY == cy) {
+		// FX/FY at the origin means "unset", and the resolve puts them
+		// on the center; anywhere else is a real focal offset.
+		return false
+	}
+
+	dc.gradStopBuf = dc.gradStopBuf[:0]
+	stops := NormalizeGradientStops(g.Stops, &dc.gradStopBuf)
+	if len(stops) == 0 {
+		return false
+	}
+	pts := dc.arcPoints(cx, cy, r, r, 0, 2*math.Pi)
+	if len(pts) < 4 {
+		return false
+	}
+
+	rings := dc.concentricRings(stops, r)
+	if len(rings) < 2 {
+		return false
+	}
+
+	segs := len(pts)/2 - 1
+	if segs < concentricMinSegs {
+		return false
+	}
+
+	// Two triangles per segment per band, and three for the innermost
+	// band when it closes on the center. An over-estimate only sizes
+	// the pooled buffers, so the center case is not special-cased here.
+	b := dc.gradientBatch(SampleGradientStopColor(stops, 0.5),
+		segs*6*(len(rings)-1))
+
+	invR := 1 / r
+	for j := 0; j+1 < len(rings); j++ {
+		r0, c0 := rings[j].radius, rings[j].color
+		r1, c1 := rings[j+1].radius, rings[j+1].color
+		if !(r1 > r0) {
+			// A hard stop — two stops at one position. The band has no
+			// area, so it contributes no geometry; the color still
+			// changes, because the next band opens on c1.
+			continue
+		}
+		if r0 <= 0 {
+			// Innermost band closes on the center: a fan, not a strip.
+			// Its rim is still this band's outer isoline, not the
+			// circle's — the two coincide only when the first stop is
+			// also the last.
+			s := r1 * invR
+			for i := 0; i+3 < len(pts); i += 2 {
+				b.Triangles = append(b.Triangles, cx, cy,
+					cx+(pts[i]-cx)*s, cy+(pts[i+1]-cy)*s,
+					cx+(pts[i+2]-cx)*s, cy+(pts[i+3]-cy)*s)
+				b.VertexColors = append(b.VertexColors, c0, c1, c1)
+			}
+			continue
+		}
+		// The rim points are already on the circle of radius r, so an
+		// inner ring is the same direction scaled — no trigonometry
+		// beyond the one arcPoints pass.
+		s0, s1 := r0*invR, r1*invR
+		for i := 0; i+3 < len(pts); i += 2 {
+			ux0, uy0 := pts[i]-cx, pts[i+1]-cy
+			ux1, uy1 := pts[i+2]-cx, pts[i+3]-cy
+			ax, ay := cx+ux0*s0, cy+uy0*s0
+			bx, by := cx+ux1*s0, cy+uy1*s0
+			ex, ey := cx+ux0*s1, cy+uy0*s1
+			fx, fy := cx+ux1*s1, cy+uy1*s1
+			// inner_i -> outer_i -> outer_i+1 -> inner_i+1 is the
+			// quad's order in the same sense the fan winds; walking
+			// the inner edge first reverses it.
+			b.Triangles = append(b.Triangles,
+				ax, ay, ex, ey, fx, fy,
+				ax, ay, fx, fy, bx, by)
+			b.VertexColors = append(b.VertexColors,
+				c0, c1, c1, c0, c1, c0)
+		}
+	}
+	return true
+}
+
+// concentricRings turns normalized stops into the ring boundaries of
+// the mesh, in increasing radius.
+//
+// Pad is what the two extra rings are for: the ramp is flat inside the
+// first stop and outside the last, so each of those regions gets a
+// boundary at the end color rather than a ramp running off the stops.
+func (dc *DrawContext) concentricRings(stops []GradientStop,
+	r float32) []gradRing {
+	dc.gradRingBuf = dc.gradRingBuf[:0]
+	first, last := stops[0], stops[len(stops)-1]
+	if first.Pos > 0 {
+		dc.gradRingBuf = append(dc.gradRingBuf,
+			gradRing{radius: 0, color: first.Color})
+	}
+	for i := range stops {
+		dc.gradRingBuf = append(dc.gradRingBuf,
+			gradRing{radius: stops[i].Pos * r, color: stops[i].Color})
+	}
+	if last.Pos < 1 {
+		dc.gradRingBuf = append(dc.gradRingBuf,
+			gradRing{radius: r, color: last.Color})
+	}
+	return dc.gradRingBuf
 }
 
 // FilledArcGradient fills an elliptical arc (a pie slice) with a

--- a/gui/canvas_draw_gradient_rings_test.go
+++ b/gui/canvas_draw_gradient_rings_test.go
@@ -1,0 +1,327 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+// The concentric fast path's whole claim is that a vertex's distance
+// from the center places it exactly on the ramp. These tests assert
+// that directly, per vertex, because a golden records only counts and
+// endpoint colors — it cannot see a band drawn at the wrong radius.
+
+// ringVertexRadiiMatchColors checks every emitted vertex against the
+// ramp: the color it carries must be the color the ramp holds at its
+// own distance from the center.
+func ringVertexRadiiMatchColors(t *testing.T, cx, cy, r float32,
+	stops []GradientStop) {
+	t.Helper()
+	dc := NewDrawContext(4*r, 4*r, nil)
+	dc.FilledCircleGradient(cx, cy, r, &CanvasGradient{
+		Radial: true, Stops: stops,
+	})
+	batches := dc.Batches()
+	if len(batches) == 0 {
+		t.Fatal("no batches emitted")
+	}
+	var norm []GradientStop
+	norm = NormalizeGradientStops(stops, &norm)
+
+	verts := 0
+	var maxR float64
+	for _, b := range batches {
+		if len(b.VertexColors)*2 != len(b.Triangles) {
+			t.Fatalf("batch lengths disagree: %d triangles floats, %d colors",
+				len(b.Triangles), len(b.VertexColors))
+		}
+		for i := range b.VertexColors {
+			x, y := b.Triangles[i*2], b.Triangles[i*2+1]
+			d := math.Hypot(float64(x-cx), float64(y-cy))
+			maxR = max(maxR, d)
+			if d > float64(r)+0.01 {
+				t.Fatalf("vertex %d at radius %.3f is outside the circle (r=%.1f)",
+					i, d, r)
+			}
+			// A vertex sits on a ring boundary, so the ramp position it
+			// stands for is exact, not interpolated.
+			pos := float32(d) / r
+			want := SampleGradientStopColor(norm, pos)
+			if got := b.VertexColors[i]; got != want {
+				t.Fatalf("vertex %d at radius %.3f (pos %.4f): color %v, want %v",
+					i, d, pos, got, want)
+			}
+			verts++
+		}
+	}
+	if verts == 0 {
+		t.Fatal("no vertices emitted")
+	}
+	// The fill must reach the rim, or the circle has a missing outer
+	// annulus that no per-vertex check would notice.
+	if maxR < float64(r)-0.5 {
+		t.Errorf("mesh reaches only radius %.3f, want %.1f", maxR, r)
+	}
+}
+
+func TestConcentricRingsMatchRamp(t *testing.T) {
+	cases := []struct {
+		name  string
+		stops []GradientStop
+	}{
+		{"two stops spanning the circle", []GradientStop{
+			{Color: RGBA(255, 255, 255, 255), Pos: 0},
+			{Color: RGBA(255, 255, 255, 0), Pos: 1},
+		}},
+		{"flat core then a ramp", []GradientStop{
+			{Color: RGB(255, 200, 0), Pos: 0.35},
+			{Color: RGBA(255, 200, 0, 0), Pos: 1},
+		}},
+		{"flat rim", []GradientStop{
+			{Color: RGB(255, 0, 0), Pos: 0},
+			{Color: RGB(0, 0, 255), Pos: 0.4},
+		}},
+		{"flat at both ends", []GradientStop{
+			{Color: RGB(255, 0, 0), Pos: 0.25},
+			{Color: RGB(0, 0, 255), Pos: 0.75},
+		}},
+		{"many stops", []GradientStop{
+			{Color: RGB(255, 0, 0), Pos: 0},
+			{Color: RGB(255, 255, 0), Pos: 0.2},
+			{Color: RGB(0, 255, 0), Pos: 0.4},
+			{Color: RGB(0, 255, 255), Pos: 0.6},
+			{Color: RGB(0, 0, 255), Pos: 0.8},
+			{Color: RGB(255, 0, 255), Pos: 1},
+		}},
+		{"unsorted and out of range", []GradientStop{
+			{Color: RGB(0, 0, 255), Pos: 1.7},
+			{Color: RGB(255, 0, 0), Pos: -0.3},
+			{Color: RGB(0, 255, 0), Pos: 0.5},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ringVertexRadiiMatchColors(t, 120, 120, 60, tc.stops)
+		})
+	}
+}
+
+// TestConcentricRingsHardStop keeps a repeated position a color jump.
+// A band of zero width contributes no geometry, but the color on the
+// far side of it must still change.
+func TestConcentricRingsHardStop(t *testing.T) {
+	red, blue := RGB(255, 0, 0), RGB(0, 0, 255)
+	dc := NewDrawContext(400, 400, nil)
+	dc.FilledCircleGradient(100, 100, 50, &CanvasGradient{
+		Radial: true,
+		Stops: []GradientStop{
+			{Color: red, Pos: 0},
+			{Color: red, Pos: 0.5},
+			{Color: blue, Pos: 0.5},
+			{Color: blue, Pos: 1},
+		},
+	})
+	var sawRed, sawBlue bool
+	for _, b := range dc.Batches() {
+		for i, c := range b.VertexColors {
+			d := math.Hypot(float64(b.Triangles[i*2]-100),
+				float64(b.Triangles[i*2+1]-100))
+			switch {
+			case d < 24.9:
+				if c != red {
+					t.Fatalf("inside the jump at r=%.2f: %v, want red", d, c)
+				}
+				sawRed = true
+			case d > 25.1:
+				if c != blue {
+					t.Fatalf("outside the jump at r=%.2f: %v, want blue", d, c)
+				}
+				sawBlue = true
+			}
+		}
+	}
+	if !sawRed || !sawBlue {
+		t.Errorf("hard stop not exercised: red=%v blue=%v", sawRed, sawBlue)
+	}
+}
+
+// TestConcentricRingsDeclined pins the cases that must stay on the
+// general path, where the ring mesh would be wrong.
+func TestConcentricRingsDeclined(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGB(255, 0, 0), Pos: 0},
+		{Color: RGB(0, 0, 255), Pos: 1},
+	}
+	cases := []struct {
+		name string
+		g    CanvasGradient
+	}{
+		{"linear", CanvasGradient{Stops: stops}},
+		{"off-center", CanvasGradient{
+			Radial: true, Stops: stops, CX: 10, CY: 100, R: 50}},
+		{"radius not the circle's", CanvasGradient{
+			Radial: true, Stops: stops, CX: 100, CY: 100, R: 20}},
+		{"offset focal", CanvasGradient{
+			Radial: true, Stops: stops, CX: 100, CY: 100, R: 50,
+			FX: 90, FY: 100}},
+		{"repeat spread", CanvasGradient{
+			Radial: true, Stops: stops, Spread: SpreadRepeat}},
+		{"reflect spread", CanvasGradient{
+			Radial: true, Stops: stops, Spread: SpreadReflect}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := NewDrawContext(400, 400, nil)
+			g := tc.g
+			if dc.fillConcentricRings(100, 100, 50, &g) {
+				t.Error("took the concentric fast path")
+			}
+		})
+	}
+}
+
+// TestConcentricRingsAccepted is the other half: the spellings that
+// must reach the fast path, including the fully explicit one.
+func TestConcentricRingsAccepted(t *testing.T) {
+	stops := []GradientStop{
+		{Color: RGB(255, 0, 0), Pos: 0},
+		{Color: RGB(0, 0, 255), Pos: 1},
+	}
+	cases := []struct {
+		name string
+		g    CanvasGradient
+	}{
+		{"defaulted geometry", CanvasGradient{Radial: true, Stops: stops}},
+		{"explicit center and radius", CanvasGradient{
+			Radial: true, Stops: stops, CX: 100, CY: 100, R: 50}},
+		{"explicit focal on center", CanvasGradient{
+			Radial: true, Stops: stops, CX: 100, CY: 100, R: 50,
+			FX: 100, FY: 100}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := NewDrawContext(400, 400, nil)
+			g := tc.g
+			if !dc.fillConcentricRings(100, 100, 50, &g) {
+				t.Error("fell through to the general path")
+			}
+		})
+	}
+}
+
+// TestConcentricRingsMatchGeneralPath is the equivalence check the
+// speedup rests on: the ring mesh and the mesh the subdivision pass
+// builds must paint the same picture.
+//
+// FilledArcGradient is the seam — it is what FilledCircleGradient
+// delegates to when the fast path declines, so calling it directly
+// with a full sweep renders the identical fill the slow way.
+func TestConcentricRingsMatchGeneralPath(t *testing.T) {
+	const cx, cy, r = 120, 120, 70
+	for _, tc := range []struct {
+		name  string
+		stops []GradientStop
+	}{
+		{"opaque ramp", []GradientStop{
+			{Color: RGB(255, 220, 120), Pos: 0},
+			{Color: RGB(255, 160, 40), Pos: 0.45},
+			{Color: RGB(200, 80, 0), Pos: 1},
+		}},
+		{"alpha ramp", []GradientStop{
+			{Color: RGBA(255, 220, 120, 255), Pos: 0},
+			{Color: RGBA(255, 200, 90, 120), Pos: 0.45},
+			{Color: RGBA(255, 180, 60, 0), Pos: 1},
+		}},
+		{"flat core", []GradientStop{
+			{Color: RGB(255, 200, 0), Pos: 0.35},
+			{Color: RGBA(255, 200, 0, 0), Pos: 1},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := CanvasGradient{Radial: true, Stops: tc.stops}
+
+			fast := NewDrawContext(4*r, 4*r, nil)
+			fast.FilledCircleGradient(cx, cy, r, &g)
+
+			slow := NewDrawContext(4*r, 4*r, nil)
+			slow.FilledArcGradient(cx, cy, r, r, 0, 2*math.Pi, &g)
+
+			var worst int
+			var worstAt float32
+			for ring := 1; ring <= 12; ring++ {
+				rad := float32(ring) / 13 * r
+				for a := range 24 {
+					ang := float64(a) / 24 * 2 * math.Pi
+					px := cx + rad*float32(math.Cos(ang))
+					py := cy + rad*float32(math.Sin(ang))
+					got, ok := sampleMeshAt(fast, px, py)
+					if !ok {
+						t.Fatalf("ring mesh does not cover radius %.1f", rad)
+					}
+					want, ok := sampleMeshAt(slow, px, py)
+					if !ok {
+						t.Fatalf("general mesh does not cover radius %.1f", rad)
+					}
+					if d := colorDelta(got, want); d > worst {
+						worst, worstAt = d, rad
+					}
+				}
+			}
+			// Both meshes are Gouraud-interpolated straight colors, so
+			// they agree wherever they place vertices the same way. The
+			// slack is for the band interiors, where the ring mesh
+			// spans a whole stop pair and the subdivided one carries
+			// extra vertices through the same straight interpolation.
+			if worst > 8 {
+				t.Errorf("worst channel delta %d at radius %.1f, want <= 8",
+					worst, worstAt)
+			}
+		})
+	}
+}
+
+func colorDelta(a, b Color) int {
+	d := 0
+	for _, p := range [][2]uint8{{a.R, b.R}, {a.G, b.G},
+		{a.B, b.B}, {a.A, b.A}} {
+		v := int(p[0]) - int(p[1])
+		if v < 0 {
+			v = -v
+		}
+		d = max(d, v)
+	}
+	return d
+}
+
+// sampleMeshAt finds the triangle covering a point and returns its
+// barycentric blend of the three vertex colors — what the backend's
+// Gouraud shading paints there.
+func sampleMeshAt(dc *DrawContext, px, py float32) (Color, bool) {
+	for _, b := range dc.Batches() {
+		for i := 0; i+5 < len(b.Triangles); i += 6 {
+			ax, ay := b.Triangles[i], b.Triangles[i+1]
+			bx, by := b.Triangles[i+2], b.Triangles[i+3]
+			cx, cy := b.Triangles[i+4], b.Triangles[i+5]
+			den := (by-cy)*(ax-cx) + (cx-bx)*(ay-cy)
+			if den == 0 {
+				continue
+			}
+			l0 := ((by-cy)*(px-cx) + (cx-bx)*(py-cy)) / den
+			l1 := ((cy-ay)*(px-cx) + (ax-cx)*(py-cy)) / den
+			l2 := 1 - l0 - l1
+			const eps = -1e-4
+			if l0 < eps || l1 < eps || l2 < eps {
+				continue
+			}
+			v := i / 2
+			c0, c1, c2 := b.VertexColors[v], b.VertexColors[v+1],
+				b.VertexColors[v+2]
+			mix := func(x, y, z uint8) uint8 {
+				return f32ToU8Saturated(l0*float32(x) +
+					l1*float32(y) + l2*float32(z))
+			}
+			return RGBA(mix(c0.R, c1.R, c2.R), mix(c0.G, c1.G, c2.G),
+				mix(c0.B, c1.B, c2.B), mix(c0.A, c1.A, c2.A)), true
+		}
+	}
+	return Color{}, false
+}

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -867,6 +867,17 @@ func goldenCases() []goldenCase {
 			build: buildCanvasGradient,
 		},
 		{
+			// The concentric radial fast path: a ramp centered on the
+			// circle it fills, which is emitted as a ring mesh rather
+			// than a subdivided fan. Multi-stop and off-[0,1] on
+			// purpose — the ring list is where the pad regions inside
+			// the first stop and outside the last are decided, and a
+			// hard stop (two stops at one position) is the case that
+			// must stay a color jump and not a zero-area band.
+			name:  "canvas_gradient_rings",
+			build: buildCanvasGradientRings,
+		},
+		{
 			// Caller-supplied per-vertex color (issue #400). The
 			// counterpart to canvas_gradient: nothing here is
 			// evaluated, so what the golden pins is that the caller's
@@ -929,6 +940,31 @@ func buildCanvasGradient(_ *Window) View {
 				Stops: []GradientStop{
 					{Color: RGBA(255, 255, 255, 255), Pos: 0},
 					{Color: RGBA(255, 255, 255, 0), Pos: 1},
+				},
+			})
+		},
+	})
+}
+
+// buildCanvasGradientRings exercises the concentric radial fill with a
+// ramp the two-stop case cannot reach: flat regions at both ends, a
+// hard stop in the middle, and stops that are neither sorted nor in
+// range on the way in.
+func buildCanvasGradientRings(_ *Window) View {
+	return DrawCanvas(DrawCanvasCfg{
+		ID:      "canvas_gradient_rings",
+		Sizing:  FixedFixed,
+		Width:   80,
+		Height:  80,
+		Version: 1,
+		OnDraw: func(dc *DrawContext) {
+			dc.FilledCircleGradient(40, 40, 35, &CanvasGradient{
+				Radial: true,
+				Stops: []GradientStop{
+					{Color: RGB(0, 0, 255), Pos: 1.4},
+					{Color: RGB(255, 0, 0), Pos: 0.2},
+					{Color: RGB(0, 255, 0), Pos: 0.6},
+					{Color: RGB(255, 255, 0), Pos: 0.6},
 				},
 			})
 		},

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -30,7 +30,10 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	if key != "" {
 		var ok bool
 		cached, ok = sm.Get(key)
-		if ok && cached.Version == shape.Version &&
+		// The entry is still claimed for its buffers when
+		// alwaysRedraw skips the version test — that is the half of
+		// the cache an animated canvas actually uses.
+		if ok && !shape.alwaysRedraw && cached.Version == shape.Version &&
 			cached.tessWidth == cw && cached.tessHeight == ch &&
 			cached.Scale == scale {
 			needsDraw = false

--- a/gui/render_draw_canvas_test.go
+++ b/gui/render_draw_canvas_test.go
@@ -839,3 +839,68 @@ func TestDrawCanvasSamePassNoReuse(t *testing.T) {
 		}
 	}
 }
+
+// TestRenderDrawCanvasAlwaysRedraw pins the escape hatch that makes an
+// animated canvas work under AnimationRefreshRenderOnly: with no view
+// pass to stamp a new Version onto the shape, the version test can
+// never fail, so alwaysRedraw is what keeps OnDraw running.
+func TestRenderDrawCanvasAlwaysRedraw(t *testing.T) {
+	w := makeWindowWithScratch()
+	callCount := 0
+	shape := &Shape{
+		shapeType: shapeDrawCanvas,
+		ID:        "always-canvas",
+		Width:     100, Height: 100,
+		Version:      1,
+		alwaysRedraw: true,
+		Color:        RGB(100, 100, 100),
+		events: &eventHandlers{
+			OnDraw: func(dc *DrawContext) {
+				callCount++
+				dc.batches = append(dc.batches, DrawCanvasTriBatch{
+					Triangles: []float32{0, 0, 1, 0, 0, 1},
+					Color:     RGB(255, 0, 0),
+				})
+			},
+		},
+	}
+	clip := makeClip(0, 0, 200, 200)
+
+	// Three passes at one unchanging Version: every one redraws.
+	for i := 1; i <= 3; i++ {
+		w.renderers = w.renderers[:0]
+		w.renderPass++
+		renderDrawCanvas(shape, clip, w)
+		if callCount != i {
+			t.Fatalf("pass %d: callCount = %d, want %d", i, callCount, i)
+		}
+	}
+
+	// The geometry still reaches the command list on a later pass, so
+	// the redraw is a real one and not a skipped draw with a stale
+	// buffer emitted behind it.
+	var svg int
+	for _, r := range w.renderers {
+		if r.Kind == RenderSvg {
+			svg++
+		}
+	}
+	if svg == 0 {
+		t.Error("no RenderSvg emitted on an always-redraw pass")
+	}
+}
+
+// TestDrawCanvasAlwaysRedrawReachesShape checks the Cfg field is
+// actually carried onto the shape; the gate above is unreachable
+// otherwise.
+func TestDrawCanvasAlwaysRedrawReachesShape(t *testing.T) {
+	w := makeWindowWithScratch()
+	v := DrawCanvas(DrawCanvasCfg{
+		ID:           "c",
+		AlwaysRedraw: true,
+		OnDraw:       func(*DrawContext) {},
+	})
+	if !v.GenerateLayout(w).Shape.alwaysRedraw {
+		t.Error("AlwaysRedraw did not reach Shape.alwaysRedraw")
+	}
+}

--- a/gui/render_gradient.go
+++ b/gui/render_gradient.go
@@ -219,12 +219,13 @@ func sampleGradRamp(stops []GradientStop, segs []gradRampSegment, pos float32) C
 	if len(stops) == 0 {
 		return RGBA(0, 0, 0, 0)
 	}
-	// Non-finite positions come from degenerate geometry; fold to
-	// the ramp start rather than propagating NaN through the lerp.
-	if pos != pos || math.IsInf(float64(pos), 0) {
-		return stops[0].Color
-	}
-	if pos <= stops[0].Pos {
+	// Non-finite positions come from degenerate geometry and must not
+	// propagate NaN through the lerp. No guard of their own is needed:
+	// NaN fails every comparison and -Inf fails this one, so both fold
+	// to the ramp start, and +Inf falls through to the end test below.
+	// That saves a float64 conversion and an IsInf on every vertex of
+	// every gradient mesh.
+	if !(pos > stops[0].Pos) {
 		return stops[0].Color
 	}
 	if pos >= stops[len(stops)-1].Pos {

--- a/gui/render_gradient_ramp_test.go
+++ b/gui/render_gradient_ramp_test.go
@@ -85,12 +85,21 @@ func TestSampleGradRampNonFinite(t *testing.T) {
 	norm = NormalizeGradientStops(stops, &norm)
 	var segs []gradRampSegment
 	segs = prepareGradRamp(norm, &segs)
-	for _, bad := range []float32{
-		float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
-		got := sampleGradRamp(norm, segs, bad)
-		// Non-finite folds to first stop.
-		if got != norm[0].Color {
-			t.Errorf("pos %v: got %v, want %v", bad, got, norm[0].Color)
+	// NaN and -Inf fold to the ramp start; +Inf folds to its end, the
+	// same side a very large finite position lands on. The dedicated
+	// non-finite guard this replaced sent +Inf to the start as well,
+	// which was the odd one out.
+	last := norm[len(norm)-1].Color
+	for _, tc := range []struct {
+		pos  float32
+		want Color
+	}{
+		{float32(math.NaN()), norm[0].Color},
+		{float32(math.Inf(-1)), norm[0].Color},
+		{float32(math.Inf(1)), last},
+	} {
+		if got := sampleGradRamp(norm, segs, tc.pos); got != tc.want {
+			t.Errorf("pos %v: got %v, want %v", tc.pos, got, tc.want)
 		}
 	}
 }

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -129,6 +129,10 @@ type Shape struct {
 	// Clip scissor-clips children to this element's bounds.
 	Clip bool
 
+	// alwaysRedraw makes a DrawCanvas re-run OnDraw every render pass
+	// instead of trusting Version. See DrawCanvasCfg.AlwaysRedraw.
+	alwaysRedraw bool
+
 	// ClipContents enables stencil-buffer clipping for nested
 	// containers. More expensive than Clip but supports nested
 	// clipping hierarchies.

--- a/gui/testdata/canvas_gradient.dark.golden
+++ b/gui/testdata/canvas_gradient.dark.golden
@@ -1,2 +1,2 @@
 Svg xy=15.00,15.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff
-Svg xy=15.00,15.00 wh=0.00,0.00 color=#ffffff80 tris=1026 vcols=513 first=#ffffffff last=#ffffff00
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#ffffff80 tris=474 vcols=237 first=#ffffffff last=#ffffff00

--- a/gui/testdata/canvas_gradient.light.golden
+++ b/gui/testdata/canvas_gradient.light.golden
@@ -1,2 +1,2 @@
 Svg xy=14.00,14.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff
-Svg xy=14.00,14.00 wh=0.00,0.00 color=#ffffff80 tris=1026 vcols=513 first=#ffffffff last=#ffffff00
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#ffffff80 tris=474 vcols=237 first=#ffffffff last=#ffffff00

--- a/gui/testdata/canvas_gradient_rings.dark.golden
+++ b/gui/testdata/canvas_gradient_rings.dark.golden
@@ -1,0 +1,1 @@
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#40bf00ff tris=2520 vcols=1260 first=#ff0000ff last=#ffff00ff

--- a/gui/testdata/canvas_gradient_rings.light.golden
+++ b/gui/testdata/canvas_gradient_rings.light.golden
@@ -1,0 +1,1 @@
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#40bf00ff tris=2520 vcols=1260 first=#ff0000ff last=#ffff00ff

--- a/gui/view_draw_canvas.go
+++ b/gui/view_draw_canvas.go
@@ -27,6 +27,27 @@ type DrawCanvasCfg struct {
 	Color     Color
 	Sizing    Sizing
 	Clip      bool
+
+	// AlwaysRedraw re-runs OnDraw on every render pass, ignoring
+	// Version.
+	//
+	// It is what makes an animated canvas work under
+	// AnimationRefreshRenderOnly. That refresh kind rebuilds the
+	// renderers from the layout already in hand and never re-runs the
+	// view function — which is the point, since a canvas animating off
+	// its own state has no reason to rebuild the widgets around it —
+	// but Version is stamped onto the shape during view generation, so
+	// a version bump made between frames would never reach the cache
+	// and the canvas would freeze on its first frame.
+	//
+	// Costs nothing where it is wanted: a canvas that bumps Version
+	// every frame never gets a cache hit anyway. The tessellation
+	// buffers are still pooled across redraws either way.
+	//
+	// exportaudit:keep — the app-side half of
+	// AnimationRefreshRenderOnly; an animated canvas is unusable with
+	// that refresh kind without it
+	AlwaysRedraw bool
 }
 
 // drawCanvasView implements View for user-drawn canvas content.
@@ -75,24 +96,25 @@ func (dv *drawCanvasView) GenerateLayout(w *Window) Layout {
 
 	layout := Layout{
 		Shape: w.allocShape(Shape{
-			shapeType: shapeDrawCanvas,
-			ID:        c.ID,
-			Version:   c.Version,
-			A11YRole:  a11yRole,
-			a11Y:      c.a11yInfo(""),
-			Width:     c.Width,
-			Height:    c.Height,
-			MinWidth:  c.MinWidth,
-			MaxWidth:  c.MaxWidth,
-			MinHeight: c.MinHeight,
-			MaxHeight: c.MaxHeight,
-			Sizing:    c.Sizing,
-			Padding:   c.Padding.Or(PaddingNone),
-			Clip:      c.Clip,
-			Color:     c.Color,
-			Radius:    c.Radius,
-			Focusable: c.Focusable,
-			events:    events,
+			shapeType:    shapeDrawCanvas,
+			ID:           c.ID,
+			Version:      c.Version,
+			A11YRole:     a11yRole,
+			a11Y:         c.a11yInfo(""),
+			Width:        c.Width,
+			Height:       c.Height,
+			MinWidth:     c.MinWidth,
+			MaxWidth:     c.MaxWidth,
+			MinHeight:    c.MinHeight,
+			MaxHeight:    c.MaxHeight,
+			Sizing:       c.Sizing,
+			Padding:      c.Padding.Or(PaddingNone),
+			Clip:         c.Clip,
+			alwaysRedraw: c.AlwaysRedraw,
+			Color:        c.Color,
+			Radius:       c.Radius,
+			Focusable:    c.Focusable,
+			events:       events,
 		}),
 	}
 	applyFixedSizingConstraints(layout.Shape)

--- a/gui/view_svg.go
+++ b/gui/view_svg.go
@@ -120,7 +120,7 @@ func (sv *svgView) GenerateLayout(w *Window) Layout {
 				AnimID:  animID,
 				Delay:   animationCycle,
 				Repeat:  true,
-				Refresh: animationRefreshRenderOnly,
+				Refresh: AnimationRefreshRenderOnly,
 				Callback: func(an *Animate, w *Window) {
 					seenMap := StateMap[string, int64](
 						w, nsSvgAnimSeen, capImageCache)

--- a/gui/window_refresh_test.go
+++ b/gui/window_refresh_test.go
@@ -39,15 +39,15 @@ func TestMarkRenderOnlyRefreshSkipsWhenLayoutPending(t *testing.T) {
 }
 
 func TestMaxAnimationRefreshKindPrefersLayout(t *testing.T) {
-	kind := maxAnimationRefreshKind(animationRefreshRenderOnly, AnimationRefreshLayout)
+	kind := maxAnimationRefreshKind(AnimationRefreshRenderOnly, AnimationRefreshLayout)
 	if kind != AnimationRefreshLayout {
 		t.Errorf("got %d, want layout", kind)
 	}
 }
 
 func TestMaxAnimationRefreshKindPrefersRenderOnlyOverNone(t *testing.T) {
-	kind := maxAnimationRefreshKind(animationRefreshNone, animationRefreshRenderOnly)
-	if kind != animationRefreshRenderOnly {
+	kind := maxAnimationRefreshKind(animationRefreshNone, AnimationRefreshRenderOnly)
+	if kind != AnimationRefreshRenderOnly {
 		t.Errorf("got %d, want render_only", kind)
 	}
 }
@@ -240,9 +240,9 @@ func TestAnimateRefreshKindOverride(t *testing.T) {
 	a := &Animate{
 		AnimID:   "test",
 		Callback: func(*Animate, *Window) {},
-		Refresh:  animationRefreshRenderOnly,
+		Refresh:  AnimationRefreshRenderOnly,
 	}
-	if a.RefreshKind() != animationRefreshRenderOnly {
+	if a.RefreshKind() != AnimationRefreshRenderOnly {
 		t.Errorf("got %d, want render_only", a.RefreshKind())
 	}
 }


### PR DESCRIPTION
A radial gradient centred on the circle it fills has isolines that are known in closed form, so the generic subdivision search in `gradmesh` is wasted work. `fillConcentricRings` detects that case and emits one quad strip per stop pair, reading vertex colors straight off the stops — no `RawT`, no `SpreadTri`, no `sampleGradRamp`, no isoline splitting.

Detection compares the caller's own `g.R`/`CX`/`CY`/`FX`/`FY` rather than a resolved copy: float32 does not always round `((cx-r)+(cx+r))*0.5` back to `cx`, so resolving first makes the fast path silently miss.

## Measured

`examples/solar_system`, Apple M5, `-benchtime 3000x`:

| benchmark | before | after | |
| --- | ---: | ---: | --- |
| `WholeFrameFullSystem` | 466 µs | 180 µs | 2.6x |
| `WholeFrameJupiter` | 654 µs | 228 µs | 2.9x |
| allocs/op (full system) | 113 | 99 | |
| allocs/op (jupiter) | 150 | 143 | |

Triangles per frame fall 19676 → 15654 (full system) and 25805 → 19371 (jupiter); batch counts are unchanged. A headless render diff over the whole example is 0.15% of pixels at max delta 1/255.

In the profile `FillTrianglesGradient` went from 58% of the frame to `fillConcentricRings` at 3%.

## Also here

- **`DrawContext.Line` no longer allocates.** It built a `[]float32` literal that escaped through `Polyline`'s recorder call even on the nil-recorder branch. 14 allocs/frame in this example; more in line-heavy apps.
- **`AnimationRefreshRenderOnly` is exported, and `DrawCanvasCfg` gains `AlwaysRedraw`.** `renderOnlyLocked` already did the right thing, but a canvas stamps `Version` during view generation, so under render-only an animated canvas would freeze. `AlwaysRedraw` is that gate; the two are meant to be set together, and the doc comments say so. Consumed by the follow-up PR.
- **`sampleGradRamp` drops a redundant `math.IsInf`.** This moves `+Inf` from the first stop to the last, which is the defensible answer; the test that pinned the old result is updated with the reasoning.

## Optimizations tried and dropped on measurement

Three planned items did not survive:

- Hoisting `RawT`'s loop invariants behind a `Prepare` step — neutral, and the first attempt pushed `RawT` from cost 119 to 216, past the inliner budget, costing 30%.
- One ramp-segment lookup per triangle instead of three scans — **25% slower**. Splitting the tight loop into helpers cost more than the saved scans.
- Skipping `f32AllFinite` on emit — `validSvgCmd` is the only guard on caller-supplied triangles from `FillTrianglesColors`, and an animated canvas never gets a cache hit anyway, so there is nothing to skip without weakening a real guard. A branch-free rewrite of the scan measured slower than the perfectly-predicted branch.

## On the new test file

My first version of the ring mesh drew the innermost fan band at the circle's radius rather than the first stop's, and **the golden test passed anyway** — the canvas golden serializer records triangle counts and endpoint colors, not vertex coordinates. It surfaced only in a headless pixel diff, where the halo came out as a visible lattice.

`gui/canvas_draw_gradient_rings_test.go` asserts the invariant directly: every emitted vertex's distance from the centre must match the ramp position of the color it carries. Plus accept/decline coverage, hard-stop behaviour, and an equivalence check sampling the ring mesh against the general path's mesh (`FilledArcGradient` is the seam that forces the slow path).

## Gates

`make check-all` exits 0; `golangci-lint` 0 issues; `make export-audit` surface clean; `make ergonomics-audit` 0 findings. `gui/testdata/canvas_gradient.{dark,light}.golden` re-recorded after reading the diff (tris 1026 → 474); `canvas_gradient_rings` added in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)