### PR TITLE
perf(examples/solar_system): render-only ticks and static dial geometry

### DIFF
--- a/examples/solar_system/belt.go
+++ b/examples/solar_system/belt.go
@@ -30,7 +30,10 @@ type rock struct {
 	orbitA, ecc, phase, periodS float32
 	zOff                        float32 // out-of-plane offset, world units
 	size                        float32
-	tint                        float32 // brightness variance
+	// col is beltColor scaled by this rock's brightness variance.
+	// Baked here rather than per frame: it is a constant, and the
+	// belt is 600 rocks.
+	col gui.Color
 }
 
 // beltRocks is built once with a fixed seed so a run and a test see
@@ -74,7 +77,7 @@ func makeBelt() []rock {
 
 		rocks = append(rocks, rock{
 			orbitA: a, ecc: ecc, phase: phase, periodS: periodS,
-			zOff: zOff, size: size, tint: tint,
+			zOff: zOff, size: size, col: scaleColor(beltColor, tint),
 		})
 	}
 	return rocks
@@ -121,14 +124,7 @@ func drawBelt(a *App, dc *gui.DrawContext) {
 		if sx+half < 0 || sx-half > dc.Width || sy+half < 0 || sy-half > dc.Height {
 			continue
 		}
-		c := beltColor
-		// Per-rock brightness variance.
-		c = gui.RGBA(
-			chan8(float32(c.R)*r.tint),
-			chan8(float32(c.G)*r.tint),
-			chan8(float32(c.B)*r.tint),
-			c.A,
-		)
+		c := r.col
 		x0, y0 := sx-half, sy-half
 		x1, y1 := sx+half, sy+half
 		m.appendTri(x0, y0, c, x1, y0, c, x1, y1, c)

--- a/examples/solar_system/dial.go
+++ b/examples/solar_system/dial.go
@@ -65,6 +65,12 @@ func init() {
 		midDay := float32(monthStartDay[i]) + float32(monthDays[i])*0.5
 		monthMidAngle[i] = 2 * float32(math.Pi) * midDay / 365
 	}
+
+	// Only now that the calendar is filled.
+	dialDayTicks = makeDialTicks(365, dialInner,
+		dialInner+(dialOuter-dialInner)*0.48)
+	dialMonthTicks = makeDialMonthTicks()
+	dialLabelSegs = makeDialLabelSegs()
 }
 
 // dialAngle is the heliocentric longitude the calendar reads as "now".
@@ -115,39 +121,18 @@ func drawDial(a *App, dc *gui.DrawContext) {
 
 	// Day ticks: 365 short radial segments.
 	if rx >= dialDayMinRx {
-		for d := range 365 {
-			theta := 2 * float32(math.Pi) * float32(d) / 365
-			// Short tick from inner to just past middle.
-			r0 := dialInner
-			r1 := dialInner + (dialOuter-dialInner)*0.48
-			wx0, wy0 := dialPolar(r0, theta)
-			wx1, wy1 := dialPolar(r1, theta)
-			sx0, sy0 := a.worldToScreen(wx0, wy0)
-			sx1, sy1 := a.worldToScreen(wx1, wy1)
-			appendDialSeg(m, sx0, sy0, sx1, sy1, colorDialTick, 0.62)
-		}
+		appendDialSegs(m, a, dialDayTicks, colorDialTick, 0.62)
 	}
 
 	// Month ticks: 12 longer segments crossing both rails.
-	for mi := range 12 {
-		theta := 2 * float32(math.Pi) * monthStartFrac[mi]
-		wx0, wy0 := dialPolar(dialInner, theta)
-		wx1, wy1 := dialPolar(dialOuter, theta)
-		sx0, sy0 := a.worldToScreen(wx0, wy0)
-		sx1, sy1 := a.worldToScreen(wx1, wy1)
-		appendDialSeg(m, sx0, sy0, sx1, sy1, colorDialMonth, 1.05)
-	}
+	appendDialSegs(m, a, dialMonthTicks, colorDialMonth, 1.05)
 
 	// Month labels — stroke font, curving along the ring.
-	emWorld := dialEmWorld
-	emPx := emWorld * z // rough: world em * zoom, but foreshortened at top/bottom; conservative gate uses max.
+	emPx := dialEmWorld * z // rough: world em * zoom, but foreshortened at top/bottom; conservative gate uses max.
 	// More precise legibility: minimum of horizontal and vertical scale. Use emWorld*z*diskTilt as worst case?
 	// Skip only when definitely illegible.
 	if emPx >= dialLabelMinPx {
-		for mi, name := range monthNames {
-			thetaMid := monthMidAngle[mi]
-			drawDialLabel(m, a, name, thetaMid, dialTextR, emWorld)
-		}
+		appendDialSegs(m, a, dialLabelSegs, colorDialText, dialStrokeW)
 	}
 
 	// Date marker — small filled triangle at dialAngle, pointing inward.
@@ -176,19 +161,95 @@ func drawDial(a *App, dc *gui.DrawContext) {
 	dc.FillTrianglesColors(m.tris, m.cols)
 }
 
+// dialDayTicks, dialMonthTicks and dialLabelSegs hold the dial's
+// static geometry in world coordinates, four floats per segment
+// (x0,y0,x1,y1). All three are pure functions of the calendar and of
+// the ring's fixed radii, so the ~2,200 sines and cosines they used to
+// cost on every frame are paid once at startup and the frame path is
+// left with worldToScreen. The ring itself never moves; only the
+// camera does.
+//
+// Filled from init, not from a var initializer, because two of them
+// read monthStartFrac and monthMidAngle — which init fills. Go orders
+// var initializers by the references it can see, and it cannot see
+// through init, so as initializers these would have run against a
+// zeroed calendar. The failure is quiet: every month lands at angle 0,
+// the segment *count* is unchanged, and only the pixels move.
+var (
+	dialDayTicks   []float32
+	dialMonthTicks []float32
+	dialLabelSegs  []float32
+)
+
+// makeDialTicks lays n evenly spaced radial segments from r0 to r1
+// around the whole ring.
+func makeDialTicks(n int, r0, r1 float32) []float32 {
+	dst := make([]float32, 0, n*4)
+	for d := range n {
+		theta := 2 * float32(math.Pi) * float32(d) / float32(n)
+		dst = appendDialTick(dst, r0, r1, theta)
+	}
+	return dst
+}
+
+// makeDialMonthTicks lays one longer segment at each month boundary,
+// which is not an even division: the months differ in length.
+func makeDialMonthTicks() []float32 {
+	dst := make([]float32, 0, 12*4)
+	for mi := range 12 {
+		theta := 2 * float32(math.Pi) * monthStartFrac[mi]
+		dst = appendDialTick(dst, dialInner, dialOuter, theta)
+	}
+	return dst
+}
+
+// appendDialTick appends one radial segment. The two endpoints share
+// an angle, so the trigonometry is done once for both.
+func appendDialTick(dst []float32, r0, r1, theta float32) []float32 {
+	c, s := cos32(theta), sin32(theta)
+	return append(dst, r0*c, r0*s, r1*c, r1*s)
+}
+
+// makeDialLabelSegs flattens all twelve month names into one segment
+// list. They share a color and a stroke width, so nothing at draw time
+// needs to know where one label ends and the next begins.
+func makeDialLabelSegs() []float32 {
+	var dst []float32
+	for mi, name := range monthNames {
+		dst = appendDialLabel(dst, name, monthMidAngle[mi],
+			dialTextR, dialEmWorld)
+	}
+	return dst
+}
+
+// appendDialSegs projects a world-space segment list, four floats per
+// segment, and thickens each one in screen space.
+func appendDialSegs(m *bodyMesh, a *App, segs []float32,
+	c gui.Color, halfW float32,
+) {
+	for i := 0; i+3 < len(segs); i += 4 {
+		sx0, sy0 := a.worldToScreen(segs[i], segs[i+1])
+		sx1, sy1 := a.worldToScreen(segs[i+2], segs[i+3])
+		appendDialSeg(m, sx0, sy0, sx1, sy1, c, halfW)
+	}
+}
+
 // dialPolar converts polar in the orbital plane (r, theta) to world
 // cartesian, with theta measured from world +x.
 func dialPolar(r, theta float32) (wx, wy float32) {
 	return r * cos32(theta), r * sin32(theta)
 }
 
-// drawDialLabel places a month name centered on thetaMid at radius R.
+// appendDialLabel places a month name centered on thetaMid at radius R,
+// appending its stroke segments to dst as world-space endpoint quads.
 // A glyph point (gx,gy) maps with gy outward radially and gx to
 // angular offset by arc length dθ = x_arc / R. Glyph "up" points
 // radially outward everywhere, so labels read from outside.
 //
-// Each segment is projected then thickened perpendicular in screen space
-// by fixed dialStrokeW, so weight stays uniform. The orbital plane is
+// Every term here is fixed by the label's own angle and radius, so the
+// whole placement is done once at init; the frame path only projects
+// the result. Each segment is thickened perpendicular in screen space
+// by fixed dialStrokeW after projection, so weight stays uniform. The orbital plane is
 // foreshortened by diskTilt, so a ring viewed at 29° squashes the
 // vertical axis to 48%: a world arc along +y reaches the screen at
 // half the length of one along +x. Without compensation a Dec/Jun
@@ -206,10 +267,12 @@ func dialPolar(r, theta float32) (wx, wy float32) {
 // Measuring each glyph's min/max X and kerning ink-to-ink makes the
 // visual gaps even; the total label shortens by about 0.7 em but stays
 // within the framed extent.
-func drawDialLabel(m *bodyMesh, a *App, name string, thetaMid, radius, emW float32) {
+func appendDialLabel(dst []float32, name string,
+	thetaMid, radius, emW float32,
+) []float32 {
 	n := len(name)
 	if n == 0 {
-		return
+		return dst
 	}
 	// Local foreshortening at thetaMid. Tangent is (-sin, cos), radial
 	// is (cos, sin); projected length per world unit is sqrt(dx^2 +
@@ -241,7 +304,7 @@ func drawDialLabel(m *bodyMesh, a *App, name string, thetaMid, radius, emW float
 		bnds = append(bnds, bounds{mn, mx})
 	}
 	if len(glyphs) == 0 {
-		return
+		return dst
 	}
 	gapInk := 0.14 * emW / ft
 	// Total ink width along the ring.
@@ -265,9 +328,7 @@ func drawDialLabel(m *bodyMesh, a *App, name string, thetaMid, radius, emW float
 				x1, y1 := poly[k+2], poly[k+3]
 				wx0, wy0 := dialGlyphOriginToWorld(x0, y0, thetaMid, radius, emW, ft, fr, origin)
 				wx1, wy1 := dialGlyphOriginToWorld(x1, y1, thetaMid, radius, emW, ft, fr, origin)
-				sx0, sy0 := a.worldToScreen(wx0, wy0)
-				sx1, sy1 := a.worldToScreen(wx1, wy1)
-				appendDialSeg(m, sx0, sy0, sx1, sy1, colorDialText, dialStrokeW)
+				dst = append(dst, wx0, wy0, wx1, wy1)
 			}
 		}
 		// Advance cursor to next ink left edge.
@@ -276,6 +337,7 @@ func drawDialLabel(m *bodyMesh, a *App, name string, thetaMid, radius, emW float
 			cursor += gapInk
 		}
 	}
+	return dst
 }
 
 // glyphBounds returns the ink extents of g in em units [0,1].

--- a/examples/solar_system/dial_test.go
+++ b/examples/solar_system/dial_test.go
@@ -203,3 +203,68 @@ func TestFullSystemTargetFinite(t *testing.T) {
 		}
 	}
 }
+
+// TestDialTablesMatchCalendar pins the dial's precomputed geometry
+// against the calendar it is derived from.
+//
+// The tables are filled from init because they read monthStartFrac and
+// monthMidAngle, which init also fills. Built as var initializers they
+// would run first, against a zeroed calendar, and every month would
+// land at angle 0. That failure changes no segment count and no
+// triangle count — only where the pixels go — so it has to be checked
+// on the coordinates.
+func TestDialTablesMatchCalendar(t *testing.T) {
+	t.Parallel()
+	if len(dialMonthTicks) != 12*4 {
+		t.Fatalf("dialMonthTicks has %d floats, want %d",
+			len(dialMonthTicks), 12*4)
+	}
+	for mi := range 12 {
+		want := 2 * float32(math.Pi) * monthStartFrac[mi]
+		// The inner endpoint of tick mi, back to an angle.
+		x, y := dialMonthTicks[mi*4], dialMonthTicks[mi*4+1]
+		got := float32(math.Atan2(float64(y), float64(x)))
+		if got < 0 {
+			got += 2 * float32(math.Pi)
+		}
+		if d := absF(got - want); d > 1e-4 {
+			t.Errorf("month %d tick at angle %v, want %v", mi, got, want)
+		}
+		if r := sqrt32(x*x + y*y); absF(r-dialInner) > 1e-2 {
+			t.Errorf("month %d tick inner radius %v, want %v",
+				mi, r, dialInner)
+		}
+	}
+
+	// Every month name must contribute strokes, and the twelve of them
+	// must be spread around the whole ring rather than stacked at one
+	// angle. Four quadrants is the coarsest check that fails when the
+	// calendar reads as zero.
+	if len(dialLabelSegs) == 0 {
+		t.Fatal("dialLabelSegs is empty")
+	}
+	var quad [4]int
+	for i := 0; i+1 < len(dialLabelSegs); i += 2 {
+		x, y := dialLabelSegs[i], dialLabelSegs[i+1]
+		q := 0
+		if x < 0 {
+			q |= 1
+		}
+		if y < 0 {
+			q |= 2
+		}
+		quad[q]++
+		// Glyphs ride the label radius, within one em box of it.
+		// The radial extent is inflated by the inverse local
+		// foreshortening, whose worst case is diskTilt.
+		maxR := dialTextR + dialEmWorld*emHeight/float32(diskTilt) + 2
+		if r := sqrt32(x*x + y*y); r < dialTextR-2 || r > maxR {
+			t.Fatalf("label point %d at radius %v, off the ring", i/2, r)
+		}
+	}
+	for q, n := range quad {
+		if n == 0 {
+			t.Errorf("no label strokes in quadrant %d: %v", q, quad)
+		}
+	}
+}

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -380,10 +380,9 @@ func drawSun(a *App, dc *gui.DrawContext) {
 	// segments for the same reason the planets use three — two would
 	// walk the middle of the face through a washed-out midpoint of the
 	// two ends.
-	a.discStops = sunDiscStops(a.discStops)
 	dc.FilledCircleGradient(cx, cy, r, &gui.CanvasGradient{
 		Radial: true,
-		Stops:  a.discStops,
+		Stops:  sunDiscRamp,
 	})
 
 	drawGranulation(dc, &a.granules, cx, cy, r)
@@ -420,6 +419,10 @@ func sunDiscTone(t float32) gui.Color {
 // The ramp runs inward, so t maps to the radius fraction
 // u = 1 - sunShellSpan*t and the stops come out in reverse order: pos
 // 0 is the core, pos 1 the limb.
+// The ramp is a function of compile-time constants alone, so it is
+// built once rather than rebuilt into a scratch every frame.
+var sunDiscRamp = sunDiscStops(nil)
+
 func sunDiscStops(dst []gui.GradientStop) []gui.GradientStop {
 	dst = dst[:0]
 	// The core tone held flat inside the innermost shell. Without a
@@ -532,6 +535,24 @@ func drawCorona(dc *gui.DrawContext, m *bodyMesh, cx, cy, r, now float32) {
 	m.tris, m.cols = m.tris[:0], m.cols[:0]
 	drift := now * coronaDriftHz * float32(coronaSteps)
 
+	// The noise the boundaries ride on is a function of the angle and
+	// the drift, not of the tier: coronaPoint used to re-sample it
+	// twice per tier at every step, for the same coronaSteps distinct
+	// answers. Sampled once here, the whole fringe costs coronaSteps
+	// noise lookups instead of 2*coronaTiers*coronaSteps.
+	var gain [coronaSteps]float32
+	for k := range gain {
+		gain[k] = 1 - coronaRagged +
+			coronaRagged*edgeAt(float32(k)+drift)
+	}
+
+	// Boundary rings, innermost first. Tier k's outer ring is tier
+	// k+1's inner one, so each of the coronaTiers+1 rings is traced
+	// once and consumed twice. m.prev and m.cur are the sphere's ring
+	// scratch, unused by this mesh and the right shape for the job.
+	inner := appendCoronaRing(m.prev[:0], cx, cy, r, 0, gain[:])
+	outer := m.cur[:0]
+
 	for tier := range coronaTiers {
 		// Innermost, brightest band first; each one starts where the
 		// last ended.
@@ -540,35 +561,59 @@ func drawCorona(dc *gui.DrawContext, m *bodyMesh, cx, cy, r, now float32) {
 		alpha := (1 - f0) * (1 - f0) * 0.5
 		col := colorSunCorona.WithOpacity(alpha)
 
-		aX, aY := coronaPoint(r, 0, f0, drift)
-		bX, bY := coronaPoint(r, 0, f1, drift)
-		for k := 1; k <= coronaSteps; k++ {
-			ang := 2 * math.Pi * float32(k) / coronaSteps
-			cX, cY := coronaPoint(r, ang, f0, drift)
-			dX, dY := coronaPoint(r, ang, f1, drift)
+		outer = appendCoronaRing(outer[:0], cx, cy, r, f1, gain[:])
+		for k := range coronaSteps {
+			i0, i1 := k*2, k*2+2
 			// The same two triangles FilledPolygon's fan emitted,
 			// through appendTri so the winding is measured: the soft
 			// backend accumulates signed coverage over the batch and a
 			// quad wound against its neighbour would carve a seam.
-			m.appendTri(cx+aX, cy+aY, col, cx+cX, cy+cY, col,
-				cx+dX, cy+dY, col)
-			m.appendTri(cx+aX, cy+aY, col, cx+dX, cy+dY, col,
-				cx+bX, cy+bY, col)
-			aX, aY, bX, bY = cX, cY, dX, dY
+			m.appendTri(inner[i0], inner[i0+1], col,
+				inner[i1], inner[i1+1], col,
+				outer[i1], outer[i1+1], col)
+			m.appendTri(inner[i0], inner[i0+1], col,
+				outer[i1], outer[i1+1], col,
+				outer[i0], outer[i0+1], col)
 		}
+		inner, outer = outer, inner
 	}
+	// Hand the scratch back so the next frame reuses the same arrays.
+	m.prev, m.cur = inner, outer
 	dc.FillTrianglesColors(m.tris, m.cols)
 }
 
-// coronaPoint is a point on the fringe boundary at fraction f of the
-// corona's reach, f = 0 being the limb itself. The boundary starts a
-// hair inside the limb so the innermost band always covers the disc's
-// polygon edge.
-func coronaPoint(r, ang, f, drift float32) (x, y float32) {
-	n := edgeAt(ang/(2*math.Pi)*coronaSteps + drift)
-	reach := coronaReach * f * (1 - coronaRagged + coronaRagged*n)
-	rr := r * (1 - 0.015 + reach)
-	return cos32(ang) * rr, sin32(ang) * rr
+// coronaDir is the unit circle the fringe boundaries are traced with,
+// as interleaved cos,sin. ang = 2*pi*k/coronaSteps takes only
+// coronaSteps distinct values however many tiers there are, so the
+// trigonometry is done once here rather than per boundary per frame.
+var coronaDir = makeCoronaDir()
+
+func makeCoronaDir() []float32 {
+	p := make([]float32, 0, coronaSteps*2)
+	for k := range coronaSteps {
+		ang := 2 * float32(math.Pi) * float32(k) / coronaSteps
+		p = append(p, cos32(ang), sin32(ang))
+	}
+	return p
+}
+
+// appendCoronaRing traces one fringe boundary at fraction f of the
+// corona's reach, f = 0 being the limb itself, as coronaSteps+1 screen
+// x,y pairs. The boundary starts a hair inside the limb so the
+// innermost band always covers the disc's polygon edge.
+//
+// The ring closes on a copy of its first point rather than on a
+// wrapped index, which is what lets the tiling loop read consecutive
+// pairs with no modulo and no seam.
+func appendCoronaRing(dst []float32, cx, cy, r, f float32,
+	gain []float32,
+) []float32 {
+	base := len(dst)
+	for k := range coronaSteps {
+		rr := r * (1 - 0.015 + coronaReach*f*gain[k])
+		dst = append(dst, cx+coronaDir[k*2]*rr, cy+coronaDir[k*2+1]*rr)
+	}
+	return append(dst, dst[base], dst[base+1])
 }
 
 // drawPlanets paints the bodies back to front. With the disc tilted,

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -83,9 +83,6 @@ type App struct {
 	glowStops []gui.GradientStop
 	haloStops []gui.GradientStop
 
-	// discStops backs the sun's disc fill, reused for the same reason.
-	discStops []gui.GradientStop
-
 	// stars is drawStars' mesh scratch, on the same footing as the two
 	// below.
 	stars bodyMesh
@@ -209,6 +206,14 @@ func main() {
 				AnimID: tickAnim,
 				Delay:  tickDelay,
 				Repeat: true,
+				// The simulation moves what the canvas paints, never
+				// what the widget tree contains: the info panel and
+				// the nav dots read a.Selected, which only an event
+				// can change. So a tick rebuilds renderers from the
+				// layout already in hand and skips the view pass
+				// entirely. selectBody asks for the layout refresh
+				// when it does move the selection.
+				Refresh: gui.AnimationRefreshRenderOnly,
 				Callback: func(_ *gui.Animate, w *gui.Window) {
 					tick(state(w))
 				},
@@ -244,12 +249,18 @@ func tick(a *App) {
 // selectBody focuses a planet by index or the sun with selSun, and
 // clears the selection with -1. Re-selecting what is already selected
 // is a no-op so a repeated click does not restart the tween.
-func selectBody(a *App, i int) {
+func selectBody(a *App, w *gui.Window, i int) {
 	if i == a.Selected {
 		return
 	}
 	a.beginTransition()
 	a.Selected = i
+	// The only App field the view reads. Under a render-only tick
+	// nothing re-runs mainView on its own, so the info panel and the
+	// nav dots would keep showing the previous body without this.
+	if w != nil {
+		w.UpdateWindow()
+	}
 	// A manual zoom belongs to the view the user was in; carrying it
 	// into the next selection is what makes zoom "fight" the camera.
 	a.UserZoom = 1
@@ -262,7 +273,7 @@ func selectBody(a *App, i int) {
 // The walk runs over a *rank* rather than over Selected directly,
 // because selSun is deliberately outside the planet index range and so
 // is not adjacent to Mercury in arithmetic.
-func stepSelection(a *App, delta int) {
+func stepSelection(a *App, w *gui.Window, delta int) {
 	n := len(planets) + 1 // the sun takes rank 0
 
 	rank := 0
@@ -272,19 +283,19 @@ func stepSelection(a *App, delta int) {
 	case a.Selected >= 0:
 		rank = a.Selected + 1
 	case delta > 0:
-		selectBody(a, selSun)
+		selectBody(a, w, selSun)
 		return
 	default:
-		selectBody(a, len(planets)-1)
+		selectBody(a, w, len(planets)-1)
 		return
 	}
 
 	rank = ((rank+delta)%n + n) % n
 	if rank == 0 {
-		selectBody(a, selSun)
+		selectBody(a, w, selSun)
 		return
 	}
-	selectBody(a, rank-1)
+	selectBody(a, w, rank-1)
 }
 
 // handleEvent takes the window-level keys, which must work without the
@@ -296,14 +307,14 @@ func handleEvent(e *gui.Event, w *gui.Window) {
 	a := state(w)
 	switch e.KeyCode {
 	case gui.KeyLeft:
-		stepSelection(a, -1)
+		stepSelection(a, w, -1)
 		e.IsHandled = true
 	case gui.KeyRight:
-		stepSelection(a, 1)
+		stepSelection(a, w, 1)
 		e.IsHandled = true
 	case gui.KeyEscape:
 		if a.Selected != -1 {
-			selectBody(a, -1)
+			selectBody(a, w, -1)
 			e.IsHandled = true
 		}
 	case gui.KeyEqual, gui.KeyKPAdd:

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -151,29 +151,29 @@ func TestSelectionWrapsBothWays(t *testing.T) {
 	a := newTestApp()
 	last := len(planets) - 1
 
-	stepSelection(a, 1)
+	stepSelection(a, nil, 1)
 	if a.Selected != selSun {
 		t.Fatalf("first Right = %d, want the sun (%d)", a.Selected, selSun)
 	}
-	stepSelection(a, 1)
+	stepSelection(a, nil, 1)
 	if a.Selected != 0 {
 		t.Fatalf("Right from the sun = %d, want 0", a.Selected)
 	}
-	stepSelection(a, -1)
+	stepSelection(a, nil, -1)
 	if a.Selected != selSun {
 		t.Errorf("Left from 0 = %d, want the sun (%d)", a.Selected, selSun)
 	}
-	stepSelection(a, -1)
+	stepSelection(a, nil, -1)
 	if a.Selected != last {
 		t.Errorf("Left from the sun = %d, want %d", a.Selected, last)
 	}
-	stepSelection(a, 1)
+	stepSelection(a, nil, 1)
 	if a.Selected != selSun {
 		t.Errorf("Right from last = %d, want the sun (%d)", a.Selected, selSun)
 	}
 
 	a.Selected = -1
-	stepSelection(a, -1)
+	stepSelection(a, nil, -1)
 	if a.Selected != last {
 		t.Errorf("first Left = %d, want %d", a.Selected, last)
 	}
@@ -189,7 +189,7 @@ func TestSunIsSelectable(t *testing.T) {
 	if got := a.hitTest(a.SunX, a.SunY); got != selSun {
 		t.Fatalf("hitTest at the sun = %d, want %d", got, selSun)
 	}
-	selectBody(a, selSun)
+	selectBody(a, nil, selSun)
 	for range tweenTicks + 4 {
 		tick(a)
 	}
@@ -248,7 +248,7 @@ func TestSunFactsPopulated(t *testing.T) {
 func TestCameraTweenReachesTarget(t *testing.T) {
 	t.Parallel()
 	a := newTestApp()
-	selectBody(a, 4) // Jupiter
+	selectBody(a, nil, 4) // Jupiter
 
 	for range tweenTicks + 4 {
 		tick(a)
@@ -270,7 +270,7 @@ func TestCameraTweenReachesTarget(t *testing.T) {
 func TestCameraFollowsOrbitingPlanet(t *testing.T) {
 	t.Parallel()
 	a := newTestApp()
-	selectBody(a, 0) // Mercury, the fastest
+	selectBody(a, nil, 0) // Mercury, the fastest
 
 	for range 2*tweenTicks + 200 {
 		tick(a)
@@ -291,13 +291,13 @@ func TestCameraFollowsOrbitingPlanet(t *testing.T) {
 func TestInterruptedTransitionIsContinuous(t *testing.T) {
 	t.Parallel()
 	a := newTestApp()
-	selectBody(a, 7)
+	selectBody(a, nil, 7)
 	for range 10 {
 		tick(a)
 	}
 	midX, midZoom := a.CamX, a.CamZoom
 
-	selectBody(a, 1)
+	selectBody(a, nil, 1)
 	if a.FromX != midX || a.FromZoom != midZoom {
 		t.Errorf("transition origin (%.3f,%.3f), want current camera "+
 			"(%.3f,%.3f)", a.FromX, a.FromZoom, midX, midZoom)
@@ -462,7 +462,7 @@ func TestShadingFacesTheSun(t *testing.T) {
 	}
 
 	b := newTestApp()
-	selectBody(b, 4)
+	selectBody(b, nil, 4)
 	for range 240 {
 		for range 30 {
 			tick(b)
@@ -871,8 +871,8 @@ func TestDrawSystemGeometryIsFinite(t *testing.T) {
 		{"full system", func(*App) {}},
 		{"hovered planet", func(a *App) { a.Hovered = 2 }},
 		{"hovered sun", func(a *App) { a.Hovered = selSun }},
-		{"selected planet", func(a *App) { selectBody(a, saturnIndex) }},
-		{"selected sun", func(a *App) { selectBody(a, selSun) }},
+		{"selected planet", func(a *App) { selectBody(a, nil, saturnIndex) }},
+		{"selected sun", func(a *App) { selectBody(a, nil, selSun) }},
 		{"zoomed in", func(a *App) { a.applyUserZoom(userZoomMax) }},
 		{"zoomed out", func(a *App) { a.applyUserZoom(userZoomMin) }},
 	}

--- a/examples/solar_system/panel.go
+++ b/examples/solar_system/panel.go
@@ -186,7 +186,7 @@ func navDot(a *App, id string, sel int, name string, size float32,
 		Colors:  gui.Flat(color),
 		A11YCfg: gui.A11YCfg{A11YLabel: name},
 		OnClick: func(ctx gui.EventCtx) {
-			selectBody(state(ctx.Window), sel)
+			selectBody(state(ctx.Window), ctx.Window, sel)
 			ctx.Consume()
 		},
 	})

--- a/examples/solar_system/view.go
+++ b/examples/solar_system/view.go
@@ -48,6 +48,12 @@ func solarCanvas(a *App) gui.View {
 		Padding:   gui.NoPadding,
 		Version:   a.Version,
 		Focusable: true,
+
+		// The tick animation refreshes renderers only, so no view pass
+		// runs to carry Version into the redraw gate. AlwaysRedraw is
+		// the other half of that pairing; without it the canvas would
+		// freeze on frame one.
+		AlwaysRedraw: true,
 		A11YCfg: gui.A11YCfg{
 			A11YLabel: "Solar system map",
 			A11YDescription: "Hover a body to identify it, click to " +
@@ -79,7 +85,8 @@ func solarCanvas(a *App) gui.View {
 			if ctx.Event == nil {
 				return
 			}
-			selectBody(a, a.hitTest(ctx.Event.MouseX, ctx.Event.MouseY))
+			selectBody(a, ctx.Window,
+				a.hitTest(ctx.Event.MouseX, ctx.Event.MouseY))
 			ctx.Consume()
 		},
 

--- a/examples/solar_system/zz_effbench_test.go
+++ b/examples/solar_system/zz_effbench_test.go
@@ -158,3 +158,113 @@ func benchWholeFrame(b *testing.B, sel int) {
 
 func BenchmarkWholeFrameFullSystem(b *testing.B) { benchWholeFrame(b, -1) }
 func BenchmarkWholeFrameJupiter(b *testing.B)    { benchWholeFrame(b, 4) }
+
+// benchWholeFrameRenderOnly drives the frame the running app actually
+// gets: the tick animation asks for AnimationRefreshRenderOnly, so
+// renderers are rebuilt from the layout already in hand and no view
+// pass runs. benchWholeFrame above keeps measuring the full rebuild,
+// which is what a selection change still costs.
+func benchWholeFrameRenderOnly(b *testing.B, sel int) {
+	a := newApp()
+	a.CanvasW, a.CanvasH = windowW, windowH
+	a.Selected = sel
+	for range 120 {
+		tick(a)
+	}
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  a,
+		Width:  windowW,
+		Height: windowH,
+	})
+	w.TestRender(mainView)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		tick(a)
+		// What the animation loop queues for this refresh kind.
+		w.RequestRedraw()
+		w.FrameFn()
+	}
+}
+
+func BenchmarkWholeFrameRenderOnlyFullSystem(b *testing.B) {
+	benchWholeFrameRenderOnly(b, -1)
+}
+
+func BenchmarkWholeFrameRenderOnlyJupiter(b *testing.B) {
+	benchWholeFrameRenderOnly(b, 4)
+}
+
+// TestRenderOnlyTickRedrawsCanvas pins the pairing the tick animation
+// depends on. Under AnimationRefreshRenderOnly no view pass runs, so
+// a.Version never reaches renderDrawCanvas's redraw gate; without
+// DrawCanvasCfg.AlwaysRedraw the second frame would replay the first
+// frame's triangles and the system would appear frozen.
+func TestRenderOnlyTickRedrawsCanvas(t *testing.T) {
+	a := newApp()
+	a.CanvasW, a.CanvasH = windowW, windowH
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  a,
+		Width:  windowW,
+		Height: windowH,
+	})
+	w.TestRender(mainView)
+
+	first := canvasTriangleSum(w)
+	// Far enough for the planets to have moved measurably, but still
+	// only render-only frames.
+	for range 30 {
+		tick(a)
+		w.RequestRedraw()
+		w.FrameFn()
+	}
+	if got := canvasTriangleSum(w); got == first {
+		t.Fatalf("canvas geometry unchanged after 30 render-only "+
+			"frames (checksum %v); AlwaysRedraw is not reaching the "+
+			"redraw gate", got)
+	}
+}
+
+// canvasTriangleSum checksums every triangle vertex the window's
+// renderers carry, which is the canvas mesh and nothing else — the
+// panel and the dots emit rects and text.
+func canvasTriangleSum(w *gui.Window) float64 {
+	var sum float64
+	for _, r := range w.Renderers() {
+		for _, v := range r.Triangles {
+			sum += float64(v)
+		}
+	}
+	return sum
+}
+
+// TestSelectBodyRefreshesView pins the other half: a selection change
+// is the one thing the render-only tick cannot show, so selectBody has
+// to ask for a layout pass itself.
+func TestSelectBodyRefreshesView(t *testing.T) {
+	a := newApp()
+	a.CanvasW, a.CanvasH = windowW, windowH
+	w := gui.NewWindow(gui.WindowCfg{
+		State:  a,
+		Width:  windowW,
+		Height: windowH,
+	})
+	w.TestRender(mainView)
+
+	selectBody(a, w, saturnIndex)
+	if !w.FrameFn() {
+		t.Fatal("selectBody did not mark the window for a rebuild")
+	}
+	want := planets[saturnIndex].Name
+	found := false
+	for _, r := range w.Renderers() {
+		if r.Text == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("info panel does not name %q after selectBody", want)
+	}
+}


### PR DESCRIPTION
**Stacked on #449** — base is `perf/canvas-gradient-fast-path`, so the diff here is the example only. GitHub will retarget this to `main` when #449 merges.

Five changes, ordered by what the profile showed *after* #449 landed.

**Render-only ticks.** The simulation moves what the canvas paints, never what the widget tree contains: the info panel and the nav dots read `a.Selected`, which only an event changes. So the tick animation asks for `AnimationRefreshRenderOnly` and the canvas sets `AlwaysRedraw`, and `selectBody` takes the `*Window` so it can ask for the layout pass itself when the selection does move.

**Dial geometry precomputed.** The 365 day ticks, the 12 month ticks and all twelve month labels are fixed by the calendar and by the ring's own radii — foreshortening compensation, ink bounds, kerning and the glyph-to-world map included. About 2,200 sines and cosines per frame become a world-space segment table built once, and the frame path is left with `worldToScreen`. This is also where the two per-label `make` calls went.

**Corona boundary rings.** The noise the fringe rides on depends on the angle and the drift, not on the tier, and the angle takes only `coronaSteps` distinct values however many tiers there are. Each of the `coronaTiers+1` boundary rings is now traced once and consumed twice — tier k's outer ring is tier k+1's inner one — instead of `coronaPoint` re-deriving both from scratch at every step of every tier.

**Belt tint and sun disc ramp** are constants, so both are built at init.

## Measured

Apple M5, `-benchtime 3000x`. Full layout rebuild:

| benchmark | before | after | |
| --- | ---: | ---: | --- |
| `WholeFrameFullSystem` | 174 µs | 156 µs | 99 → 78 allocs/op |
| `WholeFrameJupiter` | 222 µs | 206 µs | 143 → 122 allocs/op |

And the render-only frame the running app now actually gets:

| benchmark | after | |
| --- | ---: | --- |
| `WholeFrameRenderOnlyFullSystem` | 149 µs | 2 allocs/op |
| `WholeFrameRenderOnlyJupiter` | 194 µs | 2 allocs/op |

Against the pre-#449 baseline that is 466 µs → 149 µs and 654 µs → 194 µs, with 113 and 150 allocs per frame down to 2.

The headless render is unchanged but for the corona's ring closure, which now closes on a copy of its first point instead of evaluating `cos(2π)`: 0.0004% of pixels at max delta 1/255.

## Dropped on measurement

Three plan items are deliberately **not** here, because re-profiling after #449 changed the shape of the frame:

- **Nav-dot ID table** — the view phase no longer runs per frame, so there are no per-frame ID builds left to remove.
- **Folding the axis line into the body mesh** — `dc.Line` stopped allocating in #449, and the remaining `Polyline` time is all `Arc`, from the rails and orbits.
- **Star twinkle recurrence** — 220 sines per frame is below the profiler's sampling floor, and a per-star recurrence would couple `drawStars` to the tick rate for nothing.

Moving `ellipsePos`'s sanitizing branches to init was also dropped: `belt_test.go` pins that function's handling of a non-positive period and an out-of-range eccentricity.

## `TestDialTablesMatchCalendar`

This exists because the tables were first written as package-var initializers, which Go runs **before** `init()` — and `init()` is what fills `monthStartFrac` and `monthMidAngle`. Dependency analysis cannot see through `init`, so every month was placed at angle 0.

Segment counts, triangle counts and every existing dial test were unaffected; only the pixels moved. I caught it on a headless screenshot diff and bisected by file. The new test checks the coordinates: the month ticks against the calendar, and the label strokes for a spread across all four quadrants. Note the quadrant half is what actually catches it — comparing tick angles against `monthStartFrac` passes when the calendar itself reads zero, since both sides are wrong together.

`TestRenderOnlyTickRedrawsCanvas` and `TestSelectBodyRefreshesView` pin the two halves of the render-only pairing; both were confirmed to fail with their respective change reverted.

## Where the time is now

The frame is dominated by the planet sphere mesh (`appendRing`/`appendStrip`/`appendTri` plus texture sampling, ~45%), then `validSvgCmd`'s `f32AllFinite` at 13% and `meanColor` at 5.6% — both framework, both scanning geometry the tessellator just produced. Those are the next real targets, and neither is in this example.

## Gates

`make check-all` exits 0; `golangci-lint` 0 issues; export and ergonomics audits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)