### PR TITLE
ci: run CI on merge_group so a merge queue can be enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The merge queue builds each candidate against the projected
+  # post-merge state and needs the required checks to report on that
+  # commit. Without this trigger nothing reports, and every queued PR
+  # sits until the queue times out and evicts it.
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

`main` has `required_status_checks.strict = true` with 14 required
contexts and a ~10 minute suite. That serializes merging at one PR per
CI cycle: the moment any PR lands, every other open PR flips to
`BEHIND` and must rebase, and the rebase produces a new head SHA that
re-runs all 14 checks from zero.

The recent #449 / #451 / #450 stack paid this twice. Once legitimately
(#450 genuinely depends on #449) and once for nothing — #451 was a
markdown spec file with no overlap of any kind with #450's Go code, and
#450 still burned a full cycle proving it.

A merge queue gives the same guarantee `strict` gives — nothing lands
without being tested against the state it will actually land on — but
tests candidates against the *projected* post-merge state, so
independent PRs land in one cycle instead of *n*.

## What this does

Adds a `merge_group:` trigger to `ci.yml`. That is the whole diff.

It is a prerequisite, not the switch. The queue waits for the required
checks to report on the merge-group commit; without this trigger
nothing reports there and every queued PR sits until the
check-response timeout evicts it. Enabling the queue before this lands
would break merging.

## Audit of the required jobs under `merge_group`

No job needed a guard change:

- **Coverage** — the actual gate (`scripts/coverage-gate.sh`) runs
  unconditionally. Only the baseline restore/diff steps are
  `if: github.event_name == 'pull_request'`; they skip cleanly and are
  informational.
- Both `github.event.pull_request.base.sha` references (lines 90, 478)
  are already inside `pull_request`-guarded steps, so neither
  dereferences an empty context.
- **Benchmark regression gate** is `pull_request`-only, but it is not
  a required context, so it cannot stall the queue.
- Every other required job runs on all events.

## Known gap

Three required contexts — `Analyze (go)`, `Analyze (actions)`,
`Analyze (c-cpp)` — come from CodeQL **default setup**, not from a
workflow file, so there is no trigger here to add. Default setup is
documented to run on merge groups, but that is unverified on this repo.
If it does not, the first queued PR stalls and is evicted after the
check-response timeout — visible and self-healing, not destructive. The
fix would be to drop those three from required contexts (they would
still run on every PR) or convert CodeQL to an advanced workflow file.

## Follow-up, after this lands

1. Create a ruleset carrying only a `merge_queue` rule: `SQUASH`,
   `ALLGREEN`, batch 5, 5 min min-wait, 60 min check timeout.
2. Set `strict: false` on classic branch protection — the queue makes
   it redundant, and leaving both on means a PR shows `BEHIND` before
   it can even enter the queue.
3. Smoke-test with a real PR and confirm all 14 contexts report on the
   merge-group commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)