### PR TITLE
docs(contributing): document the merge queue on main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,25 @@ the bare read is also what makes `gui.Themed` subtree scoping work.
 2. Add or update tests.
 3. Run `make prepush` (fast subset: `make check`).
 4. Open a pull request against `main`.
+5. Once review and CI pass, add the PR to the merge queue — the web UI's "Merge
+   when ready" button, or `gh pr merge --auto --squash`.
+
+### Merge queue
+
+`main` merges through a queue rather than directly. The queue rebuilds each
+candidate against the state it will actually land on, so branches no longer need
+to be up to date before merging: an unrelated PR landing first does not make
+yours stale, and independent PRs land together in one CI cycle instead of one
+each.
+
+Practical consequences:
+
+- Do not rebase just because `main` moved. The queue does that, and a force-push
+  drops your entry and restarts its checks.
+- CI runs a second time on the merge-group commit. That run is the one that
+  gates the merge; the PR run is the early signal.
+- A failure evicts only the entry that caused it. The rest of the batch
+  continues.
 
 ## Claude Code hooks
 


### PR DESCRIPTION
Documents the merge queue enabled after #455, and doubles as the first
PR through it.

## Change

Adds a "Merge queue" subsection to `Submitting Changes` in
`CONTRIBUTING.md`. Two behaviours are non-obvious enough to be worth
writing down:

- **Do not rebase because `main` moved.** That was required until now
  (`strict: true`); it is now counterproductive, since a force-push
  drops the queue entry and restarts its checks.
- **CI runs twice.** The merge-group run is the one that gates the
  merge; the PR run is the early signal.

Docs only. No code, no workflow change.

## What this PR is verifying

`main` now has ruleset `21760479` ("main merge queue", SQUASH /
ALLGREEN / batch 5 / 60-min check timeout) and
`required_status_checks.strict` is `false` — the queue subsumes it.
Protection was diffed before and after; `strict` was the only field
that changed.

The open question is whether the three CodeQL contexts — `Analyze
(go)`, `Analyze (actions)`, `Analyze (c-cpp)` — report on a merge-group
commit. They come from code scanning **default setup**, not from
`ci.yml`, so the `merge_group` trigger added in #455 could not be
applied to them.

Merge this via the queue, not directly, and watch the merge-group run:

- **All 14 report** → queue is working, nothing further to do.
- **The three `Analyze` contexts hang** → the entry is evicted after 60
  minutes. Undo with
  `gh api --method DELETE repos/go-gui-org/go-gui/rulesets/21760479`,
  then either drop those three from required contexts (they would still
  run on PRs) or convert CodeQL to an advanced workflow file that can
  carry the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)