### PR TITLE
fix(backend/gl): scale Xcursor size and prefer themed cursors on HiDPI X11

### DIFF
--- a/gui/backend/gl/cursors_x11.go
+++ b/gui/backend/gl/cursors_x11.go
@@ -3,9 +3,9 @@
 package gl
 
 // cursors_x11.go — server-side wiring for themed Xcursor cursors.
-// Loads the diagonal resize images parsed in xcursor.go and uploads
-// them via the RENDER extension. Split from platform_x11.go to stay
-// under the 800-line gate for gui/ source files.
+// Loads the images parsed in xcursor.go and uploads them via the
+// RENDER extension. Split from platform_x11.go to keep it focused
+// on window setup.
 
 import (
 	"os"

--- a/gui/backend/gl/dpi_x11.go
+++ b/gui/backend/gl/dpi_x11.go
@@ -105,11 +105,12 @@ func crtcDPI(info *randr.GetCrtcInfoReply, out *randr.GetOutputInfoReply) (float
 }
 
 // maybeRescaleDPI re-evaluates the per-monitor scale when the window has
-// moved to a CRTC with a different DPI, updating plat.scale and the glyph
-// backend. It reports whether the scale changed so the caller can trigger
-// a relayout. ConfigureNotify coordinates are frame-relative under a
-// reparenting WM, so the true root position is queried explicitly and a
-// RandR rescan runs only when that position changed.
+// moved to a CRTC with a different DPI, updating plat.scale, the glyph
+// backend, and the cursor set. It reports whether the scale changed so
+// the caller can trigger a relayout. ConfigureNotify coordinates are
+// frame-relative under a reparenting WM, so the true root position is
+// queried explicitly and a RandR rescan runs only when that position
+// changed.
 func (b *Backend) maybeRescaleDPI() bool {
 	if !b.plat.haveRandr {
 		return false
@@ -136,5 +137,7 @@ func (b *Backend) maybeRescaleDPI() bool {
 	if b.glyphBack != nil {
 		b.glyphBack.dpiScale = scale
 	}
+	// Themed cursors were sized for the old monitor's scale; reload.
+	b.plat.reloadCursors()
 	return true
 }

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -231,7 +231,12 @@ func loadCursors(p *platformState) {
 	font := xproto.Font(fid)
 	xproto.OpenFont(p.conn, font, uint16(len("cursor")), "cursor")
 
-	load := func(glyph uint16) xproto.Cursor {
+	// The core cursor font ignores the Xcursor size and never scales
+	// for HiDPI (issue #453), so every shape prefers the desktop's
+	// Xcursor theme, uploaded via the RENDER extension. The font glyph
+	// is the per-shape fallback when no themed cursor is available (no
+	// theme, no RENDER, parse error) — never a hard error.
+	loadGlyph := func(glyph uint16) xproto.Cursor {
 		cid, cerr := p.conn.NewId()
 		if cerr != nil {
 			return 0
@@ -242,29 +247,49 @@ func loadCursors(p *platformState) {
 			0, 0, 0, 0xffff, 0xffff, 0xffff)
 		return c
 	}
-	p.cursors[gui.CursorDefault] = load(xcLeftPtr)
-	p.cursors[gui.CursorArrow] = load(xcLeftPtr)
-	p.cursors[gui.CursorIBeam] = load(xcXterm)
-	p.cursors[gui.CursorCrosshair] = load(xcCrosshair)
-	p.cursors[gui.CursorPointingHand] = load(xcHand2)
-	p.cursors[gui.CursorResizeEW] = load(xcSbHDoubleArrow)
-	p.cursors[gui.CursorResizeNS] = load(xcSbVDoubleArrow)
-	// The core cursor font has no rotated double-arrow glyph, so the
-	// diagonal resize shapes come from the desktop's Xcursor theme
-	// when one is available. Any failure (no theme, no RENDER, parse
-	// error) falls back to the corner glyphs — never a hard error.
+
 	// Theme and size are resolved once: each step reads X root-window
-	// properties.
+	// properties. Xcursor sizes are logical pixels; scaledCursorSize
+	// multiplies by the monitor scale to pick the image the theme
+	// intended for this DPI (issue #453).
 	theme := xcursorThemeName(p.conn, p.root)
-	size := xcursorThemeSize(p.conn, p.root)
-	p.cursors[gui.CursorResizeNWSE] = xcursorThemeCursor(p, theme, size, nwseCursorNames)
-	if p.cursors[gui.CursorResizeNWSE] == 0 {
-		p.cursors[gui.CursorResizeNWSE] = load(xcBottomRightCorner)
+	size := scaledCursorSize(xcursorThemeSize(p.conn, p.root), p.scale)
+	load := func(names []string, glyph uint16) xproto.Cursor {
+		if c := xcursorThemeCursor(p, theme, size, names); c != 0 {
+			return c
+		}
+		return loadGlyph(glyph)
 	}
-	p.cursors[gui.CursorResizeNESW] = xcursorThemeCursor(p, theme, size, neswCursorNames)
-	if p.cursors[gui.CursorResizeNESW] == 0 {
-		p.cursors[gui.CursorResizeNESW] = load(xcBottomLeftCorner)
+	p.cursors[gui.CursorDefault] = load(leftPtrCursorNames, xcLeftPtr)
+	p.cursors[gui.CursorArrow] = load(leftPtrCursorNames, xcLeftPtr)
+	p.cursors[gui.CursorIBeam] = load(xtermCursorNames, xcXterm)
+	p.cursors[gui.CursorCrosshair] = load(crosshairCursorNames, xcCrosshair)
+	p.cursors[gui.CursorPointingHand] = load(handCursorNames, xcHand2)
+	p.cursors[gui.CursorResizeEW] = load(hResizeCursorNames, xcSbHDoubleArrow)
+	p.cursors[gui.CursorResizeNS] = load(vResizeCursorNames, xcSbVDoubleArrow)
+	p.cursors[gui.CursorResizeNWSE] = load(nwseCursorNames, xcBottomRightCorner)
+	p.cursors[gui.CursorResizeNESW] = load(neswCursorNames, xcBottomLeftCorner)
+	p.cursors[gui.CursorResizeAll] = load(moveCursorNames, xcFleur)
+	p.cursors[gui.CursorNotAllowed] = load(notAllowedCursorNames, xcXCursor)
+	// reloadCursors calls this again per DPI rescale, so the font can't
+	// stay open; X protocol ordering runs the glyph-cursor creations
+	// queued above before this closes the font.
+	xproto.CloseFont(p.conn, font)
+}
+
+// reloadCursors frees the current cursor handles and loads a fresh set
+// at the current monitor scale. Called when the window moves to a
+// monitor with a different DPI so themed cursors stay correctly sized
+// (issue #453). curCursor is reset so setCursor re-applies the active
+// shape next frame. The window keeps showing the freed cursor until
+// then — the server holds its own reference from the window attribute.
+func (p *platformState) reloadCursors() {
+	for i, c := range p.cursors {
+		if c != 0 {
+			xproto.FreeCursor(p.conn, c)
+			p.cursors[i] = 0
+		}
 	}
-	p.cursors[gui.CursorResizeAll] = load(xcFleur)
-	p.cursors[gui.CursorNotAllowed] = load(xcXCursor)
+	p.curCursor = 0
+	loadCursors(p)
 }

--- a/gui/backend/gl/xcursor.go
+++ b/gui/backend/gl/xcursor.go
@@ -4,11 +4,13 @@ package gl
 
 // xcursor.go — pure-Go Xcursor cursor-file parsing and theme resolution.
 //
-// The X11 core cursor font has no rotated double-arrow glyph, so the
-// diagonal resize shapes are loaded from the desktop's Xcursor theme
-// (the same .cursor files GTK renders) and uploaded via the RENDER
-// extension's CreateCursor. Everything in this file is X-free so it
-// can be unit-tested headlessly; the X wiring lives in platform_x11.go.
+// Cursor shapes are loaded from the desktop's Xcursor theme (the same
+// .cursor files GTK renders) and uploaded via the RENDER extension's
+// CreateCursor. The X11 core cursor font ignores the Xcursor size and
+// never scales for HiDPI, so it is only the fallback when no themed
+// cursor is available (issue #453). Everything in this file is X-free
+// so it can be unit-tested headlessly; the X wiring lives in
+// platform_x11.go.
 //
 // Format reference: the Xcursor library spec (magic "Xcur", LSBFirst
 // 32-bit header/TOC, chunk types 0xfffd0001=comment, 0xfffd0002=image
@@ -157,6 +159,18 @@ func parseXcursorChunk(data []byte, pos, end uint32) (xcursorImage, error) {
 		img.Pixels[i] = binary.LittleEndian.Uint32(px[i*4:])
 	}
 	return img, nil
+}
+
+// scaledCursorSize converts the logical Xcursor size (logical pixels)
+// to the physical-pixel size the monitor's scale needs. scale ≤ 0
+// means "unknown" and leaves the size untouched; otherwise it
+// multiplies, rounds to the nearest integer, and clamps to ≥ 1 so a
+// fractional scale never rounds down to zero.
+func scaledCursorSize(size int, scale float32) int {
+	if scale <= 0 {
+		return size
+	}
+	return max(1, int(float64(size)*float64(scale)+0.5))
 }
 
 // bestFit selects the image libXcursor would render for size: the
@@ -345,13 +359,24 @@ func xcursorSearchDirs() []string {
 	return dirs
 }
 
-// Logical Xcursor names for the two diagonal resize shapes, tried in
-// order per theme dir. Themes use size_fdiag/size_bdiag (Bibata,
-// XCursor-Pro) or the aliases nwse-resize/nesw-resize (Adwaita, Yaru),
-// with the historical fd/bd_double_arrow names as a last resort.
+// Logical Xcursor names per cursor shape, tried in order per theme
+// dir. Themes use the Wayland-era names (Adwaita, Yaru) or one of the
+// classic libXcursor aliases (Bibata, XCursor-Pro, DMZ); the historical
+// core-font-derived names are last resorts. The lists cover every
+// shape the backend can show: the core cursor font ignores both the
+// Xcursor size and HiDPI scaling, so it is only a fallback (issue
+// #453).
 var (
-	nwseCursorNames = []string{"nwse-resize", "size_fdiag", "bd_double_arrow"}
-	neswCursorNames = []string{"nesw-resize", "size_bdiag", "fd_double_arrow"}
+	leftPtrCursorNames    = []string{"left_ptr", "default", "arrow", "top_left_arrow"}
+	xtermCursorNames      = []string{"xterm", "ibeam", "text"}
+	crosshairCursorNames  = []string{"crosshair", "cross", "cross_reverse", "diamond_cross", "tcross"}
+	handCursorNames       = []string{"hand2", "pointer", "hand1", "pointing_hand"}
+	hResizeCursorNames    = []string{"sb_h_double_arrow", "ew-resize", "col-resize", "h_double_arrow", "split_h", "size_hor"}
+	vResizeCursorNames    = []string{"sb_v_double_arrow", "ns-resize", "row-resize", "v_double_arrow", "split_v", "size_ver"}
+	nwseCursorNames       = []string{"nwse-resize", "size_fdiag", "bd_double_arrow"}
+	neswCursorNames       = []string{"nesw-resize", "size_bdiag", "fd_double_arrow"}
+	moveCursorNames       = []string{"fleur", "all-scroll", "move", "size_all"}
+	notAllowedCursorNames = []string{"X_cursor", "not-allowed", "circle", "crossed_circle", "no-drop"}
 )
 
 // themeInheritsOf returns the Inherits chain of theme from the first

--- a/gui/backend/gl/xcursor_test.go
+++ b/gui/backend/gl/xcursor_test.go
@@ -135,6 +135,33 @@ func TestParseXcursorFileMalformed(t *testing.T) {
 	}
 }
 
+// TestScaledCursorSize covers the HiDPI size multiplier applied to the
+// logical Xcursor size: unknown/bogus scales leave the size untouched,
+// fractional scales round, and a rounded-to-zero result clamps to 1
+// (issue #453).
+func TestScaledCursorSize(t *testing.T) {
+	cases := []struct {
+		size  int
+		scale float32
+		want  int
+	}{
+		{24, 1, 24},
+		{24, 2, 48},
+		{24, 1.5, 36},
+		{33, 1.96, 65},
+		{24, 0, 24},   // unknown scale: unscaled
+		{24, -1, 24},  // bogus scale: unscaled
+		{12, 0.25, 3}, // fractional downscale
+		{1, 0.01, 1},  // clamps, never rounds to zero
+	}
+	for _, c := range cases {
+		if got := scaledCursorSize(c.size, c.scale); got != c.want {
+			t.Errorf("scaledCursorSize(%d, %g) = %d, want %d",
+				c.size, c.scale, got, c.want)
+		}
+	}
+}
+
 func TestBestFit(t *testing.T) {
 	img := func(w int) xcursorImage { return xcursorImage{Width: w, Height: w} }
 	cases := []struct {
@@ -367,6 +394,40 @@ func TestFindThemeCursorCycle(t *testing.T) {
 	}
 }
 
+// TestFindThemeCursorAllShapes verifies every shape's name table
+// resolves through findThemeCursor: each theme provides one of the
+// table's aliases and lookup must find it. This is the headless
+// counterpart of the themed-first loading in loadCursors (issue #453).
+func TestFindThemeCursorAllShapes(t *testing.T) {
+	cases := []struct {
+		names []string
+		alias string // a name from the table, as a theme would ship it
+	}{
+		{leftPtrCursorNames, "default"},
+		{xtermCursorNames, "text"},
+		{crosshairCursorNames, "crosshair"},
+		{handCursorNames, "pointer"},
+		{hResizeCursorNames, "ew-resize"},
+		{vResizeCursorNames, "ns-resize"},
+		{nwseCursorNames, "size_fdiag"},
+		{neswCursorNames, "size_bdiag"},
+		{moveCursorNames, "all-scroll"},
+		{notAllowedCursorNames, "not-allowed"},
+	}
+	for _, tc := range cases {
+		root := t.TempDir()
+		writeTheme(t, root, "t", nil, map[string][]int{tc.alias: {24}})
+		img, err := findThemeCursor(tc.names, 24, []string{root}, "t")
+		if err != nil {
+			t.Errorf("alias %q: %v", tc.alias, err)
+			continue
+		}
+		if img.Width != 24 {
+			t.Errorf("alias %q: got %d, want 24", tc.alias, img.Width)
+		}
+	}
+}
+
 func TestSettingsIniValue(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(dir, "gtk-3.0"), 0o755)
@@ -466,7 +527,11 @@ func TestXcursorThemeCursorLive(t *testing.T) {
 		t.Fatalf("theme=%q size=%d, want non-empty positive", theme, size)
 	}
 
-	for _, names := range [][]string{nwseCursorNames, neswCursorNames} {
+	for _, names := range [][]string{
+		leftPtrCursorNames, xtermCursorNames, crosshairCursorNames,
+		handCursorNames, hResizeCursorNames, vResizeCursorNames,
+		nwseCursorNames, neswCursorNames, moveCursorNames, notAllowedCursorNames,
+	} {
 		img, err := findThemeCursor(names, size, xcursorSearchDirs(), theme)
 		if err != nil {
 			t.Skipf("no themed %s cursor (fallback glyphs in use): %v", names[0], err)


### PR DESCRIPTION
Fixes #453.

On X11, every cursor shape now prefers the desktop's Xcursor theme (uploaded via the RENDER extension), with the core cursor font glyph as the per-shape fallback. The core font ignores XCURSOR_SIZE and never scales for HiDPI, which caused tiny cursors on HiDPI setups.

Changes:
- `scaledCursorSize` multiplies the logical theme size by the monitor scale so themed images match the DPI
- All cursor shapes (default, I-beam, crosshair, hand, all resize directions, move, not-allowed) try themed names first, falling back to font glyphs
- Cursors reload when the window moves to a monitor with a different DPI (`reloadCursors`)
- Headless tests cover the size multiplier and name tables per shape

The implementation stays fault-tolerant: any failure (no theme, no RENDER, parse error) falls back to the core font glyphs — never a hard error.