### PR TITLE
fix(backend/gl): use the published Xcursor size unscaled (#453 follow-up)

### DIFF
--- a/gui/backend/gl/dpi_x11.go
+++ b/gui/backend/gl/dpi_x11.go
@@ -105,12 +105,13 @@ func crtcDPI(info *randr.GetCrtcInfoReply, out *randr.GetOutputInfoReply) (float
 }
 
 // maybeRescaleDPI re-evaluates the per-monitor scale when the window has
-// moved to a CRTC with a different DPI, updating plat.scale, the glyph
-// backend, and the cursor set. It reports whether the scale changed so
-// the caller can trigger a relayout. ConfigureNotify coordinates are
-// frame-relative under a reparenting WM, so the true root position is
-// queried explicitly and a RandR rescan runs only when that position
-// changed.
+// moved to a CRTC with a different DPI, updating plat.scale and the glyph
+// backend. It reports whether the scale changed so the caller can trigger
+// a relayout. ConfigureNotify coordinates are frame-relative under a
+// reparenting WM, so the true root position is queried explicitly and a
+// RandR rescan runs only when that position changed. Cursors are not
+// reloaded: the Xcursor size X clients see is already in device pixels
+// and does not track the per-monitor scale.
 func (b *Backend) maybeRescaleDPI() bool {
 	if !b.plat.haveRandr {
 		return false
@@ -137,7 +138,5 @@ func (b *Backend) maybeRescaleDPI() bool {
 	if b.glyphBack != nil {
 		b.glyphBack.dpiScale = scale
 	}
-	// Themed cursors were sized for the old monitor's scale; reload.
-	b.plat.reloadCursors()
 	return true
 }

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -249,11 +249,14 @@ func loadCursors(p *platformState) {
 	}
 
 	// Theme and size are resolved once: each step reads X root-window
-	// properties. Xcursor sizes are logical pixels; scaledCursorSize
-	// multiplies by the monitor scale to pick the image the theme
-	// intended for this DPI (issue #453).
+	// properties. The resolved size is already in device pixels — the
+	// compositor/settings daemon publishes the scaled value to X
+	// clients (mutter multiplies cursor-size by the scale factor for
+	// XSETTINGS and XCURSOR_SIZE), and libXcursor applies no scale of
+	// its own. Multiplying by p.scale here doubled the cursor on a
+	// 200% desktop (issue #453 follow-up).
 	theme := xcursorThemeName(p.conn, p.root)
-	size := scaledCursorSize(xcursorThemeSize(p.conn, p.root), p.scale)
+	size := xcursorThemeSize(p.conn, p.root)
 	load := func(names []string, glyph uint16) xproto.Cursor {
 		if c := xcursorThemeCursor(p, theme, size, names); c != 0 {
 			return c
@@ -271,25 +274,7 @@ func loadCursors(p *platformState) {
 	p.cursors[gui.CursorResizeNESW] = load(neswCursorNames, xcBottomLeftCorner)
 	p.cursors[gui.CursorResizeAll] = load(moveCursorNames, xcFleur)
 	p.cursors[gui.CursorNotAllowed] = load(notAllowedCursorNames, xcXCursor)
-	// reloadCursors calls this again per DPI rescale, so the font can't
-	// stay open; X protocol ordering runs the glyph-cursor creations
-	// queued above before this closes the font.
+	// X protocol ordering runs the glyph-cursor creations queued above
+	// before this closes the font.
 	xproto.CloseFont(p.conn, font)
-}
-
-// reloadCursors frees the current cursor handles and loads a fresh set
-// at the current monitor scale. Called when the window moves to a
-// monitor with a different DPI so themed cursors stay correctly sized
-// (issue #453). curCursor is reset so setCursor re-applies the active
-// shape next frame. The window keeps showing the freed cursor until
-// then — the server holds its own reference from the window attribute.
-func (p *platformState) reloadCursors() {
-	for i, c := range p.cursors {
-		if c != 0 {
-			xproto.FreeCursor(p.conn, c)
-			p.cursors[i] = 0
-		}
-	}
-	p.curCursor = 0
-	loadCursors(p)
 }

--- a/gui/backend/gl/xcursor.go
+++ b/gui/backend/gl/xcursor.go
@@ -161,18 +161,6 @@ func parseXcursorChunk(data []byte, pos, end uint32) (xcursorImage, error) {
 	return img, nil
 }
 
-// scaledCursorSize converts the logical Xcursor size (logical pixels)
-// to the physical-pixel size the monitor's scale needs. scale ≤ 0
-// means "unknown" and leaves the size untouched; otherwise it
-// multiplies, rounds to the nearest integer, and clamps to ≥ 1 so a
-// fractional scale never rounds down to zero.
-func scaledCursorSize(size int, scale float32) int {
-	if scale <= 0 {
-		return size
-	}
-	return max(1, int(float64(size)*float64(scale)+0.5))
-}
-
 // bestFit selects the image libXcursor would render for size: the
 // largest image no larger than size, or the smallest when every image
 // is larger. Images are compared by width, as the format is square.

--- a/gui/backend/gl/xcursor_test.go
+++ b/gui/backend/gl/xcursor_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -135,29 +136,18 @@ func TestParseXcursorFileMalformed(t *testing.T) {
 	}
 }
 
-// TestScaledCursorSize covers the HiDPI size multiplier applied to the
-// logical Xcursor size: unknown/bogus scales leave the size untouched,
-// fractional scales round, and a rounded-to-zero result clamps to 1
-// (issue #453).
-func TestScaledCursorSize(t *testing.T) {
-	cases := []struct {
-		size  int
-		scale float32
-		want  int
-	}{
-		{24, 1, 24},
-		{24, 2, 48},
-		{24, 1.5, 36},
-		{33, 1.96, 65},
-		{24, 0, 24},   // unknown scale: unscaled
-		{24, -1, 24},  // bogus scale: unscaled
-		{12, 0.25, 3}, // fractional downscale
-		{1, 0.01, 1},  // clamps, never rounds to zero
-	}
-	for _, c := range cases {
-		if got := scaledCursorSize(c.size, c.scale); got != c.want {
-			t.Errorf("scaledCursorSize(%d, %g) = %d, want %d",
-				c.size, c.scale, got, c.want)
+// TestXcursorThemeSizeEnv pins the sizing contract behind the #453
+// follow-up: the resolved Xcursor size is passed through in device
+// pixels, never multiplied by the monitor scale. A 200%-scale desktop
+// publishes 48 and must get 48 — the scaled re-multiply doubled the
+// cursor. The env branch returns before any X round trip, so a nil
+// conn is never dereferenced here.
+func TestXcursorThemeSizeEnv(t *testing.T) {
+	for _, want := range []int{24, 48, 96} {
+		t.Setenv("XCURSOR_SIZE", strconv.Itoa(want))
+		if got := xcursorThemeSize(nil, 0); got != want {
+			t.Errorf("xcursorThemeSize(XCURSOR_SIZE=%d) = %d, want %d",
+				want, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #457, which fixed the tiny cursor in #453 but overshot: the reporter now sees a cursor twice everyone else's on a 200%-scale desktop.

## Root cause

`#457` multiplied the resolved Xcursor size by the monitor scale. That size is already in **device pixels** — the settings daemon publishes the scaled value to X clients (mutter multiplies `cursor-size` by the scale factor for XSETTINGS and `XCURSOR_SIZE`), and libXcursor applies no scale of its own. So the multiply double-applied the 200%.

## Changes

- `xcursor.go` — remove `scaledCursorSize`
- `platform_x11.go` — pass `xcursorThemeSize` through unscaled; remove `reloadCursors`, now dead
- `dpi_x11.go` — drop the DPI-rescale cursor reload; the size does not track the per-monitor scale
- `xcursor_test.go` — replace `TestScaledCursorSize` with `TestXcursorThemeSizeEnv`, pinning unscaled passthrough (the env branch returns before any X round trip, so it runs headless)

The themed-cursor path from #457 — RENDER upload, name aliases, core-font fallback — is untouched. That is what actually fixed the original tiny cursor.

## Verification

`go build ./...`, `go test ./...` (7253 tests, 103 packages) and `golangci-lint run ./...` all clean.

Behavioral check under Xephyr, holding the size fixed and varying DPI:

```fish
Xephyr :2 -screen 1920x1200 -dpi 96 &
env DISPLAY=:2 XCURSOR_SIZE=24 go run ./examples/get_started/

Xephyr :3 -screen 1920x1200 -dpi 192 &
env DISPLAY=:3 XCURSOR_SIZE=24 go run ./examples/get_started/
```

Both cursors are now the same size. Before this change the 192-dpi case was twice as large — the reported regression.

Still worth confirming on the reporter's own 200% XWayland session with `XCURSOR_SIZE` unset; Xephyr cannot reproduce what the GNOME settings daemon publishes there.

Refs #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)