### PR TITLE
fix(gl,window): draw new text on the frame that asks for it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,14 @@ test:
 	go test -count=1 -timeout=5m $$(go list ./... | grep -v '/gui/backend/gl')
 
 # Run all tests with race detector enabled.
+#
+# gui/backend/gl is excluded rather than run cgo-free like the `test` target
+# above: -race requires cgo, so CGO_ENABLED=0 and -race cannot both hold and
+# the combination fails outright ("-race requires cgo"). Enabling cgo instead
+# reintroduces the runtime exit crash that #162 pinned CGO_ENABLED=0 to avoid,
+# so the package has no race-testable configuration on Linux at all. Nothing
+# is lost that CI covers -- it runs `make lint`/`vet`, never this target.
 test-race:
-	CGO_ENABLED=0 go test -race -count=1 -timeout=10m ./gui/backend/gl/
 	go test -race -count=1 -timeout=10m $$(go list ./... | grep -v '/gui/backend/gl')
 
 # Run go vet static analysis.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Go toolchain pin: `go 1.26.0`.
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.27.0 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.2 | cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends. |
-| `github.com/go-gui-org/go-glyph` | v1.23.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.24.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio decode + mixing (sound effects, music, mixer, fade) for `gui/audio`. |

--- a/examples/process_monitor/main.go
+++ b/examples/process_monitor/main.go
@@ -90,7 +90,8 @@ func main() {
 // startSampler launches the background sampling loop. Sampling spawns a
 // subprocess (ps/tasklist), so it must run off the frame thread. Each pass
 // takes a snapshot, then publishes it under the window lock and requests a
-// layout refresh; the backend's idle poll repaints within ~100ms.
+// layout refresh; UpdateWindow wakes the backend's idle loop, which
+// otherwise blocks until input arrives and would leave the readings stale.
 func startSampler(w *gui.Window) {
 	go func() {
 		for {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/ebitengine/purego v0.10.2
-	github.com/go-gui-org/go-glyph v1.23.0
+	github.com/go-gui-org/go-glyph v1.24.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/ebitengine/oto/v3 v3.3.2 h1:VTWBsKX9eb+dXzaF4jEwQbs4yWIdXukJ0K40KgkpY
 github.com/ebitengine/oto/v3 v3.3.2/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/go-gui-org/go-glyph v1.23.0 h1:aGLszKEHk/SEi8aNyA+pHsy3MrGA+w2GcZ9kBGgZg3U=
-github.com/go-gui-org/go-glyph v1.23.0/go.mod h1:Lx2KYrLee8t34mX/ZvjUcxN+sHhwFPVF4fcXe6wkRX0=
+github.com/go-gui-org/go-glyph v1.24.0 h1:McXsveg3yvdKt/gfIiiEkHvdaZWgtIWif5HCowdjmpo=
+github.com/go-gui-org/go-glyph v1.24.0/go.mod h1:Lx2KYrLee8t34mX/ZvjUcxN+sHhwFPVF4fcXe6wkRX0=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=

--- a/gui/backend/gl/platform_state_x11.go
+++ b/gui/backend/gl/platform_state_x11.go
@@ -108,6 +108,19 @@ func (p *platformState) setCursor(mc gui.MouseCursor) {
 
 // wake sends a no-op ClientMessage to our own window from a second
 // connection so the event-pump goroutine unblocks from WaitForEvent.
+//
+// Deliberately unchecked. Every redraw request calls this (see
+// (*gui.Window).UpdateWindow), and the overwhelming majority already run
+// on the frame thread where the loop is not parked and the wake is
+// redundant — so it must not cost a server round trip. It does not:
+// xgb's NewRequest hands the buffer to the sendRequests goroutine and
+// blocks until writeBuffer has put it on the wire, so the message is
+// flushed by the time this returns. Check() would only add a wait for an
+// error reply, and the error was never actionable here anyway.
+//
+// Nothing drains errors from wakeConn, so its cookie buffer still forces
+// an occasional round trip once it fills (xgb amortizes this at one per
+// cookieBuffer requests, ~1000) — bounded, and not per call.
 func (p *platformState) wake() {
 	if p.wakeConn == nil {
 		return
@@ -118,8 +131,7 @@ func (p *platformState) wake() {
 		Type:   p.wakeAtom,
 		Data:   xproto.ClientMessageDataUnionData32New([]uint32{0, 0, 0, 0, 0}),
 	}
-	cookie := xproto.SendEventChecked(p.wakeConn, false, p.window, 0, string(ev.Bytes()))
-	_ = cookie.Check() // forces a flush; error is not actionable here
+	xproto.SendEvent(p.wakeConn, false, p.window, 0, string(ev.Bytes()))
 }
 
 func (p *platformState) destroy() {

--- a/gui/backend/gl/text.go
+++ b/gui/backend/gl/text.go
@@ -23,6 +23,12 @@ type glyphBackend struct {
 	vao, vbo uint32
 }
 
+// Asserted, not merely implemented: RectTextureUpdater is an optional
+// interface, so a drifted signature would silently drop this backend back
+// to end-of-frame uploads and reintroduce the one-frame-blank-text bug
+// with nothing failing to compile.
+var _ glyph.RectTextureUpdater = (*glyphBackend)(nil)
+
 func newGlyphBackend(dpiScale float32) *glyphBackend {
 	gb := &glyphBackend{
 		textures: make(map[glyph.TextureID]glTexture),
@@ -87,6 +93,58 @@ func (gb *glyphBackend) UpdateTexture(id glyph.TextureID, data []byte) {
 	gogl.TexSubImage2D(gogl.TEXTURE_2D, 0, 0, 0,
 		tex.w, tex.h, gogl.RGBA, gogl.UNSIGNED_BYTE,
 		unsafe.Pointer(&data[0]))
+	gogl.BindTexture(gogl.TEXTURE_2D, 0)
+}
+
+// UpdateTextureRect implements glyph.RectTextureUpdater, uploading only
+// the rows glyph just rasterized into.
+//
+// This is what lets go-glyph push new glyphs to the GPU mid-frame, before
+// it emits the quads that sample them. GL draw calls read a texture at
+// their position in the command stream, so without a mid-frame upload a
+// glyph's first appearance renders blank until the following frame — and
+// this backend only draws a frame when something asks it to, so "the
+// following frame" can be whenever the user next moves the mouse.
+//
+// The upload is widened to whole rows and the x/w arguments ignored:
+// full rows are contiguous in the page buffer, so no unpack row length
+// has to be set (glbind exposes no glPixelStorei, and GLES2 lacks
+// GL_UNPACK_ROW_LENGTH entirely). A glyph-tall band of a 1024-wide page
+// is tens of KB against the 4 MiB the whole page would cost, so the
+// widening does not undo the point of the exercise.
+func (gb *glyphBackend) UpdateTextureRect(id glyph.TextureID, data []byte,
+	srcStride, _, y, _, h int) {
+
+	tex, ok := gb.textures[id]
+	if !ok || h <= 0 || srcStride <= 0 {
+		return
+	}
+	// Whole-row uploads hold only while a source row is exactly a texture
+	// row: TexSubImage2D advances the read pointer by width*4 per row
+	// (unpack row length is unsettable here — see above), so a padded
+	// stride would shear the page diagonally instead of merely offsetting
+	// it. Unreachable as glyph is written — a page sizes its own texture —
+	// so this trades a corrupt atlas for a blank one if that ever changes.
+	if srcStride != int(tex.w)*4 {
+		return
+	}
+	// Clamp to the texture: glyph promises an in-bounds rect, but a
+	// mismatch here is an out-of-range driver read, not a wrong pixel.
+	if y < 0 {
+		y = 0
+	}
+	if y+h > int(tex.h) {
+		h = int(tex.h) - y
+	}
+	off := y * srcStride
+	if h <= 0 || off+h*srcStride > len(data) {
+		return
+	}
+
+	gogl.BindTexture(gogl.TEXTURE_2D, tex.id)
+	gogl.TexSubImage2D(gogl.TEXTURE_2D, 0, 0, int32(y),
+		tex.w, int32(h), gogl.RGBA, gogl.UNSIGNED_BYTE,
+		unsafe.Pointer(&data[off]))
 	gogl.BindTexture(gogl.TEXTURE_2D, 0)
 }
 

--- a/gui/window_lifecycle_test.go
+++ b/gui/window_lifecycle_test.go
@@ -369,6 +369,66 @@ func TestQueueCommandWakesMain(t *testing.T) {
 	}
 }
 
+// TestRefreshRequestsWakeMain pins the contract that setting a refresh
+// flag also wakes the backend. Backends block indefinitely when FrameFn
+// reports nothing to draw, so a request that does not wake is only
+// painted when unrelated input happens to arrive — a frozen window for
+// any async caller (background samplers, image downloads, datagrid data
+// sources). macOS masked this for a long time because AppKit's idle
+// event traffic ends the block on its own; X11 is genuinely silent.
+func TestRefreshRequestsWakeMain(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*Window)
+		// The flag each entry must raise. Asserted alongside the wake so
+		// the test cannot pass on a wake that schedules nothing — the two
+		// halves are only useful together.
+		wantLayout     bool
+		wantRenderOnly bool
+	}{
+		{
+			name:       "UpdateWindow",
+			call:       func(w *Window) { w.UpdateWindow() },
+			wantLayout: true,
+		},
+		{
+			name:           "RequestRedraw",
+			call:           func(w *Window) { w.RequestRedraw() },
+			wantRenderOnly: true,
+		},
+		{
+			name: "UpdateView",
+			call: func(w *Window) {
+				w.UpdateView(func(*Window) View { return nil })
+			},
+			wantLayout: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWindow(WindowCfg{})
+			// markRenderOnlyRefresh defers to a pending full rebuild, so
+			// start from a clean slate rather than whatever NewWindow left.
+			w.refreshLayout = false
+			w.refreshRenderOnly = false
+			wakes := 0
+			w.wakeMainFn = func() { wakes++ }
+			tt.call(w)
+			if wakes != 1 {
+				t.Errorf("wakeMain called %d times, want 1", wakes)
+			}
+			if w.refreshLayout != tt.wantLayout {
+				t.Errorf("refreshLayout = %v, want %v",
+					w.refreshLayout, tt.wantLayout)
+			}
+			if w.refreshRenderOnly != tt.wantRenderOnly {
+				t.Errorf("refreshRenderOnly = %v, want %v",
+					w.refreshRenderOnly, tt.wantRenderOnly)
+			}
+		})
+	}
+}
+
 func TestSetClipboard(t *testing.T) {
 	w := &Window{}
 	var got string

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -130,8 +130,15 @@ func (w *Window) markRenderOnlyRefresh() {
 }
 
 // UpdateWindow marks the window as needing a full layout update.
+//
+// Safe to call from any goroutine: it wakes the backend's idle loop, so a
+// refresh requested off the frame thread is painted promptly rather than
+// whenever the next input event happens to arrive. Callers mutating window
+// state alongside it still need the window lock; this only schedules the
+// frame.
 func (w *Window) UpdateWindow() {
 	w.markLayoutRefresh()
+	w.wakeMain()
 }
 
 // requestRenderOnly marks the window for render-only refresh.
@@ -140,9 +147,11 @@ func (w *Window) requestRenderOnly() {
 }
 
 // RequestRedraw is an alias for RequestRenderOnly. Safe to call
-// from OnHover/OnMouseLeave callbacks.
+// from OnHover/OnMouseLeave callbacks, and from any goroutine — like
+// UpdateWindow it wakes the backend's idle loop.
 func (w *Window) RequestRedraw() {
 	w.markRenderOnlyRefresh()
+	w.wakeMain()
 }
 
 // UpdateView sets the view generator and triggers a full refresh.
@@ -152,6 +161,9 @@ func (w *Window) UpdateView(gen func(*Window) View) {
 	w.viewState.registry.Clear()
 	w.viewGenerator = gen
 	w.markLayoutRefresh()
+	// Under w.mu, which is deliberate: a wake only posts to the platform's
+	// event queue and takes no window lock, so it cannot re-enter.
+	w.wakeMain()
 }
 
 // FrameFn is called by the backend each frame. It flushes


### PR DESCRIPTION
Fixes "showing the initial view or changing views, not all the characters are
drawn at once — I sometimes have to move the mouse to trigger a frame draw."
Two independent bugs presenting as one symptom on Linux, intermittently on
Windows, and barely at all on macOS.

## 1. Glyphs rendered blank on first appearance (GL)

`renderFrame` calls `textSys.Commit()` *after* `renderersDraw`. go-glyph
rasterizes a glyph into CPU staging on first use and defers the GPU upload to
`Commit`, documenting the assumption that hosts commit before the render pass
samples the textures.

Metal and the software renderer tolerate that — they do not sample until
present time. GL does not: `glDrawArrays` reads the texture as it stands at
that point in the command stream, so a quad emitted in the same pass that
rasterized its glyph sampled empty texels. The text appeared on the *next*
frame, which in a draw-on-demand app means whenever the user next moved the
mouse.

Not a cache bug, despite looking exactly like one. The second visit rendered
correctly because `Commit` had run by then.

Fixed upstream in go-glyph v1.24.0 (go-gui-org/go-glyph#125), which uploads
dirty rects mid-frame gated on a new optional `RectTextureUpdater` interface.
This PR implements that interface for the GL backend — without it the
upstream change is inert, since the gate is exactly "does this backend
support sub-rectangle uploads".

The implementation widens each upload to whole rows and ignores `x`/`w`: full
rows are contiguous, so no unpack row length has to be set — `glbind` exposes
no `glPixelStorei` and GLES2 lacks `GL_UNPACK_ROW_LENGTH` entirely. A
glyph-tall band of a 1024-wide page is tens of KB against the 4 MiB a full
page would cost, so this does not undo the point. A stride guard keeps that
premise honest; it is unreachable as glyph is written, since a page sizes the
texture it later hands the stride for.

`var _ glyph.RectTextureUpdater = (*glyphBackend)(nil)` is deliberate: the
interface is optional, so a drifted signature would silently drop this
backend back to end-of-frame uploads and reintroduce the bug with nothing
failing to compile.

## 2. A refresh requested off the frame thread was never painted

`UpdateWindow` set `refreshLayout` and stopped. Since #405 replaced the
polling loop with a blocking one, backends park indefinitely when `FrameFn`
reports nothing to draw (`gl/runapp_x11.go` in `<-events`, Metal in
`metalPollEvent(-1)`). Setting a flag is therefore not a request to paint —
it is a note the loop reads the next time something *else* wakes it.

So the process monitor froze until the mouse moved. It is not an example-only
problem: `gui/image_download.go:324`, `gui/markdown_mermaid.go:204`,
`gui/markdown_math.go:101` and the `gui/datagrid/data_source_grid*.go`
callbacks are all async completions that call `UpdateWindow`. Those are
identified by call-site inspection, not reproduced.

`UpdateWindow`, `RequestRedraw` and `UpdateView` now wake the loop, as
`QueueCommand` and the animation loop always did.

**Why macOS masked it.** Both loops block identically, but
`nextEventMatchingMask:ALL_EVENTS ... inMode:NSDefaultRunLoopMode` runs the
Cocoa run loop and receives ambient AppKit traffic that ends the block on its
own. X11 delivers nothing at all; Win32 `GetMessage` gets some, hence
"sometimes Windows". No backend was actually correct, which is why the fix is
in the API rather than in any one event loop. macOS should now also tick on
schedule rather than whenever ambient traffic happens to land.

**Cost.** `UpdateWindow` has ~50 mostly main-thread call sites where the wake
is redundant, so it had to be cheap. The X11 wake drops `cookie.Check()`:
xgb's `NewRequest` (`xgb.go:396-410`) already blocks until `writeBuffer` has
put the message on the wire, so `Check()` only added a round trip waiting for
an error reply that was discarded anyway. Not quite free — nothing drains
errors from `wakeConn`, so its cookie buffer still forces a `noop()` round
trip when it fills, amortized at roughly one per 1000 requests. Bounded, and
documented at the call site. Win32 was audited and needs no change:
`PostMessageW` is already async.

The internal `markLayoutRefresh` / `requestRenderOnly` sites are deliberately
left alone — they all run on the frame thread, where the loop is not parked.

## Also: `make test-race` could not run

Pre-existing and unrelated, but it blocked the gate. `test-race` set
`CGO_ENABLED=0` for `gui/backend/gl` (per #162, to dodge the runtime exit
crash) while `-race` requires cgo — the two cannot both hold, so the recipe
failed outright. Enabling cgo instead reintroduces the crash, so the package
has no race-testable configuration on Linux and is excluded; the rest of the
tree is still race-tested. Latent since #257 because CI runs `lint` and
`vet`, never this target.

Happy to split this out if you'd rather keep the PR to the two fixes.

## Tests

`TestRefreshRequestsWakeMain` is table-driven over the three entry points,
asserting both the wake and the resulting refresh flag — the wake alone would
pass against a call that wakes the loop to do nothing.

`UpdateTextureRect` has no test: its guards are pure arithmetic but every
path ends in a live `gogl` call, so testing it means extracting the clamp.
Left alone.

## Verification

`make prepush` green — race, cross-lint, cross-compile, coverage, export
audit. `GOWORK=off go build ./...` passes, which is the condition that
matters here: `go.work` is gitignored, so CI resolves go-glyph from the
proxy and this did **not** compile before v1.24.0 was tagged.

`docs/dependencies.md` is regenerated — `deps-doc-check` pins the go-glyph
version a second time and fails the build if it disagrees with `go.mod`.

Bug 1 is confirmed fixed on screen. Bug 2 is verified by test and by
inspection; the on-screen check is the process monitor updating without mouse
movement.

## Related

- go-gui-org/go-glyph#125, released as v1.24.0
- #405 — introduced the blocking loop that made bug 2 reachable
- #459 — `Dialog`/`DialogDismiss` have bug 2's exact shape, not fixed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
