### PR TITLE
fix(gui): wake the backend when Dialog/DialogDismiss set the refresh flag

### DIFF
--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -327,8 +327,10 @@ func (w *Window) Dialog(cfg DialogCfg) {
 	// action, a QueueCommand from a worker) leaves the window otherwise idle,
 	// and the render-only frames a blinking cursor produces reuse the existing
 	// layout tree — the dialog would stay invisible until an unrelated event
-	// forced a rebuild.
+	// forced a rebuild. wakeMain pairs with the flag for the same reason:
+	// without it a sleeping backend never learns the flag was set.
 	w.markLayoutRefresh()
+	w.wakeMain()
 	w.SetFocus(dialogFocusID(cfg))
 }
 
@@ -337,8 +339,10 @@ func (w *Window) DialogDismiss() {
 	oldFocus := w.dialogCfg.oldFocusID
 	w.dialogCfg = DialogCfg{}
 	// Same reasoning as Dialog: without a rebuild the overlay stays on screen
-	// after a programmatic dismiss.
+	// after a programmatic dismiss, and without the wake a sleeping backend
+	// never learns the flag was set.
 	w.markLayoutRefresh()
+	w.wakeMain()
 	w.SetFocus(oldFocus)
 }
 

--- a/gui/window_lifecycle_test.go
+++ b/gui/window_lifecycle_test.go
@@ -403,6 +403,18 @@ func TestRefreshRequestsWakeMain(t *testing.T) {
 			},
 			wantLayout: true,
 		},
+		{
+			name: "Dialog",
+			call: func(w *Window) {
+				w.Dialog(DialogCfg{FocusID: "dlg"})
+			},
+			wantLayout: true,
+		},
+		{
+			name:       "DialogDismiss",
+			call:       func(w *Window) { w.DialogDismiss() },
+			wantLayout: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -116,6 +116,12 @@ func (w *Window) flushCommands() {
 
 // markLayoutRefresh requests a full layout rebuild next frame.
 // Overrides any pending render-only refresh.
+//
+// Setting the flag is not the whole request: a public entry point must also
+// call wakeMain, because backends block indefinitely when FrameFn reports
+// nothing to draw and a flag alone is only read the next time something else
+// wakes the loop. Frame-thread sites (svg, command queue, testing hooks)
+// correctly do not wake — the loop is already running.
 func (w *Window) markLayoutRefresh() {
 	w.refreshLayout = true
 	w.refreshRenderOnly = false


### PR DESCRIPTION
Fixes #459.

`(*Window).Dialog` and `DialogDismiss` called `markLayoutRefresh()` and stopped. Backends block indefinitely when `FrameFn` reports nothing to draw, so the flag alone is only read the next time something else wakes the loop — a dialog opened from a native menu action or a `NativePlatform` callback stayed invisible until unrelated input arrived. Worst on X11 (no ambient events); masked on macOS by AppKit idle traffic.

Fix: pair the flag with `w.wakeMain()` in both, matching `UpdateWindow`, `RequestRedraw` and `UpdateView`.

Also:
- `Dialog` and `DialogDismiss` added to `TestRefreshRequestsWakeMain`.
- The wake rule is now documented on `markLayoutRefresh`: public entry points must wake; frame-thread sites (svg, command queue, testing hooks) correctly must not.