### PR TITLE
perf(solar_system): hyperbolic zoom path, mipped textures and scratch reuse

### DIFF
--- a/examples/solar_system/camera.go
+++ b/examples/solar_system/camera.go
@@ -160,9 +160,147 @@ func (a *App) beginTransition() {
 	a.TweenT = 0
 }
 
+// zoomRho is the curvature of the zoom-and-pan path: how much the view
+// is allowed to widen in order to cover ground. sqrt(2) is Van Wijk and
+// Nuij's own measured optimum and is what every implementation of this
+// uses; larger zooms out more and arrives sooner, smaller flies lower
+// and further.
+const zoomRho = math.Sqrt2
+
+// zoomPath is a camera move that zooms and pans as one motion.
+//
+// Interpolating the center and the zoom separately is what made a
+// selection read as two steps. Zoom is a *ratio*, so a straight line
+// through it spends its first half covering most of the magnification
+// — from the full system to a planet that is five of the seventeen
+// times over in the first quarter of the tween — while the center is
+// only a quarter of the way across. The remaining pan then happens at
+// high magnification, where a world unit is many pixels, so the
+// destination first slides off toward the edge of the screen and only
+// afterwards swings back to the middle. Zooming in on the sun, then
+// sliding, is exactly what that looks like.
+//
+// The fix is to ask for the right thing: a path along which the view
+// appears to move at a constant rate. That is Van Wijk and Nuij,
+// "Smooth and efficient zooming and panning" (InfoVis 2003). Their
+// result is that the optimal path is a straight line in the plane
+// traversed on a hyperbolic schedule, with the view width following
+// from it — the view widens while crossing distance and narrows on
+// arrival, and the two are one motion rather than two.
+//
+// The state it interpolates is a center and a *view width* in world
+// units, not a zoom factor: the whole derivation is about how much
+// world the screen shows, and a width is what makes distance and
+// magnification the same currency.
+type zoomPath struct {
+	x0, y0, w0 float32
+	dx, dy     float32 // full displacement, in world units
+
+	// r0 and s scale the hyperbolic schedule; u1 is the displacement
+	// fraction the schedule reaches at t = 1, which normalizes the
+	// path so it lands exactly on the target.
+	r0, s, u1 float32
+
+	// pure is the degenerate straight zoom, taken when the two centers
+	// coincide and there is no direction to travel in.
+	pure bool
+}
+
+// newZoomPath solves the path from one (center, view width) to another.
+//
+// Distances are measured with the vertical axis pre-squashed by
+// diskTilt, because that is what the projection does to it: the path
+// has to be even in *apparent* motion, and a world unit north covers
+// less screen than a world unit east.
+func newZoomPath(x0, y0, w0, x1, y1, w1 float32) zoomPath {
+	p := zoomPath{x0: x0, y0: y0, w0: w0, dx: x1 - x0, dy: y1 - y0}
+	if w0 <= 0 || w1 <= 0 {
+		// No usable width to interpolate. Hold the one we have rather
+		// than invent a rate: s = 0 makes at() a straight pan.
+		p.pure = true
+		return p
+	}
+	// The apparent displacement, which is what the schedule is solved
+	// against; dx and dy stay unsquashed for reconstructing the center.
+	ex, ey := p.dx, p.dy*diskTilt
+	d2 := float64(ex*ex + ey*ey)
+	b0 := float64(w0)
+	b1 := float64(w1)
+	// A move too short to have a direction is a straight zoom, and the
+	// width is exponential in t so that equal steps are equal ratios.
+	if d2 < 1e-9 {
+		p.pure = true
+		p.s = float32(math.Log(b1 / b0))
+		return p
+	}
+	d1 := math.Sqrt(d2)
+	const rho2, rho4 = 2.0, 4.0
+	c0 := (b1*b1 - b0*b0 + rho4*d2) / (2 * b0 * rho2 * d1)
+	c1 := (b1*b1 - b0*b0 - rho4*d2) / (2 * b1 * rho2 * d1)
+	// The two path ends, in the standard asinh(-c) form. Written out
+	// as log(sqrt(c*c+1) - c) it loses the whole result to
+	// cancellation once c passes about 1e7 and returns -Inf by 1e8,
+	// which a short pan under a large change of width does reach.
+	r0 := math.Asinh(-c0)
+	r1 := math.Asinh(-c1)
+	p.r0 = float32(r0)
+	p.s = float32((r1 - r0) / zoomRho)
+	// Where the schedule lands at t = 1. Solving for it rather than
+	// trusting it to be 1 keeps rounding out of the arrival: the tween
+	// is also read at t = 1 every frame once it has settled, and a
+	// camera that stopped a hair short of a planet would never catch up
+	// to it.
+	p.u1 = p.displacement(1)
+	if p.u1 == 0 {
+		p.pure = true
+	}
+	return p
+}
+
+// displacement is the un-normalized fraction of the way along the line
+// at t, on the hyperbolic schedule.
+func (p zoomPath) displacement(t float32) float32 {
+	r0 := float64(p.r0)
+	x := zoomRho*float64(t*p.s) + r0
+	return float32(math.Cosh(r0)*math.Tanh(x) - math.Sinh(r0))
+}
+
+// at returns the center and view width at t in [0,1].
+func (p zoomPath) at(t float32) (x, y, w float32) {
+	if p.pure {
+		// Exponential in the width, linear in the center — which for a
+		// pure zoom is the same constant-rate path the general case
+		// gives, with the hyperbolic part degenerate.
+		return p.x0 + t*p.dx, p.y0 + t*p.dy,
+			p.w0 * float32(math.Exp(float64(t*p.s)))
+	}
+	u := p.displacement(t) / p.u1
+	r0 := float64(p.r0)
+	x = p.x0 + u*p.dx
+	y = p.y0 + u*p.dy
+	w = p.w0 * float32(math.Cosh(r0)/
+		math.Cosh(zoomRho*float64(t*p.s)+r0))
+	return x, y, w
+}
+
+// viewWidth is how much world the canvas spans at a given camera zoom.
+// It is the currency zoomPath works in. UserZoom is deliberately left
+// out: it is the viewer's own multiplier, and folding it in would let a
+// scroll mid-flight bend the path.
+func (a *App) viewWidth(camZoom float32) float32 {
+	if camZoom <= 0 || a.CanvasW <= 0 {
+		return 0
+	}
+	return a.CanvasW / camZoom
+}
+
 // advanceCamera steps the tween by dt and blends toward the live
 // target. At TweenT == 1 the camera equals the target exactly, so it
 // simply follows from then on.
+//
+// The path is re-solved every tick against the *live* target, for the
+// same reason target() is re-read: a selected planet keeps orbiting,
+// and a path captured at click time would aim at where it used to be.
 func (a *App) advanceCamera(dt float32) {
 	tx, ty, tz := a.target()
 	if a.TweenT < 1 {
@@ -171,10 +309,27 @@ func (a *App) advanceCamera(dt float32) {
 			a.TweenT = 1
 		}
 	}
+	if a.TweenT >= 1 {
+		// Settled: the camera simply follows its target. Solving the
+		// path here would land on exactly this and pay four logs and
+		// three hyperbolics for it, every tick, for the whole time a
+		// planet stays selected.
+		a.CamX, a.CamY, a.CamZoom = tx, ty, tz
+		return
+	}
 	k := gui.EaseInOutQuad(a.TweenT)
-	a.CamX = lerp(a.FromX, tx, k)
-	a.CamY = lerp(a.FromY, ty, k)
-	a.CamZoom = lerp(a.FromZoom, tz, k)
+	w0, w1 := a.viewWidth(a.FromZoom), a.viewWidth(tz)
+	if w0 <= 0 || w1 <= 0 {
+		// No canvas yet, or a degenerate zoom. Nothing to solve; fall
+		// back to the plain blend so the camera still tracks.
+		a.CamX = lerp(a.FromX, tx, k)
+		a.CamY = lerp(a.FromY, ty, k)
+		a.CamZoom = lerp(a.FromZoom, tz, k)
+		return
+	}
+	x, y, w := newZoomPath(a.FromX, a.FromY, w0, tx, ty, w1).at(k)
+	a.CamX, a.CamY = x, y
+	a.CamZoom = a.CanvasW / w
 }
 
 // cosElev is the cosine of the camera's elevation above the orbital

--- a/examples/solar_system/draw.go
+++ b/examples/solar_system/draw.go
@@ -738,15 +738,18 @@ func drawPlanet(a *App, dc *gui.DrawContext, i int) {
 		}
 		// Back half of the rings first, then the body, then the front
 		// half — which is what makes the rings pass behind Saturn.
+		// drawRings splits the two by the sign of the depth, so the
+		// seam is where the ring actually crosses the plane of the
+		// limb rather than wherever a fixed angle put it.
 		//
 		// The phase is read off lz rather than by calling litFraction,
 		// which would redo orbitPos and the normalization for the vector
 		// already in hand. litFraction is this same expression; see it
 		// for why the z component is the cosine of the phase angle.
 		k := (1 + lz) / 2
-		drawRings(dc, cx, cy, r, math.Pi, math.Pi, k)
+		drawRings(a, dc, p, cx, cy, r, false, k)
 		drawBody(dc, &a.body, cx, cy, r, p.Color, lx, ly, lz, sp)
-		drawRings(dc, cx, cy, r, 0, math.Pi, k)
+		drawRings(a, dc, p, cx, cy, r, true, k)
 		if hasAxis {
 			drawAxisHalf(dc, cx, cy, ax, ay, az, r, false)
 		}
@@ -868,11 +871,17 @@ type ringTex struct {
 	c0, c1, c2 float32 // quadrature component
 	spin       float32
 	k, w       float32
+
+	// lod is the pyramid level matched to this ring's vertex spacing.
+	// It is a ring property, not a vertex one: the spacing is uniform
+	// along a ring by construction, so the level is chosen once and
+	// every vertex on the ring reuses it.
+	lod float32
 }
 
 // ringTexFor folds the per-body projection and the per-ring geometry
 // into the coefficients appendRing consumes.
-func (p surfaceProj) ringTexFor(s *surface, cosPhi, sinPhi, k, w float32) ringTex {
+func (p surfaceProj) ringTexFor(s *surface, cosPhi, sinPhi, k, w, lod float32) ringTex {
 	return ringTex{
 		tex: s.tex,
 		a0:  cosPhi * p.la, a1: sinPhi * p.ua, a2: sinPhi * p.va,
@@ -880,7 +889,40 @@ func (p surfaceProj) ringTexFor(s *surface, cosPhi, sinPhi, k, w float32) ringTe
 		c0: cosPhi * p.l2, c1: sinPhi * p.u2, c2: sinPhi * p.v2,
 		spin: s.spin,
 		k:    k, w: w,
+		lod: lod,
 	}
+}
+
+// ringFootprint is the widest gap between neighbouring mesh vertices
+// around ring i, in radians of arc on the unit sphere. It is what the
+// pyramid level is chosen from: detail finer than this gap is detail
+// the mesh has no vertex to carry, so sampling it can only alias.
+//
+// Two directions have to be measured, because the mesh is not square.
+// Around the ring the gap is the ring's own radius times its angular
+// step; across rings it is the change in polar angle to the neighbour.
+// The larger of the two governs, since blurring is the safe error and
+// aliasing is not.
+//
+// cosPhi and sinPhi are ring i's own, passed in because the caller has
+// just computed them and the sine costs a square root.
+func ringFootprint(p ringPlan, b lightBasis, i, arc int,
+	cosPhi, sinPhi float32,
+) float32 {
+	phi := acos32(clamp32(cosPhi, -1, 1))
+	// Neighbour toward the far side where there is one, otherwise the
+	// neighbour behind: the two gaps differ little and the last ring is
+	// on the far side of the terminator anyway.
+	j := i + 1
+	if j >= p.count() {
+		j = i - 1
+	}
+	var dPhi float32
+	if j >= 0 {
+		dPhi = abs32(acos32(clamp32(p.cosPhi(j), -1, 1)) - phi)
+	}
+	dAz := sinPhi * 2 * b.visibleAzimuth(cosPhi, sinPhi) / float32(arc)
+	return max(dPhi, dAz)
 }
 
 // ringRamp is sphereTone rewritten as the affine map it already is.
@@ -1228,7 +1270,8 @@ func drawBody(dc *gui.DrawContext, m *bodyMesh, cx, cy, r float32,
 		var rt ringTex
 		if s != nil {
 			k, w := ringRamp(intensity)
-			rt = proj.ringTexFor(s, c, sn, k, w)
+			lod := s.tex.lodFor(ringFootprint(p, b, i, arc, c, sn))
+			rt = proj.ringTexFor(s, c, sn, k, w, lod)
 		}
 		m.cur, m.curCol = appendRing(m.cur[:0], m.curCol[:0],
 			b, r, cx, cy, c, sn, arc, col, rt)
@@ -1348,7 +1391,7 @@ func appendRing(dst []float32, cdst []gui.Color, b lightBasis,
 		sinLat := rt.a0 + ct*rt.a1 + st*rt.a2
 		p1 := rt.b0 + ct*rt.b1 + st*rt.b2
 		p2 := rt.c0 + ct*rt.c1 + st*rt.c2
-		texel := rt.tex.at(sinLat, atan2Turns(p2, p1)-rt.spin)
+		texel := rt.tex.atLod(rt.lod, sinLat, atan2Turns(p2, p1)-rt.spin)
 		cdst = append(cdst, gui.RGBA(
 			chan8(float32(texel.R)*rt.k+rt.w),
 			chan8(float32(texel.G)*rt.k+rt.w),
@@ -1441,10 +1484,64 @@ func mixColor(a, b gui.Color, t float32) gui.Color {
 // chan8 clamps a float channel into a byte.
 func chan8(v float32) uint8 { return uint8(clamp32(v, 0, 255)) }
 
-// drawRings draws Saturn's rings as three concentric ellipse arcs over
-// the given angular span.
-func drawRings(dc *gui.DrawContext, cx, cy, r, start, sweep,
-	litFrac float32,
+// ringBasis resolves a planet's ring plane into two screen-space
+// vectors, in the same camera coordinates axisDir uses.
+//
+// The rings lie in the planet's *equatorial* plane, so the plane's
+// normal is the spin axis and the projected ring is an ellipse whose
+// minor axis lies along the axis's own screen direction. Drawing an
+// axis-aligned ellipse instead — which is what this did — leaves the
+// rings level while the pole line leans, and for Saturn that is a
+// 30-degree disagreement between two things drawn from the same fact.
+//
+// e1 is the in-plane direction that lies flat in the screen, so it
+// carries no depth and is a unit vector: the ellipse's semi-major
+// axis. e2 completes the plane and carries all of it; its screen
+// length works out to |az|, which is the semi-minor axis, and its own
+// depth component is m. So a ring point at parameter theta is
+//
+//	P = R*(cos(theta)*e1 + sin(theta)*e2)
+//
+// with depth R*sin(theta)*m — the near half is exactly sin(theta) > 0,
+// which is what lets the caller split front from back without a guess.
+//
+// The degenerate case is an axis pointing straight at the viewer: the
+// ring is then face-on, m is zero and e1 is undefined. Any in-plane
+// direction will do there, so it takes screen right.
+func ringBasis(p *Planet) (e1x, e1y, e2x, e2y float32) {
+	ax, ay, az := axisDir(p)
+	m := sqrt32(ax*ax + ay*ay)
+	if m < 1e-6 {
+		return 1, 0, 0, 1
+	}
+	// e1 = normalize(axis x viewer) in screen terms: perpendicular to
+	// the axis's screen direction.
+	e1x, e1y = -ay/m, ax/m
+	// e2 = axis x e1, whose screen part is -(az/m) * (ax, ay).
+	e2x, e2y = -az*ax/m, -az*ay/m
+	return e1x, e1y, e2x, e2y
+}
+
+// ringSegs is how many line segments one half-ring is drawn with.
+// Scaled by radius for the same reason the sphere mesh is: a small
+// Saturn cannot show the difference and a zoomed one can.
+func ringSegs(rx float32) int {
+	return int(clamp32(rx*0.35, 14, 72))
+}
+
+// drawRings draws Saturn's rings as three concentric ellipse arcs in
+// the planet's equatorial plane.
+//
+// near selects the half in front of the body (depth > 0) or behind it.
+// The two calls together draw the whole ring, and the body drawn
+// between them is what makes it pass behind.
+//
+// gui.DrawContext.Arc can only draw an axis-aligned ellipse, so the
+// arc is walked as a polyline instead. That is not a workaround with a
+// cost: the same walk is what gives the exact front/back split, since
+// the sign of sin(theta) is the sign of the depth.
+func drawRings(a *App, dc *gui.DrawContext, p *Planet, cx, cy, r float32,
+	near bool, litFrac float32,
 ) {
 	// The rings take the same sunlight the body does, so they fade with
 	// the phase rather than staying bright over a night-side Saturn.
@@ -1452,13 +1549,31 @@ func drawRings(dc *gui.DrawContext, cx, cy, r, start, sweep,
 	// Stroke width scales with the body but stays hairline-ish: at
 	// r*0.10 the bands read as three brown tubes rather than rings.
 	width := clamp32(r*0.035, 1, 5)
+
+	e1x, e1y, e2x, e2y := ringBasis(p)
+	// The near half is sin(theta) > 0, so it runs theta over (0, pi)
+	// and the far half over (pi, 2pi) — a sign on the e2 term.
+	depth := float32(1)
+	if !near {
+		depth = -1
+	}
+
 	for _, k := range [3]float32{1.42, 1.70, 1.96} {
 		rx := r * k
-		ry := rx * 0.26
 		if rx < 3 {
 			continue
 		}
-		dc.Arc(cx, cy, rx, ry, start, sweep, col, width)
+		n := ringSegs(rx)
+		pts := a.ringPts[:0]
+		for i := 0; i <= n; i++ {
+			th := float32(math.Pi) * float32(i) / float32(n)
+			c, sn := cos32(th), depth*sin32(th)
+			pts = append(pts,
+				cx+rx*(c*e1x+sn*e2x),
+				cy+rx*(c*e1y+sn*e2y))
+		}
+		a.ringPts = pts
+		dc.Polyline(pts, col, width)
 	}
 }
 

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -98,6 +98,10 @@ type App struct {
 	// and flushed twice per frame, once per cell polarity.
 	granules bodyMesh
 
+	// ringPts is drawRings' polyline scratch: one ring half at a time,
+	// six halves a frame. Reused for the same reason the meshes are.
+	ringPts []float32
+
 	// belt is drawBelt's mesh scratch, dial is the calendar ring's
 	// (ticks + labels + marker in one batch). Separate so capacities
 	// settle independently, the reason documented for

--- a/examples/solar_system/main_test.go
+++ b/examples/solar_system/main_test.go
@@ -1273,7 +1273,10 @@ func BenchmarkAppendRing(b *testing.B) {
 				var rt ringTex
 				if tex {
 					k, w := ringRamp(clamp32(c, 0, 1))
-					rt = proj.ringTexFor(&s, c, sn, k, w)
+					// A fractional level, which is the case that costs the
+					// most: two levels sampled and blended. The lit
+					// side of a small body sits here.
+					rt = proj.ringTexFor(&s, c, sn, k, w, 1.5)
 				}
 				dst, cdst = appendRing(dst[:0], cdst[:0], lb, r, cx, cy,
 					c, sn, shadeArcMax, col, rt)
@@ -1390,4 +1393,161 @@ func TestPinchDeltaIsRelative(t *testing.T) {
 func nearly(got, want, tol float32) bool {
 	d := got - want
 	return d < tol && d > -tol
+}
+
+// TestZoomPathEndpointsAreExact pins the property advanceCamera relies
+// on every settled frame: at t = 1 the path is *at* the target, not
+// near it. The tween is re-solved each tick against a planet that keeps
+// orbiting, so a path that stopped a hair short would leave the camera
+// permanently trailing.
+func TestZoomPathEndpointsAreExact(t *testing.T) {
+	cases := []struct {
+		name                   string
+		x0, y0, w0, x1, y1, w1 float32
+	}{
+		{"zoom in across distance", 0, 0, 2400, 97, 72, 105},
+		{"zoom out across distance", 97, 72, 105, 0, 0, 2400},
+		{"pure zoom, same center", 10, 20, 900, 10, 20, 90},
+		{"pure pan, same width", 0, 0, 500, 300, 40, 500},
+		{"no move at all", 5, 5, 700, 5, 5, 700},
+	}
+	for _, c := range cases {
+		p := newZoomPath(c.x0, c.y0, c.w0, c.x1, c.y1, c.w1)
+		for _, e := range []struct {
+			at      float32
+			x, y, w float32
+		}{{0, c.x0, c.y0, c.w0}, {1, c.x1, c.y1, c.w1}} {
+			x, y, w := p.at(e.at)
+			// Widths span three orders of magnitude here, so the width
+			// is checked in proportion and the centers in absolute
+			// world units.
+			if !closeEnough(x, e.x, 1e-3) || !closeEnough(y, e.y, 1e-3) ||
+				!closeEnough(w, e.w, absF(e.w)*1e-4) {
+				t.Errorf("%s at t=%v: (%.4f,%.4f,%.4f), want (%v,%v,%v)",
+					c.name, e.at, x, y, w, e.x, e.y, e.w)
+			}
+		}
+	}
+}
+
+// TestZoomPathKeepsTheDestinationConverging is the anti-two-step
+// property, and it is about where the destination *appears*, which is
+// the only thing a viewer can see.
+//
+// Interpolating center and zoom separately let the destination slide
+// out toward the edge of the screen while the camera magnified the
+// space it was leaving, and only then swing back — the zoom-to-the-sun,
+// then-slide-over this replaced. Measured against where the tween comes
+// to rest, that showed up as the destination backing away by up to 19
+// px a frame and overshooting to 2.4x its starting distance. On a path
+// solved as one motion it closes monotonically.
+//
+// The reference is the resting position rather than the middle of the
+// screen, because a selection parks its planet above center to clear
+// the info panel; measuring to the center would score that offset as an
+// excursion.
+func TestZoomPathKeepsTheDestinationConverging(t *testing.T) {
+	const steps = 60
+
+	// run plays a whole transition and reports where the destination
+	// sat on screen at each step.
+	run := func(i int) []float32 {
+		a := newApp()
+		a.CanvasW, a.CanvasH = 1200, 800
+		a.Selected = -1
+		a.TweenT = 1
+		a.advanceCamera(0)
+		a.Selected = i
+		a.beginTransition()
+
+		out := make([]float32, 0, 2*(steps+1))
+		for k := 0; k <= steps; k++ {
+			a.advanceCamera(camTweenSecs / steps)
+			wx, wy := orbitPos(&planets[i], a.Time)
+			sx, sy := a.worldToScreen(wx, wy)
+			out = append(out, sx, sy)
+		}
+		return out
+	}
+
+	for i := range planets {
+		p := run(i)
+		endX, endY := p[len(p)-2], p[len(p)-1]
+		var start, prev float32
+		for k := 0; k+1 < len(p); k += 2 {
+			dx, dy := p[k]-endX, p[k+1]-endY
+			d := sqrt32(dx*dx + dy*dy)
+			if k == 0 {
+				start, prev = d, d
+				continue
+			}
+			// Half a pixel of slack for float rounding; the behaviour
+			// this replaced backed away by up to 19.
+			if d > prev+0.5 {
+				t.Errorf("%s: destination backed away %.1f px from its "+
+					"resting place at step %d", planets[i].Name,
+					d-prev, k/2)
+			}
+			if d > start+0.5 {
+				t.Errorf("%s: destination reached %.0f px from rest, "+
+					"further than the %.0f px it started at",
+					planets[i].Name, d, start)
+			}
+			prev = d
+		}
+	}
+}
+
+// TestZoomPathWithoutUsableWidths falls back rather than dividing by
+// one. A width of zero reaches newZoomPath before the first OnDraw has
+// stashed CanvasW, and the contract there is a plain pan at a held
+// width — not an invented zoom rate, and not a NaN.
+func TestZoomPathWithoutUsableWidths(t *testing.T) {
+	for _, c := range []struct{ w0, w1 float32 }{{0, 500}, {500, 0}, {0, 0}} {
+		p := newZoomPath(0, 0, c.w0, 300, 40, c.w1)
+		for _, at := range []float32{0, 0.5, 1} {
+			x, y, w := p.at(at)
+			if x != x || y != y || w != w {
+				t.Fatalf("w0=%v w1=%v at t=%v: NaN in (%v,%v,%v)",
+					c.w0, c.w1, at, x, y, w)
+			}
+			if w != c.w0 {
+				t.Errorf("w0=%v w1=%v at t=%v: width %v, want it held at %v",
+					c.w0, c.w1, at, w, c.w0)
+			}
+		}
+		// The pan still runs its whole length.
+		if x, y, _ := p.at(1); !closeEnough(x, 300, 1e-3) ||
+			!closeEnough(y, 40, 1e-3) {
+			t.Errorf("w0=%v w1=%v: ended at (%v,%v), want (300,40)",
+				c.w0, c.w1, x, y)
+		}
+	}
+}
+
+// TestCameraTweenWithoutCanvasStillTracks covers the frames before the
+// first OnDraw, where CanvasW is still zero and there is no view width
+// to solve a path in. The camera has to keep tweening on the plain
+// blend and land on the target anyway; a divide by zero here would put
+// an Inf into every coordinate the first frame draws.
+func TestCameraTweenWithoutCanvasStillTracks(t *testing.T) {
+	a := newApp()
+	a.CanvasW, a.CanvasH = 0, 0
+	a.Selected = 2
+	a.beginTransition()
+	for range 40 {
+		a.advanceCamera(camTweenSecs / 20)
+		for _, v := range []float32{a.CamX, a.CamY, a.CamZoom} {
+			if v != v || v > math.MaxFloat32/2 || v < -math.MaxFloat32/2 {
+				t.Fatalf("camera went non-finite: (%v,%v,%v)",
+					a.CamX, a.CamY, a.CamZoom)
+			}
+		}
+	}
+	tx, ty, tz := a.target()
+	if !closeEnough(a.CamX, tx, 1e-3) || !closeEnough(a.CamY, ty, 1e-3) ||
+		!closeEnough(a.CamZoom, tz, 1e-3) {
+		t.Errorf("settled at (%v,%v,%v), want the target (%v,%v,%v)",
+			a.CamX, a.CamY, a.CamZoom, tx, ty, tz)
+	}
 }

--- a/examples/solar_system/texture.go
+++ b/examples/solar_system/texture.go
@@ -42,16 +42,57 @@ const (
 // instead of crowding the poles — and, because the mesh hands sampling
 // a direction whose sin(latitude) it already has, it removes an asin
 // from the per-vertex path entirely.
-type bodyTexture struct {
+type texLevel struct {
 	w, h  int
 	texel []gui.Color
 }
+
+// bodyTexture is that grid at a pyramid of resolutions: lod[0] is full
+// detail and each level after it is a box filter of the one above, half
+// the columns and half the rows.
+//
+// The pyramid exists because the mesh cannot carry full detail. Vertices
+// are laid out in the *light* basis, so at a small body's tessellation
+// one vertex step spans about four texels — four times past the rate at
+// which the surface can be point-sampled without aliasing. The grid also
+// stands still on screen while the body turns underneath it, so the
+// alias pattern does not merely look wrong, it crawls: rings of moire
+// concentric with the sub-solar point, sweeping the lit side. Mercury
+// showed it worst because its craters are a threshold on a noise field,
+// and a step edge has no highest frequency to be under.
+//
+// Prefiltering is the fix and more vertices are not. Doubling the mesh
+// buys one octave for four times the triangles; picking a level matched
+// to the vertex spacing removes every octave the mesh cannot represent,
+// for eight texel reads.
+type bodyTexture struct {
+	lod []texLevel
+}
+
+// maxLodDim stops the pyramid while a level still has enough rows to
+// interpolate over. Below this the surface is its mean color and a
+// further level would say nothing new.
+const maxLodDim = 4
 
 // at samples the surface at a latitude given as its sine and a
 // longitude given in turns. turn is wrapped, so a caller may add spin
 // to it without normalizing; sinLat is clamped, which only matters for
 // float error at the poles.
-func (t *bodyTexture) at(sinLat, turn float32) gui.Color {
+//
+// The sample is bilinear, and that is not a quality nicety: it is what
+// keeps a spinning planet from jittering. The mesh's vertices are laid
+// out in the *light* basis, so they sit still on screen while the body
+// turns underneath them. A nearest-texel lookup therefore holds each
+// vertex's color constant for a whole texel of spin and then snaps —
+// 1/128 of a turn, about 3 px of feature travel on a mid-size disc —
+// and every vertex snaps at its own moment, which reads as the surface
+// crawling rather than rotating. Interpolating makes each vertex's
+// color a continuous function of spin, so the pattern slides.
+//
+// Longitude wraps between the last column and the first, because the
+// grid is a full circle. Latitude clamps, because the rows stop at the
+// poles.
+func (t *texLevel) at(sinLat, turn float32) gui.Color {
 	// Clamp before the float-to-int below, not after: NaN compares
 	// false against both bounds, so a clamp on the integer row would
 	// let it slip through with an unspecified value. Catch it with a
@@ -65,25 +106,178 @@ func (t *bodyTexture) at(sinLat, turn float32) gui.Color {
 	} else if sinLat != sinLat {
 		sinLat = 1
 	}
-	row := int((1 - sinLat) * 0.5 * float32(t.h))
-	if row < 0 {
-		row = 0
-	} else if row >= t.h {
-		row = t.h - 1
+	// Row centers sit at sinLat = 1 - 2*(row+0.5)/h (see makeTexture),
+	// so inverting gives a continuous coordinate whose integers land on
+	// centers once the half-texel is taken back off.
+	ry := (1-sinLat)*0.5*float32(t.h) - 0.5
+	r0 := int(floor32(ry))
+	fy := ry - float32(r0)
+	r1 := r0 + 1
+	// Above the first center and below the last there is no second row
+	// to blend with; clamping both ends onto the same row makes the
+	// blend a no-op there instead of a wrap onto the far pole.
+	if r0 < 0 {
+		r0 = 0
+	} else if r0 >= t.h {
+		r0 = t.h - 1
 	}
+	if r1 < 0 {
+		r1 = 0
+	} else if r1 >= t.h {
+		r1 = t.h - 1
+	}
+
 	// Wrap into [0,1) without math.Floor: the truncation toward zero
-	// is corrected by the negative branch.
+	// is corrected by the negative branch. NaN is caught here for the
+	// same reason it is caught above, and it has to be caught *here*
+	// rather than on the column: int(NaN) is implementation-defined,
+	// and on amd64 it is math.MinInt64, which no clamp on the column
+	// recovers from before the index.
 	f := turn - float32(int(turn))
-	if f < 0 {
+	if f != f {
+		f = 0
+	} else if f < 0 {
 		f++
 	}
-	col := int(f * float32(t.w))
-	if col < 0 {
-		col = 0
-	} else if col >= t.w {
-		col = t.w - 1
+	rx := f*float32(t.w) - 0.5
+	c0 := int(floor32(rx))
+	fx := rx - float32(c0)
+	// f is in [0,1), so rx is in [-0.5, w-0.5) and c0 is in [-1, w-1]:
+	// it can only be one step below zero, never past the far end. One
+	// conditional is enough; no modulo needed.
+	if c0 < 0 {
+		c0 += t.w
 	}
-	return t.texel[row*t.w+col]
+	c1 := c0 + 1
+	if c1 >= t.w {
+		c1 = 0
+	}
+
+	a := t.texel[r0*t.w+c0]
+	b := t.texel[r0*t.w+c1]
+	c := t.texel[r1*t.w+c0]
+	d := t.texel[r1*t.w+c1]
+	return gui.RGB(
+		bilerp8(a.R, b.R, c.R, d.R, fx, fy),
+		bilerp8(a.G, b.G, c.G, d.G, fx, fy),
+		bilerp8(a.B, b.B, c.B, d.B, fx, fy),
+	)
+}
+
+// lerp8 blends two bytes. Rounding is by the +0.5 truncation rather
+// than chan8's clamp or mixColor, because a convex combination of two
+// bytes cannot leave the byte range and the clamp would be dead work
+// on a per-vertex path.
+func lerp8(a, b uint8, t float32) uint8 {
+	return uint8(lerp(float32(a), float32(b), t) + 0.5)
+}
+
+// bilerp8 blends the four corners of one texel cell on a single
+// channel. It rounds the way lerp8 does but only once, at the end:
+// rounding the two row blends first would cost a count of bias on
+// every sample.
+func bilerp8(a, b, c, d uint8, fx, fy float32) uint8 {
+	top := lerp(float32(a), float32(b), fx)
+	bot := lerp(float32(c), float32(d), fx)
+	return uint8(lerp(top, bot, fy) + 0.5)
+}
+
+// at samples the finest level. Kept for callers with no footprint to
+// offer — the tests, and any sampling that is not per mesh vertex.
+func (t *bodyTexture) at(sinLat, turn float32) gui.Color {
+	return t.lod[0].at(sinLat, turn)
+}
+
+// atLod samples at a fractional pyramid level, blending the two levels
+// that bracket it.
+//
+// The blend is what keeps the level choice invisible. Adjacent rings of
+// one body land on different footprints and so on different levels; a
+// hard switch would draw that boundary as a visible ring of changing
+// sharpness, which is the artifact this whole path exists to remove.
+func (t *bodyTexture) atLod(lod, sinLat, turn float32) gui.Color {
+	if lod <= 0 {
+		return t.lod[0].at(sinLat, turn)
+	}
+	top := len(t.lod) - 1
+	if lod >= float32(top) {
+		return t.lod[top].at(sinLat, turn)
+	}
+	i := int(lod)
+	f := lod - float32(i)
+	a := t.lod[i].at(sinLat, turn)
+	b := t.lod[i+1].at(sinLat, turn)
+	return gui.RGB(
+		lerp8(a.R, b.R, f), lerp8(a.G, b.G, f), lerp8(a.B, b.B, f))
+}
+
+// maxLod is the coarsest level the pyramid holds, as the caller's
+// clamp bound.
+func (t *bodyTexture) maxLod() float32 { return float32(len(t.lod) - 1) }
+
+// lodFor turns a vertex spacing, in radians of arc on the unit sphere,
+// into a pyramid level.
+//
+// The reference is one texel of the longitude grid at the equator,
+// 2*pi/texW: level 0 resolves that, and every level after it doubles
+// the span. A spacing at or below one texel asks for full detail and
+// clamps to zero.
+func (t *bodyTexture) lodFor(ds float32) float32 {
+	l := log2f(ds * float32(texW) * (1 / (2 * math.Pi)))
+	return clamp32(l, 0, t.maxLod())
+}
+
+// log2f is log2 for positive floats, taken from the exponent field with
+// the mantissa folded in linearly. Worst case is about 0.086 of a level,
+// which moves the blend weight and never the choice of levels — and it
+// costs no library call on a path that runs once per ring.
+func log2f(v float32) float32 {
+	if v <= 0 {
+		return 0
+	}
+	b := math.Float32bits(v)
+	e := float32(int32(b>>23) - 127)
+	m := math.Float32frombits((b & 0x007FFFFF) | 0x3F800000)
+	return e + (m - 1)
+}
+
+// downsample box-filters a surface into one of half the columns and
+// half the rows, in place of a new buffer.
+//
+// It works on the unquantized floats rather than on the level above's
+// bytes, and that is deliberate: rounding to bytes at every level
+// compounds its own bias, so a five-level pyramid built from bytes
+// walks its mean off the planet's table color. Filtering the source
+// once per level keeps every level's mean the source's mean, and each
+// is quantized exactly once.
+//
+// A plain 2x2 average is area-correct here and would not be on most
+// lat/lon grids: rows are uniform in sin(latitude), so every texel of
+// every row covers the same area of the sphere and none of them needs
+// weighting.
+func downsample(src []rgbF, w, h int) ([]rgbF, int, int) {
+	dw, dh := w/2, h/2
+	dst := make([]rgbF, dw*dh)
+	for row := range dh {
+		s0 := (row * 2) * w
+		s1 := s0 + w
+		for col := range dw {
+			c0, c1 := col*2, col*2+1
+			sum := src[s0+c0].add(src[s0+c1]).
+				add(src[s1+c0]).add(src[s1+c1])
+			dst[row*dw+col] = sum.scale(0.25)
+		}
+	}
+	return dst, dw, dh
+}
+
+// quantize freezes a float surface into one pyramid level.
+func quantize(src []rgbF, w, h int) texLevel {
+	l := texLevel{w: w, h: h, texel: make([]gui.Color, len(src))}
+	for i, c := range src {
+		l.texel[i] = c.color()
+	}
+	return l
 }
 
 // planetTextures is built once for the process, not once per App:
@@ -383,7 +577,6 @@ func makeTextures() [len(planets)]*bodyTexture {
 // and a planet too small to show any texture still reads as the same
 // planet it did before.
 func makeTexture(base rgbF, fn texFn) *bodyTexture {
-	t := &bodyTexture{w: texW, h: texH}
 	buf := make([]rgbF, texW*texH)
 
 	for row := range texH {
@@ -403,9 +596,12 @@ func makeTexture(base rgbF, fn texFn) *bodyTexture {
 
 	normalizeMean(buf, base)
 
-	t.texel = make([]gui.Color, len(buf))
-	for i, c := range buf {
-		t.texel[i] = c.color()
+	// Build down until a level is too small to interpolate over. The
+	// whole pyramid costs a third again of the base level.
+	t := &bodyTexture{lod: []texLevel{quantize(buf, texW, texH)}}
+	for w, h := texW, texH; w/2 >= maxLodDim && h/2 >= maxLodDim; {
+		buf, w, h = downsample(buf, w, h)
+		t.lod = append(t.lod, quantize(buf, w, h))
 	}
 	return t
 }

--- a/examples/solar_system/texture_test.go
+++ b/examples/solar_system/texture_test.go
@@ -132,7 +132,7 @@ func TestRingLinearizationMatchesWorldNormal(t *testing.T) {
 			for pi := range 9 {
 				phi := float32(pi) * math.Pi / 8
 				cosPhi, sinPhi := cos32(phi), sin32(phi)
-				rt := proj.ringTexFor(s, cosPhi, sinPhi, 1, 0)
+				rt := proj.ringTexFor(s, cosPhi, sinPhi, 1, 0, 0)
 
 				for ti := range 12 {
 					tt := float32(ti) * 2 * math.Pi / 12
@@ -243,45 +243,102 @@ func TestRingRampMatchesSphereTone(t *testing.T) {
 // the row mapping at the poles, the turn wrap for negative and
 // overshooting values, and the NaN contract (a defined in-bounds texel
 // rather than an out-of-range index).
+//
+// at() is bilinear, so the exact-equality checks below all sample at
+// texel *centers*, where the blend weights are 0 or 1 and the result is
+// one stored texel. Centers sit at (n+0.5)/w in longitude, hence the
+// odd-looking turn constants. TestTextureAtIsContinuousInTurn covers
+// the between-centers behavior.
 func TestTextureAtClampsAndWraps(t *testing.T) {
-	tex := &bodyTexture{w: 128, h: 64}
+	tex := &texLevel{w: 128, h: 64}
 	tex.texel = make([]gui.Color, 128*64)
 	for i := range tex.texel {
 		tex.texel[i] = gui.RGB(uint8(i%128), uint8(i/128), 0)
 	}
 	at := func(sinLat, turn float32) gui.Color { return tex.at(sinLat, turn) }
-	if got := at(1, 0); got != tex.texel[0] {
-		t.Errorf("north pole sampled row %v, want row 0", got)
+	// Column 0's center. Rows clamp rather than wrap, so a pole
+	// samples its own row on both taps.
+	const col0 = 0.5 / 128
+	if got := at(1, col0); got != tex.texel[0] {
+		t.Errorf("north pole sampled %v, want row 0", got)
 	}
-	if got := at(-1, 0); got != tex.texel[63*128] {
-		t.Errorf("south pole sampled row %v, want row 63", got)
+	if got := at(-1, col0); got != tex.texel[63*128] {
+		t.Errorf("south pole sampled %v, want row 63", got)
 	}
-	if got := at(1.5, 0); got != tex.texel[0] {
+	if got := at(1.5, col0); got != tex.texel[0] {
 		t.Errorf("overshoot at +1.5 sampled %v, want row 0", got)
 	}
-	if got := at(-1.5, 0); got != tex.texel[63*128] {
+	if got := at(-1.5, col0); got != tex.texel[63*128] {
 		t.Errorf("overshoot at -1.5 sampled %v, want row 63", got)
 	}
-	// Longitude: f = 0.25 and 0.75 are exactly representable, so the
-	// wrapped sample must land on a known column.
+	// Longitude: column 32's center, reached from below zero and from
+	// past one, must land on the same stored texel.
+	const col32 = 32.5 / 128
 	mid := 32 * 128 // row 32, the equator
-	if got := at(0, 0.25); got != tex.texel[mid+32] {
-		t.Errorf("turn 0.25 sampled %v, want column 32", got)
+	// sinLat for row 32's center, so the row blend is a no-op too.
+	const midLat = 1 - 2*(32+0.5)/64.0
+	if got := at(midLat, col32); got != tex.texel[mid+32] {
+		t.Errorf("turn %v sampled %v, want column 32", float32(col32), got)
 	}
-	if got := at(0, -0.75); got != tex.texel[mid+32] {
-		t.Errorf("turn -0.75 sampled %v, want column 32", got)
+	if got := at(midLat, col32-1); got != tex.texel[mid+32] {
+		t.Errorf("turn %v sampled %v, want column 32", float32(col32-1), got)
 	}
-	if got := at(0, 1.25); got != tex.texel[mid+32] {
-		t.Errorf("turn 1.25 sampled %v, want column 32", got)
+	if got := at(midLat, col32+1); got != tex.texel[mid+32] {
+		t.Errorf("turn %v sampled %v, want column 32", float32(col32+1), got)
 	}
-	if got := at(0, 1); got != tex.texel[mid] {
-		t.Errorf("turn 1 sampled %v, want column 0", got)
+	// A NaN turn must not panic either, and that one is sharper than
+	// it looks: int(NaN) is implementation-defined and on amd64 it is
+	// math.MinInt64, which no clamp on the column recovers from before
+	// the index. It has to be caught on the wrapped fraction.
+	if got, want := at(0, float32(math.NaN())), at(0, 0); got != want {
+		t.Errorf("NaN turn sampled %v, want the turn-0 sample %v", got, want)
 	}
 	// NaN must not panic or produce an out-of-range index.
 	got := at(float32(math.NaN()), 0)
 	if int(got.R) >= tex.w || int(got.G) >= tex.h {
 		t.Errorf("NaN sinLat sampled (%d,%d), an out-of-range texel",
 			got.R, got.G)
+	}
+}
+
+// TestTextureAtIsContinuousInTurn is the anti-jitter property.
+//
+// A spinning body's mesh vertices sit still in the light basis while
+// the surface turns under them, so a vertex's color is a function of
+// spin alone. Nearest sampling made that function a staircase with
+// 1/texW-turn treads, which is what the surface crawling looked like.
+// Sweeping a full turn in steps far finer than a texel, no single step
+// may move a channel by more than a texel's own worth of difference —
+// which on this ramp is one count per step at most, plus one for
+// rounding.
+func TestTextureAtIsContinuousInTurn(t *testing.T) {
+	tex := &texLevel{w: 128, h: 64}
+	tex.texel = make([]gui.Color, 128*64)
+	for i := range tex.texel {
+		// A triangle wave along longitude. Adjacent columns differ by
+		// 2 everywhere *including across the wrap*, so the ramp itself
+		// contributes no discontinuity for the check to excuse.
+		col := i % 128
+		d := col - 64
+		if d < 0 {
+			d = -d
+		}
+		tex.texel[i] = gui.RGB(uint8(d*2), 0, 0)
+	}
+	const steps = 128 * 8
+	prev := tex.at(0, 0)
+	for k := 1; k <= steps; k++ {
+		turn := float32(k) / steps
+		got := tex.at(0, turn)
+		d := int(got.R) - int(prev.R)
+		if d < 0 {
+			d = -d
+		}
+		if d > 2 {
+			t.Fatalf("turn %v: R jumped %d counts (%d -> %d)",
+				turn, d, prev.R, got.R)
+		}
+		prev = got
 	}
 }
 
@@ -298,7 +355,7 @@ func TestUVCoordsStayInRange(t *testing.T) {
 			for pi := range 12 {
 				phi := float32(pi) * math.Pi / 11
 				cosPhi, sinPhi := cos32(phi), sin32(phi)
-				rt := proj.ringTexFor(s, cosPhi, sinPhi, 1, 0)
+				rt := proj.ringTexFor(s, cosPhi, sinPhi, 1, 0, 0)
 				for ti := range 16 {
 					tt := float32(ti) * 2 * math.Pi / 16
 					ct, st := cos32(tt), sin32(tt)
@@ -410,7 +467,7 @@ func TestRotationTableIsSane(t *testing.T) {
 // textured planet has to average out to it.
 func TestTextureMeanMatchesPlanetColor(t *testing.T) {
 	for i := range planets {
-		tex := planetTextures[i]
+		tex := &planetTextures[i].lod[0]
 		var sr, sg, sb float64
 		for _, c := range tex.texel {
 			sr += float64(c.R)
@@ -442,7 +499,7 @@ func TestTextureMeanMatchesPlanetColor(t *testing.T) {
 // regression to 2D noise would put a visible line down every planet.
 func TestTextureIsSeamlessInLongitude(t *testing.T) {
 	for i := range planets {
-		tex := planetTextures[i]
+		tex := &planetTextures[i].lod[0]
 		delta := func(a, b gui.Color) int {
 			d := func(x, y uint8) int {
 				if x > y {
@@ -480,9 +537,9 @@ func TestTextureIsSeamlessInLongitude(t *testing.T) {
 // ringRamp does not, which is worth at most one count.
 func TestTexturedBodyMatchesFlatWhenTextureIsUniform(t *testing.T) {
 	base := gui.RGB(180, 140, 90)
-	flatTex := &bodyTexture{w: 4, h: 2, texel: make([]gui.Color, 8)}
-	for i := range flatTex.texel {
-		flatTex.texel[i] = base
+	flatTex := &bodyTexture{lod: []texLevel{{w: 4, h: 2, texel: make([]gui.Color, 8)}}}
+	for i := range flatTex.lod[0].texel {
+		flatTex.lod[0].texel[i] = base
 	}
 
 	s := testSurface(2, 1.0) // Earth, for a non-trivial tilt
@@ -532,10 +589,10 @@ func TestTexturedBodyDoesNotAllocatePerFrame(t *testing.T) {
 		b := newLightBasis(0.6, 0.2, -0.77)
 		proj := s.project(b)
 		k, w := ringRamp(0.5)
-		rt := proj.ringTexFor(s, 0.3, 0.95, k, w)
+		rt := proj.ringTexFor(s, 0.3, 0.95, k, w, 0)
 		m.cur, m.curCol = appendRing(m.cur[:0], m.curCol[:0], b,
 			120, 200, 200, 0.3, 0.95, 64, gui.RGB(1, 2, 3), rt)
-		rt = proj.ringTexFor(s, 0.2, 0.98, k, w)
+		rt = proj.ringTexFor(s, 0.2, 0.98, k, w, 0)
 		m.prev, m.prevCol = appendRing(m.prev[:0], m.prevCol[:0], b,
 			120, 200, 200, 0.2, 0.98, 64, gui.RGB(4, 5, 6), rt)
 		m.appendStrip(64)
@@ -588,5 +645,255 @@ func TestTexturedBodyStaysNearPlanetColor(t *testing.T) {
 					planets[i].Name, ch.name, ch.ha, ch.flat)
 			}
 		}
+	}
+}
+
+// TestLodPyramidShapeAndMean pins the two properties the pyramid has
+// to hold: every level is half the one above it down to the stopping
+// size, and the box filter preserves the mean normalizeMean
+// established. A coarse level whose mean had drifted would make a
+// small planet a different color from its own nav dot.
+func TestLodPyramidShapeAndMean(t *testing.T) {
+	for i := range planets {
+		tex := planetTextures[i]
+		if len(tex.lod) < 2 {
+			t.Fatalf("%s: pyramid has %d level(s), want at least 2",
+				planets[i].Name, len(tex.lod))
+		}
+		mean := func(l *texLevel) (float64, float64, float64) {
+			var r, g, b float64
+			for _, c := range l.texel {
+				r, g, b = r+float64(c.R), g+float64(c.G), b+float64(c.B)
+			}
+			n := float64(len(l.texel))
+			return r / n, g / n, b / n
+		}
+		wr, wg, wb := mean(&tex.lod[0])
+		for k := 1; k < len(tex.lod); k++ {
+			up, l := &tex.lod[k-1], &tex.lod[k]
+			if l.w != up.w/2 || l.h != up.h/2 {
+				t.Fatalf("%s level %d: %dx%d, want %dx%d",
+					planets[i].Name, k, l.w, l.h, up.w/2, up.h/2)
+			}
+			if len(l.texel) != l.w*l.h {
+				t.Fatalf("%s level %d: %d texels for %dx%d",
+					planets[i].Name, k, len(l.texel), l.w, l.h)
+			}
+			// Every level is filtered from the unquantized source and
+			// rounded once, so the only drift is that one rounding.
+			gr, gg, gb := mean(l)
+			for _, ch := range []struct {
+				name      string
+				got, want float64
+			}{{"R", gr, wr}, {"G", gg, wg}, {"B", gb, wb}} {
+				if d := ch.got - ch.want; d > 0.5 || d < -0.5 {
+					t.Errorf("%s level %d channel %s: mean %.2f, want %.2f",
+						planets[i].Name, k, ch.name, ch.got, ch.want)
+				}
+			}
+		}
+	}
+}
+
+// TestLodSuppressesDetailTheMeshCannotCarry is the anti-moire property.
+//
+// Sampling a surface at the mesh's own vertex spacing must not swing
+// more, step to step, than sampling it at a spacing fine enough to
+// resolve it. Point sampling fails this badly: it reads whatever texel
+// it lands on, so a coarse walk across a threshold-edged surface like
+// Mercury's jumps by the full contrast of the feature it skipped over,
+// and those jumps move as the body turns. Choosing a level matched to
+// the spacing removes the octaves the walk cannot represent, so the
+// coarse walk becomes a smooth version of the fine one.
+func TestLodSuppressesDetailTheMeshCannotCarry(t *testing.T) {
+	tex := planetTextures[0] // Mercury, the worst case
+	// A vertex spacing of four texels, which is what a small body's
+	// tessellation actually gives on the lit side.
+	const stepTexels = 4
+	lod := tex.lodFor(stepTexels * 2 * math.Pi / texW)
+	if lod < 1 {
+		t.Fatalf("lodFor(%d texels) = %v, want at least 1", stepTexels, lod)
+	}
+
+	swing := func(sample func(turn float32) gui.Color) int {
+		var worst int
+		prev := sample(0)
+		for k := 1; k <= texW/stepTexels; k++ {
+			turn := float32(k) * stepTexels / texW
+			got := sample(turn)
+			for _, d := range []int{
+				int(got.R) - int(prev.R),
+				int(got.G) - int(prev.G),
+				int(got.B) - int(prev.B),
+			} {
+				if d < 0 {
+					d = -d
+				}
+				worst = max(worst, d)
+			}
+			prev = got
+		}
+		return worst
+	}
+
+	// Along the equator, where a texel is widest and the walk skips
+	// the most.
+	raw := swing(func(turn float32) gui.Color { return tex.at(0, turn) })
+	filtered := swing(func(turn float32) gui.Color {
+		return tex.atLod(lod, 0, turn)
+	})
+	if filtered >= raw {
+		t.Errorf("worst step: filtered %d, unfiltered %d — the level "+
+			"choice removed nothing", filtered, raw)
+	}
+}
+
+// TestRingPlaneIsPerpendicularToSpinAxis pins the fact that makes
+// Saturn's rings right: they lie in its equatorial plane, so both
+// in-plane basis vectors are perpendicular to the spin axis.
+//
+// The drawn pole line and the rings come from the same tilt, and an
+// axis-aligned ellipse — which is what this replaced — left them
+// disagreeing by about 30 degrees.
+func TestRingPlaneIsPerpendicularToSpinAxis(t *testing.T) {
+	for i := range planets {
+		p := &planets[i]
+		ax, ay, az := axisDir(p)
+		e1x, e1y, e2x, e2y := ringBasis(p)
+		// ringBasis returns the screen halves; e1 lies flat in the
+		// screen by construction and e2's depth is the axis's own
+		// screen-plane length.
+		m := sqrt32(ax*ax + ay*ay)
+		for _, e := range []struct {
+			name    string
+			x, y, z float32
+		}{
+			{"e1", e1x, e1y, 0},
+			{"e2", e2x, e2y, m},
+		} {
+			if d := ax*e.x + ay*e.y + az*e.z; abs32(d) > 1e-5 {
+				t.Errorf("%s: %s . axis = %v, want 0",
+					p.Name, e.name, d)
+			}
+		}
+		// Both are also the ellipse's semi-axes, so their lengths are
+		// what the projection says: e1 is a unit vector and e2's screen
+		// length is |az|.
+		if l := sqrt32(e1x*e1x + e1y*e1y); abs32(l-1) > 1e-5 {
+			t.Errorf("%s: |e1| = %v, want 1", p.Name, l)
+		}
+		if l := sqrt32(e2x*e2x + e2y*e2y); abs32(l-abs32(az)) > 1e-5 {
+			t.Errorf("%s: |e2| = %v, want |az| = %v", p.Name, l, abs32(az))
+		}
+	}
+}
+
+// TestRingHalvesSplitByDepth walks the points drawRings emits and
+// requires each half to be the one it claims.
+//
+// The drawing order is far rings, body, near rings, and that is the
+// whole of what makes the rings pass behind Saturn. If a half carried
+// a point from the other side, that point would be drawn on the wrong
+// side of the sphere.
+func TestRingHalvesSplitByDepth(t *testing.T) {
+	p := &planets[saturnIndex]
+	ax, ay, _ := axisDir(p)
+	m := sqrt32(ax*ax + ay*ay)
+	e1x, e1y, e2x, e2y := ringBasis(p)
+	// The two screen basis vectors are not orthogonal, so recovering a
+	// point's parameters means inverting the 2x2 they form.
+	det := e1x*e2y - e1y*e2x
+	if abs32(det) < 1e-6 {
+		t.Fatalf("ring basis is degenerate: det %v", det)
+	}
+
+	const cx, cy, r = 200, 200, 40
+	for _, near := range []bool{true, false} {
+		var a App
+		dc := gui.NewDrawContext(400, 400, nil)
+		drawRings(&a, dc, p, cx, cy, r, near, 1)
+		if len(a.ringPts) < 4 {
+			t.Fatalf("near=%v: drawRings emitted %d coords",
+				near, len(a.ringPts))
+		}
+		// a.ringPts holds the last (outermost) ring, radius r*1.96.
+		const outer = r * 1.96
+		for k := 0; k+1 < len(a.ringPts); k += 2 {
+			dx := (a.ringPts[k] - cx) / outer
+			dy := (a.ringPts[k+1] - cy) / outer
+			// Solve dx,dy = c*e1 + sn*e2 for c and sn.
+			c := (dx*e2y - dy*e2x) / det
+			sn := (e1x*dy - e1y*dx) / det
+			// The point is on the ring: cos^2 + sin^2 == 1.
+			if q := c*c + sn*sn; abs32(q-1) > 1e-3 {
+				t.Fatalf("near=%v point %d: cos^2+sin^2 = %v, want 1",
+					near, k/2, q)
+			}
+			// Depth is r*sin(theta)*m, and the near half is the
+			// positive one. The two endpoints sit at sin == 0, where
+			// the ring crosses the plane of the limb.
+			depth := sn * m
+			if near && depth < -1e-4 {
+				t.Errorf("near half point %d has depth %v", k/2, depth)
+			}
+			if !near && depth > 1e-4 {
+				t.Errorf("far half point %d has depth %v", k/2, depth)
+			}
+		}
+	}
+}
+
+// TestLog2fMatchesLibrary checks the bit-trick log2 against the real
+// one over the range lodFor actually feeds it. The claim in log2f's
+// comment is a worst case of about 0.086 of a level, which is small
+// enough to move a blend weight and never the choice of levels; a
+// regression past that would start snapping between levels.
+func TestLog2fMatchesLibrary(t *testing.T) {
+	var worst float64
+	// A texel spacing from a thousandth of a texel to a thousand, which
+	// covers everything between a zoomed Jupiter and a one-pixel Mercury.
+	for v := 0.001; v <= 1000; v *= 1.01 {
+		got := float64(log2f(float32(v)))
+		want := math.Log2(v)
+		if d := math.Abs(got - want); d > worst {
+			worst = d
+		}
+	}
+	if worst > 0.09 {
+		t.Errorf("log2f worst error %.4f levels, want at most 0.09", worst)
+	}
+	// Non-positive input has no logarithm; lodFor clamps to level 0
+	// anyway, so the contract is that it returns 0 rather than -Inf.
+	for _, v := range []float32{0, -1, float32(math.Inf(-1))} {
+		if got := log2f(v); got != 0 {
+			t.Errorf("log2f(%v) = %v, want 0", v, got)
+		}
+	}
+}
+
+// TestLodForClampsToThePyramid pins the two ends of the level choice.
+// A spacing the finest level already resolves must ask for full detail,
+// and a spacing coarser than the whole pyramid must stop at the last
+// level rather than index past it.
+func TestLodForClampsToThePyramid(t *testing.T) {
+	tex := planetTextures[0]
+	oneTexel := float32(2 * math.Pi / texW)
+	for _, c := range []struct {
+		name string
+		ds   float32
+		want float32
+	}{
+		{"far below a texel", oneTexel / 1000, 0},
+		{"exactly a texel", oneTexel, 0},
+		{"the whole sphere", math.Pi, tex.maxLod()},
+		{"non-positive", 0, 0},
+	} {
+		if got := tex.lodFor(c.ds); got != c.want {
+			t.Errorf("lodFor(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+	// And every level the clamp can return must be samplable.
+	for _, lod := range []float32{0, 0.5, 1, tex.maxLod(), tex.maxLod() + 5} {
+		tex.atLod(lod, 0, 0.25)
 	}
 }


### PR DESCRIPTION
Van Wijk/Nuij zoom-and-pan replaces separate center/zoom lerps so selection flies as one motion instead of zoom-then-pan. Texture pyramid with bilinear sampling removes moire on small bodies and keeps spin continuous; LOD is chosen from ring vertex footprint. `drawRings` splits halves by depth seam and reuses `App.ringPts` scratch across the six rings per frame.

- `camera.go`: `zoomPath`/`newZoomPath` hyperbolic schedule, `at()` landing exactly on target
- `texture.go`: `texLevel` pyramid, bilinear `at()`, `lodFor()`/`buildLOD`
- `draw.go`: `ringFootprint` LOD selection, `ringTex.lod` plumbing, depth-split rings
- `main.go`: `App.ringPts` scratch reuse
- Tests: `TestZoomPathEndpointsAreExact`, texture bilinear/LOD coverage, updated `ringTexFor` call sites

Preflight: branch created from `main` (merge queue: SQUASH), local `make prepush` green.