### PR TITLE
test(golden): fingerprint RenderSvg geometry so counts alone cannot pass

### DIFF
--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -13,6 +13,7 @@ package gui
 // catch a change to the role it uses.
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -1009,6 +1010,97 @@ func TestGoldenSerializerStable(t *testing.T) {
 	}
 	if colorStr(ColorTransparent) == "unset" {
 		t.Error("ColorTransparent must not serialize as unset")
+	}
+}
+
+// svgLine serializes one triangle batch, which is the unit the
+// geometry fingerprint is asserted on.
+func svgLine(tris []float32) string {
+	return serializeCmd(RenderCmd{Kind: RenderSvg, Triangles: tris})
+}
+
+// TestGoldenTriFingerprint pins the properties the fingerprint exists
+// for. A triangle count is blind to every case below except the first,
+// which is how two geometry bugs shipped through a green TestGolden
+// (issue #454).
+func TestGoldenTriFingerprint(t *testing.T) {
+	base := []float32{
+		0, 0, 60, 0, 60, 60,
+		0, 0, 60, 60, 0, 60,
+	}
+	want := svgLine(base)
+
+	if got := svgLine(base); got != want {
+		t.Errorf("fingerprint not stable:\n%s\n%s", want, got)
+	}
+
+	// A moved vertex. Same triangle count, different geometry: the
+	// bbox and the digest must both notice.
+	moved := append([]float32(nil), base...)
+	moved[2] = 55
+	got := svgLine(moved)
+	if got == want {
+		t.Errorf("moved vertex not recorded:\n%s", got)
+	}
+	if !strings.Contains(want, "bbox=0.00,0.00..60.00,60.00") ||
+		!strings.Contains(got, "bbox=0.00,0.00..60.00,60.00") {
+		t.Errorf("unexpected bbox:\nwant line: %s\n got line: %s",
+			want, got)
+	}
+
+	// Interior rearrangement: the two triangles swapped, so every
+	// vertex, the bbox and the centroid are unchanged. Only the digest
+	// can see this, and it is the shape of the #450 bug.
+	swapped := []float32{
+		0, 0, 60, 60, 0, 60,
+		0, 0, 60, 0, 60, 60,
+	}
+	if got = svgLine(swapped); got == want {
+		t.Error("swapped triangles serialized identically; " +
+			"the digest is not reading order")
+	}
+
+	// Sub-precision drift must NOT move the digest. Without this the
+	// gate reds on unrelated float noise and gets re-recorded blind,
+	// which is worse than recording nothing.
+	jittered := append([]float32(nil), base...)
+	jittered[2] += 1e-6
+	if got = svgLine(jittered); got != want {
+		t.Errorf("1e-6 of drift moved the fingerprint:\n%s\n%s",
+			want, got)
+	}
+
+	// A batch with no geometry adds no fields.
+	if got = svgLine(nil); strings.Contains(got, "digest=") {
+		t.Errorf("empty batch got a fingerprint: %s", got)
+	}
+}
+
+// TestGoldenGradientStops guards the other half of issue #454: the
+// concentric radial fill is a shader quad, so its ramp reaches the
+// golden only through the gradient pointer.
+func TestGoldenGradientStops(t *testing.T) {
+	def := GradientDef{
+		Type: GradientRadial,
+		Stops: []GradientStop{
+			{Color: RGB(255, 0, 0), Pos: 0.2},
+			{Color: RGB(0, 255, 0), Pos: 0.6},
+		},
+	}
+	line := serializeCmd(RenderCmd{Kind: RenderGradient, Gradient: &def})
+	for _, want := range []string{
+		"radial", "stops=2", "0.20 #ff0000ff", "0.60 #00ff00ff",
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("gradient line %q missing %q", line, want)
+		}
+	}
+
+	moved := def
+	moved.Stops = []GradientStop{def.Stops[0], {Color: RGB(0, 255, 0), Pos: 0.55}}
+	other := serializeCmd(RenderCmd{Kind: RenderGradient, Gradient: &moved})
+	if other == line {
+		t.Error("a moved stop serialized identically")
 	}
 }
 

--- a/gui/golden_test.go
+++ b/gui/golden_test.go
@@ -23,16 +23,27 @@ package gui
 //     (Segoe UI on Windows) where a font is reachable and stays empty
 //     where it is not, so it is noise against the geometry and colors
 //     these files pin.
-//   - Pointer fields (styles, gradients, layouts) are summarized by
-//     presence, not dereferenced. A golden is a fingerprint, not a
-//     serialization format.
+//   - Pointer fields (styles, layouts) are summarized by presence, not
+//     dereferenced. A golden is a fingerprint, not a serialization
+//     format. The gradient pointer is the exception: it is recorded by
+//     its stop list, because since the concentric radial fill lowered
+//     to a shader quad (#462) that ramp is all the command carries.
+//   - A triangle batch records a coordinate fingerprint (bbox,
+//     centroid, digest) as well as its counts, and the digest hashes
+//     values rounded to the same two decimals everything else prints.
+//     Counts alone passed two shipped geometry bugs (#449, #450);
+//     hashing raw float bits would red the suite on the first ULP of
+//     unrelated drift, which is worse than no gate (issue #454).
 //
 // Each case is recorded in both ThemeDark and ThemeLight, which is
 // what makes a per-theme styling decision checkable.
 
 import (
+	"encoding/binary"
 	"flag"
 	"fmt"
+	"hash/fnv"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,6 +108,88 @@ func f2(v float32) string {
 		v = 0
 	}
 	return fmt.Sprintf("%.2f", v)
+}
+
+// roundF2 rounds to the precision f2 prints, normalizing negative zero
+// so a value that prints 0.00 also hashes as 0.
+func roundF2(v float32) float32 {
+	r := float32(math.Round(float64(v)*100) / 100)
+	if r == 0 {
+		r = 0
+	}
+	return r
+}
+
+// triFingerprint summarizes a flat x,y triangle list: the bounding
+// box, the centroid, and a digest of every coordinate.
+//
+// The three answer different questions. The bbox catches a batch drawn
+// at the wrong size or place — the #449 fan band emitted at the full
+// circle radius. The centroid separates a shape that moved from one
+// that grew. The digest catches interior rearrangement that leaves
+// both alone, which is exactly what a triangle count cannot see.
+//
+// Rounding before hashing is load bearing: raw float32 bits would red
+// every golden on the first ULP of drift from an unrelated math
+// change, and the suite would then be re-recorded without being read.
+// Rounded, the digest is no more fragile than the numbers the file
+// already records.
+func triFingerprint(tris []float32) string {
+	if len(tris) < 2 {
+		return ""
+	}
+	minX, minY, maxX, maxY := triBounds(tris)
+
+	var sumX, sumY float64
+	n := 0
+	for i := 0; i+1 < len(tris); i += 2 {
+		sumX += float64(tris[i])
+		sumY += float64(tris[i+1])
+		n++
+	}
+
+	h := fnv.New32a()
+	var buf [4]byte
+	for _, v := range tris {
+		binary.LittleEndian.PutUint32(buf[:], math.Float32bits(roundF2(v)))
+		_, _ = h.Write(buf[:])
+	}
+
+	return fmt.Sprintf(" bbox=%s,%s..%s,%s centroid=%s,%s digest=%08x",
+		f2(minX), f2(minY), f2(maxX), f2(maxY),
+		f2(float32(sumX/float64(n))), f2(float32(sumY/float64(n))),
+		h.Sum32())
+}
+
+// gradientStr fingerprints a gradient definition by its ramp. Presence
+// alone stopped being enough when the concentric radial fill lowered to
+// a shader quad: that command carries no triangles, so the stop list is
+// the only record of what the fill paints. Every stop is printed, not a
+// sample — the stop list is the ramp.
+func gradientStr(g *GradientDef) string {
+	var b strings.Builder
+	b.WriteString(" +gradient(")
+	switch {
+	case g.Type == GradientRadial:
+		b.WriteString("radial")
+	case g.hasAngle:
+		b.WriteString("linear angle=" + f2(g.angle))
+	default:
+		fmt.Fprintf(&b, "linear dir=%d", g.Direction)
+	}
+	fmt.Fprintf(&b, " stops=%d", len(g.Stops))
+	if len(g.Stops) > 0 {
+		b.WriteString(" [")
+		for i, s := range g.Stops {
+			if i > 0 {
+				b.WriteString(" | ")
+			}
+			b.WriteString(f2(s.Pos) + " " + colorStr(s.Color))
+		}
+		b.WriteString("]")
+	}
+	b.WriteString(")")
+	return b.String()
 }
 
 // colorStr renders a Color as a diffable token. Unset colors are
@@ -164,6 +257,9 @@ func serializeCmd(c RenderCmd) string {
 				colorStr(c.VertexColors[0]),
 				colorStr(c.VertexColors[len(c.VertexColors)-1]))
 		}
+		// Counts and endpoint colors say how much was emitted and how
+		// it was shaded; the fingerprint says where the vertices are.
+		b.WriteString(triFingerprint(c.Triangles))
 	case RenderLine:
 		fmt.Fprintf(&b, " from=%s,%s", f2(c.OffsetX), f2(c.OffsetY))
 	case RenderShadow:
@@ -177,7 +273,7 @@ func serializeCmd(c RenderCmd) string {
 	// would couple the golden to struct layout without adding
 	// signal about what a user sees.
 	if c.Gradient != nil {
-		b.WriteString(" +gradient")
+		b.WriteString(gradientStr(c.Gradient))
 	}
 	if c.Shader != nil {
 		b.WriteString(" +shader")

--- a/gui/testdata/canvas_gradient.dark.golden
+++ b/gui/testdata/canvas_gradient.dark.golden
@@ -1,2 +1,2 @@
-Svg xy=15.00,15.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff
-Gradient xy=80.00,20.00 wh=50.00,50.00 radius=25.00 +gradient
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff bbox=0.00,0.00..60.00,60.00 centroid=31.67,30.00 digest=2eaef4dc
+Gradient xy=80.00,20.00 wh=50.00,50.00 radius=25.00 +gradient(radial stops=2 [0.00 #ffffffff | 1.00 #ffffff00])

--- a/gui/testdata/canvas_gradient.light.golden
+++ b/gui/testdata/canvas_gradient.light.golden
@@ -1,2 +1,2 @@
-Svg xy=14.00,14.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff
-Gradient xy=79.00,19.00 wh=50.00,50.00 radius=25.00 +gradient
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#00ff00ff tris=36 vcols=18 first=#ff0000ff last=#00ff00ff bbox=0.00,0.00..60.00,60.00 centroid=31.67,30.00 digest=2eaef4dc
+Gradient xy=79.00,19.00 wh=50.00,50.00 radius=25.00 +gradient(radial stops=2 [0.00 #ffffffff | 1.00 #ffffff00])

--- a/gui/testdata/canvas_gradient_rings.dark.golden
+++ b/gui/testdata/canvas_gradient_rings.dark.golden
@@ -1,1 +1,1 @@
-Gradient xy=20.00,20.00 wh=70.00,70.00 radius=35.00 +gradient
+Gradient xy=20.00,20.00 wh=70.00,70.00 radius=35.00 +gradient(radial stops=4 [0.20 #ff0000ff | 0.60 #00ff00ff | 0.60 #ffff00ff | 1.00 #0000ffff])

--- a/gui/testdata/canvas_gradient_rings.light.golden
+++ b/gui/testdata/canvas_gradient_rings.light.golden
@@ -1,1 +1,1 @@
-Gradient xy=19.00,19.00 wh=70.00,70.00 radius=35.00 +gradient
+Gradient xy=19.00,19.00 wh=70.00,70.00 radius=35.00 +gradient(radial stops=4 [0.20 #ff0000ff | 0.60 #00ff00ff | 0.60 #ffff00ff | 1.00 #0000ffff])

--- a/gui/testdata/canvas_vertex_colors.dark.golden
+++ b/gui/testdata/canvas_vertex_colors.dark.golden
@@ -1,2 +1,2 @@
-Svg xy=15.00,15.00 wh=0.00,0.00 color=#7f557fff tris=12 vcols=6 first=#ff0000ff last=#ffffffff
-Svg xy=15.00,15.00 wh=0.00,0.00 color=#7f557fff tris=12
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#7f557fff tris=12 vcols=6 first=#ff0000ff last=#ffffffff bbox=0.00,0.00..60.00,60.00 centroid=30.00,30.00 digest=5355de65
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#7f557fff tris=12 bbox=70.00,10.00..110.00,50.00 centroid=90.00,30.00 digest=8c6ccaf4

--- a/gui/testdata/canvas_vertex_colors.light.golden
+++ b/gui/testdata/canvas_vertex_colors.light.golden
@@ -1,2 +1,2 @@
-Svg xy=14.00,14.00 wh=0.00,0.00 color=#7f557fff tris=12 vcols=6 first=#ff0000ff last=#ffffffff
-Svg xy=14.00,14.00 wh=0.00,0.00 color=#7f557fff tris=12
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#7f557fff tris=12 vcols=6 first=#ff0000ff last=#ffffffff bbox=0.00,0.00..60.00,60.00 centroid=30.00,30.00 digest=5355de65
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#7f557fff tris=12 bbox=70.00,10.00..110.00,50.00 centroid=90.00,30.00 digest=8c6ccaf4


### PR DESCRIPTION
Closes #454

`serializeCmd` recorded only `tris=`/`vcols=`/`first=`/`last=` for `RenderSvg` batches, so two geometry bugs shipped through a green `TestGolden`:

- **#449** — concentric-gradient fan emitted at full circle radius instead of band radius.
- **#450** — dial month labels built before calendar `init()`, all 12 at angle 0 (1535 segments both ways).

Both need vertex coordinates to catch — counts and endpoint colors are blind exactly when tessellation moves vertices without adding/removing any.

### Change

- `gui/golden_test.go` — extend `serializeCmd` `RenderSvg` case with `bbox`/`centroid`/`digest`; record gradient stop ramps explicitly (concentric radial fill is now a shader quad with no triangles, #462). `FNV-1a` over `roundF2` bits — same rounding as the `f2` the file prints, so no new ULP fragility.
- `gui/golden_cases_test.go` — `TestGoldenTriFingerprint` pins moved-vertex, swapped-order, sub-precision-drift and empty-batch cases; `TestGoldenGradientStops` pins the shader-quad stop list.
- `gui/testdata/*.golden` — re-recorded (mechanical).

Out of scope: widening to `RenderLine`/`RenderShadow` (no concrete miss), making headless `-screenshot` a CI gate.