### PR TITLE
feat(widget): opt-in audio feedback for Button and Toggle (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to
 
 ### Added
 
+- **Opt-in widget audio feedback** (#446) — widgets can now play a sound when
+  the user activates them. Silent by default, and silent unless the app opts in
+  twice: a theme naming a cue per role (`theme.Sounds = gui.SoundsDefault()`)
+  and a player installed on the window (`w.SetSoundPlayer(...)`).
+
+  New in `gui`: `SoundCue` (`SoundNone`, `SoundClick`, `SoundToggleOn`,
+  `SoundToggleOff`, `SoundError`), the injected `SoundPlayer` interface,
+  `SoundSet` with `SoundsDefault()`, `Theme.Sounds` / `ThemeCfg.Sounds`,
+  `NewBeepSoundPlayer` (system alert on `SoundError`, no assets, no audio
+  library), and `(*Window).SetSoundPlayer` / `SoundPlayer` / `SetSoundVolume` /
+  `SoundVolume`. Volume is window state clamped to `0..1` where `0` is mute —
+  there is no separate mute flag.
+
+  A cue is semantic, not a sample path, which is why `gui` still does not import
+  `gui/audio`. The player is injected like `TextMeasurer` and `SvgParser` and is
+  nil in tests. `Button` and `Toggle` carry `Sound` and `SoundDisabled`;
+  precedence is `SoundDisabled > Cfg.Sound > Theme.Sounds.<role>`, resolved at
+  generation time, so a `Toggle` picks on-vs-off from its own state with no
+  extra field pair. The cue rides the shape's event record rather than a
+  closure, and fires before `OnClick` independently of `ctx.Consume()` on all
+  four activation paths: mouse, Space, Enter, and the accessibility press
+  action.
+
+  Guides at `docs/widget-sound.md` and `examples/showcase/docs/widget_sound.md`,
+  design record in `docs/specs/widget-audio-feedback.md`, and a "Sound Feedback"
+  page plus a working synthesized player in the showcase. Remaining widgets are
+  phased in as follow-ups to #446: #467, #468 and #469.
+
 - **`examples/solar_system`: calendar ring, asteroid belt and rotation axes**
   (#437) — three antique-orrery elements, all in the example, no engine change.
 
@@ -141,6 +169,15 @@ and this project adheres to
   measures tessellation rather than submission: full-system 778 -> 725 us and
   jupiter 1168 -> 1096 us, both about 6-7%. The counts above are now enforced as
   regression budgets rather than logged and forgotten.
+
+### Fixed
+
+- **`examples/showcase/docs/widget_audio.md` documented functions that are not
+  exported** — `audio.Quit`, `audio.LoadSound`, `Sound.SetVolume`,
+  `SetMusicVolume`, `PauseMusic`, `ResumeMusic`, `RewindMusic`,
+  `FadeOutChannel`, `PauseChannel`, `ResumeChannel`, `IsMusicPlaying` and
+  `IsMusicPaused` are all unexported in `gui/audio`. Corrected to the surface
+  the package actually has.
 
 ## [v0.65.0] - 2026-08-25
 

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -254,6 +254,15 @@ Nothing is marked handled for you. A callback that acts on an event calls
 in `AmendLayout` and `OnScroll`, and both `EventCtx` methods are nil-safe. See
 `docs/specs/eventctx-callback-refactor.md`.
 
+## Widget sound
+
+Silent unless the app opts in twice: `theme.Sounds = gui.SoundsDefault()` names
+a cue per role, and `w.SetSoundPlayer(...)` renders them. Either alone is
+silent, and a nil player is the default, so tests need no setup. Per instance,
+`Cfg.Sound` overrides the theme cue and `Cfg.SoundDisabled` suppresses it;
+`w.SetSoundVolume(0..1)` is the gain, where `0` is mute. The cue fires before
+`OnClick` and regardless of `ctx.Consume()`. See `docs/widget-sound.md`.
+
 ## Find it early
 
 `gui.Debug(true)`, or `GOGUI_DEBUG=1`, checks the layout every frame. It reports

--- a/docs/specs/widget-audio-feedback.md
+++ b/docs/specs/widget-audio-feedback.md
@@ -1,0 +1,199 @@
+# Spec: opt-in widget audio feedback
+
+Status: **phase 1 implemented** — `SoundCue`, `SoundPlayer`, `Theme.Sounds`,
+window volume, and the `Button` / `Toggle` proof. Phases 2–4 are follow-up
+issues.
+
+Issue: #446 — "Widgets have no audio feedback for interactions".
+
+## Motivation
+
+No widget in `gui/` emitted sound. Feedback was visual only. Two audio
+mechanisms existed and neither reached a widget:
+
+- `Window.Beep` (`gui/native_sound.go`) — the system alert, with no non-test
+  caller anywhere in the repo.
+- `gui/audio` — sampled and synthesized audio, a leaf subpackage. `gui` must not
+  import it: that would pull `beep`, `oto` and `pulse` into every consumer and
+  invert the subpackage rule.
+
+An app that wanted a click sound had to wrap `OnClick` on every widget and
+handle `BeepAvailable` plus `audio.Init` errors itself.
+
+## Design
+
+### A cue is semantic, not a sample
+
+`SoundCue` names the interaction; the injected player decides what it sounds
+like. That indirection is what keeps `gui` free of an audio dependency, and it
+lets one app map a cue to a WAV while another synthesizes it.
+
+`SoundNone` is the zero value, so an unset field is silent and needs no `set`
+flag — the same reasoning as `ColorSet` (`gui/color_set.go`).
+
+The enum is open. New cues will be added, so no code in `gui/` switches
+exhaustively over it, and the `SoundPlayer` contract requires a player to ignore
+a cue it does not recognize.
+
+### The seam is injected, like the other three
+
+`SoundPlayer` is stored per window in `windowBackend`, beside `TextMeasurer`,
+`SvgParser` and `NativePlatform`, and every call site nil-guards. One
+difference, stated in the field comment: the backend installs the other three,
+but installs **no** sound player. The app opts in with `SetSoundPlayer`, so
+silence is the default and headless tests need no setup.
+
+`NewBeepSoundPlayer` is the zero-dependency fallback: it plays the system alert
+for `SoundError` and nothing else, because an alert is the wrong sound for a
+click. It ignores gain — `NSBeep` and `MessageBeep` honor the system _alert_
+volume and expose no app-level gain.
+
+### Volume is window state, not theme state
+
+`(*Window).SetSoundVolume` / `SoundVolume`, clamped to `0..1`, default `1`.
+There is no separate mute flag: `0` is mute, and the gate is one comparison
+ahead of the player call, so a muted window costs nothing per click.
+
+Volume was deliberately **not** put on `Theme`. A theme is per-window visual
+identity keyed by `Theme.id`, and `Themed(t, build)` scopes a theme to a
+_subtree_; a loudness that changed when one panel was restyled would be
+incoherent. Volume is a user preference.
+
+It is also not expressed as a percentage of the system level, because it already
+is one: the OS mixer applies the user's output volume downstream of the app, so
+an app-level gain is inherently relative. An app cannot portably read the system
+output level and must not try.
+
+### Theme carries the role → cue map
+
+`Theme.Sounds` is a `SoundSet` — one cue per interaction role. The zero set is
+silent and is the intended default, so `ThemeDark` and `ThemeLight` make no
+sound. `ThemeMaker` copies it from `ThemeCfg` and adds no default. It is not a
+`default*Style` mirror, so `TestDefaultStylesMirrorThemeDark` needs no row and
+`applyTheme` is untouched.
+
+An app opts the whole widget set in by rebuilding through `ThemeMaker` with
+`cfg.Sounds = gui.SoundsDefault()`. Mutating an installed theme value in place
+is wrong here: `needsInstall` compares `Theme.id`, so a mutated copy carrying
+the old id can be skipped in a second window. `ThemeMaker` stamps a fresh id.
+
+A struct rather than a fixed array, so a role can be added without breaking an
+app that builds one by field name.
+
+### The cue rides the shape, not a closure
+
+The real chokepoint is `eventHandlers`, not `ContainerCfg`: the unexported
+`soundCue` field lives there, exactly like `clickOnSpace` and `clickOnEnter`,
+which exist to avoid a per-frame closure allocation. Putting it there also
+reaches the raw-`Shape` widgets (Image, Svg, Text, RTF, DrawCanvas, termgrid)
+that build `eventHandlers` directly and never touch `ContainerCfg`.
+
+Measured across `gui/` and `gui/datagrid/`: 86 click sites — 43 direct
+`ContainerCfg`, 28 `ButtonCfg` (which funnels into Button's own container), 9
+raw `eventHandlers`, 6 wrapper Cfgs. 71 of 86 inherit the plumbing from the
+`ContainerCfg.Sound` field alone.
+
+### Precedence, resolved at generation time
+
+```
+SoundDisabled  >  Cfg.Sound  >  Theme.Sounds.<role>
+```
+
+Resolution happens during `GenerateLayout`, where the widget already knows its
+own state. That is why a state-dependent toggle needs **no** `SoundOn` /
+`SoundOff` field pair: `Toggle` reads `cfg.Selected` and stamps `SoundToggleOff`
+when the click will turn it off. No runtime branch, no allocation.
+
+### Dispatch
+
+One helper, `playShapeSound(*Layout, *Window)`, nil-safe on every seam. Four
+call sites cover all click dispatch:
+
+| Path     | Site                                        |
+| -------- | ------------------------------------------- |
+| Mouse    | `callRelative`, gated on `class == evClick` |
+| Spacebar | `charHandler`, the `clickOnSpace` branch    |
+| Enter    | `keydownHandler`, the `clickOnEnter` branch |
+| A11y     | `a11yActionCallback`, `A11yActionPress`     |
+
+The cue fires **before** `OnClick` and **independently of `ctx.Consume()`**:
+sound confirms that the widget was activated, it does not participate in event
+propagation. All four paths are asserted in `gui/sound_test.go`.
+
+It is not routed through `deferCallback`. Dispatch runs from `EventFn` with no
+frame lock held, and a deferred callback may not capture a `*Layout` — the arena
+pools it.
+
+## What stays silent
+
+Pure click absorbers must never sound, and opt-in-by-default protects them with
+no special case: the Toast scrim, the ContextMenu dismiss `OnAnyClick`,
+scrollbar track/thumb/arrows, and Input's caret-placement click all consume
+without user semantics. **Never add a blanket "any `ContainerCfg.OnClick`
+sounds" rule.**
+
+One known exclusion: `gui/view_text.go` uses a package-level shared
+`textEventHandlers` singleton, which cannot carry a per-instance cue without
+becoming per-view. Link-click sound is out of scope.
+
+## Rollout
+
+- **Phase 1 (this change)** — the seam, `Button`, `Toggle`, headless tests, both
+  guides, the showcase page and player.
+- **Phase 2** (#467) — the mechanical pass: every widget whose activation
+  already lands on a `ContainerCfg` or `ButtonCfg` (Switch, Radio, ExpandPanel,
+  Select, Combobox, ListBox, Tree, TabControl, Menu, Dialog, Toast, DatePicker,
+  CommandPalette, DockLayout, Image, Svg, and `gui/datagrid`). Split by file
+  count, not one 40-file diff.
+- **Phase 3** (#468) — bespoke paths dispatch never sees: Table keyboard
+  activation (calls `OnClick` with a nil `Layout`), Input commit vs reject,
+  InputNumeric clamp, keyboard navigation (probably silent — decide it
+  explicitly), drag-terminated changes, drag-reorder drop.
+- **Phase 4** (#469) — non-click semantics (Toast appear, Dialog open, Form
+  submit, DataGrid `OnCRUDError`) and a native system-sound player:
+  `NSSound(named:)`, `PlaySound` with `SND_ALIAS`, freedesktop sound-naming IDs
+  on Linux (the beep backend already shells to `canberra-gtk-play -i bell`, so
+  `-i button-pressed` is a short step). That is cross-platform native work,
+  including ObjC, and belongs in `gui/backend/sysbeep`.
+
+## Showcase sounds are synthesized
+
+The repo ships no sound assets and does not gain any. The showcase's player
+reuses the ADSR voice already in `demo_audio.go` with a percussive, one-shot
+envelope — `voiceEnv` was extracted from the pad's package constants so the pad
+and the cue share `Fill` and `envelope` rather than forking the oscillator.
+
+Click is A5; toggle-on and toggle-off are a fourth above and below it; error is
+a low tone with a longer decay. The `audio.LoadSoundBytes` path for an app with
+its own WAVs is documented in the guide but not shipped.
+
+## Rejected
+
+- **`gui` imports `gui/audio`** — an import cycle in spirit and a dependency in
+  fact for every consumer.
+- **Volume on `Theme`** — see above.
+- **A separate mute flag** — `0` already means mute.
+- **`SoundOn` / `SoundOff` field pairs on toggles** — unnecessary once the cue
+  resolves at generation time.
+- **Shipping WAV assets** — binaries, an attribution obligation, and a guide
+  snippet nobody could copy without the files.
+
+## Documentation
+
+- `docs/widget-sound.md` and `examples/showcase/docs/widget_sound.md` — the
+  app-author guide, mirrored. Every later phase must update the cue table in
+  both.
+- `examples/showcase/docs/widget_audio.md` — cross-linked, and corrected: it
+  documented `audio.Quit`, `audio.LoadSound`, `Sound.SetVolume`,
+  `SetMusicVolume`, `PauseMusic` and several other functions that are unexported
+  in the package as it stands.
+- The guide's player is quoted whole from `examples/showcase/sound_player.go`
+  between `// doc:snippet-begin player` markers, not paraphrased, so a reader
+  can paste it. `TestSoundGuideSnippetMatchesSource`
+  (`examples/showcase/sound_snippet_test.go`) byte-compares the marked region
+  against the Go fence under the "A real player" heading in both guides and
+  names the first differing line. The block therefore compiles by construction —
+  it is part of the showcase build — and cannot rot silently in either
+  direction. Two names inside it (`ensureAudioInit`, `newVoice`) are showcase
+  plumbing, explained in prose beneath the fence rather than inlined, which
+  would have broken the byte comparison.

--- a/docs/widget-sound.md
+++ b/docs/widget-sound.md
@@ -1,0 +1,295 @@
+# Widget Sound Feedback
+
+Widgets can play a short sound when the user activates them. Nothing is audible
+until you opt in twice: a theme that names a **cue** for each interaction role,
+and a **sound player** installed on the window. Either one alone stays silent,
+which is the default for every built-in theme.
+
+This page is mirrored at `examples/showcase/docs/widget_sound.md`, and the
+running showcase has it under **Welcome → Sound Feedback**.
+
+## What a cue is
+
+`gui.SoundCue` names a semantic event, not a file:
+
+| Cue                  | Meaning                                       |
+| -------------------- | --------------------------------------------- |
+| `gui.SoundNone`      | Zero value. Silent                            |
+| `gui.SoundClick`     | Momentary activation: button, menu item, link |
+| `gui.SoundToggleOn`  | A state went off → on                         |
+| `gui.SoundToggleOff` | A state went on → off                         |
+| `gui.SoundError`     | Rejection: invalid input, refused commit      |
+
+The framework decides _which_ cue an interaction is. Your player decides what a
+cue sounds like. That split is why `gui` never imports `gui/audio`, and why an
+app can map the same cue to different assets on different platforms.
+
+The list grows over time, so a player must ignore a cue it does not recognize
+rather than treat it as an error. Do not write an exhaustive switch over
+`SoundCue`.
+
+## Turn it on in three lines
+
+```go
+cfg := w.Theme().Cfg
+cfg.Sounds = gui.SoundsDefault()            // name a cue per role
+w.SetTheme(gui.ThemeMaker(cfg))
+w.SetSoundPlayer(gui.NewBeepSoundPlayer(w)) // render them
+```
+
+Rebuild through `ThemeMaker` rather than mutating the theme value in place. A
+`Theme` carries an `id`, and theme installation skips a theme whose id is
+already installed, so a mutated copy can silently lose the change in a second
+window. `ThemeMaker` stamps a fresh id.
+
+Set `Sounds` wherever you build the themes your app installs — switching to a
+theme that does not name cues turns sound off again.
+
+`NewBeepSoundPlayer` needs no assets and no audio library: it plays the system
+alert for `SoundError` and stays silent for everything else, because an alert is
+the wrong sound for a click. It is the right choice for an app that only wants
+to signal rejection.
+
+Volume is per window, `0.0` to `1.0`:
+
+```go
+w.SetSoundVolume(0.5)
+```
+
+`0` is mute — there is no separate mute flag. Values outside the range clamp.
+The value is implicitly relative to the system output level, which the OS mixer
+applies downstream; an app cannot portably read that level and should not try.
+`NewBeepSoundPlayer` ignores gain entirely: `NSBeep` and `MessageBeep` honor the
+system _alert_ volume and expose no app-level gain.
+
+## A real player
+
+For actual click sounds, implement `gui.SoundPlayer` over `gui/audio`. Below is
+the showcase's player, quoted whole from `examples/showcase/sound_player.go`. It
+synthesizes every cue rather than loading files, so it needs no assets. A test
+compares this block against that file byte for byte: what you read here is what
+compiles.
+
+```go
+// Cue envelope: percussive, one-shot, so each cue frees its own mixer
+// channel. Short enough that fast clicking does not smear.
+var cueEnv = voiceEnv{
+	attackS: 0.008,
+	decayS:  0.060,
+	sustain: 0,
+	oneShot: true,
+}
+
+// errorEnv is longer and lets the tone ring, so a rejection reads as
+// different in kind rather than only in pitch.
+var errorEnv = voiceEnv{
+	attackS: 0.008,
+	decayS:  0.220,
+	sustain: 0,
+	oneShot: true,
+}
+
+// cuePeakLevel is the voice amplitude before the window's gain. Well
+// below the synth pads: a UI cue rides under whatever else is playing.
+const cuePeakLevel = 0.22
+
+// cueSoundPlayer maps gui.SoundCue onto synthesized blips. Nothing is
+// loaded from disk — the showcase ships no sound assets — so the same
+// code runs on every desktop platform with no licensing or size cost.
+// An app with its own WAVs swaps the switch below for
+// audio.LoadSoundBytes; see docs/widget-sound.md.
+type cueSoundPlayer struct {
+	w *gui.Window
+}
+
+var _ gui.SoundPlayer = cueSoundPlayer{}
+
+// PlaySound implements gui.SoundPlayer. It runs on the event-dispatch
+// goroutine, so it starts a voice and returns; the mixer does the work
+// on the audio thread.
+func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
+	var freq float64
+	env := cueEnv
+	switch cue {
+	case gui.SoundClick:
+		freq = 880 // A5
+	case gui.SoundToggleOn:
+		freq = 880 * 4 / 3 // a fourth up
+	case gui.SoundToggleOff:
+		freq = 880 * 3 / 4 // a fourth down
+	case gui.SoundError:
+		freq = 220
+		env = errorEnv
+	default:
+		// An unrecognised cue is ignored, not an error: gui adds cues
+		// over time and a player must not break when it does.
+		return
+	}
+	if !ensureAudioInit(p.w) {
+		return
+	}
+	// The window's volume arrives as gain; scale the voice rather than
+	// touching audio.SetMasterVolume, which the music demo owns.
+	v := newVoice(freq, cuePeakLevel*float64(gain), env)
+	// A failed start is silent on purpose: a click must never surface a
+	// mixer error to the user.
+	_ = audio.PlaySource(-1, v)
+}
+
+// SoundAvailable implements gui.SoundPlayer. gui/audio builds on every
+// desktop target this file compiles for.
+func (p cueSoundPlayer) SoundAvailable() bool { return true }
+```
+
+Two names the block leans on. `ensureAudioInit(p.w)` is showcase plumbing that
+initializes `gui/audio` once and reports a failure in the demo's status line; an
+app without one writes `if err := audio.Init(); err != nil { return }` instead.
+`newVoice` builds an `audio.Source` — see `examples/showcase/demo_audio.go` for
+the oscillator and the envelope, and
+[the audio guide](../examples/showcase/docs/widget_audio.md) for the `Source`
+contract.
+
+Install it on the window:
+
+```go
+w.SetSoundPlayer(cueSoundPlayer{w: w})
+```
+
+`PlaySound` runs on the event-dispatch goroutine, so it must be fire-and-forget:
+start the sound and return. Never block, and never allocate on the audio thread.
+
+## Playing your own files
+
+An app that ships sound assets swaps the switch for loaded samples:
+
+```go
+type filePlayer struct {
+    click, on, off, fail *audio.Sound
+}
+
+func newFilePlayer() (*filePlayer, error) {
+    if err := audio.Init(); err != nil {
+        return nil, err
+    }
+    p := &filePlayer{}
+    var err error
+    if p.click, err = audio.LoadSoundBytes(clickWav); err != nil {
+        return nil, err
+    }
+    // ... one per cue
+    return p, nil
+}
+
+func (p *filePlayer) PlaySound(cue gui.SoundCue, gain float32) {
+    var s *audio.Sound
+    switch cue {
+    case gui.SoundClick:
+        s = p.click
+    case gui.SoundToggleOn:
+        s = p.on
+    case gui.SoundToggleOff:
+        s = p.off
+    case gui.SoundError:
+        s = p.fail
+    default:
+        return
+    }
+    // gui/audio exports no per-sound volume setter today, so a
+    // file-based player either ignores gain or scales the whole mixer
+    // with audio.SetMasterVolume. Prefer pre-normalized assets.
+    _, _ = s.PlayOnce()
+}
+
+func (p *filePlayer) SoundAvailable() bool { return true }
+
+// Free every sound at teardown; never Free one while it plays.
+func (p *filePlayer) Close() {
+    p.click.Free()
+    p.on.Free()
+    p.off.Free()
+    p.fail.Free()
+}
+```
+
+Embed the WAVs with `//go:embed` and pass the bytes — `audio.LoadSoundBytes`
+avoids the temp-file dance a path-based load needs. The repo ships no sound
+assets of its own, so the showcase uses the synthesized player above.
+
+## Per-widget control
+
+Two fields on the widget's `Cfg`:
+
+| Field                | Effect                                         |
+| -------------------- | ---------------------------------------------- |
+| `Sound SoundCue`     | Overrides the theme's cue for this instance    |
+| `SoundDisabled bool` | Silences this instance whatever the theme says |
+
+Precedence, resolved once at generation time:
+
+```
+SoundDisabled  >  Cfg.Sound  >  Theme.Sounds.<role>
+```
+
+```go
+gui.Button(gui.ButtonCfg{ID: "del", Label: "Delete", Sound: gui.SoundError})
+gui.Button(gui.ButtonCfg{ID: "tick", Label: "Tick", SoundDisabled: true})
+```
+
+A `Toggle` picks its own cue from its state: a selected toggle is about to turn
+off, so it emits `SoundToggleOff`. You do not need an on/off field pair.
+
+## Which widgets sound
+
+Currently `Button` and `Toggle`. The seam itself is generic — the cue rides the
+shape's event record, so any widget can adopt it — and the remaining widgets are
+being phased in (#467, #468, #469). Widgets that only absorb clicks stay silent
+by design: the toast scrim, the context-menu dismiss layer, scrollbar tracks,
+and the caret-placement click inside an `Input`.
+
+## Platform reality
+
+- `gui/audio` does not build for `js`, `android`, or `ios`. Put your player
+  behind a `//go:build !js && !android && !ios` tag and supply an empty stub for
+  the others, the way the showcase does.
+- `BeepAvailable()` is false on mobile and wasm, and on Linux without
+  `canberra-gtk-play`.
+- The failure mode is always silence, never a panic. A nil `SoundPlayer` is the
+  default and every call site nil-guards, which is also why headless tests are
+  silent with no setup.
+- Call `SoundAvailable()` when the user genuinely needs to notice the event, and
+  add a visual cue when it returns false.
+
+## Ordering
+
+The cue fires **before** `OnClick` runs, and **regardless of whether the handler
+calls `ctx.Consume()`**. The sound confirms that the widget was activated; it
+does not take part in event propagation.
+
+Every activation path sounds, not just the mouse: click, Space, Enter, and the
+accessibility press action all emit the same cue.
+
+## Testing
+
+Widget sound is fully headless-testable. Inject a spy player and drive the
+widget with the `Test*` helpers:
+
+```go
+type spy struct{ cues []gui.SoundCue }
+
+func (s *spy) PlaySound(c gui.SoundCue, _ float32) {
+    s.cues = append(s.cues, c)
+}
+func (s *spy) SoundAvailable() bool { return true }
+
+sp := &spy{}
+w.SetSoundPlayer(sp)
+w.TestClick("save")
+// sp.cues == []gui.SoundCue{gui.SoundClick}
+```
+
+## See also
+
+- [Audio playback](../examples/showcase/docs/widget_audio.md) — the `gui/audio`
+  package: sounds, music, and live synthesis
+- `docs/specs/widget-audio-feedback.md` — the design record and the alternatives
+  that were rejected

--- a/examples/showcase/demo_audio.go
+++ b/examples/showcase/demo_audio.go
@@ -147,6 +147,14 @@ func demoAudio(w *gui.Window) gui.View {
 						Max:    100,
 						Sizing: gui.FillFit,
 						OnChange: func(v float32, ctx gui.EventCtx) {
+							if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+								v = 0
+							}
+							if v < 0 {
+								v = 0
+							} else if v > 100 {
+								v = 100
+							}
 							a := appState(ctx.Window)
 							a.AudioVolume = float64(v) / 100
 							audio.SetMasterVolume(a.AudioVolume)
@@ -161,10 +169,148 @@ func demoAudio(w *gui.Window) gui.View {
 				},
 			}),
 
+			sectionLabel(t, "Widget Sound Feedback"),
+			widgetSoundPanel(t, app),
+
 			gui.Text(gui.TextCfg{
 				Text:      app.AudioStatus,
 				TextStyle: t.N4,
 				Mode:      gui.TextModeWrap,
+			}),
+		},
+	})
+}
+
+// widgetSoundControls is the same panel, reached from the "Sound
+// Feedback" page so the guide and its switch sit together.
+func widgetSoundControls(w *gui.Window) gui.View {
+	return widgetSoundPanel(gui.CurrentTheme(), appState(w))
+}
+
+// widgetSoundPanel is the interactive half of the "Sound Feedback"
+// doc page: the opt-in switch, the window gain, and two widgets whose
+// cues differ, so the click and the two toggle cues can be compared
+// side by side.
+func widgetSoundPanel(t gui.Theme, app *ShowcaseApp) gui.View {
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Spacing: gui.SomeF(8),
+		Padding: gui.NoPadding,
+		Content: []gui.View{
+			gui.Text(gui.TextCfg{
+				Text: "Silent until you opt in twice: a theme that " +
+					"names a cue per role, and an installed " +
+					"SoundPlayer. See the Sound Feedback page.",
+				TextStyle: t.N4,
+				Mode:      gui.TextModeWrap,
+			}),
+			gui.Switch(gui.SwitchCfg{
+				ID:       "widget-sound-on",
+				Label:    "Widget sounds",
+				Selected: app.WidgetSoundOn,
+				OnClick: func(ctx gui.EventCtx) {
+					a := appState(ctx.Window)
+					a.WidgetSoundOn = !a.WidgetSoundOn
+					if a.WidgetSoundOn {
+						installWidgetSounds(ctx.Window, a.WidgetSoundBeep)
+						ctx.Window.SetSoundVolume(a.WidgetSoundVolume)
+					} else {
+						removeWidgetSounds(ctx.Window)
+					}
+					ctx.Consume()
+				},
+			}),
+			// The zero-dependency player: system alert on SoundError,
+			// silence otherwise, no audio library and no assets.
+			gui.Switch(gui.SwitchCfg{
+				ID:       "widget-sound-beep",
+				Label:    "System alert only (no audio library)",
+				Selected: app.WidgetSoundBeep,
+				OnClick: func(ctx gui.EventCtx) {
+					a := appState(ctx.Window)
+					a.WidgetSoundBeep = !a.WidgetSoundBeep
+					if a.WidgetSoundOn {
+						installWidgetSounds(ctx.Window, a.WidgetSoundBeep)
+					}
+					ctx.Consume()
+				},
+			}),
+			gui.Row(gui.ContainerCfg{
+				Sizing:  gui.FillFit,
+				Spacing: gui.SomeF(8),
+				Padding: gui.NoPadding,
+				VAlign:  gui.VAlignMiddle,
+				Content: []gui.View{
+					gui.Text(gui.TextCfg{
+						Text:      "Cue volume",
+						TextStyle: t.N4,
+						MinWidth:  90,
+					}),
+					gui.Slider(gui.SliderCfg{
+						ID:     "widget-sound-vol",
+						Value:  app.WidgetSoundVolume * 100,
+						Min:    0,
+						Max:    100,
+						Sizing: gui.FillFit,
+						OnChange: func(v float32, ctx gui.EventCtx) {
+							if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+								v = 0
+							}
+							if v < 0 {
+								v = 0
+							} else if v > 100 {
+								v = 100
+							}
+							a := appState(ctx.Window)
+							a.WidgetSoundVolume = v / 100
+							// 0 is mute; there is no separate flag.
+							ctx.Window.SetSoundVolume(a.WidgetSoundVolume)
+						},
+					}),
+					gui.Text(gui.TextCfg{
+						Text: fmt.Sprintf("%.0f%%",
+							app.WidgetSoundVolume*100),
+						TextStyle: t.N4,
+						MinWidth:  40,
+					}),
+				},
+			}),
+			gui.Row(gui.ContainerCfg{
+				Sizing:  gui.FillFit,
+				Spacing: gui.SomeF(12),
+				Padding: gui.NoPadding,
+				VAlign:  gui.VAlignMiddle,
+				Content: []gui.View{
+					gui.Button(gui.ButtonCfg{
+						ID:      "widget-sound-click",
+						Label:   "Click me",
+						Padding: gui.NewPadding(8, 16, 8, 16),
+						OnClick: func(ctx gui.EventCtx) {
+							ctx.Consume()
+						},
+					}),
+					gui.Toggle(gui.ToggleCfg{
+						ID:       "widget-sound-toggle",
+						Label:    "Toggle me",
+						Selected: app.WidgetSoundDemoOn,
+						OnClick: func(ctx gui.EventCtx) {
+							a := appState(ctx.Window)
+							a.WidgetSoundDemoOn = !a.WidgetSoundDemoOn
+							ctx.Consume()
+						},
+					}),
+					// SoundDisabled opts one instance out, whatever the
+					// theme says.
+					gui.Button(gui.ButtonCfg{
+						ID:            "widget-sound-muted",
+						Label:         "Silent button",
+						Padding:       gui.NewPadding(8, 16, 8, 16),
+						SoundDisabled: true,
+						OnClick: func(ctx gui.EventCtx) {
+							ctx.Consume()
+						},
+					}),
+				},
 			}),
 		},
 	})
@@ -212,7 +358,7 @@ var synthPadRows = [2][]synthPadDef{
 // audio-thread-exclusive apart from the release flag.
 var synthActive [len(synthPadRows) * synthPadsPerRow]*synthVoice
 
-// Envelope timings in seconds.
+// Envelope timings in seconds for the pad voice.
 const (
 	synthAttackS  = 0.01
 	synthDecayS   = 0.25
@@ -220,11 +366,35 @@ const (
 	synthSustain  = 0.35 // sustain level as a fraction of the peak
 )
 
+// voiceEnv holds the timings one voice runs on, so the pad voice and
+// the UI cue voice share Fill and envelope instead of forking the
+// oscillator (issue #446).
+type voiceEnv struct {
+	attackS  float64
+	decayS   float64
+	releaseS float64
+	// sustain is the level held after decay, as a fraction of the peak.
+	sustain float64
+	// oneShot ends the voice when the decay finishes, freeing its mixer
+	// channel with no note-off. A pad sustains until release; a UI cue
+	// has no key to lift.
+	oneShot bool
+}
+
+// padEnv is the sustaining envelope the synth pads play.
+var padEnv = voiceEnv{
+	attackS:  synthAttackS,
+	decayS:   synthDecayS,
+	releaseS: synthReleaseS,
+	sustain:  synthSustain,
+}
+
 // synthVoice is a live audio source: three harmonics of the pad's
 // frequency shaped by an ADSR envelope. Fill runs on the audio thread,
 // so the envelope state lives entirely there; the note-off arrives via
 // an atomic flag set from the UI thread.
 type synthVoice struct {
+	env          voiceEnv
 	sampleRate   float64
 	freq         float64
 	phase        float64
@@ -236,12 +406,29 @@ type synthVoice struct {
 }
 
 func newSynthVoice(freq float64) *synthVoice {
+	return newVoice(freq, 0.2, padEnv)
+}
+
+// newVoice builds a voice at the given peak level and envelope.
+func newVoice(freq, level float64, env voiceEnv) *synthVoice {
+	if math.IsNaN(freq) || math.IsInf(freq, 0) || freq <= 0 {
+		freq = 440
+	}
+	if math.IsNaN(level) || math.IsInf(level, 0) {
+		level = 0
+	}
+	if level < 0 {
+		level = 0
+	} else if level > 1 {
+		level = 1
+	}
 	v := &synthVoice{
+		env:        env,
 		sampleRate: float64(audio.SampleRate()),
 		freq:       freq,
-		level:      0.2,
+		level:      level,
 	}
-	if v.sampleRate == 0 {
+	if v.sampleRate == 0 || math.IsNaN(v.sampleRate) || math.IsInf(v.sampleRate, 0) || v.sampleRate <= 0 {
 		v.sampleRate = 44100
 	}
 	return v
@@ -277,29 +464,56 @@ func (v *synthVoice) Fill(samples [][2]float64) (int, bool) {
 // envelope advances the ADSR state by dt and returns the current
 // amplitude. Called once per sample from Fill.
 func (v *synthVoice) envelope(dt float64) float64 {
+	e := &v.env
+	// Defensive: a zero or negative timing would divide by zero and
+	// propagate Inf/NaN into the mixer. Treat it as an instant stage.
+	if e.attackS <= 0 {
+		e.attackS = 1e-6
+	}
+	if e.decayS <= 0 {
+		e.decayS = 1e-6
+	}
+	if e.releaseS <= 0 {
+		e.releaseS = 1e-6
+	}
+	if math.IsNaN(e.attackS) || math.IsInf(e.attackS, 0) {
+		e.attackS = 1e-6
+	}
+	if math.IsNaN(e.decayS) || math.IsInf(e.decayS, 0) {
+		e.decayS = 1e-6
+	}
+	if math.IsNaN(e.releaseS) || math.IsInf(e.releaseS, 0) {
+		e.releaseS = 1e-6
+	}
 	if v.releasing.Load() {
-		if v.elapsed >= synthReleaseS {
+		if v.elapsed >= e.releaseS {
 			v.done = true
 			return 0
 		}
-		amp := v.releaseLevel * (1 - v.elapsed/synthReleaseS)
+		amp := v.releaseLevel * (1 - v.elapsed/e.releaseS)
 		v.elapsed += dt
 		return amp
 	}
 	switch {
-	case v.elapsed < synthAttackS:
-		amp := v.level * (v.elapsed / synthAttackS)
+	case v.elapsed < e.attackS:
+		amp := v.level * (v.elapsed / e.attackS)
 		v.elapsed += dt
 		v.releaseLevel = amp
 		return amp
-	case v.elapsed < synthAttackS+synthDecayS:
-		t := (v.elapsed - synthAttackS) / synthDecayS
-		amp := v.level * (1 - (1-synthSustain)*t)
+	case v.elapsed < e.attackS+e.decayS:
+		t := (v.elapsed - e.attackS) / e.decayS
+		amp := v.level * (1 - (1-e.sustain)*t)
 		v.elapsed += dt
 		v.releaseLevel = amp
 		return amp
 	default:
-		amp := v.level * synthSustain
+		// A one-shot has nothing to sustain into: end it here so the
+		// mixer channel is freed without a note-off.
+		if e.oneShot {
+			v.done = true
+			return 0
+		}
+		amp := v.level * e.sustain
 		v.releaseLevel = amp
 		return amp
 	}

--- a/examples/showcase/demo_audio_other.go
+++ b/examples/showcase/demo_audio_other.go
@@ -18,3 +18,14 @@ func demoAudio(w *gui.Window) gui.View {
 		},
 	})
 }
+
+// widgetSoundControls has no audio backend on these targets, so the
+// Sound Feedback page shows why rather than a dead switch.
+func widgetSoundControls(_ *gui.Window) gui.View {
+	t := gui.CurrentTheme()
+	return gui.Text(gui.TextCfg{
+		Text:      "Widget sound is not available on this platform.",
+		TextStyle: t.N4,
+		Mode:      gui.TextModeWrap,
+	})
+}

--- a/examples/showcase/detail.go
+++ b/examples/showcase/detail.go
@@ -224,6 +224,23 @@ func componentDemo(w *gui.Window, id string) gui.View {
 	if id == "commands" {
 		return showcaseMarkdownPanel(w, "showcase-commands", docPageSource("commands"))
 	}
+	if id == "sound" {
+		// The controls go above the guide: a doc-only page cannot turn
+		// the feature on, and the Audio page is the wrong place to look
+		// for it.
+		return gui.Column(gui.ContainerCfg{
+			ID:         "sound-page",
+			Sizing:     gui.FillFill,
+			Spacing:    gui.SomeF(16),
+			Padding:    gui.NoPadding,
+			SizeBorder: gui.NoBorder,
+			Content: []gui.View{
+				widgetSoundControls(w),
+				showcaseMarkdownPanel(w, "showcase-sound",
+					docPageSource("sound")),
+			},
+		})
+	}
 	if fn, ok := componentDemos[id]; ok {
 		return fn(w)
 	}

--- a/examples/showcase/docs/widget_audio.md
+++ b/examples/showcase/docs/widget_audio.md
@@ -10,21 +10,24 @@ import "github.com/go-gui-org/go-gui/gui/audio"
 if err := audio.Init(); err != nil {
     log.Fatal(err)
 }
-defer audio.Quit()
 ```
+
+Init is idempotent, so a lazy "initialize on first sound" helper is the usual
+pattern. There is no exported shutdown: the mixer lives for the process.
 
 ## Sound Effects
 
 ```go
-// Load from file.
-click, _ := audio.LoadSound("click.wav")
-defer click.Free()
-click.PlayOnce()
-
-// Load from embedded bytes.
+// Load from embedded bytes (WAV, OGG, MP3, FLAC).
 snd, _ := audio.LoadSoundBytes(wavData)
-snd.Play(-1, 0) // channel -1 = first free, 0 = no loop
+defer snd.Free()
+
+snd.PlayOnce()   // channel -1 = first free, no loop
+snd.Play(-1, 0)  // the long form: channel, loop count
 ```
+
+Loading is bytes-only: pair it with `//go:embed` and the sound ships inside the
+binary with no path handling.
 
 ## Music
 
@@ -34,9 +37,8 @@ defer bgm.Free()
 bgm.Play(-1)          // -1 = loop forever
 bgm.FadeIn(-1, 2000)  // fade in over 2 s
 
-audio.PauseMusic()
-audio.ResumeMusic()
 audio.FadeOutMusic(1000)
+audio.HaltMusic()
 ```
 
 The showcase demo loads its music clip via `embeddedAssetPath`. The clip is the
@@ -92,11 +94,15 @@ bookkeeping is needed.
 ## Volume
 
 ```go
-audio.SetMasterVolume(0.8) // sound effects 0.0–1.0
-audio.SetMusicVolume(0.5)  // music channel 0.0–1.0
+audio.SetMasterVolume(0.8) // all sound channels 0.0–1.0
+v := audio.MasterVolume()  // read it back
 
-snd.SetVolume(0.3)         // per-sound volume
+vol := snd.Volume()        // per-sound volume, read-only today
 ```
+
+Per-sound volume has a getter but no exported setter, so normalize assets before
+embedding them, or scale a synthesized voice's own amplitude — see
+[Widget Sound Feedback](widget_sound.md).
 
 ## audio.Cfg
 
@@ -109,15 +115,14 @@ snd.SetVolume(0.3)         // per-sound volume
 
 ## Sound API
 
-| Function              | Description                          |
-| --------------------- | ------------------------------------ |
-| LoadSound(path)       | Load from file (WAV, OGG, MP3, FLAC) |
-| LoadSoundBytes(data)  | Load from byte slice                 |
-| Play(channel, loops)  | Play on channel (-1 = auto)          |
-| PlayOnce()            | Shorthand for Play(-1, 0)            |
-| FadeIn(ch, loops, ms) | Play with fade-in                    |
-| SetVolume(v)          | Per-sound volume 0.0–1.0             |
-| Free()                | Release resources                    |
+| Function              | Description                                |
+| --------------------- | ------------------------------------------ |
+| LoadSoundBytes(data)  | Load from byte slice (WAV, OGG, MP3, FLAC) |
+| Play(channel, loops)  | Play on channel (-1 = auto)                |
+| PlayOnce()            | Shorthand for Play(-1, 0)                  |
+| FadeIn(ch, loops, ms) | Play with fade-in                          |
+| Volume()              | Per-sound volume 0.0–1.0                   |
+| Free()                | Release resources                          |
 
 ## Music API
 
@@ -130,22 +135,21 @@ snd.SetVolume(0.3)         // per-sound volume
 
 ## Global Controls
 
-| Function               | Description                |
-| ---------------------- | -------------------------- |
-| SetMasterVolume(v)     | All sound channels 0.0–1.0 |
-| SetMusicVolume(v)      | Music channel 0.0–1.0      |
-| HaltChannel(ch)        | Stop channel (-1 = all)    |
-| FadeOutChannel(ch, ms) | Fade out channel           |
-| HaltMusic()            | Stop music immediately     |
-| FadeOutMusic(ms)       | Fade out music then halt   |
-| PauseMusic()           | Pause music                |
-| ResumeMusic()          | Resume music               |
-| PauseChannel(ch)       | Pause channel (-1 = all)   |
-| ResumeChannel(ch)      | Resume channel (-1 = all)  |
-| RewindMusic()          | Rewind to beginning        |
-| IsMusicPlaying()       | Whether music is playing   |
-| IsMusicPaused()        | Whether music is paused    |
-| IsPlaying(ch)          | Whether channel is playing |
+| Function           | Description                    |
+| ------------------ | ------------------------------ |
+| SetMasterVolume(v) | All sound channels 0.0–1.0     |
+| MasterVolume()     | Read the master volume         |
+| HaltChannel(ch)    | Stop channel (-1 = all)        |
+| IsPlaying(ch)      | Whether channel is playing     |
+| HaltMusic()        | Stop music immediately         |
+| FadeOutMusic(ms)   | Fade out music then halt       |
+| PlaySource(ch, s)  | Stream a live Source           |
+| SampleRate()       | Configured rate, 0 before Init |
+
+For **widget interaction sounds** — a click on a Button, a Toggle flipping — see
+[Widget Sound Feedback](widget_sound.md). That is a separate, higher-level
+opt-in: `gui` emits semantic cues and your player, built on this package,
+decides what they sound like.
 
 ## Notes
 

--- a/examples/showcase/docs/widget_sound.md
+++ b/examples/showcase/docs/widget_sound.md
@@ -1,0 +1,293 @@
+# Widget Sound Feedback
+
+Widgets can play a short sound when the user activates them. Nothing is audible
+until you opt in twice: a theme that names a **cue** for each interaction role,
+and a **sound player** installed on the window. Either one alone stays silent,
+which is the default for every built-in theme.
+
+This page is mirrored in the repo at `docs/widget-sound.md`.
+
+## What a cue is
+
+`gui.SoundCue` names a semantic event, not a file:
+
+| Cue                  | Meaning                                       |
+| -------------------- | --------------------------------------------- |
+| `gui.SoundNone`      | Zero value. Silent                            |
+| `gui.SoundClick`     | Momentary activation: button, menu item, link |
+| `gui.SoundToggleOn`  | A state went off → on                         |
+| `gui.SoundToggleOff` | A state went on → off                         |
+| `gui.SoundError`     | Rejection: invalid input, refused commit      |
+
+The framework decides _which_ cue an interaction is. Your player decides what a
+cue sounds like. That split is why `gui` never imports `gui/audio`, and why an
+app can map the same cue to different assets on different platforms.
+
+The list grows over time, so a player must ignore a cue it does not recognize
+rather than treat it as an error. Do not write an exhaustive switch over
+`SoundCue`.
+
+## Turn it on in three lines
+
+```go
+cfg := w.Theme().Cfg
+cfg.Sounds = gui.SoundsDefault()            // name a cue per role
+w.SetTheme(gui.ThemeMaker(cfg))
+w.SetSoundPlayer(gui.NewBeepSoundPlayer(w)) // render them
+```
+
+Rebuild through `ThemeMaker` rather than mutating the theme value in place. A
+`Theme` carries an `id`, and theme installation skips a theme whose id is
+already installed, so a mutated copy can silently lose the change in a second
+window. `ThemeMaker` stamps a fresh id.
+
+Set `Sounds` wherever you build the themes your app installs — switching to a
+theme that does not name cues turns sound off again.
+
+`NewBeepSoundPlayer` needs no assets and no audio library: it plays the system
+alert for `SoundError` and stays silent for everything else, because an alert is
+the wrong sound for a click. It is the right choice for an app that only wants
+to signal rejection.
+
+Volume is per window, `0.0` to `1.0`:
+
+```go
+w.SetSoundVolume(0.5)
+```
+
+`0` is mute — there is no separate mute flag. Values outside the range clamp.
+The value is implicitly relative to the system output level, which the OS mixer
+applies downstream; an app cannot portably read that level and should not try.
+`NewBeepSoundPlayer` ignores gain entirely: `NSBeep` and `MessageBeep` honor the
+system _alert_ volume and expose no app-level gain.
+
+## A real player
+
+For actual click sounds, implement `gui.SoundPlayer` over `gui/audio`. Below is
+the showcase's player, quoted whole from `examples/showcase/sound_player.go`. It
+synthesizes every cue rather than loading files, so it needs no assets. A test
+compares this block against that file byte for byte: what you read here is what
+compiles.
+
+```go
+// Cue envelope: percussive, one-shot, so each cue frees its own mixer
+// channel. Short enough that fast clicking does not smear.
+var cueEnv = voiceEnv{
+	attackS: 0.008,
+	decayS:  0.060,
+	sustain: 0,
+	oneShot: true,
+}
+
+// errorEnv is longer and lets the tone ring, so a rejection reads as
+// different in kind rather than only in pitch.
+var errorEnv = voiceEnv{
+	attackS: 0.008,
+	decayS:  0.220,
+	sustain: 0,
+	oneShot: true,
+}
+
+// cuePeakLevel is the voice amplitude before the window's gain. Well
+// below the synth pads: a UI cue rides under whatever else is playing.
+const cuePeakLevel = 0.22
+
+// cueSoundPlayer maps gui.SoundCue onto synthesized blips. Nothing is
+// loaded from disk — the showcase ships no sound assets — so the same
+// code runs on every desktop platform with no licensing or size cost.
+// An app with its own WAVs swaps the switch below for
+// audio.LoadSoundBytes; see docs/widget-sound.md.
+type cueSoundPlayer struct {
+	w *gui.Window
+}
+
+var _ gui.SoundPlayer = cueSoundPlayer{}
+
+// PlaySound implements gui.SoundPlayer. It runs on the event-dispatch
+// goroutine, so it starts a voice and returns; the mixer does the work
+// on the audio thread.
+func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
+	var freq float64
+	env := cueEnv
+	switch cue {
+	case gui.SoundClick:
+		freq = 880 // A5
+	case gui.SoundToggleOn:
+		freq = 880 * 4 / 3 // a fourth up
+	case gui.SoundToggleOff:
+		freq = 880 * 3 / 4 // a fourth down
+	case gui.SoundError:
+		freq = 220
+		env = errorEnv
+	default:
+		// An unrecognised cue is ignored, not an error: gui adds cues
+		// over time and a player must not break when it does.
+		return
+	}
+	if !ensureAudioInit(p.w) {
+		return
+	}
+	// The window's volume arrives as gain; scale the voice rather than
+	// touching audio.SetMasterVolume, which the music demo owns.
+	v := newVoice(freq, cuePeakLevel*float64(gain), env)
+	// A failed start is silent on purpose: a click must never surface a
+	// mixer error to the user.
+	_ = audio.PlaySource(-1, v)
+}
+
+// SoundAvailable implements gui.SoundPlayer. gui/audio builds on every
+// desktop target this file compiles for.
+func (p cueSoundPlayer) SoundAvailable() bool { return true }
+```
+
+Two names the block leans on. `ensureAudioInit(p.w)` is showcase plumbing that
+initializes `gui/audio` once and reports a failure in the demo's status line; an
+app without one writes `if err := audio.Init(); err != nil { return }` instead.
+`newVoice` builds an `audio.Source` — see `examples/showcase/demo_audio.go` for
+the oscillator and the envelope, and [the audio guide](widget_audio.md) for the
+`Source` contract.
+
+Install it on the window:
+
+```go
+w.SetSoundPlayer(cueSoundPlayer{w: w})
+```
+
+`PlaySound` runs on the event-dispatch goroutine, so it must be fire-and-forget:
+start the sound and return. Never block, and never allocate on the audio thread.
+
+## Playing your own files
+
+An app that ships sound assets swaps the switch for loaded samples:
+
+```go
+type filePlayer struct {
+    click, on, off, fail *audio.Sound
+}
+
+func newFilePlayer() (*filePlayer, error) {
+    if err := audio.Init(); err != nil {
+        return nil, err
+    }
+    p := &filePlayer{}
+    var err error
+    if p.click, err = audio.LoadSoundBytes(clickWav); err != nil {
+        return nil, err
+    }
+    // ... one per cue
+    return p, nil
+}
+
+func (p *filePlayer) PlaySound(cue gui.SoundCue, gain float32) {
+    var s *audio.Sound
+    switch cue {
+    case gui.SoundClick:
+        s = p.click
+    case gui.SoundToggleOn:
+        s = p.on
+    case gui.SoundToggleOff:
+        s = p.off
+    case gui.SoundError:
+        s = p.fail
+    default:
+        return
+    }
+    // gui/audio exports no per-sound volume setter today, so a
+    // file-based player either ignores gain or scales the whole mixer
+    // with audio.SetMasterVolume. Prefer pre-normalized assets.
+    _, _ = s.PlayOnce()
+}
+
+func (p *filePlayer) SoundAvailable() bool { return true }
+
+// Free every sound at teardown; never Free one while it plays.
+func (p *filePlayer) Close() {
+    p.click.Free()
+    p.on.Free()
+    p.off.Free()
+    p.fail.Free()
+}
+```
+
+Embed the WAVs with `//go:embed` and pass the bytes — `audio.LoadSoundBytes`
+avoids the temp-file dance a path-based load needs. The repo ships no sound
+assets of its own, so the showcase uses the synthesized player above.
+
+## Per-widget control
+
+Two fields on the widget's `Cfg`:
+
+| Field                | Effect                                         |
+| -------------------- | ---------------------------------------------- |
+| `Sound SoundCue`     | Overrides the theme's cue for this instance    |
+| `SoundDisabled bool` | Silences this instance whatever the theme says |
+
+Precedence, resolved once at generation time:
+
+```
+SoundDisabled  >  Cfg.Sound  >  Theme.Sounds.<role>
+```
+
+```go
+gui.Button(gui.ButtonCfg{ID: "del", Label: "Delete", Sound: gui.SoundError})
+gui.Button(gui.ButtonCfg{ID: "tick", Label: "Tick", SoundDisabled: true})
+```
+
+A `Toggle` picks its own cue from its state: a selected toggle is about to turn
+off, so it emits `SoundToggleOff`. You do not need an on/off field pair.
+
+## Which widgets sound
+
+Currently `Button` and `Toggle`. The seam itself is generic — the cue rides the
+shape's event record, so any widget can adopt it — and the remaining widgets are
+being phased in (#467, #468, #469). Widgets that only absorb clicks stay silent
+by design: the toast scrim, the context-menu dismiss layer, scrollbar tracks,
+and the caret-placement click inside an `Input`.
+
+## Platform reality
+
+- `gui/audio` does not build for `js`, `android`, or `ios`. Put your player
+  behind a `//go:build !js && !android && !ios` tag and supply an empty stub for
+  the others, the way the showcase does.
+- `BeepAvailable()` is false on mobile and wasm, and on Linux without
+  `canberra-gtk-play`.
+- The failure mode is always silence, never a panic. A nil `SoundPlayer` is the
+  default and every call site nil-guards, which is also why headless tests are
+  silent with no setup.
+- Call `SoundAvailable()` when the user genuinely needs to notice the event, and
+  add a visual cue when it returns false.
+
+## Ordering
+
+The cue fires **before** `OnClick` runs, and **regardless of whether the handler
+calls `ctx.Consume()`**. The sound confirms that the widget was activated; it
+does not take part in event propagation.
+
+Every activation path sounds, not just the mouse: click, Space, Enter, and the
+accessibility press action all emit the same cue.
+
+## Testing
+
+Widget sound is fully headless-testable. Inject a spy player and drive the
+widget with the `Test*` helpers:
+
+```go
+type spy struct{ cues []gui.SoundCue }
+
+func (s *spy) PlaySound(c gui.SoundCue, _ float32) {
+    s.cues = append(s.cues, c)
+}
+func (s *spy) SoundAvailable() bool { return true }
+
+sp := &spy{}
+w.SetSoundPlayer(sp)
+w.TestClick("save")
+// sp.cues == []gui.SoundCue{gui.SoundClick}
+```
+
+## See also
+
+- [Audio playback](widget_audio.md) — the `gui/audio` package: sounds, music,
+  and live synthesis
+- `docs/specs/widget-audio-feedback.md` — the design record and the alternatives
+  that were rejected

--- a/examples/showcase/embedded.go
+++ b/examples/showcase/embedded.go
@@ -20,6 +20,7 @@ var showcaseLocaleLabels = []string{"EN", "DE", "AR", "JA"}
 var docPageFiles = map[string]string{
 	"welcome":  "docs/welcome.md",
 	"commands": "docs/commands.md",
+	"sound":    "docs/widget_sound.md",
 }
 
 func loadEmbeddedLocales() {
@@ -104,6 +105,7 @@ var relatedExampleMap = map[string][]string{
 	"audio":               {"examples/showcase/demo_audio.go"},
 	"welcome":             {"examples/showcase/demo_welcome.go", "examples/showcase/docs/welcome.md"},
 	"commands":            {"examples/showcase/docs/commands.md", "examples/command_demo/main.go"},
+	"sound":               {"examples/showcase/docs/widget_sound.md", "examples/showcase/sound_player.go", "examples/showcase/demo_audio.go"},
 	"button":              {"examples/showcase/demo_feedback.go"},
 	"input":               {"examples/showcase/demo_input.go", "examples/multiline_input/main.go"},
 	"toggle":              {"examples/showcase/demo_selection.go"},

--- a/examples/showcase/showcase_test.go
+++ b/examples/showcase/showcase_test.go
@@ -94,8 +94,63 @@ func TestComponentDocsExist(t *testing.T) {
 }
 
 func TestDocPagesExist(t *testing.T) {
-	if doc := docPageSource("welcome"); doc == "" {
-		t.Fatal("expected doc page for welcome")
+	// Every registered doc-only page must resolve: the nav entry, the
+	// detail branch and the embedded file have to agree, and a missing
+	// mirror is otherwise only visible at runtime.
+	for id := range docPageFiles {
+		if doc := docPageSource(id); doc == "" {
+			t.Errorf("expected doc page for %s", id)
+		}
+	}
+	for _, id := range []string{"welcome", "commands", "sound"} {
+		if doc := docPageSource(id); doc == "" {
+			t.Errorf("expected doc page for %s", id)
+		}
+	}
+}
+
+// soundWiringSpy stands in for the real cue player, which needs an
+// audio device.
+type soundWiringSpy struct{ cues []gui.SoundCue }
+
+func (s *soundWiringSpy) PlaySound(c gui.SoundCue, _ float32) {
+	s.cues = append(s.cues, c)
+}
+
+func (s *soundWiringSpy) SoundAvailable() bool { return true }
+
+// Exercises the showcase's own opt-in path end to end: the theme
+// rebuild inside installWidgetSounds, then a click on a real showcase
+// button. Without this the wiring is only observable by ear.
+func TestShowcaseWidgetSoundWiring(t *testing.T) {
+	app := newShowcaseApp()
+	app.SelectedGroup = groupFeedback
+	app.SelectedComponent = "audio"
+	w := gui.NewTestWindow(gui.WindowCfg{State: app})
+	w.UpdateView(mainView)
+
+	installWidgetSounds(w, false)
+	spy := &soundWiringSpy{}
+	w.SetSoundPlayer(spy)
+	w.SetSoundVolume(0.5)
+	w.TestRender(nil)
+
+	// The demo panel sits under the "detail" scope, so the effective ID
+	// is what the public Test* API takes.
+	if err := w.TestClick("detail:widget-sound-click"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if len(spy.cues) != 1 || spy.cues[0] != gui.SoundClick {
+		t.Fatalf("cues = %v, want [SoundClick]", spy.cues)
+	}
+
+	// SoundDisabled on one instance must stay silent.
+	spy.cues = nil
+	if err := w.TestClick("detail:widget-sound-muted"); err != nil {
+		t.Fatalf("TestClick muted: %v", err)
+	}
+	if len(spy.cues) != 0 {
+		t.Fatalf("SoundDisabled button emitted %v", spy.cues)
 	}
 }
 

--- a/examples/showcase/sound_player.go
+++ b/examples/showcase/sound_player.go
@@ -1,0 +1,122 @@
+//go:build !js && !android && !ios
+
+package main
+
+import (
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/audio"
+)
+
+// This file is the whole of what an app writes to give its widgets
+// sound. It is also the source the "Sound Feedback" guide quotes, so
+// keep it self-contained and readable — the guide is only correct for
+// as long as this file compiles.
+
+// doc:snippet-begin player
+//
+// The block below is quoted verbatim by docs/widget-sound.md and by
+// examples/showcase/docs/widget_sound.md. TestSoundGuideSnippetMatchesSource
+// fails when the two drift, so keep this region self-contained: anything a
+// reader would have to go looking for belongs above the marker, not inside
+// it.
+
+// Cue envelope: percussive, one-shot, so each cue frees its own mixer
+// channel. Short enough that fast clicking does not smear.
+var cueEnv = voiceEnv{
+	attackS: 0.008,
+	decayS:  0.060,
+	sustain: 0,
+	oneShot: true,
+}
+
+// errorEnv is longer and lets the tone ring, so a rejection reads as
+// different in kind rather than only in pitch.
+var errorEnv = voiceEnv{
+	attackS: 0.008,
+	decayS:  0.220,
+	sustain: 0,
+	oneShot: true,
+}
+
+// cuePeakLevel is the voice amplitude before the window's gain. Well
+// below the synth pads: a UI cue rides under whatever else is playing.
+const cuePeakLevel = 0.22
+
+// cueSoundPlayer maps gui.SoundCue onto synthesized blips. Nothing is
+// loaded from disk — the showcase ships no sound assets — so the same
+// code runs on every desktop platform with no licensing or size cost.
+// An app with its own WAVs swaps the switch below for
+// audio.LoadSoundBytes; see docs/widget-sound.md.
+type cueSoundPlayer struct {
+	w *gui.Window
+}
+
+var _ gui.SoundPlayer = cueSoundPlayer{}
+
+// PlaySound implements gui.SoundPlayer. It runs on the event-dispatch
+// goroutine, so it starts a voice and returns; the mixer does the work
+// on the audio thread.
+func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
+	var freq float64
+	env := cueEnv
+	switch cue {
+	case gui.SoundClick:
+		freq = 880 // A5
+	case gui.SoundToggleOn:
+		freq = 880 * 4 / 3 // a fourth up
+	case gui.SoundToggleOff:
+		freq = 880 * 3 / 4 // a fourth down
+	case gui.SoundError:
+		freq = 220
+		env = errorEnv
+	default:
+		// An unrecognised cue is ignored, not an error: gui adds cues
+		// over time and a player must not break when it does.
+		return
+	}
+	if !ensureAudioInit(p.w) {
+		return
+	}
+	// The window's volume arrives as gain; scale the voice rather than
+	// touching audio.SetMasterVolume, which the music demo owns.
+	v := newVoice(freq, cuePeakLevel*float64(gain), env)
+	// A failed start is silent on purpose: a click must never surface a
+	// mixer error to the user.
+	_ = audio.PlaySource(-1, v)
+}
+
+// SoundAvailable implements gui.SoundPlayer. gui/audio builds on every
+// desktop target this file compiles for.
+func (p cueSoundPlayer) SoundAvailable() bool { return true }
+
+// doc:snippet-end player
+
+// installWidgetSounds turns widget sound on for the window: a theme
+// that names a cue per role, and a player that renders them. Both are
+// required — either alone is silent.
+//
+// beepOnly picks the zero-dependency path from the guide: the system
+// alert on SoundError and silence otherwise, with no audio library and
+// no assets. It is what an app wants when it only needs to signal a
+// rejection.
+func installWidgetSounds(w *gui.Window, beepOnly bool) {
+	// Rebuild through ThemeMaker rather than mutating the theme in
+	// place: a Theme carries an id, and installTheme skips a theme
+	// whose id is already installed, so a mutated copy can silently
+	// lose the change in a second window. ThemeMaker stamps a fresh id.
+	cfg := w.Theme().Cfg
+	cfg.Sounds = gui.SoundsDefault()
+	w.SetTheme(gui.ThemeMaker(cfg))
+
+	var p gui.SoundPlayer = cueSoundPlayer{w: w}
+	if beepOnly {
+		p = gui.NewBeepSoundPlayer(w)
+	}
+	w.SetSoundPlayer(p)
+}
+
+// removeWidgetSounds silences the window again, leaving the theme's
+// cue set in place so the toggle is symmetric.
+func removeWidgetSounds(w *gui.Window) {
+	w.SetSoundPlayer(nil)
+}

--- a/examples/showcase/sound_player_other.go
+++ b/examples/showcase/sound_player_other.go
@@ -1,0 +1,18 @@
+//go:build js || android || ios
+
+package main
+
+import "github.com/go-gui-org/go-gui/gui"
+
+// gui/audio does not build for these targets, so widget sound degrades
+// to silence rather than to a build failure. The gui/ side is
+// unchanged: a nil SoundPlayer is the default everywhere.
+
+func installWidgetSounds(_ *gui.Window, _ bool) {}
+
+func removeWidgetSounds(_ *gui.Window) {}
+
+var (
+	_ = installWidgetSounds
+	_ = removeWidgetSounds
+)

--- a/examples/showcase/sound_snippet_test.go
+++ b/examples/showcase/sound_snippet_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The "Sound Feedback" guide quotes examples/showcase/sound_player.go whole
+// rather than paraphrasing it, so a reader can paste the block and have it
+// compile. Nothing enforces that on its own: the guide is markdown and the
+// player is Go, and an edit to either is invisible to the other. This test is
+// the enforcement. It fails when the marked region and the quoted block stop
+// being byte-identical, in whichever direction the drift happened.
+
+const (
+	snippetSourceFile = "sound_player.go"
+	snippetBeginMark  = "// doc:snippet-begin player"
+	snippetEndMark    = "// doc:snippet-end player"
+)
+
+// soundGuides lists every copy of the guide. The repo keeps a mirror under
+// docs/ as well as the showcase's embedded copy, so both are checked; a fix
+// that lands in one and not the other is exactly the drift this catches.
+var soundGuides = []string{
+	"docs/widget_sound.md",
+	"../../docs/widget-sound.md",
+}
+
+// markedRegion returns the source between the snippet markers, minus the
+// marker's own explanatory comment block (which ends at the first blank
+// line) and minus surrounding blank lines.
+func markedRegion(t *testing.T, src string) string {
+	t.Helper()
+	if strings.Count(src, snippetBeginMark) != 1 ||
+		strings.Count(src, snippetEndMark) != 1 {
+		t.Fatalf("%s must contain exactly one %q and one %q",
+			snippetSourceFile, snippetBeginMark, snippetEndMark)
+	}
+	_, rest, _ := strings.Cut(src, snippetBeginMark)
+	body, _, _ := strings.Cut(rest, snippetEndMark)
+	_, code, found := strings.Cut(body, "\n\n")
+	if !found {
+		t.Fatalf("%s: no blank line after the snippet marker comment",
+			snippetSourceFile)
+	}
+	return strings.Trim(code, "\n")
+}
+
+// guideSnippet returns the first fenced Go block that follows the "A real
+// player" heading. Keyed on the heading rather than on block order so that
+// adding a snippet earlier in the guide does not silently retarget the test.
+func guideSnippet(t *testing.T, guide, doc string) string {
+	t.Helper()
+	const heading = "## A real player"
+	_, rest, found := strings.Cut(doc, heading)
+	if !found {
+		t.Fatalf("%s: no %q heading; the guide was restructured and this "+
+			"test needs retargeting", guide, heading)
+	}
+	_, rest, found = strings.Cut(rest, "```go\n")
+	if !found {
+		t.Fatalf("%s: no Go code fence under %q", guide, heading)
+	}
+	block, _, found := strings.Cut(rest, "\n```")
+	if !found {
+		t.Fatalf("%s: unterminated Go code fence under %q", guide, heading)
+	}
+	return strings.Trim(block, "\n")
+}
+
+func TestSoundGuideSnippetMatchesSource(t *testing.T) {
+	raw, err := os.ReadFile(snippetSourceFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", snippetSourceFile, err)
+	}
+	want := markedRegion(t, string(raw))
+	if !strings.Contains(want, "func (p cueSoundPlayer) PlaySound(") {
+		t.Fatalf("%s: marked region no longer contains PlaySound; the "+
+			"markers have drifted off the player", snippetSourceFile)
+	}
+
+	for _, guide := range soundGuides {
+		doc, errRead := os.ReadFile(guide)
+		if errRead != nil {
+			t.Errorf("read %s: %v", guide, errRead)
+			continue
+		}
+		got := guideSnippet(t, guide, string(doc))
+		if got == want {
+			continue
+		}
+		// Report the first differing line rather than dumping ~50 lines
+		// twice: the fix is always to copy one side over the other.
+		gotLines := strings.Split(got, "\n")
+		wantLines := strings.Split(want, "\n")
+		for i := 0; i < len(gotLines) || i < len(wantLines); i++ {
+			g, w := "<missing>", "<missing>"
+			if i < len(gotLines) {
+				g = gotLines[i]
+			}
+			if i < len(wantLines) {
+				w = wantLines[i]
+			}
+			if g == w {
+				continue
+			}
+			t.Errorf("%s: snippet drifted from %s at block line %d\n"+
+				"  guide:  %s\n  source: %s\n"+
+				"fix: copy the region between the %q markers into the "+
+				"guide's Go fence verbatim",
+				guide, snippetSourceFile, i+1, g, w, snippetBeginMark)
+			break
+		}
+	}
+}

--- a/examples/showcase/state.go
+++ b/examples/showcase/state.go
@@ -133,9 +133,16 @@ type ShowcaseApp struct {
 	SplitterDetailState gui.SplitterState
 	RangeValue          float32
 	AudioVolume         float64
-	AudioMusicLoaded    bool
-	AudioMusicPlaying   bool
-	AudioMusicPaused    bool
+	// WidgetSoundOn tracks the widget-sound opt-in (issue #446). Two
+	// things must be true for a widget to sound: a theme naming a cue
+	// per role, and an installed SoundPlayer. The switch does both.
+	WidgetSoundOn     bool
+	WidgetSoundVolume float32
+	WidgetSoundDemoOn bool
+	WidgetSoundBeep   bool
+	AudioMusicLoaded  bool
+	AudioMusicPlaying bool
+	AudioMusicPaused  bool
 
 	AnimTweenX    float32
 	AnimSpringX   float32
@@ -218,6 +225,7 @@ func newShowcaseApp() *ShowcaseApp {
 		BCPath:               append([]gui.BreadcrumbItemCfg(nil), showcaseBreadcrumbPath...),
 		TabSelected:          "overview",
 		AudioVolume:          0.8,
+		WidgetSoundVolume:    0.5,
 		SplitterMainState:    gui.SplitterState{Ratio: 0.30},
 		SplitterDetailState:  gui.SplitterState{Ratio: 0.55},
 		SidebarOpen:          true,
@@ -306,6 +314,7 @@ type DemoGroup struct {
 var demoEntries = []DemoEntry{
 	{ID: "welcome", Label: "Welcome", Group: groupWelcome, Summary: "Start here for a quick introduction to Go-Gui and this showcase.", Tags: []string{"start", "intro", "overview"}},
 	{ID: "commands", Label: "Commands & Hotkeys", Group: groupWelcome, Summary: "Centralized command registry with keyboard shortcuts, menu integration, and command palette.", Tags: []string{"command", "hotkey", "shortcut", "keyboard", "palette"}},
+	{ID: "sound", Label: "Sound Feedback", Group: groupWelcome, Summary: "Opt-in interaction sounds: semantic cues, an injected player, per-widget override.", Tags: []string{"sound", "audio", "cue", "feedback", "click", "beep", "volume"}},
 
 	{ID: "color_picker", Label: "Color Picker", Group: groupSelection, Summary: "Pick RGBA and optional HSV values.", Tags: []string{"color", "hsv", "rgba"}},
 	{ID: "date_picker", Label: "Date Picker", Group: groupSelection, Summary: "Select one or many dates from a calendar.", Tags: []string{"calendar", "dates", "selection"}},

--- a/gui/a11y_tree.go
+++ b/gui/a11y_tree.go
@@ -259,8 +259,9 @@ func a11yActionCallback(w *Window, action, index int) {
 	ev := l.Shape.events
 	switch action {
 	case A11yActionPress:
-		if ev.OnClick != nil {
+		if ev.OnClick != nil && !l.Shape.Disabled {
 			e := &Event{Type: EventMouseDown}
+			playShapeSound(l, w)
 			ev.OnClick(EventCtx{l, e, w})
 		}
 	case A11yActionIncrement:

--- a/gui/event_handlers.go
+++ b/gui/event_handlers.go
@@ -50,6 +50,7 @@ func charHandler(layout *Layout, e *Event, w *Window) {
 		events.OnClick != nil {
 		if isFocusedTarget(layout, w) {
 			e.IsHandled = true
+			playShapeSound(layout, w)
 			events.OnClick(EventCtx{layout, e, w})
 		}
 	}
@@ -106,6 +107,7 @@ func keydownHandler(layout *Layout, e *Event, w *Window) {
 		e.KeyCode == KeyEnter &&
 		events.OnClick != nil {
 		e.IsHandled = true
+		playShapeSound(layout, w)
 		events.OnClick(EventCtx{layout, e, w})
 		return
 	}

--- a/gui/event_traversal.go
+++ b/gui/event_traversal.go
@@ -58,6 +58,12 @@ func callRelative(
 	saved := *e
 	e.MouseX = saved.MouseX - layout.Shape.X
 	e.MouseY = saved.MouseY - layout.Shape.Y
+	// Sound fires before the callback and independently of whether the
+	// callback consumes: the cue confirms the widget was activated, it
+	// is not a propagation decision (issue #446).
+	if class == evClick {
+		playShapeSound(layout, w)
+	}
 	callback(EventCtx{layout, e, w})
 	handled := e.IsHandled
 	*e = saved

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -452,6 +452,12 @@ type eventHandlers struct {
 	clickButton  MouseButton // non-zero filters OnClick by mouse button
 	clickOnSpace bool        // fire OnClick on spacebar via OnChar dispatch
 	clickOnEnter bool        // fire OnClick on Enter key via OnKeyDown dispatch
+
+	// soundCue is the cue dispatch emits when this shape's OnClick
+	// fires. Resolved at generation time from the theme and the
+	// widget's Cfg, and stored here rather than in a closure for the
+	// same reason as the flags above (issue #446). SoundNone = silent.
+	soundCue SoundCue
 }
 
 // shapeButtonColors holds per-button color state read by

--- a/gui/sound.go
+++ b/gui/sound.go
@@ -1,0 +1,212 @@
+package gui
+
+import "math"
+
+// SoundCue names a semantic user-interface event. The framework emits
+// cues; the injected SoundPlayer decides what each one sounds like. A
+// cue is not a sample path, so a theme can stay silent, an app can map
+// the same cue to different assets, and gui/ never gains an audio
+// dependency.
+//
+// The zero value is SoundNone, so an unset field on a Cfg or on a
+// SoundSet is silent and no separate "set" flag is needed — the same
+// reasoning as ColorSet (see gui/color_set.go).
+//
+// The list grows over time. A player that does not recognise a cue must
+// ignore it; never write an exhaustive switch over this type.
+type SoundCue uint8
+
+// SoundCue values.
+const (
+	// SoundNone is the zero value: no sound. Exported because it is
+	// the name of "silent" in the cue vocabulary: an app's player
+	// compares against it, and a Cfg is documented as taking it.
+	// exportaudit:keep — zero-value sentinel of a public enum.
+	SoundNone SoundCue = iota
+	// SoundClick marks a momentary activation — a button press, a menu
+	// item, a link.
+	SoundClick
+	// SoundToggleOn marks a state that went off -> on.
+	SoundToggleOn
+	// SoundToggleOff marks a state that went on -> off.
+	SoundToggleOff
+	// SoundError marks a rejection: invalid input, a refused commit, a
+	// failed action.
+	SoundError
+)
+
+// SoundPlayer renders semantic UI cues as audible feedback. The
+// backend installs none — an app opts in with
+// (*Window).SetSoundPlayer. Nil in tests and by default, which is why
+// every call site nil-guards and silence is the default behaviour.
+//
+// Implementations live outside gui/ (see examples/showcase) so that
+// gui/ never imports gui/audio.
+type SoundPlayer interface {
+	// PlaySound renders cue at gain (0..1, already clamped by the
+	// window). Called on the event-dispatch goroutine, so it must be
+	// fire-and-forget: no blocking, no allocation on an audio thread.
+	// An unrecognised cue must be ignored, not reported as an error.
+	PlaySound(cue SoundCue, gain float32)
+	// SoundAvailable reports whether PlaySound can actually produce
+	// sound on this platform. Callers that need the user to notice an
+	// event use this to decide whether a visual fallback is warranted.
+	SoundAvailable() bool
+}
+
+// SoundSet maps the interaction roles the widget set knows about onto
+// cues. It lives on Theme; the zero set is silent, which is the
+// intended default, so ThemeDark and ThemeLight make no sound.
+//
+// It is a struct rather than a fixed array so that new roles can be
+// added without breaking apps that build one by field name.
+//
+// exportaudit:keep — the type of Theme.Sounds and the return of
+// SoundsDefault; an app naming its own cue map needs the name.
+type SoundSet struct {
+	// Click is the cue for a momentary activation.
+	// exportaudit:keep — caller-facing config (issue #446)
+	Click SoundCue
+	// ToggleOn is the cue for a state going off -> on.
+	// exportaudit:keep — caller-facing config (issue #446)
+	ToggleOn SoundCue
+	// ToggleOff is the cue for a state going on -> off.
+	// exportaudit:keep — caller-facing config (issue #446)
+	ToggleOff SoundCue
+	// Error is the cue for a rejection.
+	// exportaudit:keep — caller-facing config (issue #446)
+	Error SoundCue
+}
+
+// SoundsDefault returns the natural cue for every role — the one-liner
+// an app assigns to Theme.Sounds to opt the whole widget set in.
+func SoundsDefault() SoundSet {
+	return SoundSet{
+		Click:     SoundClick,
+		ToggleOn:  SoundToggleOn,
+		ToggleOff: SoundToggleOff,
+		Error:     SoundError,
+	}
+}
+
+// resolveSoundCue applies the precedence a widget Cfg promises:
+// SoundDisabled beats an explicit Cfg.Sound, which beats the theme's
+// cue for that role. Called at generation time, where the widget
+// already knows its own state, so a state-dependent cue (toggle on vs
+// off) costs no runtime branch and no allocation.
+func resolveSoundCue(themeCue, cfgCue SoundCue, disabled bool) SoundCue {
+	if disabled {
+		return SoundNone
+	}
+	if cfgCue != SoundNone {
+		return cfgCue
+	}
+	return themeCue
+}
+
+// SetSoundPlayer installs the window's sound player. Nil disables
+// widget sound without changing any theme or Cfg.
+func (w *Window) SetSoundPlayer(p SoundPlayer) {
+	w.soundPlayer = p
+}
+
+// SoundPlayer returns the window's sound player, or nil if none has
+// been set (the default, and every headless test).
+func (w *Window) SoundPlayer() SoundPlayer {
+	return w.soundPlayer
+}
+
+// SetSoundVolume sets the gain passed to the sound player, clamped to
+// 0..1. There is no separate mute flag: 0 is mute, and the gate is one
+// comparison ahead of cue resolution, so a muted window costs nothing
+// per click.
+//
+// The value is implicitly relative to the system output level, which
+// the OS mixer applies downstream — an app cannot portably read that
+// level and must not try.
+func (w *Window) SetSoundVolume(v float32) {
+	// NaN and Inf are unusable as gain; treat them as mute or
+	// full, not as a propagated NaN that silences the mixer with a
+	// NaN level downstream.
+	if math.IsNaN(float64(v)) {
+		v = 0
+	} else if math.IsInf(float64(v), 1) {
+		v = 1
+	} else if math.IsInf(float64(v), -1) {
+		v = 0
+	}
+	switch {
+	case v < 0:
+		v = 0
+	case v > 1:
+		v = 1
+	}
+	w.soundVolume = v
+	w.soundVolumeSet = true
+}
+
+// SoundVolume returns the window's sound gain, 0..1. Defaults to 1.
+func (w *Window) SoundVolume() float32 {
+	if !w.soundVolumeSet {
+		return 1
+	}
+	return w.soundVolume
+}
+
+// playShapeSound emits the shape's resolved cue. Nil-safe on every
+// seam: no layout, no shape, no events record, no cue, no player, or a
+// muted window, and it is a no-op.
+//
+// Called before OnClick and independently of ctx.Consume(): the cue
+// confirms that the widget was activated, it does not participate in
+// event propagation.
+func playShapeSound(l *Layout, w *Window) {
+	if l == nil || l.Shape == nil || l.Shape.events == nil || w == nil {
+		return
+	}
+	if l.Shape.Disabled {
+		return
+	}
+	cue := l.Shape.events.soundCue
+	if cue == SoundNone {
+		return
+	}
+	p := w.soundPlayer
+	if p == nil {
+		return
+	}
+	gain := w.SoundVolume()
+	if gain <= 0 || math.IsNaN(float64(gain)) || math.IsInf(float64(gain), 0) {
+		return
+	}
+	p.PlaySound(cue, gain)
+}
+
+// beepSoundPlayer is the zero-dependency default: it maps SoundError
+// to the system alert and every other cue to silence.
+type beepSoundPlayer struct {
+	w *Window
+}
+
+// NewBeepSoundPlayer returns a SoundPlayer backed by the platform's
+// system alert sound (Window.Beep). It plays only SoundError, because
+// an alert is the wrong sound for a click, and it needs no assets and
+// no audio library.
+//
+// It ignores gain: NSBeep and MessageBeep honour the system alert
+// volume and expose no app-level gain. An app that needs volume control
+// needs a sampled player — see gui/audio and examples/showcase.
+func NewBeepSoundPlayer(w *Window) SoundPlayer {
+	return beepSoundPlayer{w: w}
+}
+
+func (b beepSoundPlayer) PlaySound(cue SoundCue, _ float32) {
+	if cue != SoundError || b.w == nil {
+		return
+	}
+	b.w.Beep()
+}
+
+func (b beepSoundPlayer) SoundAvailable() bool {
+	return b.w != nil && b.w.BeepAvailable()
+}

--- a/gui/sound_test.go
+++ b/gui/sound_test.go
@@ -1,0 +1,405 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+// Sound cues resolve against the installed theme, and theme
+// installation is package-global, so these tests must not run in
+// parallel with each other or with anything else that installs a theme.
+
+// soundSpy records every cue the framework emits.
+type soundSpy struct {
+	cues      []SoundCue
+	gains     []float32
+	available bool
+}
+
+func (s *soundSpy) PlaySound(cue SoundCue, gain float32) {
+	s.cues = append(s.cues, cue)
+	s.gains = append(s.gains, gain)
+}
+
+func (s *soundSpy) SoundAvailable() bool { return s.available }
+
+// soundingTheme returns ThemeDark with every sound role populated —
+// what an app gets from theme.Sounds = SoundsDefault().
+func soundingTheme(t *testing.T) Theme {
+	t.Helper()
+	cfg := themeDarkCfg
+	cfg.Name = "sounding"
+	cfg.Sounds = SoundsDefault()
+	return ThemeMaker(cfg)
+}
+
+// silentTheme returns ThemeDark unchanged: the zero SoundSet, which is
+// the default every built-in theme ships.
+func silentTheme(t *testing.T) Theme {
+	t.Helper()
+	cfg := themeDarkCfg
+	cfg.Name = "silent"
+	return ThemeMaker(cfg)
+}
+
+func buttonView(cfg ButtonCfg) func(*Window) View {
+	cfg.ID = "btn"
+	cfg.Label = "Go"
+	if cfg.OnClick == nil {
+		cfg.OnClick = func(ctx EventCtx) { ctx.Consume() }
+	}
+	return func(*Window) View { return Button(cfg) }
+}
+
+func TestSoundThemeDefaultIsSilent(t *testing.T) {
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(silentTheme(t))
+	w.SetSoundPlayer(spy)
+	w.TestRender(buttonView(ButtonCfg{}))
+
+	if err := w.TestClick("btn"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if len(spy.cues) != 0 {
+		t.Errorf("silent theme emitted %v, want nothing", spy.cues)
+	}
+}
+
+func TestSoundNilPlayerDoesNotPanic(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	// No SetSoundPlayer: the default, and every headless test.
+	w.TestRender(buttonView(ButtonCfg{}))
+	if err := w.TestClick("btn"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+}
+
+// A click must sound on every path that can activate a widget: mouse,
+// spacebar, Enter and the accessibility press action.
+func TestSoundButtonAllActivationPaths(t *testing.T) {
+	restoreTheme(t)
+	th := soundingTheme(t)
+
+	activate := map[string]func(*testing.T, *Window){
+		"mouse": func(t *testing.T, w *Window) {
+			if err := w.TestClick("btn"); err != nil {
+				t.Fatalf("TestClick: %v", err)
+			}
+		},
+		"space": func(t *testing.T, w *Window) {
+			if err := w.TestType("btn", " "); err != nil {
+				t.Fatalf("TestType: %v", err)
+			}
+		},
+		"enter": func(t *testing.T, w *Window) {
+			if err := w.TestKey("btn", KeyEnter, ModNone); err != nil {
+				t.Fatalf("TestKey: %v", err)
+			}
+		},
+		"a11y_press": func(t *testing.T, w *Window) {
+			// Real a11y dispatch: build the node array the action
+			// index refers to, then press through it.
+			w.a11y.nodes = w.a11y.nodes[:0]
+			var live []liveNode
+			a11yCollect(&w.layout, -1, &w.a11y.nodes, "", &live)
+			idx := -1
+			for i := range w.a11y.nodes {
+				if w.a11y.nodes[i].Role == AccessRoleButton {
+					idx = i
+					break
+				}
+			}
+			if idx < 0 {
+				t.Fatal("no button node in the a11y tree")
+			}
+			a11yActionCallback(w, A11yActionPress, idx)
+		},
+	}
+
+	for name, act := range activate {
+		t.Run(name, func(t *testing.T) {
+			spy := &soundSpy{}
+			w := NewTestWindow(WindowCfg{})
+			w.SetTheme(th)
+			w.SetSoundPlayer(spy)
+			w.TestRender(buttonView(ButtonCfg{}))
+			act(t, w)
+			if len(spy.cues) != 1 || spy.cues[0] != SoundClick {
+				t.Errorf("cues = %v, want [SoundClick]", spy.cues)
+			}
+		})
+	}
+}
+
+func TestSoundToggleStateDependentCue(t *testing.T) {
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+
+	selected := false
+	w.TestRender(func(*Window) View {
+		return Toggle(ToggleCfg{
+			ID:       "tgl",
+			Label:    "On",
+			Selected: selected,
+			OnClick: func(ctx EventCtx) {
+				selected = !selected
+				ctx.Consume()
+			},
+		})
+	})
+
+	// Off -> on, then on -> off. The cue names what the click does.
+	for i := range 2 {
+		if err := w.TestClick("tgl"); err != nil {
+			t.Fatalf("click %d: %v", i, err)
+		}
+		w.TestRender(nil)
+	}
+	want := []SoundCue{SoundToggleOn, SoundToggleOff}
+	if len(spy.cues) != 2 ||
+		spy.cues[0] != want[0] || spy.cues[1] != want[1] {
+		t.Errorf("cues = %v, want %v", spy.cues, want)
+	}
+}
+
+func TestSoundCfgOverridesTheme(t *testing.T) {
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+	w.TestRender(buttonView(ButtonCfg{Sound: SoundError}))
+
+	if err := w.TestClick("btn"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if len(spy.cues) != 1 || spy.cues[0] != SoundError {
+		t.Errorf("cues = %v, want [SoundError]", spy.cues)
+	}
+}
+
+func TestSoundDisabledSuppresses(t *testing.T) {
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+	// SoundDisabled beats an explicit Sound, not just the theme.
+	w.TestRender(buttonView(ButtonCfg{
+		Sound: SoundError, SoundDisabled: true,
+	}))
+
+	if err := w.TestClick("btn"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if len(spy.cues) != 0 {
+		t.Errorf("SoundDisabled emitted %v, want nothing", spy.cues)
+	}
+}
+
+func TestSoundVolumeClampAndMute(t *testing.T) {
+	restoreTheme(t)
+	th := soundingTheme(t)
+
+	cases := []struct {
+		name     string
+		set      bool
+		volume   float32
+		wantPlay bool
+		wantGain float32
+	}{
+		{name: "default_is_full", wantPlay: true, wantGain: 1},
+		{name: "half", set: true, volume: 0.5,
+			wantPlay: true, wantGain: 0.5},
+		{name: "zero_mutes", set: true, volume: 0},
+		{name: "negative_clamps_to_mute", set: true, volume: -3},
+		{name: "over_one_clamps", set: true, volume: 7,
+			wantPlay: true, wantGain: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &soundSpy{}
+			w := NewTestWindow(WindowCfg{})
+			w.SetTheme(th)
+			w.SetSoundPlayer(spy)
+			if tc.set {
+				w.SetSoundVolume(tc.volume)
+			}
+			w.TestRender(buttonView(ButtonCfg{}))
+			if err := w.TestClick("btn"); err != nil {
+				t.Fatalf("TestClick: %v", err)
+			}
+			if !tc.wantPlay {
+				if len(spy.cues) != 0 {
+					t.Fatalf("emitted %v at volume %v, want nothing",
+						spy.cues, tc.volume)
+				}
+				return
+			}
+			if len(spy.gains) != 1 {
+				t.Fatalf("gains = %v, want one entry", spy.gains)
+			}
+			if spy.gains[0] != tc.wantGain {
+				t.Errorf("gain = %v, want %v", spy.gains[0], tc.wantGain)
+			}
+			// Whatever reaches the player is already clamped.
+			if got := w.SoundVolume(); got < 0 || got > 1 {
+				t.Errorf("SoundVolume = %v, out of 0..1", got)
+			}
+		})
+	}
+}
+
+func TestSoundPlayerAccessorRoundTrip(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	if w.SoundPlayer() != nil {
+		t.Error("a fresh window has a sound player")
+	}
+	spy := &soundSpy{}
+	w.SetSoundPlayer(spy)
+	if w.SoundPlayer() != spy {
+		t.Error("SoundPlayer did not return the installed player")
+	}
+	w.SetSoundPlayer(nil)
+	if w.SoundPlayer() != nil {
+		t.Error("nil did not clear the player")
+	}
+}
+
+func TestBeepSoundPlayerOnlyErrors(t *testing.T) {
+	spy := &beepSpy{available: true}
+	w := NewTestWindow(WindowCfg{})
+	w.SetNativePlatform(spy)
+	p := NewBeepSoundPlayer(w)
+
+	for _, cue := range []SoundCue{
+		SoundNone, SoundClick, SoundToggleOn, SoundToggleOff,
+	} {
+		p.PlaySound(cue, 1)
+	}
+	if spy.calls != 0 {
+		t.Errorf("non-error cues beeped %d times", spy.calls)
+	}
+	p.PlaySound(SoundError, 1)
+	if spy.calls != 1 {
+		t.Errorf("SoundError beeped %d times, want 1", spy.calls)
+	}
+	if !p.SoundAvailable() {
+		t.Error("SoundAvailable did not follow BeepAvailable")
+	}
+}
+
+func TestBeepSoundPlayerNoNativePlatform(t *testing.T) {
+	// Headless: must not panic and must report unavailable.
+	w := NewTestWindow(WindowCfg{})
+	p := NewBeepSoundPlayer(w)
+	p.PlaySound(SoundError, 1)
+	if p.SoundAvailable() {
+		t.Error("SoundAvailable = true with no native platform")
+	}
+}
+
+func TestResolveSoundCuePrecedence(t *testing.T) {
+	cases := []struct {
+		name     string
+		themeCue SoundCue
+		cfgCue   SoundCue
+		disabled bool
+		want     SoundCue
+	}{
+		{name: "theme_only", themeCue: SoundClick, want: SoundClick},
+		{name: "cfg_wins", themeCue: SoundClick,
+			cfgCue: SoundError, want: SoundError},
+		{name: "disabled_wins", themeCue: SoundClick,
+			cfgCue: SoundError, disabled: true, want: SoundNone},
+		{name: "all_unset", want: SoundNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveSoundCue(tc.themeCue, tc.cfgCue, tc.disabled)
+			if got != tc.want {
+				t.Errorf("resolveSoundCue = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSoundVolumeNaNAndInfClamped(t *testing.T) {
+	restoreTheme(t)
+	th := soundingTheme(t)
+	for _, tc := range []struct {
+		name     string
+		volume   float32
+		wantGain float32
+		wantPlay bool
+	}{
+		{name: "nan_mutes", volume: float32(math.NaN()), wantPlay: false},
+		{name: "pos_inf_clamps_to_full", volume: float32(math.Inf(1)), wantGain: 1, wantPlay: true},
+		{name: "neg_inf_mutes", volume: float32(math.Inf(-1)), wantPlay: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &soundSpy{}
+			w := NewTestWindow(WindowCfg{})
+			w.SetTheme(th)
+			w.SetSoundPlayer(spy)
+			w.SetSoundVolume(tc.volume)
+			// Gain stored must be finite and in range.
+			got := w.SoundVolume()
+			if got != got || got < 0 || got > 1 {
+				t.Fatalf("SoundVolume = %v, want finite 0..1", got)
+			}
+			w.TestRender(buttonView(ButtonCfg{}))
+			if err := w.TestClick("btn"); err != nil {
+				t.Fatalf("TestClick: %v", err)
+			}
+			if tc.wantPlay != (len(spy.cues) == 1) {
+				t.Fatalf("play = %v, cues = %v", tc.wantPlay, spy.cues)
+			}
+			if tc.wantPlay && spy.gains[0] != tc.wantGain {
+				t.Errorf("gain = %v, want %v", spy.gains[0], tc.wantGain)
+			}
+		})
+	}
+}
+
+func TestSoundDisabledWidgetSilent(t *testing.T) {
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+	// A disabled button must not emit even when the theme is sounding.
+	w.TestRender(func(*Window) View {
+		return Button(ButtonCfg{
+			ID: "btn", Label: "Go", Disabled: true,
+			OnClick: func(ctx EventCtx) { ctx.Consume() },
+		})
+	})
+	// Mouse path is blocked by traversal (isChildEnabled), so drive
+	// the a11y path which bypasses traversal and would previously
+	// emit through playShapeSound.
+	w.a11y.nodes = w.a11y.nodes[:0]
+	var live []liveNode
+	a11yCollect(&w.layout, -1, &w.a11y.nodes, "", &live)
+	idx := -1
+	for i := range w.a11y.nodes {
+		if w.a11y.nodes[i].Role == AccessRoleButton {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("no button node in the a11y tree")
+	}
+	a11yActionCallback(w, A11yActionPress, idx)
+	if len(spy.cues) != 0 {
+		t.Errorf("disabled widget emitted %v, want nothing", spy.cues)
+	}
+}

--- a/gui/theme.go
+++ b/gui/theme.go
@@ -201,6 +201,14 @@ type Theme struct {
 	ScrollDeltaPage float32
 	inspectorStyle  InspectorStyle
 
+	// Sounds maps interaction roles onto cues. The zero set is silent
+	// and is the intended default, so ThemeDark and ThemeLight make no
+	// sound. An app opts the whole widget set in with
+	// theme.Sounds = gui.SoundsDefault() and an installed SoundPlayer
+	// (issue #446).
+	// exportaudit:keep — caller-facing config (issue #446)
+	Sounds SoundSet
+
 	// id identifies this exact theme value. Stamped by ThemeMaker and
 	// re-stamped by every with*Style helper, so a derived theme never
 	// reuses its parent's id. Zero means "built outside ThemeMaker" and
@@ -286,6 +294,11 @@ type ThemeCfg struct {
 	//
 	// exportaudit:keep — themable form density.
 	SizeFieldMinWidth float32
+
+	// Sounds seeds Theme.Sounds; see there. Zero is silent, which is
+	// the default for every built-in theme.
+	// exportaudit:keep — caller-facing config (issue #446)
+	Sounds SoundSet
 
 	SizeBorder float32
 	Radius     float32

--- a/gui/theme_maker.go
+++ b/gui/theme_maker.go
@@ -689,6 +689,8 @@ func ThemeMaker(cfg ThemeCfg) Theme {
 		SizeTextLarge:  ladder.large,
 		SizeTextXLarge: ladder.xLarge,
 
+		Sounds: cfg.Sounds,
+
 		ScrollMultiplier: cfg.ScrollMultiplier,
 		ScrollDeltaLine:  cfg.ScrollDeltaLine,
 		ScrollDeltaPage:  cfg.ScrollDeltaPage,

--- a/gui/view_button.go
+++ b/gui/view_button.go
@@ -55,6 +55,17 @@ type ButtonCfg struct {
 	// The event's HoverEntered field indicates direction.
 	OnHover func(EventCtx)
 
+	// Sound overrides the theme's click cue for this button.
+	// SoundNone (the zero value) takes Theme.Sounds.Click, which is
+	// itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #446)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this button's sound regardless of the
+	// theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #446)
+	SoundDisabled bool
+
 	// AmendLayout runs after sizing. Use to reposition child
 	// overlays or adjust layout post-arrange.
 	AmendLayout func(EventCtx)
@@ -265,6 +276,11 @@ func Button(cfg ButtonCfg) View {
 
 	onClick := cfg.OnClick
 
+	// Resolved here, not at dispatch: the cue is a generation-time
+	// decision, so it rides the shape as a value rather than a closure.
+	soundCue := resolveSoundCue(
+		guiTheme.Sounds.Click, cfg.Sound, cfg.SoundDisabled)
+
 	a11yRole := cfg.A11YRole
 	if a11yRole == AccessRoleNone {
 		a11yRole = AccessRoleButton
@@ -315,6 +331,7 @@ func Button(cfg ButtonCfg) View {
 		FloatOffsetX: cfg.FloatOffsetX,
 		FloatOffsetY: cfg.FloatOffsetY,
 		OnClick:      onClick,
+		Sound:        soundCue,
 		ClickOnSpace: true,
 		ClickOnEnter: true,
 		// A button's label takes the optical correction (issue #346);

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -46,6 +46,14 @@ type ContainerCfg struct {
 	// exportaudit:keep — caller-facing config (issue #372)
 	ClickOnEnter bool
 
+	// Sound is the cue emitted when OnClick fires. SoundNone (the
+	// zero value) is silent. Widget factories resolve this from the
+	// theme's SoundSet before building the container, so a caller
+	// setting it here overrides the theme for this instance.
+	// Nothing is audible until the app installs a SoundPlayer.
+	// exportaudit:keep — caller-facing config (issue #446)
+	Sound SoundCue
+
 	// OnScroll fires when the container receives scroll events.
 	// Requires Scrollable and a scrollable Overflow/ScrollMode.
 	// exportaudit:keep — caller-facing config (issue #372)
@@ -375,7 +383,8 @@ func makeContainerEvents(c *ContainerCfg) (eventHandlers, bool) {
 		c.OnMouseDown == nil &&
 		c.OnHover == nil && c.OnGesture == nil &&
 		c.OnFileDrop == nil && c.OnIMECommit == nil &&
-		c.OnScroll == nil && c.AmendLayout == nil {
+		c.OnScroll == nil && c.AmendLayout == nil &&
+		c.Sound == SoundNone {
 		return eventHandlers{}, false
 	}
 	return eventHandlers{
@@ -395,6 +404,7 @@ func makeContainerEvents(c *ContainerCfg) (eventHandlers, bool) {
 		clickButton:  c.clickButton,
 		clickOnSpace: c.ClickOnSpace,
 		clickOnEnter: c.ClickOnEnter,
+		soundCue:     c.Sound,
 	}, true
 }
 

--- a/gui/view_toggle.go
+++ b/gui/view_toggle.go
@@ -31,6 +31,17 @@ type ToggleCfg struct {
 	Disabled    bool
 	Invisible   bool
 	Selected    bool
+
+	// Sound overrides the theme's toggle cue for this instance.
+	// SoundNone (the zero value) takes Theme.Sounds.ToggleOn or
+	// ToggleOff depending on what the next click will do (issue #446).
+	// exportaudit:keep — caller-facing config (issue #446)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this toggle's sound regardless of the
+	// theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #446)
+	SoundDisabled bool
 }
 
 // LabeledToggle is the thin form of Toggle for the common case: a
@@ -110,6 +121,16 @@ func Toggle(cfg ToggleCfg) View {
 		a11yState = AccessStateChecked
 	}
 
+	// The cue names what the click will do, not the current state: a
+	// selected toggle is about to turn off. Resolved at generation
+	// time, where the state is already known, so no runtime branch and
+	// no closure (issue #446).
+	themeCue := guiTheme.Sounds.ToggleOn
+	if cfg.Selected {
+		themeCue = guiTheme.Sounds.ToggleOff
+	}
+	soundCue := resolveSoundCue(themeCue, cfg.Sound, cfg.SoundDisabled)
+
 	return Row(ContainerCfg{
 		ID:         cfg.ID,
 		Focusable:  !cfg.FocusDisabled,
@@ -126,6 +147,7 @@ func Toggle(cfg ToggleCfg) View {
 		},
 		ClickOnSpace: true,
 		OnClick:      cfg.OnClick,
+		Sound:        soundCue,
 		clickButton:  MouseLeft,
 		MinWidth:     cfg.MinWidth,
 		OnHover: func(ctx EventCtx) {

--- a/gui/window_state.go
+++ b/gui/window_state.go
@@ -46,6 +46,15 @@ type windowBackend struct {
 	textMeasurer   TextMeasurer
 	svgParser      SvgParser
 	nativePlatform NativePlatform
+	// soundPlayer renders widget sound cues. Unlike the three above
+	// the backend installs none: the app opts in with
+	// SetSoundPlayer, so the default is silence (issue #446).
+	soundPlayer SoundPlayer
+	// soundVolume is the gain handed to soundPlayer, 0..1. Read
+	// through SoundVolume, which reports 1 until soundVolumeSet — a
+	// zero-value window is full volume, not muted.
+	soundVolume    float32
+	soundVolumeSet bool
 	clipboardSetFn func(string)
 	clipboardGetFn func() string
 	// primarySetFn/primaryGetFn drive the X11 PRIMARY selection — the


### PR DESCRIPTION
Silent by default, silent until the app opts in twice: `theme.Sounds = SoundsDefault()` and `w.SetSoundPlayer(...)`.

- `gui`: `SoundCue` (`SoundNone`, `Click`, `ToggleOn/Off`, `Error`), `SoundPlayer` interface, `SoundSet` + `SoundsDefault()`, `Theme.Sounds`/`ThemeCfg.Sounds`, `NewBeepSoundPlayer` (system alert on `SoundError`), `(*Window).SetSoundPlayer/SoundPlayer/SetSoundVolume/SoundVolume` (0..1, 0 is mute). Cues are semantic values on `shape.events.soundCue`, resolved at generation (`SoundDisabled > Cfg.Sound > Theme.Sounds.<role>`), emitted before `OnClick` independently of `ctx.Consume()` on mouse/Space/Enter/a11y paths. Added disabled-widget suppression and `NaN`/`Inf` clamping.
- `examples/showcase`: synthesized `cueSoundPlayer` (percussive blip, no assets), `Sound Feedback` page + Audio panel controls, volume handling hardened against bad floats.
- Docs: `docs/widget-sound.md`, `examples/showcase/docs/widget_sound.md`, spec `docs/specs/widget-audio-feedback.md`; `docs/dx-cheat-sheet.md` overview; `CHANGELOG.md` entry. Export audit gated.

Fixes lint-cross on `gui/audio` stubs (`GOOS=js`).

Closes #446.