### PR TITLE
feat(widget): mechanical widget pass for audio feedback (#467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to
 
 ### Added
 
+- **Widget audio feedback reaches the whole widget set** (#467) — the sound seam
+  from #446 proved itself on `Button` and `Toggle`; every other mechanical
+  widget now emits a cue, plus `gui/datagrid`. `Switch`, `Radio`,
+  `RadioButtonGroup`, `ExpandPanel`, `ColorSwatch`, `Breadcrumb`, `ThemePicker`,
+  `Select`, `Combobox`, `ListBox`, `Tree`, `TabControl`, `MenuItem`, `Dialog`,
+  `Toast`, `DatePicker`, `CommandPalette`, `DockLayout`, `Image` and `Svg` each
+  gained the same `Sound` / `SoundDisabled` pair, and `DataGridCfg` gained one
+  for the whole grid. Still silent by default: an app opts in exactly as before.
+
+  New: `gui.SoundSelection` and `SoundSet.Selection`, the role for picking one
+  option out of several — a radio, a list row, a tab, a calendar day — which
+  `SoundsDefault()` now fills. `gui.ResolveSoundCue` is exported so a widget
+  package outside `gui/` spells the precedence the same way instead of
+  re-deriving it.
+
+  Widgets that only absorb clicks stay silent by design: the toast scrim, the
+  context-menu dismiss layer, scrollbar tracks, the command-palette card, the
+  `DatePicker` field, and the caret-placement click inside an `Input`.
+  `gui.Text` is out of scope — its handler record is shared package-wide.
+
 - **Opt-in widget audio feedback** (#446) — widgets can now play a sound when
   the user activates them. Silent by default, and silent unless the app opts in
   twice: a theme naming a cue per role (`theme.Sounds = gui.SoundsDefault()`)

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -261,7 +261,11 @@ a cue per role, and `w.SetSoundPlayer(...)` renders them. Either alone is
 silent, and a nil player is the default, so tests need no setup. Per instance,
 `Cfg.Sound` overrides the theme cue and `Cfg.SoundDisabled` suppresses it;
 `w.SetSoundVolume(0..1)` is the gain, where `0` is mute. The cue fires before
-`OnClick` and regardless of `ctx.Consume()`. See `docs/widget-sound.md`.
+`OnClick` and regardless of `ctx.Consume()`. Roles are `Click`, `ToggleOn`,
+`ToggleOff`, `Selection` and `Error`; a widget picks the role, the app picks the
+sound. Feeding a resolved cue into a nested `ButtonCfg` or `ToggleCfg` means
+passing `SoundDisabled` too — those resolve their own precedence, and a resolved
+`SoundNone` reads there as "unset". See `docs/widget-sound.md`.
 
 ## Find it early
 

--- a/docs/specs/widget-audio-feedback.md
+++ b/docs/specs/widget-audio-feedback.md
@@ -1,10 +1,40 @@
 # Spec: opt-in widget audio feedback
 
-Status: **phase 1 implemented** — `SoundCue`, `SoundPlayer`, `Theme.Sounds`,
-window volume, and the `Button` / `Toggle` proof. Phases 2–4 are follow-up
-issues.
+Status: **phases 1 and 2 implemented** — phase 1 landed `SoundCue`,
+`SoundPlayer`, `Theme.Sounds`, window volume, and the `Button` / `Toggle` proof;
+phase 2 (#467) carried the seam to every remaining mechanical widget and to
+`gui/datagrid`. Phases 3 and 4 are follow-up issues.
 
-Issue: #446 — "Widgets have no audio feedback for interactions".
+Issue: #446 — "Widgets have no audio feedback for interactions". Phase 2: #467 —
+"Widget audio feedback phase 2: the mechanical widget pass".
+
+## Phase 2 decisions
+
+- **A fifth role, `SoundSelection`.** The phase-2 inventory assigns "selection"
+  to about ten widgets — a radio, a list row, a tab, a calendar day — and
+  `SoundSet` had only click, toggle and error. Overloading `Click` would have
+  made a tab indistinguishable from a button, so the constant and the
+  `SoundSet.Selection` field were added instead. The cue enum is open and
+  append-only, so `SoundSelection` sits after `SoundError`.
+- **`ResolveSoundCue` is exported.** `gui/datagrid` is outside `gui/` and cannot
+  reach the unexported `resolveSoundCue` or the package-global `guiTheme`. It
+  reads `gg.CurrentTheme().Sounds` once per generate and resolves through the
+  exported seam, rather than re-deriving the precedence.
+- **A resolved cue fed into a nested `ButtonCfg` carries `SoundDisabled` too.**
+  `ButtonCfg` and `ToggleCfg` resolve their own precedence, so a resolved
+  `SoundNone` reads there as "unset" and falls back to the theme's click cue.
+  Every site that hands a resolved cue to one of them passes
+  `SoundDisabled: cue == SoundNone` alongside it. `ContainerCfg` is a pure
+  carrier and needs no such pairing.
+- **All five `Dialog` buttons take `Click`.** There is no cancel or dismiss
+  role, and `Error` would misread a cancellation as a failure. A dismiss cue can
+  land in phase 4 with the other non-click semantics.
+- **`gui.Text` stays out of scope.** `textEventHandlers` is a package-level
+  handler record shared by every text shape, so a per-instance cue would cost
+  the zero-allocation sharing.
+- **Drag starts stay silent.** A `Tree` row, a `ListBox` reorder row and a
+  `DockLayout` tab all start a drag from the same handler that activates them.
+  The cue marks the activation; sounding a drag is phase 3's question.
 
 ## Motivation
 

--- a/docs/widget-sound.md
+++ b/docs/widget-sound.md
@@ -19,6 +19,7 @@ running showcase has it under **Welcome → Sound Feedback**.
 | `gui.SoundToggleOn`  | A state went off → on                         |
 | `gui.SoundToggleOff` | A state went on → off                         |
 | `gui.SoundError`     | Rejection: invalid input, refused commit      |
+| `gui.SoundSelection` | One option picked out of several              |
 
 The framework decides _which_ cue an interaction is. Your player decides what a
 cue sounds like. That split is why `gui` never imports `gui/audio`, and why an
@@ -117,6 +118,8 @@ func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
 		freq = 880 * 4 / 3 // a fourth up
 	case gui.SoundToggleOff:
 		freq = 880 * 3 / 4 // a fourth down
+	case gui.SoundSelection:
+		freq = 880 * 3 / 2 // a fifth up: "picked", against click's neutral A5
 	case gui.SoundError:
 		freq = 220
 		env = errorEnv
@@ -240,11 +243,36 @@ off, so it emits `SoundToggleOff`. You do not need an on/off field pair.
 
 ## Which widgets sound
 
-Currently `Button` and `Toggle`. The seam itself is generic — the cue rides the
-shape's event record, so any widget can adopt it — and the remaining widgets are
-being phased in (#467, #468, #469). Widgets that only absorb clicks stay silent
-by design: the toast scrim, the context-menu dismiss layer, scrollbar tracks,
-and the caret-placement click inside an `Input`.
+Every widget below emits a cue once the app has opted in. A widget that toggles
+names what the click will do, not what the state is, so an open panel about to
+close emits `SoundToggleOff`.
+
+| Widget                                     | Cue on activation                         |
+| ------------------------------------------ | ----------------------------------------- |
+| `Button`, `MenuItem`, `Dialog` buttons     | `Click`                                   |
+| `Toast` buttons, `CommandPalette` backdrop | `Click`                                   |
+| `Image`, `Svg`                             | `Click`                                   |
+| `Toggle`, `Switch`, `ExpandPanel`          | `ToggleOn` / `ToggleOff`                  |
+| `Select`, `Combobox`, `ThemePicker`        | `ToggleOn` / `ToggleOff` (the field)      |
+| `Radio`, `RadioButtonGroup`                | `Selection`                               |
+| `ListBox` rows, `Select` options           | `Selection`                               |
+| `TabControl`, `DockLayout` tabs            | `Selection`                               |
+| `Breadcrumb`, `ColorSwatch`                | `Selection`                               |
+| `DatePicker` day cells                     | `Selection`                               |
+| `Tree` rows                                | `Selection`, or toggle if it has children |
+| `datagrid` rows, toolbar, pager            | `Click`                                   |
+| `datagrid` sort, pin, column reorder       | `Selection`                               |
+
+Widgets that only absorb clicks stay silent by design: the toast scrim, the
+context-menu dismiss layer, scrollbar tracks, the `CommandPalette` card, the
+`DatePicker` field itself (its click only takes focus), and the caret-placement
+click inside an `Input`. So do a disabled control, a `Breadcrumb` crumb marked
+disabled, a `ListBox` subheading, and a menu separator.
+
+Text is not covered: `gui.Text` shares one package-level handler record across
+every text shape, so it cannot carry a per-instance cue without giving up that
+zero-allocation sharing. Drag, hover, focus and notification cues are still to
+come (#468, #469).
 
 ## Platform reality
 

--- a/examples/showcase/docs/widget_sound.md
+++ b/examples/showcase/docs/widget_sound.md
@@ -18,6 +18,7 @@ This page is mirrored in the repo at `docs/widget-sound.md`.
 | `gui.SoundToggleOn`  | A state went off → on                         |
 | `gui.SoundToggleOff` | A state went on → off                         |
 | `gui.SoundError`     | Rejection: invalid input, refused commit      |
+| `gui.SoundSelection` | One option picked out of several              |
 
 The framework decides _which_ cue an interaction is. Your player decides what a
 cue sounds like. That split is why `gui` never imports `gui/audio`, and why an
@@ -116,6 +117,8 @@ func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
 		freq = 880 * 4 / 3 // a fourth up
 	case gui.SoundToggleOff:
 		freq = 880 * 3 / 4 // a fourth down
+	case gui.SoundSelection:
+		freq = 880 * 3 / 2 // a fifth up: "picked", against click's neutral A5
 	case gui.SoundError:
 		freq = 220
 		env = errorEnv
@@ -238,11 +241,36 @@ off, so it emits `SoundToggleOff`. You do not need an on/off field pair.
 
 ## Which widgets sound
 
-Currently `Button` and `Toggle`. The seam itself is generic — the cue rides the
-shape's event record, so any widget can adopt it — and the remaining widgets are
-being phased in (#467, #468, #469). Widgets that only absorb clicks stay silent
-by design: the toast scrim, the context-menu dismiss layer, scrollbar tracks,
-and the caret-placement click inside an `Input`.
+Every widget below emits a cue once the app has opted in. A widget that toggles
+names what the click will do, not what the state is, so an open panel about to
+close emits `SoundToggleOff`.
+
+| Widget                                     | Cue on activation                         |
+| ------------------------------------------ | ----------------------------------------- |
+| `Button`, `MenuItem`, `Dialog` buttons     | `Click`                                   |
+| `Toast` buttons, `CommandPalette` backdrop | `Click`                                   |
+| `Image`, `Svg`                             | `Click`                                   |
+| `Toggle`, `Switch`, `ExpandPanel`          | `ToggleOn` / `ToggleOff`                  |
+| `Select`, `Combobox`, `ThemePicker`        | `ToggleOn` / `ToggleOff` (the field)      |
+| `Radio`, `RadioButtonGroup`                | `Selection`                               |
+| `ListBox` rows, `Select` options           | `Selection`                               |
+| `TabControl`, `DockLayout` tabs            | `Selection`                               |
+| `Breadcrumb`, `ColorSwatch`                | `Selection`                               |
+| `DatePicker` day cells                     | `Selection`                               |
+| `Tree` rows                                | `Selection`, or toggle if it has children |
+| `datagrid` rows, toolbar, pager            | `Click`                                   |
+| `datagrid` sort, pin, column reorder       | `Selection`                               |
+
+Widgets that only absorb clicks stay silent by design: the toast scrim, the
+context-menu dismiss layer, scrollbar tracks, the `CommandPalette` card, the
+`DatePicker` field itself (its click only takes focus), and the caret-placement
+click inside an `Input`. So do a disabled control, a `Breadcrumb` crumb marked
+disabled, a `ListBox` subheading, and a menu separator.
+
+Text is not covered: `gui.Text` shares one package-level handler record across
+every text shape, so it cannot carry a per-instance cue without giving up that
+zero-allocation sharing. Drag, hover, focus and notification cues are still to
+come (#468, #469).
 
 ## Platform reality
 

--- a/examples/showcase/sound_player.go
+++ b/examples/showcase/sound_player.go
@@ -66,6 +66,8 @@ func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
 		freq = 880 * 4 / 3 // a fourth up
 	case gui.SoundToggleOff:
 		freq = 880 * 3 / 4 // a fourth down
+	case gui.SoundSelection:
+		freq = 880 * 3 / 2 // a fifth up: "picked", against click's neutral A5
 	case gui.SoundError:
 		freq = 220
 		env = errorEnv

--- a/gui/datagrid/data_source_grid_pager.go
+++ b/gui/datagrid/data_source_grid_pager.go
@@ -234,7 +234,7 @@ func dataGridSourcePagerRow(cfg *DataGridCfg, focusID string, state dataGridSour
 
 	// Prev button.
 	content = append(content, dataGridIndicatorButton(gg.ScopeID(gridID, "src_prev"), "\u25C0", cfg.TextStyleHeader, cfg.ColorHeaderHover,
-		state.Loading || !hasPrev, dataGridHeaderControlWidth+10, func(ctx gg.EventCtx) {
+		state.Loading || !hasPrev, dataGridHeaderControlWidth+10, cfg.sounds.click, func(ctx gg.EventCtx) {
 			dataGridSourcePrevPage(gridID, kind, pageLimit, ctx.Window)
 			if focusID != "" {
 				ctx.Window.SetFocus(focusID)
@@ -249,7 +249,7 @@ func dataGridSourcePagerRow(cfg *DataGridCfg, focusID string, state dataGridSour
 	}))
 	// Next button.
 	content = append(content, dataGridIndicatorButton(gg.ScopeID(gridID, "src_next"), "\u25B6", cfg.TextStyleHeader, cfg.ColorHeaderHover,
-		state.Loading || !hasNext, dataGridHeaderControlWidth+10, func(ctx gg.EventCtx) {
+		state.Loading || !hasNext, dataGridHeaderControlWidth+10, cfg.sounds.click, func(ctx gg.EventCtx) {
 			dataGridSourceNextPage(gridID, kind, pageLimit, ctx.Window)
 			if focusID != "" {
 				ctx.Window.SetFocus(focusID)

--- a/gui/datagrid/sound_test.go
+++ b/gui/datagrid/sound_test.go
@@ -1,0 +1,120 @@
+package datagrid
+
+import (
+	"testing"
+
+	gg "github.com/go-gui-org/go-gui/gui"
+)
+
+// Widget audio feedback phase 2 (issue #467). datagrid sits outside
+// gui/, so it cannot read the package-global theme a gui/ factory
+// reads; it resolves once per generate through gg.ResolveSoundCue and
+// gg.CurrentTheme(). These tests pin that the resolution happens and
+// that the two roles land on the right controls.
+//
+// Theme installation is package-global, so nothing here runs in
+// parallel.
+
+// gridSoundSpy records every cue the framework emits.
+type gridSoundSpy struct {
+	cues []gg.SoundCue
+}
+
+func (s *gridSoundSpy) PlaySound(cue gg.SoundCue, _ float32) {
+	s.cues = append(s.cues, cue)
+}
+
+func (s *gridSoundSpy) SoundAvailable() bool { return true }
+
+// soundingGridTheme is the current theme with every cue role filled —
+// what an app gets from Theme.Sounds = gg.SoundsDefault().
+func soundingGridTheme(w *gg.Window) gg.Theme {
+	cfg := w.Theme().Cfg
+	cfg.Name = "datagrid-sounding"
+	cfg.Sounds = gg.SoundsDefault()
+	return gg.ThemeMaker(cfg)
+}
+
+// soundGrid renders a one-column, one-row grid with the sounding theme
+// installed and a spy attached.
+func soundGrid(t *testing.T, cfg DataGridCfg) (*gg.Window, *gridSoundSpy) {
+	t.Helper()
+	w := gg.NewTestWindow(gg.WindowCfg{})
+	t.Cleanup(w.Close)
+	w.SetTheme(soundingGridTheme(w))
+	spy := &gridSoundSpy{}
+	w.SetSoundPlayer(spy)
+	w.TestRender(func(*gg.Window) gg.View { return New(w, cfg) })
+	return w, spy
+}
+
+func soundGridCfg() DataGridCfg {
+	return DataGridCfg{
+		ID: "g1",
+		Columns: []GridColumnCfg{{
+			ID: "c1", Title: "Col1", Sortable: true,
+			Width: gg.SomeF(120),
+		}},
+		Rows:          []GridRow{{ID: "r1", Cells: map[string]string{"c1": "a"}}},
+		OnQueryChange: func(GridQueryState, gg.EventCtx) {},
+	}
+}
+
+// Sorting a column picks one of its orders, so it takes the selection
+// role; activating a row is the grid's click role.
+func TestGridSoundHeaderAndRowCues(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want gg.SoundCue
+	}{
+		{name: "header_sort", id: "g1:header:c1", want: gg.SoundSelection},
+		{name: "row_activate", id: "g1:row:r1", want: gg.SoundClick},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, spy := soundGrid(t, soundGridCfg())
+			if err := w.TestClick(tc.id); err != nil {
+				t.Fatalf("TestClick(%q): %v", tc.id, err)
+			}
+			if len(spy.cues) != 1 || spy.cues[0] != tc.want {
+				t.Errorf("cues = %v, want [%v]", spy.cues, tc.want)
+			}
+		})
+	}
+}
+
+// Cfg.Sound overrides both roles at once: the grid resolves one cue
+// set for every control it builds.
+func TestGridSoundCfgOverridesTheme(t *testing.T) {
+	cfg := soundGridCfg()
+	cfg.Sound = gg.SoundError
+	w, spy := soundGrid(t, cfg)
+
+	if err := w.TestClick("g1:header:c1"); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if len(spy.cues) != 1 || spy.cues[0] != gg.SoundError {
+		t.Errorf("cues = %v, want [SoundError]", spy.cues)
+	}
+}
+
+// SoundDisabled beats an explicit Sound, and it has to reach the
+// gg.ButtonCfg controls too — a resolved gg.SoundNone reads as "unset"
+// inside ButtonCfg, so those sites pass SoundDisabled as well.
+func TestGridSoundDisabledSuppresses(t *testing.T) {
+	cfg := soundGridCfg()
+	cfg.Sound = gg.SoundError
+	cfg.SoundDisabled = true
+	w, spy := soundGrid(t, cfg)
+
+	for _, id := range []string{"g1:header:c1", "g1:row:r1"} {
+		if err := w.TestClick(id); err != nil {
+			t.Fatalf("TestClick(%q): %v", id, err)
+		}
+	}
+	if len(spy.cues) != 0 {
+		t.Errorf("SoundDisabled emitted %v, want nothing", spy.cues)
+	}
+}

--- a/gui/datagrid/view_data_grid.go
+++ b/gui/datagrid/view_data_grid.go
@@ -311,6 +311,35 @@ type DataGridCfg struct {
 	Scrollbar              gg.ScrollbarOverflow
 	Disabled               bool
 	Invisible              bool
+
+	// Sound overrides the theme's cue for every control the grid
+	// builds. Row activation, the toolbar and the pager take the
+	// click role; sorting, pinning and reordering a column take the
+	// selection role. SoundNone (the zero value) takes the theme's
+	// cue for whichever applies, which is itself silent unless the
+	// app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound gg.SoundCue
+
+	// SoundDisabled suppresses every grid control's sound regardless
+	// of the theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
+
+	// sounds is Sound/SoundDisabled resolved against the theme once
+	// per generate, in applyDataGridDefaults. datagrid is outside
+	// gui/, so it cannot read the package-global guiTheme the way a
+	// gui/ factory does; resolving per control would mean one
+	// CurrentTheme() call per row (issue #467).
+	sounds dataGridSounds
+}
+
+// dataGridSounds holds the grid's cues after resolution. Two roles,
+// not one per control: a control either activates (click) or picks one
+// of several (selection).
+type dataGridSounds struct {
+	click     gg.SoundCue
+	selection gg.SoundCue
 }
 
 // boolDefault returns *p if non-nil, else def.
@@ -325,6 +354,15 @@ func boolDefault(p *bool, def bool) bool {
 // defaults and sensible fallbacks.
 func applyDataGridDefaults(cfg *DataGridCfg) {
 	s := gg.DefaultDataGridStyle
+	// One theme read for the whole grid. Every control downstream
+	// takes its cue from this struct rather than resolving its own.
+	sounds := gg.CurrentTheme().Sounds
+	cfg.sounds = dataGridSounds{
+		click: gg.ResolveSoundCue(
+			sounds.Click, cfg.Sound, cfg.SoundDisabled),
+		selection: gg.ResolveSoundCue(
+			sounds.Selection, cfg.Sound, cfg.SoundDisabled),
+	}
 	cfg.Sizing = cfg.Sizing.Or(gg.FillFill)
 	if cfg.RowHeight == 0 {
 		cfg.RowHeight = dataGridDefaultRowHeight

--- a/gui/datagrid/view_data_grid_crud.go
+++ b/gui/datagrid/view_data_grid_crud.go
@@ -189,17 +189,17 @@ func dataGridCrudToolbarRow(cfg *DataGridCfg, state dataGridCrudState, caps Grid
 		VAlign:      gg.VAlignMiddle,
 		Content: []gg.View{
 			dataGridIndicatorButton(gg.ScopeID(gridID, "crud_add"), gg.ActiveLocale.StrAdd, cfg.TextStyleFilter, cfg.ColorHeaderHover,
-				!canCreate || state.Saving, 0, func(ctx gg.EventCtx) {
+				!canCreate || state.Saving, 0, cfg.sounds.click, func(ctx gg.EventCtx) {
 					dataGridCrudAddRow(gridID, columns, onSelectionChange, focusID,
 						scrollID, pageSize, pageIndex, onPageChange, ctx.Event, ctx.Window)
 				}),
 			dataGridIndicatorButton(gg.ScopeID(gridID, "crud_delete"), gg.ActiveLocale.StrDelete, cfg.TextStyleFilter, cfg.ColorHeaderHover,
-				!canDelete || selectedCount == 0 || state.Saving, 0, func(ctx gg.EventCtx) {
+				!canDelete || selectedCount == 0 || state.Saving, 0, cfg.sounds.click, func(ctx gg.EventCtx) {
 					dataGridCrudDeleteSelected(gridID, selection, onSelectionChange,
 						focusID, ctx.Event, ctx.Window)
 				}),
 			dataGridIndicatorButton(gg.ScopeID(gridID, "crud_save"), gg.ActiveLocale.StrSave, cfg.TextStyleFilter, cfg.ColorHeaderHover,
-				!hasUnsaved || state.Saving, 0, func(ctx gg.EventCtx) {
+				!hasUnsaved || state.Saving, 0, cfg.sounds.click, func(ctx gg.EventCtx) {
 					dataGridCrudSave(dataGridCrudSaveContext{
 						gridID:            gridID,
 						dataSource:        dataSource,
@@ -214,7 +214,7 @@ func dataGridCrudToolbarRow(cfg *DataGridCfg, state dataGridCrudState, caps Grid
 					}, ctx.Event, ctx.Window)
 				}),
 			dataGridIndicatorButton(gg.ScopeID(gridID, "crud_cancel"), gg.ActiveLocale.StrCancel, cfg.TextStyleFilter, cfg.ColorHeaderHover,
-				(!hasUnsaved && state.SaveError == "") || state.Saving, 0, func(ctx gg.EventCtx) {
+				(!hasUnsaved && state.SaveError == "") || state.Saving, 0, cfg.sounds.click, func(ctx gg.EventCtx) {
 					dataGridCrudCancel(gridID, focusID, ctx.Event, ctx.Window)
 				}),
 			gg.Row(gg.ContainerCfg{

--- a/gui/datagrid/view_data_grid_edit.go
+++ b/gui/datagrid/view_data_grid_edit.go
@@ -83,6 +83,10 @@ func dataGridCellEditorView(cfg *DataGridCfg, rowID string, rowIdx int, col Grid
 			ID:       editorID,
 			Selected: checked,
 			Padding:  gg.NoPadding,
+			// Forwarded, not resolved: Toggle picks the on/off role
+			// from its own state (issue #467).
+			Sound:         cfg.Sound,
+			SoundDisabled: cfg.SoundDisabled,
 			OnClick: func(ctx gg.EventCtx) {
 				nextValue := editorFalseValue
 				if !checked {

--- a/gui/datagrid/view_data_grid_events.go
+++ b/gui/datagrid/view_data_grid_events.go
@@ -78,7 +78,7 @@ func dataGridQuickFilterRow(cfg *DataGridCfg, w *gg.Window) gg.View {
 				TextStyle: dataGridIndicatorTextStyle(cfg.TextStyleFilter),
 			}),
 			dataGridIndicatorButton(gg.ScopeID(gridID, "filter_clear"), gg.ActiveLocale.StrClear, cfg.TextStyleFilter, cfg.ColorHeaderHover,
-				clearDisabled, 0, func(ctx gg.EventCtx) {
+				clearDisabled, 0, cfg.sounds.click, func(ctx gg.EventCtx) {
 					if queryCallback == nil {
 						return
 					}
@@ -186,7 +186,7 @@ func dataGridColumnChooserRow(cfg *DataGridCfg, isOpen bool, focusID string) gg.
 		VAlign:  gg.VAlignMiddle,
 		Content: []gg.View{
 			dataGridIndicatorButton(gg.ScopeID(gridID, "column_chooser"), chooserLabel, cfg.TextStyleFilter, cfg.ColorHeaderHover,
-				false, 0, func(ctx gg.EventCtx) {
+				false, 0, cfg.sounds.click, func(ctx gg.EventCtx) {
 					dataGridToggleColumnChooserOpen(gridID, ctx.Window)
 					if focusID != "" {
 						ctx.Window.SetFocus(focusID)
@@ -208,6 +208,10 @@ func dataGridColumnChooserRow(cfg *DataGridCfg, isOpen bool, focusID string) gg.
 				Label:    col.Title,
 				Selected: !hidden,
 				Disabled: !hasVisibilityCallback,
+				// Forwarded, not resolved: Toggle picks the on/off
+				// role from its own state (issue #467).
+				Sound:         cfg.Sound,
+				SoundDisabled: cfg.SoundDisabled,
 				OnClick: dataGridMakeColumnChooserOnClick(onHiddenColumnsChange,
 					cfg.HiddenColumnIDs, columns, colID, focusID),
 			}))

--- a/gui/datagrid/view_data_grid_header.go
+++ b/gui/datagrid/view_data_grid_header.go
@@ -89,6 +89,11 @@ func dataGridHeaderCell(cfg *DataGridCfg, col GridColumnCfg, colIdx, colCount in
 		headerA11YState = gg.AccessStateSelected
 	}
 
+	headerSound := gg.SoundNone
+	if colSortable && onQueryChange != nil {
+		headerSound = cfg.sounds.selection
+	}
+
 	return gg.Row(gg.ContainerCfg{
 		ID:          dataGridHeaderCellID(cfg.ID, col.ID),
 		A11YRole:    gg.AccessRoleGridCell,
@@ -102,6 +107,10 @@ func dataGridHeaderCell(cfg *DataGridCfg, col GridColumnCfg, colIdx, colCount in
 		ColorBorder: cfg.ColorBorder,
 		SizeBorder:  cfg.SizeBorder,
 		Spacing:     gg.SomeF(0),
+		// Sorting picks one of the column's orders, so the selection
+		// role. A non-sortable column has nothing to pick and stays
+		// silent (issue #467).
+		Sound: headerSound,
 		OnClick: func(ctx gg.EventCtx) {
 			ctx.Consume()
 			if colSortable && onQueryChange != nil {
@@ -223,14 +232,14 @@ func dataGridReorderControls(cfg *DataGridCfg, col GridColumnCfg) gg.View {
 		Width:   dataGridHeaderControlsWidth(true, false, false),
 		Sizing:  gg.FixedFill,
 		Content: []gg.View{
-			dataGridOrderButton(gg.ScopeID(cfg.ID, "reorder_left", colID), leftArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, reorderCB(-1)),
-			dataGridOrderButton(gg.ScopeID(cfg.ID, "reorder_right", colID), rightArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, reorderCB(1)),
+			dataGridOrderButton(gg.ScopeID(cfg.ID, "reorder_left", colID), leftArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, cfg.sounds.selection, reorderCB(-1)),
+			dataGridOrderButton(gg.ScopeID(cfg.ID, "reorder_right", colID), rightArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover, cfg.sounds.selection, reorderCB(1)),
 		},
 	})
 }
 
-func dataGridOrderButton(id, label string, baseStyle gg.TextStyle, hoverColor gg.Color, cb func(*gg.Event, *gg.Window)) gg.View {
-	return dataGridIndicatorButton(id, label, baseStyle, hoverColor, false, dataGridHeaderControlWidth,
+func dataGridOrderButton(id, label string, baseStyle gg.TextStyle, hoverColor gg.Color, cue gg.SoundCue, cb func(*gg.Event, *gg.Window)) gg.View {
+	return dataGridIndicatorButton(id, label, baseStyle, hoverColor, false, dataGridHeaderControlWidth, cue,
 		func(ctx gg.EventCtx) {
 			cb(ctx.Event, ctx.Window)
 		})
@@ -242,7 +251,10 @@ func dataGridOrderButton(id, label string, baseStyle gg.TextStyle, hoverColor gg
 // locale string (gg.ActiveLocale.StrAdd and friends). An ID that
 // tracked the label would change identity on a locale switch, moving
 // the button's focus and per-widget state with it.
-func dataGridIndicatorButton(id, label string, baseStyle gg.TextStyle, hoverColor gg.Color, disabled bool, width float32, onClick func(gg.EventCtx)) gg.View {
+// cue is a parameter rather than read from a Cfg here: this helper is
+// shared by the header, the toolbar and both pagers, and each of those
+// already knows which role its control takes (issue #467).
+func dataGridIndicatorButton(id, label string, baseStyle gg.TextStyle, hoverColor gg.Color, disabled bool, width float32, cue gg.SoundCue, onClick func(gg.EventCtx)) gg.View {
 	sizing := gg.FitFill
 	if width > 0 {
 		sizing = gg.FixedFill
@@ -257,6 +269,12 @@ func dataGridIndicatorButton(id, label string, baseStyle gg.TextStyle, hoverColo
 		Color:      gg.ColorTransparent,
 		Colors:     gg.ColorSet{Base: gg.ColorTransparent, Hover: hoverColor, Click: hoverColor, Focus: gg.ColorTransparent, Border: gg.ColorTransparent, BorderFocus: gg.ColorTransparent},
 		Disabled:   disabled,
+		// SoundDisabled as well as Sound: gg.ButtonCfg resolves its
+		// own precedence, and a resolved gg.SoundNone reads there as
+		// "unset" and falls back to the theme. Saying both makes
+		// silence stick (issue #467).
+		Sound:         cue,
+		SoundDisabled: cue == gg.SoundNone,
 		// Wrapped rather than passed through: every toolbar control
 		// sits inside the focusable grid, which takes focus on any
 		// click that reaches it. The consume-class pre-mark stops that
@@ -291,7 +309,7 @@ func dataGridPinControl(cfg *DataGridCfg, col GridColumnCfg) gg.View {
 	colPin := col.Pin
 
 	return dataGridIndicatorButton(gg.ScopeID(cfg.ID, "pin", col.ID), label, cfg.TextStyleHeader, cfg.ColorHeaderHover,
-		false, dataGridHeaderControlWidth, func(ctx gg.EventCtx) {
+		false, dataGridHeaderControlWidth, cfg.sounds.selection, func(ctx gg.EventCtx) {
 			if onColumnPinChange == nil {
 				return
 			}

--- a/gui/datagrid/view_data_grid_header_test.go
+++ b/gui/datagrid/view_data_grid_header_test.go
@@ -245,7 +245,7 @@ func TestHeaderControlStateWithPadding(t *testing.T) {
 
 func TestOrderButtonReturnsView(t *testing.T) {
 	v := dataGridOrderButton("grid:reorder_left:col1", "◀",
-		gg.DefaultTextStyle, gg.RGBA(200, 200, 200, 255),
+		gg.DefaultTextStyle, gg.RGBA(200, 200, 200, 255), gg.SoundNone,
 		func(_ *gg.Event, _ *gg.Window) {})
 	if v == nil {
 		t.Fatal("order button should return a view")
@@ -259,8 +259,10 @@ func TestOrderButtonIDIsPerGridAndColumn(t *testing.T) {
 	hover := gg.RGBA(200, 200, 200, 255)
 	cb := func(_ *gg.Event, _ *gg.Window) {}
 
-	a := dataGridOrderButton("gridA:reorder_left:col1", "◀", style, hover, cb)
-	b := dataGridOrderButton("gridB:reorder_left:col1", "◀", style, hover, cb)
+	a := dataGridOrderButton("gridA:reorder_left:col1", "◀", style, hover,
+		gg.SoundNone, cb)
+	b := dataGridOrderButton("gridB:reorder_left:col1", "◀", style, hover,
+		gg.SoundNone, cb)
 
 	// GenerateLayout needs a usable window: a container now generates
 	// its children itself, and the Text children read window state.

--- a/gui/datagrid/view_data_grid_pager.go
+++ b/gui/datagrid/view_data_grid_pager.go
@@ -93,7 +93,7 @@ func dataGridPagerArrows() (string, string) {
 
 func dataGridPagerPrevButton(cfg *DataGridCfg, onPageChange func(int, gg.EventCtx), pageIndex int, focusID string, isFirst bool, prevArrow string) gg.View {
 	return dataGridIndicatorButton(gg.ScopeID(cfg.ID, "pager_prev"), prevArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover,
-		onPageChange == nil || isFirst, dataGridHeaderControlWidth+10,
+		onPageChange == nil || isFirst, dataGridHeaderControlWidth+10, cfg.sounds.click,
 		func(ctx gg.EventCtx) {
 			if onPageChange == nil {
 				return
@@ -109,7 +109,7 @@ func dataGridPagerPrevButton(cfg *DataGridCfg, onPageChange func(int, gg.EventCt
 
 func dataGridPagerNextButton(cfg *DataGridCfg, onPageChange func(int, gg.EventCtx), pageIndex, pageCount int, focusID string, isLast bool, nextArrow string) gg.View {
 	return dataGridIndicatorButton(gg.ScopeID(cfg.ID, "pager_next"), nextArrow, cfg.TextStyleHeader, cfg.ColorHeaderHover,
-		onPageChange == nil || isLast, dataGridHeaderControlWidth+10,
+		onPageChange == nil || isLast, dataGridHeaderControlWidth+10, cfg.sounds.click,
 		func(ctx gg.EventCtx) {
 			if onPageChange == nil {
 				return

--- a/gui/datagrid/view_data_grid_rows.go
+++ b/gui/datagrid/view_data_grid_rows.go
@@ -167,6 +167,10 @@ func dataGridRowView(dctx dataGridCtx, rowData GridRow, rowIdx int, showDeleteAc
 			Radius:     gg.SomeF(0),
 			Color:      gg.ColorTransparent,
 			Colors:     gg.ColorSet{Base: gg.ColorTransparent, Hover: cfg.ColorHeaderHover, Click: cfg.ColorHeaderHover, Focus: gg.ColorTransparent, Border: cfg.ColorBorder, BorderFocus: cfg.ColorBorder},
+			// SoundDisabled as well as Sound: a resolved gg.SoundNone
+			// reads as "unset" inside gg.ButtonCfg (issue #467).
+			Sound:         cfg.sounds.click,
+			SoundDisabled: cfg.sounds.click == gg.SoundNone,
 			OnClick: func(ctx gg.EventCtx) {
 				dataGridCrudDeleteRows(gridID, selection, onSelectionChange, []string{rowID}, focusID, ctx.Event, ctx.Window)
 			},
@@ -201,6 +205,9 @@ func dataGridRowView(dctx dataGridCtx, rowData GridRow, rowIdx int, showDeleteAc
 		SizeBorder:  gg.SomeF(0),
 		Padding:     gg.NoPadding,
 		Spacing:     gg.Some(-cfg.SizeBorder.Get(0)),
+		// Clicking a row selects it, which is the same activation a
+		// button makes — the grid's own click role (issue #467).
+		Sound: cfg.sounds.click,
 		OnClick: func(ctx gg.EventCtx) {
 			dataGridRowClick(rows, selection, gridID, multiSelect, rangeSelect,
 				onSelectionChange, editEnabled, editorFocusBase, colCount,
@@ -379,14 +386,16 @@ func dataGridDetailToggleControl(cfg *DataGridCfg, rowID string, expanded, enabl
 	onDetailExpandedChange := cfg.OnDetailExpandedChange
 	detailExpandedRowIDs := cfg.DetailExpandedRowIDs
 	return gg.Button(gg.ButtonCfg{
-		ID:         gg.ScopeID(cfg.ID, "detail_toggle", rowID),
-		Width:      dataGridHeaderControlWidth,
-		Sizing:     gg.FixedFill,
-		Padding:    gg.NoPadding,
-		SizeBorder: gg.SomeF(0),
-		Radius:     gg.SomeF(0),
-		Color:      gg.ColorTransparent,
-		Colors:     gg.ColorSet{Base: gg.ColorTransparent, Hover: cfg.ColorRowHover, Click: cfg.ColorRowHover, Focus: gg.ColorTransparent, Border: gg.ColorTransparent, BorderFocus: gg.ColorTransparent},
+		ID:            gg.ScopeID(cfg.ID, "detail_toggle", rowID),
+		Width:         dataGridHeaderControlWidth,
+		Sizing:        gg.FixedFill,
+		Padding:       gg.NoPadding,
+		SizeBorder:    gg.SomeF(0),
+		Radius:        gg.SomeF(0),
+		Color:         gg.ColorTransparent,
+		Colors:        gg.ColorSet{Base: gg.ColorTransparent, Hover: cfg.ColorRowHover, Click: cfg.ColorRowHover, Focus: gg.ColorTransparent, Border: gg.ColorTransparent, BorderFocus: gg.ColorTransparent},
+		Sound:         cfg.sounds.click,
+		SoundDisabled: cfg.sounds.click == gg.SoundNone,
 		OnClick: func(ctx gg.EventCtx) {
 			if rowID == "" || onDetailExpandedChange == nil {
 				// Nothing to toggle: pass the click on

--- a/gui/sound.go
+++ b/gui/sound.go
@@ -33,6 +33,12 @@ const (
 	// SoundError marks a rejection: invalid input, a refused commit, a
 	// failed action.
 	SoundError
+	// SoundSelection marks a choice being picked out of several — a
+	// radio, a list row, a tab, a calendar day. Distinct from
+	// SoundClick, which is a momentary activation with no "one of
+	// these" reading. Appended, not inserted: the enum is open and
+	// values are only ever added at the end (issue #467).
+	SoundSelection
 )
 
 // SoundPlayer renders semantic UI cues as audible feedback. The
@@ -76,6 +82,9 @@ type SoundSet struct {
 	// Error is the cue for a rejection.
 	// exportaudit:keep — caller-facing config (issue #446)
 	Error SoundCue
+	// Selection is the cue for picking one option out of several.
+	// exportaudit:keep — caller-facing config (issue #467)
+	Selection SoundCue
 }
 
 // SoundsDefault returns the natural cue for every role — the one-liner
@@ -86,15 +95,23 @@ func SoundsDefault() SoundSet {
 		ToggleOn:  SoundToggleOn,
 		ToggleOff: SoundToggleOff,
 		Error:     SoundError,
+		Selection: SoundSelection,
 	}
 }
 
-// resolveSoundCue applies the precedence a widget Cfg promises:
+// ResolveSoundCue applies the precedence a widget Cfg promises:
 // SoundDisabled beats an explicit Cfg.Sound, which beats the theme's
-// cue for that role. Called at generation time, where the widget
+// cue for that role. Call it at generation time, where the widget
 // already knows its own state, so a state-dependent cue (toggle on vs
 // off) costs no runtime branch and no allocation.
-func resolveSoundCue(themeCue, cfgCue SoundCue, disabled bool) SoundCue {
+//
+// Exported for widget packages outside gui/ — gui/datagrid is the one
+// in-repo case — so that a second widget set spells the precedence the
+// same way rather than re-deriving it.
+//
+// exportaudit:keep — the precedence seam for out-of-package widgets
+// (issue #467)
+func ResolveSoundCue(themeCue, cfgCue SoundCue, disabled bool) SoundCue {
 	if disabled {
 		return SoundNone
 	}
@@ -102,6 +119,13 @@ func resolveSoundCue(themeCue, cfgCue SoundCue, disabled bool) SoundCue {
 		return cfgCue
 	}
 	return themeCue
+}
+
+// resolveSoundCue is the in-package spelling of ResolveSoundCue. Every
+// gui/ widget factory goes through it, so the exported name stays a
+// seam rather than something call sites have to notice.
+func resolveSoundCue(themeCue, cfgCue SoundCue, disabled bool) SoundCue {
+	return ResolveSoundCue(themeCue, cfgCue, disabled)
 }
 
 // SetSoundPlayer installs the window's sound player. Nil disables

--- a/gui/sound_widgets_test.go
+++ b/gui/sound_widgets_test.go
@@ -1,0 +1,485 @@
+package gui
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Phase 2 of widget audio feedback (issue #467): every widget whose
+// activation lands on a ContainerCfg, a ButtonCfg or a raw
+// eventHandlers literal emits a resolved cue.
+//
+// Theme installation is package-global, so nothing here runs in
+// parallel, and every test starts with restoreTheme(t).
+
+// soundWindow builds a window with the sounding theme installed and a
+// spy attached, then renders view. It is the three lines every case
+// below would otherwise repeat.
+func soundWindow(t *testing.T, view func(*Window) View) (*Window, *soundSpy) {
+	t.Helper()
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+	w.TestRender(view)
+	return w, spy
+}
+
+// findClickable returns the first shape in tree order whose accessible
+// label matches. Rows in a ListBox, options in a Select and rows in a
+// Tree carry no ID of their own — identity there belongs to the owning
+// widget — so TestClick cannot reach them and the test has to aim at
+// the geometry instead.
+func findClickable(l *Layout, label string) *Layout {
+	if l == nil || l.Shape == nil {
+		return nil
+	}
+	if l.Shape.a11Y != nil && l.Shape.a11Y.Label == label &&
+		l.Shape.hasEvents() && l.Shape.events.OnClick != nil {
+		return l
+	}
+	for i := range l.Children {
+		if got := findClickable(&l.Children[i], label); got != nil {
+			return got
+		}
+	}
+	return nil
+}
+
+// clickLabel dispatches a real press/release at the centre of the
+// shape carrying the given accessible label, driving the same dispatch
+// path the backend does.
+func clickLabel(t *testing.T, w *Window, label string) {
+	t.Helper()
+	ly := findClickable(&w.layout, label)
+	if ly == nil {
+		t.Fatalf("no clickable shape labelled %q", label)
+	}
+	x, y, err := testHitPoint(ly, label)
+	if err != nil {
+		t.Fatalf("hit point for %q: %v", label, err)
+	}
+	down := Event{Type: EventMouseDown, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y}
+	w.EventFn(&down)
+	w.settle()
+	up := Event{Type: EventMouseUp, MouseButton: MouseLeft,
+		MouseX: x, MouseY: y}
+	w.EventFn(&up)
+	w.settle()
+	if !down.IsHandled {
+		t.Fatalf("click on %q was not handled", label)
+	}
+}
+
+// wantCues fails unless the spy recorded exactly want, in order.
+func wantCues(t *testing.T, spy *soundSpy, want ...SoundCue) {
+	t.Helper()
+	if len(spy.cues) != len(want) {
+		t.Fatalf("cues = %v, want %v", spy.cues, want)
+	}
+	for i := range want {
+		if spy.cues[i] != want[i] {
+			t.Fatalf("cues = %v, want %v", spy.cues, want)
+		}
+	}
+}
+
+func soundNoop(ctx EventCtx) { ctx.Consume() }
+
+// One case per phase-2 widget: render it, activate it once, and assert
+// the exact cue. A widget whose cue depends on its own state is driven
+// twice by TestSoundPhase2StateDependent below instead.
+func TestSoundPhase2WidgetCues(t *testing.T) {
+	restoreTheme(t)
+
+	cases := []struct {
+		name  string
+		view  func(*Window) View
+		click func(*testing.T, *Window)
+		want  SoundCue
+	}{{
+		name: "radio",
+		view: func(*Window) View {
+			return Radio(RadioCfg{ID: "rb", Label: "One", OnClick: soundNoop})
+		},
+		click: clickID("rb"),
+		want:  SoundSelection,
+	}, {
+		name: "radio_group",
+		view: func(*Window) View {
+			return RadioButtonGroupColumn(RadioButtonGroupCfg{
+				ID:       "grp",
+				Items:    []string{"One", "Two"},
+				OnSelect: func(string, EventCtx) {},
+			})
+		},
+		click: clickID(ScopeIDN("grp", "opt", 0)),
+		want:  SoundSelection,
+	}, {
+		name: "color_swatch",
+		view: func(*Window) View {
+			return ColorSwatch(ColorSwatchCfg{
+				ID: "cs", Color: RGB(10, 20, 30), OnClick: soundNoop})
+		},
+		click: clickID("cs"),
+		want:  SoundSelection,
+	}, {
+		name: "breadcrumb",
+		view: func(*Window) View {
+			return Breadcrumb(BreadcrumbCfg{
+				ID:       "bc",
+				Items:    []BreadcrumbItemCfg{{ID: "home", Label: "Home"}},
+				Selected: "home",
+				OnSelect: func(string, EventCtx) {},
+			})
+		},
+		click: clickID(bcCrumbID("bc", "home")),
+		want:  SoundSelection,
+	}, {
+		name: "listbox_row",
+		view: func(*Window) View {
+			return ListBox(ListBoxCfg{
+				ID: "lb",
+				Data: []ListBoxOption{
+					NewListBoxOption("a", "Alpha", "Alpha")},
+				OnSelect: func([]string, EventCtx) {},
+			})
+		},
+		click: clickLabelFn("Alpha"),
+		want:  SoundSelection,
+	}, {
+		name: "tab_control",
+		view: func(*Window) View {
+			return TabControl(TabControlCfg{
+				ID: "tc",
+				Items: []TabItemCfg{
+					{ID: "one", Label: "One"},
+					{ID: "two", Label: "Two"}},
+				Selected: "one",
+				OnSelect: func(string, EventCtx) {},
+			})
+		},
+		click: clickID(tabButtonID("tc", "two")),
+		want:  SoundSelection,
+	}, {
+		name: "date_picker_day",
+		view: func(*Window) View {
+			return DatePicker(DatePickerCfg{
+				ID:       "dp",
+				OnSelect: func([]time.Time, EventCtx) {},
+			})
+		},
+		click: clickID(ScopeIDN("dp", "day", 1)),
+		want:  SoundSelection,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreTheme(t)
+			w, spy := soundWindow(t, tc.view)
+			tc.click(t, w)
+			wantCues(t, spy, tc.want)
+		})
+	}
+}
+
+func clickID(id string) func(*testing.T, *Window) {
+	return func(t *testing.T, w *Window) {
+		t.Helper()
+		if err := w.TestClick(id); err != nil {
+			t.Fatalf("TestClick(%q): %v", id, err)
+		}
+	}
+}
+
+func clickLabelFn(label string) func(*testing.T, *Window) {
+	return func(t *testing.T, w *Window) {
+		t.Helper()
+		clickLabel(t, w, label)
+	}
+}
+
+// The raw eventHandlers path: Image and Svg build their handler record
+// directly instead of going through makeContainerEvents, so the cue
+// reaches them by a different line of code and needs its own case.
+func TestSoundPhase2RawEventHandlers(t *testing.T) {
+	restoreTheme(t)
+
+	// A real PNG on disk: the decode has to succeed, or the shape
+	// never reaches the tree for the click to land on.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dot.png")
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+
+	w, spy := soundWindow(t, func(*Window) View {
+		return Image(ImageCfg{
+			ID: "img", Src: path, Width: 20, Height: 20,
+			OnClick: soundNoop,
+		})
+	})
+	clickID("img")(t, w)
+	wantCues(t, spy, SoundClick)
+}
+
+// A widget whose cue depends on its own state names what the click
+// will do, not what the state is. Each case is clicked twice with a
+// re-render between, so the second click sees the flipped state.
+func TestSoundPhase2StateDependent(t *testing.T) {
+	restoreTheme(t)
+
+	cases := []struct {
+		name string
+		view func(*bool) func(*Window) View
+		id   string
+	}{{
+		name: "switch",
+		view: func(on *bool) func(*Window) View {
+			return func(*Window) View {
+				return Switch(SwitchCfg{
+					ID: "sw", Label: "On", Selected: *on,
+					OnClick: func(ctx EventCtx) {
+						*on = !*on
+						ctx.Consume()
+					},
+				})
+			}
+		},
+		id: "sw",
+	}, {
+		name: "expand_panel",
+		view: func(on *bool) func(*Window) View {
+			return func(*Window) View {
+				return ExpandPanel(ExpandPanelCfg{
+					ID:   "ep",
+					Open: *on,
+					Head: Text(TextCfg{Text: "Head"}),
+					OnToggle: func(ctx EventCtx) {
+						*on = !*on
+						ctx.Consume()
+					},
+				})
+			}
+		},
+		id: ScopeID("ep", "head"),
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreTheme(t)
+			on := false
+			w, spy := soundWindow(t, tc.view(&on))
+			for i := range 2 {
+				if err := w.TestClick(tc.id); err != nil {
+					t.Fatalf("click %d: %v", i, err)
+				}
+				w.TestRender(nil)
+			}
+			wantCues(t, spy, SoundToggleOn, SoundToggleOff)
+		})
+	}
+}
+
+// Select, Combobox and ThemePicker own their open flag in window
+// state, so the toggle drives itself: no app-side bool to flip.
+func TestSoundPhase2DropdownOpenClose(t *testing.T) {
+	restoreTheme(t)
+
+	cases := []struct {
+		name string
+		view func(*Window) View
+	}{{
+		name: "select",
+		view: func(*Window) View {
+			return Select(SelectCfg{
+				ID: "sel", Options: []string{"One", "Two"},
+				OnSelect: func([]string, EventCtx) {},
+			})
+		},
+	}, {
+		name: "combobox",
+		view: func(*Window) View {
+			return Combobox(ComboboxCfg{
+				ID: "cb", Options: []string{"Alpha", "Beta"},
+				OnSelect: func(string, EventCtx) {},
+			})
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreTheme(t)
+			id := "sel"
+			if tc.name == "combobox" {
+				id = "cb"
+			}
+			w, spy := soundWindow(t, tc.view)
+			for i := range 2 {
+				if err := w.TestClick(id); err != nil {
+					t.Fatalf("click %d: %v", i, err)
+				}
+				w.TestRender(nil)
+			}
+			wantCues(t, spy, SoundToggleOn, SoundToggleOff)
+		})
+	}
+}
+
+// The click absorbers stay silent under a sounding theme. Each one
+// exists to swallow a click that would otherwise reach what it covers;
+// a cue there would fire on every scroll drag or caret placement.
+//
+// Asserted over the whole rendered tree rather than by clicking: a
+// scrollbar track carries no ID, so there is nothing for TestClick to
+// aim at, and "no shape anywhere in this widget carries a cue" is the
+// stronger claim anyway.
+//
+// Two more absorbers are silent by construction and need no case here:
+// ContextMenu's dismissal is an OnAnyClick, which playShapeSound never
+// consults, and the CommandPalette card and Toast scrim leave Sound
+// unset on containers whose OnClick only calls ctx.Consume.
+func TestSoundPhase2AbsorbersStaySilent(t *testing.T) {
+	restoreTheme(t)
+
+	cases := []struct {
+		name string
+		view func(*Window) View
+	}{{
+		name: "scrollbar",
+		view: func(*Window) View {
+			return Column(ContainerCfg{
+				ID: "scr", Height: 40, Width: 100,
+				Sizing: FixedFixed, Scrollable: true,
+				Content: []View{Rectangle(RectangleCfg{
+					Width: 100, Height: 400, Sizing: FixedFixed})},
+			})
+		},
+	}, {
+		name: "input_caret",
+		view: func(*Window) View {
+			return Input(InputCfg{ID: "in", Text: "hello"})
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreTheme(t)
+			w, _ := soundWindow(t, tc.view)
+			if got := collectCues(&w.layout, nil); len(got) != 0 {
+				t.Errorf("%s carries cues %v, want none", tc.name, got)
+			}
+		})
+	}
+}
+
+// collectCues returns every non-silent cue in the subtree, in tree
+// order.
+func collectCues(l *Layout, acc []SoundCue) []SoundCue {
+	if l == nil || l.Shape == nil {
+		return acc
+	}
+	if l.Shape.hasEvents() && l.Shape.events.soundCue != SoundNone {
+		acc = append(acc, l.Shape.events.soundCue)
+	}
+	for i := range l.Children {
+		acc = collectCues(&l.Children[i], acc)
+	}
+	return acc
+}
+
+// Cfg.Sound and SoundDisabled have to work on every site kind, not
+// only on the ButtonCfg phase 1 proved them on.
+func TestSoundPhase2OverridesPerSiteKind(t *testing.T) {
+	restoreTheme(t)
+
+	cases := []struct {
+		name string
+		view func(cue SoundCue, off bool) func(*Window) View
+		id   string
+	}{{
+		name: "container_cfg",
+		view: func(cue SoundCue, off bool) func(*Window) View {
+			return func(*Window) View {
+				return Radio(RadioCfg{ID: "rb", Label: "One",
+					Sound: cue, SoundDisabled: off,
+					OnClick: soundNoop})
+			}
+		},
+		id: "rb",
+	}, {
+		name: "button_cfg",
+		view: func(cue SoundCue, off bool) func(*Window) View {
+			return func(*Window) View {
+				return TabControl(TabControlCfg{
+					ID: "tc",
+					Items: []TabItemCfg{
+						{ID: "one", Label: "One"},
+						{ID: "two", Label: "Two"}},
+					Selected:      "one",
+					Sound:         cue,
+					SoundDisabled: off,
+					OnSelect:      func(string, EventCtx) {},
+				})
+			}
+		},
+		id: tabButtonID("tc", "two"),
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"_override", func(t *testing.T) {
+			restoreTheme(t)
+			w, spy := soundWindow(t, tc.view(SoundError, false))
+			clickID(tc.id)(t, w)
+			wantCues(t, spy, SoundError)
+		})
+		t.Run(tc.name+"_disabled", func(t *testing.T) {
+			restoreTheme(t)
+			// SoundDisabled beats an explicit Sound, not only the
+			// theme.
+			w, spy := soundWindow(t, tc.view(SoundError, true))
+			clickID(tc.id)(t, w)
+			wantCues(t, spy)
+		})
+	}
+}
+
+// The raw eventHandlers path resolves its own precedence rather than
+// inheriting ContainerCfg's, so it gets its own override case.
+func TestSoundPhase2RawHandlerOverride(t *testing.T) {
+	restoreTheme(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dot.png")
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+
+	w, spy := soundWindow(t, func(*Window) View {
+		return Image(ImageCfg{
+			ID: "img", Src: path, Width: 20, Height: 20,
+			Sound: SoundError, OnClick: soundNoop,
+		})
+	})
+	clickID("img")(t, w)
+	wantCues(t, spy, SoundError)
+}

--- a/gui/view_breadcrumb.go
+++ b/gui/view_breadcrumb.go
@@ -99,6 +99,17 @@ type BreadcrumbCfg struct {
 	Sizing             Sizing
 	Disabled           bool
 	Invisible          bool
+
+	// Sound overrides the theme's selection cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every crumb's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 func applyBreadcrumbDefaults(cfg *BreadcrumbCfg) {
@@ -178,6 +189,12 @@ func Breadcrumb(cfg BreadcrumbCfg) View {
 
 	selectedIdx := bcSelectedIndex(cfg.Items, cfg.Selected)
 
+	// One resolve for the whole trail: every crumb takes the same
+	// role, so hoisting it out of the loop keeps the per-item cost to
+	// a value copy (issue #467).
+	soundCue := resolveSoundCue(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+
 	trailItems := make([]View, 0, len(cfg.Items)*2)
 	hasContent := bcHasAnyContent(cfg.Items)
 
@@ -218,9 +235,14 @@ func Breadcrumb(cfg BreadcrumbCfg) View {
 
 		var onClick func(EventCtx)
 		var onHover func(EventCtx)
+		// A disabled crumb gets no handler and no cue: navigating the
+		// trail is a selection, and a crumb that cannot be navigated
+		// to must not answer the click at all (issue #467).
+		crumbSound := SoundNone
 		if !isDisabled {
 			onClick = makeBcOnClick(cfg.OnSelect, item.ID, cfg.ID)
 			onHover = makeBcOnHover(hoverColor, clickColor)
+			crumbSound = soundCue
 		}
 
 		crumbContent := []View{
@@ -229,6 +251,7 @@ func Breadcrumb(cfg BreadcrumbCfg) View {
 
 		trailItems = append(trailItems, Row(ContainerCfg{
 			ID:      bcCrumbID(cfg.ID, item.ID),
+			Sound:   crumbSound,
 			Color:   crumbColor,
 			Padding: cfg.PaddingCrumb,
 			Radius:  Some(radiusCrumb),

--- a/gui/view_color_swatch.go
+++ b/gui/view_color_swatch.go
@@ -28,6 +28,17 @@ type ColorSwatchCfg struct {
 	Width  float32
 	Height float32
 	Radius Opt[float32]
+
+	// Sound overrides the theme's selection cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses the swatch's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 type colorSwatchView struct {
@@ -90,6 +101,12 @@ func (sv *colorSwatchView) GenerateLayout(w *Window) Layout {
 	// belongs to the swatch, and AmendLayout's ctx reaches only the
 	// layer's shape.
 	effID := w.EffID(cfg.ID)
+
+	soundCue := SoundNone
+	if cfg.OnClick != nil {
+		soundCue = resolveSoundCue(
+			guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+	}
 	colorCfg := ContainerCfg{
 		Float:  true,
 		Width:  cfg.Width,
@@ -126,8 +143,14 @@ func (sv *colorSwatchView) GenerateLayout(w *Window) Layout {
 			ClickOnSpace: cfg.OnClick != nil,
 			ClickOnEnter: cfg.OnClick != nil,
 			OnClick:      cfg.OnClick,
-			Width:        cfg.Width,
-			Height:       cfg.Height,
+			// Activating a swatch picks the color it shows, so the
+			// selection role, not the plain click one. A passive
+			// preview has no OnClick and so stays silent, which the
+			// nil check makes explicit rather than leaving to
+			// playShapeSound (issue #467).
+			Sound:  soundCue,
+			Width:  cfg.Width,
+			Height: cfg.Height,
 			// Fixed: the checkerboard is generated at this size.
 			Sizing:     FixedFixed,
 			Padding:    NoPadding,

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -73,6 +73,17 @@ type ComboboxCfg struct {
 	Colors   ColorSet
 	Sizing   Sizing
 	Disabled bool
+
+	// Sound overrides the theme's toggle cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses the field's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // comboboxView implements View for combobox.
@@ -272,6 +283,16 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 	colorFocus := cfg.ColorFocus
 	colorBorderFocus := cfg.ColorBorderFocus
 
+	// The field click opens or closes the dropdown, so the cue names
+	// what it is about to do (issue #467). Rows in the dropdown are
+	// ListBox items and carry the ListBox's own selection cue.
+	fieldThemeCue := guiTheme.Sounds.ToggleOn
+	if isOpen {
+		fieldThemeCue = guiTheme.Sounds.ToggleOff
+	}
+	fieldSound := resolveSoundCue(
+		fieldThemeCue, cfg.Sound, cfg.SoundDisabled)
+
 	ccfg := ContainerCfg{
 		ID:        cfg.ID,
 		Focusable: !cfg.FocusDisabled,
@@ -292,6 +313,7 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		axis:        axisLeftToRight,
 		VAlign:      VAlignMiddle,
 		AmendLayout: focusRingAmend(colorFocus, colorBorderFocus),
+		Sound:       fieldSound,
 		OnKeyDown: makeComboboxOnKeyDown(id, onSelect, id, filteredIDs,
 			dropdownScrollID, rowH, listH),
 		OnChar: makeComboboxOnChar(id),

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -64,6 +64,20 @@ type CommandPaletteCfg struct {
 	// the theme default.
 	// exportaudit:keep — caller-facing config (issue #372)
 	BackdropColor Color
+
+	// Sound overrides the theme's click cue for dismissing the palette
+	// by clicking the backdrop. SoundNone (the zero value) takes
+	// Theme.Sounds.Click, which is itself silent unless the app opted
+	// in (issue #446). The card itself stays silent: its OnClick only
+	// absorbs, so a cue there would fire on every click into the
+	// palette (issue #467).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses the backdrop's sound regardless of the
+	// theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // commandPaletteView implements View for command palette.
@@ -194,6 +208,8 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 		VAlign:      VAlignTop,
 		HAlign:      HAlignCenter,
 		Padding:     NoPadding,
+		Sound: resolveSoundCue(
+			guiTheme.Sounds.Click, cfg.Sound, cfg.SoundDisabled),
 		OnClick: func(ctx EventCtx) {
 			commandPaletteDismiss(paletteID, ctx.Window)
 			if onDismiss != nil {

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -101,6 +101,20 @@ type DatePickerCfg struct {
 	HideTodayIndicator   bool
 	MondayFirstDayOfWeek bool
 	ShowAdjacentMonths   bool
+
+	// Sound overrides the theme's selection cue for a day cell.
+	// SoundNone (the zero value) takes Theme.Sounds.Selection, which
+	// is itself silent unless the app opted in (issue #446). The
+	// field itself stays silent: clicking it only takes focus, and a
+	// cue there would fire on every tab-through of a form
+	// (issue #467).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every day cell's sound regardless of
+	// the theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 type datePickerView struct {

--- a/gui/view_date_picker_calendar.go
+++ b/gui/view_date_picker_calendar.go
@@ -153,8 +153,18 @@ func datePickerMonth(
 
 			dayVal := d
 			cfgID := cfg.ID
+			daySound := resolveSoundCue(guiTheme.Sounds.Selection,
+				cfg.Sound, cfg.SoundDisabled)
 			cells = append(cells, Button(ButtonCfg{
 				ID: ScopeIDN(cfg.ID, "day", d),
+				// Picking a day is choosing one of a month's worth,
+				// so the selection role rather than Button's own
+				// click default. SoundDisabled goes through too: a
+				// resolved SoundNone reads as "unset" inside
+				// ButtonCfg and would fall back to the theme
+				// (issue #467).
+				Sound:         daySound,
+				SoundDisabled: daySound == SoundNone,
 				// A day number is digits by construction, and figures
 				// measure shorter than caps: on the cap band every cell
 				// would land low (issue #346).
@@ -244,6 +254,9 @@ func datePickerAdjacentCell(
 		idSuffix = "next"
 	}
 
+	adjSound := resolveSoundCue(guiTheme.Sounds.Selection,
+		cfg.Sound, cfg.SoundDisabled)
+
 	return Button(ButtonCfg{
 		ID: ScopeIDN(ScopeID(cfg.ID, "day", idSuffix), "", adjDay),
 		// Digits, like the in-month cells beside it, and it has to sit
@@ -251,10 +264,14 @@ func datePickerAdjacentCell(
 		opticalDigitLabel: true,
 		Color:             ColorTransparent,
 		Colors:            ColorSet{Border: ColorTransparent}.resolved(ColorTransparent, themeButtonSet()),
-		MinWidth:          cellSize,
-		MaxWidth:          cellSize,
-		MaxHeight:         cellSize,
-		Padding:           paddingThree,
+		// An adjacent-month cell selects a day too — it just navigates
+		// first — so it takes the same cue as an in-month one.
+		Sound:         adjSound,
+		SoundDisabled: adjSound == SoundNone,
+		MinWidth:      cellSize,
+		MaxWidth:      cellSize,
+		MaxHeight:     cellSize,
+		Padding:       paddingThree,
 		Content: []View{Text(TextCfg{
 			Text:      strconv.Itoa(adjDay),
 			TextStyle: ts,

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -69,6 +69,19 @@ type DialogCfg struct {
 	// actions. Ignored for non-confirm dialog types.
 	defaultButton dialogButton
 
+	// Sound overrides the theme's click cue for every dialog button.
+	// SoundNone (the zero value) takes Theme.Sounds.Click, which is
+	// itself silent unless the app opted in (issue #446). All five
+	// buttons take the same role: dismissing a dialog is an
+	// activation, not a rejection (issue #467).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every dialog button's sound regardless
+	// of the theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
+
 	// unexported
 	visible bool
 }
@@ -149,8 +162,10 @@ func messageView(cfg DialogCfg) View {
 		SizeBorder: NoBorder,
 		Content: []View{
 			Button(ButtonCfg{
-				ID:      cfg.FocusID,
-				Content: []View{Text(TextCfg{Text: "OK"})},
+				Sound:         cfg.Sound,
+				SoundDisabled: cfg.SoundDisabled,
+				ID:            cfg.FocusID,
+				Content:       []View{Text(TextCfg{Text: "OK"})},
 				OnClick: func(ctx EventCtx) {
 					ctx.Window.DialogDismiss()
 					if onOkYes != nil {
@@ -174,8 +189,10 @@ func confirmView(cfg DialogCfg) View {
 		Spacing:    Some(SpacingMedium),
 		Content: []View{
 			Button(ButtonCfg{
-				ID:      ScopeIDN(cfg.FocusID, "", 1),
-				Content: []View{Text(TextCfg{Text: "Yes"})},
+				Sound:         cfg.Sound,
+				SoundDisabled: cfg.SoundDisabled,
+				ID:            ScopeIDN(cfg.FocusID, "", 1),
+				Content:       []View{Text(TextCfg{Text: "Yes"})},
 				OnClick: func(ctx EventCtx) {
 					ctx.Window.DialogDismiss()
 					if onOkYes != nil {
@@ -184,8 +201,10 @@ func confirmView(cfg DialogCfg) View {
 				},
 			}),
 			Button(ButtonCfg{
-				ID:      cfg.FocusID,
-				Content: []View{Text(TextCfg{Text: "No"})},
+				Sound:         cfg.Sound,
+				SoundDisabled: cfg.SoundDisabled,
+				ID:            cfg.FocusID,
+				Content:       []View{Text(TextCfg{Text: "No"})},
 				OnClick: func(ctx EventCtx) {
 					ctx.Window.DialogDismiss()
 					if onCancelNo != nil {
@@ -221,9 +240,11 @@ func promptView(cfg DialogCfg) []View {
 		Spacing:    Some(SpacingMedium),
 		Content: []View{
 			Button(ButtonCfg{
-				ID:       ScopeIDN(cfg.FocusID, "", 1),
-				Disabled: len(cfg.Reply) == 0,
-				Content:  []View{Text(TextCfg{Text: "OK"})},
+				Sound:         cfg.Sound,
+				SoundDisabled: cfg.SoundDisabled,
+				ID:            ScopeIDN(cfg.FocusID, "", 1),
+				Disabled:      len(cfg.Reply) == 0,
+				Content:       []View{Text(TextCfg{Text: "OK"})},
 				OnClick: func(ctx EventCtx) {
 					reply := ctx.Window.dialogCfg.Reply
 					ctx.Window.DialogDismiss()
@@ -233,8 +254,10 @@ func promptView(cfg DialogCfg) []View {
 				},
 			}),
 			Button(ButtonCfg{
-				ID:      ScopeIDN(cfg.FocusID, "", 2),
-				Content: []View{Text(TextCfg{Text: "Cancel"})},
+				Sound:         cfg.Sound,
+				SoundDisabled: cfg.SoundDisabled,
+				ID:            ScopeIDN(cfg.FocusID, "", 2),
+				Content:       []View{Text(TextCfg{Text: "Cancel"})},
 				OnClick: func(ctx EventCtx) {
 					ctx.Window.DialogDismiss()
 					if onCancelNo != nil {

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -44,6 +44,20 @@ type DockLayoutCfg struct {
 	// panel.
 	// exportaudit:keep — caller-facing config (issue #372)
 	HideSingleTab bool
+
+	// Sound overrides the theme's cue for the tab strip. A tab picks
+	// one panel of several, so it takes the selection role; the close
+	// button is a momentary activation, so it takes the click one.
+	// SoundNone (the zero value) takes the theme's cue for whichever
+	// applies, which is itself silent unless the app opted in
+	// (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses the tab strip's sounds regardless of
+	// the theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // dockLayoutCore holds callback-relevant fields without content
@@ -336,6 +350,11 @@ func dockTabButton(
 	}
 	colorHover := cfg.ColorTabHover
 
+	closeSound := resolveSoundCue(
+		guiTheme.Sounds.Click, cfg.Sound, cfg.SoundDisabled)
+	tabSound := resolveSoundCue(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+
 	btnContent := make([]View, 0, 3)
 	btnContent = append(btnContent, Text(TextCfg{Text: panel.Label}))
 
@@ -352,6 +371,10 @@ func dockTabButton(
 			Color:      colorTab,
 			Colors:     ColorSet{Hover: guiTheme.ColorHover}.resolved(colorTab, themeButtonSet()),
 			Radius:     SomeF(2),
+			// SoundDisabled as well as Sound: a resolved SoundNone
+			// reads as "unset" inside ButtonCfg (issue #467).
+			Sound:         closeSound,
+			SoundDisabled: closeSound == SoundNone,
 			OnClick: func(ctx EventCtx) {
 				onPanelClose(panelID, ctx)
 				// The close button sits inside its own tab button, which
@@ -380,6 +403,10 @@ func dockTabButton(
 		SizeBorder: NoBorder,
 		Color:      colorTab,
 		Colors:     ColorSet{Hover: colorHover}.resolved(colorTab, themeButtonSet()),
+		// The cue marks selecting the panel, not the drag this handler
+		// also starts: dragging is phase 3's question (issue #467).
+		Sound:         tabSound,
+		SoundDisabled: tabSound == SoundNone,
 		OnClick: func(ctx EventCtx) {
 			dockDragStart(dockID, panelID, groupID, root,
 				onLayoutChange, ctx.Layout, ctx.Event, ctx.Window)

--- a/gui/view_expand_panel.go
+++ b/gui/view_expand_panel.go
@@ -35,6 +35,17 @@ type ExpandPanelCfg struct {
 	// its focus ring. Use it for decorative or demo panels where
 	// keyboard toggling is not wanted.
 	FocusDisabled bool
+
+	// Sound overrides the theme's toggle cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses the header's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // ExpandPanel creates an expandable panel view.
@@ -59,6 +70,14 @@ func ExpandPanel(cfg ExpandPanelCfg) View {
 	if cfg.Open {
 		a11yState = AccessStateExpanded
 	}
+
+	// The cue names what the click will do: an open panel is about to
+	// close (issue #467).
+	themeCue := guiTheme.Sounds.ToggleOn
+	if cfg.Open {
+		themeCue = guiTheme.Sounds.ToggleOff
+	}
+	soundCue := resolveSoundCue(themeCue, cfg.Sound, cfg.SoundDisabled)
 
 	// The header row joins the tab order: Space/Enter toggle the
 	// panel (issue #345). The body's own focusables sit after it in
@@ -90,6 +109,7 @@ func ExpandPanel(cfg ExpandPanelCfg) View {
 				Focusable:    headFocusable,
 				ClickOnSpace: true,
 				ClickOnEnter: true,
+				Sound:        soundCue,
 				AmendLayout:  headAmend,
 				Content: []View{
 					cfg.Head,

--- a/gui/view_image.go
+++ b/gui/view_image.go
@@ -28,6 +28,17 @@ type ImageCfg struct {
 	BgColor   Color // opaque fill drawn behind image (e.g. white for mermaid PNGs)
 
 	Invisible bool
+
+	// Sound overrides the theme's click cue for this instance.
+	// SoundNone (the zero value) takes Theme.Sounds.Click, which is
+	// itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this image's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // imageView implements View for image rendering.
@@ -86,12 +97,18 @@ func (iv *imageView) GenerateLayout(w *Window) Layout {
 		height = 100
 	}
 
+	// The guard stays keyed on the callbacks, not widened to include
+	// the cue: playShapeSound only runs on the OnClick path, so a cue
+	// with no OnClick could never fire and the record would be
+	// allocated for nothing (issue #467).
 	var events *eventHandlers
 	if c.OnClick != nil || c.OnHover != nil {
 		events = w.allocEventHandlers(eventHandlers{
 			OnClick:     c.OnClick,
 			clickButton: c.clickButton,
 			OnHover:     c.OnHover,
+			soundCue: resolveSoundCue(
+				guiTheme.Sounds.Click, c.Sound, c.SoundDisabled),
 		})
 	}
 	layout := Layout{

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -93,6 +93,17 @@ type ListBoxCfg struct {
 	Disabled          bool
 	Invisible         bool
 	Reorderable       bool
+
+	// Sound overrides the theme's selection cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every row's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // ListBoxOption helpers.

--- a/gui/view_listbox_items.go
+++ b/gui/view_listbox_items.go
@@ -147,6 +147,15 @@ func listBoxItemView(
 		a11yState = AccessStateSelected
 	}
 
+	// A subheading is a caption, not a choice, and a list with no
+	// OnSelect answers nothing — both stay silent. Otherwise the row
+	// picks one of several, which is the selection role (issue #467).
+	rowSound := SoundNone
+	if hasOnSelect && !isSub {
+		rowSound = resolveSoundCue(
+			guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+	}
+
 	return Row(ContainerCfg{
 		A11YRole:  AccessRoleListItem,
 		A11YCfg:   A11YCfg{A11YLabel: dat.Name},
@@ -159,6 +168,7 @@ func listBoxItemView(
 		// which runs after arrange and therefore moves nothing.
 		SizeBorder: NoBorder,
 		Sizing:     FillFit,
+		Sound:      rowSound,
 		Content:    []View{content},
 		// The ring paints only while the list itself holds window
 		// focus. Focus is resolved after layout, so it cannot be
@@ -229,6 +239,15 @@ func listBoxReorderItemView(
 		a11yState = AccessStateSelected
 	}
 
+	// The cue marks the selection the click makes, not the drag it
+	// also starts: a drag has no activation moment to sound at, and
+	// dragging is phase 3's question (issue #467).
+	rowSound := SoundNone
+	if hasOnSelect {
+		rowSound = resolveSoundCue(
+			guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+	}
+
 	return Row(ContainerCfg{
 		ID:        layoutID,
 		A11YRole:  AccessRoleListItem,
@@ -241,6 +260,7 @@ func listBoxReorderItemView(
 		// listBoxItemRingAmend.
 		SizeBorder: NoBorder,
 		Sizing:     FillFit,
+		Sound:      rowSound,
 		Content:    []View{content},
 		AmendLayout: listBoxItemRingAmend(
 			isFocusRow, cfg.ID, cfg.ColorBorderFocus),

--- a/gui/view_menu_item.go
+++ b/gui/view_menu_item.go
@@ -186,6 +186,17 @@ func menuItem(menubarCfg MenubarCfg, itemCfg MenuItemCfg, extra ...View) View {
 		}
 	}
 
+	// A separator and a subtitle are not activations — they carry no
+	// Action and a subtitle is disabled — so they stay silent. A live
+	// item is a momentary activation, which is the click role, not the
+	// selection one: a menu is a list of commands, not of options
+	// (issue #467).
+	itemSound := SoundNone
+	if !itemCfg.Separator && !itemCfg.disabled {
+		itemSound = resolveSoundCue(
+			guiTheme.Sounds.Click, menubarCfg.Sound, menubarCfg.SoundDisabled)
+	}
+
 	itemContent := make([]View, 0, 1+len(extra))
 	itemContent = append(itemContent, content)
 	itemContent = append(itemContent, extra...)
@@ -199,6 +210,7 @@ func menuItem(menubarCfg MenubarCfg, itemCfg MenuItemCfg, extra ...View) View {
 		Padding:  itemCfg.Padding,
 		Radius:   Some(itemCfg.radius),
 		Disabled: itemCfg.disabled,
+		Sound:    itemSound,
 		OnClick:  menuItemClick(menubarCfg, itemCfg),
 		OnHover:  onHover,
 		// Reaches the label only: an attached submenu is a container,

--- a/gui/view_menubar.go
+++ b/gui/view_menubar.go
@@ -75,6 +75,17 @@ type MenubarCfg struct {
 	// would cross the window edge.
 	// exportaudit:keep — caller-facing config (issue #372)
 	FloatAutoFlip bool
+
+	// Sound overrides the theme's click cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every item's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // Menubar creates a horizontal menubar with keyboard

--- a/gui/view_radio.go
+++ b/gui/view_radio.go
@@ -26,6 +26,17 @@ type RadioCfg struct {
 	Disabled      bool
 	Selected      bool
 	Invisible     bool
+
+	// Sound overrides the theme's selection cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this radio's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // Radio creates a radio button view.
@@ -69,6 +80,11 @@ func Radio(cfg RadioCfg) View {
 		a11yState = AccessStateSelected
 	}
 
+	// A radio picks one option out of several, so it takes the
+	// selection role rather than the plain click one (issue #467).
+	soundCue := resolveSoundCue(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+
 	return Row(ContainerCfg{
 		ID:        cfg.ID,
 		Focusable: !cfg.FocusDisabled,
@@ -83,6 +99,7 @@ func Radio(cfg RadioCfg) View {
 			A11YDescription: cfg.A11YDescription,
 		},
 		OnClick:      cfg.OnClick,
+		Sound:        soundCue,
 		clickButton:  MouseLeft,
 		ClickOnSpace: true,
 		AmendLayout: amendAll(

--- a/gui/view_radio_button_group.go
+++ b/gui/view_radio_button_group.go
@@ -38,6 +38,17 @@ type RadioButtonGroupCfg struct {
 	TitleBG       Color
 	Sizing        Sizing
 	Disabled      bool
+
+	// Sound overrides the theme's selection cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every option's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // RadioButtonGroupColumn creates a vertically stacked radio
@@ -96,6 +107,11 @@ func buildRadioOptions(cfg RadioButtonGroupCfg) []View {
 			Selected:      cfg.Value == opt.Value,
 			Disabled:      cfg.Disabled,
 			TextStyle:     cfg.TextStyle,
+			// Forwarded, not resolved here: Radio owns the
+			// precedence, so the group only has to hand its own
+			// choice down to every option (issue #467).
+			Sound:         cfg.Sound,
+			SoundDisabled: cfg.SoundDisabled,
 			OnClick: func(ctx EventCtx) {
 				if onSelect != nil {
 					onSelect(optValue, ctx)

--- a/gui/view_select.go
+++ b/gui/view_select.go
@@ -67,6 +67,17 @@ type SelectCfg struct {
 	NoWrap    bool
 	Disabled  bool
 	Invisible bool
+
+	// Sound overrides the theme's toggle (the field) and selection (an option) cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses both the field's and the options' sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // selectView implements View for select (dropdown).
@@ -185,6 +196,16 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 	}
 
 	// Build the outer row layout directly.
+	// Two cues, two roles. Clicking the field opens or closes the
+	// dropdown, so it names what the click is about to do; clicking an
+	// option picks one of several, so it is a selection (issue #467).
+	fieldThemeCue := guiTheme.Sounds.ToggleOn
+	if isOpen {
+		fieldThemeCue = guiTheme.Sounds.ToggleOff
+	}
+	fieldSound := resolveSoundCue(
+		fieldThemeCue, cfg.Sound, cfg.SoundDisabled)
+
 	ccfg := ContainerCfg{
 		ID:        cfg.ID,
 		Focusable: !cfg.FocusDisabled,
@@ -215,6 +236,7 @@ func (sv *selectView) GenerateLayout(w *Window) Layout {
 		AmendLayout: amendAll(
 			opticalAmend,
 			focusRingAmend(colorFocus, colorBorderFocus)),
+		Sound:     fieldSound,
 		OnKeyDown: makeSelectOnKeyDown(&sv.cfg, id, dropdownScrollID),
 		OnClick: func(ctx EventCtx) {
 			ss := StateMap[string, bool](
@@ -259,10 +281,14 @@ func selectOptionView(
 		checkColor = cfg.TextStyle.Color
 	}
 
+	optionSound := resolveSoundCue(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+
 	return Row(ContainerCfg{
 		Color:   optColor,
 		Padding: NewPadding(0, PadSmall, 0, 1),
 		Sizing:  FillFit,
+		Sound:   optionSound,
 		Content: []View{
 			Row(ContainerCfg{
 				Padding: padTBLR(2, 0),

--- a/gui/view_svg.go
+++ b/gui/view_svg.go
@@ -50,6 +50,17 @@ type SvgCfg struct {
 	// NoAnimate disables SMIL animation (default: animated).
 	// exportaudit:keep — caller-facing config (issue #372)
 	NoAnimate bool // disable SMIL animation (default: animated)
+
+	// Sound overrides the theme's click cue for this instance.
+	// SoundNone (the zero value) takes Theme.Sounds.Click, which is
+	// itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this svg's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // svgView implements View for SVG rendering.
@@ -139,11 +150,15 @@ func (sv *svgView) GenerateLayout(w *Window) Layout {
 		}
 	}
 
+	// Guard unchanged: a cue with no OnClick can never sound, because
+	// playShapeSound only runs on the OnClick path (issue #467).
 	var events *eventHandlers
 	if c.OnClick != nil {
 		events = w.allocEventHandlers(eventHandlers{
 			OnClick:     c.OnClick,
 			clickButton: MouseLeft,
+			soundCue: resolveSoundCue(
+				guiTheme.Sounds.Click, c.Sound, c.SoundDisabled),
 		})
 	}
 	layout := Layout{

--- a/gui/view_switch.go
+++ b/gui/view_switch.go
@@ -27,6 +27,17 @@ type SwitchCfg struct {
 	Disabled      bool
 	Invisible     bool
 	Selected      bool
+
+	// Sound overrides the theme's toggle cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this switch's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // LabeledSwitch is the thin form of Switch for the common case: a
@@ -105,6 +116,15 @@ func Switch(cfg SwitchCfg) View {
 		a11yState = AccessStateChecked
 	}
 
+	// The cue names what the click will do, not the current state: a
+	// selected switch is about to turn off. Resolved at generation
+	// time, so no runtime branch and no closure (issue #467).
+	themeCue := guiTheme.Sounds.ToggleOn
+	if cfg.Selected {
+		themeCue = guiTheme.Sounds.ToggleOff
+	}
+	soundCue := resolveSoundCue(themeCue, cfg.Sound, cfg.SoundDisabled)
+
 	return Row(ContainerCfg{
 		ID:         cfg.ID,
 		Focusable:  !cfg.FocusDisabled,
@@ -123,6 +143,7 @@ func Switch(cfg SwitchCfg) View {
 		},
 		ClickOnSpace: true,
 		OnClick:      cfg.OnClick,
+		Sound:        soundCue,
 		clickButton:  MouseLeft,
 		OnHover: func(ctx EventCtx) {
 			if ctx.Layout.Shape.Disabled ||

--- a/gui/view_tab_control.go
+++ b/gui/view_tab_control.go
@@ -114,6 +114,17 @@ type TabControlCfg struct {
 	Disabled            bool
 	Invisible           bool
 	Reorderable         bool
+
+	// Sound overrides the theme's selection cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every tab's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 type tabControlView struct {
@@ -346,6 +357,15 @@ func (tv *tabControlView) GenerateLayout(w *Window) Layout {
 			a11yState = AccessStateSelected
 		}
 
+		// A disabled tab gets no handler, so it gets no cue either;
+		// picking a tab is choosing one of several, which is the
+		// selection role (issue #467).
+		tabSound := SoundNone
+		if !isDisabled {
+			tabSound = resolveSoundCue(
+				guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+		}
+
 		var onClick func(EventCtx)
 		if cfg.Reorderable && !isDisabled {
 			onClick = makeTabDragClick(cfg.ID, tabDragIdx[i],
@@ -368,6 +388,12 @@ func (tv *tabControlView) GenerateLayout(w *Window) Layout {
 			Radius:     SomeF(radiusTab),
 			Disabled:   isDisabled,
 			OnClick:    onClick,
+			// SoundDisabled as well as Sound: ButtonCfg resolves its
+			// own precedence, and a resolved SoundNone reads there as
+			// "unset" and falls back to the theme. Saying both makes
+			// silence stick.
+			Sound:         tabSound,
+			SoundDisabled: tabSound == SoundNone,
 			Content: []View{
 				Text(TextCfg{Text: item.Label, TextStyle: ts}),
 			},

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -11,6 +11,17 @@ type ThemePickerCfg struct {
 	Sizing       Sizing
 	FloatAnchor  floatAttach
 	FloatTieOff  floatAttach
+
+	// Sound overrides the theme's toggle cue for this instance.
+	// SoundNone (the zero value) takes the theme's cue for that role,
+	// which is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses the picker's sound regardless of the theme
+	// and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // ThemePicker creates a palette icon that opens a dropdown of
@@ -88,6 +99,15 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 		}))
 	}
 
+	// The click opens or closes the dropdown, so the cue names what it
+	// is about to do (issue #467). Picking a theme from the list is
+	// the ListBox's own selection cue, not this one.
+	themeCue := guiTheme.Sounds.ToggleOn
+	if isOpen {
+		themeCue = guiTheme.Sounds.ToggleOff
+	}
+	soundCue := resolveSoundCue(themeCue, cfg.Sound, cfg.SoundDisabled)
+
 	colorFocus := guiTheme.toggleStyle.ColorFocus
 	colorBorderFocus := guiTheme.toggleStyle.ColorBorderFocus
 
@@ -101,6 +121,7 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 		},
 		Sizing:  cfg.Sizing,
 		Padding: PaddingSmall,
+		Sound:   soundCue,
 		OnClick: func(ctx EventCtx) {
 			ss := StateMap[string, bool](ctx.Window, nsSelect, capModerate)
 			ss.Clear()

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -34,6 +34,20 @@ type ToastCfg struct {
 	// Severity picks the accent color and icon.
 	// exportaudit:keep — caller-facing config (issue #372)
 	Severity ToastSeverity
+
+	// Sound overrides the theme's click cue for this toast's action
+	// and dismiss buttons. SoundNone (the zero value) takes
+	// Theme.Sounds.Click, which is itself silent unless the app opted
+	// in (issue #446). Severity does not pick the cue: an error toast
+	// is a report, and the failure it reports has already sounded
+	// wherever it happened (issue #467).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this toast's button sounds regardless
+	// of the theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // toastNotification is an active toast instance.
@@ -177,9 +191,11 @@ func toastItemView(toast *toastNotification, style ToastStyle) View {
 	if toast.cfg.ActionLabel != "" && toast.cfg.OnAction != nil {
 		onAction := toast.cfg.OnAction
 		buttons = append(buttons, Button(ButtonCfg{
-			ID:      toastBtnID(id, "action"),
-			Color:   ColorTransparent,
-			Content: []View{Text(TextCfg{Text: toast.cfg.ActionLabel, TextStyle: style.TextStyle})},
+			ID:            toastBtnID(id, "action"),
+			Color:         ColorTransparent,
+			Sound:         toast.cfg.Sound,
+			SoundDisabled: toast.cfg.SoundDisabled,
+			Content:       []View{Text(TextCfg{Text: toast.cfg.ActionLabel, TextStyle: style.TextStyle})},
 			OnClick: func(ctx EventCtx) {
 				onAction(ctx)
 				toastStartExit(ctx.Window, id)
@@ -187,9 +203,11 @@ func toastItemView(toast *toastNotification, style ToastStyle) View {
 		}))
 	}
 	buttons = append(buttons, Button(ButtonCfg{
-		ID:         toastBtnID(id, "dismiss"),
-		Color:      ColorTransparent,
-		SizeBorder: NoBorder,
+		ID:            toastBtnID(id, "dismiss"),
+		Color:         ColorTransparent,
+		Sound:         toast.cfg.Sound,
+		SoundDisabled: toast.cfg.SoundDisabled,
+		SizeBorder:    NoBorder,
 		Content: []View{Text(TextCfg{
 			Text: "\u00d7", TextStyle: glyphStyle(style.TextStyle),
 		})},

--- a/gui/view_tree.go
+++ b/gui/view_tree.go
@@ -64,6 +64,19 @@ type TreeCfg struct {
 	Disabled    bool
 	Invisible   bool
 	Reorderable bool
+
+	// Sound overrides the theme's cue for a row activation. A row
+	// with children toggles, so it takes the toggle role; a leaf row
+	// selects, so it takes the selection role. SoundNone (the zero
+	// value) takes the theme's cue for whichever role applies, which
+	// is itself silent unless the app opted in (issue #446).
+	// exportaudit:keep — caller-facing config (issue #467)
+	Sound SoundCue
+
+	// SoundDisabled suppresses every row's sound regardless of the
+	// theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #467)
+	SoundDisabled bool
 }
 
 // TreeNodeCfg configures a single tree node.

--- a/gui/view_tree_rows.go
+++ b/gui/view_tree_rows.go
@@ -139,6 +139,21 @@ func treeArrowIcon(row treeFlatRow) string {
 	return IconDropRight
 }
 
+// treeRowSound resolves the cue one row's activation emits. A row with
+// children opens or closes, so the cue names what the click will do; a
+// leaf row picks one node out of the tree, which is a selection
+// (issue #467).
+func treeRowSound(cfg *TreeCfg, row treeFlatRow) SoundCue {
+	themeCue := guiTheme.Sounds.Selection
+	if row.HasChildren {
+		themeCue = guiTheme.Sounds.ToggleOn
+		if row.IsExpanded {
+			themeCue = guiTheme.Sounds.ToggleOff
+		}
+	}
+	return resolveSoundCue(themeCue, cfg.Sound, cfg.SoundDisabled)
+}
+
 func treeRowView(
 	cfg TreeCfg,
 	row treeFlatRow,
@@ -174,6 +189,7 @@ func treeRowView(
 	rootFocusID := cfg.ID
 	onSelect := cfg.OnSelect
 	onLazyLoad := cfg.OnLazyLoad
+	rowSound := treeRowSound(&cfg, row)
 
 	return Row(ContainerCfg{
 		A11YRole:  AccessRoleTreeItem,
@@ -187,6 +203,7 @@ func treeRowView(
 		),
 		Sizing:  FillFit,
 		Spacing: NoSpacing,
+		Sound:   rowSound,
 		Content: treeRowContentViews(row, iconWidth),
 		OnClick: func(ctx EventCtx) {
 			treeRowClick(
@@ -232,6 +249,9 @@ func treeDragRowView(
 	onReorder := cfg.OnReorder
 	treeID := cfg.ID
 	layoutID := treeRowID(cfg.ID, row.ID)
+	// Same cue as the plain row: the drag this handler also starts has
+	// no activation moment to sound at (issue #467).
+	rowSound := treeRowSound(&cfg, row)
 
 	return Row(ContainerCfg{
 		ID:        layoutID,
@@ -246,6 +266,7 @@ func treeDragRowView(
 		),
 		Sizing:  FillFit,
 		Spacing: NoSpacing,
+		Sound:   rowSound,
 		Content: treeRowContentViews(row, iconWidth),
 		OnClick: func(ctx EventCtx) {
 			dragReorderStart(dragReorderStartCfg{


### PR DESCRIPTION
Closes #467. Phase 2 of widget audio feedback (phase 1: #446).

Carries the opt-in sound seam to every remaining mechanical widget and to `gui/datagrid`. Still silent by default — an app opts in via `theme.Sounds = gui.SoundsDefault()` plus `SetSoundPlayer`, same as #446.

**New**

- `SoundSelection` / `SoundSet.Selection` — selection semantics (radio, list row, tab, calendar day) distinct from `Click`. `SoundsDefault()` fills it.
- `ResolveSoundCue` exported so `gui/datagrid` (outside `gui/`) resolves through the same precedence without re-deriving or reading the package-global theme. Grid reads `CurrentTheme().Sounds` once per generate.

**Widgets now emitting**

`Switch`, `Radio`, `RadioButtonGroup`, `ExpandPanel`, `ColorSwatch`, `Breadcrumb`, `ThemePicker`, `Select`, `Combobox`, `ListBox`, `Tree`, `TabControl`, `MenuItem`, `Dialog` (all five buttons → `Click`), `Toast`, `DatePicker`, `CommandPalette`, `DockLayout`, `Image`, `Svg`, plus `DataGrid` header sort (`Selection`) and row activation (`Click`). Each gained `Sound` / `SoundDisabled` following the existing `Button`/`Toggle` pattern; resolved cues fed into nested `ButtonCfg`/`ToggleCfg` carry `SoundDisabled: cue == SoundNone` so they do not fall back to the theme click.

**Silent by design** (no regression): toast scrim, context-menu dismiss layer, scrollbar tracks, command-palette card, `DatePicker` field, caret-placement click inside `Input`, and `gui.Text` (shared handler, out of scope).

**Docs & showcase**

- `docs/specs/widget-audio-feedback.md` — phase 2 decisions
- `docs/widget-sound.md` + `examples/showcase/docs/widget_sound.md` + `docs/dx-cheat-sheet.md` + `examples/showcase/sound_player.go`

**Tests**

- `gui/sound_widgets_test.go` — per-widget cue pinning + muted / silent-theme negative
- `gui/datagrid/sound_test.go` — grid header/row cues through `ResolveSoundCue`

No `and update issue 46` — #46 (Linux XIM IME) is unrelated and remains tracked separately; this PR does not touch `gui/backend/gl/`.

Verified: `make prepush` green (race ~88 packages, lint 0 issues, coverage 84.7%, exportaudit clean).