### PR TITLE
docs: reorder README tagline→showcase→code→capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,35 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/go-gui-org/go-gui)
 [![Wiki](https://img.shields.io/badge/docs-wiki-blue)](https://github.com/go-gui-org/go-gui/wiki)
 
-**Cross-platform, hybrid immediate-mode GUI framework for Go — no virtual DOM,
-no diffing, just fast, composable UI.**
+**A modern GUI framework for Go.**
+
+**Build modern, cross-platform applications entirely in Go — no browser runtime,
+no JavaScript, HTML, or CSS.**
+
+Write your UI entirely in Go. Your data stays in Go structs. Your UI stays in Go
+code. Render with native GPU acceleration — Metal on macOS, cgo-free OpenGL on
+Linux and Windows, and WebGL/WASM in the browser.
+
+https://go-gui.com · [Documentation](https://github.com/go-gui-org/go-gui/wiki)
+· [Showcase](https://go-gui-org.github.io/showcase/)
+
+---
+
+## Showcase
+
+![showcase](assets/showcase.png)
+
+Explore the widgets, layouts, animation, text rendering, and other capabilities
+interactively. Every demo includes built-in documentation.
+
+**[Open the Showcase →](https://go-gui-org.github.io/showcase/)** _Zero install.
+Instant evaluation._
+
+---
+
+## It's just Go
+
+Your UI is Go code. Your state is Go data. Your application is a Go program.
 
 ```go
 package main
@@ -43,10 +70,85 @@ func mainView(w *gui.Window) gui.View {
 }
 ```
 
-`gui.Label(text, style)` — pass the zero `TextStyle{}` for the default theme
-style. `gui.TextButton(id, label, onClick)` and `gui.SimpleWindow` are the same
-thin forwards. The `ID` argument stays explicit because identity is
-caller-owned.
+`gui.Label(text, style)` uses the default theme style with `TextStyle{}`.
+`gui.TextButton(id, label, onClick)` and `gui.SimpleWindow` are thin convenience
+forms. The `ID` argument stays explicit because identity is caller-owned.
+
+See [`examples/get_started/`](examples/get_started/) for the full runnable
+version and [`examples/web_demo/`](examples/web_demo/) for the browser build.
+
+Guides: [Debugging](https://github.com/go-gui-org/go-gui/wiki/Debugging) ·
+[Theming](https://github.com/go-gui-org/go-gui/wiki/Theming) ·
+[Testing](https://github.com/go-gui-org/go-gui/wiki/Testing)
+
+---
+
+## What it can do
+
+Go-Gui takes a different approach: a pure-Go UI with native GPU rendering. There
+is no browser runtime, JavaScript bridge, or web stack underneath your
+application.
+
+Go-Gui is also an ecosystem of composable libraries. **go-glyph** handles text,
+**go-charts** handles data visualization, and **go-edit** provides code editing
+— each usable independently or together.
+
+- **50+ widgets** — buttons, inputs, sliders, tables, trees, tabs, menus,
+  dialogs, toasts, DataGrid with CSV/XLSX/PDF export, Markdown and RTF views,
+  SVG rendering, and more
+- **Virtualized data** — `ListBox`, `Table`, and `Tree` virtualize rows they
+  own. `VirtualList` handles rows the app builds, including rows whose height is
+  known only during layout. `Window.ScrollToIndex` can address a row that does
+  not exist yet
+- **GPU-accelerated rendering** — Metal on macOS, OpenGL on Linux and Windows,
+  WebGL/WASM in the browser, and Metal/UIKit on iOS
+- **Rich interaction** — keyframe, spring, and tween animation, hero
+  transitions, gestures, scrolling, focus management, color filters, box
+  shadows, and blur effects
+- **Professional text & accessibility** — text shaping, rendering, bidirectional
+  layout, font fallback, IME, spell checking, and full accessibility support
+- **Native application integration** — file dialogs, menus, notifications,
+  printing, PDF, system tray, and other platform services
+- **Developer tools** — time-travel debugging, headless testing, headless
+  rendering, layout inspection, and pixel-level regression testing
+
+![gallery](assets/gallery.png)
+
+### Go-Gui ecosystem
+
+Build on a collection of composable Go libraries that share the same rendering
+pipeline and event system.
+
+- **go-charts** — Interactive chart widgets.
+  https://github.com/go-gui-org/go-charts
+- **go-edit** — Code editor widget. https://github.com/go-gui-org/go-edit
+- **go-map** — SMIL map widgets. https://github.com/go-gui-org/go-map
+- **go-term** — Embeddable terminal emulator.
+  https://github.com/go-gui-org/go-term
+- **go-glyph** — Text rendering engine. https://github.com/go-gui-org/go-glyph
+
+### Example applications
+
+- **go-kite** — Desktop Bluesky client. https://github.com/go-gui-org/go-kite
+
+---
+
+## Under the Hood
+
+Hybrid immediate-mode UI with a retained widget tree. No virtual DOM, no diffing
+— each frame rebuilds the UI from your view function, then the framework handles
+layout, rendering, input, and state persistence.
+
+```text
+View fn → generateViewLayout() → Layout tree
+  → layoutArrange() (Fit/Fixed/Fill sizing)
+  → renderLayout() (emits into w.renderers)
+  → Backend (Metal on macOS; native GL on Linux/Windows; WebGL/WASM on web)
+```
+
+One typed state slot per window (`gui.State[T](w)`), plus per-widget internal
+state via `StateMap`. See [`docs/architecture.md`](docs/architecture.md) for the
+full pipeline, event dispatch, and backend layer.
 
 ### Full control
 
@@ -72,96 +174,6 @@ gui.Button(gui.ButtonCfg{
 })
 ```
 
-See [`examples/get_started/`](examples/get_started/) for the full runnable
-version and [`examples/web_demo/`](examples/web_demo/) for the browser build.
-
----
-
-https://go-gui.com
-
-[Documentation](https://github.com/go-gui-org/go-gui/wiki)
-
-Guides: [Debugging](https://github.com/go-gui-org/go-gui/wiki/Debugging) ·
-[Theming](https://github.com/go-gui-org/go-gui/wiki/Theming) ·
-[Testing](https://github.com/go-gui-org/go-gui/wiki/Testing)
-
----
-
-## Try It
-
-| Platform       | Download                                                                                        |
-| -------------- | ----------------------------------------------------------------------------------------------- |
-| Browser (WASM) | [**Open Showcase**](https://go-gui-org.github.io/showcase/) — zero install, instant evaluation  |
-| macOS          | [Go-Gui-Showcase-\<version\>.dmg](https://github.com/go-gui-org/go-gui/releases)                |
-| Linux          | [go-gui-showcase-\<version\>-linux-amd64.tar.gz](https://github.com/go-gui-org/go-gui/releases) |
-| Windows        | [go-gui-showcase-\<version\>-windows-amd64.zip](https://github.com/go-gui-org/go-gui/releases)  |
-
-![showcase](assets/showcase.png)
-
-_Showcase contains the framework documentation. Every widget demo has a button
-in the upper-right corner that displays documentation about the widget._
-
-Sibling projects:
-
-- **go-charts**\
-  Interactive chart widgets. https://github.com/go-gui-org/go-charts
-
-- **go-edit**\
-  Code editor widget. https://github.com/go-gui-org/go-edit
-
-- **go-kite**\
-  Desktop Bluesky client. https://github.com/go-gui-org/go-kite
-
-- **go-map**\
-  SMIL map widgets. https://github.com/go-gui-org/go-map
-
-- **go-term**\
-  Embeddable terminal emulator. https://github.com/go-gui-org/go-term
-
-- **go-glyph**\
-  Text rendering engine. https://github.com/go-gui-org/go-glyph
-
-## Why
-
-GUI frameworks in Go target the browser and tie you to HTML/CSS and JavaScript.
-go-gui takes the opposite approach: write your UI in pure Go, render it with
-native GPU acceleration — no browser runtime, no JavaScript bridge, no DOM. Your
-data stays in Go structs. Your UI stays in Go code.
-
-The second thesis: a GUI toolkit is an **ecosystem of composable libraries**,
-not a monolith. go-glyph handles text. go-charts handles data. go-edit handles
-code. Each library is usable on its own or together — all sharing the same
-rendering pipeline and event system.
-
-## Features
-
-- **50+ widgets** — buttons, inputs, sliders, tables, trees, tabs, menus,
-  dialogs, toasts, DataGrid with virtualization (CSV/XLSX/PDF export), Markdown
-  and RTF views, SVG rendering, and more
-- **Virtualized lists, uniform or not** — `ListBox`, `Table` and `Tree`
-  virtualize rows they own. `VirtualList` handles rows the app builds, of
-  heights only the layout engine knows, and `Window.ScrollToIndex` addresses a
-  row that does not exist yet
-- **GPU-accelerated** — Metal (macOS), OpenGL (Linux/Windows), WebGL/WASM
-  (browser), Metal/UIKit (iOS)
-- **Animation subsystem** — keyframe, spring, tween, hero transitions, color
-  filters, box shadows, blur effects
-- **Touch gesture recognition** — tap, double-tap, long-press, pan, swipe,
-  pinch, rotate with automatic mouse-event synthesis
-- **Time-travel debugging** — opt-in scrubber rewinds/replays app state
-  frame-by-frame. Implement `Snapshotter` on your state type and set
-  `DebugTimeTravel: true`
-- **Headless testing** — all layout and widget logic runs without a display
-- **Headless rendering** — `gui/backend/soft` rasterizes a frame to a PNG on the
-  CPU, with real text metrics and no GPU, for CI screenshots and pixel-level
-  regression tests
-- **Cross-platform integration** — native file dialogs, menus, notifications,
-  print/PDF, system tray, IME, a11y, spell check
-- **go-glyph powered** — professional text shaping, rendering, bidirectional
-  layout
-
-![gallery](assets/gallery.png)
-
 ---
 
 ## Installation
@@ -180,11 +192,20 @@ See the
 [Installation Guide](https://github.com/go-gui-org/go-gui/wiki/Installation) for
 platform-specific instructions.
 
+### Showcase downloads
+
+| Platform       | Download                                                                                       |
+| -------------- | ---------------------------------------------------------------------------------------------- |
+| Browser (WASM) | [**Open Showcase**](https://go-gui-org.github.io/showcase/) — zero install, instant evaluation |
+| macOS          | [Go-Gui-Showcase-<version>.dmg](https://github.com/go-gui-org/go-gui/releases)                 |
+| Linux          | [go-gui-showcase-<version>-linux-amd64.tar.gz](https://github.com/go-gui-org/go-gui/releases)  |
+| Windows        | [go-gui-showcase-<version>-windows-amd64.zip](https://github.com/go-gui-org/go-gui/releases)   |
+
 ---
 
 ## Contributing
 
-1. Install **Go 1.26+** (a C toolchain too if developing on macOS, see
+1. Install **Go 1.26+** (a C toolchain too if developing on macOS; see
    [Installation](#installation)).
 2. Clone the repo.
 3. Run tests and lint:


### PR DESCRIPTION
**What:** Reorder README to strongest developer pitch.

- Tagline + promise first: "A modern GUI framework for Go" / "Build modern, cross-platform applications entirely in Go — no browser runtime, no JavaScript, HTML, or CSS."
- Showcase immediately after promise (hero image + Open Showcase CTA; table moved to Showcase downloads under Installation).
- Rename code intro to "It's just Go" with hook "Your UI is Go code...".
- What it can do: group 50+ widgets, virtualized data, GPU, rich interaction, text/a11y, native integration, dev tools; split ecosystem vs example apps.
- Under the Hood last: hybrid immediate-mode/no diffing + Full control block.

No material deleted, only reordered. `make fmt-md` passes. Companion site sync in go-gui-org.github.io@06198d0.

**Why:** Align README with "What is it? → Show me → What does writing it feel like? → What can it do? → How does it work?" per website sync discussion.