### PR TITLE
feat(canvas): add Translate/ScaleBy transform stack (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ and this project adheres to
 
 ### Added
 
+- **Canvas transform stack** (#474) — `DrawContext` gained `Translate`,
+  `ScaleBy`, `Save` and `Restore`, so drawing code written once in its own
+  coordinate space can be placed and resized without transforming a single
+  coordinate by hand. Both are relative and compose: `Translate(dx, dy)` shifts
+  the origin in current local units, `ScaleBy` multiplies the scale on each
+  axis, and `Save`/`Restore` bracket a change so it cannot leak into what
+  follows. `Restore` on an empty stack does nothing — `OnDraw` runs inside the
+  frame, so a panic there would take the window down.
+
+  The method is `ScaleBy`, not `Scale`, because `DrawContext.Scale` is the
+  device pixel ratio field. It is unrelated and unchanged.
+
+  The transform applies to everything: positions, stroke widths, font sizes,
+  image rects and gradients. Geometry is not rewritten on the CPU — the matrix
+  rides on the render command, where every backend already applies it — so a
+  transformed canvas costs no more per vertex than an untransformed one. Four
+  limits follow from that: curves are flattened in local space, so scaling a
+  circle up leaves it as faceted as the unscaled one; a non-uniform scale
+  positions and sizes a text run but does not shear its glyphs; a negative scale
+  moves an image's rect but never mirrors its content; and a concentric radial
+  gradient under a non-uniform scale gives up the single-quad shader path for
+  the ring mesh, which is more triangles for the same picture.
+
+  `TextWidth` and `FontHeight` answer in local units — the space `Text` takes
+  its arguments in — so their results must not be scaled again. A transform
+  derived from application state is an `OnDraw` input like any other: bump
+  `DrawCanvasCfg.Version` when it changes, or the cached tessellation is reused.
+
+  A `DrawRecorder` (SVG/PDF export) receives transformed coordinates, so
+  existing implementations need no change. PDF export now honors a command's
+  affine, which also fixes animated SVG printing at the wrong position. New:
+  `DrawCanvasTriBatch.Transform`. See `examples/draw_canvas` and
+  `docs/specs/draw-canvas-transform.md`.
+
 - **Frameless windows** (#473) — `WindowCfg.Decorations` selects the native
   window frame. `gui.DecorationNone` removes it entirely;
   `DecorationHiddenTitlebar` hides the macOS title bar while leaving the window

--- a/docs/specs/draw-canvas-transform.md
+++ b/docs/specs/draw-canvas-transform.md
@@ -1,0 +1,171 @@
+# Canvas transform stack
+
+Status: implemented. Issue #474.
+
+## Problem
+
+`gui.DrawContext` accepted only absolute pixel coordinates. Any responsive
+layout or viewport zoom made the caller transform every coordinate by hand
+before every draw call, and a drawing routine could not be reused at a second
+position or size without being rewritten to take an offset and a factor.
+
+## Design
+
+Four methods, all relative:
+
+```go
+func (dc *DrawContext) Translate(dx, dy float32)
+func (dc *DrawContext) ScaleBy(sx, sy float32)
+func (dc *DrawContext) Save()
+func (dc *DrawContext) Restore()
+```
+
+The transform is the axis-aligned affine `p' = (p.x*sx + tx, p.y*sy + ty)` —
+scale per axis plus translation, no rotation and no shear. That group is closed
+under composition, so an arbitrarily deep nest collapses to four floats.
+
+Composition follows HTML canvas:
+
+- `Translate(dx, dy)` → `tx += dx*sx; ty += dy*sy`. The offset is in current
+  local units, so a `Translate` after a `ScaleBy` moves by scaled units.
+- `ScaleBy(ax, ay)` → `sx *= ax; sy *= ay`. Scaling happens about the current
+  origin, so the translation is untouched.
+
+## Decisions
+
+### Geometry carries the matrix, not the vertices
+
+The active transform is stamped on `DrawCanvasTriBatch` at `takeBatch`, and
+`emitDrawCanvasGeometry` copies it onto `RenderCmd.HasXform` and its four
+fields. Those fields predate this feature — the SVG animation path already used
+them — and every renderer (`gui/backend/{gl,metal,web,ios,android}` plus `soft`)
+already applies `v*S + T` before the command origin and scale. No backend
+changed.
+
+Two reasons this beat baking coordinates at each drawing method:
+
+1. **Delegation.** `Line` calls `Polyline`, `Circle` calls `Arc` calls
+   `Polyline`, `FilledCircle` calls `FilledArc`. Baking at each public entry
+   would apply the transform twice on every one of those paths. Stamping the
+   batch makes a nested call append into an already-transformed batch, so the
+   transform applies exactly once by construction.
+2. **Cost.** Nothing is rewritten per vertex. Stroke widths, dash lengths, miter
+   joins and per-vertex gradient colors are all computed in local space and
+   mapped afterwards, so they scale for free.
+
+The price is that curve flattening picks its segment count in local space: a
+circle scaled up by 10 is as faceted as the unscaled one. Fixing it means
+feeding `max(|sx|, |sy|)` into `arcPoints` and the bezier tolerance, which is a
+follow-up, not a blocker.
+
+A transform change joins the run-length merge key in `getBatch`, because a batch
+carries one matrix for all its triangles.
+
+### `ScaleBy`, not `Scale`
+
+`DrawContext.Scale` is an existing public field holding the device pixel ratio.
+Renaming it to free the name would break `go-map`, `go-term` and `go-charts` for
+a cosmetic gain. `ScaleBy` also reads more correctly for an accumulating
+operation, and pairs with `Translate`.
+
+### Leaves bake
+
+Text, images and the lowered radial gradient bake their coordinates at record
+time. `RenderText`, `RenderImage` and `RenderGradient` have no xform fields to
+ride on, and all three are leaves — no primitive delegates to them — so baking
+there cannot double-apply.
+
+A text style's px fields scale too: `Size`, `LineSpacing`, `StrokeWidth` and
+`CellHeight` by `sy`, `LetterSpacing`, `CellWidth` and `EmojiBoxWidth` by `sx`.
+Font size takes `sy` because a font size is a vertical em measure; under a
+uniform scale, the case with an unambiguous answer, every field scales alike.
+Glyphs are not sheared by a non-uniform scale: composing
+`TextStyle.AffineTransform` would allocate per entry per frame on a path kept
+allocation-free, and it collides with the existing `RotationRadians` precedence.
+
+`TextWidth` and `FontHeight` stay in local units. They answer a question about
+the same space `Text(x, y, ...)` takes its arguments in; scaling them would
+break every centering calculation.
+
+Image rects are normalized after transform, so a negative scale lands the rect
+at the mirrored position with positive extents rather than being dropped by the
+`W <= 0` guard at emit. Image content is never mirrored.
+
+### A non-uniform scale declines the radial fast path
+
+`emitRadialGradient` lowers a concentric radial fill to one shader quad whose
+ramp is always centered with radius `max(W, H)/2`. Under a non-uniform scale the
+fill is an ellipse, which that command cannot express, so `concentricRadial`
+declines and the existing `fillConcentricRings` fallback takes over. Ring
+geometry lands in a normal batch and is therefore transformed exactly. More
+triangles, same picture.
+
+### An identity transform is no transform
+
+A context transformed and then fully restored reports itself untransformed
+(`activeXform`). Stamping the identity on every later batch would break the
+run-length merge against the batches drawn before the first `Save`, and put a
+matrix on every command for no effect.
+
+### Reset, not balance-checking
+
+`resetFor` clears the transform and the stack. It runs immediately before every
+`OnDraw`, so an unbalanced `Save` cannot survive into the next redraw or into
+another canvas sharing the window's scratch context. The stack is capped at
+`maxXformDepth` so a `Save` inside a draw loop cannot grow without bound.
+`Restore` on an empty stack is a no-op: `OnDraw` runs inside the frame, and a
+panic there would take the window down over a caller's bookkeeping slip.
+
+### Recorders see baked coordinates
+
+`DrawRecorder` is exported and implemented outside this repo. Handing over local
+coordinates plus a matrix would need a wider interface and would silently
+misplace every existing implementer's export until they adopted it. Baking makes
+them all correct with no change on their side.
+
+The baking is done by `xformRecorder`, a decorator returned from `dc.rec()`,
+rather than at each of the two dozen call sites — which would both push
+`canvas_draw.go` past its 800-line gate and give delegation a second chance to
+apply the transform twice.
+
+The decorator implements every optional extension interface, so the unwrap
+helpers (`gradientRecorder`, `vertexColorRecorder`, `imageRecorder`) assert
+against the **inner** recorder. Asserting against the decorator would always
+succeed and would quietly kill the flat-triangle degradation that keeps an
+export from dropping a gradient fill.
+
+Scalars with no axis of their own — stroke widths, dash and gap lengths, corner
+radii — take the geometric mean of the two scales, exact under a uniform one. A
+circle under a non-uniform scale is handed over as a full-sweep `Arc`, which the
+recorder API expresses exactly.
+
+### Cache
+
+No new invalidation key. The transform is a pure function of the `OnDraw` body
+and the result is already in the cache entry. The existing contract stands: a
+transform derived from application state must move `DrawCanvasCfg.Version`, like
+any other `OnDraw` input.
+
+## Fixed on the way
+
+`pdfRenderSvg` ignored `RenderCmd.HasXform` entirely, so an animated SVG already
+printed at the wrong position. It now applies the affine in the same order the
+GPU and soft backends do. The mapping is split out as `svgCmdVertex` so that
+order is assertable without a PDF writer in the way.
+
+## Verification
+
+- `gui/canvas_draw_transform_test.go` — composition in both orders, nesting,
+  empty-stack `Restore`, reset across redraws, the delegation single-apply check
+  for all three delegating pairs, batch splitting and re-merging,
+  text/image/clip baking, the radial fallback, non-finite rejection, stack
+  depth, and the recorder decorator including the unwrap degradation.
+- `gui/render_draw_canvas_test.go` — the matrix reaches the command with the
+  triangles still local, and survives batch pooling across redraws.
+- `gui/print_pdf_test.go` — `svgCmdVertex` applies the affine before the origin
+  and scale.
+- Golden case `canvas_transform`. `serializeCmd` had to learn to print the
+  matrix first: the transform rides on the command, so the triangle fingerprint
+  alone is identical with and without it and the golden would have proved
+  nothing. Every pre-existing golden is byte-unchanged, which is the proof that
+  an untransformed canvas behaves exactly as before.

--- a/examples/draw_canvas/README.md
+++ b/examples/draw_canvas/README.md
@@ -1,7 +1,7 @@
 # Draw Canvas
 
-> **Framework:** graphics **Description:** Line chart and gradient fills using
-> DrawCanvas and DrawContext. Shows flat and gradient rendering primitives.
+> **Framework:** graphics **Description:** Line chart, gradient fills and the
+> translate/scale transform stack, using DrawCanvas and DrawContext.
 
 ![Preview](screenshot.png)
 
@@ -17,7 +17,13 @@ go run ./examples/draw_canvas/
 
 ## What it demonstrates
 
-Line chart and gradient fills using DrawCanvas and DrawContext. Shows flat and
-gradient rendering primitives.
+Line chart, gradient fills, per-vertex colors and the transform stack, using
+DrawCanvas and DrawContext.
+
+The Transform panel draws one `badge` function four times. The function draws in
+its own fixed 0..60 space and knows nothing about placement or size; `Translate`
+and `ScaleBy` do the rest, including scaling its stroke widths and font size.
+The last copy uses a negative scale, which mirrors the geometry but leaves the
+label readable.
 
 See `main.go` for the implementation.

--- a/examples/draw_canvas/main.go
+++ b/examples/draw_canvas/main.go
@@ -1,5 +1,6 @@
-// Draw_canvas demonstrates the DrawCanvas widget: a line chart, and
-// the gradient fills DrawContext offers alongside its flat ones.
+// Draw_canvas demonstrates the DrawCanvas widget: a line chart, the
+// gradient fills DrawContext offers alongside its flat ones, and the
+// translate/scale transform stack.
 package main
 
 import (
@@ -95,7 +96,64 @@ func mainView(w *gui.Window) gui.View {
 				Padding: gui.PadAll(16),
 				OnDraw:  drawVertexColors,
 			}),
+			gui.Text(gui.TextCfg{
+				Text:      "Transform",
+				TextStyle: gui.CurrentTheme().B1,
+			}),
+			gui.DrawCanvas(gui.DrawCanvasCfg{
+				ID:      "transform",
+				Version: 1,
+				Width:   560,
+				Height:  180,
+				Color:   gui.RGBA(30, 30, 40, 255),
+				Radius:  8,
+				Padding: gui.PadAll(16),
+				OnDraw:  drawTransform,
+			}),
 		},
+	})
+}
+
+// drawTransform draws one badge, then the same drawing code again at
+// three scales. Nothing in badge() knows about the transform: it draws
+// once, in its own 0..60 coordinate space, and Translate/ScaleBy place
+// and size every copy.
+//
+// Save and Restore bracket each copy so the transform each one sets
+// cannot leak into the next.
+func drawTransform(dc *gui.DrawContext) {
+	x := float32(0)
+	for _, scale := range []float32{1, 1.5, 2} {
+		dc.Save()
+		dc.Translate(x, 0)
+		dc.ScaleBy(scale, scale)
+		badge(dc)
+		dc.Restore()
+		// The next copy starts past this one, in canvas units.
+		x += 60*scale + 20
+	}
+
+	// A negative scale mirrors geometry. Text is positioned and sized
+	// by the transform but never mirrored, so this badge's ring and
+	// wedge flip while its label stays readable.
+	dc.Save()
+	dc.Translate(x+120, 0)
+	dc.ScaleBy(-1.5, 1.5)
+	badge(dc)
+	dc.Restore()
+}
+
+// badge draws a ring, a wedge and a label in a fixed 60x60 box. The
+// stroke width and the font size are in that same local space, so
+// both scale with the badge rather than staying at a fixed pixel size.
+func badge(dc *gui.DrawContext) {
+	dc.FilledCircle(30, 30, 26, gui.RGBA(45, 55, 80, 255))
+	dc.Circle(30, 30, 26, gui.RGBA(120, 170, 255, 255), 2)
+	dc.FilledArc(30, 30, 20, 20, -math.Pi/2, math.Pi*1.2,
+		gui.RGBA(90, 200, 160, 255))
+	dc.Text(22, 24, "go", gui.TextStyle{
+		Size:  16,
+		Color: gui.RGBA(240, 240, 250, 255),
 	})
 }
 

--- a/examples/showcase/docs/widget_draw_canvas.md
+++ b/examples/showcase/docs/widget_draw_canvas.md
@@ -83,6 +83,54 @@ dc.Image(0, 0, 64, 64,
     gui.SomeF(0.85), gui.Black)
 ```
 
+### Transform
+
+Every drawing method takes local coordinates. `Translate` and `ScaleBy` move and
+size that local space, so drawing code written once can be placed and resized
+without touching a single coordinate.
+
+| Method    | Signature        | Description                              |
+| --------- | ---------------- | ---------------------------------------- |
+| Translate | (dx, dy float32) | Shift the origin, in current local units |
+| ScaleBy   | (sx, sy float32) | Multiply the scale on each axis          |
+| Save      | ()               | Push the current transform               |
+| Restore   | ()               | Pop back to the transform `Save` pushed  |
+
+Both are relative: they compose with what is already in force rather than
+replacing it. `Save` and `Restore` bracket a change so it cannot leak into the
+drawing that follows. Restoring with an empty stack does nothing.
+
+`ScaleBy` is not called `Scale` because `DrawContext.Scale` is the device pixel
+ratio field. The two are unrelated.
+
+```go
+for i, scale := range []float32{1, 1.5, 2} {
+    dc.Save()
+    dc.Translate(float32(i)*80, 0)
+    dc.ScaleBy(scale, scale)
+    badge(dc) // draws in its own 0..60 space, unaware of any of this
+    dc.Restore()
+}
+```
+
+The transform applies to everything: positions, stroke widths, font sizes, image
+rects and gradients. A scale of 2 doubles the width of a 1px line and the size
+of a 10px font, because both are stated in local units.
+
+Four limits are worth knowing:
+
+- Curves are flattened in local space, so scaling a circle up leaves it as
+  faceted as the unscaled one. Draw it at its final size for a smooth result.
+- A non-uniform scale positions and sizes a text run but does not shear its
+  glyphs.
+- A negative scale moves an image's rect but never mirrors its content.
+- `TextWidth` and `FontHeight` answer in local units, which is the space `Text`
+  takes its arguments in. Do not scale their results.
+
+A transform that comes from application state — a zoom level, say — is an
+`OnDraw` input like any other, so bump `Version` when it changes or the cached
+tessellation is reused.
+
 ## Keyboard Focus
 
 Setting `Focusable: true` opts the canvas into tab order (with a non-empty

--- a/gui/canvas_draw.go
+++ b/gui/canvas_draw.go
@@ -43,6 +43,18 @@ type DrawContext struct {
 	// Always > 0; defaults to 1.0 when the backend has not reported a valid scale.
 	Scale float32
 
+	// xf is the active translate+scale, xfStack the Save/Restore
+	// stack, and xfActive the gate that keeps a zero-value
+	// DrawContext behaving as an untransformed one. xfPtBuf holds a
+	// transformed copy of a caller's point slice on the recorder
+	// path, and xfRec is the lazily built recorder decorator. See
+	// canvas_draw_transform.go.
+	xf       canvasXform
+	xfStack  []canvasXform
+	xfPtBuf  []float32
+	xfRec    *xformRecorder
+	xfActive bool
+
 	lastColor Color
 	// batchIsGradient marks the current batch as vertex-colored, which
 	// blocks the run-length merge below: a flat fill must never append
@@ -56,8 +68,15 @@ type DrawContext struct {
 func (dc *DrawContext) SetRecorder(r DrawRecorder) { dc.recorder = r }
 
 func (dc *DrawContext) getBatch(color Color) *DrawCanvasTriBatch {
+	// The transform joins the run-length merge key: a batch carries
+	// one matrix for all its triangles, so a transform change must
+	// start a new batch. Compared against the live batch rather than
+	// a mirror field so there is one source of truth.
+	xf, hasXf := dc.activeXform()
 	if len(dc.batches) > 0 && !dc.batchIsGradient &&
-		dc.lastColor == color {
+		dc.lastColor == color &&
+		dc.batches[dc.currentBatchIdx].hasXform == hasXf &&
+		dc.batches[dc.currentBatchIdx].xf == xf {
 		return &dc.batches[dc.currentBatchIdx]
 	}
 	b := dc.takeBatch(color, false, defaultBatchVerts)
@@ -72,7 +91,7 @@ func (dc *DrawContext) FilledRect(x, y, w, h float32, color Color) {
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.FilledRect(x, y, w, h, color)
+		dc.rec().FilledRect(x, y, w, h, color)
 		return
 	}
 	b := dc.getBatch(color)
@@ -89,7 +108,7 @@ func (dc *DrawContext) FilledRect(x, y, w, h float32, color Color) {
 // Line draws a single line segment.
 func (dc *DrawContext) Line(x0, y0, x1, y1 float32, color Color, width float32) {
 	if dc.recorder != nil {
-		dc.recorder.Line(x0, y0, x1, y1, color, width)
+		dc.rec().Line(x0, y0, x1, y1, color, width)
 		return
 	}
 	// Through a reused array rather than a literal: Polyline hands its
@@ -107,7 +126,7 @@ func (dc *DrawContext) Polyline(points []float32, color Color, width float32) {
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.Polyline(points, color, width)
+		dc.rec().Polyline(points, color, width)
 		return
 	}
 	hw := width / 2
@@ -144,7 +163,7 @@ func (dc *DrawContext) Rect(x, y, w, h float32, color Color, width float32) {
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.Rect(x, y, w, h, color, width)
+		dc.rec().Rect(x, y, w, h, color, width)
 		return
 	}
 	hw := width / 2
@@ -178,7 +197,7 @@ func (dc *DrawContext) FilledPolygon(points []float32, color Color) {
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.FilledPolygon(points, color)
+		dc.rec().FilledPolygon(points, color)
 		return
 	}
 	b := dc.getBatch(color)
@@ -188,7 +207,7 @@ func (dc *DrawContext) FilledPolygon(points []float32, color Color) {
 // FilledCircle draws a filled circle.
 func (dc *DrawContext) FilledCircle(cx, cy, radius float32, color Color) {
 	if dc.recorder != nil {
-		dc.recorder.FilledCircle(cx, cy, radius, color)
+		dc.rec().FilledCircle(cx, cy, radius, color)
 		return
 	}
 	dc.FilledArc(cx, cy, radius, radius, 0, 2*math.Pi, color)
@@ -197,7 +216,7 @@ func (dc *DrawContext) FilledCircle(cx, cy, radius float32, color Color) {
 // Circle draws a stroked circle.
 func (dc *DrawContext) Circle(cx, cy, radius float32, color Color, width float32) {
 	if dc.recorder != nil {
-		dc.recorder.Circle(cx, cy, radius, color, width)
+		dc.rec().Circle(cx, cy, radius, color, width)
 		return
 	}
 	dc.Arc(cx, cy, radius, radius, 0, 2*math.Pi, color, width)
@@ -209,7 +228,7 @@ func (dc *DrawContext) Arc(cx, cy, rx, ry, start, sweep float32, color Color, wi
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.Arc(cx, cy, rx, ry, start, sweep, color, width)
+		dc.rec().Arc(cx, cy, rx, ry, start, sweep, color, width)
 		return
 	}
 	pts := dc.arcPoints(cx, cy, rx, ry, start, sweep)
@@ -223,7 +242,7 @@ func (dc *DrawContext) Arc(cx, cy, rx, ry, start, sweep float32, color Color, wi
 // avoiding an intermediate polygon allocation.
 func (dc *DrawContext) FilledArc(cx, cy, rx, ry, start, sweep float32, color Color) {
 	if dc.recorder != nil {
-		dc.recorder.FilledArc(cx, cy, rx, ry, start, sweep, color)
+		dc.rec().FilledArc(cx, cy, rx, ry, start, sweep, color)
 		return
 	}
 	pts := dc.arcPoints(cx, cy, rx, ry, start, sweep)
@@ -292,7 +311,7 @@ func (dc *DrawContext) FilledRoundedRect(x, y, w, h, radius float32, color Color
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.FilledRoundedRect(x, y, w, h, radius, color)
+		dc.rec().FilledRoundedRect(x, y, w, h, radius, color)
 		return
 	}
 	radius = min(radius, w/2, h/2)
@@ -310,7 +329,7 @@ func (dc *DrawContext) RoundedRect(x, y, w, h, radius float32, color Color, widt
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.RoundedRect(x, y, w, h, radius, color, width)
+		dc.rec().RoundedRect(x, y, w, h, radius, color, width)
 		return
 	}
 	radius = min(radius, w/2, h/2)
@@ -348,7 +367,7 @@ func (dc *DrawContext) DashedLine(
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.DashedLine(x0, y0, x1, y1, color, width, dashLen, gapLen)
+		dc.rec().DashedLine(x0, y0, x1, y1, color, width, dashLen, gapLen)
 		return
 	}
 	dx := x1 - x0
@@ -389,7 +408,7 @@ func (dc *DrawContext) DashedPolyline(
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.DashedPolyline(points, color, width, dashLen, gapLen)
+		dc.rec().DashedPolyline(points, color, width, dashLen, gapLen)
 		return
 	}
 	patternLen := dashLen + gapLen
@@ -442,7 +461,7 @@ func (dc *DrawContext) PolylineJoined(
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.PolylineJoined(points, color, width)
+		dc.rec().PolylineJoined(points, color, width)
 		return
 	}
 	hw := width / 2
@@ -575,7 +594,7 @@ func (dc *DrawContext) QuadBezier(
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.QuadBezier(x0, y0, cx, cy, x1, y1, color, width)
+		dc.rec().QuadBezier(x0, y0, cx, cy, x1, y1, color, width)
 		return
 	}
 	dc.bezierBuf = dc.resetBezierBuf(x0, y0)
@@ -597,7 +616,7 @@ func (dc *DrawContext) CubicBezier(
 		return
 	}
 	if dc.recorder != nil {
-		dc.recorder.CubicBezier(x0, y0, c1x, c1y, c2x, c2y, x1, y1,
+		dc.rec().CubicBezier(x0, y0, c1x, c1y, c2x, c2y, x1, y1,
 			color, width)
 		return
 	}
@@ -613,8 +632,15 @@ func (dc *DrawContext) CubicBezier(
 // The position is the top-left of the text bounding box.
 func (dc *DrawContext) Text(x, y float32, text string, style TextStyle) {
 	if dc.recorder != nil {
-		dc.recorder.Text(x, y, text, style)
+		dc.rec().Text(x, y, text, style)
 		return
+	}
+	// Text bakes: RenderText has no xform fields to ride on, and Text
+	// is a leaf — no primitive delegates to it, so this cannot
+	// double-apply.
+	if _, ok := dc.activeXform(); ok {
+		x, y = dc.xf.apply(x, y)
+		style = dc.xf.scaleTextStyle(style)
 	}
 	dc.texts = append(dc.texts, DrawCanvasTextEntry{
 		X: x, Y: y, Text: text, Style: style,
@@ -670,14 +696,17 @@ func (dc *DrawContext) ImageWithFetcher(
 		return
 	}
 	if dc.recorder != nil {
-		if ir, ok := dc.recorder.(interface {
-			Image(x, y, w, h float32, src string,
-				bgOpacity Opt[float32], bgColor Color)
-		}); ok {
+		if ir, ok := dc.imageRecorder(); ok {
 			ir.Image(x, y, w, h, src, bgOpacity, bgColor)
 			return
 		}
 	}
+	// Baked and normalized: a negative scale must land the rect at
+	// the mirrored position with positive extents, or the w <= 0
+	// guard in emitDrawCanvasImages drops it. Image content is never
+	// mirrored. The finite guards above deliberately ran on the
+	// caller's values.
+	x, y, w, h = dc.xfRect(x, y, w, h)
 	dc.images = append(dc.images, DrawCanvasImageEntry{
 		X: x, Y: y, W: w, H: h,
 		Src: src, bgOpacity: bgOpacity, BgColor: bgColor,
@@ -712,7 +741,9 @@ func (dc *DrawContext) ImageClipped(
 		return // rejected (bad geometry) or routed to a recorder
 	}
 	e := &dc.images[len(dc.images)-1]
-	e.ClipX, e.ClipY, e.ClipW, e.ClipH = clipX, clipY, clipW, clipH
+	// The image rect was baked by ImageWithFetcher; the clip rect is
+	// in the same local space and bakes here.
+	e.ClipX, e.ClipY, e.ClipW, e.ClipH = dc.xfRect(clipX, clipY, clipW, clipH)
 	e.Clipped = true
 }
 

--- a/gui/canvas_draw_batch.go
+++ b/gui/canvas_draw_batch.go
@@ -30,7 +30,12 @@ const defaultBatchVerts = 64
 // they stay distinguishable from a gradient batch carrying no colors.
 func (dc *DrawContext) takeBatch(color Color, gradient bool,
 	numVerts int) *DrawCanvasTriBatch {
+	// The transform is stamped once per batch, not per vertex: the
+	// primitives append local coordinates and the matrix travels with
+	// the command. getBatch keeps a transform change from merging two
+	// matrices into one batch.
 	nb := DrawCanvasTriBatch{Color: color}
+	nb.xf, nb.hasXform = dc.activeXform()
 	if i := len(dc.batches); i < len(dc.batchPool) {
 		// Reused at any size, deliberately. A cap on it would only
 		// force a reallocation: the cache entry holds this geometry
@@ -102,6 +107,10 @@ func (dc *DrawContext) resetFor(w, h, scale float32, tm TextMeasurer,
 	dc.lastColor = Color{}
 	dc.batchIsGradient = false
 	dc.currentBatchIdx = 0
+	// The single reset point for the transform. It runs immediately
+	// before every OnDraw, so an unbalanced Save cannot survive into
+	// the next redraw or into another canvas sharing this context.
+	dc.resetXform()
 
 	dc.arcBuf = keepScratch(dc.arcBuf)
 	dc.bezierBuf = keepScratch(dc.bezierBuf)

--- a/gui/canvas_draw_colors.go
+++ b/gui/canvas_draw_colors.go
@@ -32,7 +32,7 @@ func (dc *DrawContext) FillTrianglesColors(tris []float32,
 		return
 	}
 	if dc.recorder != nil {
-		if vr, ok := dc.recorder.(DrawVertexColorRecorder); ok {
+		if vr, ok := dc.vertexColorRecorder(); ok {
 			vr.FillTrianglesColors(tris, colors)
 			return
 		}

--- a/gui/canvas_draw_gradient.go
+++ b/gui/canvas_draw_gradient.go
@@ -36,7 +36,7 @@ func (dc *DrawContext) FillTrianglesGradient(tris []float32,
 		return
 	}
 	if dc.recorder != nil {
-		if gr, ok := dc.recorder.(DrawGradientRecorder); ok {
+		if gr, ok := dc.gradientRecorder(); ok {
 			gr.FillTrianglesGradient(tris, g)
 			return
 		}
@@ -131,7 +131,7 @@ func (dc *DrawContext) recordTriangles(tris []float32, cols []Color,
 			v := i / 2
 			col = meanColor(cols[v : v+3])
 		}
-		dc.recorder.FilledPolygon(tri[:], col)
+		dc.rec().FilledPolygon(tri[:], col)
 	}
 }
 
@@ -157,7 +157,7 @@ func (dc *DrawContext) gradientRecorderFallback(
 	if dc.recorder == nil {
 		return Color{}, false
 	}
-	if _, ok := dc.recorder.(DrawGradientRecorder); ok {
+	if _, ok := dc.gradientRecorder(); ok {
 		// The recorder handles gradients; let the shape tessellate and
 		// hand the geometry over in FillTrianglesGradient.
 		return Color{}, false
@@ -179,7 +179,7 @@ func (dc *DrawContext) FilledRectGradient(x, y, w, h float32,
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
-		dc.recorder.FilledRect(x, y, w, h, mid)
+		dc.rec().FilledRect(x, y, w, h, mid)
 		return
 	}
 	dst := dc.gradScratch()
@@ -225,6 +225,14 @@ func (dc *DrawContext) FilledCircleGradient(cx, cy, radius float32,
 func (dc *DrawContext) concentricRadial(cx, cy, r float32,
 	g *CanvasGradient) bool {
 	if dc.recorder != nil || g == nil || len(g.Stops) == 0 {
+		return false
+	}
+	// A non-uniform canvas transform turns the circle into an
+	// ellipse, and the shader quad below cannot express one: its ramp
+	// is always centered with radius max(W,H)/2. Decline, and the
+	// caller falls back to the ring mesh, which lands in a normal
+	// batch and so is transformed exactly, ellipse included.
+	if xf, ok := dc.activeXform(); ok && !xf.uniform() {
 		return false
 	}
 	if !g.Radial || g.Spread != SpreadPad || !(r > 0) {
@@ -304,8 +312,12 @@ func (dc *DrawContext) emitRadialGradient(cx, cy, r float32,
 	// overwrites, while this list has to outlive the whole redraw.
 	e.Def.Stops = append(e.Def.Stops[:0], stops...)
 	e.Def.Type = GradientRadial
-	e.X, e.Y = cx-r, cy-r
-	e.W, e.H = 2*r, 2*r
+	// Baked: RenderGradient has no xform fields to ride on. The scale
+	// is uniform here (concentricRadial declined otherwise), so the
+	// circle stays a circle and |sx| is the whole story.
+	// xfRect normalizes, so a negative (mirroring) scale still yields
+	// the bounding square's top-left corner rather than its far one.
+	e.X, e.Y, e.W, e.H = dc.xfRect(cx-r, cy-r, 2*r, 2*r)
 	e.afterBatch = len(dc.batches)
 	return true
 }
@@ -470,7 +482,7 @@ func (dc *DrawContext) concentricRings(stops []GradientStop,
 func (dc *DrawContext) FilledArcGradient(cx, cy, rx, ry, start,
 	sweep float32, g *CanvasGradient) {
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
-		dc.recorder.FilledArc(cx, cy, rx, ry, start, sweep, mid)
+		dc.rec().FilledArc(cx, cy, rx, ry, start, sweep, mid)
 		return
 	}
 	pts := dc.arcPoints(cx, cy, rx, ry, start, sweep)
@@ -490,7 +502,7 @@ func (dc *DrawContext) FilledPolygonGradient(points []float32,
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
-		dc.recorder.FilledPolygon(points, mid)
+		dc.rec().FilledPolygon(points, mid)
 		return
 	}
 	dst := dc.gradScratch()
@@ -506,7 +518,7 @@ func (dc *DrawContext) FilledRoundedRectGradient(x, y, w, h,
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
-		dc.recorder.FilledRoundedRect(x, y, w, h, radius, mid)
+		dc.rec().FilledRoundedRect(x, y, w, h, radius, mid)
 		return
 	}
 	radius = min(radius, w/2, h/2)

--- a/gui/canvas_draw_transform.go
+++ b/gui/canvas_draw_transform.go
@@ -1,0 +1,485 @@
+package gui
+
+import "math"
+
+// canvas_draw_transform.go — the translate + scale stack for
+// DrawContext (issue #474).
+//
+// The transform is the axis-aligned affine
+//
+//	p' = (p.x*sx + tx, p.y*sy + ty)
+//
+// — scale per axis plus translation, with no rotation and no shear.
+// That group is closed under composition, so an arbitrarily deep
+// Save/Translate/ScaleBy nest collapses to four floats. That is what
+// makes the geometry path free: the four floats ride on the batch and
+// then on the RenderCmd, where every backend already applies them per
+// vertex, so no triangle is ever rewritten on the CPU.
+//
+// Geometry therefore does NOT bake. Text, images and the lowered
+// radial gradient do bake, at record time, because their render
+// commands have no xform fields to ride on. They are also the three
+// paths with no primitive-to-primitive delegation, so baking there
+// cannot double-apply.
+//
+// Documented limits, all consequences of the design above:
+//
+//   - Curve flattening (arcPoints, the bezier subdivision) picks its
+//     segment count in LOCAL space, so scaling a circle up by 10x
+//     leaves it as faceted as the unscaled one. Drawing it at its
+//     final size gives a smoother result.
+//   - A non-uniform scale positions and sizes a text run but does not
+//     shear its glyphs.
+//   - A negative scale moves an image's rect but never mirrors its
+//     content.
+//   - A concentric radial gradient under a non-uniform scale gives up
+//     the single-quad shader path and falls back to the ring mesh,
+//     which transforms exactly.
+
+// maxXformDepth bounds the Save stack. A Save inside a per-frame draw
+// loop with no matching Restore would otherwise grow the slice without
+// limit for as long as the canvas keeps redrawing.
+const maxXformDepth = 256
+
+// canvasXform is the CTM. Its zero value is NOT the identity — the
+// identity is {1, 1, 0, 0} — which is why DrawContext gates on
+// xfActive rather than on the field values. A zero-value DrawContext
+// literal (tests build them directly) must behave exactly as it did
+// before this file existed.
+type canvasXform struct {
+	sx, sy, tx, ty float32
+}
+
+// identityXform is the transform a context starts every redraw with.
+var identityXform = canvasXform{sx: 1, sy: 1}
+
+// apply maps one point from local space to canvas space.
+func (x canvasXform) apply(px, py float32) (float32, float32) {
+	return px*x.sx + x.tx, py*x.sy + x.ty
+}
+
+// meanScale is the scale to apply to a length that has no axis of its
+// own — a stroke width, a dash length, a corner radius. The geometric
+// mean is exact under a uniform scale, which is the case that has a
+// right answer at all.
+func (x canvasXform) meanScale() float32 {
+	return float32(math.Sqrt(math.Abs(float64(x.sx * x.sy))))
+}
+
+// uniform reports whether the two axes scale alike. The radial
+// gradient's single-quad path and the recorder's circle methods both
+// need to know, because neither can express an ellipse.
+func (x canvasXform) uniform() bool { return x.sx == x.sy }
+
+// Translate shifts the origin by (dx, dy) measured in the CURRENT
+// local units, so a Translate after a ScaleBy moves by scaled units —
+// the same composition order HTML canvas uses.
+//
+// Composition: p -> (p+d)*S + T = p*S + (T + d*S).
+//
+// Non-finite arguments are ignored rather than poisoning every
+// subsequent vertex.
+func (dc *DrawContext) Translate(dx, dy float32) {
+	if !isFiniteF(dx) || !isFiniteF(dy) {
+		return
+	}
+	dc.ensureXform()
+	dc.xf.tx += dx * dc.xf.sx
+	dc.xf.ty += dy * dc.xf.sy
+}
+
+// ScaleBy multiplies the current scale by (sx, sy). It is named
+// ScaleBy, not Scale, because DrawContext.Scale is the device pixel
+// ratio field and predates this API; the two are unrelated.
+//
+// Composition: p -> (p*A)*S + T = p*(S*A) + T, so the translation is
+// untouched and scaling happens about the current origin.
+//
+// A zero scale is allowed and collapses geometry. Non-finite
+// arguments are ignored.
+func (dc *DrawContext) ScaleBy(sx, sy float32) {
+	if !isFiniteF(sx) || !isFiniteF(sy) {
+		return
+	}
+	dc.ensureXform()
+	dc.xf.sx *= sx
+	dc.xf.sy *= sy
+}
+
+// Save pushes the current transform so a later Restore can return to
+// it. Pushes past maxXformDepth are dropped, which unbalances the
+// stack rather than growing it without limit; the reset at the top of
+// every redraw is what actually contains the damage.
+func (dc *DrawContext) Save() {
+	dc.ensureXform()
+	if len(dc.xfStack) >= maxXformDepth {
+		return
+	}
+	dc.xfStack = append(dc.xfStack, dc.xf)
+}
+
+// Restore pops the transform Save pushed. Restoring with an empty
+// stack is a no-op: OnDraw runs inside the frame, so a panic here
+// would take the whole window down over a caller's bookkeeping slip.
+func (dc *DrawContext) Restore() {
+	n := len(dc.xfStack)
+	if n == 0 {
+		return
+	}
+	dc.xf = dc.xfStack[n-1]
+	dc.xfStack = dc.xfStack[:n-1]
+}
+
+// ensureXform promotes the zero value to the identity the first time
+// any transform method runs. After this dc.xf is meaningful and
+// dc.xfActive gates every consumer.
+func (dc *DrawContext) ensureXform() {
+	if !dc.xfActive {
+		dc.xf = identityXform
+		dc.xfActive = true
+	}
+}
+
+// resetXform returns the context to "no transform" for the next
+// redraw. Called from resetFor, which runs immediately before every
+// OnDraw, so an unbalanced Save cannot leak into the next frame or
+// into another canvas sharing the window's scratch context.
+func (dc *DrawContext) resetXform() {
+	dc.xf = canvasXform{}
+	dc.xfActive = false
+	dc.xfStack = dc.xfStack[:0]
+}
+
+// activeXform is the transform a batch should carry, and whether it
+// needs to carry one at all.
+//
+// A context that has been transformed and then restored all the way
+// back is reported as untransformed: the identity would otherwise
+// stamp every later batch, breaking the run-length merge against the
+// batches drawn before the first Save and putting a matrix on every
+// command for no effect.
+func (dc *DrawContext) activeXform() (canvasXform, bool) {
+	if !dc.xfActive || dc.xf == identityXform {
+		return canvasXform{}, false
+	}
+	return dc.xf, true
+}
+
+// xfRect maps a rect and normalizes it, so a negative scale yields a
+// positive-extent rect at the mirrored position instead of a rect the
+// emit-time w <= 0 guard silently drops. Content is not mirrored;
+// only the rect moves.
+func (dc *DrawContext) xfRect(x, y, w, h float32) (float32, float32, float32, float32) {
+	if _, ok := dc.activeXform(); !ok {
+		return x, y, w, h
+	}
+	x0, y0 := dc.xf.apply(x, y)
+	x1, y1 := dc.xf.apply(x+w, y+h)
+	return min(x0, x1), min(y0, y1), xfAbs(x1 - x0), xfAbs(y1 - y0)
+}
+
+// maxXfPoints caps the scratch buffer retained by xfPoints. A single
+// unbounded Polyline would otherwise pin tens of megabytes across frames.
+const maxXfPoints = 1 << 20 // ~4 MiB of floats
+
+// xfPoints maps a caller's point slice into the context's scratch
+// buffer. The caller's slice is never written to: a recorder may hold
+// it, and callers pass their own backing arrays.
+func (dc *DrawContext) xfPoints(points []float32) []float32 {
+	if _, ok := dc.activeXform(); !ok {
+		return points
+	}
+	if len(points) > maxXfPoints {
+		return points
+	}
+	dc.xfPtBuf = append(dc.xfPtBuf[:0], points...)
+	for i := 0; i+1 < len(dc.xfPtBuf); i += 2 {
+		dc.xfPtBuf[i], dc.xfPtBuf[i+1] =
+			dc.xf.apply(dc.xfPtBuf[i], dc.xfPtBuf[i+1])
+	}
+	return dc.xfPtBuf
+}
+
+// scaleTextStyle scales the px-valued fields of a style.
+//
+// Size, LineSpacing, StrokeWidth and CellHeight take sy: a font size
+// is a vertical em measure, and the three others are vertical by
+// construction. LetterSpacing, CellWidth and EmojiBoxWidth are
+// horizontal advances and take sx. Under a uniform scale — the case
+// with an unambiguous answer — every field scales alike.
+//
+// Glyphs are not sheared: composing TextStyle.AffineTransform would
+// allocate per entry per frame on a path kept allocation-free, and it
+// collides with the RotationRadians precedence in renderDrawCanvas.
+func (x canvasXform) scaleTextStyle(s TextStyle) TextStyle {
+	sx, sy := xfAbs(x.sx), xfAbs(x.sy)
+	s.Size *= sy
+	s.LineSpacing *= sy
+	s.StrokeWidth *= sy
+	s.CellHeight *= sy
+	s.LetterSpacing *= sx
+	s.CellWidth *= sx
+	s.EmojiBoxWidth *= sx
+	return s
+}
+
+// xfAbs is a local abs for float32. Named xfAbs rather than abs32
+// because a test helper in this package already owns that name.
+func xfAbs(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// --- recorder decorator -------------------------------------------
+//
+// A DrawRecorder (SVG/PDF export) sees BAKED coordinates. DrawRecorder
+// is exported and implemented outside this repo, so the alternative —
+// handing over local coordinates and a matrix — would need a wider
+// interface and would silently misplace every existing implementer's
+// output until they adopted it. Baking makes them all correct with no
+// change on their side.
+//
+// The decorator exists rather than baking at each of the two dozen
+// call sites, which would both bloat canvas_draw.go past its size gate
+// and give delegation (Line -> Polyline) a second chance to apply the
+// transform twice.
+
+// canvasImageRecorder is the optional image extension DrawContext.Image
+// probes for. Named here so the decorator can implement it and the
+// unwrap helper can assert it against the inner recorder.
+type canvasImageRecorder interface {
+	Image(x, y, w, h float32, src string,
+		bgOpacity Opt[float32], bgColor Color)
+}
+
+// xformRecorder wraps the caller's recorder and bakes the active
+// transform into every coordinate on the way through.
+//
+// Scalars with no axis of their own — stroke widths, dash and gap
+// lengths, corner radii — take the geometric mean of the two scales,
+// which is exact whenever the scale is uniform.
+type xformRecorder struct {
+	inner DrawRecorder
+	dc    *DrawContext
+	xf    canvasXform
+}
+
+// rec returns the recorder the drawing methods should call. With no
+// transform in force that is the caller's recorder unchanged, so the
+// decorator costs nothing on the common path.
+//
+// It does not check dc.recorder for nil: every call site is already
+// inside a `dc.recorder != nil` guard, and those guards stay because
+// they also decide whether to record at all.
+func (dc *DrawContext) rec() DrawRecorder {
+	// nil in, nil out: every call site is inside a nil guard, and
+	// returning a decorator wrapping nil would turn that contract's
+	// one failure mode into a less obvious one.
+	if dc.recorder == nil {
+		return nil
+	}
+	if _, ok := dc.activeXform(); !ok {
+		return dc.recorder
+	}
+	if dc.xfRec == nil {
+		dc.xfRec = &xformRecorder{dc: dc}
+	}
+	dc.xfRec.inner = dc.recorder
+	dc.xfRec.xf = dc.xf
+	return dc.xfRec
+}
+
+// gradientRecorder asserts DrawGradientRecorder against the INNER
+// recorder and returns something callable.
+//
+// Asserting against dc.rec() instead would always succeed — the
+// decorator implements every extension — and that would quietly kill
+// the flat-triangle degradation that stops an export dropping a
+// gradient fill.
+func (dc *DrawContext) gradientRecorder() (DrawGradientRecorder, bool) {
+	if dc.recorder == nil {
+		return nil, false
+	}
+	if _, ok := dc.recorder.(DrawGradientRecorder); !ok {
+		return nil, false
+	}
+	if _, ok := dc.activeXform(); !ok {
+		return dc.recorder.(DrawGradientRecorder), true
+	}
+	return dc.rec().(*xformRecorder), true
+}
+
+// vertexColorRecorder is gradientRecorder for DrawVertexColorRecorder,
+// and asserts against the inner recorder for the same reason.
+func (dc *DrawContext) vertexColorRecorder() (DrawVertexColorRecorder, bool) {
+	if dc.recorder == nil {
+		return nil, false
+	}
+	if _, ok := dc.recorder.(DrawVertexColorRecorder); !ok {
+		return nil, false
+	}
+	if _, ok := dc.activeXform(); !ok {
+		return dc.recorder.(DrawVertexColorRecorder), true
+	}
+	return dc.rec().(*xformRecorder), true
+}
+
+// imageRecorder is gradientRecorder for the optional image extension.
+func (dc *DrawContext) imageRecorder() (canvasImageRecorder, bool) {
+	if dc.recorder == nil {
+		return nil, false
+	}
+	if _, ok := dc.recorder.(canvasImageRecorder); !ok {
+		return nil, false
+	}
+	if _, ok := dc.activeXform(); !ok {
+		return dc.recorder.(canvasImageRecorder), true
+	}
+	return dc.rec().(*xformRecorder), true
+}
+
+func (r *xformRecorder) pt(x, y float32) (float32, float32) {
+	return r.xf.apply(x, y)
+}
+
+func (r *xformRecorder) pts(points []float32) []float32 {
+	return r.dc.xfPoints(points)
+}
+
+// ln scales a length with no axis of its own.
+func (r *xformRecorder) ln(v float32) float32 { return v * r.xf.meanScale() }
+
+func (r *xformRecorder) Line(x0, y0, x1, y1 float32, color Color, width float32) {
+	ax, ay := r.pt(x0, y0)
+	bx, by := r.pt(x1, y1)
+	r.inner.Line(ax, ay, bx, by, color, r.ln(width))
+}
+
+func (r *xformRecorder) Polyline(points []float32, color Color, width float32) {
+	r.inner.Polyline(r.pts(points), color, r.ln(width))
+}
+
+func (r *xformRecorder) FilledRect(x, y, w, h float32, color Color) {
+	nx, ny, nw, nh := r.dc.xfRect(x, y, w, h)
+	r.inner.FilledRect(nx, ny, nw, nh, color)
+}
+
+func (r *xformRecorder) Rect(x, y, w, h float32, color Color, width float32) {
+	nx, ny, nw, nh := r.dc.xfRect(x, y, w, h)
+	r.inner.Rect(nx, ny, nw, nh, color, r.ln(width))
+}
+
+// FilledCircle routes to FilledArc under a non-uniform scale: the
+// result is an ellipse, which the recorder API can express exactly as
+// a full-sweep arc but cannot express as a circle.
+func (r *xformRecorder) FilledCircle(cx, cy, radius float32, color Color) {
+	x, y := r.pt(cx, cy)
+	if r.xf.uniform() {
+		r.inner.FilledCircle(x, y, radius*xfAbs(r.xf.sx), color)
+		return
+	}
+	r.inner.FilledArc(x, y, radius*xfAbs(r.xf.sx), radius*xfAbs(r.xf.sy),
+		0, 2*math.Pi, color)
+}
+
+func (r *xformRecorder) Circle(cx, cy, radius float32, color Color, width float32) {
+	x, y := r.pt(cx, cy)
+	if r.xf.uniform() {
+		r.inner.Circle(x, y, radius*xfAbs(r.xf.sx), color, r.ln(width))
+		return
+	}
+	r.inner.Arc(x, y, radius*xfAbs(r.xf.sx), radius*xfAbs(r.xf.sy),
+		0, 2*math.Pi, color, r.ln(width))
+}
+
+// FilledArc scales the two radii per axis and leaves start/sweep
+// alone: an axis-aligned scale maps the point at parameter t on the
+// source ellipse to the point at the same t on the scaled one, so the
+// parametrization is preserved.
+func (r *xformRecorder) FilledArc(cx, cy, rx, ry, start, sweep float32, color Color) {
+	x, y := r.pt(cx, cy)
+	r.inner.FilledArc(x, y, rx*xfAbs(r.xf.sx), ry*xfAbs(r.xf.sy),
+		start, sweep, color)
+}
+
+func (r *xformRecorder) Arc(cx, cy, rx, ry, start, sweep float32,
+	color Color, width float32) {
+	x, y := r.pt(cx, cy)
+	r.inner.Arc(x, y, rx*xfAbs(r.xf.sx), ry*xfAbs(r.xf.sy),
+		start, sweep, color, r.ln(width))
+}
+
+func (r *xformRecorder) FilledPolygon(points []float32, color Color) {
+	r.inner.FilledPolygon(r.pts(points), color)
+}
+
+func (r *xformRecorder) FilledRoundedRect(x, y, w, h, radius float32, color Color) {
+	nx, ny, nw, nh := r.dc.xfRect(x, y, w, h)
+	r.inner.FilledRoundedRect(nx, ny, nw, nh, r.ln(radius), color)
+}
+
+func (r *xformRecorder) RoundedRect(x, y, w, h, radius float32,
+	color Color, width float32) {
+	nx, ny, nw, nh := r.dc.xfRect(x, y, w, h)
+	r.inner.RoundedRect(nx, ny, nw, nh, r.ln(radius), color, r.ln(width))
+}
+
+func (r *xformRecorder) DashedLine(x0, y0, x1, y1 float32, color Color,
+	width, dashLen, gapLen float32) {
+	ax, ay := r.pt(x0, y0)
+	bx, by := r.pt(x1, y1)
+	r.inner.DashedLine(ax, ay, bx, by, color,
+		r.ln(width), r.ln(dashLen), r.ln(gapLen))
+}
+
+func (r *xformRecorder) DashedPolyline(points []float32, color Color,
+	width, dashLen, gapLen float32) {
+	r.inner.DashedPolyline(r.pts(points), color,
+		r.ln(width), r.ln(dashLen), r.ln(gapLen))
+}
+
+func (r *xformRecorder) PolylineJoined(points []float32, color Color, width float32) {
+	r.inner.PolylineJoined(r.pts(points), color, r.ln(width))
+}
+
+func (r *xformRecorder) QuadBezier(x0, y0, cx, cy, x1, y1 float32,
+	color Color, width float32) {
+	ax, ay := r.pt(x0, y0)
+	bx, by := r.pt(cx, cy)
+	ex, ey := r.pt(x1, y1)
+	r.inner.QuadBezier(ax, ay, bx, by, ex, ey, color, r.ln(width))
+}
+
+func (r *xformRecorder) CubicBezier(x0, y0, c1x, c1y, c2x, c2y, x1, y1 float32,
+	color Color, width float32) {
+	ax, ay := r.pt(x0, y0)
+	bx, by := r.pt(c1x, c1y)
+	cx2, cy2 := r.pt(c2x, c2y)
+	ex, ey := r.pt(x1, y1)
+	r.inner.CubicBezier(ax, ay, bx, by, cx2, cy2, ex, ey, color, r.ln(width))
+}
+
+func (r *xformRecorder) Text(x, y float32, text string, style TextStyle) {
+	nx, ny := r.pt(x, y)
+	r.inner.Text(nx, ny, text, r.xf.scaleTextStyle(style))
+}
+
+// FillTrianglesGradient is reached only through gradientRecorder, so
+// the inner recorder is known to implement DrawGradientRecorder.
+func (r *xformRecorder) FillTrianglesGradient(tris []float32, g *CanvasGradient) {
+	r.inner.(DrawGradientRecorder).FillTrianglesGradient(r.pts(tris), g)
+}
+
+// FillTrianglesColors is reached only through vertexColorRecorder.
+func (r *xformRecorder) FillTrianglesColors(tris []float32, colors []Color) {
+	r.inner.(DrawVertexColorRecorder).FillTrianglesColors(r.pts(tris), colors)
+}
+
+// Image is reached only through imageRecorder.
+func (r *xformRecorder) Image(x, y, w, h float32, src string,
+	bgOpacity Opt[float32], bgColor Color) {
+	nx, ny, nw, nh := r.dc.xfRect(x, y, w, h)
+	r.inner.(canvasImageRecorder).Image(nx, ny, nw, nh, src, bgOpacity, bgColor)
+}

--- a/gui/canvas_draw_transform_test.go
+++ b/gui/canvas_draw_transform_test.go
@@ -1,0 +1,528 @@
+package gui
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+// wantXform asserts a batch's stamped transform.
+func wantXform(t *testing.T, b DrawCanvasTriBatch,
+	sx, sy, tx, ty float32, active bool) {
+	t.Helper()
+	gsx, gsy, gtx, gty, ok := b.Transform()
+	if ok != active {
+		t.Fatalf("Transform() ok = %v, want %v", ok, active)
+	}
+	if gsx != sx || gsy != sy || gtx != tx || gty != ty {
+		t.Errorf("Transform() = %v,%v,%v,%v, want %v,%v,%v,%v",
+			gsx, gsy, gtx, gty, sx, sy, tx, ty)
+	}
+}
+
+// A zero-value DrawContext must behave exactly as it did before the
+// transform existed: no transform, no stamp, vertices in canvas space.
+func TestXformZeroValueIsIdentity(t *testing.T) {
+	var dc DrawContext
+	dc.FilledRect(1, 2, 3, 4, Blue)
+	if len(dc.batches) != 1 {
+		t.Fatalf("batches = %d, want 1", len(dc.batches))
+	}
+	if dc.batches[0].hasXform {
+		t.Error("untouched context stamped a transform")
+	}
+	wantXform(t, dc.batches[0], 1, 1, 0, 0, false)
+	if dc.batches[0].Triangles[0] != 1 || dc.batches[0].Triangles[1] != 2 {
+		t.Errorf("first vertex = %v, want 1,2", dc.batches[0].Triangles[:2])
+	}
+}
+
+// Translate measures its offset in current local units, so order
+// matters. This is the load-bearing composition assertion.
+func TestXformComposition(t *testing.T) {
+	var a DrawContext
+	a.Translate(10, 20)
+	a.ScaleBy(2, 3)
+	a.FilledRect(1, 1, 2, 2, Blue)
+	wantXform(t, a.batches[0], 2, 3, 10, 20, true)
+
+	var b DrawContext
+	b.ScaleBy(2, 3)
+	b.Translate(10, 20)
+	b.FilledRect(1, 1, 2, 2, Blue)
+	wantXform(t, b.batches[0], 2, 3, 20, 60, true)
+
+	// Geometry is never rewritten; the matrix carries the mapping.
+	if !reflect.DeepEqual(a.batches[0].Triangles, b.batches[0].Triangles) {
+		t.Error("triangles differ between transforms; they must not be baked")
+	}
+	if a.batches[0].Triangles[0] != 1 {
+		t.Errorf("vertex baked: got %v, want local 1", a.batches[0].Triangles[0])
+	}
+}
+
+func TestXformSaveRestoreNesting(t *testing.T) {
+	var dc DrawContext
+	dc.Save()
+	dc.Translate(5, 5)
+	dc.Save()
+	dc.ScaleBy(2, 2)
+	if dc.xf != (canvasXform{sx: 2, sy: 2, tx: 5, ty: 5}) {
+		t.Fatalf("inner xf = %+v", dc.xf)
+	}
+	dc.Restore()
+	if dc.xf != (canvasXform{sx: 1, sy: 1, tx: 5, ty: 5}) {
+		t.Fatalf("after one Restore xf = %+v", dc.xf)
+	}
+	dc.Restore()
+	if dc.xf != identityXform {
+		t.Fatalf("after both Restores xf = %+v, want identity", dc.xf)
+	}
+	// Restoring past the bottom is a no-op, not a panic: OnDraw runs
+	// inside the frame.
+	dc.Restore()
+	dc.Restore()
+	if dc.xf != identityXform {
+		t.Fatalf("empty-stack Restore changed xf: %+v", dc.xf)
+	}
+}
+
+// An unbalanced Save must not survive into the next redraw, or one
+// canvas's slip would move another's geometry.
+func TestXformResetForClearsUnbalancedSave(t *testing.T) {
+	var dc DrawContext
+	dc.Save()
+	dc.Translate(100, 100)
+	dc.Save()
+	dc.resetFor(10, 10, 1, nil, drawCanvasCache{})
+	if dc.xfActive || dc.xf != (canvasXform{}) || len(dc.xfStack) != 0 {
+		t.Fatalf("resetFor left xfActive=%v xf=%+v depth=%d",
+			dc.xfActive, dc.xf, len(dc.xfStack))
+	}
+	dc.FilledRect(0, 0, 1, 1, Blue)
+	if dc.batches[0].hasXform {
+		t.Error("batch after resetFor still carries a transform")
+	}
+}
+
+// The whole design exists so a primitive that delegates to another
+// applies the transform exactly once.
+func TestXformDelegationIsSingleApply(t *testing.T) {
+	cases := []struct {
+		name       string
+		via, plain func(*DrawContext)
+	}{{
+		name:  "Line/Polyline",
+		via:   func(d *DrawContext) { d.Line(0, 0, 10, 5, Blue, 2) },
+		plain: func(d *DrawContext) { d.Polyline([]float32{0, 0, 10, 5}, Blue, 2) },
+	}, {
+		name:  "Circle/Arc",
+		via:   func(d *DrawContext) { d.Circle(5, 5, 4, Blue, 2) },
+		plain: func(d *DrawContext) { d.Arc(5, 5, 4, 4, 0, 2*math.Pi, Blue, 2) },
+	}, {
+		name:  "FilledCircle/FilledArc",
+		via:   func(d *DrawContext) { d.FilledCircle(5, 5, 4, Blue) },
+		plain: func(d *DrawContext) { d.FilledArc(5, 5, 4, 4, 0, 2*math.Pi, Blue) },
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var a, b DrawContext
+			a.Translate(3, 7)
+			a.ScaleBy(2, 2)
+			c.via(&a)
+			b.Translate(3, 7)
+			b.ScaleBy(2, 2)
+			c.plain(&b)
+			if len(a.batches) != 1 || len(b.batches) != 1 {
+				t.Fatalf("batches = %d/%d, want 1/1", len(a.batches), len(b.batches))
+			}
+			wantXform(t, a.batches[0], 2, 2, 3, 7, true)
+			if !reflect.DeepEqual(a.batches[0].Triangles, b.batches[0].Triangles) {
+				t.Error("delegated primitive produced different geometry")
+			}
+		})
+	}
+}
+
+// A batch carries one matrix, so a transform change has to break the
+// run-length merge that would otherwise fold two colors' worth of
+// geometry together.
+func TestXformBreaksBatchMerge(t *testing.T) {
+	var dc DrawContext
+	dc.FilledRect(0, 0, 1, 1, Blue)
+	dc.FilledRect(2, 2, 1, 1, Blue)
+	if len(dc.batches) != 1 {
+		t.Fatalf("same color, no transform: batches = %d, want 1", len(dc.batches))
+	}
+	dc.Translate(10, 0)
+	dc.FilledRect(0, 0, 1, 1, Blue)
+	if len(dc.batches) != 2 {
+		t.Fatalf("after Translate: batches = %d, want 2", len(dc.batches))
+	}
+	dc.FilledRect(4, 0, 1, 1, Blue)
+	if len(dc.batches) != 2 {
+		t.Fatalf("same color and transform: batches = %d, want 2", len(dc.batches))
+	}
+	// Returning to the same matrix re-merges: the key is the value,
+	// not the identity of the call that set it.
+	dc.Save()
+	dc.ScaleBy(3, 3)
+	dc.Restore()
+	dc.FilledRect(6, 0, 1, 1, Blue)
+	if len(dc.batches) != 2 {
+		t.Fatalf("after balanced Save/Restore: batches = %d, want 2", len(dc.batches))
+	}
+}
+
+// Restoring all the way back must leave batches indistinguishable
+// from ones drawn before any transform existed: an identity matrix on
+// every later command would break the merge for no effect.
+func TestXformFullRestoreIsUntransformed(t *testing.T) {
+	var dc DrawContext
+	dc.FilledRect(0, 0, 1, 1, Blue)
+	dc.Save()
+	dc.Translate(10, 10)
+	dc.FilledRect(0, 0, 1, 1, Blue)
+	dc.Restore()
+	dc.FilledRect(2, 0, 1, 1, Blue)
+	if len(dc.batches) != 3 {
+		t.Fatalf("batches = %d, want 3", len(dc.batches))
+	}
+	if dc.batches[2].hasXform {
+		t.Error("batch after a full Restore still carries a matrix")
+	}
+	if _, ok := dc.activeXform(); ok {
+		t.Error("activeXform reports the identity as active")
+	}
+}
+
+func TestXformText(t *testing.T) {
+	var dc DrawContext
+	dc.Translate(10, 20)
+	dc.ScaleBy(2, 4)
+	st := TextStyle{Size: 10, LetterSpacing: 3, LineSpacing: 5}
+	dc.Text(1, 1, "hi", st)
+	if len(dc.texts) != 1 {
+		t.Fatalf("texts = %d, want 1", len(dc.texts))
+	}
+	e := dc.texts[0]
+	if e.X != 12 || e.Y != 24 {
+		t.Errorf("position = %v,%v, want 12,24", e.X, e.Y)
+	}
+	if e.Style.Size != 40 {
+		t.Errorf("Size = %v, want 40 (scaled by sy)", e.Style.Size)
+	}
+	if e.Style.LineSpacing != 20 {
+		t.Errorf("LineSpacing = %v, want 20", e.Style.LineSpacing)
+	}
+	if e.Style.LetterSpacing != 6 {
+		t.Errorf("LetterSpacing = %v, want 6 (scaled by sx)", e.Style.LetterSpacing)
+	}
+	// Measurement answers a question about local space, which is the
+	// space Text's own arguments are in.
+	if got := dc.FontHeight(st); got != 10 {
+		t.Errorf("FontHeight = %v, want the unscaled 10", got)
+	}
+}
+
+func TestXformImageRect(t *testing.T) {
+	var dc DrawContext
+	dc.Translate(10, 10)
+	dc.ScaleBy(2, 2)
+	dc.Image(1, 1, 4, 4, "a.png", Opt[float32]{}, Color{})
+	if len(dc.images) != 1 {
+		t.Fatalf("images = %d, want 1", len(dc.images))
+	}
+	im := dc.images[0]
+	if im.X != 12 || im.Y != 12 || im.W != 8 || im.H != 8 {
+		t.Errorf("rect = %v,%v %vx%v, want 12,12 8x8", im.X, im.Y, im.W, im.H)
+	}
+
+	// A negative scale must yield a positive-extent rect at the
+	// mirrored position, or emitDrawCanvasImages drops it.
+	var neg DrawContext
+	neg.ScaleBy(-1, 1)
+	neg.Image(2, 0, 4, 4, "a.png", Opt[float32]{}, Color{})
+	m := neg.images[0]
+	if m.X != -6 || m.W != 4 {
+		t.Errorf("mirrored rect = x %v w %v, want x -6 w 4", m.X, m.W)
+	}
+}
+
+func TestXformImageClippedRect(t *testing.T) {
+	var dc DrawContext
+	dc.Translate(5, 5)
+	dc.ScaleBy(2, 2)
+	dc.ImageClipped(0, 0, 10, 10, "a.png", Opt[float32]{}, Color{}, 1, 1, 4, 4)
+	if len(dc.images) != 1 {
+		t.Fatalf("images = %d, want 1", len(dc.images))
+	}
+	im := dc.images[0]
+	if !im.Clipped {
+		t.Fatal("Clipped not set")
+	}
+	if im.ClipX != 7 || im.ClipY != 7 || im.ClipW != 8 || im.ClipH != 8 {
+		t.Errorf("clip = %v,%v %vx%v, want 7,7 8x8",
+			im.ClipX, im.ClipY, im.ClipW, im.ClipH)
+	}
+}
+
+// The lowered radial's quad cannot express an ellipse, so a
+// non-uniform scale has to fall back to the ring mesh.
+func TestXformRadialGradientLowering(t *testing.T) {
+	g := &CanvasGradient{
+		Radial: true,
+		Stops:  []GradientStop{{Pos: 0, Color: Blue}, {Pos: 1, Color: Green}},
+	}
+	var uni DrawContext
+	uni.Translate(10, 10)
+	uni.ScaleBy(2, 2)
+	uni.FilledCircleGradient(5, 5, 4, g)
+	if len(uni.Gradients()) != 1 {
+		t.Fatalf("uniform scale: gradients = %d, want 1 (lowered)",
+			len(uni.Gradients()))
+	}
+	e := uni.Gradients()[0]
+	if e.X != 12 || e.Y != 12 || e.W != 16 || e.H != 16 {
+		t.Errorf("quad = %v,%v %vx%v, want 12,12 16x16", e.X, e.Y, e.W, e.H)
+	}
+
+	var nonUni DrawContext
+	nonUni.ScaleBy(2, 3)
+	nonUni.FilledCircleGradient(5, 5, 4, g)
+	if len(nonUni.Gradients()) != 0 {
+		t.Errorf("non-uniform scale: gradients = %d, want 0 (mesh fallback)",
+			len(nonUni.Gradients()))
+	}
+	if len(nonUni.Batches()) == 0 {
+		t.Error("non-uniform scale produced no ring mesh")
+	}
+}
+
+func TestXformRejectsNonFinite(t *testing.T) {
+	nan := float32(math.NaN())
+	inf := float32(math.Inf(1))
+	var dc DrawContext
+	dc.ScaleBy(2, 2)
+	before := dc.xf
+	dc.ScaleBy(nan, 1)
+	dc.ScaleBy(1, inf)
+	dc.Translate(inf, 0)
+	dc.Translate(0, nan)
+	if dc.xf != before {
+		t.Errorf("non-finite argument changed xf: %+v, want %+v", dc.xf, before)
+	}
+}
+
+func TestXformSaveDepthIsBounded(t *testing.T) {
+	var dc DrawContext
+	for range maxXformDepth + 50 {
+		dc.Save()
+	}
+	if len(dc.xfStack) != maxXformDepth {
+		t.Errorf("stack depth = %d, want it capped at %d",
+			len(dc.xfStack), maxXformDepth)
+	}
+}
+
+// --- recorder decorator -------------------------------------------
+
+// xformCapture records the coordinates a recorder is handed, so the
+// baking can be checked call by call.
+type xformCapture struct {
+	nopRecorder
+	line    []float32
+	poly    []float32
+	rect    []float32
+	arc     []float32
+	circle  []float32
+	width   float32
+	textPos [2]float32
+	textSt  TextStyle
+}
+
+func (r *xformCapture) Line(x0, y0, x1, y1 float32, _ Color, w float32) {
+	r.line = []float32{x0, y0, x1, y1}
+	r.width = w
+}
+func (r *xformCapture) Polyline(p []float32, _ Color, w float32) {
+	r.poly = append(r.poly[:0], p...)
+	r.width = w
+}
+func (r *xformCapture) FilledRect(x, y, w, h float32, _ Color) {
+	r.rect = []float32{x, y, w, h}
+}
+func (r *xformCapture) FilledCircle(cx, cy, rad float32, _ Color) {
+	r.circle = []float32{cx, cy, rad}
+}
+func (r *xformCapture) FilledArc(cx, cy, rx, ry, _, _ float32, _ Color) {
+	r.arc = []float32{cx, cy, rx, ry}
+}
+func (r *xformCapture) Text(x, y float32, _ string, st TextStyle) {
+	r.textPos = [2]float32{x, y}
+	r.textSt = st
+}
+
+func TestXformRecorderBakesCoordinates(t *testing.T) {
+	rec := &xformCapture{}
+	var dc DrawContext
+	dc.SetRecorder(rec)
+	dc.Translate(10, 20)
+	dc.ScaleBy(2, 2)
+
+	dc.Line(0, 0, 5, 5, Blue, 3)
+	if !reflect.DeepEqual(rec.line, []float32{10, 20, 20, 30}) {
+		t.Errorf("Line = %v, want [10 20 20 30]", rec.line)
+	}
+	if rec.width != 6 {
+		t.Errorf("Line width = %v, want 6", rec.width)
+	}
+
+	dc.FilledRect(1, 1, 3, 3, Blue)
+	if !reflect.DeepEqual(rec.rect, []float32{12, 22, 6, 6}) {
+		t.Errorf("FilledRect = %v, want [12 22 6 6]", rec.rect)
+	}
+
+	dc.Text(1, 1, "hi", TextStyle{Size: 10})
+	if rec.textPos != [2]float32{12, 22} {
+		t.Errorf("Text pos = %v, want [12 22]", rec.textPos)
+	}
+	if rec.textSt.Size != 20 {
+		t.Errorf("Text size = %v, want 20", rec.textSt.Size)
+	}
+
+	// The caller's slice must come back untouched.
+	pts := []float32{0, 0, 1, 1}
+	dc.Polyline(pts, Blue, 1)
+	if !reflect.DeepEqual(pts, []float32{0, 0, 1, 1}) {
+		t.Errorf("caller slice mutated: %v", pts)
+	}
+	if !reflect.DeepEqual(rec.poly, []float32{10, 20, 12, 22}) {
+		t.Errorf("Polyline = %v, want [10 20 12 22]", rec.poly)
+	}
+}
+
+// A circle under a non-uniform scale is an ellipse, which the
+// recorder API expresses as a full-sweep arc and cannot express as a
+// circle.
+func TestXformRecorderCircleBecomesArc(t *testing.T) {
+	rec := &xformCapture{}
+	var dc DrawContext
+	dc.SetRecorder(rec)
+	dc.ScaleBy(2, 3)
+	dc.FilledCircle(1, 1, 4, Blue)
+	if rec.circle != nil {
+		t.Errorf("got FilledCircle %v under a non-uniform scale", rec.circle)
+	}
+	if !reflect.DeepEqual(rec.arc, []float32{2, 3, 8, 12}) {
+		t.Errorf("FilledArc = %v, want [2 3 8 12]", rec.arc)
+	}
+
+	// Uniform scale keeps the circle a circle.
+	rec2 := &xformCapture{}
+	var d2 DrawContext
+	d2.SetRecorder(rec2)
+	d2.ScaleBy(2, 2)
+	d2.FilledCircle(1, 1, 4, Blue)
+	if !reflect.DeepEqual(rec2.circle, []float32{2, 2, 8}) {
+		t.Errorf("FilledCircle = %v, want [2 2 8]", rec2.circle)
+	}
+}
+
+// The decorator implements every optional extension, so the unwrap
+// helpers must assert against the INNER recorder — otherwise a plain
+// recorder would appear to support gradients and lose the
+// flat-triangle degradation that keeps an export from dropping a fill.
+func TestXformRecorderUnwrapKeepsDegradation(t *testing.T) {
+	plain := &meanPolyRecorder{}
+	var dc DrawContext
+	dc.SetRecorder(plain)
+	dc.ScaleBy(2, 2)
+	if _, ok := dc.gradientRecorder(); ok {
+		t.Fatal("a plain recorder was reported as a DrawGradientRecorder")
+	}
+	if _, ok := dc.vertexColorRecorder(); ok {
+		t.Fatal("a plain recorder was reported as a DrawVertexColorRecorder")
+	}
+	dc.FillTrianglesColors(
+		[]float32{0, 0, 1, 0, 0, 1},
+		[]Color{Blue, Blue, Blue},
+	)
+	if len(plain.colors) != 1 {
+		t.Errorf("flat degradation produced %d polygons, want 1", len(plain.colors))
+	}
+}
+
+// An identity transform must be indistinguishable from no transform on
+// the recorder path: no allocation, no copy, no bake — otherwise a
+// balanced Save/Restore would leave the fast path forever.
+func TestXformIdentityIsNoOpForRecorder(t *testing.T) {
+	rec := &xformCapture{}
+	var dc DrawContext
+	dc.SetRecorder(rec)
+	dc.Save()
+	dc.Restore() // leaves xf == identity but xfActive would have been true
+	dc.FilledRect(1, 2, 3, 4, Blue)
+	if !reflect.DeepEqual(rec.rect, []float32{1, 2, 3, 4}) {
+		t.Errorf("identity baking changed rect: %v, want [1 2 3 4]", rec.rect)
+	}
+	// Also via a non-trivial transform that returns to identity.
+	rec2 := &xformCapture{}
+	var dc2 DrawContext
+	dc2.SetRecorder(rec2)
+	dc2.Save()
+	dc2.Translate(5, 5)
+	dc2.Restore()
+	dc2.Line(0, 0, 1, 1, Blue, 2)
+	if !reflect.DeepEqual(rec2.line, []float32{0, 0, 1, 1}) {
+		t.Errorf("restored identity baked Line: %v, want [0 0 1 1]", rec2.line)
+	}
+	if rec2.width != 2 {
+		t.Errorf("restored identity scaled width: %v, want 2", rec2.width)
+	}
+}
+
+// Hostile point slices must not pin an unbounded scratch buffer.
+func TestXformPointsCap(t *testing.T) {
+	var dc DrawContext
+	dc.Translate(10, 10)
+	dc.ScaleBy(2, 2)
+	huge := make([]float32, (1<<20)+10)
+	for i := range huge {
+		huge[i] = float32(i)
+	}
+	// Must not panic or allocate a retained 4 MiB+ buffer; returns
+	// the caller's slice unchanged when over cap.
+	got := dc.xfPoints(huge)
+	if &got[0] != &huge[0] {
+		t.Error("xfPoints did not return the original slice for a huge input")
+	}
+	if got[0] != 0 || got[1] != 1 {
+		t.Error("huge slice was mutated or baked despite cap")
+	}
+}
+
+func TestXformValidSvgCmdRejectsNonFiniteXform(t *testing.T) {
+	cmd := RenderCmd{
+		Kind: RenderSvg,
+		X:    0, Y: 0, Scale: 1,
+		Triangles: []float32{0, 0, 1, 0, 0, 1},
+		HasXform:  true,
+		ScaleX:    float32(math.NaN()),
+		ScaleY:    1,
+		TransX:    0,
+		TransY:    0,
+	}
+	if validSvgCmd(cmd) {
+		t.Error("validSvgCmd accepted NaN ScaleX")
+	}
+	cmd.ScaleX = 1
+	cmd.TransX = float32(math.Inf(1))
+	if validSvgCmd(cmd) {
+		t.Error("validSvgCmd accepted Inf TransX")
+	}
+	cmd.TransX = 0
+	if !validSvgCmd(cmd) {
+		t.Error("validSvgCmd rejected a finite xform")
+	}
+}

--- a/gui/canvas_draw_types.go
+++ b/gui/canvas_draw_types.go
@@ -81,10 +81,34 @@ type DrawCanvasTextEntry struct {
 // recycled by its next redraw (DrawContext.resetFor). A consumer that
 // keeps a RenderCmd past the frame it was emitted in — the print export
 // is the one in-tree case — must copy the geometry out first.
+//
+// A batch also carries the canvas transform in force when it was
+// recorded (issue #474). Geometry is stored in the local coordinates
+// the caller drew in; the matrix rides on the RenderCmd, where every
+// backend already applies it per vertex. hasXform is what makes the
+// zero value an untransformed batch — the identity is {1,1,0,0}, not
+// the zero canvasXform.
 type DrawCanvasTriBatch struct {
 	Triangles    []float32
 	VertexColors []Color
 	Color        Color
+	xf           canvasXform
+	hasXform     bool
+}
+
+// Transform reports the translate+scale in force when the batch was
+// recorded, mapping a stored vertex to canvas space as
+// (x*sx+tx, y*sy+ty). ok is false for an untransformed batch, whose
+// vertices are already in canvas space.
+//
+// It exists because Batches() hands out geometry that is no longer
+// self-describing without it.
+// exportaudit:keep — paired with Batches for out-of-package consumers
+func (b DrawCanvasTriBatch) Transform() (sx, sy, tx, ty float32, ok bool) {
+	if !b.hasXform {
+		return 1, 1, 0, 0, false
+	}
+	return b.xf.sx, b.xf.sy, b.xf.tx, b.xf.ty, true
 }
 
 // DrawCanvasImageEntry stores a deferred image drawing command.

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -888,7 +888,69 @@ func goldenCases() []goldenCase {
 			name:  "canvas_vertex_colors",
 			build: buildCanvasVertexColors,
 		},
+		{
+			// The canvas transform stack (issue #474). The transform
+			// rides on the command rather than on the vertices, so
+			// the triangle fingerprint alone cannot see it — this
+			// case is what makes serializeCmd's xform token earn its
+			// place. It pins four things at once: that an
+			// untransformed batch stays untransformed, that a
+			// transform breaks the same-color batch merge, that text
+			// and stroke widths take the scale, and that a concentric
+			// radial under a non-uniform scale gives up the shader
+			// quad for the ring mesh.
+			name:  "canvas_transform",
+			build: buildCanvasTransform,
+		},
 	}
+}
+
+// buildCanvasTransform draws each primitive twice where it can: once
+// at the identity and once under a Save/Translate/ScaleBy/Restore, so
+// the diff between the two is the whole feature. Colors are fixed
+// literals for the same reason buildCanvasGradient's are.
+func buildCanvasTransform(_ *Window) View {
+	return DrawCanvas(DrawCanvasCfg{
+		ID:      "canvas_transform",
+		Sizing:  FixedFixed,
+		Width:   160,
+		Height:  100,
+		Version: 1,
+		OnDraw: func(dc *DrawContext) {
+			red := RGB(255, 0, 0)
+			// Identity: the batch must record no transform at all.
+			dc.FilledRect(4, 4, 20, 20, red)
+
+			dc.Save()
+			dc.Translate(40, 10)
+			dc.ScaleBy(2, 2)
+			// Same color as the rect above. A shared batch would fold
+			// two matrices into one, so this must land in its own.
+			dc.FilledRect(0, 0, 20, 20, red)
+			// A stroke width is in local units and scales with the
+			// batch, which is the point of not baking vertices.
+			dc.Rect(0, 0, 20, 20, RGB(0, 0, 255), 2)
+			dc.Text(2, 24, "T", TextStyle{Size: 8, Color: RGB(0, 0, 0)})
+			dc.Restore()
+
+			// Back at the identity, and merging with nothing above.
+			dc.FilledRect(4, 40, 20, 20, RGB(0, 255, 0))
+
+			// A non-uniform scale turns the circle into an ellipse,
+			// which the single-quad shader cannot express: this must
+			// come out as the ring mesh, in a transformed batch.
+			dc.Save()
+			dc.ScaleBy(1, 2)
+			dc.FilledCircleGradient(120, 20, 15, &CanvasGradient{
+				Radial: true,
+				Stops: []GradientStop{
+					{Color: RGBA(255, 255, 255, 255), Pos: 0},
+					{Color: RGBA(255, 255, 255, 0), Pos: 1},
+				},
+			})
+			dc.Restore()
+		},
+	})
 }
 
 // buildCanvasVertexColors draws a hand-colored two-triangle mesh, then

--- a/gui/golden_test.go
+++ b/gui/golden_test.go
@@ -257,6 +257,14 @@ func serializeCmd(c RenderCmd) string {
 				colorStr(c.VertexColors[0]),
 				colorStr(c.VertexColors[len(c.VertexColors)-1]))
 		}
+		// A canvas transform rides on the command rather than on the
+		// vertices, so the fingerprint below is identical with and
+		// without it. Record the matrix or a transform golden proves
+		// nothing.
+		if c.HasXform {
+			fmt.Fprintf(&b, " xform=[%s,%s,%s,%s]",
+				f2(c.ScaleX), f2(c.ScaleY), f2(c.TransX), f2(c.TransY))
+		}
 		// Counts and endpoint colors say how much was emitted and how
 		// it was shaded; the fingerprint says where the vertices are.
 		b.WriteString(triFingerprint(c.Triangles))

--- a/gui/print_pdf.go
+++ b/gui/print_pdf.go
@@ -426,19 +426,21 @@ func pdfRenderSvg(ctx *pdfCtx, cmd RenderCmd) {
 		return
 	}
 	// Render SVG triangles as filled polygons.
-	// Vertices are in local SVG space; transform with
-	// cmd.X/Y offset and cmd.Scale (matching GPU backends).
+	// Vertices are in local SVG space; transform with the command's
+	// own affine (animateTransform, or a canvas Translate/ScaleBy)
+	// first, then the cmd.X/Y offset and cmd.Scale — the same order
+	// the GPU and soft backends apply.
 	svgScale := cmd.Scale
 	if svgScale == 0 {
 		svgScale = 1
 	}
 	for i := 0; i+5 < len(cmd.Triangles); i += 6 {
-		x1 := cmd.X + cmd.Triangles[i]*svgScale
-		y1 := cmd.Y + cmd.Triangles[i+1]*svgScale
-		x2 := cmd.X + cmd.Triangles[i+2]*svgScale
-		y2 := cmd.Y + cmd.Triangles[i+3]*svgScale
-		x3 := cmd.X + cmd.Triangles[i+4]*svgScale
-		y3 := cmd.Y + cmd.Triangles[i+5]*svgScale
+		x1, y1 := svgCmdVertex(cmd, svgScale,
+			cmd.Triangles[i], cmd.Triangles[i+1])
+		x2, y2 := svgCmdVertex(cmd, svgScale,
+			cmd.Triangles[i+2], cmd.Triangles[i+3])
+		x3, y3 := svgCmdVertex(cmd, svgScale,
+			cmd.Triangles[i+4], cmd.Triangles[i+5])
 
 		// Use vertex color if available, else cmd color.
 		var vc Color

--- a/gui/print_pdf_test.go
+++ b/gui/print_pdf_test.go
@@ -707,3 +707,43 @@ func assertPDFExists(t *testing.T, path string) {
 		t.Fatal("PDF file is empty")
 	}
 }
+
+// The PDF export applies a command's affine before the origin and
+// scale, matching every GPU backend and the soft one. Without this a
+// canvas transform — or an animated SVG — printed at the wrong place.
+func TestPDFSvgVertexAppliesXform(t *testing.T) {
+	base := RenderCmd{Kind: RenderSvg, X: 100, Y: 200, Scale: 1}
+	if x, y := svgCmdVertex(base, 1, 5, 7); x != 105 || y != 207 {
+		t.Errorf("no xform: got %v,%v want 105,207", x, y)
+	}
+
+	xf := base
+	xf.HasXform = true
+	xf.ScaleX, xf.ScaleY = 2, 3
+	xf.TransX, xf.TransY = 10, 20
+	// 5*2+10 = 20, then +100. 7*3+20 = 41, then +200.
+	if x, y := svgCmdVertex(xf, 1, 5, 7); x != 120 || y != 241 {
+		t.Errorf("with xform: got %v,%v want 120,241", x, y)
+	}
+
+	// The command scale multiplies the transformed vertex, not the
+	// raw one — the order the backends use.
+	if x, y := svgCmdVertex(xf, 2, 5, 7); x != 140 || y != 282 {
+		t.Errorf("with xform and scale 2: got %v,%v want 140,282", x, y)
+	}
+}
+
+func TestRenderToPDF_SvgTrianglesXform(t *testing.T) {
+	j := testPrintJob(t)
+	cmds := []RenderCmd{{
+		Kind:      RenderSvg,
+		Triangles: []float32{0, 0, 50, 0, 25, 50},
+		Color:     RGBA(0, 128, 0, 255),
+		HasXform:  true,
+		ScaleX:    2, ScaleY: 2, TransX: 10, TransY: 10,
+	}}
+	if err := renderToPDF(cmds, j, 800, 600); err != nil {
+		t.Fatal(err)
+	}
+	assertPDFExists(t, j.OutputPath)
+}

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -216,6 +216,11 @@ func emitDrawCanvasGeometry(cached *drawCanvasCache,
 			gi++
 		}
 		batch := &cached.Batches[bi]
+		// The canvas transform rides on the command, not on the
+		// vertices: every backend applies v*S+T before the X/Y
+		// origin and Scale below, so the triangles stay in the local
+		// coordinates the caller drew in. Scale stays 1 — it is the
+		// SVG path's own factor, and the two compose correctly.
 		emitRenderer(RenderCmd{
 			Kind:         RenderSvg,
 			Triangles:    batch.Triangles,
@@ -224,6 +229,11 @@ func emitDrawCanvasGeometry(cached *drawCanvasCache,
 			X:            ox,
 			Y:            oy,
 			Scale:        1.0,
+			HasXform:     batch.hasXform,
+			ScaleX:       batch.xf.sx,
+			ScaleY:       batch.xf.sy,
+			TransX:       batch.xf.tx,
+			TransY:       batch.xf.ty,
 		}, w)
 	}
 	for ; gi < len(cached.Gradients); gi++ {

--- a/gui/render_draw_canvas_test.go
+++ b/gui/render_draw_canvas_test.go
@@ -904,3 +904,87 @@ func TestDrawCanvasAlwaysRedrawReachesShape(t *testing.T) {
 		t.Error("AlwaysRedraw did not reach Shape.alwaysRedraw")
 	}
 }
+
+// A canvas transform reaches the backend on the command, not baked
+// into the vertices, so both halves have to be asserted: the matrix is
+// present and the triangles are still in local coordinates.
+func TestRenderDrawCanvasEmitsXform(t *testing.T) {
+	w := makeWindowWithScratch()
+	shape := &Shape{
+		shapeType: shapeDrawCanvas,
+		X:         10, Y: 20,
+		Width: 100, Height: 100,
+		Color: RGB(100, 100, 100),
+		events: &eventHandlers{
+			OnDraw: func(dc *DrawContext) {
+				dc.FilledRect(0, 0, 4, 4, Blue) // untransformed
+				dc.Translate(5, 7)
+				dc.ScaleBy(2, 3)
+				dc.FilledRect(0, 0, 4, 4, Blue) // transformed
+			},
+		},
+	}
+	renderDrawCanvas(shape, makeClip(0, 0, 200, 200), w)
+
+	var svg []RenderCmd
+	for _, r := range w.renderers {
+		if r.Kind == RenderSvg {
+			svg = append(svg, r)
+		}
+	}
+	if len(svg) != 2 {
+		t.Fatalf("RenderSvg commands = %d, want 2 (the transform breaks "+
+			"the same-color merge)", len(svg))
+	}
+	if svg[0].HasXform {
+		t.Error("first batch was drawn before any transform")
+	}
+	got := svg[1]
+	if !got.HasXform {
+		t.Fatal("second batch lost its transform")
+	}
+	if got.ScaleX != 2 || got.ScaleY != 3 || got.TransX != 5 || got.TransY != 7 {
+		t.Errorf("xform = %v,%v,%v,%v, want 2,3,5,7",
+			got.ScaleX, got.ScaleY, got.TransX, got.TransY)
+	}
+	// Local coordinates, and the origin still rides on X/Y.
+	if got.Triangles[0] != 0 || got.Triangles[2] != 4 {
+		t.Errorf("triangles were baked: %v", got.Triangles[:4])
+	}
+	if got.X != 10 || got.Y != 20 {
+		t.Errorf("origin = %v,%v, want the shape's 10,20", got.X, got.Y)
+	}
+}
+
+// The stamp has to survive the buffer pooling in takeBatch, which
+// claims the previous redraw's slices by index.
+func TestRenderDrawCanvasXformSurvivesPooling(t *testing.T) {
+	w := makeWindowWithScratch()
+	shape := &Shape{
+		shapeType: shapeDrawCanvas,
+		ID:        "pooled",
+		Width:     100, Height: 100,
+		alwaysRedraw: true,
+		Color:        RGB(100, 100, 100),
+		events: &eventHandlers{
+			OnDraw: func(dc *DrawContext) {
+				dc.ScaleBy(2, 2)
+				dc.FilledRect(0, 0, 4, 4, Blue)
+			},
+		},
+	}
+	for pass := range 3 {
+		w.renderPass++
+		w.renderers = w.renderers[:0]
+		renderDrawCanvas(shape, makeClip(0, 0, 200, 200), w)
+		for _, r := range w.renderers {
+			if r.Kind != RenderSvg {
+				continue
+			}
+			if !r.HasXform || r.ScaleX != 2 || r.ScaleY != 2 {
+				t.Fatalf("pass %d: xform lost (has=%v sx=%v sy=%v)",
+					pass, r.HasXform, r.ScaleX, r.ScaleY)
+			}
+		}
+	}
+}

--- a/gui/render_helpers.go
+++ b/gui/render_helpers.go
@@ -161,3 +161,18 @@ func quantizedScissorClip(clip drawClip, scale float32) drawClip {
 		Height: float32(sh) / scale,
 	}
 }
+
+// svgCmdVertex maps one vertex of a RenderSvg command to page space,
+// in the same order the GPU and soft backends use: the command's own
+// affine (an animateTransform, or a canvas Translate/ScaleBy) first,
+// then the command origin and scale.
+//
+// Split out from pdfRenderSvg so the order is assertable without a
+// PDF writer in the way.
+func svgCmdVertex(cmd RenderCmd, svgScale, vx, vy float32) (float32, float32) {
+	if cmd.HasXform {
+		vx = vx*cmd.ScaleX + cmd.TransX
+		vy = vy*cmd.ScaleY + cmd.TransY
+	}
+	return cmd.X + vx*svgScale, cmd.Y + vy*svgScale
+}

--- a/gui/render_validate.go
+++ b/gui/render_validate.go
@@ -110,6 +110,12 @@ func validSvgCmd(r RenderCmd) bool {
 	if !f32AllFinite3(r.X, r.Y, r.Scale) || r.Scale <= 0 {
 		return false
 	}
+	// The xform is applied per vertex in every backend, so a NaN
+	// scale would poison every triangle rather than drop one command.
+	if r.HasXform &&
+		!f32AllFinite4(r.ScaleX, r.ScaleY, r.TransX, r.TransY) {
+		return false
+	}
 	if r.HasVertexAlpha &&
 		(!f32IsFinite(r.VertexAlphaScale) ||
 			r.VertexAlphaScale < 0 ||

--- a/gui/testdata/canvas_transform.dark.golden
+++ b/gui/testdata/canvas_transform.dark.golden
@@ -1,0 +1,6 @@
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#ff0000ff tris=12 bbox=4.00,4.00..24.00,24.00 centroid=14.00,14.00 digest=22b833b5
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#ff0000ff tris=12 xform=[2.00,2.00,40.00,10.00] bbox=0.00,0.00..20.00,20.00 centroid=10.00,10.00 digest=9e03c1f5
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#0000ffff tris=48 xform=[2.00,2.00,40.00,10.00] bbox=-1.00,-1.00..21.00,21.00 centroid=10.00,10.00 digest=086c9525
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#00ff00ff tris=12 bbox=4.00,40.00..24.00,60.00 centroid=14.00,50.00 digest=e4e34eb2
+Svg xy=15.00,15.00 wh=0.00,0.00 color=#ffffff80 tris=966 vcols=483 first=#ffffffff last=#ffffff00 xform=[1.00,2.00,0.00,0.00] bbox=105.01,5.00..135.00,35.00 centroid=115.90,20.00 digest=8e0ba80d
+Text xy=59.00,73.00 wh=0.00,0.00 color=#000000ff text="T" size=16.00

--- a/gui/testdata/canvas_transform.light.golden
+++ b/gui/testdata/canvas_transform.light.golden
@@ -1,0 +1,6 @@
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#ff0000ff tris=12 bbox=4.00,4.00..24.00,24.00 centroid=14.00,14.00 digest=22b833b5
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#ff0000ff tris=12 xform=[2.00,2.00,40.00,10.00] bbox=0.00,0.00..20.00,20.00 centroid=10.00,10.00 digest=9e03c1f5
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#0000ffff tris=48 xform=[2.00,2.00,40.00,10.00] bbox=-1.00,-1.00..21.00,21.00 centroid=10.00,10.00 digest=086c9525
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#00ff00ff tris=12 bbox=4.00,40.00..24.00,60.00 centroid=14.00,50.00 digest=e4e34eb2
+Svg xy=14.00,14.00 wh=0.00,0.00 color=#ffffff80 tris=966 vcols=483 first=#ffffffff last=#ffffff00 xform=[1.00,2.00,0.00,0.00] bbox=105.01,5.00..135.00,35.00 centroid=115.90,20.00 digest=8e0ba80d
+Text xy=58.00,72.00 wh=0.00,0.00 color=#000000ff text="T" size=16.00


### PR DESCRIPTION
Closes #474.

**Adds `DrawContext.Translate`, `ScaleBy`, `Save`, `Restore`:**
- Relative, composable (HTML canvas order: `Translate` in current local units, `ScaleBy` multiplies). Bounded `Save` stack (256), no panic on empty `Restore`.
- Geometry stays local; the 4-float (`sx,sy,tx,ty`) matrix rides on `DrawCanvasTriBatch`/`RenderCmd.HasXform` and backends apply per vertex — no CPU rebake.
- Text/images/baked gradient quads where no xform fields exist; recorder decorator bakes for existing `DrawRecorder` impls (no API break). PDF export now honors the command affine (also fixes animated SVG).
- Batch merge keys on transform, so same-color draws under different matrices don't fold.
- New `DrawCanvasTriBatch.Transform()` for consumers reading `Batches()`.

**Limits (by design):** curve flattening in local space, text not sheared, negative scale moves rect not mirrors content, non-uniform scale falls back from shader quad to ring mesh.

**Tests/coverage:** `TestXform*` (composition, delegation single-apply, batch break, save/restore, text/image, radial lowering, non-finite, depth cap, recorder baking, identity no-op, xfPoints cap, validSvgCmd xform), `TestRenderDrawCanvas*`, `TestPDFSvgVertex*`, golden `canvas_transform`.

**Docs/examples:** `docs/specs/draw-canvas-transform.md`, `examples/draw_canvas`, `CHANGELOG.md`.