### PR TITLE
fix(audio): resample to output rate and fix RewindMusic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,7 +239,31 @@ and this project adheres to
   jupiter 1168 -> 1096 us, both about 6-7%. The counts above are now enforced as
   regression budgets rather than logged and forgotten.
 
+- **`audio.LoadMusicBytes`** — loads a music track from in-memory bytes, so a
+  track embedded in the binary can stream as music instead of being buffered
+  whole as a `Sound`. Mirrors `LoadSoundBytes`; format is detected from the
+  leading magic bytes. `examples/solar_system` now loads its ambience this way,
+  which drops about 22 MB of resident decoded audio.
+
 ### Fixed
+
+- **Audio played at the wrong pitch and speed unless the asset happened to match
+  the output rate** — `gui/audio` decoded WAV/OGG/FLAC/MP3 and fed the result
+  straight into a mixer running at the rate `audio.Init` opened (44100 Hz by
+  default), with no rate conversion anywhere in the package. A 16 kHz file
+  therefore played 2.76x too fast, about 1.5 octaves sharp, which is what the
+  solar_system ambience track was doing. Decoded audio now converts to the
+  output rate: a `Sound` converts once in `LoadSoundBytes`, so playback stays a
+  plain buffer read with no per-play cost, and music converts as it streams
+  because its decoder must stay seekable for looping and rewind. Assets already
+  authored at the output rate take an identity path and are untouched.
+
+- **`audio.RewindMusic` never rewound anything** — it type-asserted the playing
+  streamer to a `beep.StreamSeeker`, but the chain's outermost wrapper is a
+  volume control, so the assert always failed and the call was a silent no-op.
+  The decoder is now reached through a handle held for that purpose, and the
+  seek runs on the audio thread at the top of the next fill rather than from the
+  caller's goroutine, where it would tear the decoder mid-read.
 
 - **`examples/showcase/docs/widget_audio.md` documented functions that are not
   exported** — `audio.Quit`, `audio.LoadSound`, `Sound.SetVolume`,

--- a/examples/solar_system/ambience.go
+++ b/examples/solar_system/ambience.go
@@ -12,28 +12,32 @@ import (
 //go:embed spacey-ambience.wav
 var ambienceWAV []byte
 
-// ambienceSound keeps the decoded buffer alive for the life of the
-// program. The mixer retains its own streamer, but the Sound's buffer
-// is the owning copy, so it must not be GC'd or Freed while looping.
-var ambienceSound *audio.Sound //nolint:unused // retained for GC
+// ambienceMusic keeps the decoder alive for the life of the program.
+// The mixer holds the streamer chain, but this is the owning handle —
+// it must not be Freed while the track loops.
+var ambienceMusic *audio.Music //nolint:unused // retained for GC
 
 // startAmbience inits the audio subsystem and loops the embedded
 // spacey-ambience.wav forever as background. Failure is logged, not
 // fatal — the orrery runs silently when no audio server is present
 // (e.g. headless CI or missing PulseAudio).
+//
+// Music rather than Sound: a Music decodes as it plays, where a Sound
+// would hold the whole 4 MB track decoded and resampled to the output
+// rate — about 22 MB resident for a clip that plays once and repeats.
 func startAmbience() {
 	if err := audio.Init(); err != nil {
 		log.Printf("solar_system: audio init: %v", err)
 		return
 	}
-	snd, err := audio.LoadSoundBytes(ambienceWAV)
+	m, err := audio.LoadMusicBytes(ambienceWAV)
 	if err != nil {
 		log.Printf("solar_system: load ambience: %v", err)
 		return
 	}
-	ambienceSound = snd
-	// channel -1 = first free, loops -1 = forever.
-	if _, err := snd.Play(-1, -1); err != nil {
+	ambienceMusic = m
+	// loops -1 = forever.
+	if err := m.Play(-1); err != nil {
 		log.Printf("solar_system: play ambience: %v", err)
 		return
 	}

--- a/gui/audio/audio_test.go
+++ b/gui/audio/audio_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gopxl/beep/v2"
 )
 
 // TestMain skips the whole package under the race detector. Many tests
@@ -911,5 +913,357 @@ func TestMusicPlayLoopForever(t *testing.T) {
 
 	if err := m.Play(-1); err != nil {
 		t.Errorf("Play with loops=-1 returned error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resampling
+// ---------------------------------------------------------------------------
+
+// countingStreamer yields n frames of silence, then drains.  Used to
+// measure how many output frames a resampler produces for a known input
+// length, which is the pitch/speed bug expressed as a count.
+type countingStreamer struct {
+	left int
+}
+
+func (c *countingStreamer) Stream(samples [][2]float64) (int, bool) {
+	if c.left <= 0 {
+		return 0, false
+	}
+	n := min(len(samples), c.left)
+	clear(samples[:n])
+	c.left -= n
+	return n, true
+}
+
+func (c *countingStreamer) Err() error { return nil }
+
+// TestResampleToIdentity gates the no-alloc claim: matching or unknown
+// rates must hand back the very same streamer, not a wrapper.
+func TestResampleToIdentity(t *testing.T) {
+	src := &countingStreamer{left: 10}
+	tests := []struct {
+		name     string
+		from, to beep.SampleRate
+	}{
+		{name: "equal", from: 44100, to: 44100},
+		{name: "zero source", from: 0, to: 44100},
+		{name: "zero dest", from: 44100, to: 0},
+		{name: "both zero", from: 0, to: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resampleTo(tt.from, tt.to, src); got != beep.Streamer(src) {
+				t.Errorf("resampleTo(%d, %d, s) wrapped the streamer, want identity",
+					tt.from, tt.to)
+			}
+		})
+	}
+}
+
+// TestResampleToStretches is the headless form of the bug report: a
+// stream decoded at 8000 Hz must produce 44100/8000 as many frames when
+// converted, or it plays that many times too fast.
+func TestResampleToStretches(t *testing.T) {
+	const (
+		inFrames = 8000
+		from     = beep.SampleRate(8000)
+		to       = beep.SampleRate(44100)
+	)
+	s := resampleTo(from, to, &countingStreamer{left: inFrames})
+	if _, isSame := s.(*countingStreamer); isSame {
+		t.Fatal("resampleTo returned the source streamer for mismatched rates")
+	}
+
+	var (
+		buf   [512][2]float64
+		total int
+	)
+	for {
+		n, ok := s.Stream(buf[:])
+		total += n
+		if !ok {
+			break
+		}
+	}
+
+	want := inFrames * int(to) / int(from)
+	// beep's interpolator can be a window short at the tail; a couple of
+	// frames of slack keeps the test about rate, not about edge handling.
+	if diff := total - want; diff < -8 || diff > 8 {
+		t.Errorf("streamed %d frames, want ~%d (diff %d)", total, want, diff)
+	}
+}
+
+// TestLoadSoundBytesResamples checks the load-time conversion: the
+// 8000 Hz wavSilence fixture must land in the buffer at the output rate.
+func TestLoadSoundBytesResamples(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Skipf("audio init unavailable: %v", err)
+	}
+	defer quit()
+
+	snd, err := LoadSoundBytes(wavSilence)
+	if err != nil {
+		t.Fatalf("LoadSoundBytes returned error: %v", err)
+	}
+	defer snd.Free()
+
+	if got, want := int(snd.format.SampleRate), SampleRate(); got != want {
+		t.Errorf("buffer sample rate = %d, want %d", got, want)
+	}
+	if snd.format.Precision < 2 {
+		t.Errorf("buffer precision = %d, want >= 2 after resampling",
+			snd.format.Precision)
+	}
+	// wavSilence holds 10 frames at 8000 Hz.
+	want := 10 * SampleRate() / 8000
+	if diff := snd.buffer.Len() - want; diff < -8 || diff > 8 {
+		t.Errorf("buffer length = %d frames, want ~%d", snd.buffer.Len(), want)
+	}
+}
+
+// TestSoundPlayResampled plays a resampled sound on a loop, which is the
+// wrapping order most at risk: Loop2 needs the seeker underneath.
+func TestSoundPlayResampled(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Skipf("audio init unavailable: %v", err)
+	}
+	defer quit()
+
+	snd, err := LoadSoundBytes(wavSilence)
+	if err != nil {
+		t.Fatalf("LoadSoundBytes returned error: %v", err)
+	}
+	defer snd.Free()
+
+	ch, err := snd.Play(-1, -1)
+	if err != nil {
+		t.Fatalf("Play returned error: %v", err)
+	}
+	if ch < 0 {
+		t.Fatalf("Play returned channel %d, want >= 0", ch)
+	}
+	HaltChannel(ch)
+}
+
+// TestMusicPlayResampled exercises the play-time conversion path, which
+// music takes because its decoder stream must stay seekable.
+func TestMusicPlayResampled(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Skipf("audio init unavailable: %v", err)
+	}
+	defer quit()
+
+	path := filepath.Join(t.TempDir(), "silence.wav")
+	if err := os.WriteFile(path, wavSilence, 0644); err != nil {
+		t.Skipf("cannot write temp WAV: %v", err)
+	}
+	m, err := LoadMusic(path)
+	if err != nil {
+		t.Skipf("LoadMusic failed: %v", err)
+	}
+	defer m.Free()
+
+	if int(m.format.SampleRate) == SampleRate() {
+		t.Fatalf("fixture rate %d matches output rate; test proves nothing",
+			m.format.SampleRate)
+	}
+	if err := m.Play(-1); err != nil {
+		t.Fatalf("Play returned error: %v", err)
+	}
+	if !isMusicPlaying() {
+		t.Error("music not playing after Play")
+	}
+	HaltMusic()
+}
+
+// ---------------------------------------------------------------------------
+// rewind
+// ---------------------------------------------------------------------------
+
+// seekSpy is a StreamSeeker that records Seek calls and the position it
+// streams from, so a test can tell a real rewind from a silent no-op.
+type seekSpy struct {
+	pos   int
+	total int
+	seeks int
+}
+
+func (s *seekSpy) Stream(samples [][2]float64) (int, bool) {
+	if s.pos >= s.total {
+		return 0, false
+	}
+	n := min(len(samples), s.total-s.pos)
+	clear(samples[:n])
+	s.pos += n
+	return n, true
+}
+
+func (s *seekSpy) Err() error    { return nil }
+func (s *seekSpy) Len() int      { return s.total }
+func (s *seekSpy) Position() int { return s.pos }
+func (s *seekSpy) Seek(p int) error {
+	s.seeks++
+	s.pos = p
+	return nil
+}
+
+// TestRewindStreamerDefersSeek pins the two properties the wrapper
+// exists for: nothing is seeked until the audio thread streams again,
+// and one request produces exactly one seek.
+func TestRewindStreamerDefersSeek(t *testing.T) {
+	spy := &seekSpy{total: 100}
+	rw := &rewindStreamer{StreamSeeker: spy}
+
+	var buf [10][2]float64
+	rw.Stream(buf[:])
+	if spy.pos != 10 {
+		t.Fatalf("position after one Stream = %d, want 10", spy.pos)
+	}
+
+	rw.request()
+	if spy.seeks != 0 {
+		t.Errorf("request() seeked immediately (%d seeks); the seek must "+
+			"wait for the audio thread", spy.seeks)
+	}
+
+	rw.Stream(buf[:])
+	if spy.seeks != 1 {
+		t.Errorf("seeks after Stream = %d, want 1", spy.seeks)
+	}
+	if spy.pos != 10 {
+		t.Errorf("position after rewind + Stream = %d, want 10 "+
+			"(rewound to 0, then streamed 10)", spy.pos)
+	}
+
+	// The request is one-shot: a later Stream must not seek again.
+	rw.Stream(buf[:])
+	if spy.seeks != 1 {
+		t.Errorf("seeks after extra Stream = %d, want 1 (request is "+
+			"one-shot)", spy.seeks)
+	}
+}
+
+// TestRewindStreamerIsSeekable gates the embedding: beep.Loop2 rejects a
+// source that is not a StreamSeeker, so losing that would silently drop
+// looping back to play-once.
+func TestRewindStreamerIsSeekable(t *testing.T) {
+	rw := &rewindStreamer{StreamSeeker: &seekSpy{total: 100}}
+	if _, ok := beep.Streamer(rw).(beep.StreamSeeker); !ok {
+		t.Fatal("rewindStreamer is not a beep.StreamSeeker")
+	}
+	if _, err := beep.Loop2(rw); err != nil {
+		t.Errorf("beep.Loop2 rejected rewindStreamer: %v", err)
+	}
+}
+
+// TestRewindMusicReachesDecoder is the regression: RewindMusic used to
+// type-assert ctrl.Streamer to a beep.StreamSeeker, which never held
+// because the chain's outermost wrapper is a volumeStreamer.
+func TestRewindMusicReachesDecoder(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Skipf("audio init unavailable: %v", err)
+	}
+	defer quit()
+
+	path := filepath.Join(t.TempDir(), "silence.wav")
+	if err := os.WriteFile(path, wavSilence, 0644); err != nil {
+		t.Skipf("cannot write temp WAV: %v", err)
+	}
+	m, err := LoadMusic(path)
+	if err != nil {
+		t.Skipf("LoadMusic failed: %v", err)
+	}
+	defer m.Free()
+
+	if err := m.Play(0); err != nil {
+		t.Fatalf("Play returned error: %v", err)
+	}
+	bb, ok := backend.(*beepBackend)
+	if !ok {
+		t.Fatalf("backend is %T, want *beepBackend", backend)
+	}
+	// The old implementation asserted this to a beep.StreamSeeker and
+	// gave up when it was not one. Pin that it never is, so the handle
+	// below stays the only way in.
+	if _, seekable := bb.music.ctrl.Streamer.(beep.StreamSeeker); seekable {
+		t.Error("ctrl.Streamer is seekable; the outer chain is expected " +
+			"not to be, and the rewind handle exists for that reason")
+	}
+	if bb.music.rewind.Load() == nil {
+		t.Fatal("playing music left no rewind handle; RewindMusic is a no-op")
+	}
+	rewindMusic()
+	if !bb.music.rewind.Load().pending.Load() {
+		t.Error("rewindMusic did not mark a pending seek")
+	}
+
+	HaltMusic()
+	if bb.music.rewind.Load() != nil {
+		t.Error("HaltMusic left a stale rewind handle")
+	}
+}
+
+// TestLoadMusicBytes covers the in-memory loader added so embedded
+// tracks can stream instead of being buffered as a Sound.
+func TestLoadMusicBytes(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Skipf("audio init unavailable: %v", err)
+	}
+	defer quit()
+
+	m, err := LoadMusicBytes(wavSilence)
+	if err != nil {
+		t.Fatalf("LoadMusicBytes returned error: %v", err)
+	}
+	defer m.Free()
+
+	if got := int(m.format.SampleRate); got != 8000 {
+		t.Errorf("decoded sample rate = %d, want 8000 (the fixture's own "+
+			"rate; music converts at play time)", got)
+	}
+	if err := m.Play(-1); err != nil {
+		t.Fatalf("Play returned error: %v", err)
+	}
+	if !isMusicPlaying() {
+		t.Error("music not playing after Play")
+	}
+	HaltMusic()
+}
+
+// TestLoadMusicBytesErrors covers the rejected inputs.
+func TestLoadMusicBytesErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: nil},
+		{name: "too short", data: []byte{'R', 'I'}},
+		{name: "unrecognized", data: []byte("not audio at all")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := LoadMusicBytes(tt.data); err == nil {
+				t.Error("LoadMusicBytes returned nil error, want failure")
+			}
+		})
+	}
+}
+
+// TestDecodeBytesID3 exercises the MP3 branch that starts with an
+// ID3v2 tag rather than a sync word, which a naive magic check would
+// miss.  The fixture is a synthetic ID3 header with valid sync after
+// it; the decoder is expected to accept it or fail at decode time, but
+// not with "unrecognized audio format".
+func TestDecodeBytesID3(t *testing.T) {
+	// ID3v2 header: "ID3" + ver(3,0) + flags(0) + size(0,0,0,10)
+	// followed by a fake MP3 frame sync 0xFF 0xFB.  If the magic check
+	// does not recognise ID3, decodeBytes returns "unrecognized".
+	id3 := []byte{'I', 'D', '3', 3, 0, 0, 0, 0, 0, 10, 0xFF, 0xFB, 0x90, 0x00}
+	if _, _, err := decodeBytes(id3); err != nil &&
+		strings.Contains(err.Error(), "unrecognized") {
+		t.Errorf("decodeBytes(ID3) = unrecognized, want mp3 branch: %v", err)
 	}
 }

--- a/gui/audio/backend.go
+++ b/gui/audio/backend.go
@@ -26,6 +26,7 @@ type Backend interface {
 	SetMusicVolume(v float64)
 	MusicVolume() float64
 	LoadMusic(path string) (*Music, error)
+	LoadMusicBytes(data []byte) (*Music, error)
 	LoadSound(path string) (*Sound, error)
 	LoadSoundBytes(data []byte) (*Sound, error)
 	MusicFree(m *Music)

--- a/gui/audio/backend_beep.go
+++ b/gui/audio/backend_beep.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/gopxl/beep/v2"
@@ -22,6 +23,13 @@ var _ Backend = (*beepBackend)(nil)
 type musicState struct {
 	ctrl   *beep.Ctrl
 	volume float64
+	// rewind is the innermost wrapper of the streamer currently in
+	// ctrl, kept so RewindMusic can reach the decoder underneath: by the
+	// time the chain is built, ctrl holds a volumeStreamer, which is not
+	// seekable.  Nil when no track is playing.  Atomic so RewindMusic
+	// (app goroutine) and the chain builders / onComplete (audio thread)
+	// do not race.
+	rewind atomic.Pointer[rewindStreamer]
 }
 
 // ---------------------------------------------------------------------------
@@ -72,6 +80,7 @@ func (b *beepBackend) Quit() {
 	outputClose()
 	b.channels.halt(-1)
 	b.music.ctrl.Streamer = nil
+	b.music.rewind.Store(nil)
 	b.initialized = false
 }
 
@@ -113,6 +122,14 @@ func (b *beepBackend) LoadMusic(path string) (*Music, error) {
 	return &Music{beepStream: stream, format: format}, nil
 }
 
+func (b *beepBackend) LoadMusicBytes(data []byte) (*Music, error) {
+	stream, format, err := decodeBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Music{beepStream: stream, format: format}, nil
+}
+
 func (b *beepBackend) LoadSound(path string) (*Sound, error) {
 	// #nosec G304 — path is a public-API argument; loading a caller-named
 	// audio file by arbitrary path is the intended behavior.
@@ -135,9 +152,19 @@ func (b *beepBackend) LoadSoundBytes(data []byte) (*Sound, error) {
 		return nil, err
 	}
 	defer func() { _ = stream.Close() }()
-	buf := beep.NewBuffer(format)
-	buf.Append(stream)
-	return &Sound{buffer: buf, format: format, volume: 1}, nil
+	// Convert to the output rate once, here, so playback stays a plain
+	// buffer read.  b.sampleRate is 0 when Init has not run yet; buffer
+	// at the source rate then and let the play path convert instead.
+	outFormat := format
+	if b.sampleRate > 0 && format.SampleRate != b.sampleRate {
+		outFormat.SampleRate = b.sampleRate
+		// Rounding an interpolated signal back down to 8-bit throws
+		// away most of what the resampler just computed.
+		outFormat.Precision = max(format.Precision, 2)
+	}
+	buf := beep.NewBuffer(outFormat)
+	buf.Append(resampleTo(format.SampleRate, outFormat.SampleRate, stream))
+	return &Sound{buffer: buf, format: outFormat, volume: 1}, nil
 }
 
 // --- music playback ---
@@ -147,6 +174,7 @@ func (b *beepBackend) MusicFree(m *Music) {
 		return
 	}
 	b.music.ctrl.Streamer = nil
+	b.music.rewind.Store(nil)
 	_ = m.beepStream.Close()
 	m.beepStream = nil
 }
@@ -176,25 +204,35 @@ func (b *beepBackend) MusicFadeIn(m *Music, loops, ms int) error {
 }
 
 func (b *beepBackend) musicChain(m *Music, loops int) beep.Streamer {
+	// Innermost, so RewindMusic reaches the decoder and Loop2 still sees
+	// a seeker.  Held on musicState because the chain above it is not
+	// seekable and cannot be unwrapped.
+	rw := &rewindStreamer{StreamSeeker: m.beepStream}
+	b.music.rewind.Store(rw)
+
 	var s beep.Streamer
 	switch {
 	case loops == 0:
-		s = m.beepStream
+		s = rw
 	case loops < 0:
-		ls, err := beep.Loop2(m.beepStream)
+		ls, err := beep.Loop2(rw)
 		if err != nil {
-			s = m.beepStream
+			s = rw
 		} else {
 			s = ls
 		}
 	default:
-		ls, err := beep.Loop2(m.beepStream, beep.LoopTimes(loops))
+		ls, err := beep.Loop2(rw, beep.LoopTimes(loops))
 		if err != nil {
-			s = m.beepStream
+			s = rw
 		} else {
 			s = ls
 		}
 	}
+	// Music streams live rather than buffering, and both MusicPlay and
+	// Loop2 need the decoder's seeker, so the rate conversion happens
+	// here at play time rather than at load.
+	s = resampleTo(m.format.SampleRate, b.sampleRate, s)
 	return &volumeStreamer{
 		streamer: s,
 		getVolume: func() float64 {
@@ -216,6 +254,7 @@ func (b *beepBackend) musicChainFade(m *Music, loops, ms int) beep.Streamer {
 
 func (b *beepBackend) HaltMusic() {
 	b.music.ctrl.Streamer = nil
+	b.music.rewind.Store(nil)
 }
 
 func (b *beepBackend) FadeOutMusic(ms int) {
@@ -229,7 +268,10 @@ func (b *beepBackend) FadeOutMusic(ms int) {
 		startVol:   1,
 		targetVol:  0,
 		endSamples: b.sampleRate.N(time.Duration(ms) * time.Millisecond),
-		onComplete: func() { b.music.ctrl.Streamer = nil },
+		onComplete: func() {
+			b.music.ctrl.Streamer = nil
+			b.music.rewind.Store(nil)
+		},
 	}
 }
 
@@ -250,8 +292,10 @@ func (b *beepBackend) IsMusicPaused() bool {
 }
 
 func (b *beepBackend) RewindMusic() {
-	if ssc, ok := b.music.ctrl.Streamer.(beep.StreamSeeker); ok {
-		_ = ssc.Seek(0)
+	// The seek runs on the audio thread, at the top of the next Stream
+	// call, so it cannot tear the decoder mid-read.
+	if r := b.music.rewind.Load(); r != nil {
+		r.request()
 	}
 }
 
@@ -274,26 +318,11 @@ func (b *beepBackend) SoundPlay(s *Sound, channel, loops int) (int, error) {
 	if channel < 0 || channel >= b.channels.numChannels() {
 		return -1, errors.New("audio: no free channel for sound")
 	}
-	var streamer beep.Streamer
-	switch {
-	case loops == 0:
-		streamer = s.buffer.Streamer(0, s.buffer.Len())
-	case loops < 0:
-		ls, err := beep.Loop2(s.buffer.Streamer(0, s.buffer.Len()))
-		if err != nil {
-			streamer = s.buffer.Streamer(0, s.buffer.Len())
-		} else {
-			streamer = ls
-		}
-	default:
-		ls, err := beep.Loop2(s.buffer.Streamer(0, s.buffer.Len()),
-			beep.LoopTimes(loops))
-		if err != nil {
-			streamer = s.buffer.Streamer(0, s.buffer.Len())
-		} else {
-			streamer = ls
-		}
-	}
+	// No-op when LoadSoundBytes already converted the buffer; only a
+	// Sound loaded before Init still carries a foreign rate.  Wrapping
+	// here, outside Loop2, keeps the seeker the loop needs.
+	streamer := resampleTo(s.format.SampleRate, b.sampleRate,
+		soundStreamer(s, loops))
 	b.channels.set(channel, &volumeStreamer{
 		streamer:  streamer,
 		getVolume: func() float64 { return s.volume },
@@ -311,26 +340,10 @@ func (b *beepBackend) SoundFadeIn(s *Sound, channel, loops, ms int) (int, error)
 	if channel < 0 || channel >= b.channels.numChannels() {
 		return -1, errors.New("audio: no free channel for sound")
 	}
-	var streamer beep.Streamer
-	switch {
-	case loops == 0:
-		streamer = s.buffer.Streamer(0, s.buffer.Len())
-	case loops < 0:
-		ls, err := beep.Loop2(s.buffer.Streamer(0, s.buffer.Len()))
-		if err != nil {
-			streamer = s.buffer.Streamer(0, s.buffer.Len())
-		} else {
-			streamer = ls
-		}
-	default:
-		ls, err := beep.Loop2(s.buffer.Streamer(0, s.buffer.Len()),
-			beep.LoopTimes(loops))
-		if err != nil {
-			streamer = s.buffer.Streamer(0, s.buffer.Len())
-		} else {
-			streamer = ls
-		}
-	}
+	// See SoundPlay.  The fade must stay outside the resampler: its
+	// endSamples is counted in output-rate samples.
+	streamer := resampleTo(s.format.SampleRate, b.sampleRate,
+		soundStreamer(s, loops))
 	volStreamer := &volumeStreamer{
 		streamer:  streamer,
 		getVolume: func() float64 { return s.volume },
@@ -344,6 +357,26 @@ func (b *beepBackend) SoundFadeIn(s *Sound, channel, loops, ms int) (int, error)
 	}
 	b.channels.set(channel, fade)
 	return channel, nil
+}
+
+// soundStreamer builds a seekable streamer for s with the requested
+// looping, falling back to play-once when Loop2 rejects the source.
+func soundStreamer(s *Sound, loops int) beep.Streamer {
+	base := s.buffer.Streamer(0, s.buffer.Len())
+	switch {
+	case loops == 0:
+		return base
+	case loops < 0:
+		if ls, err := beep.Loop2(base); err == nil {
+			return ls
+		}
+		return base
+	default:
+		if ls, err := beep.Loop2(base, beep.LoopTimes(loops)); err == nil {
+			return ls
+		}
+		return base
+	}
 }
 
 func (b *beepBackend) SoundSetVolume(s *Sound, v float64) {

--- a/gui/audio/decode.go
+++ b/gui/audio/decode.go
@@ -68,6 +68,8 @@ func decodeBytes(data []byte) (beep.StreamSeekCloser, beep.Format, error) {
 		return wav.Decode(newReadSeekCloser(data))
 	case data[0] == 0xFF && len(data) > 1 && data[1]&0xE0 == 0xE0:
 		return mp3.Decode(newReadCloser(data))
+	case len(data) >= 3 && string(data[:3]) == "ID3":
+		return mp3.Decode(newReadCloser(data))
 	case string(data[:4]) == "OggS":
 		return vorbis.Decode(newReadCloser(data))
 	case string(data[:4]) == "fLaC":

--- a/gui/audio/music.go
+++ b/gui/audio/music.go
@@ -20,6 +20,18 @@ func LoadMusic(path string) (*Music, error) {
 	return backend.LoadMusic(path)
 }
 
+// LoadMusicBytes loads a music track from in-memory bytes, for a track
+// embedded in the binary.  The format is detected from the leading
+// magic bytes; WAV, MP3, OGG and FLAC are supported.  The caller must
+// not modify data after this call.
+//
+// Prefer this over [LoadSoundBytes] for anything long — a [Music]
+// decodes as it plays, where a [Sound] holds the whole track decoded at
+// the output rate.
+func LoadMusicBytes(data []byte) (*Music, error) {
+	return backend.LoadMusicBytes(data)
+}
+
 // Play starts music playback.  loops is the number of extra loops
 // (0 = play once, -1 = loop forever).  Any currently playing music
 // is halted first.

--- a/gui/audio/resample.go
+++ b/gui/audio/resample.go
@@ -1,0 +1,25 @@
+//go:build !js && !android && !ios
+
+package audio
+
+import "github.com/gopxl/beep/v2"
+
+// resampleQuality is the beep interpolation window.  4 is beep's
+// documented "good quality" point; 1 is audibly rough, and past ~8 the
+// cost climbs with no gain on speech/ambience material.
+const resampleQuality = 4
+
+// resampleTo wraps s so it streams at the dst rate when it was decoded
+// at src.  Returns s unchanged when the rates already match or either
+// rate is unknown (0) — the identity case must not allocate, because
+// every playback path calls through here.
+//
+// The output sink runs at one fixed rate (see [Init]), so a stream left
+// at its own rate plays at dst/src speed: a 16 kHz file into a 44.1 kHz
+// speaker runs 2.76x fast, about 1.5 octaves sharp.
+func resampleTo(src, dst beep.SampleRate, s beep.Streamer) beep.Streamer {
+	if src <= 0 || dst <= 0 || src == dst {
+		return s
+	}
+	return beep.Resample(resampleQuality, src, dst, s)
+}

--- a/gui/audio/streamers.go
+++ b/gui/audio/streamers.go
@@ -4,6 +4,7 @@ package audio
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/gopxl/beep/v2"
 )
@@ -277,4 +278,33 @@ func (n *neverDrain) Err() error {
 		return nil
 	}
 	return n.streamer.Err()
+}
+
+// ---------------------------------------------------------------------------
+// rewindStreamer
+// ---------------------------------------------------------------------------
+
+// rewindStreamer wraps a seekable decoder so a rewind asked for by the
+// app goroutine happens on the audio thread, at the top of the next
+// Stream call.  Seeking the decoder directly from the caller would tear
+// its internal state while the sink is mid-read.
+//
+// The embedded [beep.StreamSeeker] supplies Seek, Len, Position and Err
+// unchanged, so [beep.Loop2] still accepts this wrapper as its source.
+type rewindStreamer struct {
+	beep.StreamSeeker
+	pending atomic.Bool
+}
+
+// request marks a rewind.  Safe from any goroutine; the seek itself is
+// deferred to the next Stream call.
+func (r *rewindStreamer) request() { r.pending.Store(true) }
+
+func (r *rewindStreamer) Stream(samples [][2]float64) (int, bool) {
+	if r.pending.CompareAndSwap(true, false) {
+		// A failed seek leaves the stream where it was — playback
+		// continues rather than dropping out, and Err reports it.
+		_ = r.Seek(0)
+	}
+	return r.StreamSeeker.Stream(samples)
 }


### PR DESCRIPTION
**What**

- Decoded audio now converts to the output rate: `Sound` converts once in `LoadSoundBytes` (buffer at output rate, playback stays a plain buffer read), music converts at play time because its decoder must stay seekable for looping/rewind. Identity path when rates already match (no allocation).
- `RewindMusic` now reaches the decoder via an atomic `rewindStreamer` handle and defers `Seek(0)` to the audio thread (was a silent no-op: type-asserted the outer `volumeStreamer` to `StreamSeeker`).
- Add `LoadMusicBytes` so embedded tracks (solar_system ambience) can stream as `Music` instead of buffering whole as `Sound` (~22 MB saved).
- Harden `decodeBytes` to recognise ID3-prefixed MP3s; make `musicState.rewind` race-free (`atomic.Pointer`, `Quit`/`FadeOut` clear atomically); simplify `SoundPlay`/`SoundFadeIn` via shared `soundStreamer` helper.

**Why**

- 16 kHz file into 44.1 kHz mixer played 2.76x fast (~1.5 octaves sharp) — the solar_system ambience was affected.
- `RewindMusic` tore decoder state mid-read when called from app goroutine; now deferred.

**Testing**

- `make prepush` green locally.
- New tests: `TestResampleToIdentity`, `TestResampleToStretches`, `TestLoadSoundBytesResamples`, `TestSoundPlayResampled`, `TestMusicPlayResampled`, `TestRewindStreamerDefersSeek`, `TestRewindStreamerIsSeekable`, `TestRewindMusicReachesDecoder`, `TestLoadMusicBytes`, `TestLoadMusicBytesErrors`, `TestDecodeBytesID3`.

**Risk**

Low. Output-rate conversion is gated behind identity check; no per-play cost for `Sound`. Music path only adds a lightweight resampler wrapper.