### PR TITLE
feat(audio): widget audio feedback reaches keyboard and drag paths (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,33 @@ and this project adheres to
   no-op there. New: `gui.WindowDecoration`, `gui.WindowEdge`. See
   `examples/frameless` and `docs/specs/frameless-windows.md`.
 
+- **Widget audio feedback reaches the keyboard and drag paths** (#468) — phases
+  1 and 2 hooked every interaction event dispatch can see. The interactions that
+  call a callback directly, usually with a nil `Layout`, now raise their own
+  cue: `Table`, `ListBox` and `Tree` keyboard activation sound `Selection`,
+  `Menu` keyboard activation sounds `Click`, a drag-reorder drop and a dock
+  panel drop sound `Selection`, and the splitter's collapse toggle sounds
+  `ToggleOn` / `ToggleOff`.
+
+  `SoundError` gets its first real consumer, which is what `NewBeepSoundPlayer`
+  was built for: an `Input` sounds it whenever a keystroke is refused — a
+  character a mask has no slot for, a paste that does not fit, a backspace over
+  a mask literal, or a `PreTextChange` veto — and an arrow key or a step that
+  cannot move sounds it too. A successful Enter commit sounds `Click`.
+
+  Movement is silent, refusal is not: an arrow key that moves a selection makes
+  no sound, because a held key would machine-gun the cue. Continuous drag stays
+  silent throughout — slider thumb, splitter handle, colour plane and wheel — as
+  do a drag cancelled with Escape, a drop that lands where the item already was,
+  and an `Input` commit caused by blur. Each of those is a recorded decision in
+  `docs/specs/widget-audio-feedback.md`, not an omission.
+
+  New: `TableCfg`, `InputCfg` and `SplitterCfg` gained the `Sound` /
+  `SoundDisabled` pair. `SliderCfg` and `NumericInputCfg` gained `SoundDisabled`
+  alone — neither has an activation moment to sound at, so a `Sound` field would
+  name a cue that never plays. On an `Input`, `Sound` names the Enter-commit cue
+  only; rejection always takes the theme's `Error` role.
+
 - **Widget audio feedback reaches the whole widget set** (#467) — the sound seam
   from #446 proved itself on `Button` and `Toggle`; every other mechanical
   widget now emits a cue, plus `gui/datagrid`. `Switch`, `Radio`,

--- a/docs/specs/widget-audio-feedback.md
+++ b/docs/specs/widget-audio-feedback.md
@@ -1,12 +1,69 @@
 # Spec: opt-in widget audio feedback
 
-Status: **phases 1 and 2 implemented** — phase 1 landed `SoundCue`,
+Status: **phases 1, 2 and 3 implemented** — phase 1 landed `SoundCue`,
 `SoundPlayer`, `Theme.Sounds`, window volume, and the `Button` / `Toggle` proof;
 phase 2 (#467) carried the seam to every remaining mechanical widget and to
-`gui/datagrid`. Phases 3 and 4 are follow-up issues.
+`gui/datagrid`; phase 3 (#468) reached the paths dispatch never sees. Phase 4 is
+a follow-up issue.
 
 Issue: #446 — "Widgets have no audio feedback for interactions". Phase 2: #467 —
-"Widget audio feedback phase 2: the mechanical widget pass".
+"Widget audio feedback phase 2: the mechanical widget pass". Phase 3: #468 —
+"Widget audio feedback phase 3: paths dispatch does not see".
+
+## Phase 3 decisions
+
+Phase 3 covers the interactions that call a callback directly, usually with a
+nil `Layout`, so `playShapeSound` has no shape to read a cue off.
+
+- **A second helper, `playSoundCue(SoundCue, *Window)`.** Factored out of
+  `playShapeSound`, which now resolves the cue off the shape and delegates.
+  Every guard past the shape — nil window, `SoundNone`, nil player, zero or
+  non-finite gain — lives in the new helper, so a new call site inherits the
+  silence guarantees rather than restating them. `(*Window).SoundVolume` does
+  not go through `lockForAPI`, so a cue may be emitted inline even under the
+  frame lock; no phase-3 site needs `deferCallback`.
+- **A resolved pair, `soundCues{act, reject}`.** Most phase-3 paths need two
+  cues: the one for a change that lands and the one for a change refused.
+  `resolveSoundCues` builds the pair at generation time and it travels by value,
+  so a handler closure captures a `SoundCue` rather than a `*Layout` the arena
+  pools. Only `act` takes the `Cfg.Sound` override — `Cfg.Sound` names a
+  widget's activation sound, not its refusal, so `reject` stays on the theme's
+  `Error` role. `SoundDisabled` suppresses both.
+- **Refusal sounds; movement does not.** An arrow key that moves a selection is
+  silent, because a held arrow key would machine-gun the cue. An arrow key that
+  cannot move — already at `Min`, at row 0, at the last row, at the end of a
+  menu — emits `Theme.Sounds.Error`. The asymmetry is the point: silence is the
+  normal case, so the cue carries information.
+- **`NumericInput` reports its own clamp.** `numericInputStepResultClamped`
+  returns whether the step was refused, rather than the call site re-deriving it
+  by recomputing the seed — a duplicate that would drift the moment the stepping
+  rule changed. `numericInputStepResultMode` stays as the two-value wrapper its
+  existing callers use.
+- **A drag never sounds; a drop sometimes does.** Continuous drag — slider
+  thumb, splitter handle, colour plane and wheel — stays silent throughout: it
+  has no activation moment, and a cue per move would be a buzz. Only a
+  drag-reorder drop that actually moves an item sounds, on `Selection`. A cancel
+  (Escape), a drop that lands where the item already was, and a dock panel
+  released outside every zone are all silent, and the guards that distinguish
+  them were already in the code.
+- **The splitter's collapse toggle is the one drag-adjacent activation.**
+  `splitterToggleCollapse` already reports direction, so collapse takes
+  `ToggleOn` and expand takes `ToggleOff`. The collapse buttons carry the same
+  state-dependent cue through the ordinary click path.
+- **The Input's Enter commit sounds; its blur commit does not.** Enter is a
+  deliberate activation and takes `Click`. Blur is incidental — focus moved for
+  some other reason — and its commit runs under the frame lock through
+  `deferCallback`, so keeping it silent avoids that seam entirely.
+- **`SoundError` gets its first real consumer.** Every Input rejection sounds
+  it: a character a mask has no slot for, a paste the mask cannot fit, a
+  backspace over a mask literal, and a `PreTextChange` veto. That is what
+  `NewBeepSoundPlayer` was built for — it plays `SoundError` and nothing else.
+  An unmasked field that cannot delete is at the start or end of its text; that
+  is an edge, not a rejection, and stays silent.
+- **Five widgets gained sound config.** `TableCfg`, `InputCfg` and `SplitterCfg`
+  take the usual `Sound` / `SoundDisabled` pair. `SliderCfg` and
+  `NumericInputCfg` take `SoundDisabled` alone: neither has an activation moment
+  to sound at, so a `Sound` field would name a cue that never plays.
 
 ## Phase 2 decisions
 
@@ -154,6 +211,24 @@ It is not routed through `deferCallback`. Dispatch runs from `EventFn` with no
 frame lock held, and a deferred callback may not capture a `*Layout` — the arena
 pools it.
 
+The paths dispatch never sees raise their own cue with
+`playSoundCue(SoundCue, *Window)`, at the call site, keeping the same ordering:
+before the callback, independent of consumption.
+
+| Path                     | Site                                              |
+| ------------------------ | ------------------------------------------------- |
+| Table keyboard activate  | `tableOnKeyDown`, the `listCoreSelectItem` branch |
+| ListBox keyboard select  | `listBoxOnKeyDown`, same branch                   |
+| Tree keyboard select     | `treeOnKeyDown`, `KeyEnter`/`KeySpace`            |
+| Menu keyboard activate   | `menuOnKeyDown`, `KeySpace`/`KeyEnter`            |
+| Input Enter commit       | `inputCommitEnter`                                |
+| Input reject             | `inputTextChange`, `inputKeyPaste`, delete        |
+| NumericInput clamp       | `numericInputApplyStep`                           |
+| Slider clamp             | `sliderOnKeyDown`                                 |
+| Drag-reorder drop        | `dragReorderOnMouseUp`, `dragReorderKeyboardMove` |
+| Dock panel drop          | `dockDragOnMouseUp`                               |
+| Splitter collapse toggle | `splitterOnHandleKeyDown`                         |
+
 ## What stays silent
 
 Pure click absorbers must never sound, and opt-in-by-default protects them with
@@ -166,6 +241,25 @@ One known exclusion: `gui/view_text.go` uses a package-level shared
 `textEventHandlers` singleton, which cannot carry a per-instance cue without
 becoming per-view. Link-click sound is out of scope.
 
+Phase 3 adds these deliberate silences. Each was decided, not omitted:
+
+- **Arrow-key movement** in ListBox, Menu, Tree, Table and Slider. Only a move
+  that is refused sounds.
+- **Tree expand and collapse** on Left and Right. They are arrow keys, and the
+  rule above governs them.
+- **Continuous drag** — `sliderMouseMove`, `splitterEmitChange` from a drag
+  move, and `colorDragTrack` in `gui/view_color_drag.go`.
+- **The Input blur commit**, in `inputAmendLayout`.
+- **A drag cancel and a no-op drop**, including a dock panel released outside
+  every drop zone.
+- **An unmasked Input delete at the start or end of its text.**
+
+Two candidates were deferred rather than decided against. A slider **snap or
+detent** cue needs drag-path snapping that does not exist — `SliderCfg.Step` is
+consulted only by the keyboard path. A **colour drag-end** cue needs a commit
+moment the colour widgets do not have: they write the value on every move, so
+release commits nothing.
+
 ## Rollout
 
 - **Phase 1 (this change)** — the seam, `Button`, `Toggle`, headless tests, both
@@ -175,10 +269,11 @@ becoming per-view. Link-click sound is out of scope.
   Select, Combobox, ListBox, Tree, TabControl, Menu, Dialog, Toast, DatePicker,
   CommandPalette, DockLayout, Image, Svg, and `gui/datagrid`). Split by file
   count, not one 40-file diff.
-- **Phase 3** (#468) — bespoke paths dispatch never sees: Table keyboard
-  activation (calls `OnClick` with a nil `Layout`), Input commit vs reject,
-  InputNumeric clamp, keyboard navigation (probably silent — decide it
-  explicitly), drag-terminated changes, drag-reorder drop.
+- **Phase 3** (#468) — the paths dispatch never sees: Table, ListBox, Tree and
+  Menu keyboard activation, Input commit and reject, NumericInput and Slider
+  clamp, the splitter's collapse toggle, and the drag-reorder and dock drops.
+  Keyboard movement and continuous drag were decided silent; the decisions are
+  in "What stays silent" above.
 - **Phase 4** (#469) — non-click semantics (Toast appear, Dialog open, Form
   submit, DataGrid `OnCRUDError`) and a native system-sound player:
   `NSSound(named:)`, `PlaySound` with `SND_ALIAS`, freedesktop sound-naming IDs

--- a/docs/widget-sound.md
+++ b/docs/widget-sound.md
@@ -241,6 +241,14 @@ gui.Button(gui.ButtonCfg{ID: "tick", Label: "Tick", SoundDisabled: true})
 A `Toggle` picks its own cue from its state: a selected toggle is about to turn
 off, so it emits `SoundToggleOff`. You do not need an on/off field pair.
 
+`SliderCfg` and `NumericInputCfg` take `SoundDisabled` alone. Neither has an
+activation moment to sound at, so their only cue is the `Error` a refused step
+or a refused arrow key emits, and a `Sound` field would name a cue that never
+plays.
+
+On an `Input`, `Sound` names the Enter-commit cue only. Rejection always takes
+`Theme.Sounds.Error`; `SoundDisabled` silences both.
+
 ## Which widgets sound
 
 Every widget below emits a cue once the app has opted in. A widget that toggles
@@ -263,6 +271,29 @@ close emits `SoundToggleOff`.
 | `datagrid` rows, toolbar, pager            | `Click`                                   |
 | `datagrid` sort, pin, column reorder       | `Selection`                               |
 
+Keyboard and drag paths sound too, and refusal is its own cue:
+
+| Interaction                                    | Cue                      |
+| ---------------------------------------------- | ------------------------ |
+| `Table`, `ListBox`, `Tree` keyboard activation | `Selection`              |
+| `Menu` keyboard activation                     | `Click`                  |
+| `Input` Enter commit                           | `Click`                  |
+| `Input` rejection (mask, paste, delete, veto)  | `Error`                  |
+| Arrow key already at a bound or list edge      | `Error`                  |
+| `NumericInput` step at `Min` or `Max`          | `Error`                  |
+| Drag-reorder drop that moves an item           | `Selection`              |
+| Dock panel dropped into a zone                 | `Selection`              |
+| `Splitter` collapse toggle                     | `ToggleOn` / `ToggleOff` |
+
+Movement is silent, refusal is not. An arrow key that moves a selection makes no
+sound — a held arrow key would machine-gun the cue — while an arrow key that
+cannot move emits `Error`. Continuous drag is silent for the same reason: the
+slider thumb, the splitter handle and the colour plane and wheel say nothing
+while dragging, and only the splitter's collapse toggle and a drop that really
+moves something are cues. A drag cancelled with Escape, a drop that lands where
+the item already was, and an `Input` commit caused by blur are all silent by
+decision.
+
 Widgets that only absorb clicks stay silent by design: the toast scrim, the
 context-menu dismiss layer, scrollbar tracks, the `CommandPalette` card, the
 `DatePicker` field itself (its click only takes focus), and the caret-placement
@@ -271,8 +302,8 @@ disabled, a `ListBox` subheading, and a menu separator.
 
 Text is not covered: `gui.Text` shares one package-level handler record across
 every text shape, so it cannot carry a per-instance cue without giving up that
-zero-allocation sharing. Drag, hover, focus and notification cues are still to
-come (#468, #469).
+zero-allocation sharing. Hover, focus and notification cues are still to come
+(#469).
 
 ## Platform reality
 
@@ -294,7 +325,10 @@ calls `ctx.Consume()`**. The sound confirms that the widget was activated; it
 does not take part in event propagation.
 
 Every activation path sounds, not just the mouse: click, Space, Enter, and the
-accessibility press action all emit the same cue.
+accessibility press action all emit the same cue. Keyboard activation that never
+reaches event dispatch — a `Table` row activated with Enter, an `Input`
+rejection, a drag-reorder drop — raises its cue at its own call site, with the
+same ordering.
 
 ## Testing
 

--- a/examples/showcase/docs/widget_sound.md
+++ b/examples/showcase/docs/widget_sound.md
@@ -239,6 +239,14 @@ gui.Button(gui.ButtonCfg{ID: "tick", Label: "Tick", SoundDisabled: true})
 A `Toggle` picks its own cue from its state: a selected toggle is about to turn
 off, so it emits `SoundToggleOff`. You do not need an on/off field pair.
 
+`SliderCfg` and `NumericInputCfg` take `SoundDisabled` alone. Neither has an
+activation moment to sound at, so their only cue is the `Error` a refused step
+or a refused arrow key emits, and a `Sound` field would name a cue that never
+plays.
+
+On an `Input`, `Sound` names the Enter-commit cue only. Rejection always takes
+`Theme.Sounds.Error`; `SoundDisabled` silences both.
+
 ## Which widgets sound
 
 Every widget below emits a cue once the app has opted in. A widget that toggles
@@ -261,6 +269,29 @@ close emits `SoundToggleOff`.
 | `datagrid` rows, toolbar, pager            | `Click`                                   |
 | `datagrid` sort, pin, column reorder       | `Selection`                               |
 
+Keyboard and drag paths sound too, and refusal is its own cue:
+
+| Interaction                                    | Cue                      |
+| ---------------------------------------------- | ------------------------ |
+| `Table`, `ListBox`, `Tree` keyboard activation | `Selection`              |
+| `Menu` keyboard activation                     | `Click`                  |
+| `Input` Enter commit                           | `Click`                  |
+| `Input` rejection (mask, paste, delete, veto)  | `Error`                  |
+| Arrow key already at a bound or list edge      | `Error`                  |
+| `NumericInput` step at `Min` or `Max`          | `Error`                  |
+| Drag-reorder drop that moves an item           | `Selection`              |
+| Dock panel dropped into a zone                 | `Selection`              |
+| `Splitter` collapse toggle                     | `ToggleOn` / `ToggleOff` |
+
+Movement is silent, refusal is not. An arrow key that moves a selection makes no
+sound — a held arrow key would machine-gun the cue — while an arrow key that
+cannot move emits `Error`. Continuous drag is silent for the same reason: the
+slider thumb, the splitter handle and the colour plane and wheel say nothing
+while dragging, and only the splitter's collapse toggle and a drop that really
+moves something are cues. A drag cancelled with Escape, a drop that lands where
+the item already was, and an `Input` commit caused by blur are all silent by
+decision.
+
 Widgets that only absorb clicks stay silent by design: the toast scrim, the
 context-menu dismiss layer, scrollbar tracks, the `CommandPalette` card, the
 `DatePicker` field itself (its click only takes focus), and the caret-placement
@@ -269,8 +300,8 @@ disabled, a `ListBox` subheading, and a menu separator.
 
 Text is not covered: `gui.Text` shares one package-level handler record across
 every text shape, so it cannot carry a per-instance cue without giving up that
-zero-allocation sharing. Drag, hover, focus and notification cues are still to
-come (#468, #469).
+zero-allocation sharing. Hover, focus and notification cues are still to come
+(#469).
 
 ## Platform reality
 
@@ -292,7 +323,10 @@ calls `ctx.Consume()`**. The sound confirms that the widget was activated; it
 does not take part in event propagation.
 
 Every activation path sounds, not just the mouse: click, Space, Enter, and the
-accessibility press action all emit the same cue.
+accessibility press action all emit the same cue. Keyboard activation that never
+reaches event dispatch — a `Table` row activated with Enter, an `Input`
+rejection, a drag-reorder drop — raises its cue at its own call site, with the
+same ordering.
 
 ## Testing
 

--- a/gui/dock_layout_drag.go
+++ b/gui/dock_layout_drag.go
@@ -29,6 +29,10 @@ const (
 
 // dockDragState tracks an in-progress dock panel drag.
 type dockDragState struct {
+	// dropCue sounds when the panel lands in a zone. Resolved by the
+	// caller at generation time and carried here, because the drop
+	// fires from a MouseLock callback with a nil Layout (issue #468).
+	dropCue      SoundCue
 	panelID      string
 	sourceGroup  string
 	hoverGroupID string
@@ -73,6 +77,7 @@ func dockDragStart(
 	dockID, panelID, sourceGroup string,
 	root *DockNode,
 	onLayoutChange func(*DockNode, EventCtx),
+	dropCue SoundCue,
 	layout *Layout, e *Event, w *Window,
 ) {
 	// Ghost base offset: tab position relative to dock container.
@@ -88,6 +93,7 @@ func dockDragStart(
 	absMouseY := layout.Shape.Y + e.MouseY
 	state := dockDragState{
 		active:      false,
+		dropCue:     dropCue,
 		panelID:     panelID,
 		sourceGroup: sourceGroup,
 		mouseX:      absMouseX,
@@ -156,6 +162,9 @@ func dockDragOnMouseUp(
 	w.MouseUnlock()
 
 	if state.active && state.hoverZone != dockDropNone && onLayoutChange != nil {
+		// A drop that lands nowhere falls through to the clear below
+		// and stays silent, as does a cancel (issue #468).
+		playSoundCue(state.dropCue, w)
 		newRoot := dockTreeMovePanel(
 			root, state.panelID, state.hoverGroupID,
 			state.hoverZone)

--- a/gui/dock_layout_drag_test.go
+++ b/gui/dock_layout_drag_test.go
@@ -100,6 +100,7 @@ func TestDockDragCaptureLossDoesNotDrop(t *testing.T) {
 		root := DockPanelGroup("g1", []string{"p1", "p2"}, "p1")
 		dockDragStart("dock", "p1", "g1", root,
 			func(*DockNode, EventCtx) { *dropped = true },
+			SoundNone,
 			&Layout{Shape: &Shape{ID: "tab"}}, &Event{}, w)
 		// Hovering a drop zone: a release here would dock the panel.
 		state := dockDragGet(w, "dock")

--- a/gui/drag_reorder.go
+++ b/gui/drag_reorder.go
@@ -113,26 +113,31 @@ const (
 
 // dragReorderState tracks an in-progress drag-reorder operation.
 type dragReorderState struct {
-	itemID            string
-	itemLayoutIDs     []string
-	itemMids          []float32
-	sourceIndex       int
-	currentIndex      int
-	itemCount         int
-	idsLen            int
-	idsHash           uint64
-	midsOffset        int
-	startMouseX       float32
-	startMouseY       float32
-	mouseX            float32
-	mouseY            float32
-	itemX             float32
-	itemY             float32
-	itemWidth         float32
-	itemHeight        float32
-	parentX           float32
-	parentY           float32
-	scrollID          string
+	itemID        string
+	itemLayoutIDs []string
+	itemMids      []float32
+	sourceIndex   int
+	currentIndex  int
+	itemCount     int
+	idsLen        int
+	idsHash       uint64
+	midsOffset    int
+	startMouseX   float32
+	startMouseY   float32
+	mouseX        float32
+	mouseY        float32
+	itemX         float32
+	itemY         float32
+	itemWidth     float32
+	itemHeight    float32
+	parentX       float32
+	parentY       float32
+	scrollID      string
+	// dropCue is resolved by the widget at generation time and rides
+	// the drag state: the drop fires from a MouseLock callback with a
+	// nil Layout, so there is no shape left to read a cue off
+	// (issue #468).
+	dropCue           SoundCue
 	containerStart    float32
 	containerEnd      float32
 	startScrollX      float32
@@ -209,6 +214,10 @@ type dragReorderStartCfg struct {
 	MidsOffset    int
 	scrollID      string
 	Axis          dragReorderAxis
+	// DropCue sounds when the drag ends on a real move. A cancel and
+	// a drop that lands where the item already was stay silent: the
+	// drag itself is never the cue (issue #468).
+	DropCue SoundCue
 }
 
 // dragReorderStart initiates a drag-reorder from an OnClick
@@ -289,6 +298,7 @@ func dragReorderStart(cfg dragReorderStartCfg, w *Window) {
 		parentY:        parentY,
 		itemID:         itemID,
 		scrollID:       scrollID,
+		dropCue:        cfg.DropCue,
 		containerStart: containerStart,
 		containerEnd:   containerEnd,
 		startScrollX:   startScrollX,
@@ -495,6 +505,7 @@ func dragReorderOnMouseUp(
 	if wasActive && !state.cancelled &&
 		gap != src && gap != src+1 {
 		if onReorder != nil && src >= 0 && src < len(itemIDs) {
+			playSoundCue(state.dropCue, w)
 			movedID := itemIDs[src]
 			beforeID := ""
 			if gap < len(itemIDs) {
@@ -582,6 +593,7 @@ func dragReorderKeyboardMove(
 	currentIndex int,
 	itemIDs []string,
 	onReorder func(string, string, EventCtx),
+	dropCue SoundCue,
 	w *Window,
 ) bool {
 	itemCount := len(itemIDs)
@@ -628,6 +640,9 @@ func dragReorderKeyboardMove(
 		beforeID = itemIDs[newIndex]
 	}
 	w.AnimateLayout(LayoutTransitionCfg{})
+	// Alt+arrow commits a reorder without a drag; same cue, same
+	// reason dispatch cannot raise it (issue #468).
+	playSoundCue(dropCue, w)
 	onReorder(movedID, beforeID, EventCtx{nil, nil, w})
 	return true
 }

--- a/gui/drag_reorder_test.go
+++ b/gui/drag_reorder_test.go
@@ -253,7 +253,8 @@ func TestDragReorderKeyboardMoveRequiresAlt(t *testing.T) {
 	handled := dragReorderKeyboardMove(
 		KeyDown, ModNone, dragReorderVertical, 1,
 		[]string{"a", "b", "c"},
-		func(string, string, EventCtx) { called = true }, w)
+		func(string, string, EventCtx) { called = true },
+		SoundNone, w)
 	if handled || called {
 		t.Error("should not handle without Alt modifier")
 	}
@@ -271,7 +272,7 @@ func TestDragReorderKeyboardMovePayloadAndBoundary(t *testing.T) {
 			called = true
 			moved = m
 			before = b
-		}, w)
+		}, SoundNone, w)
 	if !handled || !called {
 		t.Error("Alt+Right should be handled")
 	}
@@ -284,7 +285,8 @@ func TestDragReorderKeyboardMovePayloadAndBoundary(t *testing.T) {
 	handled = dragReorderKeyboardMove(
 		KeyLeft, ModAlt, dragReorderHorizontal, 0,
 		[]string{"a", "b", "c"},
-		func(string, string, EventCtx) { boundaryCalled = true }, w)
+		func(string, string, EventCtx) { boundaryCalled = true },
+		SoundNone, w)
 	if handled || boundaryCalled {
 		t.Error("Alt+Left at 0 should be a no-op")
 	}
@@ -390,7 +392,8 @@ func TestDragReorderCancelsOnMidDragMutation(t *testing.T) {
 	// Simulate list mutation before mouse-up.
 	dragReorderIDsMetaSet(w, dragKey, []string{"a", "c"})
 	dragReorderOnMouseUp(dragKey, []string{"a", "c"},
-		func(string, string, EventCtx) { called = true }, w)
+		func(string, string, EventCtx) { called = true },
+		w)
 	if called {
 		t.Error("callback should not fire on mutation")
 	}

--- a/gui/input_numeric.go
+++ b/gui/input_numeric.go
@@ -586,16 +586,31 @@ func numericInputCommitResultMode(text string, value, minVal, maxVal Opt[float64
 }
 
 func numericInputStepResultMode(text string, value, minVal, maxVal Opt[float64], decimals int, stepCfg NumericStepCfg, locale NumericLocaleCfg, direction float64, modifiers Modifier, mc numericModeCfg) (Opt[float64], string) {
+	v, s, _ := numericInputStepResultClamped(text, value, minVal, maxVal, decimals, stepCfg, locale, direction, modifiers, mc)
+	return v, s
+}
+
+// numericInputStepResultClamped is numericInputStepResultMode plus the
+// fact the caller needs to sound a cue: whether the step was refused
+// because the value already sat at Min or Max.
+//
+// Reported here rather than re-derived at the call site, which would
+// have to recompute the seed and would drift the moment the stepping
+// rule changes (issue #468). Always false for direction == 0, which is
+// a commit, not a step.
+func numericInputStepResultClamped(text string, value, minVal, maxVal Opt[float64], decimals int, stepCfg NumericStepCfg, locale NumericLocaleCfg, direction float64, modifiers Modifier, mc numericModeCfg) (Opt[float64], string, bool) {
 	loc := numericLocaleNormalize(locale)
 	if direction == 0 {
-		return numericInputCommitResultMode(text, value, minVal, maxVal, decimals, loc, mc)
+		v, s := numericInputCommitResultMode(text, value, minVal, maxVal, decimals, loc, mc)
+		return v, s, false
 	}
 	normalized := numericStepCfgNormalize(stepCfg)
 	stepDisplay := numericStepDelta(normalized, modifiers)
 	delta := numericModeStepDelta(stepDisplay, mc)
 	seed := numericStepSeedMode(text, value, minVal, decimals, loc, mc)
 	clamped := numericClamp(seed+(delta*direction), minVal, maxVal)
-	return Some(clamped), numericModeFormatValue(clamped, decimals, loc, mc)
+	return Some(clamped), numericModeFormatValue(clamped, decimals, loc, mc),
+		clamped == seed
 }
 
 func numericInputPreCommitTransformMode(current, proposed string, decimals int, locale NumericLocaleCfg, mc numericModeCfg) (string, bool) {

--- a/gui/sound.go
+++ b/gui/sound.go
@@ -128,6 +128,31 @@ func resolveSoundCue(themeCue, cfgCue SoundCue, disabled bool) SoundCue {
 	return ResolveSoundCue(themeCue, cfgCue, disabled)
 }
 
+// soundCues is the resolved pair a path outside event dispatch needs:
+// the cue for a change that lands, and the cue for one that is refused
+// — an arrow key already at the bound, a keystroke a mask rejects.
+//
+// Resolved at generation time and passed by value, so a handler closure
+// captures a plain SoundCue rather than a *Layout the arena pools
+// (issue #468).
+type soundCues struct {
+	act    SoundCue
+	reject SoundCue
+}
+
+// resolveSoundCues resolves that pair from a widget Cfg.
+//
+// Only act takes the Cfg override: Cfg.Sound names the widget's
+// activation sound, not its refusal, so the reject cue stays the
+// theme's Error role. SoundDisabled suppresses both — a widget opted
+// out of sound must not still beep.
+func resolveSoundCues(themeAct, cfgAct SoundCue, disabled bool) soundCues {
+	return soundCues{
+		act:    resolveSoundCue(themeAct, cfgAct, disabled),
+		reject: resolveSoundCue(guiTheme.Sounds.Error, SoundNone, disabled),
+	}
+}
+
 // SetSoundPlayer installs the window's sound player. Nil disables
 // widget sound without changing any theme or Cfg.
 func (w *Window) SetSoundPlayer(p SoundPlayer) {
@@ -191,8 +216,20 @@ func playShapeSound(l *Layout, w *Window) {
 	if l.Shape.Disabled {
 		return
 	}
-	cue := l.Shape.events.soundCue
-	if cue == SoundNone {
+	playSoundCue(l.Shape.events.soundCue, w)
+}
+
+// playSoundCue emits an already-resolved cue on the paths dispatch never
+// sees — table keyboard activation, an Input reject, a drag drop — where
+// there is no Shape to read the cue off (issue #468).
+//
+// Every guard playShapeSound relies on past the shape lives here, so a
+// new call site inherits the nil-player, zero-Theme.Sounds and muted
+// cases for free. It takes no lock: SoundVolume does not go through
+// lockForAPI, so a cue may be emitted inline even under the frame lock,
+// and no site needs deferCallback.
+func playSoundCue(cue SoundCue, w *Window) {
+	if cue == SoundNone || w == nil {
 		return
 	}
 	p := w.soundPlayer

--- a/gui/sound_keyboard_test.go
+++ b/gui/sound_keyboard_test.go
@@ -1,0 +1,541 @@
+package gui
+
+import "testing"
+
+// Phase 3 of widget audio feedback (issue #468): the paths event
+// dispatch never sees — keyboard activation that calls a callback
+// directly with a nil Layout, a keystroke a mask or validator refuses,
+// an arrow key already at a bound, and a drag that ends on a real move.
+//
+// Every case drives the real keyboard or drag path. None calls
+// playSoundCue or playShapeSound directly: the point of the phase is
+// that these paths reach the cue at all, which only the real path
+// proves. Theme installation is package-global, so nothing here runs
+// in parallel and every test starts with restoreTheme(t).
+
+// --- Table -----------------------------------------------------------
+
+func tableSoundRows() []TableRowCfg {
+	return []TableRowCfg{
+		{Cells: []TableCellCfg{{Value: "r0"}}},
+		{Cells: []TableCellCfg{{Value: "r1"}}},
+	}
+}
+
+func TestSoundTableKeyboardActivation(t *testing.T) {
+	restoreTheme(t)
+	activated := 0
+	rows := tableSoundRows()
+	for i := range rows {
+		rows[i].OnClick = func(ctx EventCtx) { activated++ }
+	}
+	w, spy := soundWindow(t, func(*Window) View {
+		return Table(TableCfg{
+			ID:        "tbl",
+			Focusable: true,
+			Data:      rows,
+		})
+	})
+	if err := w.TestKey("tbl", KeyEnter, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	if activated != 1 {
+		t.Fatalf("row activated %d times, want 1", activated)
+	}
+	wantCues(t, spy, SoundSelection)
+}
+
+func TestSoundTableKeyboardEdgeClampErrors(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, func(*Window) View {
+		return Table(TableCfg{
+			ID:        "tbl",
+			Focusable: true,
+			Data:      tableSoundRows(),
+		})
+	})
+	// The active row starts at 0, so Up is refused.
+	if err := w.TestKey("tbl", KeyUp, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy, SoundError)
+}
+
+func TestSoundTableKeyboardMovementSilent(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, func(*Window) View {
+		return Table(TableCfg{
+			ID:        "tbl",
+			Focusable: true,
+			Data:      tableSoundRows(),
+		})
+	})
+	if err := w.TestKey("tbl", KeyDown, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy)
+}
+
+// --- Input -----------------------------------------------------------
+
+// inputSoundView renders one Input, letting the caller shape the Cfg.
+func inputSoundView(build func(*InputCfg)) func(*Window) View {
+	return func(*Window) View {
+		cfg := InputCfg{ID: "fld"}
+		build(&cfg)
+		return Input(cfg)
+	}
+}
+
+func TestSoundInputMaskRejectErrors(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {
+		// A digits-only mask: a letter has no slot to land in.
+		c.Mask = "999"
+	}))
+	if err := w.TestType("fld", "x"); err != nil {
+		t.Fatalf("TestType: %v", err)
+	}
+	wantCues(t, spy, SoundError)
+}
+
+func TestSoundInputMaskAcceptSilent(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {
+		c.Mask = "999"
+		c.OnTextChanged = func(string, EventCtx) {}
+	}))
+	if err := w.TestType("fld", "1"); err != nil {
+		t.Fatalf("TestType: %v", err)
+	}
+	wantCues(t, spy)
+}
+
+func TestSoundInputValidatorRejectErrors(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {
+		c.PreTextChange = func(current, _ string) (string, bool) {
+			return current, false
+		}
+	}))
+	if err := w.TestType("fld", "a"); err != nil {
+		t.Fatalf("TestType: %v", err)
+	}
+	wantCues(t, spy, SoundError)
+}
+
+func TestSoundInputDeleteOverMaskLiteralErrors(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {
+		// The cursor sits at 0, so a backspace has no character
+		// behind it that the mask allows removing.
+		c.Mask = "(999)"
+		c.Text = "(123)"
+	}))
+	if err := w.TestKey("fld", KeyBackspace, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy, SoundError)
+}
+
+func TestSoundInputUnmaskedDeleteAtEdgeSilent(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {}))
+	// Backspace in an empty unmasked field is an edge, not a
+	// rejection.
+	if err := w.TestKey("fld", KeyBackspace, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy)
+}
+
+func TestSoundInputEnterCommitClicks(t *testing.T) {
+	restoreTheme(t)
+	committed := ""
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {
+		c.Text = "hi"
+		c.OnTextCommit = func(s string, _ InputCommitReason, _ EventCtx) {
+			committed = s
+		}
+	}))
+	if err := w.TestKey("fld", KeyEnter, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	if committed != "hi" {
+		t.Fatalf("committed %q, want %q", committed, "hi")
+	}
+	wantCues(t, spy, SoundClick)
+}
+
+// The Enter commit is the one Input path that takes Cfg.Sound; the
+// reject path stays on the theme's Error role either way.
+func TestSoundInputCfgOverridesCommitNotReject(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {
+		c.Mask = "999"
+		c.Sound = SoundSelection
+		c.OnTextCommit = func(string, InputCommitReason, EventCtx) {}
+	}))
+	if err := w.TestType("fld", "x"); err != nil {
+		t.Fatalf("TestType: %v", err)
+	}
+	if err := w.TestKey("fld", KeyEnter, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy, SoundError, SoundSelection)
+}
+
+func TestSoundInputDisabledSuppressesBoth(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, inputSoundView(func(c *InputCfg) {
+		c.Mask = "999"
+		c.SoundDisabled = true
+		c.OnTextCommit = func(string, InputCommitReason, EventCtx) {}
+	}))
+	if err := w.TestType("fld", "x"); err != nil {
+		t.Fatalf("TestType: %v", err)
+	}
+	if err := w.TestKey("fld", KeyEnter, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy)
+}
+
+// The acceptance criterion for the phase: SoundError reaches
+// NewBeepSoundPlayer, the player that plays that cue and nothing else,
+// through the real reject path.
+func TestSoundInputRejectReachesBeepPlayer(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(NewBeepSoundPlayer(w))
+	w.TestRender(inputSoundView(func(c *InputCfg) {
+		c.Mask = "999"
+		c.OnTextChanged = func(string, EventCtx) {}
+	}))
+	// No native platform in a headless window, so the beep is a
+	// no-op; the assertion is that neither the accepted keystroke nor
+	// the refused one panics on the way there.
+	if err := w.TestType("fld", "1"); err != nil {
+		t.Fatalf("TestType accepted: %v", err)
+	}
+	if err := w.TestType("fld", "x"); err != nil {
+		t.Fatalf("TestType refused: %v", err)
+	}
+}
+
+// --- NumericInput ----------------------------------------------------
+
+func numericSoundView(value, minVal, maxVal float64) func(*Window) View {
+	return func(*Window) View {
+		return NumericInput(NumericInputCfg{
+			ID:      "num",
+			Value:   Some(value),
+			Min:     Some(minVal),
+			Max:     Some(maxVal),
+			StepCfg: NumericStepCfg{Step: 1, ShowButtons: true},
+			OnValueCommit: func(Opt[float64], string, EventCtx) {
+			},
+		})
+	}
+}
+
+func TestSoundNumericStepClampErrors(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, numericSoundView(10, 0, 10))
+	if err := w.TestClick(ScopeID("num", "step_up")); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	if len(spy.cues) == 0 || spy.cues[len(spy.cues)-1] != SoundError {
+		t.Fatalf("cues = %v, want the last to be SoundError", spy.cues)
+	}
+}
+
+func TestSoundNumericStepThatMovesDoesNotError(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, numericSoundView(5, 0, 10))
+	if err := w.TestClick(ScopeID("num", "step_up")); err != nil {
+		t.Fatalf("TestClick: %v", err)
+	}
+	for _, c := range spy.cues {
+		if c == SoundError {
+			t.Fatalf("cues = %v, want no SoundError", spy.cues)
+		}
+	}
+}
+
+// --- Slider ----------------------------------------------------------
+
+func sliderSoundView(value float32) func(*Window) View {
+	return func(*Window) View {
+		return Slider(SliderCfg{
+			ID:       "sld",
+			Value:    value,
+			Min:      0,
+			Max:      10,
+			Step:     1,
+			OnChange: func(float32, EventCtx) {},
+		})
+	}
+}
+
+func TestSoundSliderArrowAtBoundErrors(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, sliderSoundView(10))
+	if err := w.TestKey("sld", KeyRight, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy, SoundError)
+}
+
+func TestSoundSliderArrowThatMovesIsSilent(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, sliderSoundView(5))
+	if err := w.TestKey("sld", KeyRight, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy)
+}
+
+// --- ListBox ---------------------------------------------------------
+
+func listBoxSoundView(sel []string) func(*Window) View {
+	return func(*Window) View {
+		return ListBox(ListBoxCfg{
+			ID: "lb",
+			Data: []ListBoxOption{
+				{ID: "a", Name: "Alpha"},
+				{ID: "b", Name: "Beta"},
+			},
+			SelectedIDs: sel,
+			OnSelect:    func([]string, EventCtx) {},
+		})
+	}
+}
+
+func TestSoundListBoxKeyboardActivationSelects(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, listBoxSoundView(nil))
+	if err := w.TestKey("lb", KeyEnter, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy, SoundSelection)
+}
+
+func TestSoundListBoxArrowMovementSilentEdgeErrors(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, listBoxSoundView(nil))
+	// Down moves off row 0 and stays silent.
+	if err := w.TestKey("lb", KeyDown, ModNone); err != nil {
+		t.Fatalf("TestKey down: %v", err)
+	}
+	wantCues(t, spy)
+	// Down again is refused: row 1 is the last.
+	if err := w.TestKey("lb", KeyDown, ModNone); err != nil {
+		t.Fatalf("TestKey down again: %v", err)
+	}
+	wantCues(t, spy, SoundError)
+}
+
+// --- Drag reorder ----------------------------------------------------
+
+// dragReorderSoundState arms a drag the way dragReorderStart does,
+// then drives the real mouse-up. Building the state directly is the
+// only way to reach the drop without a backend to move the mouse.
+func dragReorderSoundState(
+	w *Window, key string, cue SoundCue, src, gap int,
+) {
+	w.layout = Layout{Shape: &Shape{ID: "root"}}
+	state := dragReorderState{
+		started:      true,
+		active:       true,
+		sourceIndex:  src,
+		currentIndex: gap,
+		itemCount:    3,
+		dropCue:      cue,
+	}
+	dragReorderSet(w, key, state)
+}
+
+func TestSoundDragReorderDropSelects(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	spy := &soundSpy{}
+	w.SetSoundPlayer(spy)
+	dragReorderSoundState(w, "lb", SoundSelection, 0, 2)
+
+	moved := false
+	dragReorderOnMouseUp("lb", []string{"a", "b", "c"},
+		func(string, string, EventCtx) { moved = true }, w)
+	if !moved {
+		t.Fatal("a real move must fire OnReorder")
+	}
+	wantCues(t, spy, SoundSelection)
+}
+
+func TestSoundDragReorderNoOpDropSilent(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	spy := &soundSpy{}
+	w.SetSoundPlayer(spy)
+	// gap == src: the item lands where it already was.
+	dragReorderSoundState(w, "lb", SoundSelection, 1, 1)
+
+	dragReorderOnMouseUp("lb", []string{"a", "b", "c"},
+		func(string, string, EventCtx) {
+			t.Fatal("a no-op drop must not reorder")
+		}, w)
+	wantCues(t, spy)
+}
+
+func TestSoundDragReorderCancelSilent(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	spy := &soundSpy{}
+	w.SetSoundPlayer(spy)
+	dragReorderSoundState(w, "lb", SoundSelection, 0, 2)
+	state := dragReorderGet(w, "lb")
+	state.cancelled = true
+	dragReorderSet(w, "lb", state)
+
+	dragReorderOnMouseUp("lb", []string{"a", "b", "c"},
+		func(string, string, EventCtx) {
+			t.Fatal("a cancelled drag must not reorder")
+		}, w)
+	wantCues(t, spy)
+}
+
+func TestSoundDragReorderKeyboardMoveSelects(t *testing.T) {
+	restoreTheme(t)
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	spy := &soundSpy{}
+	w.SetSoundPlayer(spy)
+	w.layout = Layout{Shape: &Shape{ID: "root"}}
+
+	if !dragReorderKeyboardMove(KeyDown, ModAlt, dragReorderVertical,
+		0, []string{"a", "b", "c"},
+		func(string, string, EventCtx) {}, SoundSelection, w) {
+		t.Fatal("Alt+Down must reorder")
+	}
+	wantCues(t, spy, SoundSelection)
+
+	// At the last index there is nowhere to go: no move, no cue.
+	spy.cues = nil
+	if dragReorderKeyboardMove(KeyDown, ModAlt, dragReorderVertical,
+		2, []string{"a", "b", "c"},
+		func(string, string, EventCtx) {}, SoundSelection, w) {
+		t.Fatal("Alt+Down at the last index must be a no-op")
+	}
+	wantCues(t, spy)
+}
+
+// --- Splitter --------------------------------------------------------
+
+func splitterSoundView(collapsed SplitterCollapsed) func(*Window) View {
+	return func(*Window) View {
+		return Splitter(SplitterCfg{
+			ID:        "spl",
+			Focusable: true,
+			Collapsed: collapsed,
+			First: SplitterPaneCfg{
+				Collapsible: true,
+				Content:     []View{Text(TextCfg{Text: "one"})},
+			},
+			Second: SplitterPaneCfg{
+				Content: []View{Text(TextCfg{Text: "two"})},
+			},
+			OnChange: func(float32, SplitterCollapsed, EventCtx) {},
+		})
+	}
+}
+
+func TestSoundSplitterCollapseToggles(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, splitterSoundView(splitterCollapseNone))
+	if err := w.TestKey("spl", KeyHome, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy, SoundToggleOn)
+}
+
+func TestSoundSplitterExpandTogglesOff(t *testing.T) {
+	restoreTheme(t)
+	w, spy := soundWindow(t, splitterSoundView(SplitterCollapseFirst))
+	// Enter on an already-collapsed splitter expands it.
+	if err := w.TestKey("spl", KeyEnter, ModNone); err != nil {
+		t.Fatalf("TestKey: %v", err)
+	}
+	wantCues(t, spy, SoundToggleOff)
+}
+
+// --- Silence guarantees ----------------------------------------------
+
+// Every new site must stay silent and panic-free with no player, with
+// a theme that names no cues, and at zero volume. Driven through the
+// same real paths as the sounding cases above.
+func TestSoundPhase3SilentConfigurations(t *testing.T) {
+	restoreTheme(t)
+	drive := func(t *testing.T, w *Window) {
+		t.Helper()
+		w.TestRender(func(*Window) View {
+			return Column(ContainerCfg{
+				ID: "root",
+				Content: []View{
+					Input(InputCfg{ID: "fld", Mask: "999"}),
+					Slider(SliderCfg{
+						ID: "sld", Value: 10, Min: 0, Max: 10,
+						Step:     1,
+						OnChange: func(float32, EventCtx) {},
+					}),
+					Table(TableCfg{
+						ID: "tbl", Focusable: true,
+						Data: tableSoundRows(),
+					}),
+				},
+			})
+		})
+		if err := w.TestType(ScopeID("root", "fld"), "x"); err != nil {
+			t.Fatalf("TestType: %v", err)
+		}
+		if err := w.TestKey(ScopeID("root", "sld"),
+			KeyRight, ModNone); err != nil {
+			t.Fatalf("TestKey slider: %v", err)
+		}
+		if err := w.TestKey(ScopeID("root", "tbl"),
+			KeyUp, ModNone); err != nil {
+			t.Fatalf("TestKey table: %v", err)
+		}
+	}
+
+	t.Run("no player", func(t *testing.T) {
+		restoreTheme(t)
+		w := NewTestWindow(WindowCfg{})
+		w.SetTheme(soundingTheme(t))
+		drive(t, w)
+	})
+
+	t.Run("silent theme", func(t *testing.T) {
+		restoreTheme(t)
+		w := NewTestWindow(WindowCfg{})
+		w.SetTheme(silentTheme(t))
+		spy := &soundSpy{}
+		w.SetSoundPlayer(spy)
+		drive(t, w)
+		wantCues(t, spy)
+	})
+
+	t.Run("zero volume", func(t *testing.T) {
+		restoreTheme(t)
+		w := NewTestWindow(WindowCfg{})
+		w.SetTheme(soundingTheme(t))
+		spy := &soundSpy{}
+		w.SetSoundPlayer(spy)
+		w.SetSoundVolume(0)
+		drive(t, w)
+		wantCues(t, spy)
+	})
+}

--- a/gui/view_dock_layout.go
+++ b/gui/view_dock_layout.go
@@ -409,7 +409,8 @@ func dockTabButton(
 		SoundDisabled: tabSound == SoundNone,
 		OnClick: func(ctx EventCtx) {
 			dockDragStart(dockID, panelID, groupID, root,
-				onLayoutChange, ctx.Layout, ctx.Event, ctx.Window)
+				onLayoutChange, tabSound,
+				ctx.Layout, ctx.Event, ctx.Window)
 			if onPanelSelect != nil {
 				onPanelSelect(groupID, panelID, ctx)
 			}

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -96,6 +96,21 @@ type InputCfg struct {
 	// interaction entirely and announces AccessStateDisabled.
 	ReadOnly bool
 
+	// Sound overrides the theme's click cue for an Enter commit.
+	// SoundNone (the zero value) takes Theme.Sounds.Click.
+	//
+	// Rejection is separate and always takes Theme.Sounds.Error: a
+	// keystroke a mask or a PreTextChange validator refuses, whether
+	// typed, pasted, or a delete over a mask literal. Both are
+	// suppressed by SoundDisabled below (issue #468).
+	// exportaudit:keep — caller-facing config (issue #468)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this field's sound regardless of the
+	// theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #468)
+	SoundDisabled bool
+
 	// Scrollable opts a multiline input into the scroll system.
 	// Scroll state is keyed by Cfg.ID - pass that same id to
 	// Window.ScrollVerticalTo. Requires Mode == InputMultiline.
@@ -202,6 +217,8 @@ func Input(cfg InputCfg) View {
 		OnKeyUp:             cfg.OnKeyUp,
 		preTextChange:       cfg.PreTextChange,
 		postCommitNormalize: cfg.PostCommitNormalize,
+		cues: resolveSoundCues(
+			guiTheme.Sounds.Click, cfg.Sound, cfg.SoundDisabled),
 	}
 	hcfg.CompiledMask = hcfg.compiledMask()
 
@@ -372,14 +389,19 @@ type inputHandlerCfg struct {
 	OnKeyUp             func(EventCtx)
 	preTextChange       func(current, proposed string) (string, bool)
 	postCommitNormalize func(text string, reason InputCommitReason) string
-	Mask                string
-	maskTokens          []MaskTokenDef
-	FocusID             string
-	scrollID            string
-	IsPassword          bool
-	ReadOnly            bool
-	Mode                inputMode
-	MaskPreset          InputMaskPreset
+	// cues are resolved at generation time and travel by value:
+	// act sounds an Enter commit, reject sounds a refused keystroke.
+	// Neither path reaches event dispatch, so neither can read a cue
+	// off the shape (issue #468).
+	cues       soundCues
+	Mask       string
+	maskTokens []MaskTokenDef
+	FocusID    string
+	scrollID   string
+	IsPassword bool
+	ReadOnly   bool
+	Mode       inputMode
+	MaskPreset InputMaskPreset
 }
 
 // fireTextChanged notifies the caller that the text changed. Every

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -49,6 +49,11 @@ func inputTextChange(hcfg inputHandlerCfg, layout *Layout, text, ins string, id 
 		text = inputInsert(text, ins, id, w)
 		return text, true
 	}
+	// The one line both refusals reach: a mask with no slot for this
+	// character, or a PreTextChange validator that vetoed it. Nothing
+	// changed and nothing consumed the event in a way dispatch could
+	// sound, so the cue is raised here (issue #468).
+	playSoundCue(hcfg.cues.reject, w)
 	return text, false
 }
 
@@ -196,10 +201,10 @@ func makeInputOnKeyDown(hcfg inputHandlerCfg) func(EventCtx) {
 				text, id, ctx.Event, ctx.Window)
 		case KeyBackspace:
 			text, textChanged = inputKeyBackspaceOrDelete(
-				text, id, false, mask, ctx.Layout, ctx.Window)
+				text, id, false, mask, ctx.Layout, ctx.Window, hcfg.cues.reject)
 		case KeyDelete:
 			text, textChanged = inputKeyBackspaceOrDelete(
-				text, id, true, mask, ctx.Layout, ctx.Window)
+				text, id, true, mask, ctx.Layout, ctx.Window, hcfg.cues.reject)
 		default:
 			handled = false
 		}
@@ -294,14 +299,24 @@ func inputKeyUndoRedo(
 	return text, false, true
 }
 
+// inputKeyBackspaceOrDelete removes a grapheme, or refuses to.
+//
+// rejectCue sounds only for a masked field: the delete landed on a mask
+// literal, which is a refusal the user should hear. An unmasked field
+// that cannot delete is at the start or end of its text — an edge, not
+// a rejection — and stays silent (issue #468).
 func inputKeyBackspaceOrDelete(
 	text string, id string, forward bool,
 	mask *CompiledInputMask, layout *Layout, w *Window,
+	rejectCue SoundCue,
 ) (string, bool) {
 	if newText, ok := inputHandleDelete(
 		text, id, forward, mask, layout, w,
 	); ok {
 		return newText, true
+	}
+	if mask != nil {
+		playSoundCue(rejectCue, w)
 	}
 	return text, false
 }

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -225,12 +225,15 @@ func inputKeyPaste(
 			})
 			return res.Text, true
 		}
+		// The mask has no room for the pasted text (issue #468).
+		playSoundCue(hcfg.cues.reject, w)
 		return text, false
 	}
 	if hcfg.preTextChange != nil {
 		proposed := inputProposedText(text, clip, id, w)
 		adjusted, ok := hcfg.preTextChange(text, proposed)
 		if !ok {
+			playSoundCue(hcfg.cues.reject, w)
 			return text, false
 		}
 		if adjusted == proposed {
@@ -248,6 +251,11 @@ func inputCommitEnter(
 	hcfg inputHandlerCfg,
 	layout *Layout, text string, e *Event, w *Window,
 ) {
+	// Enter is a deliberate activation, so it sounds like one — before
+	// the callbacks and independently of whether they consume, the way
+	// dispatch sounds a click. The blur commit stays silent by
+	// decision: it is incidental, not an activation (issue #468).
+	playSoundCue(hcfg.cues.act, w)
 	commitText := text
 	if normalized := hcfg.normalizeOnCommit(
 		text, InputCommitEnter,

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -65,6 +65,15 @@ type NumericInputCfg struct {
 	// entirely.
 	ReadOnly bool
 
+	// SoundDisabled suppresses the field's sound regardless of the
+	// theme. There is no Sound field to pair with it: the step
+	// buttons already sound through the ordinary click path, so the
+	// only cue this control raises on its own is Theme.Sounds.Error
+	// for a step refused because the value already sits at Min or
+	// Max (issue #468).
+	// exportaudit:keep — caller-facing config (issue #468)
+	SoundDisabled bool
+
 	Disabled  bool
 	Invisible bool
 }
@@ -346,10 +355,19 @@ func numericInputApplyStep(
 		return
 	}
 	modeCfg := numericModeCfgFromInput(cfg)
-	value, committed := numericInputStepResultMode(
+	value, committed, clamped := numericInputStepResultClamped(
 		cfg.Text, cfg.Value, cfg.Min, cfg.Max,
 		cfg.Decimals, stepCfg, locale, dir,
 		e.Modifiers, modeCfg)
+	if clamped {
+		// The step was understood but the value could not move: it
+		// already sat at Min or Max. The button's own click cue, if
+		// the theme sets one, still fires through dispatch; this
+		// adds the refusal on top (issue #468).
+		playSoundCue(
+			resolveSoundCue(guiTheme.Sounds.Error, SoundNone,
+				cfg.SoundDisabled), w)
+	}
 	if cfg.OnValueCommit != nil {
 		cfg.OnValueCommit(value, committed, EventCtx{layout, nil, w})
 	}

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -160,6 +160,11 @@ func ListBox(cfg ListBoxCfg) View {
 	isMultiple := cfg.Multiple
 	onSelect := cfg.OnSelect
 	selectedIDs := cfg.SelectedIDs
+	// Resolved once, at generation time: the keyboard path calls
+	// onSelect with a nil Layout, so it carries its cues by value
+	// rather than reading them off a shape (issue #468).
+	keyCues := resolveSoundCues(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
 
 	return Column(ContainerCfg{
 		ID:       cfg.ID,
@@ -174,7 +179,7 @@ func ListBox(cfg ListBoxCfg) View {
 		OnKeyDown: func(ctx EventCtx) {
 			listBoxOnKeyDown(listBoxID, itemIDs,
 				isMultiple, onSelect, selectedIDs,
-				"", 0, 0, nil, ctx.Event, ctx.Window)
+				"", 0, 0, nil, keyCues, ctx.Event, ctx.Window)
 		},
 		Width:       cfg.MaxWidth,
 		Height:      cfg.Height,
@@ -223,6 +228,11 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 	isMultiple := cfg.Multiple
 	onSelect := cfg.OnSelect
 	selectedIDs := cfg.SelectedIDs
+	// Resolved once, at generation time: the keyboard path calls
+	// onSelect with a nil Layout, so it carries its cues by value
+	// rather than reading them off a shape (issue #468).
+	keyCues := resolveSoundCues(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
 	itemIDs := cache.itemIDs
 	itemDataIndices := cache.itemDataIndices
 
@@ -293,14 +303,16 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 				if curIdx >= 0 && curIdx < len(itemIDs) &&
 					dragReorderKeyboardMove(ctx.Event.KeyCode,
 						ctx.Event.Modifiers, dragReorderVertical,
-						curIdx, itemIDs, onReorder, ctx.Window) {
+						curIdx, itemIDs, onReorder, keyCues.act,
+						ctx.Window) {
 					ctx.Consume()
 					return
 				}
 			}
 			listBoxOnKeyDown(listBoxID, itemIDs,
 				isMultiple, onSelect, selectedIDs,
-				scrollID, rowH, listH, itemDataIndices, ctx.Event, ctx.Window)
+				scrollID, rowH, listH, itemDataIndices, keyCues,
+				ctx.Event, ctx.Window)
 		},
 		Width:       cfg.MaxWidth,
 		Height:      cfg.Height,
@@ -441,6 +453,7 @@ func listBoxOnKeyDown(
 	selectedIDs []string,
 	scrollID string, rowH, listH float32,
 	itemDataIndices []int,
+	cues soundCues,
 	e *Event,
 	w *Window,
 ) {
@@ -466,6 +479,10 @@ func listBoxOnKeyDown(
 			datID := itemIDs[curIdx]
 			ids := listBoxNextSelectedIDs(
 				selectedIDs, datID, isMultiple)
+			// Keyboard activation reaches onSelect directly, with a
+			// nil Layout, so dispatch never sees it and the row's own
+			// cue cannot fire (issue #468).
+			playSoundCue(cues.act, w)
 			onSelect(ids, EventCtx{nil, e, w})
 		}
 		return
@@ -480,7 +497,12 @@ func listBoxOnKeyDown(
 				rowH, listH, w)
 		}
 		w.UpdateWindow()
+		return
 	}
+	// Already at the first or last row. Movement itself is silent by
+	// decision — a held arrow key would machine-gun the cue — so the
+	// refusal is the only thing worth hearing (issue #468).
+	playSoundCue(cues.reject, w)
 }
 
 func applyListBoxDefaults(cfg *ListBoxCfg) {

--- a/gui/view_listbox_items.go
+++ b/gui/view_listbox_items.go
@@ -242,6 +242,11 @@ func listBoxReorderItemView(
 	// The cue marks the selection the click makes, not the drag it
 	// also starts: a drag has no activation moment to sound at, and
 	// dragging is phase 3's question (issue #467).
+	// The drop cue is resolved unconditionally: a reorder is a change
+	// whether or not the list also reports selection (issue #468).
+	dropCue := resolveSoundCue(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
+
 	rowSound := SoundNone
 	if hasOnSelect {
 		rowSound = resolveSoundCue(
@@ -267,6 +272,7 @@ func listBoxReorderItemView(
 		OnClick: func(ctx EventCtx) {
 			dragReorderStart(dragReorderStartCfg{
 				DragKey:       listBoxID,
+				DropCue:       dropCue,
 				Index:         dragIdx,
 				ItemID:        datID,
 				Axis:          dragReorderVertical,

--- a/gui/view_menu.go
+++ b/gui/view_menu.go
@@ -91,6 +91,12 @@ func menuOnKeyDown(cfg MenubarCfg,
 		if !found {
 			return
 		}
+		// Keyboard activation reaches the item's Action directly,
+		// with a nil Layout, so dispatch never sees it and the item's
+		// own click cue cannot fire. The cue leads the callbacks and
+		// ignores consumption, matching the mouse path (issue #468).
+		playSoundCue(resolveSoundCue(guiTheme.Sounds.Click,
+			cfg.Sound, cfg.SoundDisabled), w)
 		if item.Action != nil {
 			item.Action(&item, EventCtx{nil, e, w})
 		}
@@ -129,6 +135,11 @@ func menuOnKeyDown(cfg MenubarCfg,
 		if target != "" && target != sel {
 			sm.Set(cfg.ID, target)
 			w.viewState.menuKeyNav = true
+		} else {
+			// No neighbour that way: the edge of the menu. Movement
+			// itself stays silent (issue #468).
+			playSoundCue(resolveSoundCue(guiTheme.Sounds.Error,
+				SoundNone, cfg.SoundDisabled), w)
 		}
 		e.IsHandled = true
 	}

--- a/gui/view_slider.go
+++ b/gui/view_slider.go
@@ -35,8 +35,17 @@ type SliderCfg struct {
 	// FocusDisabled opts out of the default-on focus. Focus also
 	// requires a non-empty ID; without one the control is inert.
 	FocusDisabled bool
-	Color         Color
-	ColorBorder   Color
+
+	// SoundDisabled suppresses the slider's sound regardless of the
+	// theme. There is no Sound field to pair with it: a slider has
+	// no activation moment to sound at — arrow movement and drag are
+	// both deliberately silent — so Theme.Sounds.Error on an arrow
+	// key already at Min or Max is the only cue it emits (#468).
+	// exportaudit:keep — caller-facing config (issue #468)
+	SoundDisabled bool
+
+	Color       Color
+	ColorBorder Color
 	// ColorThumb paints the thumb. Unset takes the theme default.
 	// exportaudit:keep — caller-facing config (issue #372)
 	ColorThumb Color
@@ -119,6 +128,11 @@ func Slider(cfg SliderCfg) View {
 	step := cfg.Step
 	vertical := cfg.Vertical
 	roundValue := cfg.RoundValue
+	// Resolved at generation time and captured by value: the key
+	// handler reports a refused move, which dispatch never sees
+	// because nothing was activated (issue #468).
+	rejectCue := resolveSoundCue(
+		guiTheme.Sounds.Error, SoundNone, cfg.SoundDisabled)
 	size := cfg.Size
 	szBorder := sizeBorder
 	thumbSize := cfg.ThumbSize
@@ -218,8 +232,9 @@ func Slider(cfg SliderCfg) View {
 			}
 		},
 		OnKeyDown: func(ctx EventCtx) {
-			sliderOnKeyDown(ctx.Layout, ctx.Event, ctx.Window,
-				onChange, value, minVal, maxVal, step, roundValue)
+			sliderOnKeyDown(ctx.Event, ctx.Window,
+				onChange, value, minVal, maxVal, step, roundValue,
+				rejectCue)
 		},
 		Content: []View{
 			container(ContainerCfg{
@@ -386,10 +401,16 @@ func sliderMouseMove(
 	}
 }
 
+// sliderOnKeyDown moves the value by one step, or to a bound.
+//
+// rejectCue sounds when the key was understood but the value could not
+// move — an arrow already at Min or Max. Movement itself is silent by
+// decision: a held arrow key would machine-gun the cue (issue #468).
 func sliderOnKeyDown(
-	_ *Layout, e *Event, w *Window,
+	e *Event, w *Window,
 	onChange func(float32, EventCtx),
 	curValue, minVal, maxVal, step float32, roundValue bool,
+	rejectCue SoundCue,
 ) {
 	if onChange == nil || e.Modifiers != ModNone {
 		return
@@ -413,7 +434,9 @@ func sliderOnKeyDown(
 	}
 	if v != curValue {
 		onChange(v, EventCtx{nil, e, w})
+		return
 	}
+	playSoundCue(rejectCue, w)
 }
 
 // applySliderDefaults fills zero-value color fields from the theme.

--- a/gui/view_slider_test.go
+++ b/gui/view_slider_test.go
@@ -84,8 +84,8 @@ func TestSliderKeyDown(t *testing.T) {
 			var got float32
 			onChange := func(v float32, ctx EventCtx) { got = v }
 			e := &Event{KeyCode: tt.key}
-			sliderOnKeyDown(nil, e, &Window{},
-				onChange, 50, 0, 100, 1, false)
+			sliderOnKeyDown(e, &Window{},
+				onChange, 50, 0, 100, 1, false, SoundNone)
 			if got != tt.want {
 				t.Errorf("key %d: got %f, want %f",
 					tt.key, got, tt.want)
@@ -193,15 +193,15 @@ func TestSliderKeyDownHandled(t *testing.T) {
 	onChange := func(_ float32, ctx EventCtx) {}
 	// Recognized key sets IsHandled
 	e := &Event{KeyCode: KeyRight}
-	sliderOnKeyDown(nil, e, &Window{},
-		onChange, 50, 0, 100, 1, false)
+	sliderOnKeyDown(e, &Window{},
+		onChange, 50, 0, 100, 1, false, SoundNone)
 	if !e.IsHandled {
 		t.Error("arrow key should set IsHandled")
 	}
 	// Unrecognized key does not set IsHandled
 	e2 := &Event{KeyCode: KeyA}
-	sliderOnKeyDown(nil, e2, &Window{},
-		onChange, 50, 0, 100, 1, false)
+	sliderOnKeyDown(e2, &Window{},
+		onChange, 50, 0, 100, 1, false, SoundNone)
 	if e2.IsHandled {
 		t.Error("unrecognized key should not set IsHandled")
 	}

--- a/gui/view_splitter.go
+++ b/gui/view_splitter.go
@@ -174,8 +174,21 @@ type SplitterCfg struct {
 	Orientation         splitterOrientation
 	Collapsed           SplitterCollapsed
 	ShowCollapseButtons bool
-	Disabled            bool
-	Invisible           bool
+
+	// Sound overrides the theme's toggle cues for the collapse
+	// toggle — Theme.Sounds.ToggleOn when a pane collapses,
+	// ToggleOff when it expands again. Dragging the handle is never
+	// a cue: it is continuous, not an activation (issue #468).
+	// exportaudit:keep — caller-facing config (issue #468)
+	Sound SoundCue
+
+	// SoundDisabled suppresses the splitter's sound regardless of
+	// the theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #468)
+	SoundDisabled bool
+
+	Disabled  bool
+	Invisible bool
 }
 
 // splitterCore holds callback-relevant fields.
@@ -199,6 +212,11 @@ type splitterCore struct {
 	colorHandle       Color
 	colorHandleHover  Color
 	colorHandleActive Color
+	// Collapse cues, resolved at generation time. The handle's key
+	// path reaches onChange directly, so dispatch never sees the
+	// toggle (issue #468).
+	soundCollapse SoundCue
+	soundExpand   SoundCue
 }
 
 type splitterComputed struct {
@@ -237,6 +255,10 @@ func newSplitterCore(cfg *SplitterCfg) *splitterCore {
 		colorHandle:       cfg.ColorHandle,
 		colorHandleHover:  cfg.ColorHandleHover,
 		colorHandleActive: cfg.ColorHandleActive,
+		soundCollapse: resolveSoundCue(
+			guiTheme.Sounds.ToggleOn, cfg.Sound, cfg.SoundDisabled),
+		soundExpand: resolveSoundCue(
+			guiTheme.Sounds.ToggleOff, cfg.Sound, cfg.SoundDisabled),
 	}
 }
 

--- a/gui/view_splitter_handle.go
+++ b/gui/view_splitter_handle.go
@@ -96,6 +96,14 @@ func splitterButton(cfg *SplitterCfg, core *splitterCore,
 		Size:  size,
 	}
 	icon := splitterButtonIcon(core, target)
+	// State-dependent, resolved here: clicking a pane that is already
+	// collapsed expands it. A resolved cue fed into a nested ButtonCfg
+	// must also pass SoundDisabled, or the theme's Click would win
+	// where the cue came out silent (issue #467's convention).
+	btnSound := core.soundCollapse
+	if splitterEffectiveCollapsed(core, core.collapsed) == target {
+		btnSound = core.soundExpand
+	}
 	return Button(ButtonCfg{
 		ID:      id + splitterButtonSuffix[target],
 		Width:   size,
@@ -108,10 +116,12 @@ func splitterButton(cfg *SplitterCfg, core *splitterCore,
 		// hook skips a disabled button, so a disabled one keeps the
 		// uncorrected position — cosmetic, and disabled splitter buttons
 		// are not a state the widget produces today.
-		AmendLayout: centerGlyphOnInk(icon, ts),
-		Color:       cfg.ColorButton,
-		Colors:      ColorSet{Hover: cfg.ColorButtonHover, Click: cfg.ColorButtonActive, Focus: cfg.ColorButtonHover}.resolved(cfg.ColorButton, themeButtonSet()),
-		Radius:      cfg.RadiusBorder,
+		AmendLayout:   centerGlyphOnInk(icon, ts),
+		Color:         cfg.ColorButton,
+		Colors:        ColorSet{Hover: cfg.ColorButtonHover, Click: cfg.ColorButtonActive, Focus: cfg.ColorButtonHover}.resolved(cfg.ColorButton, themeButtonSet()),
+		Radius:        cfg.RadiusBorder,
+		Sound:         btnSound,
+		SoundDisabled: btnSound == SoundNone,
 		OnClick: func(ctx EventCtx) {
 			splitterOnButtonClick(core, target, ctx.Event, ctx.Window)
 		},
@@ -188,11 +198,13 @@ func splitterOnKeydown(core *splitterCore, e *Event, w *Window) {
 		if isNone && core.first.collapsible {
 			nextCollapsed = SplitterCollapseFirst
 			handled = true
+			playSoundCue(core.soundCollapse, w)
 		}
 	case KeyEnd:
 		if isNone && core.second.collapsible {
 			nextCollapsed = SplitterCollapseSecond
 			handled = true
+			playSoundCue(core.soundCollapse, w)
 		}
 	// Space reads from KeyCode, not CharCode: backends populate
 	// CharCode only on EventChar, so a keydown-only handler that tested
@@ -202,6 +214,16 @@ func splitterOnKeydown(core *splitterCore, e *Event, w *Window) {
 		if isNone {
 			nextCollapsed, handled = splitterToggleCollapse(
 				core, nextCollapsed)
+			if handled {
+				// splitterCollapseNone as the *next* state means a
+				// pane just expanded; anything else means one just
+				// collapsed (issue #468).
+				cue := core.soundCollapse
+				if nextCollapsed == splitterCollapseNone {
+					cue = core.soundExpand
+				}
+				playSoundCue(cue, w)
+			}
 		}
 	}
 	// Arrow keys clear collapse state.

--- a/gui/view_tab_control.go
+++ b/gui/view_tab_control.go
@@ -229,10 +229,12 @@ func makeTabDragClick(
 	tabLayoutIDs []string,
 	onSelect func(string, EventCtx),
 	focusID string,
+	dropCue SoundCue,
 ) func(EventCtx) {
 	return func(ctx EventCtx) {
 		dragReorderStart(dragReorderStartCfg{
 			DragKey:       controlID,
+			DropCue:       dropCue,
 			Index:         dragIdx,
 			ItemID:        itemID,
 			Axis:          dragReorderHorizontal,
@@ -370,7 +372,7 @@ func (tv *tabControlView) GenerateLayout(w *Window) Layout {
 		if cfg.Reorderable && !isDisabled {
 			onClick = makeTabDragClick(cfg.ID, tabDragIdx[i],
 				item.ID, tabIDs, onReorder, tabLayoutIDs,
-				cfg.OnSelect, cfg.ID)
+				cfg.OnSelect, cfg.ID, tabSound)
 		} else if !isDisabled {
 			onClick = makeTabOnClick(
 				cfg.OnSelect, item.ID, cfg.ID)
@@ -433,6 +435,10 @@ func (tv *tabControlView) GenerateLayout(w *Window) Layout {
 	onSelect := cfg.OnSelect
 	focusID := cfg.ID
 	reorderable := cfg.Reorderable
+	// Resolved at generation time: the Alt+arrow reorder commits with
+	// a nil Layout, so it carries its cue by value (issue #468).
+	tabDropCue := resolveSoundCue(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
 	controlID := cfg.ID
 
 	return generateViewLayout(Column(ContainerCfg{
@@ -464,7 +470,7 @@ func (tv *tabControlView) GenerateLayout(w *Window) Layout {
 						if dragReorderKeyboardMove(
 							ctx.Event.KeyCode, ctx.Event.Modifiers,
 							dragReorderHorizontal,
-							idx, tabIDs, onReorder, ctx.Window) {
+							idx, tabIDs, onReorder, tabDropCue, ctx.Window) {
 							ctx.Consume()
 							return
 						}

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -113,6 +113,17 @@ type TableCfg struct {
 	// display surface until its rows are navigable.
 	Focusable bool
 
+	// Sound overrides the theme's selection cue for keyboard row
+	// activation. SoundNone (the zero value) takes
+	// Theme.Sounds.Selection, itself silent unless the app opted in.
+	// exportaudit:keep — caller-facing config (issue #468)
+	Sound SoundCue
+
+	// SoundDisabled suppresses this table's sound regardless of the
+	// theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #468)
+	SoundDisabled bool
+
 	// Sizing
 	Sizing       Sizing
 	BorderStyle  TableBorderStyle

--- a/gui/view_table_keys.go
+++ b/gui/view_table_keys.go
@@ -37,13 +37,18 @@ func tableFocusWiring(
 	}
 	data := cfg.Data
 	activeKey := cfg.ID
+	// Resolved here, at generation time, and captured by value: the
+	// handler below gets a nil ctx.Layout on the activate path, so
+	// there is no Shape for dispatch to read a cue off (issue #468).
+	cues := resolveSoundCues(
+		guiTheme.Sounds.Selection, cfg.Sound, cfg.SoundDisabled)
 	return tableFocusState{
 		focusable: true,
 		ring:      focusRingAmend(Color{}, cfg.ColorBorderFocus),
 		onKeyDown: func(ctx EventCtx) {
 			tableOnKeyDown(data, selected, multiSelect, onSelect,
 				activeKey, scrollID, rowH, listH, bodyRowOffset,
-				ctx.Event, ctx.Window)
+				cues, ctx.Event, ctx.Window)
 		},
 	}
 }
@@ -100,6 +105,7 @@ func tableOnKeyDown(
 	activeKey, scrollID string,
 	rowH, listH float32,
 	bodyRowOffset int,
+	cues soundCues,
 	e *Event, w *Window,
 ) {
 	if len(data) == 0 {
@@ -129,6 +135,9 @@ func tableOnKeyDown(
 	}
 
 	if action == listCoreSelectItem {
+		// The cue fires before the callbacks and independently of
+		// whether they consume, matching the mouse path.
+		playSoundCue(cues.act, w)
 		// Activate the active row as a click on it would.
 		if row := data[cur]; row.OnClick != nil {
 			row.OnClick(EventCtx{nil, e, w})
@@ -145,7 +154,9 @@ func tableOnKeyDown(
 	if !changed {
 		// Already clamped at an edge (Up at row 0, End at the last):
 		// still consume, so the key does not fall through to the
-		// page — ListBox and datagrid do the same.
+		// page — ListBox and datagrid do the same. Nothing moved, so
+		// the refusal is what there is to hear (issue #468).
+		playSoundCue(cues.reject, w)
 		e.IsHandled = true
 		return
 	}

--- a/gui/view_table_keys_test.go
+++ b/gui/view_table_keys_test.go
@@ -23,7 +23,7 @@ func TestTableOnKeyDownMovesSelection(t *testing.T) {
 	key := func(k KeyCode) {
 		e := &Event{KeyCode: k}
 		tableOnKeyDown(tableTestRows(), nil, false, onSelect,
-			"tbl", "", 0, 0, 0, e, w)
+			"tbl", "", 0, 0, 0, soundCues{}, e, w)
 	}
 
 	key(KeyDown)
@@ -63,7 +63,7 @@ func TestTableOnKeyDownShiftRange(t *testing.T) {
 	key := func(k KeyCode, mods Modifier) {
 		e := &Event{KeyCode: k, Modifiers: mods}
 		tableOnKeyDown(tableTestRows(), nil, true, onSelect,
-			"tbl", "", 0, 0, 0, e, w)
+			"tbl", "", 0, 0, 0, soundCues{}, e, w)
 	}
 
 	// Plain movement anchors; Shift extends from the anchor.
@@ -90,7 +90,7 @@ func TestTableOnKeyDownNoOnSelectStillMoves(t *testing.T) {
 	w := &Window{}
 	e := &Event{KeyCode: KeyDown}
 	tableOnKeyDown(tableTestRows(), nil, false, nil,
-		"tbl", "", 0, 0, 0, e, w)
+		"tbl", "", 0, 0, 0, soundCues{}, e, w)
 	if !e.IsHandled {
 		t.Fatal("movement without OnSelect must still consume")
 	}
@@ -110,7 +110,7 @@ func TestTableOnKeyDownActivate(t *testing.T) {
 	w := &Window{}
 	key := func(k KeyCode) {
 		tableOnKeyDown(rows, nil, false, nil,
-			"tbl", "", 0, 0, 0, &Event{KeyCode: k}, w)
+			"tbl", "", 0, 0, 0, soundCues{}, &Event{KeyCode: k}, w)
 	}
 
 	key(KeyDown) // active -> 1
@@ -133,7 +133,7 @@ func TestTableOnKeyDownActivateTogglesSelection(t *testing.T) {
 	selected := map[int]bool{1: true}
 	key := func(k KeyCode) {
 		tableOnKeyDown(tableTestRows(), selected, true,
-			onSelect, "tbl", "", 0, 0, 0, &Event{KeyCode: k}, w)
+			onSelect, "tbl", "", 0, 0, 0, soundCues{}, &Event{KeyCode: k}, w)
 		selected = got
 	}
 
@@ -156,7 +156,7 @@ func TestTableOnKeyDownIgnoresUnrelatedKeys(t *testing.T) {
 	for _, k := range []KeyCode{KeyEscape, KeyPageUp, KeyA} {
 		e := &Event{KeyCode: k}
 		tableOnKeyDown(tableTestRows(), nil, false, nil,
-			"tbl", "", 0, 0, 0, e, w)
+			"tbl", "", 0, 0, 0, soundCues{}, e, w)
 		if e.IsHandled {
 			t.Errorf("KeyCode %d consumed; want travel", k)
 		}
@@ -171,14 +171,14 @@ func TestTableOnKeyDownClampedEdgesConsume(t *testing.T) {
 	for _, k := range []KeyCode{KeyUp, KeyHome} {
 		e := &Event{KeyCode: k}
 		tableOnKeyDown(tableTestRows(), nil, false, nil,
-			"tbl", "", 0, 0, 0, e, w)
+			"tbl", "", 0, 0, 0, soundCues{}, e, w)
 		if !e.IsHandled {
 			t.Errorf("KeyCode %d at row 0 must consume", k)
 		}
 	}
 	e := &Event{KeyCode: KeyEnd}
 	tableOnKeyDown(tableTestRows(), nil, false, nil,
-		"tbl", "", 0, 0, 0, e, w)
+		"tbl", "", 0, 0, 0, soundCues{}, e, w)
 	if !e.IsHandled {
 		t.Error("End at the last row must consume")
 	}
@@ -190,7 +190,7 @@ func TestTableOnKeyDownModifiedKeysTravel(t *testing.T) {
 	e := &Event{KeyCode: KeyDown, Modifiers: ModCtrl}
 	tableOnKeyDown(tableTestRows(), nil, false,
 		func(_ map[int]bool, _ int, _ EventCtx) { called = true },
-		"tbl", "", 0, 0, 0, e, w)
+		"tbl", "", 0, 0, 0, soundCues{}, e, w)
 	if e.IsHandled || called {
 		t.Error("Ctrl+Down must travel untouched")
 	}
@@ -199,7 +199,7 @@ func TestTableOnKeyDownModifiedKeysTravel(t *testing.T) {
 func TestTableOnKeyDownEmptyDataTravels(t *testing.T) {
 	w := &Window{}
 	e := &Event{KeyCode: KeyDown}
-	tableOnKeyDown(nil, nil, false, nil, "tbl", "", 0, 0, 0, e, w)
+	tableOnKeyDown(nil, nil, false, nil, "tbl", "", 0, 0, 0, soundCues{}, e, w)
 	if e.IsHandled {
 		t.Error("empty table must not consume keys")
 	}
@@ -214,7 +214,7 @@ func TestTableOnKeyDownScrollsIntoView(t *testing.T) {
 	// rowH 20, listH 40: End lands on row 9, whose bottom (200) is
 	// past the 40px viewport, so the scroll settles at 200-40.
 	tableOnKeyDown(rows, nil, false, nil, "tbl", "sc", 20, 40, 0,
-		&Event{KeyCode: KeyEnd}, w)
+		soundCues{}, &Event{KeyCode: KeyEnd}, w)
 	if got := w.scrollY().GetOr("sc", 0); got != -160 {
 		t.Fatalf("scroll = %v, want -160", got)
 	}
@@ -231,12 +231,12 @@ func TestTableOnKeyDownFreezeBodyOffset(t *testing.T) {
 	// Move to row 1: body row 0, no scroll. Then End: data 9 ->
 	// body 8, bottom 180 > 40 -> 180-40.
 	tableOnKeyDown(rows, nil, false, nil, "tbl", "sc", 20, 40, 1,
-		&Event{KeyCode: KeyDown}, w)
+		soundCues{}, &Event{KeyCode: KeyDown}, w)
 	if got := w.scrollY().GetOr("sc", 0); got != 0 {
 		t.Fatalf("scroll after row 1 = %v, want 0", got)
 	}
 	tableOnKeyDown(rows, nil, false, nil, "tbl", "sc", 20, 40, 1,
-		&Event{KeyCode: KeyEnd}, w)
+		soundCues{}, &Event{KeyCode: KeyEnd}, w)
 	if got := w.scrollY().GetOr("sc", 0); got != -140 {
 		t.Fatalf("scroll after End = %v, want -140", got)
 	}

--- a/gui/view_tree.go
+++ b/gui/view_tree.go
@@ -274,6 +274,9 @@ func (tv *treeView) GenerateLayout(w *Window) Layout {
 					return
 				}
 				if ctx.Event.Modifiers.Has(ModAlt) {
+					treeDropCue := resolveSoundCue(
+						guiTheme.Sounds.Selection,
+						cfg.Sound, cfg.SoundDisabled)
 					fid := StateReadOr(
 						ctx.Window, nsTreeFocus, cfg.ID, "")
 					if fid != "" {
@@ -284,7 +287,7 @@ func (tv *treeView) GenerateLayout(w *Window) Layout {
 							dragReorderKeyboardMove(
 								ctx.Event.KeyCode, ctx.Event.Modifiers,
 								dragReorderVertical,
-								si, sibs, onReorder, ctx.Window) {
+								si, sibs, onReorder, treeDropCue, ctx.Window) {
 							ctx.Consume()
 							return
 						}
@@ -293,7 +296,10 @@ func (tv *treeView) GenerateLayout(w *Window) Layout {
 			}
 			treeOnKeyDown(cfg.ID, visibleIDs, rowByID,
 				cfg.OnSelect, cfg.OnLazyLoad,
-				scrollID, rowHeight, listHeight, ctx.Event, ctx.Window)
+				scrollID, rowHeight, listHeight,
+				resolveSoundCues(guiTheme.Sounds.Selection,
+					cfg.Sound, cfg.SoundDisabled),
+				ctx.Event, ctx.Window)
 		},
 		Sizing:      cfg.Sizing,
 		Width:       cfg.Width,

--- a/gui/view_tree_rows.go
+++ b/gui/view_tree_rows.go
@@ -271,6 +271,7 @@ func treeDragRowView(
 		OnClick: func(ctx EventCtx) {
 			dragReorderStart(dragReorderStartCfg{
 				DragKey:       treeID,
+				DropCue:       rowSound,
 				Index:         sibIdx,
 				ItemID:        rowID,
 				Axis:          dragReorderVertical,
@@ -392,6 +393,7 @@ func treeOnKeyDown(
 	scrollID string,
 	rowHeight float32,
 	listHeight float32,
+	cues soundCues,
 	e *Event,
 	w *Window,
 ) {
@@ -408,6 +410,11 @@ func treeOnKeyDown(
 		if cur > 0 {
 			next = cur - 1
 		}
+		if next == cur {
+			// Already on the first row. Movement is silent by
+			// decision; only the refusal sounds (issue #468).
+			playSoundCue(cues.reject, w)
+		}
 		focusMap.Set(treeID, visibleIDs[next])
 		treeScrollTo(scrollID, next, rowHeight, listHeight, w)
 		e.IsHandled = true
@@ -415,6 +422,9 @@ func treeOnKeyDown(
 		next := 0
 		if cur >= 0 {
 			next = min(cur+1, len(visibleIDs)-1)
+		}
+		if next == cur {
+			playSoundCue(cues.reject, w)
 		}
 		focusMap.Set(treeID, visibleIDs[next])
 		treeScrollTo(scrollID, next, rowHeight, listHeight, w)
@@ -467,6 +477,9 @@ func treeOnKeyDown(
 		if cur < 0 {
 			return
 		}
+		// Keyboard activation, with a nil Layout: dispatch never sees
+		// it, so the row's own cue cannot fire (issue #468).
+		playSoundCue(cues.act, w)
 		if onSelect != nil {
 			onSelect(focusedID, EventCtx{nil, e, w})
 		}

--- a/gui/view_tree_test.go
+++ b/gui/view_tree_test.go
@@ -264,19 +264,19 @@ func TestTreeOnKeyDownNavigation(t *testing.T) {
 	treeFocusedSet(w, "tree", "b")
 
 	eUp := &Event{KeyCode: KeyUp}
-	treeOnKeyDown("tree", visibleIDs, rowByID, nil, nil, "", 0, 0, eUp, w)
+	treeOnKeyDown("tree", visibleIDs, rowByID, nil, nil, "", 0, 0, soundCues{}, eUp, w)
 	if got := StateReadOr(w, nsTreeFocus, "tree", ""); got != "a" {
 		t.Fatalf("focus after KeyUp = %q, want %q", got, "a")
 	}
 
 	eEnd := &Event{KeyCode: KeyEnd}
-	treeOnKeyDown("tree", visibleIDs, rowByID, nil, nil, "", 0, 0, eEnd, w)
+	treeOnKeyDown("tree", visibleIDs, rowByID, nil, nil, "", 0, 0, soundCues{}, eEnd, w)
 	if got := StateReadOr(w, nsTreeFocus, "tree", ""); got != "c" {
 		t.Fatalf("focus after KeyEnd = %q, want %q", got, "c")
 	}
 
 	eHome := &Event{KeyCode: KeyHome}
-	treeOnKeyDown("tree", visibleIDs, rowByID, nil, nil, "", 0, 0, eHome, w)
+	treeOnKeyDown("tree", visibleIDs, rowByID, nil, nil, "", 0, 0, soundCues{}, eHome, w)
 	if got := StateReadOr(w, nsTreeFocus, "tree", ""); got != "a" {
 		t.Fatalf("focus after KeyHome = %q, want %q", got, "a")
 	}
@@ -290,6 +290,7 @@ func TestTreeOnKeyDownNavigation(t *testing.T) {
 		func(id string, ctx EventCtx) { selectedID = id },
 		nil,
 		"", 0, 0,
+		soundCues{},
 		eEnter,
 		w,
 	)
@@ -320,6 +321,7 @@ func TestTreeOnKeyDownLeftCollapses(t *testing.T) {
 		nil,
 		nil,
 		"", 0, 0,
+		soundCues{},
 		&Event{KeyCode: KeyLeft},
 		w,
 	)
@@ -353,8 +355,8 @@ func TestTreeOnKeyDownRightTriggersLazyLoad(t *testing.T) {
 	}
 
 	eRight := &Event{KeyCode: KeyRight}
-	treeOnKeyDown("tree", visibleIDs, rowByID, nil, onLazyLoad, "", 0, 0, eRight, w)
-	treeOnKeyDown("tree", visibleIDs, rowByID, nil, onLazyLoad, "", 0, 0, &Event{KeyCode: KeyRight}, w)
+	treeOnKeyDown("tree", visibleIDs, rowByID, nil, onLazyLoad, "", 0, 0, soundCues{}, eRight, w)
+	treeOnKeyDown("tree", visibleIDs, rowByID, nil, onLazyLoad, "", 0, 0, soundCues{}, &Event{KeyCode: KeyRight}, w)
 
 	if !treeExpandedState(w, "tree")["remote"] {
 		t.Fatal("remote should be expanded after KeyRight")

--- a/gui/view_widget_test.go
+++ b/gui/view_widget_test.go
@@ -713,7 +713,7 @@ func TestListBoxOnKeyDownHandled(t *testing.T) {
 	e := &Event{KeyCode: KeyDown}
 	listBoxOnKeyDown("lb", itemIDs, false,
 		func(_ []string, ctx EventCtx) {}, nil,
-		"", 0, 0, nil, e, w)
+		"", 0, 0, nil, soundCues{}, e, w)
 	if !e.IsHandled {
 		t.Fatal("expected key navigation event to be handled")
 	}
@@ -722,7 +722,7 @@ func TestListBoxOnKeyDownHandled(t *testing.T) {
 	called := false
 	listBoxOnKeyDown("lb", itemIDs, false,
 		func(_ []string, ctx EventCtx) { called = true },
-		nil, "", 0, 0, nil, e, w)
+		nil, "", 0, 0, nil, soundCues{}, e, w)
 	if !e.IsHandled {
 		t.Fatal("expected key select event to be handled")
 	}


### PR DESCRIPTION
Phase 3 of widget audio feedback (#468) — the paths event dispatch never sees.

**Keyboard activation** (`Selection` unless noted): `Table`/`ListBox`/`Tree` Enter/Space, `Menu` Enter/Space (`Click`), splitter `Home`/`End`/Space/Enter toggle (`ToggleOn`/`ToggleOff`).

**Rejections** (`SoundError`, the first real consumer of `NewBeepSoundPlayer`): `Input` mask/validator/paste/delete refusals, arrow keys at bounds (`Slider`, `Table`, `ListBox`, `Tree`), `NumericInput` step at `Min`/`Max`, `Menu` navigation at edge. `Input` Enter commit sounds `Click` (takes `Cfg.Sound`).

**Movement & continuous drag stay silent** — slider thumb, splitter handle, colour plane/wheel, cancelled drag, no-op drop, blur commit — recorded decisions in `docs/specs/widget-audio-feedback.md`.

Carries the cue by value from generation time (`resolveSoundCues`/`resolveSoundCue` + `playSoundCue`) so `nil Layout` callback paths work; adds `Sound`/`SoundDisabled` to `TableCfg`/`InputCfg`/`SplitterCfg` and `SoundDisabled` alone to `SliderCfg`/`NumericInputCfg`.

Fixes #468