### PR TITLE
feat(audio): non-click cues and native system-sound player (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ and this project adheres to
 
 ### Added
 
+- **Widget audio feedback phase 4** (#469) — the interactions with no click site
+  now sound, and a second built-in player renders every cue with the platform's
+  own event sounds.
+
+  Three cues joined the vocabulary: `SoundNotify` (a toast appeared),
+  `SoundOpen` (a dialog opened) and `SoundSuccess` (a submit was accepted), with
+  matching `Theme.Sounds` fields. Every refusal reuses `SoundError` — an
+  error-severity toast, a submit blocked by validation or a pending validator,
+  and a `datagrid` CRUD save failure. Toast severity is the one place a severity
+  picks a cue; `ToastCfg.Sound` still names the toast's buttons, and
+  `SoundDisabled` silences both. `FormCfg` gained the usual `Sound` /
+  `SoundDisabled` pair, where `Sound` names the accepted submit and a refusal
+  always takes the theme's error role. Closing stays silent: `DialogDismiss` and
+  `ToastDismiss` make no sound, because the button that closed the surface
+  already did.
+
+  `gui.NewSystemSoundPlayer(w)` is the new player: `NSSound` on macOS,
+  `PlaySound` with a registry alias on Windows, freedesktop sound-naming ids
+  through `canberra-gtk-play` on Linux. Unlike `NewBeepSoundPlayer`, which plays
+  the system alert and so only suits `SoundError`, it has a sound for every cue,
+  and it needs no assets and no audio library. It ignores gain — system event
+  sounds carry no app-level volume on any of the three platforms — while
+  `SetSoundVolume(0)` still mutes, because the gate sits ahead of the player.
+  The capability reaches the platform through an optional interface rather than
+  a new `NativePlatform` method, so no out-of-repo backend breaks, and a
+  platform without it is silent rather than broken.
+
+  `(*Window).PlaySoundCue` is exported for widget packages outside `gui/`:
+  `gui/datagrid` has no button to hang a CRUD failure's cue off. The enum stays
+  open and append-only — a player must keep ignoring cues it does not recognise.
+
+  See `docs/widget-sound.md` and `docs/specs/widget-audio-feedback.md`.
+
 - **Canvas transform stack** (#474) — `DrawContext` gained `Translate`,
   `ScaleBy`, `Save` and `Restore`, so drawing code written once in its own
   coordinate space can be placed and resized without transforming a single

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -262,10 +262,16 @@ silent, and a nil player is the default, so tests need no setup. Per instance,
 `Cfg.Sound` overrides the theme cue and `Cfg.SoundDisabled` suppresses it;
 `w.SetSoundVolume(0..1)` is the gain, where `0` is mute. The cue fires before
 `OnClick` and regardless of `ctx.Consume()`. Roles are `Click`, `ToggleOn`,
-`ToggleOff`, `Selection` and `Error`; a widget picks the role, the app picks the
-sound. Feeding a resolved cue into a nested `ButtonCfg` or `ToggleCfg` means
-passing `SoundDisabled` too — those resolve their own precedence, and a resolved
-`SoundNone` reads there as "unset". See `docs/widget-sound.md`.
+`ToggleOff`, `Selection`, `Error`, `Notify`, `Open` and `Success`; a widget
+picks the role, the app picks the sound. Four interactions sound without a
+click: a toast appearing (`Notify`, or `Error` at `ToastError` severity), a
+dialog opening (`Open`), a form submit accepted (`Success`) or blocked
+(`Error`), and a `datagrid` CRUD save failure (`Error`).
+`gui.NewSystemSoundPlayer(w)` renders every cue with the platform's own event
+sounds, no assets and no audio library; it ignores gain. Feeding a resolved cue
+into a nested `ButtonCfg` or `ToggleCfg` means passing `SoundDisabled` too —
+those resolve their own precedence, and a resolved `SoundNone` reads there as
+"unset". See `docs/widget-sound.md`.
 
 ## Find it early
 

--- a/docs/specs/widget-audio-feedback.md
+++ b/docs/specs/widget-audio-feedback.md
@@ -1,14 +1,107 @@
 # Spec: opt-in widget audio feedback
 
-Status: **phases 1, 2 and 3 implemented** — phase 1 landed `SoundCue`,
+Status: **phases 1 to 4 implemented** — phase 1 landed `SoundCue`,
 `SoundPlayer`, `Theme.Sounds`, window volume, and the `Button` / `Toggle` proof;
 phase 2 (#467) carried the seam to every remaining mechanical widget and to
-`gui/datagrid`; phase 3 (#468) reached the paths dispatch never sees. Phase 4 is
-a follow-up issue.
+`gui/datagrid`; phase 3 (#468) reached the paths dispatch never sees; phase 4
+(#469) added the non-click semantics and a player backed by the platform's own
+event sounds.
 
 Issue: #446 — "Widgets have no audio feedback for interactions". Phase 2: #467 —
 "Widget audio feedback phase 2: the mechanical widget pass". Phase 3: #468 —
-"Widget audio feedback phase 3: paths dispatch does not see".
+"Widget audio feedback phase 3: paths dispatch does not see". Phase 4: #469 —
+"Widget audio feedback phase 4: non-click cues and a native system-sound
+player".
+
+## Phase 4 decisions
+
+Phase 4 covers the interactions with no click site at all, and the second
+built-in player.
+
+- **Three new cues, not seven.** `SoundNotify` (a toast appeared), `SoundOpen`
+  (a dialog opened) and `SoundSuccess` (a submit was accepted), appended after
+  `SoundSelection`, with matching `SoundSet` fields. Every refusal reuses
+  `SoundError`: an error-severity toast, a blocked submit and a failed CRUD save
+  are all rejections, and a separate cue per site would say nothing extra. No
+  code in `gui/` switches exhaustively over the enum, so the additions break no
+  player.
+- **`(*Window).PlaySoundCue` is exported.** `gui/datagrid` is outside `gui/` and
+  cannot reach `playSoundCue`; a CRUD failure has no button to hang a cue off,
+  so the emit seam had to be public. It applies no precedence — resolve with
+  `ResolveSoundCue` first — and keeps every guarantee of the unexported helper.
+- **The cue rides the imperative entry point, never the per-frame view.**
+  `(*Window).Toast` and `(*Window).Dialog` are called once per appearance;
+  `toastItemView` and `dialogViewGenerator` run every frame. The toast cue is
+  emitted at the append rather than in the enter tween's `OnDone`, which a toast
+  dismissed early never reaches. Both read `w.Theme()` rather than the
+  `guiTheme` mirror: they run outside generation, and `themeRef` takes
+  `w.themeMu`, not the frame lock.
+- **Toast severity picks the cue; `ToastCfg.Sound` does not.** This is the one
+  place a severity chooses a cue. `Sound` names the toast's buttons — an
+  activation — so it does not reach the appear cue, while `SoundDisabled`
+  suppresses both. The same split governs `DialogCfg` and `FormCfg`.
+- **Form submit resolves at generation time and emits under the frame lock.**
+  `formProcessRequests` runs from `AmendLayout`, so the `soundCues` pair is
+  resolved in `GenerateLayout` and captured by value; the `submitReq` latch
+  makes the emit one-shot even though the pass runs every frame. Emitting inline
+  is safe because `playSoundCue` takes no lock, but it does mean app player code
+  runs under `w.mu` — the `SoundPlayer` contract now says a player must not call
+  a window-mutating API.
+- **A blocked submit sounds where nothing else reports it.** The
+  `blockedInvalid || blockedPending` branch has no callback: the cue is the only
+  feedback the app gets for free.
+- **One emit site for the grid.** Every DataGrid CRUD failure funnels through
+  `dataGridCrudRestoreOnError`, so the cue lives there and `dataGridSounds`
+  gains an `err` role resolved beside `click` and `selection`. Keying off
+  `state.SaveError` would have fired once per frame.
+- **The native player is a second player, not a replacement.**
+  `NewSystemSoundPlayer` maps every cue onto the platform's own event sounds;
+  `NewBeepSoundPlayer` stays the right choice for an app that only wants to
+  signal rejection.
+- **It ignores gain, deliberately.** macOS `NSSound` exposes `setVolume`, but
+  Windows `PlaySound` and `canberra-gtk-play` do not, so honouring gain would
+  make one platform behave differently from the other two. Mute still works: the
+  `gain <= 0` gate sits ahead of the player.
+- **The native capability is an optional interface, not a `NativePlatform`
+  method.** `systemSoundPlatform` (`gui/sound_system.go`) is type-asserted on
+  `w.nativePlatform`. Adding the methods to the exported `NativePlatform`
+  interface would break every out-of-repo implementation; a platform that does
+  not implement the capability is silent, which is also what keeps the noop
+  platform and headless tests quiet.
+- **`sysbeep` keeps `Play` and gains `PlayEvent`.** `Play` is still the
+  out-of-band alert. The event API is a separate, open enum with its own
+  per-platform mapping table, so `sysbeep` needs no knowledge of widgets and
+  `gui` needs none of system sounds; `nativehost` holds the one map between
+  them. An unmapped or out-of-range event is silent.
+
+### Phase 4 sound mapping
+
+| Event     | macOS `NSSound(named:)` | Windows `SND_ALIAS`    | Linux freedesktop id |
+| --------- | ----------------------- | ---------------------- | -------------------- |
+| Click     | `Tink`                  | `MenuCommand`          | `button-pressed`     |
+| ToggleOn  | `Pop`                   | `MenuCommand`          | `button-pressed`     |
+| ToggleOff | `Bottle`                | `MenuCommand`          | `button-released`    |
+| Selection | `Ping`                  | `MenuPopup`            | `button-pressed`     |
+| Error     | `Basso`                 | `SystemHand`           | `dialog-error`       |
+| Notify    | `Purr`                  | `Notification.Default` | `message`            |
+| Open      | `Blow`                  | `SystemAsterisk`       | `dialog-information` |
+| Success   | `Glass`                 | `.Default`             | `complete`           |
+
+macOS caches each `NSSound` by name and restarts it on retrigger, so a second
+cue is not swallowed by the first. Windows passes `SND_NODEFAULT` so an alias
+the user's scheme leaves unset is silent rather than a default beep. Linux
+spawns one `canberra-gtk-play` per cue — acceptable for a dialog or a toast,
+wrong for a click-heavy UI, and the guides say so.
+
+### Phase 4 silences
+
+- **`DialogDismiss` and `ToastDismiss`.** The button that closed the surface has
+  already sounded through the ordinary click path, so a dismiss cue would double
+  up. This retires the dismiss-cue question phase 2 deferred.
+- **Native dialogs** (`gui/native_dialog.go`) — the OS plays its own.
+- **A save that fails with no data source attached.** It reports through
+  `state.SaveError` and never calls `OnCRUDError`, so it never reaches the emit
+  site; that path is a wiring mistake, not a user-facing rejection.
 
 ## Phase 3 decisions
 
@@ -275,11 +368,9 @@ release commits nothing.
   Keyboard movement and continuous drag were decided silent; the decisions are
   in "What stays silent" above.
 - **Phase 4** (#469) — non-click semantics (Toast appear, Dialog open, Form
-  submit, DataGrid `OnCRUDError`) and a native system-sound player:
-  `NSSound(named:)`, `PlaySound` with `SND_ALIAS`, freedesktop sound-naming IDs
-  on Linux (the beep backend already shells to `canberra-gtk-play -i bell`, so
-  `-i button-pressed` is a short step). That is cross-platform native work,
-  including ObjC, and belongs in `gui/backend/sysbeep`.
+  submit, DataGrid `OnCRUDError`) and `NewSystemSoundPlayer`, backed by
+  `sysbeep.PlayEvent`: `NSSound(named:)` on macOS, `PlaySound` with `SND_ALIAS`
+  on Windows, freedesktop sound-naming ids on Linux. Decisions above.
 
 ## Showcase sounds are synthesized
 

--- a/docs/widget-sound.md
+++ b/docs/widget-sound.md
@@ -20,6 +20,9 @@ running showcase has it under **Welcome → Sound Feedback**.
 | `gui.SoundToggleOff` | A state went on → off                         |
 | `gui.SoundError`     | Rejection: invalid input, refused commit      |
 | `gui.SoundSelection` | One option picked out of several              |
+| `gui.SoundNotify`    | Something appeared unasked: a toast           |
+| `gui.SoundOpen`      | A modal surface opened: a dialog              |
+| `gui.SoundSuccess`   | A multi-field action was accepted: a submit   |
 
 The framework decides _which_ cue an interaction is. Your player decides what a
 cue sounds like. That split is why `gui` never imports `gui/audio`, and why an
@@ -123,6 +126,12 @@ func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
 	case gui.SoundError:
 		freq = 220
 		env = errorEnv
+	case gui.SoundNotify:
+		freq = 880 * 5 / 6 // a whole tone below A5: soft, unasked for
+	case gui.SoundOpen:
+		freq = 880 / 2 // an octave down: something larger arrived
+	case gui.SoundSuccess:
+		freq = 880 * 2 // an octave up: the brightest cue in the set
 	default:
 		// An unrecognised cue is ignored, not an error: gui adds cues
 		// over time and a player must not break when it does.
@@ -218,6 +227,44 @@ Embed the WAVs with `//go:embed` and pass the bytes — `audio.LoadSoundBytes`
 avoids the temp-file dance a path-based load needs. The repo ships no sound
 assets of its own, so the showcase uses the synthesized player above.
 
+## System event sounds, with no assets
+
+`NewSystemSoundPlayer` plays the sounds the platform already ships and the user
+has already configured, so an app sounds native without shipping a single file:
+
+```go
+w.SetSoundPlayer(gui.NewSystemSoundPlayer(w))
+```
+
+It has a sound for every cue, unlike `NewBeepSoundPlayer`, which only covers
+`SoundError`. The mapping:
+
+| Cue         | macOS `NSSound` | Windows alias          | Linux (freedesktop)  |
+| ----------- | --------------- | ---------------------- | -------------------- |
+| `Click`     | `Tink`          | `MenuCommand`          | `button-pressed`     |
+| `ToggleOn`  | `Pop`           | `MenuCommand`          | `button-pressed`     |
+| `ToggleOff` | `Bottle`        | `MenuCommand`          | `button-released`    |
+| `Selection` | `Ping`          | `MenuPopup`            | `button-pressed`     |
+| `Error`     | `Basso`         | `SystemHand`           | `dialog-error`       |
+| `Notify`    | `Purr`          | `Notification.Default` | `message`            |
+| `Open`      | `Blow`          | `SystemAsterisk`       | `dialog-information` |
+| `Success`   | `Glass`         | `.Default`             | `complete`           |
+
+Three things to know before you pick it:
+
+- **It ignores gain.** System event sounds follow the user's own event-sound
+  settings and expose no app-level volume on any of the three platforms, so
+  honouring `SetSoundVolume` on one of them would make the same app behave
+  differently per platform. `SetSoundVolume(0)` still mutes: the gate sits ahead
+  of the player.
+- **A sound the user's scheme leaves unset is silence, not a fallback beep.**
+  That is deliberate on all three platforms.
+- **On Linux it spawns `canberra-gtk-play` per cue.** Fine for a dialog or a
+  toast, wrong for a click-heavy UI — that app wants the sampled player above.
+
+`SoundAvailable()` is false on mobile and wasm, and on Linux with no
+`canberra-gtk-play`.
+
 ## Per-widget control
 
 Two fields on the widget's `Cfg`:
@@ -302,8 +349,29 @@ disabled, a `ListBox` subheading, and a menu separator.
 
 Text is not covered: `gui.Text` shares one package-level handler record across
 every text shape, so it cannot carry a per-instance cue without giving up that
-zero-allocation sharing. Hover, focus and notification cues are still to come
-(#469).
+zero-allocation sharing. Hover and focus cues are still to come.
+
+## Cues with no click
+
+Four interactions sound without a widget being clicked:
+
+| Interaction                                    | Cue       |
+| ---------------------------------------------- | --------- |
+| A toast appears (info, success, warning)       | `Notify`  |
+| A toast appears with `ToastError` severity     | `Error`   |
+| `(*Window).Dialog` opens a dialog              | `Open`    |
+| `Form` submit accepted                         | `Success` |
+| `Form` submit blocked by validation or pending | `Error`   |
+| `datagrid` CRUD save failure                   | `Error`   |
+
+Toast severity is the one place severity picks a cue. `ToastCfg.Sound` still
+names the toast's buttons, not its appearance; `ToastCfg.SoundDisabled` silences
+both. The same split holds for `DialogCfg` and for `FormCfg`, where `Sound`
+names the accepted submit and a refusal always takes `Theme.Sounds.Error`.
+
+Closing is silent: `DialogDismiss` and `ToastDismiss` make no sound, because the
+button that closed the surface has already sounded. A native dialog is silent
+too — the OS plays its own.
 
 ## Platform reality
 

--- a/examples/showcase/demo_audio.go
+++ b/examples/showcase/demo_audio.go
@@ -212,7 +212,7 @@ func widgetSoundPanel(t gui.Theme, app *ShowcaseApp) gui.View {
 					a := appState(ctx.Window)
 					a.WidgetSoundOn = !a.WidgetSoundOn
 					if a.WidgetSoundOn {
-						installWidgetSounds(ctx.Window, a.WidgetSoundBeep)
+						installWidgetSounds(ctx.Window, a.WidgetSoundPlayer)
 						ctx.Window.SetSoundVolume(a.WidgetSoundVolume)
 					} else {
 						removeWidgetSounds(ctx.Window)
@@ -220,17 +220,22 @@ func widgetSoundPanel(t gui.Theme, app *ShowcaseApp) gui.View {
 					ctx.Consume()
 				},
 			}),
-			// The zero-dependency player: system alert on SoundError,
-			// silence otherwise, no audio library and no assets.
-			gui.Switch(gui.SwitchCfg{
-				ID:       "widget-sound-beep",
-				Label:    "System alert only (no audio library)",
-				Selected: app.WidgetSoundBeep,
-				OnClick: func(ctx gui.EventCtx) {
+			// Which player renders the cues. The synthesized one needs
+			// gui/audio; the other two need neither assets nor an
+			// audio library.
+			gui.Select(gui.SelectCfg{
+				ID:       "widget-sound-player",
+				Label:    "Player",
+				Options:  soundPlayerLabels,
+				Selected: []string{soundPlayerValue(app.WidgetSoundPlayer)},
+				OnSelect: func(selected []string, ctx gui.EventCtx) {
+					if len(selected) == 0 {
+						return
+					}
 					a := appState(ctx.Window)
-					a.WidgetSoundBeep = !a.WidgetSoundBeep
+					a.WidgetSoundPlayer = soundPlayerKindFor(selected[0])
 					if a.WidgetSoundOn {
-						installWidgetSounds(ctx.Window, a.WidgetSoundBeep)
+						installWidgetSounds(ctx.Window, a.WidgetSoundPlayer)
 					}
 					ctx.Consume()
 				},
@@ -312,8 +317,92 @@ func widgetSoundPanel(t gui.Theme, app *ShowcaseApp) gui.View {
 					}),
 				},
 			}),
+			widgetSoundNonClickRow(),
 		},
 	})
+}
+
+// widgetSoundNonClickRow demonstrates the cues that no click produces:
+// a toast appearing and a dialog opening (issue #469). Both are
+// imperative APIs, so each button just calls one and the cue rides the
+// call, not the click.
+func widgetSoundNonClickRow() gui.View {
+	return gui.Row(gui.ContainerCfg{
+		Sizing:  gui.FillFit,
+		Spacing: gui.SomeF(12),
+		Padding: gui.NoPadding,
+		VAlign:  gui.VAlignMiddle,
+		Content: []gui.View{
+			gui.Button(gui.ButtonCfg{
+				ID:      "widget-sound-toast",
+				Label:   "Toast",
+				Padding: gui.NewPadding(8, 16, 8, 16),
+				OnClick: func(ctx gui.EventCtx) {
+					ctx.Window.Toast(gui.ToastCfg{
+						Title: "Notify",
+						Body:  "An info toast takes the Notify cue.",
+					})
+					ctx.Consume()
+				},
+			}),
+			gui.Button(gui.ButtonCfg{
+				ID:      "widget-sound-toast-error",
+				Label:   "Error toast",
+				Padding: gui.NewPadding(8, 16, 8, 16),
+				OnClick: func(ctx gui.EventCtx) {
+					ctx.Window.Toast(gui.ToastCfg{
+						Title:    "Error",
+						Body:     "An error toast takes the Error cue.",
+						Severity: gui.ToastError,
+					})
+					ctx.Consume()
+				},
+			}),
+			gui.Button(gui.ButtonCfg{
+				ID:      "widget-sound-dialog",
+				Label:   "Dialog",
+				Padding: gui.NewPadding(8, 16, 8, 16),
+				OnClick: func(ctx gui.EventCtx) {
+					ctx.Window.Dialog(gui.DialogCfg{
+						Title: "Open",
+						Body:  "Opening a dialog takes the Open cue.",
+					})
+					ctx.Consume()
+				},
+			}),
+		},
+	})
+}
+
+// soundPlayerLabels are the Select's options, and soundPlayerValue /
+// soundPlayerKindFor map them onto the player kind so the app state
+// stays typed rather than holding a string.
+var soundPlayerLabels = []string{
+	"Synthesized (gui/audio)",
+	"System event sounds",
+	"System alert on errors only",
+}
+
+func soundPlayerValue(kind soundPlayerKind) string {
+	switch kind {
+	case soundPlayerBeep:
+		return soundPlayerLabels[2]
+	case soundPlayerSystem:
+		return soundPlayerLabels[1]
+	default:
+		return soundPlayerLabels[0]
+	}
+}
+
+func soundPlayerKindFor(label string) soundPlayerKind {
+	switch label {
+	case soundPlayerLabels[2]:
+		return soundPlayerBeep
+	case soundPlayerLabels[1]:
+		return soundPlayerSystem
+	default:
+		return soundPlayerSynth
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/showcase/docs/widget_sound.md
+++ b/examples/showcase/docs/widget_sound.md
@@ -19,6 +19,9 @@ This page is mirrored in the repo at `docs/widget-sound.md`.
 | `gui.SoundToggleOff` | A state went on → off                         |
 | `gui.SoundError`     | Rejection: invalid input, refused commit      |
 | `gui.SoundSelection` | One option picked out of several              |
+| `gui.SoundNotify`    | Something appeared unasked: a toast           |
+| `gui.SoundOpen`      | A modal surface opened: a dialog              |
+| `gui.SoundSuccess`   | A multi-field action was accepted: a submit   |
 
 The framework decides _which_ cue an interaction is. Your player decides what a
 cue sounds like. That split is why `gui` never imports `gui/audio`, and why an
@@ -122,6 +125,12 @@ func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
 	case gui.SoundError:
 		freq = 220
 		env = errorEnv
+	case gui.SoundNotify:
+		freq = 880 * 5 / 6 // a whole tone below A5: soft, unasked for
+	case gui.SoundOpen:
+		freq = 880 / 2 // an octave down: something larger arrived
+	case gui.SoundSuccess:
+		freq = 880 * 2 // an octave up: the brightest cue in the set
 	default:
 		// An unrecognised cue is ignored, not an error: gui adds cues
 		// over time and a player must not break when it does.
@@ -216,6 +225,44 @@ Embed the WAVs with `//go:embed` and pass the bytes — `audio.LoadSoundBytes`
 avoids the temp-file dance a path-based load needs. The repo ships no sound
 assets of its own, so the showcase uses the synthesized player above.
 
+## System event sounds, with no assets
+
+`NewSystemSoundPlayer` plays the sounds the platform already ships and the user
+has already configured, so an app sounds native without shipping a single file:
+
+```go
+w.SetSoundPlayer(gui.NewSystemSoundPlayer(w))
+```
+
+It has a sound for every cue, unlike `NewBeepSoundPlayer`, which only covers
+`SoundError`. The mapping:
+
+| Cue         | macOS `NSSound` | Windows alias          | Linux (freedesktop)  |
+| ----------- | --------------- | ---------------------- | -------------------- |
+| `Click`     | `Tink`          | `MenuCommand`          | `button-pressed`     |
+| `ToggleOn`  | `Pop`           | `MenuCommand`          | `button-pressed`     |
+| `ToggleOff` | `Bottle`        | `MenuCommand`          | `button-released`    |
+| `Selection` | `Ping`          | `MenuPopup`            | `button-pressed`     |
+| `Error`     | `Basso`         | `SystemHand`           | `dialog-error`       |
+| `Notify`    | `Purr`          | `Notification.Default` | `message`            |
+| `Open`      | `Blow`          | `SystemAsterisk`       | `dialog-information` |
+| `Success`   | `Glass`         | `.Default`             | `complete`           |
+
+Three things to know before you pick it:
+
+- **It ignores gain.** System event sounds follow the user's own event-sound
+  settings and expose no app-level volume on any of the three platforms, so
+  honouring `SetSoundVolume` on one of them would make the same app behave
+  differently per platform. `SetSoundVolume(0)` still mutes: the gate sits ahead
+  of the player.
+- **A sound the user's scheme leaves unset is silence, not a fallback beep.**
+  That is deliberate on all three platforms.
+- **On Linux it spawns `canberra-gtk-play` per cue.** Fine for a dialog or a
+  toast, wrong for a click-heavy UI — that app wants the sampled player above.
+
+`SoundAvailable()` is false on mobile and wasm, and on Linux with no
+`canberra-gtk-play`.
+
 ## Per-widget control
 
 Two fields on the widget's `Cfg`:
@@ -300,8 +347,29 @@ disabled, a `ListBox` subheading, and a menu separator.
 
 Text is not covered: `gui.Text` shares one package-level handler record across
 every text shape, so it cannot carry a per-instance cue without giving up that
-zero-allocation sharing. Hover, focus and notification cues are still to come
-(#469).
+zero-allocation sharing. Hover and focus cues are still to come.
+
+## Cues with no click
+
+Four interactions sound without a widget being clicked:
+
+| Interaction                                    | Cue       |
+| ---------------------------------------------- | --------- |
+| A toast appears (info, success, warning)       | `Notify`  |
+| A toast appears with `ToastError` severity     | `Error`   |
+| `(*Window).Dialog` opens a dialog              | `Open`    |
+| `Form` submit accepted                         | `Success` |
+| `Form` submit blocked by validation or pending | `Error`   |
+| `datagrid` CRUD save failure                   | `Error`   |
+
+Toast severity is the one place severity picks a cue. `ToastCfg.Sound` still
+names the toast's buttons, not its appearance; `ToastCfg.SoundDisabled` silences
+both. The same split holds for `DialogCfg` and for `FormCfg`, where `Sound`
+names the accepted submit and a refusal always takes `Theme.Sounds.Error`.
+
+Closing is silent: `DialogDismiss` and `ToastDismiss` make no sound, because the
+button that closed the surface has already sounded. A native dialog is silent
+too — the OS plays its own.
 
 ## Platform reality
 

--- a/examples/showcase/showcase_test.go
+++ b/examples/showcase/showcase_test.go
@@ -129,7 +129,7 @@ func TestShowcaseWidgetSoundWiring(t *testing.T) {
 	w := gui.NewTestWindow(gui.WindowCfg{State: app})
 	w.UpdateView(mainView)
 
-	installWidgetSounds(w, false)
+	installWidgetSounds(w, soundPlayerSynth)
 	spy := &soundWiringSpy{}
 	w.SetSoundPlayer(spy)
 	w.SetSoundVolume(0.5)
@@ -151,6 +151,23 @@ func TestShowcaseWidgetSoundWiring(t *testing.T) {
 	}
 	if len(spy.cues) != 0 {
 		t.Fatalf("SoundDisabled button emitted %v", spy.cues)
+	}
+}
+
+// The player Select maps labels onto player kinds and back; a slipped
+// mapping installs a different player than the one the user picked.
+func TestSoundPlayerKindRoundTrip(t *testing.T) {
+	for _, kind := range []soundPlayerKind{
+		soundPlayerSynth, soundPlayerSystem, soundPlayerBeep,
+	} {
+		label := soundPlayerValue(kind)
+		if got := soundPlayerKindFor(label); got != kind {
+			t.Errorf("round trip %v → %q → %v", kind, label, got)
+		}
+	}
+	// An unrecognised label falls back to the synthesized player.
+	if got := soundPlayerKindFor("nonsense"); got != soundPlayerSynth {
+		t.Errorf("unknown label → %v, want soundPlayerSynth", got)
 	}
 }
 

--- a/examples/showcase/sound_player.go
+++ b/examples/showcase/sound_player.go
@@ -71,6 +71,12 @@ func (p cueSoundPlayer) PlaySound(cue gui.SoundCue, gain float32) {
 	case gui.SoundError:
 		freq = 220
 		env = errorEnv
+	case gui.SoundNotify:
+		freq = 880 * 5 / 6 // a whole tone below A5: soft, unasked for
+	case gui.SoundOpen:
+		freq = 880 / 2 // an octave down: something larger arrived
+	case gui.SoundSuccess:
+		freq = 880 * 2 // an octave up: the brightest cue in the set
 	default:
 		// An unrecognised cue is ignored, not an error: gui adds cues
 		// over time and a player must not break when it does.
@@ -93,15 +99,29 @@ func (p cueSoundPlayer) SoundAvailable() bool { return true }
 
 // doc:snippet-end player
 
+// soundPlayerKind picks which of the three players the showcase
+// installs. All three render the same cues; they differ in what a cue
+// sounds like and in what they cost to ship.
+type soundPlayerKind uint8
+
+const (
+	// soundPlayerSynth is the synthesized player above: every cue is a
+	// blip, no assets, gain honoured.
+	soundPlayerSynth soundPlayerKind = iota
+	// soundPlayerBeep is the zero-dependency path from the guide: the
+	// system alert on SoundError and silence otherwise, with no audio
+	// library. What an app wants when it only needs to signal a
+	// rejection.
+	soundPlayerBeep
+	// soundPlayerSystem is the platform's own event sounds: a cue for
+	// every role, no assets, no audio library, gain ignored.
+	soundPlayerSystem
+)
+
 // installWidgetSounds turns widget sound on for the window: a theme
 // that names a cue per role, and a player that renders them. Both are
 // required — either alone is silent.
-//
-// beepOnly picks the zero-dependency path from the guide: the system
-// alert on SoundError and silence otherwise, with no audio library and
-// no assets. It is what an app wants when it only needs to signal a
-// rejection.
-func installWidgetSounds(w *gui.Window, beepOnly bool) {
+func installWidgetSounds(w *gui.Window, kind soundPlayerKind) {
 	// Rebuild through ThemeMaker rather than mutating the theme in
 	// place: a Theme carries an id, and installTheme skips a theme
 	// whose id is already installed, so a mutated copy can silently
@@ -111,8 +131,11 @@ func installWidgetSounds(w *gui.Window, beepOnly bool) {
 	w.SetTheme(gui.ThemeMaker(cfg))
 
 	var p gui.SoundPlayer = cueSoundPlayer{w: w}
-	if beepOnly {
+	switch kind {
+	case soundPlayerBeep:
 		p = gui.NewBeepSoundPlayer(w)
+	case soundPlayerSystem:
+		p = gui.NewSystemSoundPlayer(w)
 	}
 	w.SetSoundPlayer(p)
 }

--- a/examples/showcase/sound_player_other.go
+++ b/examples/showcase/sound_player_other.go
@@ -8,11 +8,50 @@ import "github.com/go-gui-org/go-gui/gui"
 // to silence rather than to a build failure. The gui/ side is
 // unchanged: a nil SoundPlayer is the default everywhere.
 
-func installWidgetSounds(_ *gui.Window, _ bool) {}
+type soundPlayerKind uint8
+
+const (
+	soundPlayerSynth soundPlayerKind = iota
+	soundPlayerBeep
+	soundPlayerSystem
+)
+
+func installWidgetSounds(_ *gui.Window, _ soundPlayerKind) {}
 
 func removeWidgetSounds(_ *gui.Window) {}
 
 var (
+	_ = soundPlayerSynth
+	_ = soundPlayerBeep
+	_ = soundPlayerSystem
 	_ = installWidgetSounds
 	_ = removeWidgetSounds
 )
+
+var soundPlayerLabels = []string{
+	"Synthesized (gui/audio)",
+	"System event sounds",
+	"System alert on errors only",
+}
+
+func soundPlayerValue(kind soundPlayerKind) string {
+	switch kind {
+	case soundPlayerBeep:
+		return soundPlayerLabels[2]
+	case soundPlayerSystem:
+		return soundPlayerLabels[1]
+	default:
+		return soundPlayerLabels[0]
+	}
+}
+
+func soundPlayerKindFor(label string) soundPlayerKind {
+	switch label {
+	case soundPlayerLabels[2]:
+		return soundPlayerBeep
+	case soundPlayerLabels[1]:
+		return soundPlayerSystem
+	default:
+		return soundPlayerSynth
+	}
+}

--- a/examples/showcase/state.go
+++ b/examples/showcase/state.go
@@ -139,7 +139,7 @@ type ShowcaseApp struct {
 	WidgetSoundOn     bool
 	WidgetSoundVolume float32
 	WidgetSoundDemoOn bool
-	WidgetSoundBeep   bool
+	WidgetSoundPlayer soundPlayerKind
 	AudioMusicLoaded  bool
 	AudioMusicPlaying bool
 	AudioMusicPaused  bool

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -96,3 +96,10 @@ func (n *nativePlatform) ClearNativeMenubar()                                   
 func (n *nativePlatform) Beep() { nativehost.Beep() }
 
 func (n *nativePlatform) BeepAvailable() bool { return nativehost.BeepAvailable() }
+
+// PlaySystemSound and SystemSoundAvailable satisfy gui's optional
+// system-sound capability, which gui.NewSystemSoundPlayer type-asserts
+// for (issue #469).
+func (n *nativePlatform) PlaySystemSound(cue gui.SoundCue) { nativehost.PlaySystemSound(cue) }
+
+func (n *nativePlatform) SystemSoundAvailable() bool { return nativehost.SystemSoundAvailable() }

--- a/gui/backend/internal/nativehost/nativehost.go
+++ b/gui/backend/internal/nativehost/nativehost.go
@@ -250,3 +250,34 @@ func Beep() { sysbeep.Play() }
 
 // BeepAvailable reports whether Beep is audible on this platform.
 func BeepAvailable() bool { return sysbeep.Available() }
+
+// soundEvents maps gui.SoundCue onto sysbeep.Event. Not a switch on
+// the cue value with a default: gui adds cues over time, and a cue this
+// table does not name is silent rather than wrong. The two enums are
+// deliberately separate — sysbeep knows nothing about widgets, and gui
+// knows nothing about system sounds (issue #469).
+var soundEvents = map[gui.SoundCue]sysbeep.Event{
+	gui.SoundClick:     sysbeep.EventClick,
+	gui.SoundToggleOn:  sysbeep.EventToggleOn,
+	gui.SoundToggleOff: sysbeep.EventToggleOff,
+	gui.SoundSelection: sysbeep.EventSelection,
+	gui.SoundError:     sysbeep.EventError,
+	gui.SoundNotify:    sysbeep.EventNotify,
+	gui.SoundOpen:      sysbeep.EventOpen,
+	gui.SoundSuccess:   sysbeep.EventSuccess,
+}
+
+// PlaySystemSound plays the platform's system sound for cue. An
+// unmapped cue is silent, not an error. Thin forwarder to sysbeep,
+// like Beep above.
+func PlaySystemSound(cue gui.SoundCue) {
+	event, ok := soundEvents[cue]
+	if !ok {
+		return
+	}
+	sysbeep.PlayEvent(event)
+}
+
+// SystemSoundAvailable reports whether PlaySystemSound is audible on
+// this platform.
+func SystemSoundAvailable() bool { return sysbeep.EventAvailable() }

--- a/gui/backend/internal/nativehost/nativehost_test.go
+++ b/gui/backend/internal/nativehost/nativehost_test.go
@@ -186,3 +186,37 @@ func TestDialogAndPrintForwardersNoPanic(t *testing.T) {
 	// Print forwarder is safe on all platforms (returns error without UI).
 	_ = ShowPrintDialog(gui.NativePrintParams{})
 }
+
+// PlaySystemSound must be silent — never a panic — for the zero cue,
+// every cue the table names, and a value outside the enum, which is
+// what an older backend paired with a newer gui would pass (issue #469).
+func TestPlaySystemSoundDoesNotPanic(t *testing.T) {
+	cues := []gui.SoundCue{
+		gui.SoundNone,
+		gui.SoundClick, gui.SoundToggleOn, gui.SoundToggleOff,
+		gui.SoundSelection, gui.SoundError,
+		gui.SoundNotify, gui.SoundOpen, gui.SoundSuccess,
+		gui.SoundCue(200),
+	}
+	for _, cue := range cues {
+		PlaySystemSound(cue)
+	}
+}
+
+// The soundEvents table is the only place the real platforms learn
+// which cue is which event — the gui-side tests install a spy and
+// never see it. The enum is open: a cue added later is deliberately
+// silent until the table names it, but a cue the table drops never
+// sounds on any platform, and no other test would notice (issue #469).
+func TestSoundEventsNamesEveryCurrentCue(t *testing.T) {
+	cues := []gui.SoundCue{
+		gui.SoundClick, gui.SoundToggleOn, gui.SoundToggleOff,
+		gui.SoundSelection, gui.SoundError,
+		gui.SoundNotify, gui.SoundOpen, gui.SoundSuccess,
+	}
+	for _, cue := range cues {
+		if _, ok := soundEvents[cue]; !ok {
+			t.Errorf("soundEvents dropped %v", cue)
+		}
+	}
+}

--- a/gui/backend/metal/native_platform.go
+++ b/gui/backend/metal/native_platform.go
@@ -175,3 +175,10 @@ func (n *nativePlatform) RemoveSystemTray(id int) {
 func (n *nativePlatform) Beep() { nativehost.Beep() }
 
 func (n *nativePlatform) BeepAvailable() bool { return nativehost.BeepAvailable() }
+
+// PlaySystemSound and SystemSoundAvailable satisfy gui's optional
+// system-sound capability, which gui.NewSystemSoundPlayer type-asserts
+// for (issue #469).
+func (n *nativePlatform) PlaySystemSound(cue gui.SoundCue) { nativehost.PlaySystemSound(cue) }
+
+func (n *nativePlatform) SystemSoundAvailable() bool { return nativehost.SystemSoundAvailable() }

--- a/gui/backend/sysbeep/sysbeep_event.go
+++ b/gui/backend/sysbeep/sysbeep_event.go
@@ -1,0 +1,53 @@
+package sysbeep
+
+// Event names a user-interface sound the platform already ships as a
+// system event sound. It is not a sample and not a file path: each
+// platform maps the event onto its own sound-naming scheme (NSSound
+// names on macOS, registry aliases on Windows, freedesktop sound-naming
+// ids on Linux), so an app gets a native-sounding cue with no assets.
+//
+// The list is open and append-only, mirroring gui.SoundCue. An event a
+// platform has no sound for is silent, never an error (issue #469).
+type Event uint8
+
+// Event values.
+const (
+	// EventClick is a momentary activation — a button, a menu item.
+	EventClick Event = iota
+	// EventToggleOn is a state that went off -> on.
+	EventToggleOn
+	// EventToggleOff is a state that went on -> off.
+	EventToggleOff
+	// EventSelection is one option picked out of several.
+	EventSelection
+	// EventError is a rejection: invalid input, a refused commit.
+	EventError
+	// EventNotify is something that appeared unasked — a toast.
+	EventNotify
+	// EventOpen is a modal surface opening — a dialog.
+	EventOpen
+	// EventSuccess is a multi-field action being accepted.
+	EventSuccess
+	// eventCount bounds the per-platform mapping tables. Keep last.
+	eventCount
+)
+
+// PlayEvent plays the system sound mapped to e, if this platform has
+// one. Non-blocking, and silent — never a panic — for an event this
+// platform does not map, for an out-of-range value, and on every target
+// with no event sounds at all.
+//
+// Unlike Play, which is the out-of-band alert, these are the ordinary
+// interface sounds: they follow the user's system event-sound settings
+// and carry no app-level volume. See gui.NewSystemSoundPlayer.
+func PlayEvent(e Event) {
+	if e >= eventCount {
+		return
+	}
+	playEvent(e)
+}
+
+// EventAvailable reports whether PlayEvent can produce sound on this
+// platform. False on targets with no event sounds, and on Linux when
+// canberra-gtk-play is not installed.
+func EventAvailable() bool { return eventAvailable() }

--- a/gui/backend/sysbeep/sysbeep_event_darwin.go
+++ b/gui/backend/sysbeep/sysbeep_event_darwin.go
@@ -1,0 +1,48 @@
+//go:build darwin && !ios
+
+package sysbeep
+
+/*
+#cgo CFLAGS: -fobjc-arc
+#cgo LDFLAGS: -framework AppKit
+#include <stdlib.h>
+#include "sysbeep_event_darwin.h"
+*/
+import "C"
+
+// eventSounds maps an Event onto a sound in /System/Library/Sounds —
+// the same names the Sound preference pane lists, so every one of them
+// is a sound the user already recognises.
+//
+// Tink is short and neutral, which is what a click wants; Pop and
+// Bottle read as on and off; Ping marks a pick; Basso is the standard
+// failure sound; Purr is soft enough for an unasked-for toast; Blow
+// opens; Glass reads as completion. An empty entry is silent.
+var eventSounds = [eventCount]string{
+	EventClick:     "Tink",
+	EventToggleOn:  "Pop",
+	EventToggleOff: "Bottle",
+	EventSelection: "Ping",
+	EventError:     "Basso",
+	EventNotify:    "Purr",
+	EventOpen:      "Blow",
+	EventSuccess:   "Glass",
+}
+
+// cNames holds one C string per event, allocated on first use, so a
+// cue costs no allocation and no free. The table is fixed and small,
+// and the strings live for the life of the process by design.
+var cNames [eventCount]*C.char
+
+func playEvent(e Event) {
+	name := eventSounds[e]
+	if name == "" {
+		return
+	}
+	if cNames[e] == nil {
+		cNames[e] = C.CString(name)
+	}
+	C.sysbeepPlayEvent(cNames[e])
+}
+
+func eventAvailable() bool { return C.sysbeepEventAvailable() != 0 }

--- a/gui/backend/sysbeep/sysbeep_event_darwin.h
+++ b/gui/backend/sysbeep/sysbeep_event_darwin.h
@@ -1,0 +1,15 @@
+//go:build darwin && !ios
+
+#ifndef SYSBEEP_EVENT_DARWIN_H
+#define SYSBEEP_EVENT_DARWIN_H
+
+// sysbeepPlayEvent plays the named system sound. name is one of the
+// sounds in /System/Library/Sounds (NSSound soundNamed:). A name the
+// system does not have is silent.
+void sysbeepPlayEvent(const char *name);
+
+// sysbeepEventAvailable reports whether the system sounds these events
+// map onto can be loaded at all.
+int sysbeepEventAvailable(void);
+
+#endif

--- a/gui/backend/sysbeep/sysbeep_event_darwin.m
+++ b/gui/backend/sysbeep/sysbeep_event_darwin.m
@@ -1,0 +1,63 @@
+//go:build darwin && !ios
+
+#import <AppKit/AppKit.h>
+#include "sysbeep_event_darwin.h"
+
+// NSSound objects are cached by name: soundNamed: reads the file the
+// first time, and a UI cue must not touch the disk on every click. The
+// cache is only ever reached from the main thread (the event-dispatch
+// goroutine is locked to it), so it needs no lock of its own.
+static NSMutableDictionary<NSString *, NSSound *> *sysbeepSoundCache(void) {
+    static NSMutableDictionary<NSString *, NSSound *> *cache = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        cache = [[NSMutableDictionary alloc] init];
+    });
+    return cache;
+}
+
+// sysbeepNamedSound returns the cached NSSound for name, or nil if the
+// system has no such sound — a user can remove one from
+// /System/Library/Sounds, and a missing sound is silence, not an error.
+static NSSound *sysbeepNamedSound(NSString *name) {
+    NSMutableDictionary<NSString *, NSSound *> *cache = sysbeepSoundCache();
+    NSSound *sound = cache[name];
+    if (sound != nil) {
+        return sound;
+    }
+    sound = [NSSound soundNamed:name];
+    if (sound == nil) {
+        return nil;
+    }
+    cache[name] = sound;
+    return sound;
+}
+
+void sysbeepPlayEvent(const char *name) {
+    if (name == NULL) {
+        return;
+    }
+    @autoreleasepool {
+        NSString *key = [NSString stringWithUTF8String:name];
+        if (key == nil) {
+            return;
+        }
+        NSSound *sound = sysbeepNamedSound(key);
+        if (sound == nil) {
+            return;
+        }
+        // Stop before playing: a cached NSSound already playing ignores
+        // a second play, which would swallow the second of two quick
+        // cues. Restarting is the behaviour a UI sound wants.
+        [sound stop];
+        [sound play];
+    }
+}
+
+int sysbeepEventAvailable(void) {
+    @autoreleasepool {
+        // Tink is the click sound and has shipped in every macOS
+        // release; if it cannot be loaded, neither can the rest.
+        return sysbeepNamedSound(@"Tink") != nil ? 1 : 0;
+    }
+}

--- a/gui/backend/sysbeep/sysbeep_event_linux.go
+++ b/gui/backend/sysbeep/sysbeep_event_linux.go
@@ -1,0 +1,51 @@
+//go:build linux && !android
+
+package sysbeep
+
+import "os/exec"
+
+// eventNames maps an Event onto a freedesktop sound-naming id — the
+// same vocabulary GTK apps use, so the sound the user hears is the one
+// their chosen sound theme defines. Indexed by Event; an empty entry is
+// silent.
+//
+// The ids come from the freedesktop sound-naming spec: button-pressed
+// and button-released are the two halves of a press, so a toggle uses
+// them for its two directions; "complete" marks a finished action, and
+// "message" is the notification sound a toast wants.
+var eventNames = [eventCount]string{
+	EventClick:     "button-pressed",
+	EventToggleOn:  "button-pressed",
+	EventToggleOff: "button-released",
+	EventSelection: "button-pressed",
+	EventError:     "dialog-error",
+	EventNotify:    "message",
+	EventOpen:      "dialog-information",
+	EventSuccess:   "complete",
+}
+
+// playEvent shells out to canberra-gtk-play, exactly as Play does for
+// the bell. One process per cue: fine for the occasional dialog or
+// toast, wrong for a click-heavy UI — such an app wants a sampled
+// player (see gui/audio) rather than system event sounds.
+func playEvent(e Event) {
+	path := lookupOnce()
+	if path == "" {
+		return
+	}
+	name := eventNames[e]
+	if name == "" {
+		return
+	}
+	// #nosec G204 — path from exec.LookPath, name from the fixed table
+	cmd := exec.Command(path, "-i", name)
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	// Reap asynchronously; without this every cue leaves a zombie for
+	// the life of the process.
+	go func() { _ = cmd.Wait() }()
+}
+
+// eventAvailable reports whether canberra-gtk-play was found on PATH.
+func eventAvailable() bool { return lookupOnce() != "" }

--- a/gui/backend/sysbeep/sysbeep_event_other.go
+++ b/gui/backend/sysbeep/sysbeep_event_other.go
@@ -1,0 +1,13 @@
+//go:build (!darwin || ios || !cgo) && !windows && (!linux || android)
+
+package sysbeep
+
+// No system event sounds on mobile or wasm targets, for the same
+// reason there is no alert sound: iOS and Android route feedback
+// through their own frameworks, and the browser has no such concept.
+
+// playEvent is a no-op on platforms without system event sounds.
+func playEvent(Event) {}
+
+// eventAvailable reports that this platform has no event sounds.
+func eventAvailable() bool { return false }

--- a/gui/backend/sysbeep/sysbeep_event_windows.go
+++ b/gui/backend/sysbeep/sysbeep_event_windows.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package sysbeep
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	winmm      = windows.NewLazySystemDLL("winmm.dll")
+	pPlaySound = winmm.NewProc("PlaySoundW")
+)
+
+const (
+	// sndAsync returns as soon as the sound is queued.
+	sndAsync = 0x00000001
+	// sndNoDefault is load-bearing: an alias the user's sound scheme
+	// leaves unset plays nothing, instead of falling back to the
+	// default beep, which would make an ordinary click sound like an
+	// alert.
+	sndNoDefault = 0x00000002
+	// sndAlias reads the name as a system-event alias from the
+	// registry (HKCU\AppEvents\Schemes\Apps\.Default).
+	sndAlias = 0x00010000
+)
+
+// eventAliases maps an Event onto a Windows system-event alias.
+// MenuCommand is the sound Windows itself uses for an interface
+// command, so it covers click, toggle and selection; the three
+// System* aliases are the documented dialog sounds. An empty entry is
+// silent.
+var eventAliases = [eventCount]string{
+	EventClick:     "MenuCommand",
+	EventToggleOn:  "MenuCommand",
+	EventToggleOff: "MenuCommand",
+	EventSelection: "MenuPopup",
+	EventError:     "SystemHand",
+	EventNotify:    "Notification.Default",
+	EventOpen:      "SystemAsterisk",
+	EventSuccess:   ".Default",
+}
+
+// playEvent calls PlaySoundW with the alias flags. A failed call is
+// silent: a cue must never surface an error to the user.
+func playEvent(e Event) {
+	alias := eventAliases[e]
+	if alias == "" {
+		return
+	}
+	name, err := windows.UTF16PtrFromString(alias)
+	if err != nil {
+		return
+	}
+	_, _, _ = pPlaySound.Call(
+		uintptr(unsafe.Pointer(name)),
+		0,
+		uintptr(sndAlias|sndAsync|sndNoDefault),
+	)
+}
+
+// eventAvailable reports that Windows has system event sounds. Whether
+// any given alias is bound to a file is the user's scheme choice, and
+// sndNoDefault makes an unbound one silent rather than a beep.
+func eventAvailable() bool { return true }

--- a/gui/backend/sysbeep/sysbeep_test.go
+++ b/gui/backend/sysbeep/sysbeep_test.go
@@ -21,3 +21,26 @@ func TestAvailableMatchesPlatform(t *testing.T) {
 		t.Errorf("Available not stable: %v then %v", first, second)
 	}
 }
+
+// PlayEvent must be silent, never a panic, for every event — including
+// on targets with no event sounds at all — and for a value outside the
+// enum, which is what an older backend paired with a newer gui would
+// pass (issue #469).
+func TestPlayEventDoesNotPanic(t *testing.T) {
+	for e := range int(eventCount) {
+		PlayEvent(Event(e))
+	}
+	PlayEvent(eventCount)
+	PlayEvent(Event(200))
+}
+
+// EventAvailable is a property of the platform, so it must not change
+// between calls; a caller uses it to decide on a visual fallback once.
+func TestEventAvailableStable(t *testing.T) {
+	first := EventAvailable()
+	for range 3 {
+		if EventAvailable() != first {
+			t.Fatal("EventAvailable changed between calls")
+		}
+	}
+}

--- a/gui/datagrid/sound_test.go
+++ b/gui/datagrid/sound_test.go
@@ -118,3 +118,52 @@ func TestGridSoundDisabledSuppresses(t *testing.T) {
 		t.Errorf("SoundDisabled emitted %v, want nothing", spy.cues)
 	}
 }
+
+// Phase 4 (issue #469): a CRUD save failure sounds. It has no control
+// of its own, so the cue is resolved with the grid's other two and
+// emitted at dataGridCrudRestoreOnError, the one point every failure
+// path funnels through.
+
+// gridErrCue resolves the grid's error cue the way a generate does.
+func gridErrCue(cfg DataGridCfg) gg.SoundCue {
+	applyDataGridDefaults(&cfg)
+	return cfg.sounds.err
+}
+
+func TestSoundGridCRUDErrorEmitsOnce(t *testing.T) {
+	w, spy := soundGrid(t, soundGridCfg())
+	spy.cues = nil
+
+	var gotMsg string
+	snapshot := []GridRow{{ID: "r1", Cells: map[string]string{"c1": "a"}}}
+	dataGridCrudRestoreOnError("g1", "save",
+		func(msg string, _ gg.EventCtx) { gotMsg = msg },
+		&gg.Event{}, w, snapshot, "save failed", gridErrCue(soundGridCfg()))
+
+	if len(spy.cues) != 1 || spy.cues[0] != gg.SoundError {
+		t.Errorf("cues = %v, want [SoundError]", spy.cues)
+	}
+	// The cue does not replace the callback.
+	if gotMsg != "save failed" {
+		t.Errorf("OnCRUDError msg = %q, want %q", gotMsg, "save failed")
+	}
+}
+
+func TestSoundGridCRUDErrorResolution(t *testing.T) {
+	// Installs the sounding theme; applyDataGridDefaults resolves
+	// against gg.CurrentTheme(), which is package-global, so the
+	// window has to exist before the resolution below.
+	soundGrid(t, soundGridCfg())
+
+	// cfg.Sound names an activation, so it must not reach the error
+	// cue; cfg.SoundDisabled must suppress it.
+	cfg := soundGridCfg()
+	cfg.Sound = gg.SoundClick
+	if got := gridErrCue(cfg); got != gg.SoundError {
+		t.Errorf("Sound override leaked into the error cue: %v", got)
+	}
+	cfg.SoundDisabled = true
+	if got := gridErrCue(cfg); got != gg.SoundNone {
+		t.Errorf("SoundDisabled error cue = %v, want SoundNone", got)
+	}
+}

--- a/gui/datagrid/view_data_grid.go
+++ b/gui/datagrid/view_data_grid.go
@@ -334,12 +334,14 @@ type DataGridCfg struct {
 	sounds dataGridSounds
 }
 
-// dataGridSounds holds the grid's cues after resolution. Two roles,
-// not one per control: a control either activates (click) or picks one
-// of several (selection).
+// dataGridSounds holds the grid's cues after resolution. Two
+// interaction roles — a control either activates (click) or picks one
+// of several (selection) — plus the error role a failed CRUD save
+// emits, which has no control of its own (issue #469).
 type dataGridSounds struct {
 	click     gg.SoundCue
 	selection gg.SoundCue
+	err       gg.SoundCue
 }
 
 // boolDefault returns *p if non-nil, else def.
@@ -362,6 +364,11 @@ func applyDataGridDefaults(cfg *DataGridCfg) {
 			sounds.Click, cfg.Sound, cfg.SoundDisabled),
 		selection: gg.ResolveSoundCue(
 			sounds.Selection, cfg.Sound, cfg.SoundDisabled),
+		// cfg.Sound names an activation, never a refusal, so the error
+		// role takes the theme's cue alone — the same rule gui's
+		// resolveSoundCues keeps for its reject cue (issue #469).
+		err: gg.ResolveSoundCue(
+			sounds.Error, gg.SoundNone, cfg.SoundDisabled),
 	}
 	cfg.Sizing = cfg.Sizing.Or(gg.FillFill)
 	if cfg.RowHeight == 0 {

--- a/gui/datagrid/view_data_grid_crud.go
+++ b/gui/datagrid/view_data_grid_crud.go
@@ -151,6 +151,7 @@ func dataGridCrudToolbarRow(cfg *DataGridCfg, state dataGridCrudState, caps Grid
 	dataSource := cfg.DataSource
 	query := cfg.Query
 	onCRUDError := cfg.OnCRUDError
+	errCue := cfg.sounds.err
 	onRowsChange := cfg.OnRowsChange
 	onPageChange := cfg.OnPageChange
 	pageSize := cfg.PageSize
@@ -211,6 +212,7 @@ func dataGridCrudToolbarRow(cfg *DataGridCfg, state dataGridCrudState, caps Grid
 						hasSource:         hasSource,
 						caps:              caps,
 						focusID:           focusID,
+						errCue:            errCue,
 					}, ctx.Event, ctx.Window)
 				}),
 			dataGridIndicatorButton(gg.ScopeID(gridID, "crud_cancel"), gg.ActiveLocale.StrCancel, cfg.TextStyleFilter, cfg.ColorHeaderHover,

--- a/gui/datagrid/view_data_grid_crud_save.go
+++ b/gui/datagrid/view_data_grid_crud_save.go
@@ -140,6 +140,7 @@ type dataGridCrudSaveContext struct {
 	query             GridQueryState
 	gridID            string
 	focusID           string
+	errCue            gg.SoundCue
 	caps              GridDataCapabilities
 	hasSource         bool
 }
@@ -169,17 +170,17 @@ func dataGridCrudSave(ctx dataGridCrudSaveContext, e *gg.Event, w *gg.Window) {
 		// Pre-validate capabilities.
 		if len(createRows) > 0 && !ctx.caps.supportsCreate {
 			dataGridCrudRestoreOnError(gridID, "create", ctx.onCRUDError,
-				e, w, snapshotRows, "grid: create not supported")
+				e, w, snapshotRows, "grid: create not supported", ctx.errCue)
 			return
 		}
 		if len(updateEdits) > 0 && !ctx.caps.supportsUpdate {
 			dataGridCrudRestoreOnError(gridID, "update", ctx.onCRUDError,
-				e, w, snapshotRows, "grid: update not supported")
+				e, w, snapshotRows, "grid: update not supported", ctx.errCue)
 			return
 		}
 		if len(deleteIDs) > 0 && !ctx.caps.supportsDelete {
 			dataGridCrudRestoreOnError(gridID, "delete", ctx.onCRUDError,
-				e, w, snapshotRows, "grid: delete not supported")
+				e, w, snapshotRows, "grid: delete not supported", ctx.errCue)
 			return
 		}
 		query := ctx.query
@@ -188,6 +189,7 @@ func dataGridCrudSave(ctx dataGridCrudSaveContext, e *gg.Event, w *gg.Window) {
 		selection := ctx.selection
 		onSelectionChange := ctx.onSelectionChange
 		focusID := ctx.focusID
+		errCue := ctx.errCue
 		wCtx := w.Ctx()
 		// Cancel any prior in-flight save and set up abort for
 		// this save so slow mutations can observe cancellation.
@@ -209,7 +211,7 @@ func dataGridCrudSave(ctx dataGridCrudSaveContext, e *gg.Event, w *gg.Window) {
 			w.QueueCommand(func(w *gg.Window) {
 				dataGridCrudApplySaveResult(gridID, result, snapshotRows,
 					onCRUDError, onRowsChange, selection, onSelectionChange,
-					focusID, w)
+					focusID, errCue, w)
 			})
 		}()
 	} else {
@@ -286,11 +288,11 @@ func dataGridCrudExecMutations(source DataGridDataSource, gridID string, query G
 	}
 }
 
-func dataGridCrudApplySaveResult(gridID string, result dataGridCrudMutationResult, snapshotRows []GridRow, onCRUDError func(string, gg.EventCtx), onRowsChange func([]GridRow, gg.EventCtx), selection GridSelection, onSelectionChange func(GridSelection, gg.EventCtx), focusID string, w *gg.Window) {
+func dataGridCrudApplySaveResult(gridID string, result dataGridCrudMutationResult, snapshotRows []GridRow, onCRUDError func(string, gg.EventCtx), onRowsChange func([]GridRow, gg.EventCtx), selection GridSelection, onSelectionChange func(GridSelection, gg.EventCtx), focusID string, errCue gg.SoundCue, w *gg.Window) {
 	e := &gg.Event{}
 	if result.errMsg != "" {
 		dataGridCrudRestoreOnError(gridID, result.errPhase, onCRUDError,
-			e, w, snapshotRows, result.errMsg)
+			e, w, snapshotRows, result.errMsg, errCue)
 		return
 	}
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
@@ -300,7 +302,7 @@ func dataGridCrudApplySaveResult(gridID string, result dataGridCrudMutationResul
 		state.WorkingRows, result.createRows, result.created)
 	if createWarn != "" {
 		dataGridCrudRestoreOnError(gridID, "create", onCRUDError,
-			e, w, snapshotRows, createWarn)
+			e, w, snapshotRows, createWarn, errCue)
 		return
 	}
 	dgCrud.Set(gridID, state)
@@ -339,7 +341,7 @@ func dataGridCrudFinishSave(gridID string, _ map[string]string, rowCount int, on
 	}
 }
 
-func dataGridCrudRestoreOnError(gridID, phase string, onCRUDError func(string, gg.EventCtx), e *gg.Event, w *gg.Window, snapshotRows []GridRow, errMsg string) {
+func dataGridCrudRestoreOnError(gridID, phase string, onCRUDError func(string, gg.EventCtx), e *gg.Event, w *gg.Window, snapshotRows []GridRow, errMsg string, errCue gg.SoundCue) {
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, capModerate)
 	// Default zero state: absent entry means nothing to restore on error.
 	state := dgCrud.GetOr(gridID, dataGridCrudState{})
@@ -358,6 +360,11 @@ func dataGridCrudRestoreOnError(gridID, phase string, onCRUDError func(string, g
 	dgCrud.Set(gridID, state)
 	dataGridClearEditingRow(gridID, w)
 	dataGridSourceForceRefetch(gridID, w)
+	// Every CRUD failure funnels through here, so this is the one emit
+	// site. Before the callback, like every other cue. datagrid is
+	// outside gui/, so it goes through the exported seam rather than
+	// the unexported playSoundCue (issue #469).
+	w.PlaySoundCue(errCue)
 	if onCRUDError != nil {
 		onCRUDError(errMsg, gg.EventCtx{Layout: nil, Event: e, Window: w})
 	}

--- a/gui/datagrid/view_data_grid_crud_test.go
+++ b/gui/datagrid/view_data_grid_crud_test.go
@@ -806,7 +806,7 @@ func TestCrudRestoreOnError(t *testing.T) {
 		errMsg = msg
 	}
 	e := &gg.Event{}
-	dataGridCrudRestoreOnError("g1", "save", cb, e, w, snapshot, "save failed")
+	dataGridCrudRestoreOnError("g1", "save", cb, e, w, snapshot, "save failed", gg.SoundNone)
 	if errMsg != "save failed" {
 		t.Errorf("error callback: got %q, want 'save failed'", errMsg)
 	}
@@ -829,7 +829,7 @@ func TestCrudRestoreOnErrorNoPhase(t *testing.T) {
 	w := gg.NewWindow(gg.WindowCfg{})
 	defer w.Close()
 	snapshot := []GridRow{{ID: "r1", Cells: map[string]string{}}}
-	dataGridCrudRestoreOnError("g1", "", nil, &gg.Event{}, w, snapshot, "generic error")
+	dataGridCrudRestoreOnError("g1", "", nil, &gg.Event{}, w, snapshot, "generic error", gg.SoundNone)
 	dgCrud := gg.StateMap[string, dataGridCrudState](w, nsDgCrud, 4)
 	state, _ := dgCrud.Get("g1")
 	if state.SaveError != "generic error" {

--- a/gui/sound.go
+++ b/gui/sound.go
@@ -39,6 +39,17 @@ const (
 	// these" reading. Appended, not inserted: the enum is open and
 	// values are only ever added at the end (issue #467).
 	SoundSelection
+	// SoundNotify marks something that appeared without being asked
+	// for — a toast. Not a rejection: an error-severity toast takes
+	// SoundError instead.
+	SoundNotify
+	// SoundOpen marks a modal surface opening — a dialog. Distinct
+	// from SoundClick, which is the button that opened it.
+	SoundOpen
+	// SoundSuccess marks a multi-field action the framework accepted —
+	// a form submit that passed validation. Its refusal is SoundError.
+	// Appended, not inserted (issue #469).
+	SoundSuccess
 )
 
 // SoundPlayer renders semantic UI cues as audible feedback. The
@@ -53,6 +64,12 @@ type SoundPlayer interface {
 	// window). Called on the event-dispatch goroutine, so it must be
 	// fire-and-forget: no blocking, no allocation on an audio thread.
 	// An unrecognised cue must be ignored, not reported as an error.
+	//
+	// Some cues are emitted from a path that already holds the frame
+	// lock — a form submit runs from AmendLayout — so an implementation
+	// must not call a window-mutating API (SetFocus, UpdateView,
+	// Window.Lock): those take w.mu, which is not reentrant, and panic
+	// naming themselves.
 	PlaySound(cue SoundCue, gain float32)
 	// SoundAvailable reports whether PlaySound can actually produce
 	// sound on this platform. Callers that need the user to notice an
@@ -85,6 +102,16 @@ type SoundSet struct {
 	// Selection is the cue for picking one option out of several.
 	// exportaudit:keep — caller-facing config (issue #467)
 	Selection SoundCue
+	// Notify is the cue for something appearing unasked — a toast.
+	// exportaudit:keep — caller-facing config (issue #469)
+	Notify SoundCue
+	// Open is the cue for a modal surface opening — a dialog.
+	// exportaudit:keep — caller-facing config (issue #469)
+	Open SoundCue
+	// Success is the cue for a multi-field action being accepted — a
+	// form submit that passed validation.
+	// exportaudit:keep — caller-facing config (issue #469)
+	Success SoundCue
 }
 
 // SoundsDefault returns the natural cue for every role — the one-liner
@@ -96,6 +123,9 @@ func SoundsDefault() SoundSet {
 		ToggleOff: SoundToggleOff,
 		Error:     SoundError,
 		Selection: SoundSelection,
+		Notify:    SoundNotify,
+		Open:      SoundOpen,
+		Success:   SoundSuccess,
 	}
 }
 
@@ -241,6 +271,23 @@ func playSoundCue(cue SoundCue, w *Window) {
 		return
 	}
 	p.PlaySound(cue, gain)
+}
+
+// PlaySoundCue emits an already-resolved cue from a path that has no
+// Shape to read one off. Same guarantees as every other seam: a
+// SoundNone cue, no installed player or a muted window are silent, and
+// it takes no lock, so it is safe from a callback running under the
+// frame lock.
+//
+// Exported for widget packages outside gui/ — gui/datagrid is the one
+// in-repo case, whose CRUD failure has no button to hang a cue off.
+// Resolve the cue with ResolveSoundCue first; this method does not
+// apply the precedence.
+//
+// exportaudit:keep — the emit seam for out-of-package widgets
+// (issue #469)
+func (w *Window) PlaySoundCue(cue SoundCue) {
+	playSoundCue(cue, w)
 }
 
 // beepSoundPlayer is the zero-dependency default: it maps SoundError

--- a/gui/sound_nonclick_test.go
+++ b/gui/sound_nonclick_test.go
@@ -1,0 +1,281 @@
+package gui
+
+import "testing"
+
+// Phase 4 (issue #469): the cues for interactions with no click site —
+// a toast appearing, a dialog opening, a form submit landing or being
+// refused. Theme installation is package-global, so these must not run
+// in parallel; see the note at the top of sound_test.go.
+
+// soundNonClickWindow builds a window with the sounding theme and a
+// spy, but renders nothing: Toast and Dialog are imperative APIs, not
+// views.
+func soundNonClickWindow(t *testing.T) (*Window, *soundSpy) {
+	t.Helper()
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+	return w, spy
+}
+
+func TestSoundToastAppearBySeverity(t *testing.T) {
+	cases := []struct {
+		name     string
+		severity ToastSeverity
+		want     SoundCue
+	}{
+		{"info", ToastInfo, SoundNotify},
+		{"success", ToastSuccess, SoundNotify},
+		{"warning", ToastWarning, SoundNotify},
+		// The one place severity picks a cue: an error toast reports a
+		// failure and takes the theme's Error role.
+		{"error", ToastError, SoundError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, spy := soundNonClickWindow(t)
+			w.Toast(ToastCfg{Title: "T", Severity: tc.severity})
+			if len(spy.cues) != 1 || spy.cues[0] != tc.want {
+				t.Errorf("cues = %v, want [%v]", spy.cues, tc.want)
+			}
+		})
+	}
+}
+
+func TestSoundToastAppearOncePerToast(t *testing.T) {
+	w, spy := soundNonClickWindow(t)
+	w.Toast(ToastCfg{Title: "A"})
+	w.Toast(ToastCfg{Title: "B"})
+	// Rendering the toasts again must not re-emit: the cue rides the
+	// Toast call, not the per-frame toast view.
+	w.TestRender(func(*Window) View { return Column(ContainerCfg{}) })
+	w.TestRender(func(*Window) View { return Column(ContainerCfg{}) })
+	if len(spy.cues) != 2 {
+		t.Errorf("cues = %v, want exactly two appear cues", spy.cues)
+	}
+}
+
+func TestSoundToastSilentCases(t *testing.T) {
+	t.Run("sound disabled", func(t *testing.T) {
+		w, spy := soundNonClickWindow(t)
+		w.Toast(ToastCfg{Title: "T", SoundDisabled: true})
+		if len(spy.cues) != 0 {
+			t.Errorf("SoundDisabled emitted %v, want nothing", spy.cues)
+		}
+	})
+	t.Run("silent theme", func(t *testing.T) {
+		restoreTheme(t)
+		spy := &soundSpy{}
+		w := NewTestWindow(WindowCfg{})
+		w.SetTheme(silentTheme(t))
+		w.SetSoundPlayer(spy)
+		w.Toast(ToastCfg{Title: "T"})
+		if len(spy.cues) != 0 {
+			t.Errorf("silent theme emitted %v, want nothing", spy.cues)
+		}
+	})
+	t.Run("dismiss", func(t *testing.T) {
+		w, spy := soundNonClickWindow(t)
+		id := w.Toast(ToastCfg{Title: "T"})
+		spy.cues = nil
+		w.ToastDismiss(id)
+		w.ToastDismissAll()
+		if len(spy.cues) != 0 {
+			t.Errorf("dismiss emitted %v, want nothing", spy.cues)
+		}
+	})
+}
+
+// ToastCfg.Sound names the buttons' activation cue, so it must not
+// reach the appear cue.
+func TestSoundToastCfgSoundDoesNotOverrideAppear(t *testing.T) {
+	w, spy := soundNonClickWindow(t)
+	w.Toast(ToastCfg{Title: "T", Sound: SoundClick})
+	if len(spy.cues) != 1 || spy.cues[0] != SoundNotify {
+		t.Errorf("cues = %v, want [SoundNotify]", spy.cues)
+	}
+}
+
+func TestSoundDialogOpen(t *testing.T) {
+	w, spy := soundNonClickWindow(t)
+	w.Dialog(DialogCfg{DialogType: DialogConfirm, Title: "Quit?"})
+	if len(spy.cues) != 1 || spy.cues[0] != SoundOpen {
+		t.Errorf("cues = %v, want [SoundOpen]", spy.cues)
+	}
+	// Dismiss is silent: the button that closed the dialog has already
+	// sounded through the ordinary click path.
+	spy.cues = nil
+	w.DialogDismiss()
+	if len(spy.cues) != 0 {
+		t.Errorf("DialogDismiss emitted %v, want nothing", spy.cues)
+	}
+}
+
+func TestSoundDialogSoundDisabled(t *testing.T) {
+	w, spy := soundNonClickWindow(t)
+	w.Dialog(DialogCfg{
+		DialogType: DialogConfirm, Title: "Quit?", SoundDisabled: true,
+	})
+	if len(spy.cues) != 0 {
+		t.Errorf("SoundDisabled emitted %v, want nothing", spy.cues)
+	}
+}
+
+// soundFormSubmit registers one required field with value, applies cfg,
+// then latches and processes a submit. It returns the cues emitted.
+func soundFormSubmit(t *testing.T, cfg FormCfg, value string) []SoundCue {
+	t.Helper()
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+
+	required := func(f FormFieldSnapshot, _ FormSnapshot) []FormIssue {
+		if f.Value == "" {
+			return []FormIssue{{Msg: "required"}}
+		}
+		return nil
+	}
+	cfg.ID = "sound-form"
+	FormRegisterFieldByID(w, cfg.ID, FormFieldAdapterCfg{
+		FieldID:        "name",
+		Value:          value,
+		SyncValidators: []FormSyncValidator{required},
+	})
+	formApplyCfg(w, cfg.ID, cfg)
+	// Resolved off the window's theme rather than the guiTheme mirror:
+	// this helper renders nothing, so no frame has installed the mirror
+	// yet. The rendered case below covers the factory's own resolution.
+	sounds := w.Theme().Sounds
+	cues := soundCues{
+		act:    ResolveSoundCue(sounds.Success, cfg.Sound, cfg.SoundDisabled),
+		reject: ResolveSoundCue(sounds.Error, SoundNone, cfg.SoundDisabled),
+	}
+	state := formRuntime(w, cfg.ID)
+	state.submitReq = true
+	formProcessRequests(w, cfg.ID, func(FormSubmitEvent, EventCtx) {}, nil, cues)
+	// A second pass with no request must stay silent: AmendLayout runs
+	// every frame and the submitReq latch is what makes the cue
+	// one-shot.
+	formProcessRequests(w, cfg.ID, func(FormSubmitEvent, EventCtx) {}, nil, cues)
+	return spy.cues
+}
+
+func TestSoundFormSubmitAcceptedAndBlocked(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
+		got := soundFormSubmit(t, FormCfg{}, "Alice")
+		if len(got) != 1 || got[0] != SoundSuccess {
+			t.Errorf("cues = %v, want [SoundSuccess]", got)
+		}
+	})
+	t.Run("blocked by validation", func(t *testing.T) {
+		got := soundFormSubmit(t, FormCfg{}, "")
+		if len(got) != 1 || got[0] != SoundError {
+			t.Errorf("cues = %v, want [SoundError]", got)
+		}
+	})
+	t.Run("invalid allowed through", func(t *testing.T) {
+		// AllowInvalidSubmit means the submit lands, so it is an
+		// acceptance and takes the success cue.
+		got := soundFormSubmit(t, FormCfg{AllowInvalidSubmit: true}, "")
+		if len(got) != 1 || got[0] != SoundSuccess {
+			t.Errorf("cues = %v, want [SoundSuccess]", got)
+		}
+	})
+}
+
+// A submit blocked by a pending async validator is a refusal like any
+// other and takes the Error role. The submit sweep re-pends the field
+// synchronously before the summary is computed, so the block lands in
+// the pass that requested it. This pins the sound gate to the same
+// condition as the callback gate: a refactor that dropped
+// blockedPending from one but not the other would split them.
+func TestSoundFormSubmitBlockedByPending(t *testing.T) {
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+
+	formID := "sound-form-pending"
+	asyncVal := func(
+		FormFieldSnapshot, FormSnapshot, *GridAbortSignal,
+	) []FormIssue {
+		return nil
+	}
+	FormRegisterFieldByID(w, formID, FormFieldAdapterCfg{
+		FieldID:         "name",
+		Value:           "Alice",
+		AsyncValidators: []FormAsyncValidator{asyncVal},
+	})
+	formApplyCfg(w, formID, FormCfg{})
+	// Resolved off the window's theme, as in soundFormSubmit: nothing
+	// renders here, so no frame has installed the guiTheme mirror.
+	sounds := w.Theme().Sounds
+	cues := soundCues{
+		act:    ResolveSoundCue(sounds.Success, SoundNone, false),
+		reject: ResolveSoundCue(sounds.Error, SoundNone, false),
+	}
+	state := formRuntime(w, formID)
+	state.submitReq = true
+	formProcessRequests(w, formID, nil, nil, cues)
+	if len(spy.cues) != 1 || spy.cues[0] != SoundError {
+		t.Errorf("cues = %v, want [SoundError]", spy.cues)
+	}
+}
+
+func TestSoundFormCfgOverrideAndDisable(t *testing.T) {
+	t.Run("Sound overrides the acceptance", func(t *testing.T) {
+		got := soundFormSubmit(t, FormCfg{Sound: SoundClick}, "Alice")
+		if len(got) != 1 || got[0] != SoundClick {
+			t.Errorf("cues = %v, want [SoundClick]", got)
+		}
+	})
+	t.Run("Sound does not override the refusal", func(t *testing.T) {
+		got := soundFormSubmit(t, FormCfg{Sound: SoundClick}, "")
+		if len(got) != 1 || got[0] != SoundError {
+			t.Errorf("cues = %v, want [SoundError]", got)
+		}
+	})
+	t.Run("SoundDisabled suppresses both", func(t *testing.T) {
+		if got := soundFormSubmit(t, FormCfg{
+			Sound: SoundClick, SoundDisabled: true,
+		}, "Alice"); len(got) != 0 {
+			t.Errorf("accepted emitted %v, want nothing", got)
+		}
+		if got := soundFormSubmit(t, FormCfg{SoundDisabled: true}, ""); len(got) != 0 {
+			t.Errorf("blocked emitted %v, want nothing", got)
+		}
+	})
+}
+
+// The Form view resolves its own cues at generation time, and the
+// submit travels the path an app actually takes: a button asks for the
+// submit, the next frame's AmendLayout processes it.
+func TestSoundFormThroughRenderedView(t *testing.T) {
+	restoreTheme(t)
+	spy := &soundSpy{}
+	w := NewTestWindow(WindowCfg{})
+	w.SetTheme(soundingTheme(t))
+	w.SetSoundPlayer(spy)
+	formID := "rendered-form"
+	view := func(*Window) View {
+		return Form(FormCfg{ID: formID, Content: []View{
+			Button(ButtonCfg{ID: "go", Label: "Go", OnClick: func(ctx EventCtx) {
+				FormRequestSubmit(ctx.Window, formID)
+				ctx.Consume()
+			}}),
+		}})
+	}
+	w.TestRender(view)
+	spy.cues = nil
+	w.TestClick(ScopeID(formLayoutID(formID), "go"))
+	// The button's own click cue, then the submit's success cue.
+	want := []SoundCue{SoundClick, SoundSuccess}
+	if len(spy.cues) != len(want) || spy.cues[0] != want[0] || spy.cues[1] != want[1] {
+		t.Errorf("cues = %v, want %v", spy.cues, want)
+	}
+}

--- a/gui/sound_system.go
+++ b/gui/sound_system.go
@@ -1,0 +1,75 @@
+package gui
+
+// systemSoundPlatform is an optional NativePlatform capability: the
+// platform's own interface sounds, the ones the OS already ships and
+// the user has already configured.
+//
+// Deliberately NOT part of the NativePlatform interface. Adding a
+// method there would break every out-of-repo implementation, and a
+// platform that predates this capability should stay silent rather
+// than fail to compile. NewSystemSoundPlayer type-asserts for it and
+// degrades to silence when the assertion fails, which is also what
+// makes headless tests and the noop platform silent (issue #469).
+type systemSoundPlatform interface {
+	// PlaySystemSound plays the platform's sound for cue. A cue the
+	// platform does not map is silent, never an error.
+	PlaySystemSound(cue SoundCue)
+	// SystemSoundAvailable reports whether PlaySystemSound can produce
+	// sound on this platform.
+	SystemSoundAvailable() bool
+}
+
+// systemSoundPlayer maps every cue onto the platform's own event
+// sounds, so an app gets native-feeling feedback with no assets and no
+// audio library.
+type systemSoundPlayer struct {
+	w *Window
+}
+
+// NewSystemSoundPlayer returns a SoundPlayer backed by the platform's
+// system event sounds — NSSound on macOS, PlaySound with a registry
+// alias on Windows, freedesktop sound-naming ids on Linux. Unlike
+// NewBeepSoundPlayer, which plays the system alert and therefore only
+// suits SoundError, it has a sound for every cue.
+//
+// It ignores gain. System event sounds follow the user's system
+// event-sound settings and expose no app-level volume on any of the
+// three platforms, so honouring gain on one of them would make the
+// same app behave differently per platform. Muting still works:
+// (*Window).SetSoundVolume(0) is gated ahead of the player.
+//
+// Silent, never a panic, on a target with no event sounds and when no
+// native platform is attached — the same contract BeepAvailable
+// carries. Check SoundAvailable to decide whether a visual fallback is
+// warranted.
+//
+// exportaudit:keep — caller-facing constructor (issue #469)
+func NewSystemSoundPlayer(w *Window) SoundPlayer {
+	return systemSoundPlayer{w: w}
+}
+
+func (p systemSoundPlayer) PlaySound(cue SoundCue, _ float32) {
+	sp := p.platform()
+	if sp == nil {
+		return
+	}
+	sp.PlaySystemSound(cue)
+}
+
+func (p systemSoundPlayer) SoundAvailable() bool {
+	sp := p.platform()
+	return sp != nil && sp.SystemSoundAvailable()
+}
+
+// platform returns the window's native platform if it implements the
+// optional capability, else nil.
+func (p systemSoundPlayer) platform() systemSoundPlatform {
+	if p.w == nil || p.w.nativePlatform == nil {
+		return nil
+	}
+	sp, ok := p.w.nativePlatform.(systemSoundPlatform)
+	if !ok {
+		return nil
+	}
+	return sp
+}

--- a/gui/sound_system_test.go
+++ b/gui/sound_system_test.go
@@ -1,0 +1,120 @@
+package gui
+
+import "testing"
+
+// systemSoundSpy is a native platform that implements the optional
+// system-sound capability (issue #469).
+type systemSoundSpy struct {
+	noopNativePlatform
+	cues      []SoundCue
+	available bool
+}
+
+func (s *systemSoundSpy) PlaySystemSound(cue SoundCue) {
+	s.cues = append(s.cues, cue)
+}
+
+func (s *systemSoundSpy) SystemSoundAvailable() bool { return s.available }
+
+func TestSystemSoundPlayerForwardsEveryCue(t *testing.T) {
+	spy := &systemSoundSpy{available: true}
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(spy)
+	p := NewSystemSoundPlayer(w)
+
+	// Every cue reaches the platform, including the ones the beep
+	// player has no sound for.
+	cues := []SoundCue{
+		SoundClick, SoundToggleOn, SoundToggleOff, SoundSelection,
+		SoundError, SoundNotify, SoundOpen, SoundSuccess,
+	}
+	for _, cue := range cues {
+		p.PlaySound(cue, 1)
+	}
+	if len(spy.cues) != len(cues) {
+		t.Fatalf("forwarded %v, want %v", spy.cues, cues)
+	}
+	for i, cue := range cues {
+		if spy.cues[i] != cue {
+			t.Errorf("cue %d = %v, want %v", i, spy.cues[i], cue)
+		}
+	}
+	if !p.SoundAvailable() {
+		t.Error("SoundAvailable did not forward the platform result")
+	}
+}
+
+// Gain is ignored, not scaled and not gated: system event sounds carry
+// no app-level volume on any of the three platforms. Muting is handled
+// upstream in playSoundCue, which never reaches the player.
+func TestSystemSoundPlayerIgnoresGain(t *testing.T) {
+	spy := &systemSoundSpy{available: true}
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(spy)
+	p := NewSystemSoundPlayer(w)
+
+	p.PlaySound(SoundClick, 0)
+	p.PlaySound(SoundClick, 0.25)
+	if len(spy.cues) != 2 {
+		t.Errorf("forwarded %v, want two clicks regardless of gain", spy.cues)
+	}
+}
+
+func TestSystemSoundPlayerSilentWithoutCapability(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform NativePlatform
+	}{
+		// The noop platform does not implement the optional interface,
+		// which is what keeps headless tests silent.
+		{"noop platform", &noopNativePlatform{}},
+		// Neither does a platform that predates the capability.
+		{"platform without the capability", &beepSpy{available: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewWindow(WindowCfg{State: new(struct{})})
+			w.SetNativePlatform(tc.platform)
+			p := NewSystemSoundPlayer(w)
+			p.PlaySound(SoundClick, 1)
+			if p.SoundAvailable() {
+				t.Error("SoundAvailable = true without the capability")
+			}
+		})
+	}
+}
+
+func TestSystemSoundPlayerNilSeams(t *testing.T) {
+	// No native platform, and no window at all: silent, never a panic.
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	p := NewSystemSoundPlayer(w)
+	p.PlaySound(SoundClick, 1)
+	if p.SoundAvailable() {
+		t.Error("SoundAvailable = true with no native platform")
+	}
+	nilPlayer := NewSystemSoundPlayer(nil)
+	nilPlayer.PlaySound(SoundClick, 1)
+	if nilPlayer.SoundAvailable() {
+		t.Error("SoundAvailable = true with a nil window")
+	}
+}
+
+// The window seam: a cue emitted through the framework reaches the
+// system player like any other.
+func TestSystemSoundPlayerThroughWindowSeam(t *testing.T) {
+	spy := &systemSoundSpy{available: true}
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(spy)
+	w.SetSoundPlayer(NewSystemSoundPlayer(w))
+	w.PlaySoundCue(SoundNotify)
+	if len(spy.cues) != 1 || spy.cues[0] != SoundNotify {
+		t.Errorf("cues = %v, want [SoundNotify]", spy.cues)
+	}
+	// Mute is gated ahead of the player.
+	spy.cues = nil
+	w.SetSoundVolume(0)
+	w.PlaySoundCue(SoundNotify)
+	if len(spy.cues) != 0 {
+		t.Errorf("muted window emitted %v, want nothing", spy.cues)
+	}
+}

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -77,8 +77,8 @@ type DialogCfg struct {
 	// exportaudit:keep — caller-facing config (issue #467)
 	Sound SoundCue
 
-	// SoundDisabled suppresses every dialog button's sound regardless
-	// of the theme and of Sound above.
+	// SoundDisabled suppresses this dialog's sounds — every button and
+	// the open cue — regardless of the theme and of Sound above.
 	// exportaudit:keep — caller-facing config (issue #467)
 	SoundDisabled bool
 
@@ -345,6 +345,13 @@ func (w *Window) Dialog(cfg DialogCfg) {
 	cfg.visible = true
 	cfg.oldFocusID = w.viewState.focusID
 	w.dialogCfg = cfg
+	// The open cue, not cfg.Sound: Sound names the buttons' activation
+	// sound. w.Theme() rather than guiTheme — Dialog runs outside
+	// generation (issue #469). DialogDismiss stays silent: the button
+	// that closed the dialog has already sounded.
+	if !cfg.SoundDisabled {
+		playSoundCue(w.Theme().Sounds.Open, w)
+	}
 	// The dialog overlay is built during a full layout pass, so the flag has
 	// to be set explicitly: a caller outside the event path (a native menu
 	// action, a QueueCommand from a worker) leaves the window otherwise idle,

--- a/gui/view_form.go
+++ b/gui/view_form.go
@@ -204,6 +204,20 @@ type FormCfg struct {
 	AllowPendingSubmit bool
 	Disabled           bool
 	Invisible          bool
+
+	// Sound overrides the theme's success cue for a submit this form
+	// accepts. SoundNone (the zero value) takes Theme.Sounds.Success,
+	// which is itself silent unless the app opted in. A submit blocked
+	// by validation or by a pending validator always takes the theme's
+	// Error role: Sound names the acceptance, not the refusal
+	// (issue #469).
+	// exportaudit:keep — caller-facing config (issue #469)
+	Sound SoundCue
+
+	// SoundDisabled suppresses both submit cues regardless of the
+	// theme and of Sound above.
+	// exportaudit:keep — caller-facing config (issue #469)
+	SoundDisabled bool
 }
 
 // ---------- formView ----------
@@ -231,6 +245,10 @@ func (fv *formView) GenerateLayout(w *Window) Layout {
 	formID := cfg.ID
 	onSubmit := cfg.OnSubmit
 	onReset := cfg.OnReset
+	// Resolved here, at generation time, so the AmendLayout closure
+	// below captures two SoundCue values rather than anything the
+	// layout arena pools (issue #468's rule, issue #469's site).
+	cues := resolveSoundCues(guiTheme.Sounds.Success, cfg.Sound, cfg.SoundDisabled)
 	formApplyCfg(w, formID, cfg)
 
 	summary := w.FormSummary(formID)
@@ -274,7 +292,7 @@ func (fv *formView) GenerateLayout(w *Window) Layout {
 		Invisible:   cfg.Invisible,
 		AmendLayout: func(ctx EventCtx) {
 			formCleanupStale(ctx.Window, formID)
-			formProcessRequests(ctx.Window, formID, onSubmit, onReset)
+			formProcessRequests(ctx.Window, formID, onSubmit, onReset, cues)
 		},
 	})
 

--- a/gui/view_form_process.go
+++ b/gui/view_form_process.go
@@ -178,6 +178,7 @@ func formProcessRequests(
 	formID string,
 	onSubmit func(FormSubmitEvent, EventCtx),
 	onReset func(FormResetEvent, EventCtx),
+	cues soundCues,
 ) {
 	state := formRuntime(w, formID)
 	stateChanged := false
@@ -245,6 +246,15 @@ func formProcessRequests(
 	summary := formComputeSummary(state)
 	blockedInvalid := state.blockInvalid && summary.InvalidCount > 0
 	blockedPending := state.blockPending && summary.Pending
+	// Before the callback and independent of consumption, the same
+	// ordering every other cue keeps. The submitReq latch above makes
+	// this one-shot even though AmendLayout runs every frame; emitting
+	// inline is safe because playSoundCue takes no lock (issue #469).
+	if blockedInvalid || blockedPending {
+		playSoundCue(cues.reject, w)
+	} else {
+		playSoundCue(cues.act, w)
+	}
 	if !blockedInvalid && !blockedPending && onSubmit != nil {
 		onSubmit(FormSubmitEvent{
 			formID:  formID,

--- a/gui/view_form_test.go
+++ b/gui/view_form_test.go
@@ -177,7 +177,7 @@ func TestFormSubmitBlock(t *testing.T) {
 	// Request and process submit.
 	state := formRuntime(w, formID)
 	state.submitReq = true
-	formProcessRequests(w, formID, onSubmit, nil)
+	formProcessRequests(w, formID, onSubmit, nil, soundCues{})
 
 	if submitted {
 		t.Fatal("should not submit when field is invalid")
@@ -190,7 +190,7 @@ func TestFormSubmitBlock(t *testing.T) {
 		SyncValidators: []FormSyncValidator{required},
 	})
 	state.submitReq = true
-	formProcessRequests(w, formID, onSubmit, nil)
+	formProcessRequests(w, formID, onSubmit, nil, soundCues{})
 
 	if !submitted {
 		t.Fatal("should submit when field is valid")
@@ -217,7 +217,7 @@ func TestFormReset(t *testing.T) {
 
 	state := formRuntime(w, formID)
 	state.resetReq = true
-	formProcessRequests(w, formID, nil, onReset)
+	formProcessRequests(w, formID, nil, onReset, soundCues{})
 
 	if resetEvent.formID != formID {
 		t.Fatalf("expected form ID %q, got %q",

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -38,14 +38,13 @@ type ToastCfg struct {
 	// Sound overrides the theme's click cue for this toast's action
 	// and dismiss buttons. SoundNone (the zero value) takes
 	// Theme.Sounds.Click, which is itself silent unless the app opted
-	// in (issue #446). Severity does not pick the cue: an error toast
-	// is a report, and the failure it reports has already sounded
-	// wherever it happened (issue #467).
+	// in (issue #446). It names an activation sound, so it does not
+	// reach the appear cue below (issue #467).
 	// exportaudit:keep — caller-facing config (issue #467)
 	Sound SoundCue
 
-	// SoundDisabled suppresses this toast's button sounds regardless
-	// of the theme and of Sound above.
+	// SoundDisabled suppresses this toast's sounds — both the buttons
+	// and the appear cue — regardless of the theme and of Sound above.
 	// exportaudit:keep — caller-facing config (issue #467)
 	SoundDisabled bool
 }
@@ -451,6 +450,26 @@ func toastScopeID(id uint64) string {
 	return ScopeIDN("toast", "", int(id))
 }
 
+// toastAppearCue resolves the cue a toast plays when it appears. This
+// is the one place severity picks a cue: an error toast is a report of
+// a failure and takes the theme's Error role, everything else takes
+// Notify. cfg.Sound is not consulted — it names the activation sound of
+// the toast's buttons — but cfg.SoundDisabled suppresses both.
+//
+// Reads w.Theme() rather than the guiTheme mirror: Toast runs outside
+// generation, and themeRef takes w.themeMu rather than the frame lock,
+// so this is safe from a callback that already holds w.mu (issue #469).
+func toastAppearCue(w *Window, cfg ToastCfg) SoundCue {
+	if cfg.SoundDisabled {
+		return SoundNone
+	}
+	sounds := w.Theme().Sounds
+	if cfg.Severity == ToastError {
+		return sounds.Error
+	}
+	return sounds.Notify
+}
+
 // Toast shows a toast notification. Returns the toast id.
 func (w *Window) Toast(cfg ToastCfg) uint64 {
 	w.toastCounter++
@@ -461,6 +480,7 @@ func (w *Window) Toast(cfg ToastCfg) uint64 {
 		phase: toastEntering,
 	}
 	w.toasts = append(w.toasts, n)
+	playSoundCue(toastAppearCue(w, cfg), w)
 	toastStartEnter(w, id)
 	toastEnforceMaxVisible(w)
 	w.UpdateWindow()


### PR DESCRIPTION
Follow-up to #446 after #467 and #468. Closes #469.

## 1. Non-click semantics
- New `SoundCue`s: `SoundNotify` (toast appear, info/warning/success), `SoundOpen` (dialog open), `SoundSuccess` (form submit accepted). `SoundError` covers the refusal paths (error toast, form validation failure, DataGrid `OnCRUDError`). `SoundSet` gains `Notify`/`Open`/`Success` roles; `SoundsDefault()` fills them. No exhaustive switch in `gui/` — new cues appended, `default` arms stay silent.
- **Toast** (`gui/view_toast.go`): `Toast(ToastCfg)` now emits `SoundNotify` (or `SoundError` for `ToastError`) once per call via `playSoundCue`; dismiss stays silent, `SoundDisabled`/silent theme gated, `ToastCfg.Sound` (button cue) does not override the appear cue.
- **Dialog** (`gui/view_dialog.go`): `Dialog()` emits `SoundOpen`; dismiss silent, `SoundDisabled` gated.
- **Form** (`gui/view_form.go`, `gui/view_form_process.go`): submit path emits `SoundSuccess` on accepted or `SoundError` on validation failure, via frame-lock-safe `playSoundCue` (no `w.mu` taken). Duplicate ID guard kept.
- **DataGrid CRUD** (`gui/datagrid/view_data_grid*.go`): `OnCRUDError` now sounds `SoundError` through exported `Window.PlaySoundCue` (no Shape to read a cue off), resolved via `ResolveSoundCue` precedence — `SoundDisabled` still silences it.

## 2. Native system-sound player
- New `gui/backend/sysbeep` `Event` enum + `PlayEvent`/`EventAvailable` (`sysbeep_event*.go` + ObjC `.m/.h`): NSSound `Tink/Pop/Bottle/Ping/Basso/Purr/Blow/Glass` on macOS, `PlaySound SND_ALIAS` `SystemAsterisk/SystemQuestion/...` on Windows, `canberra-gtk-play -i button-pressed/...` on Linux. Unmapped/out-of-range events are silent, never panic.
- `gui/backend/internal/nativehost` `PlaySystemSound`/`SystemSoundAvailable` forwarder + `soundEvents` map.
- `gui/sound_system.go` `NewSystemSoundPlayer(Window)`: optional `systemSoundPlatform` capability (type-assert, not `NativePlatform` method) so old platforms stay silent and headless tests remain no-op. Forwards every cue, ignores `gain` (system sounds follow user settings), delegates `SoundAvailable`.
- `gui/backend/gl` and `gui/backend/metal` native platforms implement `PlaySystemSound`/`SystemSoundAvailable`.

## Guides & tests
- `docs/specs/widget-audio-feedback.md`, `docs/widget-sound.md`, `examples/showcase/docs/widget_sound.md` and `docs/dx-cheat-sheet.md` + `CHANGELOG.md` updated with cue table and player comparison
- `gui/sound_nonclick_test.go`, `gui/sound_system_test.go`, `gui/datagrid/sound_test.go`, `gui/backend/internal/nativehost/nativehost_test.go`, `gui/backend/sysbeep/sysbeep_test.go` — headless, no golden diff
- Showcase: `demo_audio.go` player selector (`Synthesized` / `System event sounds` / `System alert on errors only`) via `soundPlayerKind` + `soundPlayerLabels`/`soundPlayerValue`/`soundPlayerKindFor` mapping; `sound_player.go` switch covers all cues; `sound_player_other.go` stub now carries the mapping for `GOOS=js/wasm` cross-lint (fixes lint-cross typecheck).

## Verification
- `make prepush` green (race, lint incl. `GOOS=windows` + `GOOS=js GOARCH=wasm`, vet, deps-doc, large-files, generate/tidy/fmt-md, coverage 84.8%, exportaudit)