### PR TITLE
changelog: add v0.66.0 (widget audio, canvas transform, frameless windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.66.0] - 2026-09-01
+
+Widget audio feedback covers every mechanical widget and every remaining
+interaction — keyboard activation, drag-drop and input rejection — with a native
+system-sound player that needs no assets; the canvas gains a transform stack,
+windows gain frameless mode, the solar-system example gains a calendar ring,
+asteroid belt and rotation axes, and audio resampling and music playback are
+fixed alongside an allocation-free DrawCanvas redraw.
+
 ### Added
 
 - **Widget audio feedback phase 4** (#469) — the interactions with no click site


### PR DESCRIPTION
Release v0.66.0 — widget audio feedback phases 2-4, canvas transform stack, frameless windows, solar-system orrery additions, audio fixes, and DrawCanvas allocation-free redraw.

35 commits since v0.65.0.

Cut for sync-siblings propagation to consumers (go-charts, go-edit, go-kite, go-map, go-term).