### PR TITLE
fix(ios): add missing metalSetGradientTM2 and link-check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,30 @@ jobs:
             CGO_LDFLAGS="-isysroot $SDK -arch arm64 -miphoneos-version-min=15.0" \
             go build -buildmode=c-archive -tags ios -o /dev/null .
 
+      - name: Build c-archive (simulator)
+        working-directory: examples/ios_demo
+        run: |
+          SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
+          CC=$(xcrun --sdk iphonesimulator --find clang)
+          CGO_ENABLED=1 GOOS=ios GOARCH=arm64 \
+            CC="$CC" \
+            CGO_CFLAGS="-isysroot $SDK -arch arm64 -mios-simulator-version-min=17.0" \
+            CGO_LDFLAGS="-isysroot $SDK -arch arm64 -mios-simulator-version-min=17.0" \
+            go build -buildmode=c-archive -tags ios -o ios/libgoguiapp.a .
+
+      - name: Build simulator .app (link check)
+        working-directory: examples/ios_demo
+        run: |
+          xcodebuild -project ios/IOSDemo.xcodeproj \
+            -scheme IOSDemo \
+            -sdk iphonesimulator \
+            -arch arm64 \
+            -derivedDataPath /tmp/ios-build \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
       - name: Vet backend
         run: |
           SDK=$(xcrun --sdk iphoneos --show-sdk-path)

--- a/gui/backend/ios/metal_darwin.m
+++ b/gui/backend/ios/metal_darwin.m
@@ -624,6 +624,16 @@ void metalSetTM(const float* m) {
     [_enc setVertexBytes:m length:64 atIndex:2];
 }
 
+// metalSetGradientTM2 hands the gradient fragment shader stops 4-7.
+// The fragment stage has its own buffer index space, and the gradient
+// pipeline binds nothing else there, so index 0 is free. Bound to the
+// fragment stage rather than passed down as varyings because the
+// values are constant across the quad.
+void metalSetGradientTM2(const float* m) {
+    if (!_enc) return;
+    [_enc setFragmentBytes:m length:64 atIndex:0];
+}
+
 void metalSetScissor(int x, int y, int w, int h, int viewH) {
     if (!_enc) return;
     // Clamp to viewport.


### PR DESCRIPTION
iOS simulator .app links `libgoguiapp.a` and would have caught the missing gradient tm2 symbol that shipped in v0.66.0 (ff3287d8 added the header/Go call but not the .m body). Promote the release-only xcodebuild to CI so PRs fail the same way.

Fixes release 33546472140 linker error: `_metalSetGradientTM2` not found for arm64.

Changes:
- `gui/backend/ios/metal_darwin.m`: add `metalSetGradientTM2` (mirrors `gui/backend/metal/metal_darwin.m:725`)
- `.github/workflows/ci.yml`: build simulator c-archive + `xcodebuild` link check

No tag move — to be released as v0.66.1 patch.