### PR TITLE
feat(markdown): render callback — MarkdownCfg.RenderBlock (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Markdown render callback** (#484) — `MarkdownCfg.RenderBlock` is consulted
+  for every parsed block during layout, so an app can add a block type markdown
+  does not have (callouts, numbered headings) or drop one, without rewriting the
+  source string. It receives a styled `MarkdownElement` — the block's kind, its
+  runs, its plain text, its index, and the document's resolved effective ID —
+  and returns a replacement view, `nil` to drop the block, or `ok=false` to take
+  the default renderer. The showcase dog-foods it with `> [!NOTE]` /
+  `> [!WARNING]` / `> [!TIP]` callouts. Spec:
+  `docs/specs/markdown-render-callback.md`.
+
+### Fixed
+
+- **Markdown list at the end of a document** (#484) — the pending-list flush
+  lived inside the list branch of `markdownBuildContent` and fired only on the
+  last block, so a document ending in a list depended on that branch being
+  reached. It now runs after the loop, where every exit path reaches it. Output
+  for existing documents is unchanged, pinned by the new `markdown_blocks`
+  golden.
+
 ## [v0.66.1] - 2026-09-01
 
 ### Fixed

--- a/docs/specs/markdown-render-callback.md
+++ b/docs/specs/markdown-render-callback.md
@@ -1,10 +1,10 @@
 # Markdown render callback
 
-Status: proposed. Written 2026-08-24. Revised 2026-08-28 after review against
-`gui/view_markdown.go`. Modeled on Bun's `bun:markdown`
-`renderMarkdown({ data, callback })`: the caller gets every parsed markdown
-element in a callback and can replace its output. Additive, not a breaking
-change.
+Issue: #484. Status: landed. Written 2026-08-24. Revised 2026-08-28 after review
+against `gui/view_markdown.go`, and again on 2026-09-01 as it landed. Modeled on
+Bun's `bun:markdown` `renderMarkdown({ data, callback })`: the caller gets every
+parsed markdown element in a callback and can replace its output. Additive, not
+a breaking change.
 
 ## Problem
 
@@ -155,7 +155,8 @@ diagrams. `mdRenderImage` is suppressed when the hook replaces an image block.
 
 Hook writers own their IDs and a11y: compose with `ScopeID(el.DocID, …)` or
 `ScopeIDN(el.DocID, …, el.Index)` (the `gui.Debug` gate catches collisions), and
-set `A11YRole`/`A11YLabel` where appropriate — `AccessRoleNote` for callouts.
+set `A11YRole`/`A11YLabel` where appropriate. There is no `AccessRoleNote`; a
+callout takes `AccessRoleGroup` with a label naming its kind.
 
 The hook runs during `GenerateLayout`, under the frame lock. `SetFocus`,
 `ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take
@@ -240,14 +241,18 @@ place; `(nil, true)` drops the block. Plus one test per loop-state rule —
   `CodeLanguage == "mermaid"`; a block with overlapping flags resolves to the
   branch the render switch would take.
 
-Golden: add a `gui/golden_test.go` case with a `RenderBlock` (callout or heading
-wrap) in both `ThemeDark` and `ThemeLight`. Existing markdown goldens must be
-unchanged by the tail-flush move — that is the proof it is behavior-preserving.
-`TestDuplicateIDs` over a hooked document with an ID collision proves the debug
-gate covers hook-built views. New exports (`MarkdownElement`,
-`MarkdownBlockKind` and its eleven constants, `MarkdownTable`, `RenderBlock`)
-need consumers or `// exportaudit:keep`; the showcase covers `RenderBlock`,
-`MarkdownElement` and a few kinds, the rest take markers.
+Golden: the markdown widget had no golden coverage at all, so there were no
+existing recordings for the tail-flush move to be checked against. Two cases
+were added to `gui/golden_cases_test.go`, both in `ThemeDark` and `ThemeLight`:
+`markdown_blocks`, recorded **before** any change to the loop, is the baseline
+that proves the tail-flush move is behavior-preserving; `markdown_callout`
+renders the same source under a `RenderBlock` that tints the blockquote, so the
+diff between the two is exactly what a hook can move. `TestDuplicateIDs` over a
+hooked document with an ID collision proves the debug gate covers hook-built
+views. New exports (`MarkdownElement`, `MarkdownBlockKind` and its eleven
+constants, `MarkdownTable`, `RenderBlock`) need consumers or
+`// exportaudit:keep`; the showcase covers `RenderBlock`, `MarkdownElement` and
+a few kinds, the rest take markers.
 
 ## Out of scope
 

--- a/examples/showcase/demo_text.go
+++ b/examples/showcase/demo_text.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/go-gui-org/go-glyph"
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/highlight"
@@ -417,12 +419,83 @@ func demoMarkdown(w *gui.Window) gui.View {
 	style := gui.DefaultMarkdownStyle()
 	style.CodeHighlighter = highlight.Default()
 	return w.Markdown(gui.MarkdownCfg{
-		ID:        "showcase_markdown",
-		Focusable: true,
-		Style:     style,
-		Padding:   gui.NoPadding,
-		Source:    embeddedText("docs/markdown_demo.md"),
+		ID:          "showcase_markdown",
+		Focusable:   true,
+		Style:       style,
+		Padding:     gui.NoPadding,
+		Source:      embeddedText("docs/markdown_demo.md"),
+		RenderBlock: renderMarkdownCallout,
 	})
+}
+
+// calloutMarkers are the blockquote prefixes the showcase promotes to
+// a callout, each with the theme color it tints. The convention is the
+// app's: markdown has no callouts, and RenderBlock is what lets an app
+// add one without rewriting the source string.
+var calloutMarkers = []struct {
+	marker string
+	label  string
+	color  func(gui.Theme) gui.Color
+}{
+	{"[!NOTE]", "Note",
+		func(t gui.Theme) gui.Color { return t.ColorAccentSubtle }},
+	{"[!WARNING]", "Warning",
+		func(t gui.Theme) gui.Color { return t.ColorWarningSubtle }},
+	{"[!TIP]", "Tip",
+		func(t gui.Theme) gui.Color { return t.ColorSuccessSubtle }},
+}
+
+// renderMarkdownCallout is the showcase's MarkdownCfg.RenderBlock. It
+// claims blockquotes whose text opens with a known marker and returns
+// a tinted panel; everything else returns ok=false and takes the
+// default renderer.
+//
+// The body renders as plain text rather than as el.Content, because
+// the marker has to come off the front and trimming it out of styled
+// runs is more machinery than a demo needs. A hook that must keep
+// inline styling would slice el.Content instead.
+func renderMarkdownCallout(
+	w *gui.Window, el gui.MarkdownElement,
+) (gui.View, bool) {
+	if el.Kind != gui.MarkdownKindBlockquote {
+		return nil, false
+	}
+	text := strings.TrimSpace(el.PlainText)
+	for _, c := range calloutMarkers {
+		body, found := strings.CutPrefix(text, c.marker)
+		if !found {
+			continue
+		}
+		t := w.Theme()
+		return gui.Column(gui.ContainerCfg{
+			// Index, not the marker: two notes in one document would
+			// otherwise claim the same identity.
+			ID:      gui.ScopeIDN(el.DocID, "callout", el.Index),
+			Sizing:  gui.FillFit,
+			Padding: gui.PadAll(t.SpacingMedium),
+			Spacing: gui.Some(t.SpacingSmall),
+			// The tint is the whole signal, so no border: a container
+			// reserves border space whether or not it paints one, and
+			// an unset SizeBorder would inherit the theme's and add
+			// height for a line this design does not draw.
+			SizeBorder: gui.NoBorder,
+			Radius:     gui.SomeF(6),
+			Color:      c.color(t),
+			A11YRole:   gui.AccessRoleGroup,
+			A11YCfg:    gui.A11YCfg{A11YLabel: c.label},
+			Content: []gui.View{
+				gui.Text(gui.TextCfg{
+					Text:      c.label,
+					TextStyle: t.B4,
+				}),
+				gui.Text(gui.TextCfg{
+					Text: strings.TrimSpace(body),
+					Mode: gui.TextModeWrap,
+				}),
+			},
+		}), true
+	}
+	return nil, false
 }
 
 func sectionLabel(t gui.Theme, text string) gui.View {

--- a/examples/showcase/docs/markdown_demo.md
+++ b/examples/showcase/docs/markdown_demo.md
@@ -88,6 +88,19 @@ combine with bold: ++**bold underline**++.
 > > within quoted material. This is useful for email threads or forum
 > > discussions where multiple levels of response exist.
 
+### Callouts
+
+Callouts are not markdown. The showcase renders them with
+`MarkdownCfg.RenderBlock`, which replaces the output of any block the app
+recognises. A blockquote that opens with a marker becomes a tinted panel; every
+other block falls through to the default renderer.
+
+> [!NOTE] Blockquotes that start with a marker render as a callout. The marker
+> is stripped and the rest of the quote becomes the body.
+
+> [!WARNING] The convention is the app's, not the parser's. Another app can read
+> the same source and render plain blockquotes.
+
 ## Code
 
 ### Inline Code

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -902,7 +902,62 @@ func goldenCases() []goldenCase {
 			name:  "canvas_transform",
 			build: buildCanvasTransform,
 		},
+		{
+			// The markdown block loop (issue #484). The render switch
+			// in markdownBuildContent carries cross-block state --
+			// pending list items, the blockquote closing spacer, and
+			// the rune offsets selection keys on -- none of which any
+			// other case reaches. The source ends on a list item so
+			// the tail flush is recorded: that flush is what moves
+			// when RenderBlock lands, and this recording is the proof
+			// the move is behavior-preserving.
+			name:  "markdown_blocks",
+			build: buildMarkdownBlocks,
+		},
+		{
+			// The same source under a RenderBlock hook (issue #484).
+			// Diffed against markdown_blocks it shows exactly what a
+			// hook can move: the blockquote becomes a tinted callout
+			// container, and everything else -- the heading, the code
+			// block, the rule, the list and its tail flush -- is
+			// byte-identical, which is what "falls back to the default
+			// renderer" has to mean.
+			name:  "markdown_callout",
+			build: buildMarkdownCallout,
+		},
 	}
+}
+
+// goldenMarkdownSource exercises one block of every kind the loop
+// dispatches without a fetch: heading, paragraph, blockquote, fenced
+// code, horizontal rule, and a list that runs to the end of the
+// document. Math and mermaid are left out -- both go out to a fetcher
+// and would record a loading placeholder rather than a block.
+const goldenMarkdownSource = `# Heading
+
+A paragraph of body text.
+
+> A quoted line.
+
+` + "```go" + `
+x := 1
+` + "```" + `
+
+---
+
+- first item
+- second item
+`
+
+// buildMarkdownBlocks records the document focusable, so makeCtx takes
+// the per-block branch and the rune offsets reach the recording
+// through each block's stamped start.
+func buildMarkdownBlocks(w *Window) View {
+	return w.Markdown(MarkdownCfg{
+		ID:        "md",
+		Focusable: true,
+		Source:    goldenMarkdownSource,
+	})
 }
 
 // buildCanvasTransform draws each primitive twice where it can: once
@@ -1173,4 +1228,35 @@ func TestGoldenNegativeZero(t *testing.T) {
 	if got := f2(neg); got != "0.00" {
 		t.Errorf("f2(-0): got %q, want %q", got, "0.00")
 	}
+}
+
+// buildMarkdownCallout hooks the one blockquote in
+// goldenMarkdownSource and returns a tinted container in its place --
+// the callout shape the showcase dog-foods. Every other kind falls
+// through to the default renderer.
+func buildMarkdownCallout(w *Window) View {
+	return w.Markdown(MarkdownCfg{
+		ID:        "md",
+		Focusable: true,
+		Source:    goldenMarkdownSource,
+		RenderBlock: func(win *Window, el MarkdownElement) (View, bool) {
+			if el.Kind != MarkdownKindBlockquote {
+				return nil, false
+			}
+			t := win.Theme()
+			return Column(ContainerCfg{
+				ID:          ScopeIDN(el.DocID, "callout", el.Index),
+				Sizing:      FillFit,
+				Padding:     PadAll(8),
+				SizeBorder:  SomeF(1),
+				Color:       t.ColorAccentSubtle,
+				ColorBorder: t.ColorAccent,
+				A11YRole:    AccessRoleGroup,
+				A11YCfg:     A11YCfg{A11YLabel: "Note"},
+				Content: []View{
+					Text(TextCfg{Text: el.PlainText}),
+				},
+			}), true
+		},
+	})
 }

--- a/gui/markdown_render_block_test.go
+++ b/gui/markdown_render_block_test.go
@@ -1,0 +1,531 @@
+package gui
+
+// Tests for MarkdownCfg.RenderBlock (issue #484).
+//
+// The hook is a new first branch of markdownBuildContent's render
+// switch, and that loop carries three pieces of cross-block state a
+// naive branch corrupts: the rune offsets selection keys on, the
+// pending-list accumulator, and the tail flush. There is one test per
+// rule below the dispatch tests, because each of the three fails
+// silently -- a wrong offset only shows up as a bad selection, and a
+// dropped list only shows up as missing text.
+
+import (
+	"strings"
+	"testing"
+)
+
+// mdHookLayout renders one source with one hook and returns the
+// composed layout. cfg fields other than the hook match
+// markdownLayoutForSource, so a hooked and an unhooked render of the
+// same source are comparable.
+func mdHookLayout(
+	t *testing.T, source string, focusable bool,
+	hook func(*Window, MarkdownElement) (View, bool),
+) Layout {
+	t.Helper()
+
+	w := &Window{}
+	return generateViewLayout(w.Markdown(MarkdownCfg{
+		ID:          "md",
+		Source:      source,
+		Style:       DefaultMarkdownStyle(),
+		Focusable:   focusable,
+		RenderBlock: hook,
+	}), w)
+}
+
+// mdCollectText walks a composed layout and returns every plain and
+// rich text string it renders, in tree order.
+func mdCollectText(l Layout) []string {
+	var out []string
+	var walk func(Layout)
+	walk = func(n Layout) {
+		if n.Shape.TC != nil {
+			if n.Shape.TC.Text != "" {
+				out = append(out, n.Shape.TC.Text)
+			}
+			if rt := n.Shape.TC.rTFRuns; rt != nil && len(rt.Runs) > 0 {
+				out = append(out, richTextPlain(*rt))
+			}
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(l)
+	return out
+}
+
+// mdBlockStarts returns the rune offset stamped on every selectable
+// block, in tree order. This is what a selection resolves against, so
+// it is the observable that must not move when a block is hooked.
+//
+// markdownID is the discriminator: applyMdCtx stamps it only for the
+// blocks that were handed a ctx, which is exactly the six selectable
+// kinds. A code block or a rule leaves it empty.
+func mdBlockStarts(l Layout) []uint32 {
+	var out []uint32
+	var walk func(Layout)
+	walk = func(n Layout) {
+		if tc := n.Shape.TC; tc != nil && tc.markdownID != "" {
+			out = append(out, tc.markdownBlockStart)
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(l)
+	return out
+}
+
+// mdMarker is a text view a hook returns in place of a block, chosen
+// so it cannot collide with any source text.
+func mdMarker(tag string) View {
+	return Text(TextCfg{Text: "<<" + tag + ">>"})
+}
+
+func mdHasText(l Layout, want string) bool {
+	for _, s := range mdCollectText(l) {
+		if strings.Contains(s, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Dispatch ---
+
+// TestMarkdownRenderBlockKinds pins the Kind each block arrives with.
+// The parsed flags are not mutually exclusive, so a kind derived in a
+// different order than the render switch would disagree with the
+// branch actually taken.
+func TestMarkdownRenderBlockKinds(t *testing.T) {
+	const source = "# Head\n\nBody text.\n\n> Quoted.\n\n" +
+		"```go\nx := 1\n```\n\n---\n\n- item\n"
+
+	var got []MarkdownBlockKind
+	mdHookLayout(t, source, false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			got = append(got, el.Kind)
+			return nil, false
+		})
+
+	want := []MarkdownBlockKind{
+		MarkdownKindHeading,
+		MarkdownKindParagraph,
+		MarkdownKindBlockquote,
+		MarkdownKindCode,
+		MarkdownKindHR,
+		MarkdownKindList,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("kinds: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("block %d: got kind %d, want %d",
+				i, got[i], want[i])
+		}
+	}
+}
+
+// TestMarkdownRenderBlockMermaidIsCode pins the one kind with no
+// constant of its own: renderMdMermaid dispatches from inside the code
+// branch, so a hook must match on the language, not on a kind.
+func TestMarkdownRenderBlockMermaidIsCode(t *testing.T) {
+	var kind MarkdownBlockKind
+	var lang string
+	seen := false
+	mdHookLayout(t, "```mermaid\ngraph TD;\n```\n", false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			kind, lang, seen = el.Kind, el.CodeLanguage, true
+			return nil, false
+		})
+
+	if !seen {
+		t.Fatal("hook never fired for a mermaid fence")
+	}
+	if kind != MarkdownKindCode {
+		t.Errorf("mermaid kind: got %d, want MarkdownKindCode", kind)
+	}
+	if lang != "mermaid" {
+		t.Errorf("mermaid language: got %q, want %q", lang, "mermaid")
+	}
+}
+
+// TestMarkdownRenderBlockElementFields checks the derived fields a
+// hook cannot recompute: the resolved document ID, source-order index,
+// and the unstyled text.
+func TestMarkdownRenderBlockElementFields(t *testing.T) {
+	var els []MarkdownElement
+	mdHookLayout(t, "# Title\n\nA **bold** word.\n", false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			els = append(els, el)
+			return nil, false
+		})
+
+	if len(els) != 2 {
+		t.Fatalf("got %d elements, want 2", len(els))
+	}
+	for i, el := range els {
+		if el.DocID != "md" {
+			t.Errorf("block %d DocID: got %q, want %q",
+				i, el.DocID, "md")
+		}
+		if el.Index != i {
+			t.Errorf("block %d Index: got %d", i, el.Index)
+		}
+	}
+	if els[0].HeaderLevel != 1 {
+		t.Errorf("heading level: got %d, want 1", els[0].HeaderLevel)
+	}
+	if got := els[1].PlainText; !strings.Contains(got, "bold") {
+		t.Errorf("PlainText: got %q, want it to contain %q",
+			got, "bold")
+	}
+	if strings.Contains(els[1].PlainText, "**") {
+		t.Errorf("PlainText kept markup: %q", els[1].PlainText)
+	}
+}
+
+// TestMarkdownRenderBlockFallback: ok=false must render exactly what
+// no hook at all renders.
+func TestMarkdownRenderBlockFallback(t *testing.T) {
+	const source = "# Head\n\nBody text.\n\n- item\n"
+
+	plain := mdCollectText(markdownLayoutForSource(t, source))
+	hooked := mdCollectText(mdHookLayout(t, source, false,
+		func(_ *Window, _ MarkdownElement) (View, bool) {
+			return mdMarker("never"), false
+		}))
+
+	if len(plain) != len(hooked) {
+		t.Fatalf("ok=false changed the output: %v vs %v",
+			plain, hooked)
+	}
+	for i := range plain {
+		if plain[i] != hooked[i] {
+			t.Errorf("text %d: got %q, want %q",
+				i, hooked[i], plain[i])
+		}
+	}
+}
+
+// TestMarkdownRenderBlockReplaces: ok=true with a view renders that
+// view in the block's place.
+func TestMarkdownRenderBlockReplaces(t *testing.T) {
+	l := mdHookLayout(t, "# Head\n\nBody text.\n", false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			if el.Kind != MarkdownKindHeading {
+				return nil, false
+			}
+			return mdMarker("head"), true
+		})
+
+	if !mdHasText(l, "<<head>>") {
+		t.Error("replacement view did not render")
+	}
+	if mdHasText(l, "Head") {
+		t.Error("the replaced heading still rendered")
+	}
+	if !mdHasText(l, "Body text.") {
+		t.Error("the unhooked paragraph stopped rendering")
+	}
+}
+
+// TestMarkdownRenderBlockDrops: ok=true with a nil view drops the
+// block and leaves its neighbors alone.
+func TestMarkdownRenderBlockDrops(t *testing.T) {
+	l := mdHookLayout(t, "# Head\n\nBody text.\n", false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			return nil, el.Kind == MarkdownKindHeading
+		})
+
+	if mdHasText(l, "Head") {
+		t.Error("the dropped heading still rendered")
+	}
+	if !mdHasText(l, "Body text.") {
+		t.Error("the unhooked paragraph stopped rendering")
+	}
+}
+
+// --- Loop state ---
+
+// TestMarkdownRenderBlockOffsetsUnchanged is loop-state rule 1. A
+// hooked code block must not advance the document's rune offsets,
+// because the default code branch does not: if it did, a selection
+// over the blocks after it would land on the wrong runes in the hooked
+// document only.
+func TestMarkdownRenderBlockOffsetsUnchanged(t *testing.T) {
+	const source = "First paragraph.\n\n```go\nx := 1\n```\n\n" +
+		"Second paragraph.\n\n- item one\n- item two\n"
+
+	w := &Window{}
+	plain := mdBlockStarts(generateViewLayout(w.Markdown(MarkdownCfg{
+		ID:        "md",
+		Source:    source,
+		Style:     DefaultMarkdownStyle(),
+		Focusable: true,
+	}), w))
+
+	hooked := mdBlockStarts(mdHookLayout(t, source, true,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			if el.Kind != MarkdownKindCode {
+				return nil, false
+			}
+			return mdMarker("code"), true
+		}))
+
+	if len(plain) == 0 {
+		t.Fatal("no selectable blocks recorded offsets")
+	}
+	if len(plain) != len(hooked) {
+		t.Fatalf("selectable block count moved: %v vs %v",
+			plain, hooked)
+	}
+	for i := range plain {
+		if plain[i] != hooked[i] {
+			t.Errorf("block %d start: got %d, want %d",
+				i, hooked[i], plain[i])
+		}
+	}
+}
+
+// TestMarkdownRenderBlockOffsetsAdvanceForSelectable is the other half
+// of rule 1: a hooked paragraph must still advance the offsets,
+// because the paragraph branch would have. Hooking a selectable block
+// without advancing would shift every block after it.
+func TestMarkdownRenderBlockOffsetsAdvanceForSelectable(t *testing.T) {
+	const source = "First paragraph.\n\nSecond paragraph.\n\n" +
+		"Third paragraph.\n"
+
+	w := &Window{}
+	plain := mdBlockStarts(generateViewLayout(w.Markdown(MarkdownCfg{
+		ID:        "md",
+		Source:    source,
+		Style:     DefaultMarkdownStyle(),
+		Focusable: true,
+	}), w))
+	if len(plain) != 3 {
+		t.Fatalf("got %d selectable blocks, want 3", len(plain))
+	}
+
+	hooked := mdBlockStarts(mdHookLayout(t, source, true,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			if el.Index != 1 {
+				return nil, false
+			}
+			return mdMarker("para"), true
+		}))
+
+	// The hooked block itself is no longer selectable, so it drops out
+	// of the list; the block after it must keep the offset it had.
+	if len(hooked) != 2 {
+		t.Fatalf("got %d selectable blocks, want 2", len(hooked))
+	}
+	if hooked[0] != plain[0] || hooked[1] != plain[2] {
+		t.Errorf("offsets moved: got %v, want %v and %v",
+			hooked, plain[0], plain[2])
+	}
+}
+
+// TestMarkdownRenderBlockListOrder is loop-state rule 2. A hooked list
+// item appends straight to the content, so any items already pending
+// in the accumulator have to be flushed first or they render after
+// their own later sibling.
+func TestMarkdownRenderBlockListOrder(t *testing.T) {
+	l := mdHookLayout(t, "- alpha\n- beta\n- gamma\n", false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			if el.Kind != MarkdownKindList ||
+				!strings.Contains(el.PlainText, "beta") {
+				return nil, false
+			}
+			return mdMarker("beta"), true
+		})
+
+	texts := mdCollectText(l)
+	pos := func(want string) int {
+		for i, s := range texts {
+			if strings.Contains(s, want) {
+				return i
+			}
+		}
+		return -1
+	}
+	iAlpha, iBeta, iGamma := pos("alpha"), pos("<<beta>>"), pos("gamma")
+	if iAlpha < 0 || iBeta < 0 || iGamma < 0 {
+		t.Fatalf("missing text: alpha=%d beta=%d gamma=%d in %v",
+			iAlpha, iBeta, iGamma, texts)
+	}
+	if iAlpha >= iBeta || iBeta >= iGamma {
+		t.Errorf("out of source order: alpha=%d beta=%d gamma=%d",
+			iAlpha, iBeta, iGamma)
+	}
+}
+
+// TestMarkdownRenderBlockLastListItem is loop-state rule 3. The tail
+// flush used to live inside the list case, so a hooked final item
+// skipped it and the earlier items were silently dropped.
+func TestMarkdownRenderBlockLastListItem(t *testing.T) {
+	l := mdHookLayout(t, "- alpha\n- beta\n", false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			if el.Kind != MarkdownKindList ||
+				!strings.Contains(el.PlainText, "beta") {
+				return nil, false
+			}
+			return mdMarker("beta"), true
+		})
+
+	if !mdHasText(l, "alpha") {
+		t.Error("the earlier list item was dropped")
+	}
+	if !mdHasText(l, "<<beta>>") {
+		t.Error("the hooked final item did not render")
+	}
+}
+
+// TestMarkdownRenderBlockTailListUnhooked guards the same flush from
+// the other side: an unhooked document ending on a list item must
+// still render it after the flush moved out of the list case.
+func TestMarkdownRenderBlockTailListUnhooked(t *testing.T) {
+	l := markdownLayoutForSource(t, "Intro.\n\n- alpha\n- beta\n")
+	if !mdHasText(l, "alpha") || !mdHasText(l, "beta") {
+		t.Errorf("trailing list not rendered: %v", mdCollectText(l))
+	}
+}
+
+// --- Hook-built IDs ---
+
+// TestMarkdownRenderBlockIDsScoped proves the debug gate sees inside
+// hook output. A hook owns its IDs: composed from el.DocID with
+// ScopeIDN they are unique per block, and the sweep stays quiet.
+func TestMarkdownRenderBlockIDsScoped(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(win *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				win.Markdown(MarkdownCfg{
+					ID:     "doc",
+					Source: "One.\n\nTwo.\n\nThree.\n",
+					RenderBlock: func(
+						_ *Window, el MarkdownElement,
+					) (View, bool) {
+						return ProgressBar(ProgressBarCfg{
+							ID: ScopeIDN(el.DocID, "hooked",
+								el.Index),
+							Percent: 50,
+						}), true
+					},
+				}),
+			},
+		})
+	})
+
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+// TestMarkdownRenderBlockIDCollisionReported is the same shape with
+// the Index dropped, so every hooked block claims one identity. The
+// gate must report it rather than let the blocks silently share a
+// state slot.
+func TestMarkdownRenderBlockIDCollisionReported(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(win *Window) View {
+		return Column(ContainerCfg{
+			Sizing: FillFill,
+			Content: []View{
+				win.Markdown(MarkdownCfg{
+					ID:     "doc",
+					Source: "One.\n\nTwo.\n\nThree.\n",
+					RenderBlock: func(
+						_ *Window, el MarkdownElement,
+					) (View, bool) {
+						return ProgressBar(ProgressBarCfg{
+							ID:      ScopeID(el.DocID, "hooked"),
+							Percent: 50,
+						}), true
+					},
+				}),
+			},
+		})
+	})
+
+	got := w.TestDuplicateIDs()
+	if len(got) == 0 {
+		t.Fatal("a hook claiming one ID for every block went unreported")
+	}
+	if !strings.Contains(got[0], "doc:hooked") {
+		t.Errorf("finding does not name the collided ID: %q", got[0])
+	}
+}
+
+// TestMarkdownRenderBlockRemainingKinds covers the five kinds the
+// main dispatch test does not: table, image, math, definition term
+// and definition value. Missing any one is a silent wrong-Kind bug
+// for hooks that branch on el.Kind.
+func TestMarkdownRenderBlockRemainingKinds(t *testing.T) {
+	const source = "| H1 | H2 |\n|---|---|\n| a | b |\n\n" +
+		"![alt](image.png)\n\n$$\nE = mc^2\n$$\n\n" +
+		"Term\n: Definition value.\n"
+
+	var got []MarkdownBlockKind
+	var tableDataSeen bool
+	mdHookLayout(t, source, false,
+		func(_ *Window, el MarkdownElement) (View, bool) {
+			got = append(got, el.Kind)
+			if el.Kind == MarkdownKindTable {
+				if el.TableData == nil {
+					t.Error("table element has nil TableData")
+				} else {
+					tableDataSeen = true
+				}
+			} else if el.TableData != nil {
+				t.Errorf("non-table kind %d has non-nil TableData",
+					el.Kind)
+			}
+			return nil, false
+		})
+
+	want := []MarkdownBlockKind{
+		MarkdownKindTable,
+		MarkdownKindImage,
+		MarkdownKindMath,
+		MarkdownKindDefTerm,
+		MarkdownKindDefValue,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("kinds: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("block %d: got kind %d, want %d",
+				i, got[i], want[i])
+		}
+	}
+	if !tableDataSeen {
+		t.Error("table block TableData was never non-nil")
+	}
+}
+
+// TestMarkdownRenderBlockEmptySource verifies a document with no
+// blocks still builds: the hook fires zero times and the doc copy
+// button alone keeps the layout valid.
+func TestMarkdownRenderBlockEmptySource(t *testing.T) {
+	calls := 0
+	l := mdHookLayout(t, "", false,
+		func(_ *Window, _ MarkdownElement) (View, bool) {
+			calls++
+			return nil, false
+		})
+	if calls != 0 {
+		t.Fatalf("empty source: hook called %d times, want 0", calls)
+	}
+	// Layout must still have the document container (copy button).
+	if l.Shape == nil {
+		t.Fatal("empty source produced no layout")
+	}
+}

--- a/gui/markdown_types.go
+++ b/gui/markdown_types.go
@@ -42,3 +42,93 @@ type parsedTable struct {
 	Alignments []HorizontalAlign
 	Rows       [][]RichText
 }
+
+// MarkdownBlockKind names a parsed markdown block for
+// MarkdownElement.Kind. Paragraph is zero — it is the render switch's
+// default branch, so a zero MarkdownElement reads as the generic case
+// rather than as a heading.
+// exportaudit:keep — caller-facing config (issue #484)
+type MarkdownBlockKind int
+
+// The eleven kinds markdownBuildContent dispatches on. Mermaid has no
+// kind of its own: renderMdMermaid dispatches from inside the code
+// branch on CodeLanguage == "mermaid", so a hook sees
+// MarkdownKindCode with that language.
+//
+// exportaudit:keep — caller-facing config (issue #484). The set is the
+// render switch, so a kind an app happens not to match on today is
+// still part of the contract; dropping the unmatched ones would make
+// the constant a hook writer needs next the one that is missing.
+const (
+	MarkdownKindParagraph MarkdownBlockKind = iota
+	MarkdownKindHeading
+	MarkdownKindCode
+	MarkdownKindTable
+	MarkdownKindHR
+	MarkdownKindBlockquote
+	MarkdownKindImage
+	MarkdownKindMath
+	MarkdownKindList
+	MarkdownKindDefTerm
+	MarkdownKindDefValue
+)
+
+// MarkdownElement is one parsed, styled markdown block, passed to
+// MarkdownCfg.RenderBlock. It mirrors markdownBlock field-for-field
+// except the unexported baseStyle, plus Kind, Index, DocID, PlainText
+// and the exported table. A curated subset would omit fields real
+// hooks need — list indent, task state, image dimensions, code
+// language — and force the writer to re-derive them.
+// exportaudit:keep — caller-facing config (issue #484)
+type MarkdownElement struct {
+	// TableData is nil for every kind but MarkdownKindTable.
+	TableData *MarkdownTable
+	// DocID is the document's effective ID, already resolved by
+	// Markdown before the build pass. Compose inner IDs from it with
+	// ScopeID / ScopeIDN; do not call EffID on it again.
+	DocID string
+	// PlainText is Content with the styling dropped. It is derived per
+	// hooked block rather than cached on the block, so the cost lands
+	// on the documents that install a hook.
+	PlainText    string
+	ListPrefix   string
+	ImageSrc     string
+	ImageAlt     string
+	CodeLanguage string
+	MathLatex    string
+	AnchorSlug   string
+	// Content is the styled runs, so a hook reuses MarkdownStyle
+	// instead of re-styling raw text.
+	Content RichText
+	Kind    MarkdownBlockKind
+	// Index is the block's source-order position among the cached
+	// styled blocks, so it shifts when the source changes. Headings
+	// should compose IDs from AnchorSlug instead.
+	Index           int
+	HeaderLevel     int
+	BlockquoteDepth int
+	ListIndent      int
+	ImageWidth      float32
+	ImageHeight     float32
+	IsCode          bool
+	IsHR            bool
+	IsBlockquote    bool
+	IsImage         bool
+	IsTable         bool
+	IsList          bool
+	IsMath          bool
+	IsDefTerm       bool
+	IsDefValue      bool
+	IsTaskItem      bool
+	TaskChecked     bool
+}
+
+// MarkdownTable mirrors parsedTable exactly. No column count: that
+// belongs to the parser's table, not the styled form. Exported
+// because a table's cells cannot be rebuilt from RichText alone.
+// exportaudit:keep — caller-facing config (issue #484)
+type MarkdownTable struct {
+	Headers    []RichText
+	Alignments []HorizontalAlign
+	Rows       [][]RichText
+}

--- a/gui/testdata/markdown_blocks.dark.golden
+++ b/gui/testdata/markdown_blocks.dark.golden
@@ -1,0 +1,12 @@
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=47.00,33.00 wh=0.00,0.00 text="" +glyphlayout
+Clip xy=0.00,0.00 wh=0.00,0.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=30.00,61.00 wh=260.00,1.00 color=#ffffff14 fill
+Text xy=30.00,62.00 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
+RTF xy=60.80,62.00 wh=0.00,0.00 text="" +glyphlayout
+Text xy=30.00,81.60 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
+RTF xy=60.80,81.60 wh=0.00,0.00 text="" +glyphlayout
+Text xy=275.40,39.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
+Text xy=290.40,21.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/testdata/markdown_blocks.light.golden
+++ b/gui/testdata/markdown_blocks.light.golden
@@ -1,0 +1,12 @@
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=45.00,31.00 wh=0.00,0.00 text="" +glyphlayout
+Clip xy=0.00,0.00 wh=0.00,0.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=28.00,59.00 wh=264.00,1.00 color=#e6eaefff fill
+Text xy=28.00,60.00 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
+RTF xy=58.80,60.00 wh=0.00,0.00 text="" +glyphlayout
+Text xy=28.00,79.60 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
+RTF xy=58.80,79.60 wh=0.00,0.00 text="" +glyphlayout
+Text xy=277.40,37.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
+Text xy=291.40,20.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/testdata/markdown_callout.dark.golden
+++ b/gui/testdata/markdown_callout.dark.golden
@@ -1,0 +1,14 @@
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
+Rect xy=30.00,33.00 wh=260.00,37.60 color=#4d82f028 radius=6.00 fill
+StrokeRect xy=30.00,33.00 wh=260.00,37.60 color=#4d82f0ff radius=6.00 thickness=1.00
+Text xy=39.00,42.00 wh=0.00,0.00 color=#e6e8ebff text="A quoted line." size=14.00
+Clip xy=0.00,0.00 wh=0.00,0.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=30.00,98.60 wh=260.00,1.00 color=#ffffff14 fill
+Text xy=30.00,99.60 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
+RTF xy=60.80,99.60 wh=0.00,0.00 text="" +glyphlayout
+Text xy=30.00,119.20 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
+RTF xy=60.80,119.20 wh=0.00,0.00 text="" +glyphlayout
+Text xy=275.40,77.57 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
+Text xy=290.40,21.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/testdata/markdown_callout.light.golden
+++ b/gui/testdata/markdown_callout.light.golden
@@ -1,0 +1,14 @@
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
+Rect xy=28.00,31.00 wh=264.00,37.60 color=#2f6fe01e radius=6.00 fill
+StrokeRect xy=28.00,31.00 wh=264.00,37.60 color=#2f6fe0ff radius=6.00 thickness=1.00
+Text xy=37.00,40.00 wh=0.00,0.00 color=#1a1d21ff text="A quoted line." size=14.00
+Clip xy=0.00,0.00 wh=0.00,0.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=28.00,96.60 wh=264.00,1.00 color=#e6eaefff fill
+Text xy=28.00,97.60 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
+RTF xy=58.80,97.60 wh=0.00,0.00 text="" +glyphlayout
+Text xy=28.00,117.20 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
+RTF xy=58.80,117.20 wh=0.00,0.00 text="" +glyphlayout
+Text xy=277.40,75.57 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
+Text xy=291.40,20.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -160,6 +160,21 @@ type MarkdownCfg struct {
 	// when DisableExternalAPIs is true.
 	// exportaudit:keep — caller-facing config (issue #372)
 	MermaidFetcher MermaidFetcher
+
+	// RenderBlock, when non-nil, is consulted for every block during
+	// layout. Return ok=false to fall back to the default renderer;
+	// ok=true replaces the block's output, with a view or with nil to
+	// drop the block entirely.
+	//
+	// It runs once per block per frame over the cached styled blocks,
+	// so it must be cheap and pure: build View structs, do not fetch
+	// or parse. It runs during GenerateLayout, under the frame lock,
+	// so SetFocus, ClearFocus, UpdateView, ClearDrawCanvasCache and
+	// Window.Lock all panic from it; QueueCommand is the remedy and
+	// is permitted. Hook writers own their IDs — compose them with
+	// ScopeID(el.DocID, …) or ScopeIDN — and their a11y roles.
+	// exportaudit:keep — caller-facing config (issue #484)
+	RenderBlock func(w *Window, el MarkdownElement) (View, bool)
 }
 
 // MathFetcher fetches a LaTeX math expression as a PNG image.
@@ -412,6 +427,99 @@ func markdownTriggerMathFetches(
 	}
 }
 
+// mdKindOf names the branch markdownBuildContent's render switch
+// would take for a block. The flags are not mutually exclusive, so
+// the test order here copies that switch exactly; a second
+// hand-written order would silently disagree with the fallthrough
+// dispatch. Mermaid is deliberately absent: it dispatches from inside
+// the code branch on CodeLanguage, so it reads as code here.
+func mdKindOf(block markdownBlock) MarkdownBlockKind {
+	switch {
+	case block.IsMath:
+		return MarkdownKindMath
+	case block.IsCode:
+		return MarkdownKindCode
+	case block.IsTable:
+		return MarkdownKindTable
+	case block.IsHR:
+		return MarkdownKindHR
+	case block.IsBlockquote:
+		return MarkdownKindBlockquote
+	case block.IsImage:
+		return MarkdownKindImage
+	case block.HeaderLevel > 0:
+		return MarkdownKindHeading
+	case block.IsDefTerm:
+		return MarkdownKindDefTerm
+	case block.IsDefValue:
+		return MarkdownKindDefValue
+	case block.IsList:
+		return MarkdownKindList
+	default:
+		return MarkdownKindParagraph
+	}
+}
+
+// mdKindSelectable reports whether a kind's default renderer takes a
+// per-block ctx, and so advances the document's rune offsets. Six of
+// the eleven do; math, code, tables, rules and images do not. It sits
+// beside mdKindOf so the two lists cannot drift.
+func mdKindSelectable(kind MarkdownBlockKind) bool {
+	switch kind {
+	case MarkdownKindBlockquote, MarkdownKindHeading,
+		MarkdownKindDefTerm, MarkdownKindDefValue,
+		MarkdownKindList, MarkdownKindParagraph:
+		return true
+	default:
+		return false
+	}
+}
+
+// mdElementOf copies a styled block into the exported form the render
+// hook sees. PlainText and the table copy are built here rather than
+// cached on markdownBlock, so a document with no hook pays neither.
+func mdElementOf(
+	block markdownBlock, kind MarkdownBlockKind, index int, docID string,
+) MarkdownElement {
+	el := MarkdownElement{
+		DocID:           docID,
+		PlainText:       richTextPlain(block.Content),
+		ListPrefix:      block.ListPrefix,
+		ImageSrc:        block.ImageSrc,
+		ImageAlt:        block.ImageAlt,
+		CodeLanguage:    block.CodeLanguage,
+		MathLatex:       block.MathLatex,
+		AnchorSlug:      block.AnchorSlug,
+		Content:         block.Content,
+		Kind:            kind,
+		Index:           index,
+		HeaderLevel:     block.HeaderLevel,
+		BlockquoteDepth: block.BlockquoteDepth,
+		ListIndent:      block.ListIndent,
+		ImageWidth:      block.ImageWidth,
+		ImageHeight:     block.ImageHeight,
+		IsCode:          block.IsCode,
+		IsHR:            block.IsHR,
+		IsBlockquote:    block.IsBlockquote,
+		IsImage:         block.IsImage,
+		IsTable:         block.IsTable,
+		IsList:          block.IsList,
+		IsMath:          block.IsMath,
+		IsDefTerm:       block.IsDefTerm,
+		IsDefValue:      block.IsDefValue,
+		IsTaskItem:      block.IsTaskItem,
+		TaskChecked:     block.TaskChecked,
+	}
+	if block.TableData != nil {
+		el.TableData = &MarkdownTable{
+			Headers:    block.TableData.Headers,
+			Alignments: block.TableData.Alignments,
+			Rows:       block.TableData.Rows,
+		}
+	}
+	return el
+}
+
 // markdownBuildContent converts parsed blocks into views,
 // handling list accumulation and blockquote spacing.
 func markdownBuildContent(
@@ -460,6 +568,37 @@ func markdownBuildContent(
 			listItems = nil
 		}
 
+		if cfg.RenderBlock != nil {
+			kind := mdKindOf(block)
+			v, ok := cfg.RenderBlock(w,
+				mdElementOf(block, kind, i, cfg.ID))
+			if ok {
+				// Rune offsets belong to the document, not to the
+				// renderer. Advancing them here for a kind whose
+				// default branch never would -- code, a table -- gives
+				// a hooked document different offsets from the same
+				// document unhooked, so selection breaks in the hooked
+				// case only. makeCtx is what advances them; the ctx
+				// itself is unused because a hooked block is not
+				// selectable text.
+				if selEnabled && mdKindSelectable(kind) {
+					makeCtx(block)
+				}
+				// A hooked list item skips the accumulator, so any
+				// items already pending have to land before it or they
+				// render after their own siblings.
+				if len(listItems) > 0 {
+					content = append(content,
+						mdFlushListItems(listItems, cfg))
+					listItems = nil
+				}
+				if v != nil {
+					content = append(content, v)
+				}
+				continue
+			}
+		}
+
 		switch {
 		case block.IsMath:
 			content = append(content, mdRenderMathBlock(block, cfg, w))
@@ -488,15 +627,18 @@ func markdownBuildContent(
 		case block.IsList:
 			listItems = append(listItems,
 				mdRenderListItem(block, cfg, mode, makeCtx(block)))
-			if i == len(blocks)-1 && len(listItems) > 0 {
-				content = append(content,
-					mdFlushListItems(listItems, cfg))
-				listItems = nil
-			}
 		default:
 			content = append(content,
 				mdRenderParagraph(block, cfg, mode, makeCtx(block)))
 		}
+	}
+
+	// A document that ends inside a list has no following block to
+	// flush it, so the tail flush lives here rather than in the list
+	// case: every way out of the loop reaches it, including a block
+	// the render hook took over.
+	if len(listItems) > 0 {
+		content = append(content, mdFlushListItems(listItems, cfg))
 	}
 	return content
 }


### PR DESCRIPTION
Closes #484.

Add `MarkdownCfg.RenderBlock func(w *Window, el MarkdownElement) (View, bool)` — additive, not breaking. Fires per cached styled block during `GenerateLayout` (under frame lock). `ok=false` falls back to default; `ok=true` replaces with view or `nil` to drop.

**Types (`gui/markdown_types.go`)**
- `MarkdownBlockKind` (Paragraph zero) + 11 constants, `MarkdownElement` (mirrors `markdownBlock` + `Index`, `DocID`, `PlainText`, `TableData`), `MarkdownTable`
- `Kind` via `mdKindOf` matching render-switch order; mermaid stays `MarkdownKindCode` with `CodeLanguage=="mermaid"`; `DocID` is `w.EffID(cfg.ID)`; `PlainText` derived per hooked block

**Loop state (`gui/view_markdown.go`)**
1. Rune offsets advance only for 6 selectable kinds via `mdKindSelectable`
2. Pending `listItems` flush before hook output to preserve source order
3. Tail flush moves out of `IsList` branch to after loop (unchanged output for unhooked docs)

**Tests & goldens**
- 14 cases in `gui/markdown_render_block_test.go` (dispatch, fallback/replace/drop, offset rules, list order/tail, ID scoping)
- Goldens `markdown_blocks` (baseline) + `markdown_callout` (hook) in `gui/golden_cases_test.go` — diff is exactly what a hook can move
- `TestDuplicateIDs` covers hook-built ID collisions

**Dog-food & docs**
- `examples/showcase/demo_text.go` renders `> [!NOTE]`/`> [!WARNING]`/`> [!TIP]` as callouts
- Spec `docs/specs/markdown-render-callback.md` updated to landed
- `CHANGELOG.md` Unreleased Added + Fixed

`make prepush` green, `golangci-lint` 0 issues.