### PR TITLE
fix(date-picker): stabilize height across months

### DIFF
--- a/gui/testdata/datepicker_disabled.dark.golden
+++ b/gui/testdata/datepicker_disabled.dark.golden
@@ -10,12 +10,12 @@ Text xy=149.80,58.60 wh=0.00,0.00 color=#e6e8eb80 text="W" size=14.00
 Text xy=187.80,58.60 wh=0.00,0.00 color=#e6e8eb80 text="T" size=14.00
 Text xy=225.80,58.60 wh=0.00,0.00 color=#e6e8eb80 text="F" size=14.00
 Text xy=263.80,58.60 wh=0.00,0.00 color=#e6e8eb80 text="S" size=14.00
-Text xy=35.80,88.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
-Text xy=73.80,88.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
-Text xy=111.80,88.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
-Text xy=149.80,88.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
-Text xy=187.80,88.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
-Text xy=225.80,88.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
+Text xy=35.80,89.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
+Text xy=73.80,89.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
+Text xy=111.80,89.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
+Text xy=149.80,89.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
+Text xy=187.80,89.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
+Text xy=225.80,89.19 wh=0.00,0.00 color=#e6e8eb80 text=" " size=14.00
 Text xy=263.80,89.19 wh=0.00,0.00 color=#e6e8eb80 text="1" size=14.00
 Text xy=35.80,120.79 wh=0.00,0.00 color=#e6e8eb80 text="2" size=14.00
 Text xy=73.80,120.79 wh=0.00,0.00 color=#e6e8eb80 text="3" size=14.00

--- a/gui/testdata/datepicker_disabled.light.golden
+++ b/gui/testdata/datepicker_disabled.light.golden
@@ -9,12 +9,12 @@ Text xy=147.80,54.60 wh=0.00,0.00 color=#1a1d2195 text="W" size=14.00
 Text xy=185.80,54.60 wh=0.00,0.00 color=#1a1d2195 text="T" size=14.00
 Text xy=223.80,54.60 wh=0.00,0.00 color=#1a1d2195 text="F" size=14.00
 Text xy=261.80,54.60 wh=0.00,0.00 color=#1a1d2195 text="S" size=14.00
-Text xy=33.80,83.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
-Text xy=71.80,83.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
-Text xy=109.80,83.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
-Text xy=147.80,83.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
-Text xy=185.80,83.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
-Text xy=223.80,83.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
+Text xy=33.80,85.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
+Text xy=71.80,85.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
+Text xy=109.80,85.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
+Text xy=147.80,85.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
+Text xy=185.80,85.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
+Text xy=223.80,85.19 wh=0.00,0.00 color=#1a1d2195 text=" " size=14.00
 Text xy=261.80,85.19 wh=0.00,0.00 color=#1a1d2195 text="1" size=14.00
 Text xy=33.80,116.79 wh=0.00,0.00 color=#1a1d2195 text="2" size=14.00
 Text xy=71.80,116.79 wh=0.00,0.00 color=#1a1d2195 text="3" size=14.00

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -168,15 +168,21 @@ func (dv *datePickerView) GenerateLayout(w *Window) Layout {
 		content = append(content, datePickerCalendar(cfg, state, w))
 	}
 
-	// Stable size: 7 columns wide, 6 day rows + gaps tall.
-	// Include padding + border so min covers full outer box.
+	// Stable width: 7 columns wide + gaps, plus padding and border so
+	// the min covers the full outer box. Width has to be pinned
+	// because the month/year roller is narrower than the grid.
+	//
+	// Height is deliberately NOT pinned. A cell's height comes from
+	// its measured text, which is well short of cellSize (that value
+	// is a column width), so a 6*cellSize floor left a blank band
+	// under the last week row. The grid always emits six rows, so the
+	// natural height is already stable month to month, and the roller
+	// matches it through CalBodyHeight above.
 	cellSize := datePickerCellSize(cfg)
 	pad := cfg.Padding.Or(dn.Padding)
 	sizeBorder := cfg.SizeBorder.Get(dn.SizeBorder)
 	padW := float32(pad.Left+pad.Right) + 2*sizeBorder
-	padH := float32(pad.Top+pad.Bottom) + 2*sizeBorder
 	minWidth := 7*cellSize + 6*cellSpacing + padW
-	minHeight := 6*cellSize + 6*cellSpacing + padH
 
 	cfgID := cfg.ID
 	col := Column(ContainerCfg{
@@ -194,7 +200,6 @@ func (dv *datePickerView) GenerateLayout(w *Window) Layout {
 		Padding:     cfg.Padding,
 		Spacing:     Some(cellSpacing),
 		MinWidth:    minWidth,
-		MinHeight:   minHeight,
 		Disabled:    cfg.Disabled,
 		Invisible:   cfg.Invisible,
 		Content:     content,

--- a/gui/view_date_picker_calendar.go
+++ b/gui/view_date_picker_calendar.go
@@ -117,8 +117,14 @@ func datePickerMonth(
 						MinWidth:          cellSize,
 						MaxWidth:          cellSize,
 						MaxHeight:         cellSize,
-						Padding:           paddingThree,
-						Content:           []View{Text(TextCfg{Text: " "})},
+						// Transparent, but the same 2px the in-month
+						// cells reserve: a row of spacers measures 4px
+						// shorter without it, so a month that fills
+						// only five rows would size the whole picker
+						// shorter than a six-row one.
+						SizeBorder: SomeF(2),
+						Padding:    paddingThree,
+						Content:    []View{Text(TextCfg{Text: " "})},
 					}))
 				}
 				continue
@@ -271,7 +277,10 @@ func datePickerAdjacentCell(
 		MinWidth:      cellSize,
 		MaxWidth:      cellSize,
 		MaxHeight:     cellSize,
-		Padding:       paddingThree,
+		// Matches the in-month cells' reserve so every row measures
+		// the same height — see the spacer cell above.
+		SizeBorder: SomeF(2),
+		Padding:    paddingThree,
 		Content: []View{Text(TextCfg{
 			Text:      strconv.Itoa(adjDay),
 			TextStyle: ts,

--- a/gui/view_date_picker_size_test.go
+++ b/gui/view_date_picker_size_test.go
@@ -1,0 +1,54 @@
+package gui
+
+import (
+	"testing"
+	"time"
+)
+
+// A calendar month spans four to six week rows, but the grid always
+// emits six: a short month's trailing rows are spacers (or
+// adjacent-month days). Those cells have to reserve the same border as
+// an in-month cell, or the picker resizes as the user pages through
+// the year. Covers 36 consecutive months in both adjacent-day modes
+// and every WeekdaysLen so a wider cellSize does not reintroduce
+// drift.
+func TestDatePickerHeightStableAcrossMonths(t *testing.T) {
+	for _, adj := range []bool{false, true} {
+		for _, wdLen := range []DatePickerWeekdayLen{
+			WeekdayOneLetter, WeekdayThreeLetter, WeekdayFull,
+		} {
+			var want float32
+			for m := 1; m <= 12; m++ {
+				for _, y := range []int{2026, 2027, 2028} {
+					w := NewWindow(WindowCfg{State: new(int), Width: 600, Height: 800})
+					w.viewGenerator = func(win *Window) View {
+						return Column(ContainerCfg{Sizing: FillFill,
+							Content: []View{DatePicker(DatePickerCfg{
+								ID: "dp", ShowAdjacentMonths: adj,
+								WeekdaysLen: wdLen,
+								Dates: []time.Time{
+									time.Date(y, time.Month(m), 1, 0, 0, 0, 0, time.UTC),
+								},
+							})}})
+					}
+					n := time.Date(y, time.Month(m), 1, 12, 0, 0, 0, time.UTC)
+					w.setVirtualNow(&n)
+					w.refreshLayout = true
+					w.FrameFn()
+					l, ok := w.layout.FindByID("dp")
+					if !ok {
+						t.Fatal("no picker")
+					}
+					if want == 0 {
+						want = l.Shape.Height
+					}
+					if l.Shape.Height != want {
+						t.Errorf("adj=%v wdLen=%v %d-%02d height=%v want %v",
+							adj, wdLen, y, m, l.Shape.Height, want)
+					}
+				}
+			}
+			t.Logf("adj=%v wdLen=%v height=%v", adj, wdLen, want)
+		}
+	}
+}


### PR DESCRIPTION
Stabilize DatePicker height month-to-month.

- Pin only width (7*cellSize + gaps + padding/border); remove
  6*cellSize MinHeight that left a blank band because cell height
  comes from measured text, not column width.
- Grid always emits six rows so natural height is already stable;
  roller matches via CalBodyHeight.
- Reserve 2px border on spacer and adjacent-month cells so five-row
  months measure the same as six-row ones.
- Update goldens for the 1px layout shift; add
  `TestDatePickerHeightStableAcrossMonths` covering 36 months ×
  both adjacent modes × all WeekdaysLen.

Fixes height jitter when paging through the year.