### PR TITLE
feat(buildapp): package Windows and Linux targets

### DIFF
--- a/.github/workflows/deploy-showcase.yml
+++ b/.github/workflows/deploy-showcase.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           cd examples/showcase
           GOOS=js GOARCH=wasm go build \
-            -ldflags "-X github.com/go-gui-org/go-gui/gui.Version=$(git describe --tags --always --dirty)" \
+            -ldflags "-X github.com/go-gui-org/go-gui/gui.Version=$(git describe --tags --always)" \
             -o main.wasm .
           cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,12 @@ jobs:
         working-directory: go-gui
         run: |
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          tar czf "go-gui-showcase-${VERSION}-linux-amd64.tar.gz" \
-            -C build showcase-linux
+          # buildapp names the installed executable after the file's
+          # basename, so stage it as plain "showcase" first.
+          mkdir -p build/pkg && cp build/showcase-linux build/pkg/showcase
+          go run ./cmd/buildapp -platform linux -o . \
+            -version "${VERSION}" -name "Go-Gui Showcase" \
+            -icon gui/default_icon.png build/pkg/showcase
 
       - uses: actions/upload-artifact@v7
         with:
@@ -120,8 +124,10 @@ jobs:
           repository: go-gui-org/go-glyph
           path: go-glyph
 
-      # msys2 is kept only for the `zip` tool the Package step uses; the
-      # showcase itself builds cgo-free (purego GL bindings, #155).
+      # msys2 gives the job a POSIX shell and `make`, so the Build step
+      # runs the same build-windows target a developer runs locally.
+      # The `zip` tool is no longer needed: buildapp writes the archive
+      # itself.  The showcase builds cgo-free (purego GL bindings, #155).
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -129,7 +135,7 @@ jobs:
           release: false
           path-type: inherit
           install: >-
-            zip
+            make
 
       - uses: actions/setup-go@v6
         with:
@@ -141,20 +147,16 @@ jobs:
 
       - name: Build showcase
         working-directory: go-gui
-        run: |
-          VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
-            go build -ldflags \
-              "-X github.com/go-gui-org/go-gui/gui.Version=${VERSION} \
-               -X github.com/go-gui-org/go-gui/gui.Commit=$(git rev-parse --short HEAD)" \
-            -o build/showcase-windows.exe ./examples/showcase/
+        run: make build-windows
 
       - name: Package
         working-directory: go-gui
         run: |
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          zip "go-gui-showcase-${VERSION}-windows-amd64.zip" \
-            build/showcase-windows.exe
+          mkdir -p build/pkg && cp build/showcase-windows.exe build/pkg/showcase.exe
+          go run ./cmd/buildapp -platform windows -o . \
+            -version "${VERSION}" -name "Go-Gui Showcase" \
+            -icon gui/default_icon.png build/pkg/showcase.exe
 
       - uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to
 
 ### Added
 
+- **`buildapp` packages Windows and Linux, not only macOS** — `-platform`
+  selects the packager, defaulting to the host `GOOS` so every existing
+  invocation keeps working. `-platform windows` embeds an icon into the PE image
+  (a `.rsrc` section carrying `RT_ICON` and `RT_GROUP_ICON`, from a `.png` or a
+  `.ico`) and writes a `.zip`; `-platform linux` writes a `.tar.gz` holding the
+  binary, a freedesktop `.desktop` entry with `Terminal=false`, a hicolor icon
+  and an `install.sh` that installs into `~/.local`. `make release` and the
+  release workflow now package all three targets through it, so the Linux
+  tarball is menu-installable and the Windows `.exe` carries its icon. Details:
+  `cmd/buildapp/README.md`.
+
 - **Markdown render callback** (#484) — `MarkdownCfg.RenderBlock` is consulted
   for every parsed block during layout, so an app can add a block type markdown
   does not have (callouts, numbered headings) or drop one, without rewriting the
@@ -22,12 +33,25 @@ and this project adheres to
 
 ### Fixed
 
+- **Windows builds opened a console window** — neither `make build-windows` nor
+  the release workflow passed `-H windowsgui`, so the loader gave the process a
+  console and every launch showed an empty terminal window behind the app
+  window. Both now set it.
+
 - **Markdown list at the end of a document** (#484) — the pending-list flush
   lived inside the list branch of `markdownBuildContent` and fired only on the
   last block, so a document ending in a list depended on that branch being
   reached. It now runs after the loop, where every exit path reaches it. Output
   for existing documents is unchanged, pinned by the new `markdown_blocks`
   golden.
+
+### Changed
+
+- **Default bundle identifier is now slugged** — `buildapp` derived it by
+  lower-casing the display name, so `-name "Go-Gui Showcase"` produced
+  `local.gogui.go-gui showcase`: invalid as a `CFBundleIdentifier` and unusable
+  as a freedesktop icon key. It is now `local.gogui.go-gui-showcase`. A name
+  with no spaces or punctuation is unaffected. Pass `-id` to pin the old value.
 
 ## [v0.66.1] - 2026-09-01
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# No --dirty: CI runs `go mod edit -replace` before every build, so the
+# tree is always dirty at build time and every release binary would
+# report a -dirty version.
+VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS  = -X github.com/go-gui-org/go-gui/gui.Version=$(VERSION) \
            -X github.com/go-gui-org/go-gui/gui.Commit=$(COMMIT)
@@ -14,14 +17,21 @@ LINT_ARGS ?=
 # Desktop builds are cgo-free since the purego GL bindings (#155): the
 # backend/gl uses X11/xgb + purego EGL on Linux and Win32 syscalls on
 # Windows. Only macOS (Metal) and the mobile backends need cgo.
+# GOOS/GOARCH are explicit: without them a macOS developer running
+# `make release` gets a Mach-O binary in the "linux" tarball.  The
+# purego backend cross-compiles cleanly, so this costs nothing on a
+# Linux host either.
 build-linux:
-	CGO_ENABLED=0 \
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 	go build -ldflags "$(LDFLAGS)" \
 	  -o build/showcase-linux ./examples/showcase/
 
+# -H windowsgui marks the PE as a GUI-subsystem image.  Without it the
+# Windows loader allocates a console for the process, so every launch
+# shows an empty terminal window behind the app window.
 build-windows:
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
-	go build -ldflags "$(LDFLAGS)" \
+	go build -ldflags "$(LDFLAGS) -H windowsgui" \
 	  -o build/showcase-windows.exe ./examples/showcase/
 
 build-macos:
@@ -72,11 +82,21 @@ build-examples:
 		echo "All buildable examples compiled to examples/bin/."; \
 	fi
 
+# Packaging goes through cmd/buildapp on all three desktop targets, so
+# each archive carries what its platform needs to look like an
+# application: a .desktop entry and icon on Linux, an icon resource on
+# Windows, a signed .app on macOS.  The binary is staged under
+# build/pkg/ first because buildapp takes the installed executable's
+# name from the file's basename, and "showcase-linux" would end up in
+# the Exec= line of the desktop entry.
 release: build-linux build-windows build-macos build-wasm
-	tar czf build/go-gui-showcase-$(VERSION)-linux-amd64.tar.gz \
-	  -C build showcase-linux
-	cd build && zip go-gui-showcase-$(VERSION)-windows-amd64.zip \
-	  showcase-windows.exe
+	mkdir -p build/pkg
+	cp build/showcase-linux build/pkg/showcase
+	cp build/showcase-windows.exe build/pkg/showcase.exe
+	go run ./cmd/buildapp -platform linux -o build -version $(VERSION) \
+	  -name "Go-Gui Showcase" -icon gui/default_icon.png build/pkg/showcase
+	go run ./cmd/buildapp -platform windows -o build -version $(VERSION) \
+	  -name "Go-Gui Showcase" -icon gui/default_icon.png build/pkg/showcase.exe
 	cd build && go run ../cmd/buildapp -version $(VERSION) \
 	  -name "Go-Gui Showcase" showcase-macos
 	hdiutil create -srcfolder "build/Go-Gui Showcase.app" \

--- a/cmd/buildapp/README.md
+++ b/cmd/buildapp/README.md
@@ -1,8 +1,18 @@
 # buildapp
 
-Wraps a compiled go-gui binary into a macOS `.app` bundle. You can then
-double-click the bundle, drag it to `/Applications`, and display it in the Dock
-with a proper name and icon.
+Packages a compiled go-gui binary as a release artefact. One binary in, one
+artefact out.
+
+| Platform | Output                 | What it adds                                                        |
+| -------- | ---------------------- | ------------------------------------------------------------------- |
+| macOS    | signed `.app`          | `Info.plist`, `.icns` icon, code signature, optional bundled dylibs |
+| Windows  | `.zip` with the `.exe` | icon resource in the PE image                                       |
+| Linux    | `.tar.gz`              | `.desktop` entry, icon, `install.sh`                                |
+
+The macOS bundle can be double-clicked, dragged to `/Applications`, and shows in
+the Dock with a proper name and icon. The Linux archive installs into `~/.local`
+and shows in the application menu. The Windows `.exe` shows its icon in
+Explorer, the taskbar and Alt-Tab.
 
 ## Install
 
@@ -19,20 +29,30 @@ go run ./cmd/buildapp [flags] <binary>
 ## Usage
 
 ```
-buildapp [-o outdir] [-name Name] [-id bundle.id] [-icon icon.png|.icns] [-version 1.0] [-sign identity] <binary>
+buildapp [-platform darwin|windows|linux] [-o outdir] [-name Name] [-id bundle.id]
+         [-icon icon.png|.icns|.ico] [-version 1.0] [-sign identity] <binary>
 ```
 
-Positional arg: path to a compiled Mach-O executable.
+Positional arg: path to the compiled executable. It must match `-platform`:
+Mach-O for `darwin`, PE for `windows`, ELF for `linux`.
 
-| Flag           | Default                        | Purpose                                             |
-| -------------- | ------------------------------ | --------------------------------------------------- |
-| `-o`           | `.`                            | Output directory                                    |
-| `-name`        | binary basename, capped        | Bundle display name                                 |
-| `-id`          | `local.gogui.<name>`           | `CFBundleIdentifier`                                |
-| `-icon`        | none                           | `.png` (auto-converted) or `.icns`                  |
-| `-version`     | `1.0`                          | `CFBundleVersion` / short version                   |
-| `-bundle-deps` | `false`                        | Bundle non-system dylibs into `Contents/Frameworks` |
-| `-sign`        | `$BUILDAPP_SIGN_IDENTITY`, `-` | `codesign` identity. `-` is ad-hoc                  |
+**The executable's basename becomes the installed program name** (the `Exec=`
+line on Linux, the file inside the `.zip` on Windows, `Contents/MacOS/<name>` on
+macOS). Stage it under a clean name before packaging; `showcase-linux` in,
+`Exec=showcase-linux` out.
+
+| Flag           | Default                        | Purpose                                                    |
+| -------------- | ------------------------------ | ---------------------------------------------------------- |
+| `-platform`    | host `GOOS`                    | Target packager: `darwin`, `windows` or `linux`            |
+| `-o`           | `.`                            | Output directory                                           |
+| `-name`        | binary basename, capped        | Bundle display name                                        |
+| `-id`          | `local.gogui.<name>`           | `CFBundleIdentifier`                                       |
+| `-icon`        | none                           | `.png` everywhere; also `.icns` (macOS), `.ico` (Windows)  |
+| `-version`     | `1.0`                          | `CFBundleVersion` / short version                          |
+| `-bundle-deps` | `false`                        | macOS: bundle non-system dylibs into `Contents/Frameworks` |
+| `-sign`        | `$BUILDAPP_SIGN_IDENTITY`, `-` | macOS: `codesign` identity. `-` is ad-hoc                  |
+
+## macOS
 
 ### Signing
 
@@ -137,15 +157,7 @@ buildapp converts `.png` icons to `.icns` via `sips` and `iconutil` (both ship
 with macOS). Intermediate iconset files live in the system temp directory, and
 the tool removes them on exit.
 
-## Example
-
-```
-go build -o /tmp/getstarted ./examples/get_started
-buildapp -o /tmp -name GetStarted -icon gui/default_icon.png /tmp/getstarted
-open /tmp/GetStarted.app
-```
-
-## Bundle layout
+### macOS bundle layout
 
 ```
 GetStarted.app/
@@ -155,11 +167,79 @@ GetStarted.app/
     Resources/getstarted.icns   (only when -icon supplied)
 ```
 
-## Notes
+Notes:
 
-- macOS only.
 - The tool overwrites an existing `.app` at the destination without prompting.
 - The bundle is always signed — ad-hoc by default, see [Signing](#signing). It
   does not perform notarization. Run `notarytool` separately for distribution.
 - Shared libraries are bundled only with `-bundle-deps`. Without it, the target
   machine must have them installed.
+- The macOS packager runs on macOS only: it needs `sips`, `iconutil` and
+  `codesign`.
+
+## Windows
+
+Two things make a Go binary look like an application on Windows. Only the second
+is buildapp's job.
+
+**1. Build with the GUI subsystem.** Without this the loader gives the process a
+console, so an empty terminal window appears behind the app window:
+
+```
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
+  go build -ldflags "-H windowsgui" -o build/showcase.exe ./examples/showcase/
+```
+
+**2. Embed an icon.** `buildapp -platform windows` appends a `.rsrc` section
+carrying `RT_ICON` and `RT_GROUP_ICON` resources, then zips the result:
+
+```
+buildapp -platform windows -o dist -name "Go-Gui Showcase" -version 1.2.3 \
+  -icon gui/default_icon.png build/showcase.exe
+# dist/go-gui-showcase-1.2.3-windows-amd64.zip
+```
+
+`-icon` takes a `.png` or a `.ico`. A PNG is embedded as-is: since Vista an icon
+directory entry may hold a PNG stream verbatim, so no conversion and no external
+tool is needed. A `.ico` contributes all of its images.
+
+Injection is refused when the binary already carries a resource directory, which
+happens when a `.syso` was linked in. Use one or the other, not both.
+
+Notarization has no Windows equivalent here: the `.exe` is not Authenticode
+signed. Run `signtool` separately if you need that.
+
+## Linux
+
+`buildapp -platform linux` writes a tarball with the freedesktop.org layout, so
+the app can appear in the application menu:
+
+```
+buildapp -platform linux -o dist -name "Go-Gui Showcase" -version 1.2.3 \
+  -icon gui/default_icon.png build/showcase
+# dist/go-gui-showcase-1.2.3-linux-amd64.tar.gz
+```
+
+```
+go-gui-showcase-1.2.3-linux-amd64/
+  bin/showcase
+  share/applications/local.gogui.go-gui-showcase.desktop
+  share/icons/hicolor/256x256/apps/local.gogui.go-gui-showcase.png
+  install.sh
+```
+
+The user runs `./install.sh` to copy those into `~/.local` (no privileges
+needed), or `./install.sh /usr/local` with `sudo` for a system-wide install.
+
+`-icon` must be a `.png` here. The `.desktop` entry sets `Terminal=false`, which
+is what stops a terminal emulator opening beside the app.
+
+## Example
+
+```
+go build -o /tmp/getstarted ./examples/get_started
+buildapp -o /tmp -name GetStarted -icon gui/default_icon.png /tmp/getstarted
+open /tmp/GetStarted.app
+```
+
+`make release` runs all three packagers over `examples/showcase`.

--- a/cmd/buildapp/linux.go
+++ b/cmd/buildapp/linux.go
@@ -1,0 +1,241 @@
+// Linux packaging: a .tar.gz holding the binary, a .desktop entry, an
+// icon and an install script.
+//
+// A bare binary in a tarball is not installable in any desktop sense:
+// nothing puts it in the application menu, and nothing gives it an
+// icon.  The freedesktop.org layout below is what every menu
+// implementation reads, and it works unprivileged out of ~/.local.
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"debug/elf"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// desktopTmpl is a freedesktop.org Desktop Entry.  Terminal=false is
+// the field that stops a terminal emulator opening alongside the app.
+// Icon names the icon *theme key*, not a path, so it must match the
+// basename installed under share/icons/hicolor.
+const desktopTmpl = `[Desktop Entry]
+Type=Application
+Name={{.Name}}
+Exec={{.Exec}}
+Icon={{.Icon}}
+Terminal=false
+Categories={{.Categories}}
+`
+
+// installShTmpl copies the payload files into a prefix.  The default
+// prefix is ~/.local, which needs no privileges and which every current
+// desktop searches.  update-desktop-database is optional: menus pick
+// the entry up on next login without it.
+const installShTmpl = `#!/bin/sh
+# Install {{.Name}}.  Usage: ./install.sh [prefix]   (default ~/.local)
+set -eu
+prefix="${1:-$HOME/.local}"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+install -Dm755 "$here/bin/{{.Exec}}" "$prefix/bin/{{.Exec}}"
+install -Dm644 "$here/share/applications/{{.ID}}.desktop" \
+  "$prefix/share/applications/{{.ID}}.desktop"
+{{- if .HasIcon}}
+install -Dm644 "$here/share/icons/hicolor/{{.IconSize}}/apps/{{.ID}}.png" \
+  "$prefix/share/icons/hicolor/{{.IconSize}}/apps/{{.ID}}.png"
+{{- end}}
+
+command -v update-desktop-database >/dev/null 2>&1 &&
+  update-desktop-database "$prefix/share/applications" || true
+
+echo "installed to $prefix"
+echo "if {{.Exec}} is not found, add $prefix/bin to PATH"
+`
+
+// linuxIconDir is the hicolor sub-directory the icon is filed under.
+// Icons are copied, not rescaled, so one nominal size is enough; menus
+// scale whatever they find.
+const linuxIconDir = "256x256"
+
+// defaultCategories keeps the entry out of the "Other" menu bucket.
+const defaultCategories = "Utility;"
+
+// buildLinux writes <outdir>/<slug>-<version>-linux-<arch>.tar.gz.
+func buildLinux(o bundleOpts) error {
+	arch, err := elfArch(o.Binary)
+	if err != nil {
+		return err
+	}
+	execName := filepath.Base(o.Binary)
+	root := fmt.Sprintf("%s-%s-linux-%s", slug(o.Name), o.Version, arch)
+
+	// Files are assembled in memory: the payload is one binary plus two
+	// short text files, and staging on disk would only add cleanup.
+	var files []tarEntry
+
+	bin, err := os.ReadFile(o.Binary) // #nosec G304 — CLI flag
+	if err != nil {
+		return err
+	}
+	files = append(files, tarEntry{root + "/bin/" + execName, 0o755, bin})
+
+	hasIcon := o.Icon != ""
+	if hasIcon {
+		if ext := strings.ToLower(filepath.Ext(o.Icon)); ext != ".png" {
+			return fmt.Errorf("linux icon must be .png, got %q", ext)
+		}
+		png, ierr := os.ReadFile(o.Icon) // #nosec G304 — CLI flag
+		if ierr != nil {
+			return ierr
+		}
+		files = append(files, tarEntry{
+			root + "/share/icons/hicolor/" + linuxIconDir + "/apps/" + o.ID + ".png",
+			0o644, png,
+		})
+	}
+
+	desktop, err := renderTmpl(desktopTmpl, map[string]string{
+		"Name": o.Name, "Exec": execName, "Icon": o.ID,
+		"Categories": defaultCategories,
+	})
+	if err != nil {
+		return err
+	}
+	files = append(files, tarEntry{
+		root + "/share/applications/" + o.ID + ".desktop", 0o644, desktop,
+	})
+
+	script, err := renderTmpl(installShTmpl, map[string]any{
+		"Name": o.Name, "Exec": execName, "ID": o.ID,
+		"HasIcon": hasIcon, "IconSize": linuxIconDir,
+	})
+	if err != nil {
+		return err
+	}
+	files = append(files, tarEntry{root + "/install.sh", 0o755, script})
+
+	if err = os.MkdirAll(o.OutDir, 0o755); err != nil { // #nosec G301
+		return err
+	}
+	dst := filepath.Join(o.OutDir, root+".tar.gz")
+	if err = writeTarGz(dst, files); err != nil {
+		return err
+	}
+	fmt.Println(dst)
+	return nil
+}
+
+// tarEntry is one regular file in the archive.
+type tarEntry struct {
+	Name string
+	Mode int64
+	Data []byte
+}
+
+// writeTarGz writes entries to path.  Modification times are left at
+// the zero value so two builds of the same input produce byte-identical
+// archives.
+func writeTarGz(path string, entries []tarEntry) error {
+	f, err := os.Create(path) // #nosec G304 — CLI flag
+	if err != nil {
+		return err
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     e.Name,
+			Mode:     e.Mode,
+			Size:     int64(len(e.Data)),
+			Format:   tar.FormatPAX,
+		}
+		if err = tw.WriteHeader(hdr); err != nil {
+			return closeAll(err, tw, gz, f)
+		}
+		if _, err = tw.Write(e.Data); err != nil {
+			return closeAll(err, tw, gz, f)
+		}
+	}
+	return closeAll(nil, tw, gz, f)
+}
+
+// closeAll closes cs in order, returning the first error seen — either
+// the caller's err or the first close failure.
+func closeAll(err error, cs ...io.Closer) error {
+	for _, c := range cs {
+		if cerr := c.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}
+	return err
+}
+
+// elfArch validates that path is an ELF executable and maps its machine
+// field onto the Go arch name used in the archive filename.
+func elfArch(path string) (string, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if fi.IsDir() {
+		return "", fmt.Errorf("%s is a directory", path)
+	}
+	f, err := elf.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("%s is not an ELF executable: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	switch f.Machine {
+	case elf.EM_X86_64:
+		return "amd64", nil
+	case elf.EM_AARCH64:
+		return "arm64", nil
+	case elf.EM_386:
+		return "386", nil
+	case elf.EM_ARM:
+		return "arm", nil
+	case elf.EM_RISCV:
+		return "riscv64", nil
+	default:
+		return "", fmt.Errorf("unsupported ELF machine %v", f.Machine)
+	}
+}
+
+// slug maps a display name onto a filename-safe token: lower case, with
+// runs of anything outside [a-z0-9._-] collapsed to a single dash.
+func slug(name string) string {
+	var b strings.Builder
+	dash := false
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_':
+			b.WriteRune(r)
+			dash = false
+		default:
+			if !dash && b.Len() > 0 {
+				b.WriteByte('-')
+				dash = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+// renderTmpl executes a text/template against data and returns bytes.
+func renderTmpl(tmpl string, data any) ([]byte, error) {
+	t, err := template.New("t").Parse(tmpl)
+	if err != nil {
+		return nil, err
+	}
+	var b strings.Builder
+	if err = t.Execute(&b, data); err != nil {
+		return nil, err
+	}
+	return []byte(b.String()), nil
+}

--- a/cmd/buildapp/linux_test.go
+++ b/cmd/buildapp/linux_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readTarGz returns every regular file in the archive, keyed by path.
+func readTarGz(t *testing.T, path string) (map[string]string, map[string]int64) {
+	t.Helper()
+	f, err := os.Open(path) // #nosec G304 — test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := map[string]string{}
+	mode := map[string]int64{}
+	tr := tar.NewReader(gz)
+	for {
+		hdr, rerr := tr.Next()
+		if errors.Is(rerr, io.EOF) {
+			break
+		}
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		b, rerr := io.ReadAll(tr)
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		body[hdr.Name] = string(b)
+		mode[hdr.Name] = hdr.Mode
+	}
+	return body, mode
+}
+
+func TestBuildLinuxLayout(t *testing.T) {
+	bin := crossStub(t, "linux", "amd64", "showcase")
+	out := t.TempDir()
+	icon := writeTestPNG(t, 256)
+
+	err := build(bundleOpts{
+		Platform: "linux", Binary: bin, OutDir: out,
+		Name: "Go-Gui Showcase", Version: "1.2.3", Icon: icon,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tgz := filepath.Join(out, "go-gui-showcase-1.2.3-linux-amd64.tar.gz")
+	body, mode := readTarGz(t, tgz)
+
+	const root = "go-gui-showcase-1.2.3-linux-amd64"
+	want := []string{
+		root + "/bin/showcase",
+		root + "/share/applications/local.gogui.go-gui-showcase.desktop",
+		root + "/share/icons/hicolor/256x256/apps/local.gogui.go-gui-showcase.png",
+		root + "/install.sh",
+	}
+	for _, w := range want {
+		if _, ok := body[w]; !ok {
+			t.Errorf("missing archive entry %q; got %v", w, keys(body))
+		}
+	}
+	if got := mode[root+"/bin/showcase"]; got != 0o755 {
+		t.Errorf("binary mode = %o, want 755", got)
+	}
+	if got := mode[root+"/install.sh"]; got != 0o755 {
+		t.Errorf("install.sh mode = %o, want 755", got)
+	}
+}
+
+func TestBuildLinuxDesktopEntry(t *testing.T) {
+	bin := crossStub(t, "linux", "amd64", "showcase")
+	out := t.TempDir()
+	err := build(bundleOpts{
+		Platform: "linux", Binary: bin, OutDir: out,
+		Name: "Showcase", ID: "org.gogui.showcase", Version: "9",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := readTarGz(t, filepath.Join(out, "showcase-9-linux-amd64.tar.gz"))
+	desktop := body["showcase-9-linux-amd64/share/applications/org.gogui.showcase.desktop"]
+
+	// Terminal=false is the line that stops a terminal emulator opening
+	// beside the app, which is the whole point of the entry.
+	for _, want := range []string{
+		"[Desktop Entry]", "Type=Application", "Name=Showcase",
+		"Exec=showcase", "Icon=org.gogui.showcase", "Terminal=false",
+		"Categories=Utility;",
+	} {
+		if !strings.Contains(desktop, want) {
+			t.Errorf("desktop entry missing %q:\n%s", want, desktop)
+		}
+	}
+}
+
+// With no -icon the archive must carry no icon file, and install.sh
+// must not try to install one.
+func TestBuildLinuxWithoutIcon(t *testing.T) {
+	bin := crossStub(t, "linux", "amd64", "showcase")
+	out := t.TempDir()
+	if err := build(bundleOpts{
+		Platform: "linux", Binary: bin, OutDir: out, Version: "1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := readTarGz(t, filepath.Join(out, "showcase-1-linux-amd64.tar.gz"))
+	for name := range body {
+		if strings.Contains(name, "/icons/") {
+			t.Errorf("unexpected icon entry %q", name)
+		}
+	}
+	if s := body["showcase-1-linux-amd64/install.sh"]; strings.Contains(s, "hicolor") {
+		t.Errorf("install.sh references an icon that is not in the archive:\n%s", s)
+	}
+}
+
+func TestBuildLinuxRejectsNonPNGIcon(t *testing.T) {
+	bin := crossStub(t, "linux", "amd64", "showcase")
+	icns := filepath.Join(t.TempDir(), "icon.icns")
+	if err := os.WriteFile(icns, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := build(bundleOpts{
+		Platform: "linux", Binary: bin, OutDir: t.TempDir(), Icon: icns,
+	})
+	if err == nil || !strings.Contains(err.Error(), "must be .png") {
+		t.Fatalf("err = %v, want a .png complaint", err)
+	}
+}
+
+func TestElfArchRejectsNonELF(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "text")
+	if err := os.WriteFile(p, []byte("not an elf"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := elfArch(p); err == nil {
+		t.Fatal("expected an error for a text file")
+	}
+}
+
+func TestSlug(t *testing.T) {
+	cases := map[string]string{
+		"Go-Gui Showcase": "go-gui-showcase",
+		"Showcase":        "showcase",
+		"  spaced  out  ": "spaced-out",
+		"v1.2_beta":       "v1.2_beta",
+		"!!!":             "",
+		"A/B\\C":          "a-b-c",
+	}
+	for in, want := range cases {
+		if got := slug(in); got != want {
+			t.Errorf("slug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/buildapp/macos.go
+++ b/cmd/buildapp/macos.go
@@ -1,0 +1,357 @@
+// macOS bundling: wraps a Mach-O executable in a signed .app bundle.
+//
+// Everything that shells out to Apple's tool-chain (sips, iconutil,
+// otool, install_name_tool, codesign) lives here.  The file carries no
+// build constraint so that the whole tool still compiles and vets on
+// Linux and Windows hosts; the macOS paths simply fail at run time
+// there when the tools are absent.
+package main
+
+import (
+	"debug/macho"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+const infoPlistTmpl = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key><string>{{.Exec}}</string>
+	<key>CFBundleIdentifier</key><string>{{.ID}}</string>
+	<key>CFBundleName</key><string>{{.Name}}</string>
+	<key>CFBundlePackageType</key><string>APPL</string>
+	<key>CFBundleVersion</key><string>{{.Version}}</string>
+	<key>CFBundleShortVersionString</key><string>{{.Version}}</string>
+	<key>LSMinimumSystemVersion</key><string>11.0</string>
+	<key>NSHighResolutionCapable</key><true/>
+{{- if .Icon}}
+	<key>CFBundleIconFile</key><string>{{.Icon}}</string>
+{{- end}}
+</dict>
+</plist>
+`
+
+func validateMachO(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		return fmt.Errorf("%s is a directory", path)
+	}
+	f, err := macho.Open(path)
+	if err != nil {
+		// also accept fat binaries
+		if ff, ferr := macho.OpenFat(path); ferr == nil {
+			_ = ff.Close()
+			return nil
+		}
+		return fmt.Errorf("%s is not a Mach-O executable: %w", path, err)
+	}
+	_ = f.Close()
+	return nil
+}
+
+// #nosec G304 — path is developer-controlled CLI flag
+func writePlist(path, execName, id, name, version, icon string) error {
+	t := template.Must(template.New("plist").Parse(infoPlistTmpl))
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return t.Execute(f, map[string]string{
+		"Exec": execName, "ID": id, "Name": name, "Version": version, "Icon": icon,
+	})
+}
+
+// installIcon places an .icns file in resDir and returns its basename.
+// Accepts an .icns passthrough or converts a .png via sips+iconutil.
+func installIcon(icon, resDir, execName string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(icon))
+	icnsName := execName + ".icns"
+	dst := filepath.Join(resDir, icnsName)
+	switch ext {
+	case ".icns":
+		if err := copyFile(icon, dst, 0o644); err != nil {
+			return "", err
+		}
+	case ".png":
+		if _, err := exec.LookPath("sips"); err != nil {
+			return "", errors.New("sips not found (needed for .png icon)")
+		}
+		if _, err := exec.LookPath("iconutil"); err != nil {
+			return "", errors.New("iconutil not found (needed for .png icon)")
+		}
+		if err := pngToIcns(icon, dst); err != nil {
+			return "", err
+		}
+	default:
+		return "", fmt.Errorf("unsupported icon type %q (need .png or .icns)", ext)
+	}
+	return icnsName, nil
+}
+
+// #nosec G204,G301 — build tool, all args from flags or temp dirs
+func pngToIcns(png, outIcns string) error {
+	tmp, err := os.MkdirTemp("", "buildapp-icon-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+	iconset := filepath.Join(tmp, "icon.iconset")
+	if err = os.Mkdir(iconset, 0o755); err != nil {
+		return err
+	}
+	sizes := []struct {
+		px   int
+		name string
+	}{
+		{16, "icon_16x16.png"}, {32, "icon_16x16@2x.png"},
+		{32, "icon_32x32.png"}, {64, "icon_32x32@2x.png"},
+		{128, "icon_128x128.png"}, {256, "icon_128x128@2x.png"},
+		{256, "icon_256x256.png"}, {512, "icon_256x256@2x.png"},
+		{512, "icon_512x512.png"}, {1024, "icon_512x512@2x.png"},
+	}
+	for _, s := range sizes {
+		out := filepath.Join(iconset, s.name)
+		cmd := exec.Command("sips", "-z", strconv.Itoa(s.px), strconv.Itoa(s.px), png, "--out", out)
+		if b, cerr := cmd.CombinedOutput(); cerr != nil {
+			return fmt.Errorf("sips: %v: %s", cerr, b)
+		}
+	}
+	cmd := exec.Command("iconutil", "-c", "icns", iconset, "-o", outIcns)
+	if b, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("iconutil: %v: %s", err, b)
+	}
+	return nil
+}
+
+// bundleDeps copies non-system dylibs referenced by binary into
+// Contents/Frameworks, rewrites all install names to @rpath form, adds
+// an rpath of @executable_path/../Frameworks, and re-signs every
+// modified file with signID. Recurses through transitive dependencies.
+// #nosec G204,G301 — build tool, args from otool output on own binaries
+func bundleDeps(binary, contents, signID string) error {
+	for _, tool := range []string{"otool", "install_name_tool", "codesign"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			return fmt.Errorf("%s not found", tool)
+		}
+	}
+	fw := filepath.Join(contents, "Frameworks")
+	if err := os.MkdirAll(fw, 0o755); err != nil {
+		return err
+	}
+
+	// queue of Mach-O files to process; map tracks dylibs already copied
+	// (key = original absolute path, value = bundled basename).
+	copied := map[string]string{}
+	queue := []string{binary}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		deps, err := otoolDeps(cur)
+		if err != nil {
+			return err
+		}
+		for _, dep := range deps {
+			if isSystemLib(dep) {
+				continue
+			}
+			base := filepath.Base(dep)
+			if _, seen := copied[dep]; !seen {
+				dst := filepath.Join(fw, base)
+				if err = copyFile(dep, dst, 0o755); err != nil {
+					return fmt.Errorf("copy %s: %w", dep, err)
+				}
+				copied[dep] = base
+				if err = exec.Command("install_name_tool",
+					"-id", "@rpath/"+base, dst).Run(); err != nil {
+					return fmt.Errorf("install_name_tool -id %s: %w", dst, err)
+				}
+				queue = append(queue, dst)
+			}
+			if err = exec.Command("install_name_tool",
+				"-change", dep, "@rpath/"+base, cur).Run(); err != nil {
+				return fmt.Errorf("install_name_tool -change %s: %w", cur, err)
+			}
+		}
+	}
+
+	// rpath only on the executable; dylibs resolve via the same loader
+	if err := exec.Command("install_name_tool",
+		"-add_rpath", "@executable_path/../Frameworks", binary).Run(); err != nil {
+		return fmt.Errorf("add_rpath: %w", err)
+	}
+
+	// re-sign everything we touched: install_name_tool invalidates the
+	// existing signature, and an unsigned Mach-O will not load on Apple
+	// Silicon.  Capture codesign's output — with a caller-supplied
+	// identity the usual failure is "identity not found", which is
+	// unreadable from the exit status alone.
+	signTargets := []string{binary}
+	for _, base := range copied {
+		signTargets = append(signTargets, filepath.Join(fw, base))
+	}
+	for _, t := range signTargets {
+		cmd := exec.Command("codesign", "-s", signID, "--force", t)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("codesign %s: %v: %s", t, err, out)
+		}
+	}
+	return nil
+}
+
+// otoolDeps returns the LC_LOAD_DYLIB paths recorded in path. The
+// binary's own LC_ID_DYLIB (first line) is dropped.
+// #nosec G204 — build tool, path from own binary
+func otoolDeps(path string) ([]string, error) {
+	out, err := exec.Command("otool", "-L", path).Output()
+	if err != nil {
+		return nil, fmt.Errorf("otool -L %s: %w", path, err)
+	}
+	lines := strings.Split(string(out), "\n")
+	if len(lines) < 2 {
+		return nil, nil
+	}
+	deps := make([]string, 0, len(lines))
+	// lines[0] is "<path>:"; for dylibs lines[1] is the LC_ID_DYLIB self-ref
+	start := 1
+	if strings.HasSuffix(path, ".dylib") && len(lines) > 1 {
+		start = 2
+	}
+	for _, ln := range lines[start:] {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		// "<path> (compatibility version ..., current version ...)"
+		if i := strings.Index(ln, " ("); i > 0 {
+			ln = ln[:i]
+		}
+		// skip @rpath/@loader_path/@executable_path entries already rewritten
+		if strings.HasPrefix(ln, "@") {
+			continue
+		}
+		deps = append(deps, ln)
+	}
+	return deps, nil
+}
+
+// signBundle signs the entire .app bundle with signID.  A missing
+// bundle-level signature causes Gatekeeper to report the app as
+// "damaged" even when every binary inside is individually signed.
+//
+// signID "-" is ad-hoc: no certificate, no team identifier, so TCC has
+// no designated requirement to key a grant against and falls back to the
+// cdhash.  The cdhash changes on every rebuild, so every ad-hoc rebuild
+// silently revokes screen recording, microphone, camera, accessibility
+// and friends — see README, "Signing".  Pass a real identity to keep
+// grants across rebuilds.
+//
+// --deep re-signs the nested code under Contents/Frameworks that
+// bundleDeps already signed.  Apple deprecates it for distribution
+// signing; it is kept here because the bundle carries no entitlements
+// and no nested code beyond those dylibs, so a same-identity re-sign
+// costs nothing.
+// #nosec G204 — build tool, appDir from temp dir
+func signBundle(appDir, signID string) error {
+	if _, err := exec.LookPath("codesign"); err != nil {
+		return errors.New("codesign not found")
+	}
+	cmd := exec.Command("codesign", "-s", signID, "--force", "--deep", appDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%v: %s", err, out)
+	}
+	return nil
+}
+
+// isSystemLib reports whether path lives in a macOS-shipped location and
+// can be safely left as an absolute reference.
+func isSystemLib(path string) bool {
+	switch {
+	case strings.HasPrefix(path, "/usr/lib/"),
+		strings.HasPrefix(path, "/System/Library/"),
+		strings.HasPrefix(path, "/Library/Apple/"):
+		return true
+	}
+	return false
+}
+
+// #nosec G301 — standard macOS .app bundle permissions
+func buildMacOS(o bundleOpts) error {
+	if err := validateMachO(o.Binary); err != nil {
+		return err
+	}
+	execName := filepath.Base(o.Binary)
+	o.SignID = signIdentityOr(o.SignID)
+
+	stage, err := os.MkdirTemp("", "buildapp-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(stage) }()
+
+	appDir := filepath.Join(stage, o.Name+".app")
+	contents := filepath.Join(appDir, "Contents")
+	macosDir := filepath.Join(contents, "MacOS")
+	resDir := filepath.Join(contents, "Resources")
+	if err = os.MkdirAll(macosDir, 0o755); err != nil {
+		return err
+	}
+	if err = os.MkdirAll(resDir, 0o755); err != nil {
+		return err
+	}
+
+	iconField := ""
+	if o.Icon != "" {
+		icnsName, ierr := installIcon(o.Icon, resDir, execName)
+		if ierr != nil {
+			return ierr
+		}
+		iconField = icnsName
+	}
+
+	if err = writePlist(filepath.Join(contents, "Info.plist"), execName, o.ID, o.Name, o.Version, iconField); err != nil {
+		return err
+	}
+	stagedBin := filepath.Join(macosDir, execName)
+	if err = copyFile(o.Binary, stagedBin, 0o755); err != nil {
+		return err
+	}
+
+	if o.BundleDeps {
+		if err = bundleDeps(stagedBin, contents, o.SignID); err != nil {
+			return fmt.Errorf("bundle deps: %w", err)
+		}
+	}
+
+	// Sign the entire .app bundle.  Without a bundle-level signature
+	// macOS Gatekeeper reports the app as damaged even when individual
+	// binaries inside are signed.
+	if err = signBundle(appDir, o.SignID); err != nil {
+		return fmt.Errorf("sign bundle: %w", err)
+	}
+
+	if err = os.MkdirAll(o.OutDir, 0o755); err != nil {
+		return err
+	}
+	dst := filepath.Join(o.OutDir, o.Name+".app")
+	if err = os.RemoveAll(dst); err != nil {
+		return err
+	}
+	if err = moveDir(appDir, dst); err != nil {
+		return err
+	}
+	fmt.Println(dst)
+	return nil
+}

--- a/cmd/buildapp/main.go
+++ b/cmd/buildapp/main.go
@@ -1,26 +1,30 @@
-// buildapp wraps a compiled go-gui binary into a macOS .app bundle.
+// buildapp packages a compiled go-gui binary for release.
+//
+// macOS gets a signed .app bundle, Windows a .zip holding a
+// GUI-subsystem .exe with an embedded icon, Linux a .tar.gz holding the
+// binary plus a .desktop entry and icon.
 //
 // Usage:
 //
-//	buildapp [-o outdir] [-name Name] [-id bundle.id] [-icon icon.png]
-//	         [-sign identity] <binary>
+//	buildapp [-platform darwin|windows|linux] [-o outdir] [-name Name]
+//	         [-id bundle.id] [-icon icon.png] [-sign identity] <binary>
 package main
 
 import (
-	"debug/macho"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
+	"runtime"
 	"strings"
-	"text/template"
 )
 
 type bundleOpts struct {
+	// Platform selects the packager.  Empty means the host GOOS, which
+	// keeps every pre-existing invocation working unchanged.
+	Platform   string
 	Binary     string
 	OutDir     string
 	Name       string
@@ -40,25 +44,6 @@ const envSignIdentity = "BUILDAPP_SIGN_IDENTITY"
 // adHocIdentity is codesign's spelling of "sign with no certificate".
 const adHocIdentity = "-"
 
-const infoPlistTmpl = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>CFBundleExecutable</key><string>{{.Exec}}</string>
-	<key>CFBundleIdentifier</key><string>{{.ID}}</string>
-	<key>CFBundleName</key><string>{{.Name}}</string>
-	<key>CFBundlePackageType</key><string>APPL</string>
-	<key>CFBundleVersion</key><string>{{.Version}}</string>
-	<key>CFBundleShortVersionString</key><string>{{.Version}}</string>
-	<key>LSMinimumSystemVersion</key><string>11.0</string>
-	<key>NSHighResolutionCapable</key><true/>
-{{- if .Icon}}
-	<key>CFBundleIconFile</key><string>{{.Icon}}</string>
-{{- end}}
-</dict>
-</plist>
-`
-
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "buildapp:", err)
@@ -68,6 +53,8 @@ func main() {
 
 func run() error {
 	var o bundleOpts
+	flag.StringVar(&o.Platform, "platform", runtime.GOOS,
+		"target platform: darwin, windows or linux")
 	flag.StringVar(&o.OutDir, "o", ".", "output directory")
 	flag.StringVar(&o.Name, "name", "", "bundle display name (default: binary basename)")
 	flag.StringVar(&o.ID, "id", "", "bundle identifier (default: local.gogui.<name>)")
@@ -106,113 +93,37 @@ func signIdentityOr(id string) string {
 	return id
 }
 
-// #nosec G301 — standard macOS .app bundle permissions
+// build dispatches to the packager for o.Platform.  Name and ID
+// defaulting is shared, because every platform derives the same two
+// values from the binary's basename.
 func build(o bundleOpts) error {
-	if err := validateMachO(o.Binary); err != nil {
-		return err
+	if o.Platform == "" {
+		o.Platform = runtime.GOOS
+	}
+	if o.Binary == "" {
+		return errors.New("no binary given")
 	}
 	execName := filepath.Base(o.Binary)
 	if o.Name == "" {
 		o.Name = strings.ToUpper(execName[:1]) + execName[1:]
 	}
 	if o.ID == "" {
-		o.ID = "local.gogui." + strings.ToLower(o.Name)
+		// slug, not plain lower-casing: a display name with spaces
+		// would otherwise produce an identifier with spaces, which is
+		// invalid as a CFBundleIdentifier and unusable as a
+		// freedesktop icon key or filename.
+		o.ID = "local.gogui." + slug(o.Name)
 	}
-	o.SignID = signIdentityOr(o.SignID)
-
-	stage, err := os.MkdirTemp("", "buildapp-*")
-	if err != nil {
-		return err
+	switch o.Platform {
+	case "darwin":
+		return buildMacOS(o)
+	case "windows":
+		return buildWindows(o)
+	case "linux":
+		return buildLinux(o)
+	default:
+		return fmt.Errorf("unsupported -platform %q (need darwin, windows or linux)", o.Platform)
 	}
-	defer func() { _ = os.RemoveAll(stage) }()
-
-	appDir := filepath.Join(stage, o.Name+".app")
-	contents := filepath.Join(appDir, "Contents")
-	macosDir := filepath.Join(contents, "MacOS")
-	resDir := filepath.Join(contents, "Resources")
-	if err = os.MkdirAll(macosDir, 0o755); err != nil {
-		return err
-	}
-	if err = os.MkdirAll(resDir, 0o755); err != nil {
-		return err
-	}
-
-	iconField := ""
-	if o.Icon != "" {
-		icnsName, ierr := installIcon(o.Icon, resDir, execName)
-		if ierr != nil {
-			return ierr
-		}
-		iconField = icnsName
-	}
-
-	if err = writePlist(filepath.Join(contents, "Info.plist"), execName, o.ID, o.Name, o.Version, iconField); err != nil {
-		return err
-	}
-	stagedBin := filepath.Join(macosDir, execName)
-	if err = copyFile(o.Binary, stagedBin, 0o755); err != nil {
-		return err
-	}
-
-	if o.BundleDeps {
-		if err = bundleDeps(stagedBin, contents, o.SignID); err != nil {
-			return fmt.Errorf("bundle deps: %w", err)
-		}
-	}
-
-	// Sign the entire .app bundle.  Without a bundle-level signature
-	// macOS Gatekeeper reports the app as damaged even when individual
-	// binaries inside are signed.
-	if err = signBundle(appDir, o.SignID); err != nil {
-		return fmt.Errorf("sign bundle: %w", err)
-	}
-
-	if err = os.MkdirAll(o.OutDir, 0o755); err != nil {
-		return err
-	}
-	dst := filepath.Join(o.OutDir, o.Name+".app")
-	if err = os.RemoveAll(dst); err != nil {
-		return err
-	}
-	if err = moveDir(appDir, dst); err != nil {
-		return err
-	}
-	fmt.Println(dst)
-	return nil
-}
-
-func validateMachO(path string) error {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if fi.IsDir() {
-		return fmt.Errorf("%s is a directory", path)
-	}
-	f, err := macho.Open(path)
-	if err != nil {
-		// also accept fat binaries
-		if ff, ferr := macho.OpenFat(path); ferr == nil {
-			_ = ff.Close()
-			return nil
-		}
-		return fmt.Errorf("%s is not a Mach-O executable: %w", path, err)
-	}
-	_ = f.Close()
-	return nil
-}
-
-// #nosec G304 — path is developer-controlled CLI flag
-func writePlist(path, execName, id, name, version, icon string) error {
-	t := template.Must(template.New("plist").Parse(infoPlistTmpl))
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-	return t.Execute(f, map[string]string{
-		"Exec": execName, "ID": id, "Name": name, "Version": version, "Icon": icon,
-	})
 }
 
 // #nosec G304 — src/dst are developer-controlled CLI flags
@@ -233,68 +144,6 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	return out.Close()
 }
 
-// installIcon places an .icns file in resDir and returns its basename.
-// Accepts an .icns passthrough or converts a .png via sips+iconutil.
-func installIcon(icon, resDir, execName string) (string, error) {
-	ext := strings.ToLower(filepath.Ext(icon))
-	icnsName := execName + ".icns"
-	dst := filepath.Join(resDir, icnsName)
-	switch ext {
-	case ".icns":
-		if err := copyFile(icon, dst, 0o644); err != nil {
-			return "", err
-		}
-	case ".png":
-		if _, err := exec.LookPath("sips"); err != nil {
-			return "", errors.New("sips not found (needed for .png icon)")
-		}
-		if _, err := exec.LookPath("iconutil"); err != nil {
-			return "", errors.New("iconutil not found (needed for .png icon)")
-		}
-		if err := pngToIcns(icon, dst); err != nil {
-			return "", err
-		}
-	default:
-		return "", fmt.Errorf("unsupported icon type %q (need .png or .icns)", ext)
-	}
-	return icnsName, nil
-}
-
-// #nosec G204,G301 — build tool, all args from flags or temp dirs
-func pngToIcns(png, outIcns string) error {
-	tmp, err := os.MkdirTemp("", "buildapp-icon-*")
-	if err != nil {
-		return err
-	}
-	defer func() { _ = os.RemoveAll(tmp) }()
-	iconset := filepath.Join(tmp, "icon.iconset")
-	if err = os.Mkdir(iconset, 0o755); err != nil {
-		return err
-	}
-	sizes := []struct {
-		px   int
-		name string
-	}{
-		{16, "icon_16x16.png"}, {32, "icon_16x16@2x.png"},
-		{32, "icon_32x32.png"}, {64, "icon_32x32@2x.png"},
-		{128, "icon_128x128.png"}, {256, "icon_128x128@2x.png"},
-		{256, "icon_256x256.png"}, {512, "icon_256x256@2x.png"},
-		{512, "icon_512x512.png"}, {1024, "icon_512x512@2x.png"},
-	}
-	for _, s := range sizes {
-		out := filepath.Join(iconset, s.name)
-		cmd := exec.Command("sips", "-z", strconv.Itoa(s.px), strconv.Itoa(s.px), png, "--out", out)
-		if b, cerr := cmd.CombinedOutput(); cerr != nil {
-			return fmt.Errorf("sips: %v: %s", cerr, b)
-		}
-	}
-	cmd := exec.Command("iconutil", "-c", "icns", iconset, "-o", outIcns)
-	if b, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("iconutil: %v: %s", err, b)
-	}
-	return nil
-}
-
 // moveDir moves src to dst, falling back to copy+remove across devices.
 func moveDir(src, dst string) error {
 	if err := os.Rename(src, dst); err == nil {
@@ -304,159 +153,6 @@ func moveDir(src, dst string) error {
 		return err
 	}
 	return os.RemoveAll(src)
-}
-
-// bundleDeps copies non-system dylibs referenced by binary into
-// Contents/Frameworks, rewrites all install names to @rpath form, adds
-// an rpath of @executable_path/../Frameworks, and re-signs every
-// modified file with signID. Recurses through transitive dependencies.
-// #nosec G204,G301 — build tool, args from otool output on own binaries
-func bundleDeps(binary, contents, signID string) error {
-	for _, tool := range []string{"otool", "install_name_tool", "codesign"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			return fmt.Errorf("%s not found", tool)
-		}
-	}
-	fw := filepath.Join(contents, "Frameworks")
-	if err := os.MkdirAll(fw, 0o755); err != nil {
-		return err
-	}
-
-	// queue of Mach-O files to process; map tracks dylibs already copied
-	// (key = original absolute path, value = bundled basename).
-	copied := map[string]string{}
-	queue := []string{binary}
-
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-
-		deps, err := otoolDeps(cur)
-		if err != nil {
-			return err
-		}
-		for _, dep := range deps {
-			if isSystemLib(dep) {
-				continue
-			}
-			base := filepath.Base(dep)
-			if _, seen := copied[dep]; !seen {
-				dst := filepath.Join(fw, base)
-				if err = copyFile(dep, dst, 0o755); err != nil {
-					return fmt.Errorf("copy %s: %w", dep, err)
-				}
-				copied[dep] = base
-				if err = exec.Command("install_name_tool",
-					"-id", "@rpath/"+base, dst).Run(); err != nil {
-					return fmt.Errorf("install_name_tool -id %s: %w", dst, err)
-				}
-				queue = append(queue, dst)
-			}
-			if err = exec.Command("install_name_tool",
-				"-change", dep, "@rpath/"+base, cur).Run(); err != nil {
-				return fmt.Errorf("install_name_tool -change %s: %w", cur, err)
-			}
-		}
-	}
-
-	// rpath only on the executable; dylibs resolve via the same loader
-	if err := exec.Command("install_name_tool",
-		"-add_rpath", "@executable_path/../Frameworks", binary).Run(); err != nil {
-		return fmt.Errorf("add_rpath: %w", err)
-	}
-
-	// re-sign everything we touched: install_name_tool invalidates the
-	// existing signature, and an unsigned Mach-O will not load on Apple
-	// Silicon.  Capture codesign's output — with a caller-supplied
-	// identity the usual failure is "identity not found", which is
-	// unreadable from the exit status alone.
-	signTargets := []string{binary}
-	for _, base := range copied {
-		signTargets = append(signTargets, filepath.Join(fw, base))
-	}
-	for _, t := range signTargets {
-		cmd := exec.Command("codesign", "-s", signID, "--force", t)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("codesign %s: %v: %s", t, err, out)
-		}
-	}
-	return nil
-}
-
-// otoolDeps returns the LC_LOAD_DYLIB paths recorded in path. The
-// binary's own LC_ID_DYLIB (first line) is dropped.
-// #nosec G204 — build tool, path from own binary
-func otoolDeps(path string) ([]string, error) {
-	out, err := exec.Command("otool", "-L", path).Output()
-	if err != nil {
-		return nil, fmt.Errorf("otool -L %s: %w", path, err)
-	}
-	lines := strings.Split(string(out), "\n")
-	if len(lines) < 2 {
-		return nil, nil
-	}
-	deps := make([]string, 0, len(lines))
-	// lines[0] is "<path>:"; for dylibs lines[1] is the LC_ID_DYLIB self-ref
-	start := 1
-	if strings.HasSuffix(path, ".dylib") && len(lines) > 1 {
-		start = 2
-	}
-	for _, ln := range lines[start:] {
-		ln = strings.TrimSpace(ln)
-		if ln == "" {
-			continue
-		}
-		// "<path> (compatibility version ..., current version ...)"
-		if i := strings.Index(ln, " ("); i > 0 {
-			ln = ln[:i]
-		}
-		// skip @rpath/@loader_path/@executable_path entries already rewritten
-		if strings.HasPrefix(ln, "@") {
-			continue
-		}
-		deps = append(deps, ln)
-	}
-	return deps, nil
-}
-
-// signBundle signs the entire .app bundle with signID.  A missing
-// bundle-level signature causes Gatekeeper to report the app as
-// "damaged" even when every binary inside is individually signed.
-//
-// signID "-" is ad-hoc: no certificate, no team identifier, so TCC has
-// no designated requirement to key a grant against and falls back to the
-// cdhash.  The cdhash changes on every rebuild, so every ad-hoc rebuild
-// silently revokes screen recording, microphone, camera, accessibility
-// and friends — see README, "Signing".  Pass a real identity to keep
-// grants across rebuilds.
-//
-// --deep re-signs the nested code under Contents/Frameworks that
-// bundleDeps already signed.  Apple deprecates it for distribution
-// signing; it is kept here because the bundle carries no entitlements
-// and no nested code beyond those dylibs, so a same-identity re-sign
-// costs nothing.
-// #nosec G204 — build tool, appDir from temp dir
-func signBundle(appDir, signID string) error {
-	if _, err := exec.LookPath("codesign"); err != nil {
-		return errors.New("codesign not found")
-	}
-	cmd := exec.Command("codesign", "-s", signID, "--force", "--deep", appDir)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%v: %s", err, out)
-	}
-	return nil
-}
-
-// isSystemLib reports whether path lives in a macOS-shipped location and
-// can be safely left as an absolute reference.
-func isSystemLib(path string) bool {
-	switch {
-	case strings.HasPrefix(path, "/usr/lib/"),
-		strings.HasPrefix(path, "/System/Library/"),
-		strings.HasPrefix(path, "/Library/Apple/"):
-		return true
-	}
-	return false
 }
 
 func copyTree(src, dst string) error {

--- a/cmd/buildapp/stub_test.go
+++ b/cmd/buildapp/stub_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// crossStub compiles a trivial main package for goos/goarch and returns
+// the path of the resulting executable.  The Windows and Linux
+// packagers both need a real, well-formed binary of the target format,
+// and cross-compiling one is cheaper and more faithful than checking in
+// a fixture.
+func crossStub(t *testing.T, goos, goarch, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "stub.go")
+	const prog = "package main\n\nfunc main() {}\n"
+	if err := os.WriteFile(src, []byte(prog), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, name)
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Env = append(os.Environ(),
+		"GOOS="+goos, "GOARCH="+goarch, "CGO_ENABLED=0")
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("cannot cross-compile for %s/%s: %v: %s", goos, goarch, err, b)
+	}
+	return out
+}
+
+// writeTestPNG writes a solid px-by-px PNG and returns its path.
+func writeTestPNG(t *testing.T, px int) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, px, px))
+	for y := range px {
+		for x := range px {
+			img.Set(x, y, color.RGBA{R: 0x30, G: 0x60, B: 0xc0, A: 0xff})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(t.TempDir(), "icon.png")
+	if err := os.WriteFile(p, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}

--- a/cmd/buildapp/windows.go
+++ b/cmd/buildapp/windows.go
@@ -1,0 +1,506 @@
+// Windows packaging: a .zip holding the .exe with an embedded icon.
+//
+// Two things make a Go binary look like an application on Windows: the
+// GUI subsystem flag (`go build -ldflags "-H windowsgui"`, which stops
+// the loader opening a console window) and an icon resource in the PE
+// image (which is what Explorer, the taskbar and Alt-Tab draw).  The
+// first belongs to the compile step.  This file does the second.
+//
+// The icon is injected into an already-linked PE by appending a .rsrc
+// section, rather than by emitting a .syso for the Go linker to consume.
+// A .syso would have to exist before `go build` runs, which would make
+// packaging a two-phase step and would put a generated file in the
+// user's package directory.  Appending keeps buildapp's shape: one
+// compiled binary in, one release artefact out.
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"debug/pe"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Windows resource type ids (winuser.h).
+const (
+	rtIcon      = 3
+	rtGroupIcon = 14
+)
+
+// resLangID is the language the resources are filed under.  Windows
+// falls back to the first available language when the requested one is
+// missing, so a single neutral entry is enough; 1033 (en-US) is what
+// every resource compiler emits by default.
+const resLangID = 1033
+
+// Sizes of the three resource-directory structures, in bytes.
+const (
+	resDirSize      = 16 // IMAGE_RESOURCE_DIRECTORY
+	resEntrySize    = 8  // IMAGE_RESOURCE_DIRECTORY_ENTRY
+	resDataEntrySz  = 16 // IMAGE_RESOURCE_DATA_ENTRY
+	resSubdirFlag   = 0x80000000
+	peResourceDirIx = 2 // IMAGE_DIRECTORY_ENTRY_RESOURCE
+)
+
+// buildWindows writes <outdir>/<slug>-<version>-windows-<arch>.zip.
+func buildWindows(o bundleOpts) error {
+	exe, err := os.ReadFile(o.Binary) // #nosec G304 — CLI flag
+	if err != nil {
+		return err
+	}
+	arch, err := peArch(o.Binary)
+	if err != nil {
+		return err
+	}
+
+	if o.Icon != "" {
+		images, ierr := loadIconImages(o.Icon)
+		if ierr != nil {
+			return ierr
+		}
+		exe, ierr = injectIcon(exe, images)
+		if ierr != nil {
+			return fmt.Errorf("embed icon: %w", ierr)
+		}
+	}
+
+	if err = os.MkdirAll(o.OutDir, 0o755); err != nil { // #nosec G301
+		return err
+	}
+	base := fmt.Sprintf("%s-%s-windows-%s", slug(o.Name), o.Version, arch)
+	dst := filepath.Join(o.OutDir, base+".zip")
+	if err = writeZip(dst, filepath.Base(o.Binary), exe); err != nil {
+		return err
+	}
+	fmt.Println(dst)
+	return nil
+}
+
+// peArch validates that path is a PE executable and maps its machine
+// field onto the Go arch name used in the archive filename.
+func peArch(path string) (string, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if fi.IsDir() {
+		return "", fmt.Errorf("%s is a directory", path)
+	}
+	f, err := pe.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("%s is not a PE executable: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	switch f.Machine {
+	case pe.IMAGE_FILE_MACHINE_AMD64:
+		return "amd64", nil
+	case pe.IMAGE_FILE_MACHINE_I386:
+		return "386", nil
+	case pe.IMAGE_FILE_MACHINE_ARM64:
+		return "arm64", nil
+	default:
+		return "", fmt.Errorf("unsupported PE machine 0x%x", f.Machine)
+	}
+}
+
+// iconImage is one image inside an icon group: the encoded bytes plus
+// the descriptive fields the RT_GROUP_ICON directory repeats.
+type iconImage struct {
+	Width    byte // 0 means 256
+	Height   byte // 0 means 256
+	Colors   byte
+	Planes   uint16
+	BitCount uint16
+	Data     []byte
+}
+
+// loadIconImages reads a .ico (all of its images) or a .png (one
+// image).  A PNG needs no conversion: since Vista an icon directory
+// entry may hold a PNG stream verbatim, which is how every 256x256
+// icon is stored in practice.
+func loadIconImages(path string) ([]iconImage, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 — CLI flag
+	if err != nil {
+		return nil, err
+	}
+	switch ext := strings.ToLower(filepath.Ext(path)); ext {
+	case ".ico":
+		return parseICO(raw)
+	case ".png":
+		img, perr := pngIconImage(raw)
+		if perr != nil {
+			return nil, perr
+		}
+		return []iconImage{img}, nil
+	default:
+		return nil, fmt.Errorf("unsupported icon type %q (need .png or .ico)", ext)
+	}
+}
+
+// pngSignature is the fixed 8-byte header every PNG file starts with.
+var pngSignature = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+// pngIconImage wraps a PNG as a single icon image, reading its pixel
+// dimensions out of the IHDR chunk (the first chunk, always at a fixed
+// offset).  Dimensions of 256 or more are stored as 0, which is the
+// icon format's escape for "256 or larger".
+func pngIconImage(raw []byte) (iconImage, error) {
+	const ihdrEnd = 24 // 8 signature + 4 length + 4 type + 8 dimensions
+	if len(raw) < ihdrEnd || !bytes.Equal(raw[:8], pngSignature) {
+		return iconImage{}, errors.New("not a PNG file")
+	}
+	w := binary.BigEndian.Uint32(raw[16:20])
+	h := binary.BigEndian.Uint32(raw[20:24])
+	return iconImage{
+		Width: iconDim(w), Height: iconDim(h),
+		Planes: 1, BitCount: 32, Data: raw,
+	}, nil
+}
+
+// iconDim encodes a pixel dimension into the single byte the icon
+// directory has for it.  256 and above collapse to 0.
+func iconDim(px uint32) byte {
+	if px >= 256 {
+		return 0
+	}
+	return byte(px)
+}
+
+// parseICO reads an ICONDIR plus its ICONDIRENTRY table.
+func parseICO(raw []byte) ([]iconImage, error) {
+	const dirSize, entrySize = 6, 16
+	if len(raw) < dirSize {
+		return nil, errors.New("truncated .ico header")
+	}
+	if binary.LittleEndian.Uint16(raw[2:4]) != 1 {
+		return nil, errors.New("not an icon file (idType != 1)")
+	}
+	n := int(binary.LittleEndian.Uint16(raw[4:6]))
+	if n == 0 {
+		return nil, errors.New(".ico contains no images")
+	}
+	if len(raw) < dirSize+n*entrySize {
+		return nil, errors.New("truncated .ico directory")
+	}
+	images := make([]iconImage, 0, n)
+	for i := range n {
+		e := raw[dirSize+i*entrySize:]
+		size := binary.LittleEndian.Uint32(e[8:12])
+		off := binary.LittleEndian.Uint32(e[12:16])
+		end := uint64(off) + uint64(size)
+		if end > uint64(len(raw)) {
+			return nil, fmt.Errorf(".ico image %d runs past end of file", i)
+		}
+		images = append(images, iconImage{
+			Width: e[0], Height: e[1], Colors: e[2],
+			Planes:   binary.LittleEndian.Uint16(e[4:6]),
+			BitCount: binary.LittleEndian.Uint16(e[6:8]),
+			Data:     raw[off:end],
+		})
+	}
+	return images, nil
+}
+
+// groupIconData builds the RT_GROUP_ICON payload: a GRPICONDIR
+// followed by one GRPICONDIRENTRY per image.  The entry is the .ico
+// directory entry with the 4-byte file offset replaced by the 2-byte
+// resource id of the matching RT_ICON.
+func groupIconData(images []iconImage) []byte {
+	buf := make([]byte, 0, 6+14*len(images))
+	buf = binary.LittleEndian.AppendUint16(buf, 0)                   // reserved
+	buf = binary.LittleEndian.AppendUint16(buf, 1)                   // type: icon
+	buf = binary.LittleEndian.AppendUint16(buf, uint16(len(images))) // count
+	for i, im := range images {
+		buf = append(buf, im.Width, im.Height, im.Colors, 0)
+		buf = binary.LittleEndian.AppendUint16(buf, im.Planes)
+		buf = binary.LittleEndian.AppendUint16(buf, im.BitCount)
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(len(im.Data)))
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(i+1)) // RT_ICON id
+	}
+	return buf
+}
+
+// resLeaf is one resource to place in the directory tree.
+type resLeaf struct {
+	Type uint32 // RT_ICON or RT_GROUP_ICON
+	ID   uint32 // resource id within the type
+	Data []byte
+}
+
+// buildResourceSection lays out a .rsrc section for leaves, which must
+// be sorted by (Type, ID) — the loader binary-searches the directories.
+//
+// baseRVA is where the section will be mapped.  It is needed up front
+// because IMAGE_RESOURCE_DATA_ENTRY records an RVA, not a
+// section-relative offset; every other pointer in the tree *is*
+// section-relative.
+func buildResourceSection(leaves []resLeaf, baseRVA uint32) []byte {
+	// Group leaves by type, preserving the sorted order.
+	type group struct {
+		Type   uint32
+		Leaves []resLeaf
+	}
+	var groups []group
+	for _, l := range leaves {
+		if n := len(groups); n > 0 && groups[n-1].Type == l.Type {
+			groups[n-1].Leaves = append(groups[n-1].Leaves, l)
+			continue
+		}
+		groups = append(groups, group{Type: l.Type, Leaves: []resLeaf{l}})
+	}
+
+	// Pass one: fix every offset.  The tree is three levels deep
+	// (type -> id -> language), then the data-entry block, then the
+	// raw bytes.
+	off := uint32(resDirSize + len(groups)*resEntrySize) // root dir
+	idDirOff := make([]uint32, len(groups))
+	for i, g := range groups {
+		idDirOff[i] = off
+		off += resDirSize + uint32(len(g.Leaves))*resEntrySize
+	}
+	langDirOff := make([]uint32, len(leaves))
+	for i := range leaves {
+		langDirOff[i] = off
+		off += resDirSize + resEntrySize // one language each
+	}
+	dataEntryOff := make([]uint32, len(leaves))
+	for i := range leaves {
+		dataEntryOff[i] = off
+		off += resDataEntrySz
+	}
+	dataOff := make([]uint32, len(leaves))
+	for i, l := range leaves {
+		off = align(off, 4) // keep image data 4-byte aligned
+		dataOff[i] = off
+		off += uint32(len(l.Data))
+	}
+
+	sec := make([]byte, off)
+	putResDir(sec, 0, len(groups))
+	// Root entries point at the per-type id directories.
+	for i, g := range groups {
+		e := resDirSize + i*resEntrySize
+		binary.LittleEndian.PutUint32(sec[e:], g.Type)
+		binary.LittleEndian.PutUint32(sec[e+4:], idDirOff[i]|resSubdirFlag)
+	}
+	leafIx := 0
+	for i, g := range groups {
+		putResDir(sec, idDirOff[i], len(g.Leaves))
+		for j, l := range g.Leaves {
+			e := int(idDirOff[i]) + resDirSize + j*resEntrySize
+			binary.LittleEndian.PutUint32(sec[e:], l.ID)
+			binary.LittleEndian.PutUint32(sec[e+4:], langDirOff[leafIx]|resSubdirFlag)
+
+			putResDir(sec, langDirOff[leafIx], 1)
+			le := int(langDirOff[leafIx]) + resDirSize
+			binary.LittleEndian.PutUint32(sec[le:], resLangID)
+			binary.LittleEndian.PutUint32(sec[le+4:], dataEntryOff[leafIx])
+
+			d := int(dataEntryOff[leafIx])
+			binary.LittleEndian.PutUint32(sec[d:], baseRVA+dataOff[leafIx])
+			binary.LittleEndian.PutUint32(sec[d+4:], uint32(len(l.Data)))
+			// CodePage and Reserved stay zero.
+			copy(sec[dataOff[leafIx]:], l.Data)
+			leafIx++
+		}
+	}
+	return sec
+}
+
+// putResDir writes an IMAGE_RESOURCE_DIRECTORY with n id-keyed entries
+// and no name-keyed entries.
+func putResDir(sec []byte, off uint32, n int) {
+	// Characteristics, TimeDateStamp, MajorVersion, MinorVersion and
+	// NumberOfNamedEntries all stay zero.
+	binary.LittleEndian.PutUint16(sec[off+14:], uint16(n))
+}
+
+// align rounds v up to the next multiple of a.
+func align(v, a uint32) uint32 {
+	if a == 0 {
+		return v
+	}
+	return (v + a - 1) / a * a
+}
+
+// injectIcon appends a .rsrc section carrying images to a PE image and
+// returns the rewritten file.
+//
+// Appending is only safe on an image that has no resources yet and no
+// data past its last section; both are checked.  Go-linked binaries
+// satisfy both unless a .syso was already linked in.
+func injectIcon(exe []byte, images []iconImage) ([]byte, error) {
+	h, err := parsePEHeader(exe)
+	if err != nil {
+		return nil, err
+	}
+	if h.ResourceSize != 0 {
+		return nil, errors.New("binary already has a resource directory; " +
+			"rebuild without a .syso, or supply no -icon")
+	}
+	if h.SectionTableEnd+peSectionHeaderSize > h.SizeOfHeaders {
+		return nil, errors.New("no room in the PE header for another section")
+	}
+	if uint32(len(exe)) > h.RawEnd {
+		return nil, fmt.Errorf("binary has %d bytes past its last section",
+			uint32(len(exe))-h.RawEnd)
+	}
+
+	leaves := make([]resLeaf, 0, len(images)+1)
+	for i, im := range images {
+		leaves = append(leaves, resLeaf{Type: rtIcon, ID: uint32(i + 1), Data: im.Data})
+	}
+	leaves = append(leaves, resLeaf{Type: rtGroupIcon, ID: 1, Data: groupIconData(images)})
+
+	newVA := align(h.VirtEnd, h.SectionAlignment)
+	rsrc := buildResourceSection(leaves, newVA)
+	rawOff := align(h.RawEnd, h.FileAlignment)
+	rawSize := align(uint32(len(rsrc)), h.FileAlignment)
+
+	out := make([]byte, rawOff+rawSize)
+	copy(out, exe)
+	copy(out[rawOff:], rsrc)
+
+	// Section header for the new .rsrc.
+	sh := out[h.SectionTableEnd:]
+	copy(sh[:8], ".rsrc\x00\x00\x00")
+	binary.LittleEndian.PutUint32(sh[8:], uint32(len(rsrc))) // VirtualSize
+	binary.LittleEndian.PutUint32(sh[12:], newVA)            // VirtualAddress
+	binary.LittleEndian.PutUint32(sh[16:], rawSize)          // SizeOfRawData
+	binary.LittleEndian.PutUint32(sh[20:], rawOff)           // PointerToRawData
+	// Relocations, line numbers and their counts stay zero.
+	// IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ
+	binary.LittleEndian.PutUint32(sh[36:], 0x40000040)
+
+	binary.LittleEndian.PutUint16(out[h.NumSectionsOff:], h.NumSections+1)
+	binary.LittleEndian.PutUint32(out[h.SizeOfImageOff:],
+		align(newVA+uint32(len(rsrc)), h.SectionAlignment))
+	binary.LittleEndian.PutUint32(out[h.ResourceDirOff:], newVA)
+	binary.LittleEndian.PutUint32(out[h.ResourceDirOff+4:], uint32(len(rsrc)))
+
+	setPEChecksum(out, h.CheckSumOff)
+	return out, nil
+}
+
+// peSectionHeaderSize is the size of one IMAGE_SECTION_HEADER.
+const peSectionHeaderSize = 40
+
+// peHeader collects the header fields injectIcon reads or rewrites.
+// Offsets are absolute file offsets so the caller can patch in place.
+type peHeader struct {
+	NumSections      uint16
+	NumSectionsOff   uint32
+	SectionTableEnd  uint32 // where a new section header would go
+	SizeOfHeaders    uint32
+	SectionAlignment uint32
+	FileAlignment    uint32
+	SizeOfImageOff   uint32
+	CheckSumOff      uint32
+	ResourceDirOff   uint32 // DataDirectory[2]
+	ResourceSize     uint32
+	VirtEnd          uint32 // end of the highest-mapped section
+	RawEnd           uint32 // end of the last section's raw data
+}
+
+// parsePEHeader reads the DOS stub, COFF header, optional header and
+// section table by hand.  debug/pe is used for validation elsewhere but
+// gives no file offsets, and offsets are what a rewrite needs.
+func parsePEHeader(exe []byte) (peHeader, error) {
+	var h peHeader
+	if len(exe) < 0x40 || exe[0] != 'M' || exe[1] != 'Z' {
+		return h, errors.New("not a PE file (no MZ signature)")
+	}
+	poff := binary.LittleEndian.Uint32(exe[0x3c:])
+	if uint64(poff)+24 > uint64(len(exe)) ||
+		!bytes.Equal(exe[poff:poff+4], []byte("PE\x00\x00")) {
+		return h, errors.New("not a PE file (no PE signature)")
+	}
+	coff := poff + 4
+	h.NumSectionsOff = coff + 2
+	h.NumSections = binary.LittleEndian.Uint16(exe[h.NumSectionsOff:])
+	optSize := uint32(binary.LittleEndian.Uint16(exe[coff+16:]))
+	opt := coff + 20
+	if uint64(opt)+uint64(optSize) > uint64(len(exe)) {
+		return h, errors.New("truncated PE optional header")
+	}
+
+	// The optional header is identical up to offset 64 for PE32 and
+	// PE32+; only the data directory moves, because PE32 carries an
+	// extra 4-byte BaseOfData and PE32+ widens four fields to 8 bytes.
+	var dataDir uint32
+	switch magic := binary.LittleEndian.Uint16(exe[opt:]); magic {
+	case 0x10b: // PE32
+		dataDir = opt + 96
+	case 0x20b: // PE32+
+		dataDir = opt + 112
+	default:
+		return h, fmt.Errorf("unknown optional header magic 0x%x", magic)
+	}
+	h.SectionAlignment = binary.LittleEndian.Uint32(exe[opt+32:])
+	h.FileAlignment = binary.LittleEndian.Uint32(exe[opt+36:])
+	h.SizeOfImageOff = opt + 56
+	h.SizeOfHeaders = binary.LittleEndian.Uint32(exe[opt+60:])
+	h.CheckSumOff = opt + 64
+	h.ResourceDirOff = dataDir + peResourceDirIx*8
+	if uint64(h.ResourceDirOff)+8 > uint64(len(exe)) {
+		return h, errors.New("truncated PE data directory")
+	}
+	h.ResourceSize = binary.LittleEndian.Uint32(exe[h.ResourceDirOff+4:])
+
+	secTable := opt + optSize
+	h.SectionTableEnd = secTable + uint32(h.NumSections)*peSectionHeaderSize
+	if uint64(h.SectionTableEnd) > uint64(len(exe)) {
+		return h, errors.New("truncated PE section table")
+	}
+	for i := range int(h.NumSections) {
+		s := exe[secTable+uint32(i)*peSectionHeaderSize:]
+		vend := binary.LittleEndian.Uint32(s[12:]) + binary.LittleEndian.Uint32(s[8:])
+		rend := binary.LittleEndian.Uint32(s[20:]) + binary.LittleEndian.Uint32(s[16:])
+		h.VirtEnd = max(h.VirtEnd, vend)
+		h.RawEnd = max(h.RawEnd, rend)
+	}
+	if h.SectionAlignment == 0 || h.FileAlignment == 0 {
+		return h, errors.New("PE alignment fields are zero")
+	}
+	return h, nil
+}
+
+// setPEChecksum recomputes the optional header CheckSum: a 16-bit
+// ones-complement sum over the whole file with the field zeroed, plus
+// the file size.  Windows only enforces it for drivers and boot
+// images, but tools that do read it flag a stale value.
+func setPEChecksum(out []byte, off uint32) {
+	binary.LittleEndian.PutUint32(out[off:], 0)
+	var sum uint32
+	n := len(out) &^ 1 // an odd trailing byte pads with zero, so contributes nothing
+	for i := 0; i < n; i += 2 {
+		sum += uint32(binary.LittleEndian.Uint16(out[i:]))
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	sum = (sum >> 16) + (sum & 0xffff)
+	sum += sum >> 16
+	sum &= 0xffff
+	binary.LittleEndian.PutUint32(out[off:], sum+uint32(len(out)))
+}
+
+// writeZip writes a one-entry archive holding data under name.
+func writeZip(path, name string, data []byte) error {
+	f, err := os.Create(path) // #nosec G304 — CLI flag
+	if err != nil {
+		return err
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Deflate})
+	if err != nil {
+		return closeAll(err, zw, f)
+	}
+	if _, err = w.Write(data); err != nil {
+		return closeAll(err, zw, f)
+	}
+	return closeAll(nil, zw, f)
+}

--- a/cmd/buildapp/windows_test.go
+++ b/cmd/buildapp/windows_test.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"debug/pe"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// rsrcSection returns the .rsrc section bytes of exe plus the RVA it is
+// mapped at, after checking that the resource data directory agrees
+// with the section header.
+func rsrcSection(t *testing.T, exe []byte) ([]byte, uint32) {
+	t.Helper()
+	f, err := pe.NewFile(bytes.NewReader(exe))
+	if err != nil {
+		t.Fatalf("rewritten binary no longer parses as PE: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	sec := f.Section(".rsrc")
+	if sec == nil {
+		t.Fatal("no .rsrc section")
+	}
+	data, err := sec.Data()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dirRVA, dirSize uint32
+	switch oh := f.OptionalHeader.(type) {
+	case *pe.OptionalHeader64:
+		dirRVA = oh.DataDirectory[peResourceDirIx].VirtualAddress
+		dirSize = oh.DataDirectory[peResourceDirIx].Size
+	case *pe.OptionalHeader32:
+		dirRVA = oh.DataDirectory[peResourceDirIx].VirtualAddress
+		dirSize = oh.DataDirectory[peResourceDirIx].Size
+	default:
+		t.Fatalf("unexpected optional header %T", oh)
+	}
+	if dirRVA != sec.VirtualAddress {
+		t.Errorf("resource directory RVA = %#x, section VA = %#x", dirRVA, sec.VirtualAddress)
+	}
+	if dirSize != sec.VirtualSize {
+		t.Errorf("resource directory size = %d, section VirtualSize = %d", dirSize, sec.VirtualSize)
+	}
+	// Section data is padded up to FileAlignment; trim to the mapped size.
+	return data[:sec.VirtualSize], sec.VirtualAddress
+}
+
+// lookupResource walks type -> id -> first language and returns the
+// leaf bytes, mirroring what the Windows loader does.
+func lookupResource(t *testing.T, sec []byte, baseRVA, typ, id uint32) []byte {
+	t.Helper()
+	idDir, ok := dirEntry(sec, 0, typ)
+	if !ok {
+		t.Fatalf("resource type %d not found", typ)
+	}
+	langDir, ok := dirEntry(sec, idDir, id)
+	if !ok {
+		t.Fatalf("resource %d/%d not found", typ, id)
+	}
+	// Take whatever the single language entry is.
+	if n := binary.LittleEndian.Uint16(sec[langDir+14:]); n != 1 {
+		t.Fatalf("language directory has %d entries, want 1", n)
+	}
+	dataEntry := binary.LittleEndian.Uint32(sec[langDir+resDirSize+4:])
+	if dataEntry&resSubdirFlag != 0 {
+		t.Fatal("language entry points at a directory, not a leaf")
+	}
+	rva := binary.LittleEndian.Uint32(sec[dataEntry:])
+	size := binary.LittleEndian.Uint32(sec[dataEntry+4:])
+	off := rva - baseRVA
+	if uint64(off)+uint64(size) > uint64(len(sec)) {
+		t.Fatalf("leaf %d/%d runs past the section", typ, id)
+	}
+	return sec[off : off+size]
+}
+
+// dirEntry finds the id-keyed entry named want in the directory at off
+// and returns the sub-directory offset it points at.
+func dirEntry(sec []byte, off, want uint32) (uint32, bool) {
+	named := uint32(binary.LittleEndian.Uint16(sec[off+12:]))
+	ids := uint32(binary.LittleEndian.Uint16(sec[off+14:]))
+	for i := named; i < named+ids; i++ {
+		e := off + resDirSize + i*resEntrySize
+		if binary.LittleEndian.Uint32(sec[e:]) != want {
+			continue
+		}
+		sub := binary.LittleEndian.Uint32(sec[e+4:])
+		return sub &^ resSubdirFlag, sub&resSubdirFlag != 0
+	}
+	return 0, false
+}
+
+func TestInjectIconBuildsResourceTree(t *testing.T) {
+	bin := crossStub(t, "windows", "amd64", "showcase.exe")
+	exe, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pngPath := writeTestPNG(t, 256)
+	png, err := os.ReadFile(pngPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := injectIcon(exe, []iconImage{
+		{Width: 0, Height: 0, Planes: 1, BitCount: 32, Data: png},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sec, base := rsrcSection(t, out)
+
+	// The RT_ICON leaf must be the PNG, byte for byte.
+	if got := lookupResource(t, sec, base, rtIcon, 1); !bytes.Equal(got, png) {
+		t.Errorf("RT_ICON payload is %d bytes, want the %d-byte PNG", len(got), len(png))
+	}
+
+	// The RT_GROUP_ICON leaf must describe exactly that one image and
+	// point at resource id 1.
+	grp := lookupResource(t, sec, base, rtGroupIcon, 1)
+	if len(grp) != 6+14 {
+		t.Fatalf("group icon is %d bytes, want 20", len(grp))
+	}
+	if n := binary.LittleEndian.Uint16(grp[4:6]); n != 1 {
+		t.Errorf("group icon count = %d, want 1", n)
+	}
+	if sz := binary.LittleEndian.Uint32(grp[14:18]); sz != uint32(len(png)) {
+		t.Errorf("group icon dwBytesInRes = %d, want %d", sz, len(png))
+	}
+	if id := binary.LittleEndian.Uint16(grp[18:20]); id != 1 {
+		t.Errorf("group icon nID = %d, want 1", id)
+	}
+}
+
+// The original sections must survive the rewrite untouched: an injected
+// section is only safe if it is purely additive.
+func TestInjectIconPreservesOriginalSections(t *testing.T) {
+	bin := crossStub(t, "windows", "amd64", "showcase.exe")
+	exe, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := pe.NewFile(bytes.NewReader(exe))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = before.Close() }()
+
+	png := writeTestPNG(t, 32)
+	images, err := loadIconImages(png)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := injectIcon(exe, images)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := pe.NewFile(bytes.NewReader(out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = after.Close() }()
+
+	if len(after.Sections) != len(before.Sections)+1 {
+		t.Fatalf("section count %d -> %d, want +1", len(before.Sections), len(after.Sections))
+	}
+	for i, s := range before.Sections {
+		a := after.Sections[i]
+		if a.Name != s.Name || a.VirtualAddress != s.VirtualAddress ||
+			a.Offset != s.Offset || a.Size != s.Size {
+			t.Errorf("section %d (%s) moved", i, s.Name)
+		}
+	}
+	// The bytes of the original image are a prefix of the new file.
+	if !bytes.Equal(out[:len(exe)], exe) {
+		// The header is patched in place, so compare past the headers.
+		t.Log("headers differ, as expected; checking section payloads")
+		for _, s := range before.Sections {
+			want, rerr := s.Data()
+			if rerr != nil {
+				t.Fatal(rerr)
+			}
+			got := out[s.Offset : s.Offset+s.Size]
+			if !bytes.Equal(got, want) {
+				t.Errorf("section %s payload changed", s.Name)
+			}
+		}
+	}
+}
+
+func TestInjectIconRejectsExistingResources(t *testing.T) {
+	bin := crossStub(t, "windows", "amd64", "showcase.exe")
+	exe, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	images, err := loadIconImages(writeTestPNG(t, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	once, err := injectIcon(exe, images)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A second pass must refuse rather than produce two resource
+	// directories, only one of which the loader would ever see.
+	if _, err = injectIcon(once, images); err == nil ||
+		!strings.Contains(err.Error(), "already has a resource directory") {
+		t.Fatalf("err = %v, want a refusal", err)
+	}
+}
+
+func TestBuildWindowsZip(t *testing.T) {
+	bin := crossStub(t, "windows", "amd64", "showcase.exe")
+	out := t.TempDir()
+	err := build(bundleOpts{
+		Platform: "windows", Binary: bin, OutDir: out,
+		Name: "Go-Gui Showcase", Version: "1.2.3", Icon: writeTestPNG(t, 256),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	zpath := filepath.Join(out, "go-gui-showcase-1.2.3-windows-amd64.zip")
+	zr, err := zip.OpenReader(zpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = zr.Close() }()
+	if len(zr.File) != 1 || zr.File[0].Name != "showcase.exe" {
+		t.Fatalf("zip holds %d entries, want showcase.exe", len(zr.File))
+	}
+	rc, err := zr.File[0].Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, base := rsrcSection(t, body); base == 0 {
+		t.Error("zipped exe carries no mapped .rsrc section")
+	}
+}
+
+func TestPngIconImageDimensions(t *testing.T) {
+	for _, px := range []int{16, 48, 256} {
+		raw, err := os.ReadFile(writeTestPNG(t, px))
+		if err != nil {
+			t.Fatal(err)
+		}
+		img, err := pngIconImage(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := byte(px)
+		if px >= 256 {
+			want = 0 // the format's escape for "256 or larger"
+		}
+		if img.Width != want || img.Height != want {
+			t.Errorf("%dpx PNG -> %dx%d, want %d", px, img.Width, img.Height, want)
+		}
+	}
+}
+
+func TestLoadIconImagesRejectsUnsupported(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "icon.icns")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadIconImages(p); err == nil {
+		t.Fatal("expected an error for .icns on windows")
+	}
+}
+
+func TestPeArchRejectsNonPE(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "text")
+	if err := os.WriteFile(p, []byte("not a pe"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := peArch(p); err == nil {
+		t.Fatal("expected an error for a text file")
+	}
+}
+
+func TestBuildRejectsUnknownPlatform(t *testing.T) {
+	err := build(bundleOpts{Platform: "plan9", Binary: "x"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported -platform") {
+		t.Fatalf("err = %v, want an unsupported-platform error", err)
+	}
+}


### PR DESCRIPTION
Split the macOS-only packager into per-platform backends behind a
`-platform` flag (darwin/windows/linux, default host `GOOS`):

- **Windows** — embeds an icon into the PE (`RT_ICON`/`RT_GROUP_ICON`
  from `.png` or `.ico`) and writes a `.zip`; `make build-windows`
  now passes `-H windowsgui` so the loader does not open a console.
- **Linux** — writes a `.tar.gz` with a freedesktop `.desktop` entry
  (`Terminal=false`), hicolor icon and `install.sh` into `~/.local`.
- **Identifier** — default bundle ID is now slugged (`go-gui showcase`
  → `go-gui-showcase`); names without spaces/punctuation are
  unaffected (`-id` still pins it).
- `make release` and `.github/workflows/release.yml` route all three
  targets through `buildapp`; `deploy-showcase.yml` drops `--dirty`
  from `VERSION` (CI is always dirty after `go mod edit -replace`).

`cmd/buildapp` is now `main.go` (dispatch + shared helpers) plus
`macos.go` / `windows.go` / `linux.go` with their own tests.