### PR TITLE
fix(rtf): report dropped link activations; fix drag past a paragraph (#488)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ deep-dive/
 .direnv/
 .tokensave/
 .codegraph/
+.codehound-cache/
+.goslop-cache/
 
 # Pinned linter binary, built by `make lint` from tools/lint.
 /.bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,37 @@ and this project adheres to
 
 ### Fixed
 
+- **RTF link activation dropped anchors and relative links** (#488) — the
+  context menu's "Open Link" had no anchor branch, so `#some-heading` went to
+  the platform opener, which rejects every scheme outside http/https/mailto, and
+  the error was discarded: left-click scrolled to the heading, the menu did
+  nothing. Relative links (`/docs/x`, `./y`, `?q=1`) failed the same way on both
+  paths. Both call sites now share one `rtfOpenLink` path: an anchor scrolls, an
+  http/https/mailto link opens, and anything else — a relative link with no
+  document base URI, an unresolved anchor, a failed opener — is reported through
+  the `gui.Debug` gate (`DebugCallbacks`) instead of failing in silence.
+
+- **A link click in selectable text started a drag-select** (#488) — both
+  selectable paths (`rtfSelectOnClick` and `markdownBlockOnClick`) ran link
+  activation and then armed drag-select on the same click, locking the mouse.
+  The release never came back to the widget — the link had opened a browser,
+  scrolled the view away, or raised the context menu over the pointer — so the
+  lock stayed up and the pointer kept extending the selection with no button
+  held. A click that activated a link now still collapses the selection under
+  the pointer, the way a browser drops the old highlight, but no longer arms the
+  drag. A click on a non-link run is unchanged.
+
+- **Drag-selecting past the top or bottom of a paragraph stopped mid-line** —
+  `glyph.GetClosestOffset` snaps an out-of-band y to the nearest line and then
+  still reads the column from x, so a drag carried above a paragraph selected
+  its first line only as far as the pointer's column, and one carried below
+  selected the last line only that far. All four drag paths (Text, Input, RTF
+  and markdown) now widen the hit test once the pointer leaves the text band:
+  upward takes the line through its beginning, downward through its end, which
+  is what every platform's text view does. Inside the text nothing changes. The
+  markdown path gets the same rule in the gap between two blocks, where the hit
+  test picks the block above.
+
 - **Windows builds opened a console window** — neither `make build-windows` nor
   the release workflow passed `-H windowsgui`, so the loader gave the process a
   console and every launch showed an empty terminal window behind the app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,8 @@ walks the composed tree every frame and reports to stderr (`gui/debug.go`):
 - a scrollable listbox that resolved to height 0
 - a container setting both `Wrap` and `Overflow` (wrap wins)
 - a callback that acted without `ctx.Consume()` while an ancestor also handles
+- a link the user activated that opened nothing (unknown anchor, relative link,
+  failed platform opener)
 
 Findings are warn-once per window. The gate allocates and walks the whole tree —
 dev only, never production. Categories gate independently via

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -85,10 +85,12 @@ const (
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugWrapOverflow
 
-	// DebugCallbacks reports an app callback the frame pass could not
-	// run: deferred callbacks that kept re-queueing themselves round
-	// after round, so the frame bounded the loop and dropped the rest
-	// rather than spin forever.
+	// DebugCallbacks reports a user-visible action the frame pass could
+	// not carry out: deferred callbacks that kept re-queueing
+	// themselves round after round, so the frame bounded the loop and
+	// dropped the rest rather than spin forever; and a link activation
+	// that resolved to nothing (an unknown anchor, a relative link with
+	// no base URI, or a platform opener that failed).
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugCallbacks
 
@@ -243,6 +245,10 @@ const (
 	// debugCheckDeferredLoop fires from flushDeferredCallbacks when
 	// deferred app callbacks keep re-queueing past the batch bound.
 	debugCheckDeferredLoop
+	// debugCheckLinkNotOpened fires from rtfOpenLink when a link the
+	// user activated does nothing: an unresolved anchor, a relative
+	// reference with no base URI, or a platform opener that failed.
+	debugCheckLinkNotOpened
 )
 
 // checkCategory maps an internal check to the public category that
@@ -265,7 +271,7 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugGradientResampled
 	case debugCheckWrapOverflow:
 		return DebugWrapOverflow
-	case debugCheckDeferredLoop:
+	case debugCheckDeferredLoop, debugCheckLinkNotOpened:
 		return DebugCallbacks
 	}
 	return 0

--- a/gui/markdown_anchor_interaction_test.go
+++ b/gui/markdown_anchor_interaction_test.go
@@ -144,11 +144,12 @@ func TestMarkdownAnchorLinkScrollsToView(t *testing.T) {
 				MouseX: x, MouseY: y}
 			w.EventFn(&down)
 			w.settle()
-			// Selection-enabled documents lock the mouse on click to
-			// drive drag-select; plain documents must not.
-			if locked := w.mouseIsLocked(); locked != tc.focusable {
-				t.Errorf("mouse locked = %v, want %v",
-					locked, tc.focusable)
+			// A click that activated a link never arms drag-select,
+			// selection-enabled or not: the release lands on whatever
+			// the navigation put under the pointer, so a lock taken
+			// here would never be lifted (issue #488).
+			if w.mouseIsLocked() {
+				t.Error("link click locked the mouse for drag-select")
 			}
 			w.EventFn(&Event{Type: EventMouseUp, MouseButton: MouseLeft,
 				MouseX: x, MouseY: y})

--- a/gui/markdown_select.go
+++ b/gui/markdown_select.go
@@ -162,7 +162,10 @@ func mdWalkBlocks(l *Layout, mdID string, out *[]mdBlockInfo) {
 // markdownBlockOnClick is the OnClick handler for RTF blocks inside a
 // markdown widget with cross-block selection enabled.
 func markdownBlockOnClick(ctx EventCtx) {
-	rtfOnClick(ctx)
+	// A link click still collapses the selection under the pointer, the
+	// way a browser drops the old highlight — but it must not arm the
+	// drag below. See the linkHit guard before MouseLock.
+	linkHit := rtfClickLink(ctx)
 	if ctx.Event.MouseButton == MouseRight {
 		return
 	}
@@ -211,6 +214,16 @@ func markdownBlockOnClick(ctx EventCtx) {
 	}
 	imap.Set(mdID, st)
 	ctx.Consume()
+
+	// The click activated a link, so it is spent: navigation owns it.
+	// Arming the drag here would lock the mouse for a release that
+	// never reaches this widget — the link opened a browser, scrolled
+	// the view away, or raised a context menu over the pointer — and
+	// the pointer would then keep extending the selection with no
+	// button held.
+	if linkHit {
+		return
+	}
 
 	// Capture drag state. Copy layout value so it's safe across frames.
 	anchorBeg := st.SelBeg
@@ -265,7 +278,9 @@ func mdHitAbsRune(
 	fallbackStart uint32,
 ) uint32 {
 	if len(blocks) == 0 {
-		bi := fallbackGL.GetClosestOffset(mx, my)
+		top, bot := glyphTextBand(&fallbackGL)
+		x := textDragEdgeX(mx, my, top, bot)
+		bi := fallbackGL.GetClosestOffset(x, my)
 		return fallbackStart + uint32(byteToRuneIndex(fallbackText, bi))
 	}
 	// Find the block the mouse is over, defaulting to the last block above.
@@ -280,8 +295,13 @@ func mdHitAbsRune(
 			best = b
 		}
 	}
-	relX := mx - best.ShapeX
 	relY := my - best.ShapeY
+	// Above the first block or below the last one — and in the gap
+	// between two blocks, where the block above is chosen — the drag
+	// takes the whole line rather than stopping at the pointer's
+	// column; see textDragEdgeX.
+	top, bot := glyphTextBand(&best.Layout)
+	relX := textDragEdgeX(mx-best.ShapeX, relY, top, bot)
 	bi := best.Layout.GetClosestOffset(relX, relY)
 	localRune := uint32(byteToRuneIndex(best.FlatText, bi))
 	return best.StartRune + localRune

--- a/gui/rtf_link_open_test.go
+++ b/gui/rtf_link_open_test.go
@@ -1,0 +1,330 @@
+package gui
+
+// rtf_link_open_test.go covers RTF link activation (issue #488): the
+// single rtfOpenLink path shared by left-click and the "Open Link"
+// context-menu action, the anchor branch on both, and the links that
+// cannot be opened at all — reported through the Debug gate instead of
+// being handed to the platform opener, which rejects them silently.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// rtfOpenErrPlatform fails every OpenURI call, standing in for a
+// missing xdg-open or a non-zero exit from the platform handler.
+type rtfOpenErrPlatform struct {
+	noopNativePlatform
+	calls int
+}
+
+func (p *rtfOpenErrPlatform) OpenURI(_ string) error {
+	p.calls++
+	return errors.New("no handler")
+}
+
+// rtfLinkDebugWindow returns a window with the Debug gate collecting
+// findings into the returned slice instead of writing to stderr.
+func rtfLinkDebugWindow(t *testing.T) (*Window, *[]string) {
+	t.Helper()
+	prevOn := DebugEnabled()
+	Debug(true)
+	t.Cleanup(func() { Debug(prevOn) })
+
+	w := newTestWindow()
+	found := new([]string)
+	w.debug.collect = found
+	return w, found
+}
+
+// TestRtfOpenLinkAbsoluteReachesPlatform asserts an allowlisted scheme
+// still goes to the platform opener and reports nothing.
+func TestRtfOpenLinkAbsoluteReachesPlatform(t *testing.T) {
+	w, found := rtfLinkDebugWindow(t)
+	p := &rtfURLCapturePlatform{}
+	w.nativePlatform = p
+
+	rtfOpenLink(w, "https://example.com/a", "")
+
+	if p.opened != "https://example.com/a" {
+		t.Fatalf("OpenURI = %q, want the link", p.opened)
+	}
+	if len(*found) != 0 {
+		t.Fatalf("unexpected findings: %v", *found)
+	}
+}
+
+// TestRtfOpenLinkRelativeIsReportedNotOpened asserts a relative link —
+// which markdown.IsSafeURL admits, so it renders as a link — is never
+// handed to OpenURI, whose allowlist would reject it silently.
+func TestRtfOpenLinkRelativeIsReportedNotOpened(t *testing.T) {
+	for _, link := range []string{
+		"/docs/x", "./y", "../z", "?q=1", "docs/x.md",
+	} {
+		w, found := rtfLinkDebugWindow(t)
+		p := &rtfURLCapturePlatform{}
+		w.nativePlatform = p
+
+		rtfOpenLink(w, link, "")
+
+		if p.opened != "" {
+			t.Errorf("link %q: OpenURI called with %q, want no call",
+				link, p.opened)
+		}
+		if len(*found) != 1 ||
+			!strings.Contains((*found)[0], link) {
+			t.Errorf("link %q: findings = %v, want one naming it",
+				link, *found)
+		}
+	}
+}
+
+// TestRtfOpenLinkPlatformErrorIsReported asserts a failing opener is
+// reported rather than discarded.
+func TestRtfOpenLinkPlatformErrorIsReported(t *testing.T) {
+	w, found := rtfLinkDebugWindow(t)
+	p := &rtfOpenErrPlatform{}
+	w.nativePlatform = p
+
+	rtfOpenLink(w, "https://example.com", "")
+
+	if p.calls != 1 {
+		t.Fatalf("OpenURI calls = %d, want 1", p.calls)
+	}
+	if len(*found) != 1 ||
+		!strings.Contains((*found)[0], "no handler") {
+		t.Fatalf("findings = %v, want one naming the error", *found)
+	}
+}
+
+// TestRtfOpenLinkUnknownAnchorIsReported asserts an anchor naming no
+// shape reports instead of falling through to the platform.
+func TestRtfOpenLinkUnknownAnchorIsReported(t *testing.T) {
+	w, found := rtfLinkDebugWindow(t)
+	p := &rtfURLCapturePlatform{}
+	w.nativePlatform = p
+
+	rtfOpenLink(w, "#nowhere", "md")
+
+	if p.opened != "" {
+		t.Fatalf("OpenURI called with %q, want no call", p.opened)
+	}
+	if len(*found) != 1 ||
+		!strings.Contains((*found)[0], "#nowhere") {
+		t.Fatalf("findings = %v, want one naming the anchor", *found)
+	}
+}
+
+// TestShowLinkContextMenuCarriesMarkdownID asserts the document scope
+// travels into the menu state: the Action callback runs with no RTF
+// layout in reach, so it cannot read TC.markdownID back.
+func TestShowLinkContextMenuCarriesMarkdownID(t *testing.T) {
+	w := newTestWindow()
+	showLinkContextMenu(w, "#heading", 10, 20, 7, "panel:md")
+
+	st := StateReadOr(
+		w, nsRtfLinkMenu, nsRtfLinkMenu, rtfLinkMenuState{})
+	if st.MarkdownID != "panel:md" {
+		t.Fatalf("MarkdownID = %q, want %q", st.MarkdownID, "panel:md")
+	}
+}
+
+// TestRtfLinkMenuOpenAnchorScrollsToView is the issue's repro: right-
+// click an in-document anchor, choose "Open Link", and the view must
+// scroll the same way a left-click does. Before the fix the menu
+// action handed "#heading" to OpenURI, which rejected it.
+func TestRtfLinkMenuOpenAnchorScrollsToView(t *testing.T) {
+	w := mdAnchorWindow(t, mdAnchorSource, false, false, false)
+
+	block, ok := mdAnchorFindBlock(&w.layout, "view:md", "jump")
+	if !ok {
+		t.Fatal("no link block in the window")
+	}
+	x, y := block.Shape.X+15, block.Shape.Y+10
+	w.EventFn(&Event{Type: EventMouseDown, MouseButton: MouseRight,
+		MouseX: x, MouseY: y})
+	w.settle()
+
+	st := StateReadOr(
+		w, nsRtfLinkMenu, nsRtfLinkMenu, rtfLinkMenuState{})
+	if !st.Open || st.Link != "#heading" {
+		t.Fatalf("menu state = %+v, want open on #heading", st)
+	}
+
+	if _, before, err := w.TestScrollOffset("view"); err != nil {
+		t.Fatalf("scroll offset before: %v", err)
+	} else if before != 0 {
+		t.Fatalf("scroll offset before = %g, want 0", before)
+	}
+
+	if err := w.TestClick(
+		ScopeID(rtfLinkMenuFocusID, "open_link")); err != nil {
+		t.Fatalf("click Open Link: %v", err)
+	}
+	w.settle()
+
+	_, after, err := w.TestScrollOffset("view")
+	if err != nil {
+		t.Fatalf("scroll offset after: %v", err)
+	}
+	// scrollToView pins the target to the container top; the sign of
+	// the resulting offset is the scroll system's, so assert movement.
+	if after == 0 {
+		t.Fatalf("scroll offset after = 0, want the view moved")
+	}
+}
+
+// TestRtfOpenLinkTrimsWhitespace asserts a link the render gate saw as
+// an anchor (markdown.IsSafeURL trims before classifying) still takes
+// the anchor branch here, rather than reading the leading space and
+// reporting the link as unopenable.
+func TestRtfOpenLinkTrimsWhitespace(t *testing.T) {
+	w := mdAnchorWindow(t, mdAnchorSource, false, false, false)
+	prevOn := DebugEnabled()
+	Debug(true)
+	defer Debug(prevOn)
+	var found []string
+	w.debug.collect = &found
+
+	rtfOpenLink(w, "  #heading\n", "view:md")
+
+	if len(found) != 0 {
+		t.Fatalf("findings = %v, want none", found)
+	}
+	if _, sy, err := w.TestScrollOffset("view"); err != nil {
+		t.Fatalf("scroll offset: %v", err)
+	} else if sy == 0 {
+		t.Fatal("padded anchor did not scroll the container")
+	}
+}
+
+// TestRtfOpenLinkBlankLinkIsInert asserts an empty or whitespace-only
+// link reports nothing and calls nothing: there is no user mistake to
+// name and no target to reach.
+func TestRtfOpenLinkBlankLinkIsInert(t *testing.T) {
+	for _, link := range []string{"", "   "} {
+		w, found := rtfLinkDebugWindow(t)
+		p := &rtfURLCapturePlatform{}
+		w.nativePlatform = p
+
+		rtfOpenLink(w, link, "")
+
+		if p.opened != "" || len(*found) != 0 {
+			t.Errorf("link %q: opened %q, findings %v; want neither",
+				link, p.opened, *found)
+		}
+	}
+}
+
+// TestRtfOpenLinkNilPlatformIsInert asserts the headless case — tests
+// and any window with no native platform injected — neither panics nor
+// reports: the link is fine, the opener is simply absent.
+func TestRtfOpenLinkNilPlatformIsInert(t *testing.T) {
+	w, found := rtfLinkDebugWindow(t)
+	w.nativePlatform = nil
+
+	rtfOpenLink(w, "https://example.com", "")
+
+	if len(*found) != 0 {
+		t.Fatalf("findings = %v, want none", *found)
+	}
+}
+
+// TestRtfOpenLinkReportIsBounded asserts a long link is shortened
+// before it becomes a message and a warn-once key: link text is the
+// document author's, and the key is retained for the window's life.
+func TestRtfOpenLinkReportIsBounded(t *testing.T) {
+	w, found := rtfLinkDebugWindow(t)
+	long := "/docs/" + strings.Repeat("x", 4096)
+
+	rtfOpenLink(w, long, "")
+
+	if len(*found) != 1 {
+		t.Fatalf("findings = %d, want 1", len(*found))
+	}
+	if len((*found)[0]) > rtfLinkMaxReportLen+200 {
+		t.Fatalf("finding is %d bytes, want the link shortened",
+			len((*found)[0]))
+	}
+	if !strings.Contains((*found)[0], "...") {
+		t.Fatalf("finding = %q, want the shortened marker", (*found)[0])
+	}
+}
+
+// TestRtfOpenLinkReportsOncePerLink asserts the warn-once key is the
+// link, so a repeatedly clicked bad link does not flood stderr.
+func TestRtfOpenLinkReportsOncePerLink(t *testing.T) {
+	w, found := rtfLinkDebugWindow(t)
+
+	rtfOpenLink(w, "/docs/x", "")
+	rtfOpenLink(w, "/docs/x", "")
+	rtfOpenLink(w, "/docs/y", "")
+
+	if len(*found) != 2 {
+		t.Fatalf("findings = %v, want one per distinct link", *found)
+	}
+}
+
+// TestRtfLinkIsOpenable pins the scheme allowlist mirrored from
+// nativehost.ValidateOpenURI, including the case-insensitivity a URI
+// scheme has and the schemes that must never reach the opener.
+func TestRtfLinkIsOpenable(t *testing.T) {
+	for link, want := range map[string]bool{
+		"http://a":    true,
+		"HTTPS://a":   true,
+		"MailTo:a@b":  true,
+		"http:/a":     false,
+		"httpx://a":   false,
+		"javascript:": false,
+		"file:///a":   false,
+		"#a":          false,
+		"/a":          false,
+		"":            false,
+		"htt":         false,
+	} {
+		if got := rtfLinkIsOpenable(link); got != want {
+			t.Errorf("rtfLinkIsOpenable(%q) = %v, want %v",
+				link, got, want)
+		}
+	}
+}
+
+// TestRtfSelectLinkClickDoesNotArmDrag is the reported symptom: in a
+// selectable RTF the link click armed drag-select as well as
+// navigating. The lock survives the release — the release lands on
+// whatever the navigation put under the pointer — so moving the mouse
+// afterwards kept extending the selection with no button held.
+func TestRtfSelectLinkClickDoesNotArmDrag(t *testing.T) {
+	h := newRtfSelectHarness(t, rtfTwoRuns())
+	h.w.SetNativePlatform(&rtfURLCapturePlatform{})
+
+	x, y := rtfRunePoint(h.shape(t), 8) // inside the link run
+	h.press(x, y)
+
+	if h.w.mouseIsLocked() {
+		t.Fatal("link click armed drag-select")
+	}
+
+	// The pointer moves with no button held. Nothing may extend the
+	// selection the click collapsed.
+	h.release(x, y)
+	x0, y0 := rtfRunePoint(h.shape(t), 0)
+	h.move(x0, y0)
+	expectRtfSel(t, h, 8, 8)
+}
+
+// TestRtfSelectPlainClickStillArmsDrag is the other half: a click on a
+// non-link run must keep locking the mouse, or the fix above would
+// have taken drag-select away from the widget entirely.
+func TestRtfSelectPlainClickStillArmsDrag(t *testing.T) {
+	h := newRtfSelectHarness(t, rtfTwoRuns())
+
+	x, y := rtfRunePoint(h.shape(t), 2) // inside the plain run
+	h.press(x, y)
+
+	if !h.w.mouseIsLocked() {
+		t.Fatal("plain click did not arm drag-select")
+	}
+	h.release(x, y)
+}

--- a/gui/rtf_select_interaction_test.go
+++ b/gui/rtf_select_interaction_test.go
@@ -898,9 +898,8 @@ func TestRtfSelectScrollDragEdgeScrolls(t *testing.T) {
 	}
 
 	// Drag below the viewport (y=810): arms edge scroll. The mouse is
-	// far below both text lines, so the x coordinate resolves within
-	// the nearest (second) line: window x = ShapeX + byte*10 + 5 with
-	// byte 19 ('e' of "beta") at the cursor.
+	// far below both text lines, so the drag takes the last line whole
+	// (textDragEdgeX) and the column under the cursor stops mattering.
 	const dragX = 86.5
 	move(dragX, 810)
 	if !w.HasAnimation(animIDTextDragScroll) {
@@ -923,9 +922,26 @@ func TestRtfSelectScrollDragEdgeScrolls(t *testing.T) {
 			y, preDragY)
 	}
 	is = StateReadOr(w, nsInput, "view:rtf", inputState{})
-	if is.selectBeg != 2 || is.selectEnd != 19 {
-		t.Errorf("selection after tick = [%d,%d), want [2,19)",
+	if is.selectBeg != 2 || is.selectEnd != 22 {
+		t.Errorf("selection after tick = [%d,%d), want [2,22) — "+
+			"a drag below the text takes the last line whole",
 			is.selectBeg, is.selectEnd)
+	}
+
+	// Drag back onto the press point, which the scroll moved up the
+	// window: the selection must collapse to rune 2 again. This is
+	// what proves the ShapeX/ShapeY/scrollDelta translation survives
+	// the container scrolling under the cursor — the edge-clamped
+	// assertions above no longer read the column.
+	//
+	// The animation moved the offset without a re-arrange, so the drag
+	// path — not the layout — carries the delta: the press point is
+	// now that much further up the window.
+	move(x0, y0+(y-preDragY))
+	is = StateReadOr(w, nsInput, "view:rtf", inputState{})
+	if is.selectBeg != 2 || is.selectEnd != 2 {
+		t.Errorf("selection back at the press point = [%d,%d), "+
+			"want [2,2)", is.selectBeg, is.selectEnd)
 	}
 
 	// Dragging back inside the viewport disarms the animation.
@@ -942,8 +958,8 @@ func TestRtfSelectScrollDragEdgeScrolls(t *testing.T) {
 		t.Error("edge-scroll animation survived the release")
 	}
 	is = StateReadOr(w, nsInput, "view:rtf", inputState{})
-	if is.selectBeg != 2 || is.selectEnd != 19 {
-		t.Errorf("selection after release = [%d,%d), want [2,19)",
+	if is.selectBeg != 2 || is.selectEnd != 22 {
+		t.Errorf("selection after release = [%d,%d), want [2,22)",
 			is.selectBeg, is.selectEnd)
 	}
 }

--- a/gui/text_drag_edge_test.go
+++ b/gui/text_drag_edge_test.go
@@ -1,0 +1,331 @@
+package gui
+
+// text_drag_edge_test.go covers the drag hit test once the pointer has
+// left the text: a drag carried above the text takes its first line
+// through the beginning, and one carried below takes its last line
+// through the end, instead of stopping at the pointer's column.
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+// mdDragText is two lines of 10px chars, laid out by the RTF
+// selection suite's measurer: line 1 at y [0,20), line 2 at y [20,40).
+const mdDragText = "alpha beta\ngamma delta"
+
+// TestTextDragEdgeX pins the helper both drag paths share: inside the
+// band the column is the pointer's, outside it the drag reaches past
+// one end of the line.
+func TestTextDragEdgeX(t *testing.T) {
+	const top, bot = 0, 40
+	for _, tc := range []struct {
+		name string
+		x, y float32
+		want float32
+	}{
+		{name: "inside_top_edge", x: 33, y: 0, want: 33},
+		{name: "inside", x: 33, y: 20, want: 33},
+		{name: "inside_bottom_edge", x: 33, y: 40, want: 33},
+		{name: "above", x: 33, y: -1, want: -textDragReach},
+		{name: "far_above", x: 33, y: -900, want: -textDragReach},
+		{name: "below", x: 33, y: 41, want: textDragReach},
+		{name: "far_below", x: 33, y: 900, want: textDragReach},
+	} {
+		if got := textDragEdgeX(tc.x, tc.y, top, bot); got != tc.want {
+			t.Errorf("%s: textDragEdgeX(%g, %g) = %g, want %g",
+				tc.name, tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+// TestGlyphTextBand covers both the ordinary band and the one an
+// empty layout reports: no lines means an empty band at the origin,
+// which is harmless because a layout with no lines has no offset but
+// zero to return either way.
+func TestGlyphTextBand(t *testing.T) {
+	gl := rtfSelCharLayout(mdDragText, nil)
+	if top, bot := glyphTextBand(&gl); top != 0 || bot != 40 {
+		t.Errorf("band = [%g,%g), want [0,40)", top, bot)
+	}
+	if top, bot := glyphTextBand(&glyph.Layout{}); top != 0 || bot != 0 {
+		t.Errorf("empty band = [%g,%g), want [0,0)", top, bot)
+	}
+}
+
+// TestRtfSelectDragAboveTakesFirstLineWhole is the reported symptom:
+// the drag leaves the top of the paragraph, so the first line must be
+// selected through its beginning, not to the column the pointer left
+// at. The pointer sits at column 3, which is what the old behaviour
+// returned.
+func TestRtfSelectDragAboveTakesFirstLineWhole(t *testing.T) {
+	h := newRtfSelectHarness(t, RichText{Runs: []RichTextRun{
+		{Text: mdDragText, Style: TextStyle{Size: 14}},
+	}})
+	ly := h.shape(t)
+
+	// Press rune 15 ('a' of "delta"), line 2 at local y=30.
+	h.press(ly.Shape.X+45, ly.Shape.Y+30)
+	// Drag above the text, still at column 3.
+	h.move(ly.Shape.X+35, ly.Shape.Y-40)
+
+	expectRtfSel(t, h, 15, 0)
+}
+
+// TestRtfSelectDragBelowTakesLastLineWhole is the same case downward:
+// the last line runs to its end, rune 22.
+func TestRtfSelectDragBelowTakesLastLineWhole(t *testing.T) {
+	h := newRtfSelectHarness(t, RichText{Runs: []RichTextRun{
+		{Text: mdDragText, Style: TextStyle{Size: 14}},
+	}})
+	ly := h.shape(t)
+
+	// Press rune 3 ('h' of "alpha"), line 1 at local y=10.
+	h.press(ly.Shape.X+35, ly.Shape.Y+10)
+	// Drag below the text, still at column 3.
+	h.move(ly.Shape.X+35, ly.Shape.Y+140)
+
+	expectRtfSel(t, h, 3, 22)
+}
+
+// TestRtfSelectDragInsideKeepsColumn is the other half: while the
+// pointer is still over the text, the column decides the position, so
+// the edge rule cannot swallow an ordinary drag.
+func TestRtfSelectDragInsideKeepsColumn(t *testing.T) {
+	h := newRtfSelectHarness(t, RichText{Runs: []RichTextRun{
+		{Text: mdDragText, Style: TextStyle{Size: 14}},
+	}})
+	ly := h.shape(t)
+
+	h.press(ly.Shape.X+5, ly.Shape.Y+10)
+	// Line 2 ('m' of "gamma", byte 13 → rune 13), column 2.
+	h.move(ly.Shape.X+25, ly.Shape.Y+30)
+
+	expectRtfSel(t, h, 0, 13)
+}
+
+// mdDragBlocks lays two paragraphs out one under the other, 10px
+// apart, the way markdownBlockAmendSel records them: block 0 at
+// y [0,40), block 1 at y [50,90).
+func mdDragBlocks() []mdBlockInfo {
+	gl := rtfSelCharLayout(mdDragText, nil)
+	runes := uint32(utf8RuneCount(mdDragText))
+	return []mdBlockInfo{
+		{FlatText: mdDragText, Layout: gl, H: 40, StartRune: 0,
+			RuneLen: runes, ShapeX: 0, ShapeY: 0},
+		{FlatText: mdDragText, Layout: gl, H: 40, StartRune: runes,
+			RuneLen: runes, ShapeX: 0, ShapeY: 50},
+	}
+}
+
+// TestMdHitAbsRuneOutsideBlockTakesLineWhole covers the markdown drag
+// path, where a paragraph is one block among several: above the first
+// block the hit is the start of its first line, below the last block
+// the end of its last line, and in the gap between two blocks the end
+// of the block above — the block the hit test picks there.
+func TestMdHitAbsRuneOutsideBlockTakesLineWhole(t *testing.T) {
+	blocks := mdDragBlocks()
+	runes := uint32(utf8RuneCount(mdDragText))
+	// Column 3 in every case: the old behaviour returned it.
+	const x = 35
+
+	for _, tc := range []struct {
+		name string
+		y    float32
+		want uint32
+	}{
+		{name: "above_first_block", y: -30, want: 0},
+		{name: "in_the_gap", y: 45, want: runes},
+		{name: "below_last_block", y: 200, want: runes * 2},
+		{name: "inside_first_block", y: 10, want: 3},
+	} {
+		got := mdHitAbsRune(x, tc.y, blocks,
+			glyph.Layout{}, "", 0)
+		if got != tc.want {
+			t.Errorf("%s: mdHitAbsRune(y=%g) = %d, want %d",
+				tc.name, tc.y, got, tc.want)
+		}
+	}
+}
+
+// TestInputDragStateDragEdge covers the Input path, which reads its
+// band from the drag state's own layout copy: a drag above the field's
+// text takes the first line through its beginning, one below takes the
+// last line through its end.
+func TestInputDragStateDragEdge(t *testing.T) {
+	// Two lines of two chars, 10px wide each: line 1 y [0,9),
+	// line 2 y [9,20).
+	text := "abcd"
+	gl := glyph.Layout{
+		Lines: []glyph.Line{
+			{StartIndex: 0, Length: 2,
+				Rect: glyph.Rect{X: 0, Y: 0, Width: 20, Height: 9}},
+			{StartIndex: 2, Length: 2,
+				Rect: glyph.Rect{X: 0, Y: 9, Width: 20, Height: 11}},
+		},
+		CharRectByIndex: map[int]int{0: 0, 1: 1, 2: 2, 3: 3},
+		CharRects: []glyph.CharRect{
+			{Rect: glyph.Rect{X: 0, Y: 0, Width: 10, Height: 9}, Index: 0},
+			{Rect: glyph.Rect{X: 10, Y: 0, Width: 10, Height: 9}, Index: 1},
+			{Rect: glyph.Rect{X: 0, Y: 9, Width: 10, Height: 11}, Index: 2},
+			{Rect: glyph.Rect{X: 10, Y: 9, Width: 10, Height: 11}, Index: 3},
+		},
+		// A real shaped layout carries a cursor position past the last
+		// character; GetClosestOffset returns a line's end only where
+		// one exists, so the fixture must have it too.
+		LogAttrs: []glyph.LogAttr{
+			{IsCursorPosition: true}, {IsCursorPosition: true},
+			{IsCursorPosition: true}, {IsCursorPosition: true},
+			{IsCursorPosition: true},
+		},
+		LogAttrByIndex: map[int]int{0: 0, 1: 1, 2: 2, 3: 3, 4: 4},
+	}
+	w := newTestWindow()
+	d := &inputDragState{displayText: text, gl: gl}
+
+	// Above the text at column 1: the whole first line, so rune 0.
+	if got := d.computeRunePos(15, -5, w); got != 0 {
+		t.Errorf("above = %d, want 0", got)
+	}
+	// Below the text at column 0: the whole last line, so rune 4.
+	if got := d.computeRunePos(5, 30, w); got != 4 {
+		t.Errorf("below = %d, want 4", got)
+	}
+	// Still over the text: the column decides, unchanged.
+	if got := d.computeRunePos(15, 4, w); got != 1 {
+		t.Errorf("inside = %d, want 1", got)
+	}
+}
+
+// TestMdHitAbsRuneFallbackTakesLineWhole covers mdHitAbsRune's
+// no-blocks path, which hits the widget's own layout directly. The
+// edge rule has to reach it too, or a markdown widget whose blocks
+// were never recorded keeps the old mid-line behaviour.
+func TestMdHitAbsRuneFallbackTakesLineWhole(t *testing.T) {
+	gl := rtfSelCharLayout(mdDragText, nil)
+	runes := uint32(utf8RuneCount(mdDragText))
+
+	if got := mdHitAbsRune(35, -40, nil, gl, mdDragText, 0); got != 0 {
+		t.Errorf("above = %d, want 0", got)
+	}
+	if got := mdHitAbsRune(35, 140, nil, gl, mdDragText, 0); got != runes {
+		t.Errorf("below = %d, want %d", got, runes)
+	}
+	if got := mdHitAbsRune(25, 30, nil, gl, mdDragText, 0); got != 13 {
+		t.Errorf("inside = %d, want 13", got)
+	}
+}
+
+// --- Text widget ---
+//
+// The Text widget's existing drag tests (view_text_select_test.go)
+// build their window with no text measurer, so the click path takes
+// its char-width fallback: a single line, no glyph geometry, and so no
+// band for the edge rule to leave. These three drive the same widget
+// through EventFn with a measurer installed, which is what puts real
+// lines under the drag.
+
+// textDragMeasurer shapes plain text with the deterministic
+// 10x20-per-byte layout the RTF suite uses, so a column and a line are
+// exact pixel counts. Only LayoutText differs from the RTF measurer it
+// embeds: that one returns a bare height, which inputGlyphLayout
+// reports as ok=false, dropping the widget back to the fallback above.
+type textDragMeasurer struct{ rtfSelTestMeasurer }
+
+func (textDragMeasurer) LayoutText(
+	text string, _ TextStyle, _ float32,
+) (glyph.Layout, error) {
+	return rtfSelCharLayout(text, nil), nil
+}
+
+// newTextDragWindow renders one focusable Text filling the window,
+// measured by textDragMeasurer. It is newTextSelWindow with the
+// measurer installed before the render, which the layout needs: a
+// single-line Text is one line box high whatever its text says, so a
+// press on the second line would fall outside the shape and never
+// reach the widget. Wrap mode sizes the shape from the glyph layout
+// instead.
+func newTextDragWindow(t *testing.T, text string) (*Window, *Layout) {
+	t.Helper()
+	w := NewTestWindow(WindowCfg{Width: 800, Height: 800})
+	w.textMeasurer = textDragMeasurer{}
+	w.TestRender(func(_ *Window) View {
+		return Text(TextCfg{
+			ID: "txtdrag", Text: text, Focusable: true,
+			Mode: TextModeWrap, TextStyle: TextStyle{Size: 14},
+		})
+	})
+	ly, ok := w.layout.FindByID("txtdrag")
+	if !ok {
+		t.Fatal("no text with effective ID txtdrag")
+	}
+	return w, ly
+}
+
+// textDragMouse dispatches one mouse event and settles the frame.
+func textDragMouse(
+	w *Window, typ EventType, btn MouseButton, x, y float32,
+) {
+	e := Event{Type: typ, MouseButton: btn, MouseX: x, MouseY: y}
+	w.EventFn(&e)
+	w.settle()
+}
+
+// expectTextDragSel asserts the selection the dragged widget holds.
+// A backward drag is stored anchor-first, so beg > end is expected
+// there rather than normalised.
+func expectTextDragSel(t *testing.T, w *Window, beg, end uint32) {
+	t.Helper()
+	is := getInputState(w, "txtdrag")
+	if is.selectBeg != beg || is.selectEnd != end {
+		t.Errorf("selection = [%d,%d), want [%d,%d)",
+			is.selectBeg, is.selectEnd, beg, end)
+	}
+}
+
+// TestTextDragInsideKeepsColumn is the control: while the pointer is
+// over the text the column decides where the selection ends, so the
+// edge rule cannot swallow an ordinary drag. It also pins the fixture
+// — press and move both map to the rune the geometry says.
+func TestTextDragInsideKeepsColumn(t *testing.T) {
+	w, ly := newTextDragWindow(t, mdDragText)
+
+	textDragMouse(w, EventMouseDown, MouseLeft,
+		ly.Shape.X+5, ly.Shape.Y+10)
+	// Line 2 ('m' of "gamma", byte 13 → rune 13), column 2.
+	textDragMouse(w, EventMouseMove, MouseInvalid,
+		ly.Shape.X+25, ly.Shape.Y+30)
+
+	expectTextDragSel(t, w, 0, 13)
+}
+
+// TestTextDragAboveTakesFirstLineWhole is the reported symptom on the
+// Text path: the drag leaves the top of the text, so the first line
+// is selected through its beginning, not to the column the pointer
+// left at (column 3, which is what the old behaviour returned).
+func TestTextDragAboveTakesFirstLineWhole(t *testing.T) {
+	w, ly := newTextDragWindow(t, mdDragText)
+
+	// Press rune 15 ('a' of "delta") on line 2.
+	textDragMouse(w, EventMouseDown, MouseLeft,
+		ly.Shape.X+45, ly.Shape.Y+30)
+	textDragMouse(w, EventMouseMove, MouseInvalid,
+		ly.Shape.X+35, ly.Shape.Y-40)
+
+	expectTextDragSel(t, w, 15, 0)
+}
+
+// TestTextDragBelowTakesLastLineWhole is the same case downward: the
+// last line runs to its end, rune 22.
+func TestTextDragBelowTakesLastLineWhole(t *testing.T) {
+	w, ly := newTextDragWindow(t, mdDragText)
+
+	// Press rune 3 ('h' of "alpha") on line 1.
+	textDragMouse(w, EventMouseDown, MouseLeft,
+		ly.Shape.X+35, ly.Shape.Y+10)
+	textDragMouse(w, EventMouseMove, MouseInvalid,
+		ly.Shape.X+35, ly.Shape.Y+140)
+
+	expectTextDragSel(t, w, 3, 22)
+}

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -194,8 +194,12 @@ func (d *inputDragState) computeRunePos(
 		sNow := sy.GetOr(d.scrollID, 0)
 		scrollDelta = sNow - d.scrollY0
 	}
-	relX := mx - d.txtOffX
 	relY := my - (d.txtOffY + scrollDelta)
+	// A drag carried above or below the text selects to the line's
+	// edge rather than stopping at the pointer's column; see
+	// textDragEdgeX.
+	top, bot := glyphTextBand(&d.gl)
+	relX := textDragEdgeX(mx-d.txtOffX, relY, top, bot)
 	byteIdx := d.gl.GetClosestOffset(relX, relY)
 	return byteToRuneIndex(d.displayText, byteIdx)
 }

--- a/gui/view_rtf.go
+++ b/gui/view_rtf.go
@@ -482,40 +482,138 @@ func rtfTooltipView(ts *tooltipState) View {
 }
 
 func rtfOnClick(ctx EventCtx) {
+	rtfClickLink(ctx)
+}
+
+// rtfClickLink activates the link under the pointer, if there is one,
+// and reports whether it took the click. A selectable RTF needs the
+// answer: a click that navigated must not also start a drag-select,
+// which would lock the mouse and leave the caller tracking the pointer
+// after the button is released (the release lands on whatever the
+// navigation put in front, so the lock is never lifted).
+func rtfClickLink(ctx EventCtx) bool {
 	if !ctx.Layout.Shape.hasRtfLayout() {
-		return
+		return false
 	}
 	layout := ctx.Layout.Shape.TC.rTFLayout
 	for _, run := range layout.Items {
 		if run.IsObject {
 			continue
 		}
-		if rtfHitTest(run, ctx.Event.MouseX, ctx.Event.MouseY) {
-			found := rtfFindRunAtIndex(ctx.Layout, run.StartIndex)
-			if found.Link != "" && markdown.IsSafeURL(found.Link) {
-				if ctx.Event.MouseButton == MouseRight {
-					showLinkContextMenu(ctx.Window, found.Link,
-						ctx.Event.MouseX,
-						ctx.Event.MouseY,
-						rtfRunsKey(ctx.Layout.Shape.TC.rTFRuns))
-					ctx.Consume()
-					return
-				}
-				if len(found.Link) > 0 &&
-					found.Link[0] == '#' {
-					if id, ok := rtfResolveAnchor(ctx.Window,
-						ctx.Layout.Shape.TC.markdownID,
-						found.Link[1:]); ok {
-						ctx.Window.scrollToView(id)
-					}
-				} else if ctx.Window.nativePlatform != nil {
-					_ = ctx.Window.nativePlatform.OpenURI(found.Link)
-				}
-				ctx.Consume()
-			}
+		if !rtfHitTest(run, ctx.Event.MouseX, ctx.Event.MouseY) {
+			continue
+		}
+		found := rtfFindRunAtIndex(ctx.Layout, run.StartIndex)
+		if found.Link == "" || !markdown.IsSafeURL(found.Link) {
+			return false
+		}
+		if ctx.Event.MouseButton == MouseRight {
+			showLinkContextMenu(ctx.Window, found.Link,
+				ctx.Event.MouseX,
+				ctx.Event.MouseY,
+				rtfRunsKey(ctx.Layout.Shape.TC.rTFRuns),
+				ctx.Layout.Shape.TC.markdownID)
+			ctx.Consume()
+			return true
+		}
+		rtfOpenLink(ctx.Window, found.Link,
+			ctx.Layout.Shape.TC.markdownID)
+		ctx.Consume()
+		return true
+	}
+	return false
+}
+
+// rtfOpenLink activates a link the user clicked or chose "Open Link"
+// on. It is the single activation path: left-click and the context
+// menu both route here, so an in-document anchor behaves the same way
+// from either. markdownID scopes the anchor lookup (see
+// [rtfResolveAnchor]); it is "" for a standalone RTF block.
+//
+// Three kinds of link reach this point, because the render gate
+// (markdown.IsSafeURL) admits all three:
+//
+//   - '#slug' — scroll the named target into view.
+//   - http/https/mailto — hand to the platform opener.
+//   - anything else (relative paths, '?query') — nothing the widget
+//     can act on. There is no document base URI to resolve against, so
+//     the link is reported and dropped rather than handed to OpenURI,
+//     which rejects every scheme outside the allowlist anyway.
+//
+// Failures are reported through the [Debug] gate; a link that will not
+// open is a development-time mistake, not something the frame can act
+// on at runtime.
+func rtfOpenLink(w *Window, link, markdownID string) {
+	// markdown.IsSafeURL classifies the trimmed link, so " #slug" is
+	// rendered as an anchor. Trim here too, or the branch below reads
+	// the space and the anchor is reported as unopenable.
+	link = strings.TrimSpace(link)
+	if link == "" {
+		return
+	}
+	if link[0] == '#' {
+		if id, ok := rtfResolveAnchor(w, markdownID, link[1:]); ok {
+			w.scrollToView(id)
 			return
 		}
+		short := rtfLinkShort(link)
+		w.debugWarn(debugCheckLinkNotOpened, short,
+			"link %q names no target in this window "+
+				"(anchor unresolved)", short)
+		return
 	}
+	if !rtfLinkIsOpenable(link) {
+		short := rtfLinkShort(link)
+		w.debugWarn(debugCheckLinkNotOpened, short,
+			"link %q is relative; the platform opener takes only "+
+				"http, https and mailto URIs, and the widget has no "+
+				"base URI to resolve against", short)
+		return
+	}
+	if w.nativePlatform == nil {
+		return
+	}
+	if err := w.nativePlatform.OpenURI(link); err != nil {
+		short := rtfLinkShort(link)
+		w.debugWarn(debugCheckLinkNotOpened, short,
+			"link %q could not be opened: %v", short, err)
+	}
+}
+
+// rtfLinkMaxReportLen caps the link text a diagnostic carries. A link
+// comes from the rendered document, so its length is the document
+// author's choice, and the warn-once key is retained for the life of
+// the window: a document full of long links would otherwise grow the
+// warn map by their full size.
+const rtfLinkMaxReportLen = 120
+
+// rtfLinkShort caps a link for a diagnostic. The shortened text is
+// both the message and the warn-once key, so one bad link reports once
+// per window and the retained key stays bounded.
+func rtfLinkShort(link string) string {
+	if len(link) > rtfLinkMaxReportLen {
+		return link[:rtfLinkMaxReportLen] + "..."
+	}
+	return link
+}
+
+// rtfLinkOpenableSchemes mirrors the scheme allowlist in
+// nativehost.ValidateOpenURI, which lives in a backend-internal
+// package the gui package cannot import. Package level so the
+// activation path ranges over it without copying the array.
+var rtfLinkOpenableSchemes = [...]string{
+	"http://", "https://", "mailto:",
+}
+
+// rtfLinkIsOpenable reports whether the platform opener accepts link.
+func rtfLinkIsOpenable(link string) bool {
+	for _, scheme := range &rtfLinkOpenableSchemes {
+		if len(link) >= len(scheme) &&
+			strings.EqualFold(link[:len(scheme)], scheme) {
+			return true
+		}
+	}
+	return false
 }
 
 // rtfResolveAnchor resolves an in-document anchor ('#slug') to the
@@ -545,11 +643,15 @@ func rtfResolveAnchor(
 
 // rtfLinkMenuState holds state for the RTF link context menu.
 type rtfLinkMenuState struct {
-	Link     string
-	BlockKey uint64 // identifies the owning RTF block
-	X        float32
-	Y        float32
-	Open     bool
+	Link string
+	// MarkdownID scopes an anchor link's target lookup, captured from
+	// the owning block when the menu opened. The Action callback runs
+	// with no RTF layout in reach, so it cannot read it back.
+	MarkdownID string
+	BlockKey   uint64 // identifies the owning RTF block
+	X          float32
+	Y          float32
+	Open       bool
 }
 
 // Absolute: the popup is generated as a child of the RTF block, so a
@@ -562,16 +664,17 @@ const rtfLinkMenuFocusID = "gui:rtf:link_menu"
 // showLinkContextMenu opens a context menu for an RTF link.
 func showLinkContextMenu(
 	w *Window, link string, mx, my float32,
-	blockKey uint64,
+	blockKey uint64, markdownID string,
 ) {
 	sm := StateMap[string, rtfLinkMenuState](
 		w, nsRtfLinkMenu, capFew)
 	sm.Set(nsRtfLinkMenu, rtfLinkMenuState{
-		Open:     true,
-		Link:     link,
-		X:        mx,
-		Y:        my,
-		BlockKey: blockKey,
+		Open:       true,
+		Link:       link,
+		MarkdownID: markdownID,
+		X:          mx,
+		Y:          my,
+		BlockKey:   blockKey,
 	})
 	w.SetFocus(rtfLinkMenuFocusID)
 }
@@ -590,6 +693,7 @@ func rtfLinkMenuDismiss(w *Window) {
 // for RTF link right-click.
 func rtfLinkMenuView(w *Window, st rtfLinkMenuState) View {
 	link := st.Link
+	markdownID := st.MarkdownID
 	return menu(w, MenubarCfg{
 		ID: rtfLinkMenuFocusID,
 		Items: []MenuItemCfg{
@@ -599,9 +703,8 @@ func rtfLinkMenuView(w *Window, st rtfLinkMenuState) View {
 		Action: func(id string, ctx EventCtx) {
 			switch id {
 			case "open_link":
-				if ctx.Window.nativePlatform != nil &&
-					markdown.IsSafeURL(link) {
-					_ = ctx.Window.nativePlatform.OpenURI(link)
+				if markdown.IsSafeURL(link) {
+					rtfOpenLink(ctx.Window, link, markdownID)
 				}
 			case "copy_link":
 				ctx.Window.SetClipboard(link)

--- a/gui/view_rtf_select.go
+++ b/gui/view_rtf_select.go
@@ -28,7 +28,10 @@ func rtfMarkdownAmendLayout(ctx EventCtx) {
 // rtfSelectOnClick handles clicks for an RTF widget with selection enabled.
 // Link navigation (rtfOnClick) runs first; selection state is always updated.
 func rtfSelectOnClick(ctx EventCtx) {
-	rtfOnClick(ctx)
+	// A link click still collapses the selection under the pointer, the
+	// way a browser drops the old highlight — but it must not arm the
+	// drag below. See the linkHit guard before MouseLock.
+	linkHit := rtfClickLink(ctx)
 	if ctx.Event.MouseButton == MouseRight {
 		return
 	}
@@ -76,6 +79,16 @@ func rtfSelectOnClick(ctx EventCtx) {
 	imap.Set(focusID, is)
 	ctx.Consume()
 
+	// The click activated a link, so it is spent: navigation owns it.
+	// Arming the drag here would lock the mouse for a release that
+	// never reaches this widget — the link opened a browser, scrolled
+	// the view away, or raised a context menu over the pointer — and
+	// the pointer would then keep extending the selection with no
+	// button held.
+	if linkHit {
+		return
+	}
+
 	anchorPos := is.selectBeg
 	anchorEnd := is.selectEnd
 	dragShapeX := shape.X
@@ -102,6 +115,10 @@ func rtfSelectOnClick(ctx EventCtx) {
 		}
 	}
 
+	// The drag extends to a line's edge once it leaves the text band;
+	// see textDragEdgeX.
+	dragTop, dragBot := glyphTextBand(gl)
+
 	computeRunePos := func(mx, my float32, w *Window) int {
 		scrollDelta := float32(0)
 		if scrollID != "" {
@@ -110,8 +127,8 @@ func rtfSelectOnClick(ctx EventCtx) {
 			sNow := sy.GetOr(scrollID, 0)
 			scrollDelta = sNow - dragScrollY0
 		}
-		rx := mx - dragShapeX
 		ry := my - (dragShapeY + scrollDelta)
+		rx := textDragEdgeX(mx-dragShapeX, ry, dragTop, dragBot)
 		bi := gl.GetClosestOffset(rx, ry)
 		return byteToRuneIndex(flatText, bi)
 	}

--- a/gui/view_rtf_test.go
+++ b/gui/view_rtf_test.go
@@ -651,7 +651,7 @@ func rtfLayoutCacheLen(w *Window) int {
 
 func TestShowLinkContextMenuSetsState(t *testing.T) {
 	w := newTestWindow()
-	showLinkContextMenu(w, "https://example.com", 50, 100, 42)
+	showLinkContextMenu(w, "https://example.com", 50, 100, 42, "")
 
 	st := StateReadOr(
 		w, nsRtfLinkMenu, nsRtfLinkMenu, rtfLinkMenuState{})
@@ -677,7 +677,7 @@ func TestShowLinkContextMenuSetsState(t *testing.T) {
 
 func TestRtfLinkMenuDismissClearsState(t *testing.T) {
 	w := newTestWindow()
-	showLinkContextMenu(w, "https://example.com", 50, 100, 0)
+	showLinkContextMenu(w, "https://example.com", 50, 100, 0, "")
 	rtfLinkMenuDismiss(w)
 
 	st := StateReadOr(
@@ -741,7 +741,7 @@ func TestRtfOnClickRightClickShowsMenu(t *testing.T) {
 
 func TestRtfAmendTooltipDismissesMenuOnFocusLoss(t *testing.T) {
 	w := newTestWindow()
-	showLinkContextMenu(w, "https://example.com", 50, 100, 0)
+	showLinkContextMenu(w, "https://example.com", 50, 100, 0, "")
 	// Simulate focus moving away.
 	w.ClearFocus()
 

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -11,6 +11,42 @@ const (
 	doubleClickThresholdMs = 400
 )
 
+// textDragReach is a horizontal distance no laid-out line can span,
+// used to push a drag hit test past one end of a line.
+const textDragReach = 1e6
+
+// textDragEdgeX widens a drag hit test that has left the text band.
+// glyph.GetClosestOffset snaps an out-of-band y to the nearest line
+// and then still reads the column from x, so a drag carried above a
+// paragraph stops part-way along its first line. Every platform's text
+// view instead selects through the beginning of that line going up,
+// and through the end of it going down, which is what pushing x past
+// the line's end produces. y, top and bottom are all in the glyph
+// layout's own coordinates. Inside the band x is returned unchanged,
+// so this only ever affects a drag that has left the text.
+func textDragEdgeX(x, y, top, bottom float32) float32 {
+	switch {
+	case y < top:
+		return -textDragReach
+	case y > bottom:
+		return textDragReach
+	}
+	return x
+}
+
+// glyphTextBand returns a laid-out text's vertical extent in its own
+// coordinates. An empty layout gives an empty band at the origin;
+// either edge then reads as out of band, which costs nothing because
+// a layout with no lines has no offset but zero to return.
+func glyphTextBand(l *glyph.Layout) (top, bottom float32) {
+	if len(l.Lines) == 0 {
+		return 0, 0
+	}
+	first := l.Lines[0].Rect
+	last := l.Lines[len(l.Lines)-1].Rect
+	return first.Y, last.Y + last.Height
+}
+
 // textOnClick handles click events for text selection.
 // Single-click places cursor, double-click selects word,
 // drag-to-select via MouseLock.
@@ -86,6 +122,10 @@ func textOnClick(ctx EventCtx) {
 	anchorEnd := is.selectEnd
 	dragGL := gl
 	dragGLOK := glOK
+	// The drag extends to a line's edge once it leaves the text band;
+	// see textDragEdgeX. Constant for the drag, so read it once here
+	// rather than on every mouse-move.
+	dragTop, dragBot := glyphTextBand(&dragGL)
 	dragFocusID := focusID
 	dragShapeX := shape.X
 	dragShapeY := shape.Y
@@ -124,8 +164,9 @@ func textOnClick(ctx EventCtx) {
 				sNow := sy.GetOr(scrollID, 0)
 				scrollDelta = sNow - dragScrollY0
 			}
-			rx := mx - dragShapeX
 			ry := my - (dragShapeY + scrollDelta)
+			rx := textDragEdgeX(mx-dragShapeX, ry,
+				dragTop, dragBot)
 			bi := dragGL.GetClosestOffset(rx, ry)
 			return byteToRuneIndex(text, bi)
 		}


### PR DESCRIPTION
Fixes #488.

Three related defects in RTF/markdown text, plus two cache dirs added to `.gitignore`.

### Link activation (#488)

The context menu's "Open Link" had no in-document-anchor branch, so activating an anchor opened nothing. A relative link passed `markdown.IsSafeURL` (the render gate) but then failed `nativehost.ValidateOpenURI` in silence, and a failed platform opener was silent too.

Both call sites now go through one `rtfOpenLink(w, link, markdownID)`:

- an in-document anchor scrolls into view
- a link no opener will take (relative, or a scheme outside http/https/mailto) reports through the existing `gui.Debug` gate
- an opener error reports the same way

Reported under `DebugCallbacks` rather than a new exported category, so `export-audit` stays flat, and via `debugWarn` so it is warn-once per subject.

### Link click in selectable text

Clicking a link in selectable RTF also armed the drag-select. The mouseup was consumed by the link path, so moving the mouse afterwards kept extending the selection with no button held. `rtfClickLink` now returns whether it consumed the press; the select paths skip `MouseLock` when it did.

### Drag past a paragraph

Dragging above or below a paragraph selected the edge line only as far as the pointer's column. `glyph.GetClosestOffset` snaps an out-of-band y to the nearest line and then still reads the column from x — correct for caret placement, wrong for a drag, which should reach the line's beginning (up) or end (down).

`textDragEdgeX` widens the hit test once the pointer leaves the text band, with `glyphTextBand` giving the band from the laid-out lines. Applied at all four hit-test sites: Text, Input, RTF, markdown.

### Tests

- `gui/rtf_link_open_test.go` — 13 tests over the activation policy: anchors, relative links, unsupported schemes, opener failure, both call sites.
- `gui/text_drag_edge_test.go` — the edge rule across all four paths. The Text cases install a text measurer before render, which the pre-existing harness in `view_text_select_test.go` does not; without one the click path takes its char-width fallback and there are no lines for the rule to leave.

Each behavioural change was mutation-checked: neutering `textDragEdgeX` fails the intended tests and nothing else.

`make prepush` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)