### PR TITLE
fix(dpi): resync the text stack after a monitor-to-monitor move (#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to
 
 ### Fixed
 
+- **Text stayed pinned to the old monitor's DPI after a window moved between
+  displays** (#490) — a `TextSystem` reads its scale from the backend once, at
+  construction, so glyph shaping and rasterization kept the density of the
+  display the window was created on while shapes and canvases followed the new
+  one, and text spilled out of the boxes laid out for it. Every backend now
+  pushes a changed scale into both halves of the text stack (quad placement and
+  `(*glyph.TextSystem).SetDPIScale`). Windows additionally handles
+  `WM_DPICHANGED`, which was unhandled: the process is per-monitor-v2 aware, so
+  the system does not resize the window itself and no `WM_SIZE` followed a
+  monitor move — nothing resynced at all. macOS gains
+  `windowDidChangeBackingProperties`, which is the only notification a
+  Retina-to-non-Retina move sends when the window's content size does not
+  change. Requires go-glyph v1.25.0.
+
 - **RTF link activation dropped anchors and relative links** (#488) — the
   context menu's "Open Link" had no anchor branch, so `#some-heading` went to
   the platform opener, which rejects every scheme outside http/https/mailto, and

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Go toolchain pin: `go 1.26.0`.
 | ------ | ------- | ------- |
 | `github.com/alecthomas/chroma/v2` | v2.27.0 | Syntax highlighting in the markdown widget. |
 | `github.com/ebitengine/purego` | v0.10.2 | cgo-free dynamic loading of libEGL and the OpenGL entry points (`gui/backend/internal/glbind`) for the native Linux and Windows backends. |
-| `github.com/go-gui-org/go-glyph` | v1.24.0 | Text shaping + glyph rasterization. Required by every backend. |
+| `github.com/go-gui-org/go-glyph` | v1.25.0 | Text shaping + glyph rasterization. Required by every backend. |
 | `github.com/go-pdf/fpdf` | v0.9.0 | PDF generation for the print-dialog backend. |
 | `github.com/godbus/dbus/v5` | v5.2.2 | Linux native platform: notifications, portals. |
 | `github.com/gopxl/beep/v2` | v2.1.1 | Audio decode + mixing (sound effects, music, mixer, fade) for `gui/audio`. |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/ebitengine/purego v0.10.2
-	github.com/go-gui-org/go-glyph v1.24.0
+	github.com/go-gui-org/go-glyph v1.25.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/ebitengine/oto/v3 v3.3.2 h1:VTWBsKX9eb+dXzaF4jEwQbs4yWIdXukJ0K40KgkpY
 github.com/ebitengine/oto/v3 v3.3.2/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/go-gui-org/go-glyph v1.24.0 h1:McXsveg3yvdKt/gfIiiEkHvdaZWgtIWif5HCowdjmpo=
-github.com/go-gui-org/go-glyph v1.24.0/go.mod h1:Lx2KYrLee8t34mX/ZvjUcxN+sHhwFPVF4fcXe6wkRX0=
+github.com/go-gui-org/go-glyph v1.25.0 h1:4lzLvQpb68hMAOfMfwua4MlHzCjRMocj6TWW9l2wQEY=
+github.com/go-gui-org/go-glyph v1.25.0/go.mod h1:Lx2KYrLee8t34mX/ZvjUcxN+sHhwFPVF4fcXe6wkRX0=
 github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
 github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=

--- a/gui/backend/gl/apply_dpi_test.go
+++ b/gui/backend/gl/apply_dpi_test.go
@@ -1,0 +1,117 @@
+//go:build !js && !darwin && !android
+
+package gl
+
+import (
+	"bytes"
+	"log"
+	"math"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestApplyDPIScale_GL(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var b *Backend
+		b.applyDPIScale(2) // must not panic
+	})
+
+	t.Run("valid update", func(t *testing.T) {
+		b := &Backend{dpiScale: 1}
+		b.glyphBack = &glyphBackend{dpiScale: 1}
+		b.applyDPIScale(2)
+		if b.dpiScale != 2 {
+			t.Fatalf("dpiScale = %v, want 2", b.dpiScale)
+		}
+		if b.glyphBack.dpiScale != 2 {
+			t.Fatalf("glyphBack.dpiScale = %v, want 2", b.glyphBack.dpiScale)
+		}
+	})
+
+	t.Run("reject NaN", func(t *testing.T) {
+		b := &Backend{dpiScale: 1}
+		b.applyDPIScale(float32(math.NaN()))
+		if b.dpiScale != 1 {
+			t.Fatalf("NaN accepted: dpiScale = %v, want 1", b.dpiScale)
+		}
+	})
+
+	t.Run("reject Inf", func(t *testing.T) {
+		b := &Backend{dpiScale: 1}
+		b.applyDPIScale(float32(math.Inf(1)))
+		if b.dpiScale != 1 {
+			t.Fatalf("Inf accepted: dpiScale = %v", b.dpiScale)
+		}
+	})
+
+	t.Run("reject non-positive", func(t *testing.T) {
+		for _, s := range []float32{0, -1} {
+			b := &Backend{dpiScale: 1}
+			b.applyDPIScale(s)
+			if b.dpiScale != 1 {
+				t.Fatalf("scale %v accepted: got %v", s, b.dpiScale)
+			}
+		}
+	})
+
+	t.Run("reject absurdly large", func(t *testing.T) {
+		b := &Backend{dpiScale: 1}
+		b.applyDPIScale(100)
+		if b.dpiScale != 1 {
+			t.Fatalf("large scale accepted: dpiScale = %v, want 1", b.dpiScale)
+		}
+	})
+
+	t.Run("early return same scale", func(t *testing.T) {
+		b := &Backend{dpiScale: 2}
+		b.glyphBack = &glyphBackend{dpiScale: 2}
+		b.applyDPIScale(2)
+		if b.dpiScale != 2 {
+			t.Fatalf("dpiScale changed on same-scale call: %v", b.dpiScale)
+		}
+	})
+
+	t.Run("accept upper bound", func(t *testing.T) {
+		b := &Backend{dpiScale: 1}
+		b.glyphBack = &glyphBackend{dpiScale: 1}
+		b.applyDPIScale(8)
+		if b.dpiScale != 8 {
+			t.Fatalf("scale 8 rejected: dpiScale = %v, want 8", b.dpiScale)
+		}
+	})
+
+	// The reject path leaves the glyph backend alone as well: adopting a
+	// broken scale in one half and not the other is worse than keeping
+	// both at the old density.
+	t.Run("reject leaves glyph backend untouched", func(t *testing.T) {
+		b := &Backend{dpiScale: 2}
+		b.glyphBack = &glyphBackend{dpiScale: 2}
+		b.applyDPIScale(0)
+		if b.glyphBack.dpiScale != 2 {
+			t.Fatalf("glyphBack.dpiScale = %v, want 2", b.glyphBack.dpiScale)
+		}
+	})
+
+	// With the dev gate on, a rejected scale must leave evidence — that
+	// log line is the only trace of a failed platform DPI query.
+	t.Run("reject logs under debug gate", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stderr) })
+		gui.Debug(true)
+		t.Cleanup(func() { gui.Debug(false) })
+
+		b := &Backend{dpiScale: 1}
+		b.applyDPIScale(float32(math.NaN()))
+		if b.dpiScale != 1 {
+			t.Fatalf("NaN accepted under debug: dpiScale = %v", b.dpiScale)
+		}
+		if !strings.Contains(buf.String(), "rejected implausible dpi scale") {
+			t.Fatalf("no reject log emitted; got %q", buf.String())
+		}
+	})
+
+}

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -12,6 +12,7 @@ package gl
 
 import (
 	"log"
+	"math"
 	"os"
 	"sync"
 
@@ -223,9 +224,44 @@ func (b *Backend) renderFrame(w *gui.Window) {
 // platform window and updates the viewport and projection.
 func (b *Backend) handleResize() {
 	b.physW, b.physH = b.plat.drawableSize()
-	b.dpiScale = b.plat.dpiScale()
+	b.applyDPIScale(b.plat.dpiScale())
 	gogl.Viewport(0, 0, b.physW, b.physH)
 	b.updateProjection()
+}
+
+// applyDPIScale adopts a new device scale for the whole backend. Text
+// needs both halves: glyphBack.dpiScale places the quads, and the text
+// system shapes and rasterizes at the new density. Without the second
+// half a window moved to a differently scaled monitor keeps rendering
+// glyphs at the density of the monitor it was created on, so text drifts
+// out of the boxes laid out for it.
+func (b *Backend) applyDPIScale(s float32) {
+	if b == nil {
+		return
+	}
+	// Guard against NaN/Inf/zero/negative and absurd scales that would
+	// make the glyph rasterizer allocate excessively or divide by zero.
+	// Plausible desktop scales are ~0.5-5.0; cap at 8.
+	if s != s || math.IsInf(float64(s), 0) || s <= 0 || s > 8 {
+		// An implausible value means the platform DPI query failed.
+		// Keeping the old scale beats adopting a broken one, but the
+		// symptom is mis-sized text with no trace of the cause, so
+		// leave evidence when the dev gate is on.
+		if gui.DebugEnabled() {
+			log.Printf("gl: rejected implausible dpi scale %v", s)
+		}
+		return
+	}
+	if s == b.dpiScale {
+		return
+	}
+	b.dpiScale = s
+	if b.glyphBack != nil {
+		b.glyphBack.dpiScale = s
+	}
+	if b.textSys != nil {
+		b.textSys.SetDPIScale(s)
+	}
 }
 
 func (b *Backend) updateProjection() {

--- a/gui/backend/gl/dpi_x11.go
+++ b/gui/backend/gl/dpi_x11.go
@@ -105,8 +105,8 @@ func crtcDPI(info *randr.GetCrtcInfoReply, out *randr.GetOutputInfoReply) (float
 }
 
 // maybeRescaleDPI re-evaluates the per-monitor scale when the window has
-// moved to a CRTC with a different DPI, updating plat.scale and the glyph
-// backend. It reports whether the scale changed so the caller can trigger
+// moved to a CRTC with a different DPI, updating plat.scale and the text
+// stack. It reports whether the scale changed so the caller can trigger
 // a relayout. ConfigureNotify coordinates are frame-relative under a
 // reparenting WM, so the true root position is queried explicitly and a
 // RandR rescan runs only when that position changed. Cursors are not
@@ -135,8 +135,6 @@ func (b *Backend) maybeRescaleDPI() bool {
 		return false
 	}
 	b.plat.scale = scale
-	if b.glyphBack != nil {
-		b.glyphBack.dpiScale = scale
-	}
+	b.applyDPIScale(scale)
 	return true
 }

--- a/gui/backend/gl/events_win32.go
+++ b/gui/backend/gl/events_win32.go
@@ -33,6 +33,12 @@ const (
 	wmMButtonUp   = 0x0208
 	wmMouseWheel  = 0x020A
 	wmMouseHWheel = 0x020E
+	wmDPIChanged  = 0x02E0
+
+	// SetWindowPos flags used when adopting the rect Windows suggests
+	// for a new monitor: move and size only, leave stacking and focus.
+	swpNoZOrder   = 0x0004
+	swpNoActivate = 0x0010
 
 	wmCaptureChanged = 0x0215
 
@@ -76,6 +82,25 @@ func (b *Backend) logicalXY(px, py int32) (float32, float32) {
 		s = 1
 	}
 	return float32(px) / s, float32(py) / s
+}
+
+// dpiChangedBounds reads the suggested window rect WM_DPICHANGED passes
+// in lParam and returns it as SetWindowPos arguments. Screen coordinates
+// are signed: a monitor left of or above the primary one yields negative
+// positions, which the Win32 call takes as 32-bit ints.
+func dpiChangedBounds(lparam uintptr) (x, y, cx, cy int32, ok bool) {
+	if lparam == 0 {
+		return 0, 0, 0, 0, false
+	}
+	rc := (*rectW)(ptrFromLParam(lparam))
+	// Use 64-bit intermediate to avoid int32 overflow on degenerate
+	// inputs, then bound the result to a plausible window size.
+	w := int64(rc.right) - int64(rc.left)
+	h := int64(rc.bottom) - int64(rc.top)
+	if w <= 0 || h <= 0 || w > 16384 || h > 16384 {
+		return 0, 0, 0, 0, false
+	}
+	return rc.left, rc.top, int32(w), int32(h), true
 }
 
 // handleMessage translates a window message to a gui.Event and
@@ -185,6 +210,22 @@ func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
 		// Repaint live during modal drag-resize.
 		w.FrameFn()
 		b.renderFrame(w)
+		return 0, true
+
+	case wmDPIChanged:
+		// The process is per-monitor-v2 aware, so DefWindowProc does
+		// not resize a top-level window when it crosses to a monitor
+		// with another scale factor: the app must adopt the rect
+		// Windows suggests, already scaled for the new monitor. That
+		// SetWindowPos is what produces the WM_SIZE below, which
+		// refreshes the client size and the DPI scale. Skipping this
+		// message leaves text and geometry pinned to the DPI the
+		// window was created at (issue #490).
+		if x, y, cx, cy, ok := dpiChangedBounds(lparam); ok {
+			pSetWindowPos.Call(b.plat.hwnd, 0,
+				uintptr(x), uintptr(y), uintptr(cx), uintptr(cy),
+				swpNoZOrder|swpNoActivate)
+		}
 		return 0, true
 
 	case wmPaint:

--- a/gui/backend/gl/events_win32_test.go
+++ b/gui/backend/gl/events_win32_test.go
@@ -4,6 +4,7 @@ package gl
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/go-gui-org/go-gui/gui"
 )
@@ -140,5 +141,51 @@ func TestNotchesToLines_HonoursSystemSetting(t *testing.T) {
 func TestSysParamUint_FallsBackOnBogusAction(t *testing.T) {
 	if got := sysParamUint(0xFFFF, defaultScrollLines); got != defaultScrollLines {
 		t.Errorf("fallback = %d, want %d", got, defaultScrollLines)
+	}
+}
+
+// WM_DPICHANGED carries the rect Windows wants the window moved to. The
+// decode must survive negative screen coordinates, which is what a
+// monitor placed left of or above the primary one produces.
+func TestDPIChangedBounds(t *testing.T) {
+	rc := rectW{left: -1920, top: -200, right: -640, bottom: 520}
+
+	x, y, cx, cy, ok := dpiChangedBounds(uintptr(unsafe.Pointer(&rc)))
+
+	if !ok {
+		t.Fatal("ok = false, want true for a non-nil rect")
+	}
+	if x != -1920 || y != -200 {
+		t.Errorf("position = (%d,%d), want (-1920,-200)", x, y)
+	}
+	if cx != 1280 || cy != 720 {
+		t.Errorf("size = (%d,%d), want (1280,720)", cx, cy)
+	}
+}
+
+// A null lParam must be reported, not dereferenced.
+func TestDPIChangedBoundsNil(t *testing.T) {
+	if _, _, _, _, ok := dpiChangedBounds(0); ok {
+		t.Error("ok = true for a nil lParam, want false")
+	}
+}
+
+func TestDPIChangedBoundsDegenerate(t *testing.T) {
+	cases := []struct {
+		name string
+		rc   rectW
+	}{
+		{"zero width", rectW{left: 0, top: 0, right: 0, bottom: 100}},
+		{"zero height", rectW{left: 0, top: 0, right: 100, bottom: 0}},
+		{"negative width", rectW{left: 100, top: 0, right: 0, bottom: 100}},
+		{"negative height", rectW{left: 0, top: 100, right: 100, bottom: 0}},
+		{"too large", rectW{left: 0, top: 0, right: 20000, bottom: 20000}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, _, _, ok := dpiChangedBounds(uintptr(unsafe.Pointer(&tc.rc))); ok {
+				t.Errorf("dpiChangedBounds(%v) = ok true, want false", tc.rc)
+			}
+		})
 	}
 }

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -48,6 +48,7 @@ var (
 	pSetCursor        = user32.NewProc("SetCursor")
 	pGetClientRect    = user32.NewProc("GetClientRect")
 	pSetWindowTextW   = user32.NewProc("SetWindowTextW")
+	pSetWindowPos     = user32.NewProc("SetWindowPos")
 	pScreenToClient   = user32.NewProc("ScreenToClient")
 	pSetCapture       = user32.NewProc("SetCapture")
 	pReleaseCapture   = user32.NewProc("ReleaseCapture")

--- a/gui/backend/metal/apply_dpi_test.go
+++ b/gui/backend/metal/apply_dpi_test.go
@@ -1,0 +1,122 @@
+//go:build darwin && cgo && !ios
+
+package metal
+
+import (
+	"bytes"
+	"log"
+	"math"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestApplyDPIScale(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var ws *windowState
+		ws.applyDPIScale(2) // must not panic
+	})
+
+	t.Run("valid update", func(t *testing.T) {
+		ws := &windowState{dpiScale: 1}
+		ws.glyphBack = &metalGlyphBackend{dpiScale: 1}
+		ws.applyDPIScale(2)
+		if ws.dpiScale != 2 {
+			t.Fatalf("dpiScale = %v, want 2", ws.dpiScale)
+		}
+		if ws.glyphBack.dpiScale != 2 {
+			t.Fatalf("glyphBack.dpiScale = %v, want 2", ws.glyphBack.dpiScale)
+		}
+	})
+
+	t.Run("early return same scale", func(t *testing.T) {
+		ws := &windowState{dpiScale: 2}
+		ws.glyphBack = &metalGlyphBackend{dpiScale: 2}
+		// Should not change; call with same scale is no-op
+		ws.applyDPIScale(2)
+		if ws.dpiScale != 2 {
+			t.Fatalf("dpiScale changed on same-scale call: %v", ws.dpiScale)
+		}
+	})
+
+	t.Run("reject NaN", func(t *testing.T) {
+		ws := &windowState{dpiScale: 1}
+		ws.applyDPIScale(float32(math.NaN()))
+		if ws.dpiScale != 1 {
+			t.Fatalf("NaN accepted: dpiScale = %v, want 1", ws.dpiScale)
+		}
+	})
+
+	t.Run("reject Inf", func(t *testing.T) {
+		ws := &windowState{dpiScale: 1}
+		ws.applyDPIScale(float32(math.Inf(1)))
+		if ws.dpiScale != 1 {
+			t.Fatalf("Inf accepted: dpiScale = %v, want 1", ws.dpiScale)
+		}
+		ws.applyDPIScale(float32(math.Inf(-1)))
+		if ws.dpiScale != 1 {
+			t.Fatalf("-Inf accepted: dpiScale = %v, want 1", ws.dpiScale)
+		}
+	})
+
+	t.Run("reject non-positive", func(t *testing.T) {
+		for _, s := range []float32{0, -1, -0.5} {
+			ws := &windowState{dpiScale: 1}
+			ws.applyDPIScale(s)
+			if ws.dpiScale != 1 {
+				t.Fatalf("scale %v accepted: got %v, want 1", s, ws.dpiScale)
+			}
+		}
+	})
+
+	t.Run("reject absurdly large", func(t *testing.T) {
+		ws := &windowState{dpiScale: 1}
+		ws.applyDPIScale(100)
+		if ws.dpiScale != 1 {
+			t.Fatalf("large scale accepted: dpiScale = %v, want 1", ws.dpiScale)
+		}
+	})
+
+	t.Run("accept upper bound", func(t *testing.T) {
+		ws := &windowState{dpiScale: 1}
+		ws.glyphBack = &metalGlyphBackend{dpiScale: 1}
+		ws.applyDPIScale(5)
+		if ws.dpiScale != 5 {
+			t.Fatalf("scale 5 rejected: dpiScale = %v, want 5", ws.dpiScale)
+		}
+	})
+
+	// The reject path leaves the glyph backend alone as well: adopting a
+	// broken scale in one half and not the other is worse than keeping
+	// both at the old density.
+	t.Run("reject leaves glyph backend untouched", func(t *testing.T) {
+		ws := &windowState{dpiScale: 2}
+		ws.glyphBack = &metalGlyphBackend{dpiScale: 2}
+		ws.applyDPIScale(0)
+		if ws.glyphBack.dpiScale != 2 {
+			t.Fatalf("glyphBack.dpiScale = %v, want 2", ws.glyphBack.dpiScale)
+		}
+	})
+
+	// With the dev gate on, a rejected scale must leave evidence — that
+	// log line is the only trace of a failed backing-scale query.
+	t.Run("reject logs under debug gate", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stderr) })
+		gui.Debug(true)
+		t.Cleanup(func() { gui.Debug(false) })
+
+		ws := &windowState{dpiScale: 1}
+		ws.applyDPIScale(float32(math.NaN()))
+		if ws.dpiScale != 1 {
+			t.Fatalf("NaN accepted under debug: dpiScale = %v", ws.dpiScale)
+		}
+		if !strings.Contains(buf.String(), "rejected implausible dpi scale") {
+			t.Fatalf("no reject log emitted; got %q", buf.String())
+		}
+	})
+
+}

--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"runtime"
 	"unsafe"
@@ -686,10 +687,42 @@ func (ws *windowState) handleResize() {
 	ws.physW = int32(fbW)
 	ws.physH = int32(fbH)
 	if logW > 0 {
-		ws.dpiScale = float32(fbW) / float32(logW)
+		ws.applyDPIScale(float32(fbW) / float32(logW))
 	}
 	C.metalResize(ws.ctx, fbW, fbH)
 	ws.updateProjection()
+}
+
+// applyDPIScale adopts a new backing scale for the whole window. Text
+// needs both halves: glyphBack.dpiScale places the quads, and the text
+// system shapes and rasterizes at the new density. Without the second
+// half a window dragged between a Retina and a non-Retina display keeps
+// rendering glyphs at the density it was created at, so text drifts out
+// of the boxes laid out for it.
+func (ws *windowState) applyDPIScale(s float32) {
+	if ws == nil {
+		return
+	}
+	if s != s || math.IsInf(float64(s), 0) || s <= 0 || s > 8 {
+		// An implausible value means the backing-scale query failed.
+		// Keeping the old scale beats adopting a broken one, but the
+		// symptom is mis-sized text with no trace of the cause, so
+		// leave evidence when the dev gate is on.
+		if gui.DebugEnabled() {
+			log.Printf("metal: rejected implausible dpi scale %v", s)
+		}
+		return
+	}
+	if s == ws.dpiScale {
+		return
+	}
+	ws.dpiScale = s
+	if ws.glyphBack != nil {
+		ws.glyphBack.dpiScale = s
+	}
+	if ws.textSys != nil {
+		ws.textSys.SetDPIScale(s)
+	}
 }
 
 func (ws *windowState) updateProjection() {

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -593,6 +593,21 @@ static uint32_t _nextWindowID = 1;
                          (int)bounds.size.height);
 }
 
+- (void)windowDidChangeBackingProperties:(NSNotification *)notification {
+    // A window dragged between a Retina and a non-Retina display changes
+    // backing scale without changing its content size, so windowDidResize
+    // never fires and the text stack would keep rasterizing at the old
+    // density. Route it through the same path: metalWindowGetFramebufferSize
+    // recomputes the drawable from the new backingScaleFactor, and the Go
+    // side re-derives the DPI scale from it. The notification also covers
+    // color-space changes, where the recomputed scale is unchanged and the
+    // Go side does nothing.
+    NSRect bounds = self.contentView.bounds;
+    goMetalWindowResized(_windowID,
+                         (int)bounds.size.width,
+                         (int)bounds.size.height);
+}
+
 - (BOOL)windowShouldClose:(NSWindow *)sender {
     goMetalWindowShouldClose(_windowID);
     return NO; // Go decides when to destroy


### PR DESCRIPTION
Addresses #490. **Deliberately no `Fixes`/`Closes` keyword** — the behaviour
cannot be verified on a single-display machine, so the issue stays open for the
reporter to confirm.

## The defect

A window dragged to a display with a different scale factor kept its text at
the old density while shape geometry followed the new one, so text overflowed
the boxes laid out for it. Two faults, in both halves of the text stack:

1. **glyph pinned its scale at construction.** `NewTextSystem` read
   `DrawBackend.DPIScale()` once and had no setter, so even where the backend
   noticed the change (X11, `dpi_x11.go`) the glyphs stayed rasterized at the
   old DPI and were resampled. Fixed upstream in
   go-gui-org/go-glyph#127, released as **v1.25.0** and required here.
2. **Windows never noticed at all.** The process is per-monitor-v2 aware, so
   `DefWindowProc` does not resize a top-level window on a DPI change.
   `WM_DPICHANGED` was unhandled, no `WM_SIZE` followed, and `handleResize`
   never ran — not even `b.dpiScale` updated. macOS had the same gap:
   `handleResize` is reached only from `windowDidResize`, and a
   Retina-to-non-Retina move with no size change fires nothing.

## Changes

- **gl**: `applyDPIScale` is the single propagation seam — it pushes a changed
  scale to `glyphBack.dpiScale` (quad placement) and to
  `textSys.SetDPIScale` (shaping, rasterization, cache purge). Called from
  `handleResize`; the partial X11 fix in `maybeRescaleDPI` now routes through
  it, so X11 gains re-rasterization it never had.
- **gl/windows**: handle `WM_DPICHANGED` by applying the suggested `RECT` with
  `SetWindowPos` (`SWP_NOZORDER|SWP_NOACTIVATE`), which produces the `WM_SIZE`
  the existing path already handles.
- **metal**: mirror `applyDPIScale` in `windowState.handleResize`, and add
  `windowDidChangeBackingProperties` in `metal_window_darwin.m` so a
  backing-scale change with no size change still resyncs.

No go-gui cache invalidation is needed beyond this: the `DrawCanvas` cache keys
on `Scale`, and the plain-text layout cache lives on `Shape.TC`, rebuilt per
frame. `gui/backend/web` is untouched on purpose — it passes `dpiScale=1` to
glyph and applies DPI as a Canvas2D transform, so a `devicePixelRatio` change
already flows through.

## Testing

Unit tests cover the new seams (`apply_dpi_test.go` in both backends) and the
`WM_DPICHANGED` `lParam` rect decode (`events_win32_test.go`, Windows CI only).

`make check-all` and `make export-audit` pass; `GOOS=windows` and `GOOS=linux`
builds and `GOOS=windows go vet ./gui/backend/gl/` are clean.

**The monitor-move behaviour itself is not verified locally — this machine has
one display.** Coverage is compile plus unit tests; the visual result rests on
review and on the issue reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)