### PR TITLE
fix(combobox): clip a dropdown that does not scroll (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to
 
 ### Fixed
 
+- **A combobox dropdown painted its rows outside itself** (#492) —
+  `MaxDropdownHeight` capped the dropdown container but nothing held the rows
+  in, so a list longer than the cap drew over whatever was behind the dropdown.
+  A dropdown that does not scroll now clips its contents, which truncates the
+  list at the border instead. The rows below the cap stay unreachable without
+  `ComboboxCfg.Scrollable`; issue #492 tracks making scrolling the default.
+
 - **Text stayed pinned to the old monitor's DPI after a window moved between
   displays** (#490) — a `TextSystem` reads its scale from the backend once, at
   construction, so glyph shaping and rasterization kept the density of the

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -258,6 +258,13 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 			FloatOffsetY: -sizeBorder,
 			FloatZIndex:  cfg.FloatZIndex,
 			Scrollable:   cfg.Scrollable,
+			// MaxHeight alone does not hold the rows in: a list
+			// taller than the cap paints its overflow over whatever
+			// is under the dropdown. A scrollable dropdown already
+			// clips through its viewport, so the stencil is only
+			// needed for the other one, where it truncates the list
+			// instead of letting it escape.
+			ClipContents: !cfg.Scrollable,
 			Padding:      cfg.Padding,
 			Spacing:      SomeF(0),
 			Content:      dropdownContent,


### PR DESCRIPTION
`MaxDropdownHeight` capped the dropdown container, but nothing held the rows in: a list longer than the cap was laid out in full and drawn in full, over whatever sat behind the dropdown. The caller asked for a maximum height and got no maximum height.

Found in go-speedtest, where a 40-entry LibreSpeed server list drew about 12 rows past the bottom border, over the chart behind it.

## Change

One line in `gui/view_combobox.go`: `ClipContents: !cfg.Scrollable` on the dropdown container.

A scrollable dropdown already clips through its scroll viewport, so the stencil bracket is only set on the other one — no extra per-frame work on the path that was already correct.

## Scope

This stops the paint-over. It does not make the rows below the cap reachable, so it is a floor, not a fix. #492 proposes inverting `Scrollable` to `ScrollDisabled` so scrolling is the default; that is a breaking change and is left to its own PR.

## Verification

`go test ./gui/` passes, combobox goldens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)