### PR TITLE
feat(window): min/max window size limits (#494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to
 
 ### Added
 
+- **Minimum and maximum window size** (#494) — `WindowCfg` gains `MinWidth`,
+  `MinHeight`, `MaxWidth` and `MaxHeight`, in the same logical pixels as
+  `Width`/`Height`. The limits are handed to the OS at window creation, so the
+  resize drag itself stops at the bound instead of the app trying to correct an
+  already-applied size. Zero on a field leaves that bound unset; a ceiling below
+  its floor is raised to the floor; `FixedSize` still wins over all four. On
+  macOS and Windows the ceiling also caps the maximize button. Honored by the
+  macOS, Windows and X11 backends; the web backend fills its viewport as before
+  and ignores them. Details: `docs/specs/window-size-limits.md`.
+
 - **`buildapp` packages Windows and Linux, not only macOS** — `-platform`
   selects the packager, defaulting to the host `GOOS` so every existing
   invocation keeps working. `-platform windows` embeds an icon into the PE image
@@ -31,14 +41,33 @@ and this project adheres to
   `> [!WARNING]` / `> [!TIP]` callouts. Spec:
   `docs/specs/markdown-render-callback.md`.
 
+### Changed
+
+- **BREAKING: `ComboboxCfg.Scrollable` is removed; the dropdown always scrolls**
+  (#492) — the field was opt-in, so a caller who set `MaxDropdownHeight` or took
+  the theme default got a cap that did not cap. Scrolling is now the behaviour,
+  not a choice, which is what `Select`'s dropdown already did
+  (`gui/view_select.go`). Callers that set `Scrollable: true` delete the line;
+  callers that never set it gain a reachable list. A dropdown short enough to
+  fit is unchanged, because the scroll system adds no scrollbar when the content
+  fits.
+
 ### Fixed
+
+- **`WindowCfg.FixedSize` was a silent no-op on X11** (#494) — only the macOS
+  and Windows backends honored it; an X11 window stayed freely resizable. X11
+  has no resizable style bit, so the fix rides on the `WM_NORMAL_HINTS` property
+  added for the window size limits: a fixed window is expressed as minimum ==
+  maximum. Linux apps that set `FixedSize` will see their windows stop resizing,
+  which is the documented behavior they already asked for.
 
 - **A combobox dropdown painted its rows outside itself** (#492) —
   `MaxDropdownHeight` capped the dropdown container but nothing held the rows
   in, so a list longer than the cap drew over whatever was behind the dropdown.
-  A dropdown that does not scroll now clips its contents, which truncates the
-  list at the border instead. The rows below the cap stay unreachable without
-  `ComboboxCfg.Scrollable`; issue #492 tracks making scrolling the default.
+  The dropdown now scrolls, so its viewport clips the overflow and the rows
+  below the cap stay reachable with the wheel and the arrow keys. Found in
+  go-speedtest, where a 40-entry server list drew about 12 rows past the bottom
+  border, over the chart behind it.
 
 - **Text stayed pinned to the old monitor's DPI after a window moved between
   displays** (#490) — a `TextSystem` reads its scale from the backend once, at

--- a/README.md
+++ b/README.md
@@ -157,11 +157,13 @@ need the knobs — fonts, colors, sizing, padding, events:
 
 ```go
 w := gui.NewWindow(gui.WindowCfg{
-    State:  &App{},
-    Title:  "Counter",
-    Width:  300,
-    Height: 150,
-    OnInit: func(w *gui.Window) { w.UpdateView(mainView) },
+    State:     &App{},
+    Title:     "Counter",
+    Width:     300,
+    Height:    150,
+    MinWidth:  200, // the OS stops the resize drag here
+    MinHeight: 120,
+    OnInit:    func(w *gui.Window) { w.UpdateView(mainView) },
 })
 
 gui.Button(gui.ButtonCfg{

--- a/docs/specs/frameless-windows.md
+++ b/docs/specs/frameless-windows.md
@@ -115,3 +115,9 @@ coordinates, which the Go-side event no longer carries.
   event paths in `platform_win32.go`, `platform_x11.go`, `events_win32.go`,
   `events_x11.go`.
 - `examples/frameless/`.
+
+## See also
+
+- `docs/specs/window-size-limits.md` — `MinWidth`/`MaxWidth` and friends. It
+  extends the Win32 `WM_GETMINMAXINFO` handler described here, and it is what
+  finally makes `FixedSize` work on X11.

--- a/docs/specs/window-size-limits.md
+++ b/docs/specs/window-size-limits.md
@@ -1,0 +1,148 @@
+# Window size limits
+
+Status: implemented. Issue #494.
+
+## Problem
+
+`gui.WindowCfg` could set a starting size but not a floor. A user could drag a
+window below the size its content needs, and the app had no way to stop it.
+
+An app-level fix is not possible. The resize drag is serviced by the OS window
+server (macOS), the window procedure (Windows) or the window manager (X11)
+before the app is told anything. By the time an `EventResized` arrives, the new
+size is already applied. An app that resized itself back would fight the drag
+and flicker. The limit must be declared to the platform, which is what all three
+platforms already offer.
+
+## Solution
+
+Four fields on `WindowCfg`, in the same logical pixels as `Width`/`Height`:
+
+```go
+gui.NewWindow(gui.WindowCfg{
+    Width: 800, Height: 600,
+    MinWidth: 400, MinHeight: 300,
+    MaxWidth: 1600, MaxHeight: 1200,
+})
+```
+
+Zero on a field means that bound is unset. The limits are applied once, at
+window creation. There is no runtime setter — a window whose usable size changes
+while it runs is a different feature, and no caller has asked for it.
+
+## Normalization
+
+`gui/window_size_limits.go` holds the whole policy, so the three native backends
+cannot disagree about the edge cases. `WindowSizeLimits(cfg)` returns a
+`SizeLimits`, applying these rules in order:
+
+1. `FixedSize` collapses both bounds onto `Width`/`Height`, so a fixed window is
+   expressed as minimum == maximum. A `FixedSize` window with no usable
+   `Width`/`Height` falls through to the ordinary rules rather than pinning the
+   window to zero.
+2. A negative value reads as unset. It is a caller mistake, not a smaller
+   window, and must not reach a platform call.
+3. A ceiling below its floor is contradictory. The floor is the stronger promise
+   — content stops fitting below it — so the ceiling is raised to meet it rather
+   than the floor being dropped.
+4. Every bound is capped at 32767 pixels, the largest extent an X11 drawable
+   coordinate can carry and a comfortable guard for the `int32` Win32 track
+   sizes. No display comes near it, so a caller asking for more gets the ceiling
+   instead of a value that wraps negative inside a backend.
+
+`SizeLimits.None()` lets a backend skip the platform call entirely, leaving the
+window's platform defaults untouched rather than writing a no-op limit.
+
+## Units
+
+`WindowCfg` speaks logical pixels. What each platform wants differs, so the
+conversion is the backend's, not the caller's:
+
+| Platform | Unit wanted   | Conversion                          |
+| -------- | ------------- | ----------------------------------- |
+| macOS    | points        | none — Cocoa content size is points |
+| Windows  | device pixels | `SizeLimits.Scaled(dpi/96)`         |
+| X11      | device pixels | `SizeLimits.Scaled(dpiScale)`       |
+
+`Scaled` is the only place that conversion lives, so Windows and X11 cannot
+resolve the same `MinWidth` to different client sizes. It keeps an unset field
+at zero, so "unset" survives scaling instead of becoming a zero-pixel bound;
+raises a sub-pixel result to 1 so a small floor is not scaled away entirely; and
+re-applies the 32767 cap so a high scale cannot carry a bound out of range.
+
+It truncates rather than rounds, matching how both backends scale `Width` and
+`Height`. Rounding would let a floor equal to the created size land a pixel
+above it, and the window would grow by that pixel as it opened — most visibly
+under `FixedSize`, which is expressed as a floor at exactly the created size.
+
+## Per-platform mechanism
+
+**macOS** (`gui/backend/metal/metal_window_darwin.m`). A new
+`metalWindowSetSizeLimits` calls `setContentMinSize:` and `setContentMaxSize:`,
+called from `createWindowState` just after `metalWindowCreate`.
+`metalWindowCreate`'s signature is unchanged — the limits are a separate setter,
+so the create call does not grow four more parameters. AppKit has no "no
+maximum" sentinel; `CGFLOAT_MAX` is the idiom and is what an unconstrained
+window already carries.
+
+**Windows** (`gui/backend/gl/decoration_win32.go`). `WM_GETMINMAXINFO` was
+already handled, but only for a frameless window's maximize rect. The frameless
+gate is gone: two independent concerns write different `MINMAXINFO` fields, and
+both may apply to one window, so neither short-circuits the other.
+`applySizeLimits` fills `ptMinTrackSize`/`ptMaxTrackSize`, writing only the
+constrained axes so an unset axis keeps the default Windows supplied.
+
+Track size is the outer frame while `WindowCfg` speaks client area, so
+`trackSizeFor` adds the frame overhead via the same `AdjustWindowRectExForDpi`
+call `New` applies to `Width`/`Height`. Without it a `MinWidth` would mean a
+smaller client area on Windows than elsewhere. The result is computed at create
+time and stored on `platformState`; the message handler does no conversion and
+no allocation per message.
+
+**X11** (`gui/backend/gl/platform_x11.go`). `setSizeHints` writes
+`WM_NORMAL_HINTS` with the `PMinSize` and `PMaxSize` flags of `XSizeHints`. The
+property is written whole (18 words) because window managers read it at fixed
+offsets. A bound is only honored when both its axes carry a value, so a one-axis
+limit fills the other axis with a permissive value rather than a zero the WM
+would read as "0 pixels".
+
+The X11 backend rescales on a monitor-to-monitor move, so `dpi_x11.go` rewrites
+the hints at the new scale. `platformState.limits` keeps the logical values for
+that, since the physical ones are only correct for one scale.
+
+Web, iOS and Android ignore the limits. The web backend fills its viewport and
+already ignores `Width`/`Height`; iOS and Android are OS-sized.
+
+## FixedSize on X11
+
+`WindowCfg.FixedSize` was a silent no-op on X11 before this change — only macOS
+(a style mask bit) and Windows (a window style) honored it. X11 has no resizable
+style bit; `WM_NORMAL_HINTS` is the only way to constrain a drag, which is
+exactly the property this change introduces. Rule 1 of the normalization above
+reports a fixed window as minimum == maximum, so the X11 backend gets the fix
+without a second code path.
+
+This is a behavior change for Linux apps that set `FixedSize`: their windows now
+actually stop resizing.
+
+## Testing
+
+`windowSizeLimits`, `None` and `Scaled` carry the policy and need no window, so
+they are unit tested directly in `gui/window_size_limits_test.go` — unset,
+negative, max-below-min, the `FixedSize` collapse, and the fall-through when a
+`FixedSize` window has no dimensions.
+
+`trackSizeFor` and `applySizeLimits` are testable without a window too, driven
+against a synthetic `MINMAXINFO` in `decoration_win32_test.go`, matching how
+`windowStyleFor` is already tested.
+
+No golden test applies. Nothing about the rendered widget tree changes; the
+limits never reach the layout pipeline.
+
+Enforcement itself is a platform behavior and is verified by hand: drag a
+window's corner inward and confirm it stops, per platform.
+
+## See also
+
+- `docs/specs/frameless-windows.md` — owns `FixedSize` and the Win32
+  `WM_GETMINMAXINFO` handler this change extends.

--- a/examples/showcase/demo_selection.go
+++ b/examples/showcase/demo_selection.go
@@ -216,7 +216,6 @@ func demoCombobox(w *gui.Window) gui.View {
 			}),
 			gui.Combobox(gui.ComboboxCfg{
 				ID:          "combobox-demo",
-				Scrollable:  true,
 				Placeholder: "Type to search...",
 				Value:       app.ComboboxValue,
 				Options:     []string{"Go", "Rust", "Zig", "C", "C++", "Python", "TypeScript", "JavaScript", "Ruby", "Elixir"},

--- a/examples/showcase/docs/widget_combobox.md
+++ b/examples/showcase/docs/widget_combobox.md
@@ -31,33 +31,31 @@ gui.Combobox(gui.ComboboxCfg{
 
 ## Virtualization
 
-The dropdown list virtualizes when `Scrollable: true` and
-`MaxDropdownHeight > 0`. Scroll state is keyed by the widget's ID +
-`".dropdown"`.
+The dropdown always scrolls, and virtualizes its rows once
+`MaxDropdownHeight > 0` caps the list. Scroll state is keyed by the widget's
+ID + `".dropdown"`.
 
 ```go
 gui.Combobox(gui.ComboboxCfg{
-    ID:                 "large-cb",
-    Scrollable:         true,
-    MaxDropdownHeight:  200,
-    Options:            largeList,
+    ID:                "large-cb",
+    MaxDropdownHeight: 200,
+    Options:           largeList,
 })
 ```
 
 ## Key Properties
 
-| Property          | Type     | Description                                    |
-| ----------------- | -------- | ---------------------------------------------- |
-| Value             | string   | Current selection                              |
-| Placeholder       | string   | Hint text shown when empty                     |
-| Options           | []string | Searchable options                             |
-| MaxDropdownHeight | float32  | Max dropdown pixel height                      |
-| Scrollable        | bool     | Opt into the scroll system (state keyed by ID) |
-| MinWidth          | float32  | Minimum width                                  |
-| MaxWidth          | float32  | Maximum width                                  |
-| FloatZIndex       | int      | Z-order for dropdown overlay                   |
-| Sizing            | Sizing   | Combined axis sizing mode                      |
-| Disabled          | bool     | Disable interaction                            |
+| Property          | Type     | Description                  |
+| ----------------- | -------- | ---------------------------- |
+| Value             | string   | Current selection            |
+| Placeholder       | string   | Hint text shown when empty   |
+| Options           | []string | Searchable options           |
+| MaxDropdownHeight | float32  | Max dropdown pixel height    |
+| MinWidth          | float32  | Minimum width                |
+| MaxWidth          | float32  | Maximum width                |
+| FloatZIndex       | int      | Z-order for dropdown overlay |
+| Sizing            | Sizing   | Combined axis sizing mode    |
+| Disabled          | bool     | Disable interaction          |
 
 ## Appearance
 

--- a/gui/backend/gl/decoration_win32.go
+++ b/gui/backend/gl/decoration_win32.go
@@ -110,6 +110,78 @@ func wmszFor(edge gui.WindowEdge) uintptr {
 	return 0
 }
 
+// trackSizeFor converts logical content-size limits into the outer
+// frame track sizes WM_GETMINMAXINFO reports. Windows sizes a window by
+// its whole frame, but WindowCfg speaks in client area, so the same
+// AdjustWindowRectExForDpi expansion New applies to Width/Height is
+// applied here — otherwise a MinWidth would mean a smaller client area
+// on Windows than on the other platforms.
+//
+// Returns zeroed points for the axes with no limit; the caller leaves
+// those fields of MINMAXINFO alone so Windows keeps its defaults. Split
+// out of the message handler so the conversion is unit testable without
+// a window, and so the handler itself stays allocation-free.
+func trackSizeFor(limits gui.SizeLimits, style uintptr, dpi uint32) (minTrack, maxTrack pointL) {
+	if limits.None() {
+		// Nothing to measure, and no reason to pay for the syscall on
+		// the ordinary window that sets no bounds at all.
+		return minTrack, maxTrack
+	}
+	// The frame overhead is the same for both bounds, so it is measured
+	// once against an empty client rect rather than per bound.
+	var rc rectW
+	pAdjustRectDpi.Call(uintptr(unsafe.Pointer(&rc)), style, 0, 0, uintptr(dpi))
+	frameW := rc.right - rc.left
+	frameH := rc.bottom - rc.top
+
+	// SizeLimits.Scaled owns the logical -> physical conversion for
+	// every backend, so a MinWidth resolves to the same client size
+	// here as it does on X11.
+	phys := limits.Scaled(float32(dpi) / 96.0)
+	if phys.MinW > 0 {
+		minTrack.x = int32(phys.MinW) + frameW
+	}
+	if phys.MinH > 0 {
+		minTrack.y = int32(phys.MinH) + frameH
+	}
+	if phys.MaxW > 0 {
+		maxTrack.x = int32(phys.MaxW) + frameW
+	}
+	if phys.MaxH > 0 {
+		maxTrack.y = int32(phys.MaxH) + frameH
+	}
+	return minTrack, maxTrack
+}
+
+// applySizeLimits answers WM_GETMINMAXINFO with the configured track
+// sizes. Each axis is written only when it is constrained, so an unset
+// axis keeps the default Windows already put in the struct.
+func (b *Backend) applySizeLimits(lparam uintptr) bool {
+	if lparam == 0 {
+		return false
+	}
+	minT, maxT := b.plat.minTrack, b.plat.maxTrack
+	if minT == (pointL{}) && maxT == (pointL{}) {
+		return false
+	}
+	mmi := (*minMaxInfo)(ptrFromLParam(lparam))
+	if minT.x > 0 {
+		mmi.ptMinTrackSize.x = minT.x
+	}
+	if minT.y > 0 {
+		mmi.ptMinTrackSize.y = minT.y
+	}
+	// ptMaxTrackSize caps the maximize button as well as the drag,
+	// which matches what setContentMaxSize: does on macOS.
+	if maxT.x > 0 {
+		mmi.ptMaxTrackSize.x = maxT.x
+	}
+	if maxT.y > 0 {
+		mmi.ptMaxTrackSize.y = maxT.y
+	}
+	return true
+}
+
 // clampMaximizeToWorkArea answers WM_GETMINMAXINFO for a frameless
 // window. Zeroing the non-client area in WM_NCCALCSIZE also removes the
 // inset Windows normally applies when maximizing, so without this the

--- a/gui/backend/gl/decoration_win32_test.go
+++ b/gui/backend/gl/decoration_win32_test.go
@@ -4,6 +4,7 @@ package gl
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/go-gui-org/go-gui/gui"
 )
@@ -104,5 +105,75 @@ func TestNcCalcSizeFrameless(t *testing.T) {
 	}
 	if _, handled := b.handleMessage(wmNcCalcSize, 0, 0); handled {
 		t.Error("wparam=0 handled; want fall-through to DefWindowProc")
+	}
+}
+
+// applySizeLimits writes only the constrained axes, so an unset axis
+// keeps whatever default Windows already put in MINMAXINFO.
+func TestApplySizeLimitsPartialAxes(t *testing.T) {
+	t.Parallel()
+	b := &Backend{}
+	b.plat.w = gui.NewTestWindow(gui.WindowCfg{})
+	b.plat.minTrack = pointL{x: 500}
+	b.plat.maxTrack = pointL{y: 900}
+
+	mmi := minMaxInfo{
+		ptMinTrackSize: pointL{x: 10, y: 20},
+		ptMaxTrackSize: pointL{x: 3000, y: 4000},
+	}
+	if !b.applySizeLimits(uintptr(unsafe.Pointer(&mmi))) {
+		t.Fatal("applySizeLimits reported not handled")
+	}
+	if mmi.ptMinTrackSize.x != 500 {
+		t.Errorf("min x = %d, want 500", mmi.ptMinTrackSize.x)
+	}
+	if mmi.ptMinTrackSize.y != 20 {
+		t.Errorf("min y = %d, want the untouched 20", mmi.ptMinTrackSize.y)
+	}
+	if mmi.ptMaxTrackSize.y != 900 {
+		t.Errorf("max y = %d, want 900", mmi.ptMaxTrackSize.y)
+	}
+	if mmi.ptMaxTrackSize.x != 3000 {
+		t.Errorf("max x = %d, want the untouched 3000", mmi.ptMaxTrackSize.x)
+	}
+}
+
+// A window with no limits must not claim the message, so DefWindowProc
+// still supplies the defaults.
+func TestApplySizeLimitsUnconstrained(t *testing.T) {
+	t.Parallel()
+	b := &Backend{}
+	b.plat.w = gui.NewTestWindow(gui.WindowCfg{})
+	var mmi minMaxInfo
+	if b.applySizeLimits(uintptr(unsafe.Pointer(&mmi))) {
+		t.Error("unconstrained window claimed WM_GETMINMAXINFO")
+	}
+	// A null lparam is a message we cannot answer, not a crash.
+	if b.applySizeLimits(0) {
+		t.Error("null lparam reported handled")
+	}
+}
+
+// The track size is the outer frame, so the frame overhead is added to
+// the scaled client bound. Only the delta is asserted, since the exact
+// frame size depends on the host's metrics.
+func TestTrackSizeForAddsFrameAndScale(t *testing.T) {
+	t.Parallel()
+	style := windowStyleFor(gui.WindowCfg{})
+	limits := gui.SizeLimits{MinW: 400, MinH: 300}
+
+	at96, _ := trackSizeFor(limits, style, 96)
+	at192, _ := trackSizeFor(limits, style, 192)
+
+	if at96.x <= 400 {
+		t.Errorf("min x = %d, want more than the 400 client width", at96.x)
+	}
+	if at192.x <= at96.x {
+		t.Errorf("192 dpi min x = %d, want more than 96 dpi %d",
+			at192.x, at96.x)
+	}
+	// An unset axis stays zero so the caller skips it.
+	if _, maxT := trackSizeFor(limits, style, 96); maxT != (pointL{}) {
+		t.Errorf("max track = %+v, want zero when unset", maxT)
 	}
 }

--- a/gui/backend/gl/dpi_x11.go
+++ b/gui/backend/gl/dpi_x11.go
@@ -136,5 +136,9 @@ func (b *Backend) maybeRescaleDPI() bool {
 	}
 	b.plat.scale = scale
 	b.applyDPIScale(scale)
+	// The hints were written in physical pixels for the old scale, so a
+	// monitor move would otherwise leave the floor enforcing the wrong
+	// logical size.
+	setSizeHints(b.plat.conn, b.plat.window, b.plat.limits.Scaled(scale))
 	return true
 }

--- a/gui/backend/gl/events_win32.go
+++ b/gui/backend/gl/events_win32.go
@@ -261,10 +261,20 @@ func (b *Backend) handleMessage(msg, wparam, lparam uintptr) (uintptr, bool) {
 		return 0, false
 
 	case wmGetMinMaxInfo:
+		// Two independent concerns write different MINMAXINFO fields:
+		// the frameless clamp fixes the maximize rect, the size limits
+		// fix the track sizes. Both may apply to the same window, so
+		// neither short-circuits the other.
+		handled := false
 		if b.plat.frameless {
-			return b.clampMaximizeToWorkArea(lparam)
+			if _, ok := b.clampMaximizeToWorkArea(lparam); ok {
+				handled = true
+			}
 		}
-		return 0, false
+		if b.applySizeLimits(lparam) {
+			handled = true
+		}
+		return 0, handled
 
 	case wmClose:
 		gui.DispatchCloseRequest(w)

--- a/gui/backend/gl/platform_state_x11.go
+++ b/gui/backend/gl/platform_state_x11.go
@@ -67,6 +67,11 @@ type platformState struct {
 	physW, physH int32
 	scale        float32
 
+	// limits holds the configured resize bounds in logical pixels, kept
+	// so a DPI change can rewrite WM_NORMAL_HINTS at the new scale
+	// without re-reading the window config.
+	limits gui.SizeLimits
+
 	// Input method. ime is nil when none is reachable, in which case
 	// key presses keep going straight through the keysym path. imeBuf
 	// is reused by drainIME to keep the handoff allocation-free.

--- a/gui/backend/gl/platform_win32.go
+++ b/gui/backend/gl/platform_win32.go
@@ -198,6 +198,12 @@ type platformState struct {
 	// frameless records DecorationNone: WM_NCCALCSIZE and
 	// WM_GETMINMAXINFO only deviate from the default for such a window.
 	frameless bool
+	// minTrack and maxTrack are the outer-frame resize bounds in
+	// physical pixels, precomputed at create time so the
+	// WM_GETMINMAXINFO handler does no conversion per message. A zero
+	// component means that axis is unconstrained.
+	minTrack  pointL
+	maxTrack  pointL
 	cursors   [11]uintptr
 	curCursor uintptr
 	w         *gui.Window
@@ -451,6 +457,11 @@ func New(w *gui.Window) (*Backend, error) {
 	winW := rc.right - rc.left
 	winH := rc.bottom - rc.top
 
+	// Resize bounds share the style and DPI used for the initial size,
+	// so the floor means the same client area as Width/Height does.
+	limits := gui.WindowSizeLimits(cfg)
+	minTrack, maxTrack := trackSizeFor(limits, style, dpi)
+
 	hwnd, _, err := pCreateWindowExW.Call(
 		0,
 		uintptr(unsafe.Pointer(className)),
@@ -467,6 +478,8 @@ func New(w *gui.Window) (*Backend, error) {
 	b := &Backend{}
 	b.plat.hwnd = hwnd
 	b.plat.frameless = cfg.Decorations == gui.DecorationNone
+	b.plat.minTrack = minTrack
+	b.plat.maxTrack = maxTrack
 	registerWindow(hwnd, b)
 	// Detach the IME until a text widget takes focus and IMEStart
 	// re-attaches it, matching the focus gating on macOS and X11. Without

--- a/gui/backend/gl/platform_x11.go
+++ b/gui/backend/gl/platform_x11.go
@@ -119,6 +119,9 @@ func New(w *gui.Window) (*Backend, error) {
 	b.plat.curCrtc = crtc
 
 	setWindowTitle(conn, win, title)
+	// Hints are in physical pixels, matching the CreateWindow call.
+	b.plat.limits = gui.WindowSizeLimits(cfg)
+	setSizeHints(conn, win, b.plat.limits.Scaled(scale))
 	setWindowIcon(conn, win, cfg)
 	setWindowDecorations(conn, win, cfg.Decorations)
 	if cfg.WMClass != "" {
@@ -197,6 +200,84 @@ func setWindowTitle(conn *xgb.Conn, win xproto.Window, title string) {
 	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
 		xproto.AtomWmName, xproto.AtomString, 8,
 		uint32(len(title)), []byte(title))
+}
+
+// XSizeHints flag bits (Xutil.h). Only the two size bounds are used;
+// the rest of the structure is left zeroed.
+const (
+	sizeHintPMinSize = 1 << 4
+	sizeHintPMaxSize = 1 << 5
+)
+
+// sizeHintWords is the length of XSizeHints in 32-bit words. The
+// property is written whole even though only a few words are set,
+// because window managers read it by fixed offset.
+const sizeHintWords = 18
+
+// maxSizeHintExtent is the largest extent an X drawable coordinate can
+// carry, since they are 16-bit signed. Stands in for "no maximum".
+const maxSizeHintExtent = 1<<15 - 1
+
+// setSizeHints writes WM_NORMAL_HINTS so the window manager enforces
+// the resize bounds. X11 has no resizable style bit — this property is
+// the only way to constrain a drag, which is also why it is what makes
+// WindowCfg.FixedSize work here (WindowSizeLimits reports a fixed
+// window as min == max).
+//
+// Sizes must be physical pixels, since that is the unit CreateWindow
+// was given; the caller scales before calling. A window with nothing
+// constrained writes no property at all, leaving the WM's defaults.
+func setSizeHints(conn *xgb.Conn, win xproto.Window, limits gui.SizeLimits) {
+	if limits.None() {
+		return
+	}
+	words := sizeHintWordsFor(limits)
+
+	buf := make([]byte, 0, sizeHintWords*4)
+	for _, wd := range words {
+		buf = append(buf,
+			byte(wd), byte(wd>>8), byte(wd>>16), byte(wd>>24))
+	}
+	xproto.ChangeProperty(conn, xproto.PropModeReplace, win,
+		xproto.AtomWmNormalHints, xproto.AtomWmSizeHints, 32,
+		sizeHintWords, buf)
+}
+
+// sizeHintWordsFor lays the limits out in the XSizeHints word order.
+// Split from setSizeHints so the flag bits and the word offsets -- the
+// part a window manager reads positionally, and the easiest thing here
+// to get wrong -- are testable without an X server.
+func sizeHintWordsFor(limits gui.SizeLimits) [sizeHintWords]uint32 {
+	var words [sizeHintWords]uint32
+	// A flag covers both axes at once, so a one-axis limit still has to
+	// say something about the other. For a minimum, zero already means
+	// "no floor", so an unset axis is written as it stands.
+	if limits.MinW > 0 || limits.MinH > 0 {
+		words[0] |= sizeHintPMinSize
+		words[5] = uint32(limits.MinW)
+		words[6] = uint32(limits.MinH)
+	}
+	// A maximum has no such luck: zero there would read as "0 pixels"
+	// and pin the window shut, so an unset axis needs maxHintOr.
+	if limits.MaxW > 0 || limits.MaxH > 0 {
+		words[0] |= sizeHintPMaxSize
+		words[7] = maxHintOr(limits.MaxW)
+		words[8] = maxHintOr(limits.MaxH)
+	}
+	return words
+}
+
+// maxHintOr substitutes a practically unbounded extent for an unset
+// axis. X11 has no "no maximum" sentinel, and a zero would pin the
+// window shut, so an unconstrained axis gets the largest size the
+// 16-bit X drawable coordinate space can express. A set value is
+// already inside that range: gui.WindowSizeLimits caps every bound at
+// the same ceiling.
+func maxHintOr(v int) uint32 {
+	if v <= 0 {
+		return maxSizeHintExtent
+	}
+	return uint32(v)
 }
 
 // setupCloseProtocol registers WM_DELETE_WINDOW so the window manager's

--- a/gui/backend/gl/size_hints_x11_test.go
+++ b/gui/backend/gl/size_hints_x11_test.go
@@ -1,0 +1,64 @@
+//go:build linux && !js && !android
+
+package gl
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// An unset maximum axis must not pin the window shut. X11 has no
+// "no maximum" sentinel, so the substitute has to be a large extent.
+func TestMaxHintOrSubstitutesLargeExtent(t *testing.T) {
+	t.Parallel()
+	if got := maxHintOr(800); got != 800 {
+		t.Errorf("maxHintOr(800) = %d, want 800", got)
+	}
+	unset := maxHintOr(0)
+	if unset < 1<<14 {
+		t.Errorf("maxHintOr(0) = %d, want a large extent", unset)
+	}
+	if maxHintOr(-5) != unset {
+		t.Error("a negative maximum should read as unset")
+	}
+}
+
+// Window managers read WM_NORMAL_HINTS by fixed offset, so the flag
+// bits and the word positions are the contract, not an implementation
+// detail. A wrong offset here silently produces a window nobody can
+// resize.
+func TestSizeHintWordsForLayout(t *testing.T) {
+	t.Parallel()
+
+	// Both bounds set: flags carry PMinSize|PMaxSize and every one of
+	// the four values lands in its own word.
+	both := sizeHintWordsFor(gui.SizeLimits{
+		MinW: 400, MinH: 300, MaxW: 800, MaxH: 600,
+	})
+	if want := uint32(sizeHintPMinSize | sizeHintPMaxSize); both[0] != want {
+		t.Errorf("flags = %#x, want %#x", both[0], want)
+	}
+	for i, want := range map[int]uint32{5: 400, 6: 300, 7: 800, 8: 600} {
+		if both[i] != want {
+			t.Errorf("word %d = %d, want %d", i, both[i], want)
+		}
+	}
+
+	// Only a floor: the maximum words stay zero and PMaxSize is unset,
+	// so the window manager imposes no ceiling of its own.
+	minOnly := sizeHintWordsFor(gui.SizeLimits{MinW: 400, MinH: 300})
+	if minOnly[0]&sizeHintPMaxSize != 0 {
+		t.Error("PMaxSize set with no maximum configured")
+	}
+	if minOnly[7] != 0 || minOnly[8] != 0 {
+		t.Errorf("max words = %d,%d, want zero", minOnly[7], minOnly[8])
+	}
+
+	// One ceiling axis only: the other axis must be permissive, never
+	// the zero that would pin the window shut.
+	oneAxis := sizeHintWordsFor(gui.SizeLimits{MaxW: 800})
+	if oneAxis[8] < 1<<14 {
+		t.Errorf("unset max height = %d, want a large extent", oneAxis[8])
+	}
+}

--- a/gui/backend/metal/backend.go
+++ b/gui/backend/metal/backend.go
@@ -512,6 +512,15 @@ func createWindowState(w *gui.Window) (*windowState, error) {
 		return nil, errors.New("metalWindowCreate failed")
 	}
 
+	// Cocoa content sizes are points, the same unit WindowCfg uses, so
+	// the limits go across unscaled. Skipped entirely when nothing is
+	// constrained, leaving the window's AppKit defaults untouched.
+	if limits := gui.WindowSizeLimits(cfg); !limits.None() {
+		C.metalWindowSetSizeLimits(win,
+			C.int(limits.MinW), C.int(limits.MinH),
+			C.int(limits.MaxW), C.int(limits.MaxH))
+	}
+
 	iconPNG := cfg.IconPNG
 	if len(iconPNG) == 0 {
 		iconPNG = gui.DefaultIconPNG

--- a/gui/backend/metal/callbacks.go
+++ b/gui/backend/metal/callbacks.go
@@ -10,6 +10,7 @@ package metal
 
 // Test helpers — defined in metal_window.m.
 int metalTestActivationPolicyIsRegular(void);
+void metalTestSizeLimits(GoGuiNSWindow w, int *minW, int *minH, int *maxW, int *maxH);
 int metalTestDelegateIsSet(void);
 int metalTestMainMenuExists(void);
 int metalTestMenuQuitWired(void);
@@ -124,6 +125,15 @@ func goMetalPumpFrames() {
 
 func testActivationPolicyRegular() bool {
 	return C.metalTestActivationPolicyIsRegular() != 0
+}
+
+// testSizeLimits reads back the window's content size limits. Used to
+// confirm the WindowCfg limits reached AppKit, which no Go-side check
+// can observe.
+func testSizeLimits(win C.GoGuiNSWindow) (minW, minH, maxW, maxH int) {
+	var a, b, c, d C.int
+	C.metalTestSizeLimits(win, &a, &b, &c, &d)
+	return int(a), int(b), int(c), int(d)
 }
 
 func testDelegateSet() bool {

--- a/gui/backend/metal/icon_test.go
+++ b/gui/backend/metal/icon_test.go
@@ -108,6 +108,36 @@ func runMainThreadTests() {
 		panic("metal.New with activation: " + err.Error())
 	}
 
+	// 5b. WindowCfg size limits must reach the NSWindow. Nothing on
+	//     the Go side can observe this: AppKit enforces the bound
+	//     inside the resize drag, so a wrong handle cast or a missed
+	//     call is invisible until a user drags the window.
+	lw := gui.NewWindow(gui.WindowCfg{
+		State:  new(int),
+		Width:  400,
+		Height: 400,
+		// Only MaxWidth is set, so the readback also proves an unset
+		// axis is left unconstrained rather than pinned to zero.
+		MinWidth: 300, MinHeight: 250, MaxWidth: 900,
+	})
+	lb, err := New(lw)
+	if err != nil {
+		panic("metal.New with size limits: " + err.Error())
+	}
+	minW, minH, maxW, maxH := testSizeLimits(lb.window)
+	if minW != 300 || minH != 250 {
+		panic(fmt.Sprintf(
+			"contentMinSize = %dx%d, want 300x250", minW, minH))
+	}
+	if maxW != 900 {
+		panic(fmt.Sprintf("contentMaxSize width = %d, want 900", maxW))
+	}
+	if maxH != 0 {
+		panic(fmt.Sprintf(
+			"contentMaxSize height = %d, want unconstrained", maxH))
+	}
+	lb.Destroy()
+
 	// 6. Window must have a delegate for close/resize/focus
 	//    callbacks. Regression test for single-window close
 	//    button not working.

--- a/gui/backend/metal/metal_window.h
+++ b/gui/backend/metal/metal_window.h
@@ -25,6 +25,14 @@ typedef void *GoGuiNSWindow;
 GoGuiNSWindow metalWindowCreate(const char *title, int width, int height,
                                 int fixedSize, int decorations);
 
+// Constrain interactive resizing to the given content-size bounds, in
+// logical pixels (points, which is what AppKit's content size uses, so
+// no DPI scaling applies here). A zero minimum means no floor; a zero
+// maximum means no ceiling. setContentMaxSize: also caps the maximize
+// (zoom) button, not only the drag.
+void metalWindowSetSizeLimits(GoGuiNSWindow w, int minW, int minH,
+                              int maxW, int maxH);
+
 // Hand the window to AppKit's own move loop, using the last mouse-down
 // event as the gesture's origin. No-op when no press has been seen.
 void metalWindowStartDrag(GoGuiNSWindow w);

--- a/gui/backend/metal/metal_window_darwin.m
+++ b/gui/backend/metal/metal_window_darwin.m
@@ -789,6 +789,23 @@ void metalWindowSetTitle(GoGuiNSWindow w, const char *title) {
     if (nsTitle) [gw->nsWindow setTitle:nsTitle];
 }
 
+void metalWindowSetSizeLimits(GoGuiNSWindow w, int minW, int minH,
+                              int maxW, int maxH) {
+    if (!w) return;
+    GoGuiWindow *gw = (GoGuiWindow *)w;
+    // A zero on either axis means "unconstrained on that axis", so each
+    // axis is decided on its own rather than skipping the whole call.
+    NSSize minSize = NSMakeSize(minW > 0 ? (CGFloat)minW : 0.0,
+                                minH > 0 ? (CGFloat)minH : 0.0);
+    [gw->nsWindow setContentMinSize:minSize];
+
+    // AppKit has no "no maximum" sentinel; CGFLOAT_MAX is the idiom,
+    // and is what a window carries before anyone sets a ceiling.
+    NSSize maxSize = NSMakeSize(maxW > 0 ? (CGFloat)maxW : CGFLOAT_MAX,
+                                maxH > 0 ? (CGFloat)maxH : CGFLOAT_MAX);
+    [gw->nsWindow setContentMaxSize:maxSize];
+}
+
 void metalWindowStartDrag(GoGuiNSWindow w) {
     if (!w || !_lastMouseDown) return;
     GoGuiWindow *gw = (GoGuiWindow *)w;
@@ -1624,6 +1641,23 @@ void metalStopFramePump(void) {
 // split would force exposing those symbols via the header, widening
 // the production surface just to relocate test code. Keeping the
 // helpers here preserves that encapsulation.
+
+// metalTestSizeLimits reports the window's content size limits so a
+// test can confirm setContentMinSize:/setContentMaxSize: actually
+// landed on the NSWindow. An unset maximum comes back as 0 rather than
+// CGFLOAT_MAX, so the caller does not have to know AppKit's sentinel.
+void metalTestSizeLimits(GoGuiNSWindow w, int *minW, int *minH,
+                         int *maxW, int *maxH) {
+    *minW = 0; *minH = 0; *maxW = 0; *maxH = 0;
+    if (!w) return;
+    GoGuiWindow *gw = (GoGuiWindow *)w;
+    NSSize mn = [gw->nsWindow contentMinSize];
+    NSSize mx = [gw->nsWindow contentMaxSize];
+    *minW = (int)mn.width;
+    *minH = (int)mn.height;
+    *maxW = mx.width  >= CGFLOAT_MAX ? 0 : (int)mx.width;
+    *maxH = mx.height >= CGFLOAT_MAX ? 0 : (int)mx.height;
+}
 
 int metalTestActivationPolicyIsRegular(void) {
     return [NSApp activationPolicy] == NSApplicationActivationPolicyRegular ? 1 : 0;

--- a/gui/list_core_alloc_bench_test.go
+++ b/gui/list_core_alloc_bench_test.go
@@ -45,10 +45,9 @@ func BenchmarkComboboxGenerateLayout(b *testing.B) {
 	options := benchmarkOptions(500)
 	w := newTestWindow()
 	cfg := ComboboxCfg{
-		ID:         "bench-cb",
-		Options:    options,
-		OnSelect:   func(_ string, ctx EventCtx) {},
-		Scrollable: true,
+		ID:       "bench-cb",
+		Options:  options,
+		OnSelect: func(_ string, ctx EventCtx) {},
 	}
 
 	b.Run("closed", func(b *testing.B) {

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -53,9 +53,6 @@ type ComboboxCfg struct {
 	// requires a non-empty ID; without one the control is inert.
 	FocusDisabled bool
 
-	// Scrollable opts the dropdown into the scroll system. Scroll
-	// state is keyed by ScopeID(Cfg.ID, "dropdown").
-	Scrollable       bool
 	Color            Color
 	ColorBorder      Color
 	ColorBorderFocus Color
@@ -156,16 +153,14 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 		cfg.TextStyle, cfg.Padding.Or(PaddingNone), w)
 	pad := cfg.Padding.Or(PaddingNone)
 	listH := cfg.MaxDropdownHeight - 2*sizeBorder - pad.Top - pad.Bottom
-	var scrollY float32
 	// The dropdown is a child of the container that claims cfg.ID, so
 	// its shape carries the plain leaf below and the framework joins it.
 	// The key here is that same join, spelled out because this read
 	// happens during generation.
 	dropdownScrollID := ScopeID(id, "dropdown")
-	if cfg.Scrollable {
-		// Default 0: unscrolled dropdown before first scroll event.
-		scrollY = w.scrollY().GetOr(dropdownScrollID, 0)
-	}
+	// The dropdown always scrolls, so the offset is always live.
+	// Default 0: unscrolled dropdown before the first scroll event.
+	scrollY := w.scrollY().GetOr(dropdownScrollID, 0)
 	first, last := listCoreVisibleRange(len(filtered), rowH, listH, scrollY)
 	// Index space: the *filtered* items, so it moves with the query.
 	listHeightRegisterUniform(w, dropdownScrollID, len(filtered),
@@ -257,17 +252,16 @@ func (cv *comboboxView) GenerateLayout(w *Window) Layout {
 			FloatTieOff:  FloatTopLeft,
 			FloatOffsetY: -sizeBorder,
 			FloatZIndex:  cfg.FloatZIndex,
-			Scrollable:   cfg.Scrollable,
 			// MaxHeight alone does not hold the rows in: a list
-			// taller than the cap paints its overflow over whatever
-			// is under the dropdown. A scrollable dropdown already
-			// clips through its viewport, so the stencil is only
-			// needed for the other one, where it truncates the list
-			// instead of letting it escape.
-			ClipContents: !cfg.Scrollable,
-			Padding:      cfg.Padding,
-			Spacing:      SomeF(0),
-			Content:      dropdownContent,
+			// taller than the cap would paint its overflow over
+			// whatever is under the dropdown. The scroll viewport
+			// both clips it and gives the caller a way to reach the
+			// rows below the cap, so it is not optional (issue #492).
+			// Scroll state is keyed by ScopeID(Cfg.ID, "dropdown").
+			Scrollable: true,
+			Padding:    cfg.Padding,
+			Spacing:    SomeF(0),
+			Content:    dropdownContent,
 			AmendLayout: func(ctx EventCtx) {
 				if ctx.Layout.Parent == nil {
 					return

--- a/gui/view_combobox_test.go
+++ b/gui/view_combobox_test.go
@@ -347,10 +347,9 @@ func TestComboboxScrollEndToEnd(t *testing.T) {
 
 	// Generate the layout (simulates next frame).
 	v := Combobox(ComboboxCfg{
-		ID:         "cb-e2e",
-		Scrollable: true,
-		Options:    options,
-		OnSelect:   func(_ string, ctx EventCtx) {},
+		ID:       "cb-e2e",
+		Options:  options,
+		OnSelect: func(_ string, ctx EventCtx) {},
 	})
 	layout := generateViewLayout(v, w)
 

--- a/gui/window_cfg.go
+++ b/gui/window_cfg.go
@@ -41,6 +41,23 @@ type WindowCfg struct {
 	WMClass string
 	Width   int
 	Height  int
+	// MinWidth and MinHeight set the smallest size the user can drag
+	// the window to, in the same logical pixels as Width and Height.
+	// Zero means no floor. Honored by the macOS, Windows and X11
+	// backends; ignored elsewhere. FixedSize wins over both.
+	// exportaudit:keep — caller-facing config (issue #494)
+	MinWidth int
+	// exportaudit:keep — caller-facing config (issue #494)
+	MinHeight int
+	// MaxWidth and MaxHeight set the largest size the user can drag
+	// the window to, in logical pixels. Zero means no ceiling. A
+	// ceiling below its floor is raised to the floor. On Windows and
+	// macOS the ceiling also caps the maximize button, not only the
+	// drag.
+	// exportaudit:keep — caller-facing config (issue #494)
+	MaxWidth int
+	// exportaudit:keep — caller-facing config (issue #494)
+	MaxHeight int
 	// MaxImageBytes caps source image file size for decoded image
 	// loads. Zero or negative selects backend defaults.
 	MaxImageBytes int64

--- a/gui/window_size_limits.go
+++ b/gui/window_size_limits.go
@@ -1,0 +1,113 @@
+package gui
+
+// SizeLimits carries a window's normalized resize bounds in the same
+// logical pixels WindowCfg.Width and WindowCfg.Height use. A zero
+// field means "unset": no floor, or no ceiling, on that axis. Each
+// backend scales these to physical pixels itself, since the logical
+// -> physical factor is the backend's own DPI state.
+// exportaudit:keep — backend-facing (issue #494)
+type SizeLimits struct {
+	MinW int
+	MinH int
+	MaxW int
+	MaxH int
+}
+
+// None reports whether nothing is constrained, so a backend can skip
+// the platform call entirely rather than write a no-op hint.
+// exportaudit:keep — backend-facing (issue #494)
+func (l SizeLimits) None() bool {
+	return l.MinW == 0 && l.MinH == 0 && l.MaxW == 0 && l.MaxH == 0
+}
+
+// WindowSizeLimits normalizes the four WindowCfg limit fields into the
+// single form every backend consumes. Centralized so the three native
+// backends cannot disagree about the edge cases.
+//
+// Rules, in order:
+//
+//   - FixedSize collapses both bounds onto Width/Height, so a fixed
+//     window is expressed as min == max. This is what lets the X11
+//     backend honor FixedSize at all: it has no resizable style bit,
+//     only WM_NORMAL_HINTS. A FixedSize window with no usable
+//     Width/Height falls through to the ordinary rules rather than
+//     pinning the window to zero.
+//   - A negative value is not a smaller window, it is a caller
+//     mistake; treat it as unset rather than propagating it into a
+//     platform call.
+//   - A ceiling below its floor is contradictory. The floor is the
+//     stronger promise (content stops fitting below it), so raise the
+//     ceiling to meet it instead of dropping the floor.
+//
+// exportaudit:keep — backend-facing (issue #494)
+func WindowSizeLimits(cfg WindowCfg) SizeLimits {
+	if cfg.FixedSize && cfg.Width > 0 && cfg.Height > 0 {
+		return SizeLimits{
+			MinW: cfg.Width, MinH: cfg.Height,
+			MaxW: cfg.Width, MaxH: cfg.Height,
+		}
+	}
+	l := SizeLimits{
+		MinW: clampUnset(cfg.MinWidth),
+		MinH: clampUnset(cfg.MinHeight),
+		MaxW: clampUnset(cfg.MaxWidth),
+		MaxH: clampUnset(cfg.MaxHeight),
+	}
+	// Only a set ceiling can contradict a floor; an unset one stays
+	// unset so the backend omits the max hint.
+	if l.MaxW != 0 && l.MaxW < l.MinW {
+		l.MaxW = l.MinW
+	}
+	if l.MaxH != 0 && l.MaxH < l.MinH {
+		l.MaxH = l.MinH
+	}
+	return l
+}
+
+// maxWindowExtent is the largest bound any backend is handed, in
+// pixels. It is the X11 ceiling -- drawable coordinates are 16-bit
+// signed, so a larger hint wraps into nonsense -- and it doubles as the
+// overflow guard for the Win32 int32 track sizes. No real display comes
+// close, so a caller asking for more gets the ceiling rather than a
+// wrapped value.
+const maxWindowExtent = 1<<15 - 1
+
+// clampUnset folds a negative size to zero ("unset") and holds a
+// nonsense-large one down to what the platforms can express.
+func clampUnset(v int) int {
+	if v < 0 {
+		return 0
+	}
+	return min(v, maxWindowExtent)
+}
+
+// Scaled returns the limits in physical pixels for a backend whose
+// logical -> physical factor is s. Used by the X11 and Windows
+// backends, which create windows in device pixels; macOS takes points
+// and uses the unscaled values directly. A zero field stays zero so
+// "unset" survives scaling. This is the only place the conversion
+// lives, so the two backends cannot round a bound differently.
+// exportaudit:keep — backend-facing (issue #494)
+func (l SizeLimits) Scaled(s float32) SizeLimits {
+	return SizeLimits{
+		MinW: scaleLimit(l.MinW, s),
+		MinH: scaleLimit(l.MinH, s),
+		MaxW: scaleLimit(l.MaxW, s),
+		MaxH: scaleLimit(l.MaxH, s),
+	}
+}
+
+func scaleLimit(v int, s float32) int {
+	if v == 0 {
+		return 0
+	}
+	// Truncated rather than rounded, because that is exactly how the
+	// X11 and Windows backends convert Width/Height. Rounding here
+	// would let a floor equal to the created size land a pixel above
+	// it, and the window would grow by that pixel the moment it opened
+	// -- most visibly under FixedSize, which is expressed as a floor at
+	// the created size. A sub-pixel scale must still not truncate a
+	// real floor away to "unset", hence the 1; a high scale must not
+	// carry a bound past what the platforms can express, hence the cap.
+	return min(max(int(float32(v)*s), 1), maxWindowExtent)
+}

--- a/gui/window_size_limits_test.go
+++ b/gui/window_size_limits_test.go
@@ -1,0 +1,119 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+func TestWindowSizeLimits(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  WindowCfg
+		want SizeLimits
+	}{
+		{
+			name: "unset",
+			cfg:  WindowCfg{Width: 800, Height: 600},
+			want: SizeLimits{},
+		},
+		{
+			name: "min only",
+			cfg:  WindowCfg{MinWidth: 400, MinHeight: 300},
+			want: SizeLimits{MinW: 400, MinH: 300},
+		},
+		{
+			name: "max only",
+			cfg:  WindowCfg{MaxWidth: 1200, MaxHeight: 900},
+			want: SizeLimits{MaxW: 1200, MaxH: 900},
+		},
+		{
+			name: "negative reads as unset",
+			cfg:  WindowCfg{MinWidth: -10, MaxHeight: -1, MinHeight: 300},
+			want: SizeLimits{MinH: 300},
+		},
+		{
+			// The floor is the stronger promise, so the ceiling moves.
+			name: "max below min is raised to min",
+			cfg: WindowCfg{
+				MinWidth: 500, MaxWidth: 200,
+				MinHeight: 400, MaxHeight: 100,
+			},
+			want: SizeLimits{MinW: 500, MinH: 400, MaxW: 500, MaxH: 400},
+		},
+		{
+			name: "fixed size collapses onto width/height",
+			cfg: WindowCfg{
+				Width: 640, Height: 480, FixedSize: true,
+				MinWidth: 100, MaxWidth: 2000,
+			},
+			want: SizeLimits{MinW: 640, MinH: 480, MaxW: 640, MaxH: 480},
+		},
+		{
+			// A FixedSize window with no size to pin to must not be
+			// pinned to zero; the ordinary rules apply instead.
+			name: "fixed size without dimensions falls through",
+			cfg:  WindowCfg{FixedSize: true, MinWidth: 300},
+			want: SizeLimits{MinW: 300},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WindowSizeLimits(tc.cfg)
+			if got != tc.want {
+				t.Errorf("WindowSizeLimits() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSizeLimitsNone(t *testing.T) {
+	if !(SizeLimits{}).None() {
+		t.Error("zero SizeLimits should report None")
+	}
+	if (SizeLimits{MinW: 1}).None() {
+		t.Error("a set floor should not report None")
+	}
+	if (SizeLimits{MaxH: 1}).None() {
+		t.Error("a set ceiling should not report None")
+	}
+}
+
+func TestSizeLimitsScaled(t *testing.T) {
+	got := SizeLimits{MinW: 400, MinH: 300, MaxW: 800}.Scaled(2)
+	want := SizeLimits{MinW: 800, MinH: 600, MaxW: 1600}
+	if got != want {
+		t.Errorf("Scaled(2) = %+v, want %+v", got, want)
+	}
+	// Unset must survive scaling as unset, not become a 0-pixel bound.
+	if (SizeLimits{}).Scaled(2) != (SizeLimits{}) {
+		t.Error("scaling an unset limit should stay unset")
+	}
+	// A sub-pixel result must not round a real floor away.
+	if got := (SizeLimits{MinW: 1}).Scaled(0.1); got.MinW != 1 {
+		t.Errorf("Scaled(0.1).MinW = %d, want 1", got.MinW)
+	}
+	// Truncated, not rounded: the backends size a new window the same
+	// way, so a floor equal to the created size must not land above it
+	// and push the window a pixel wider the moment it opens.
+	if got := (SizeLimits{MinW: 401}).Scaled(1.5); got.MinW != 601 {
+		t.Errorf("Scaled(1.5).MinW = %d, want the truncated 601", got.MinW)
+	}
+	// Scaling must not carry a bound past what a backend can express:
+	// X11 hints are 16-bit and the Win32 track sizes are int32.
+	if got := (SizeLimits{MaxW: maxWindowExtent}).Scaled(4); got.MaxW != maxWindowExtent {
+		t.Errorf("Scaled(4).MaxW = %d, want the %d cap",
+			got.MaxW, maxWindowExtent)
+	}
+}
+
+// A nonsense-large configured bound is held to the platform ceiling
+// rather than wrapping into a negative when a backend narrows it.
+func TestWindowSizeLimitsCapsHugeValues(t *testing.T) {
+	got := WindowSizeLimits(WindowCfg{
+		MinWidth: math.MaxInt, MaxHeight: math.MaxInt,
+	})
+	if got.MinW != maxWindowExtent || got.MaxH != maxWindowExtent {
+		t.Errorf("WindowSizeLimits = %+v, want both axes at %d",
+			got, maxWindowExtent)
+	}
+}


### PR DESCRIPTION
## Summary

- **Min/max window size** (#494) — `WindowCfg` gains `MinWidth`, `MinHeight`, `MaxWidth`, `MaxHeight`, in the same logical pixels as `Width`/`Height`. The resize drag is serviced by the OS before the app is told anything, so this has to be a platform-enforced feature, not an app-level workaround. Honored by macOS (`setContentMinSize:`/`setContentMaxSize:`), Windows (`WM_GETMINMAXINFO` track sizes), and X11 (`WM_NORMAL_HINTS`). Zero leaves a bound unset; a ceiling below its floor is raised to the floor; `FixedSize` still wins over both; on Windows and macOS the ceiling also caps the maximize button.
- **Fixed along the way:** `WindowCfg.FixedSize` was a silent no-op on X11 — only macOS and Windows honored it. X11 has no resizable style bit, so the fix rides the same `WM_NORMAL_HINTS` property this change introduces (fixed size == min == max).
- **BREAKING:** `ComboboxCfg.Scrollable` is removed; the dropdown always scrolls (#492 follow-up). It was opt-in, so a caller who set `MaxDropdownHeight` got a cap that didn't actually hold rows in — only the scroll viewport clips overflow and keeps rows below the cap reachable, matching what `Select`'s dropdown already did.

## Details

Full policy lives in `gui/window_size_limits.go` so the three native backends can't disagree about edge cases (negative-as-unset, ceiling-below-floor, `FixedSize` collapse, and a cap at the largest extent an X11 drawable coordinate can carry). Spec: `docs/specs/window-size-limits.md`.

macOS verified end-to-end via a Cocoa main-thread readback test (`gui/backend/metal/icon_test.go`) that reads `contentMinSize`/`contentMaxSize` back off a real `NSWindow`. Windows and X11 verified by cross-compile, cross-lint, and unit tests of the pure conversion helpers (`trackSizeFor`, `applySizeLimits`, `sizeHintWordsFor`) — no hardware to drag a real window on for those two.

## Testing

- `make prepush` — race tests, lint, cross-lint, cross-compile (darwin/windows/linux), coverage gate, export audit: all green.
- `golangci-lint run ./...` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)