### PR TITLE
fix(scrollbar): inset the horizontal track by GapEnd, not outset

### DIFF
--- a/gui/view_scrollbar.go
+++ b/gui/view_scrollbar.go
@@ -174,7 +174,7 @@ func scrollbarAmendLayout(
 			scrollOffset = -v
 		}
 
-		layout.Shape.X -= gapEnd
+		layout.Shape.X += gapEnd
 		layout.Shape.Y -= gapEdge
 		layout.Shape.Width -= gapEnd + gapEnd
 

--- a/gui/view_scrollbar_test.go
+++ b/gui/view_scrollbar_test.go
@@ -413,3 +413,65 @@ func TestScrollbarGapEdgeExplicitZero(t *testing.T) {
 		t.Errorf("20px gap moved the bar %v, want %v", got, want)
 	}
 }
+
+// scrollbarTrackH arranges a horizontally scrolling row and returns
+// the horizontal bar's track layout together with the scroller it
+// rides in, so a test can state the inset against the container
+// rather than against a hard-coded pixel.
+func scrollbarTrackH(t *testing.T, override *ScrollbarCfg) (track, scroller *Layout) {
+	t.Helper()
+
+	w := NewWindow(WindowCfg{State: new(int), Width: 300, Height: 200})
+	w.viewGenerator = func(*Window) View {
+		// Fixed-width cells wider than the 300px window, so the bar
+		// has something to scroll and stays visible.
+		cells := make([]View, 40)
+		for i := range cells {
+			cells[i] = Column(ContainerCfg{Sizing: FixedFill, Width: 40})
+		}
+		return Row(ContainerCfg{
+			ID:            "scroller",
+			Sizing:        FillFill,
+			Scrollable:    true,
+			ScrollMode:    ScrollHorizontalOnly,
+			ScrollbarCfgX: override,
+			Content:       cells,
+		})
+	}
+	w.refreshLayout = true
+	w.FrameFn()
+
+	sc, ok := w.layout.FindByID("scroller")
+	if !ok {
+		t.Fatal("scroller not found")
+	}
+	// container() appends the horizontal bar first, then the
+	// vertical one, so the horizontal track is the second to last
+	// child.
+	return &sc.Children[len(sc.Children)-2], sc
+}
+
+// TestScrollbarGapEndHorizontal pins the direction GapEnd is applied
+// in. The horizontal branch used to subtract it, putting the track
+// outside its container instead of inset at both ends (issue #497).
+func TestScrollbarGapEndHorizontal(t *testing.T) {
+	track, sc := scrollbarTrackH(t, nil)
+	gapEnd := DefaultScrollbarStyle.GapEnd
+
+	gutterX := sc.Shape.X + sc.Shape.Padding.Left
+	gutterWidth := sc.Shape.Width - sc.Shape.Padding.Width()
+
+	if got, want := track.Shape.X, gutterX+gapEnd; got != want {
+		t.Errorf("track X = %v, want %v (inset by GapEnd, not outset)", got, want)
+	}
+	if got, want := track.Shape.Width, gutterWidth-gapEnd-gapEnd; got != want {
+		t.Errorf("track width = %v, want %v", got, want)
+	}
+	// The two end insets must match: that is what "centred in the
+	// gutter" means, and it is the property the sign bug broke.
+	leadIn := track.Shape.X - gutterX
+	trailIn := (gutterX + gutterWidth) - (track.Shape.X + track.Shape.Width)
+	if leadIn != trailIn {
+		t.Errorf("end insets = %v and %v, want equal", leadIn, trailIn)
+	}
+}


### PR DESCRIPTION
The vertical branch of `scrollbarAmendLayout` adds `GapEnd` to `Y`; the horizontal branch subtracted it from `X`, so the track began 2px **outside** its container and was 4px shorter — off-centre by 4px instead of inset by 2px at each end. The thumb inherited the shift, since its X derives from `layout.Shape.X`.

`gui/view_scrollbar.go:177` now reads `layout.Shape.X += gapEnd`, mirroring the vertical branch.

## Test

`TestScrollbarGapEndHorizontal` arranges a horizontally scrolling row and asserts the track's X, width, and equal end insets against the scroller. It fails before the fix (`track X = 12, want 16`) and passes after.

## Verification

- `go test ./gui/...` green; no golden drift (no golden covers a visible horizontal bar).
- `make check-all` green.

Drag math is untouched: `scrollbarMouseMove` / `offsetMouseChangeX` read the scrollable layout found by `findLayoutByScrollID`, not the bar's geometry.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)