### PR TITLE
fix(palette): follow the scroll offset when virtualizing results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **A scrolled command palette showed blank rows** (#504) — the results viewport
+  is always `Scrollable`, but the virtualized window read the scroll offset only
+  when the caller had set `CommandPaletteCfg.Scrollable`. With the flag unset
+  the window stayed pinned at index 0 while the viewport scrolled, so scrolling
+  past the first screen revealed the trailing transparent spacer instead of
+  items. The offset is now always read.
+
+### Deprecated
+
+- **`CommandPaletteCfg.Scrollable` is a no-op** and is scheduled for removal in
+  #504. The results list always scrolls. Callers can delete the line now.
+
 ## [v0.68.0] - 2026-09-05
 
 ### Added

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -49,8 +49,10 @@ type CommandPaletteCfg struct {
 	Width       float32
 	MaxHeight   float32
 
-	// Scrollable opts the results list into the scroll system. Scroll
-	// state is keyed by ScopeID(Cfg.ID, "scroll").
+	// Scrollable is a no-op and is scheduled for removal (issue #504).
+	// The results list always scrolls; scroll state is keyed by
+	// ScopeID(Cfg.ID, "scroll").
+	// exportaudit:keep — deprecated caller-facing config (issue #504)
 	Scrollable     bool
 	Color          Color
 	ColorBorder    Color
@@ -149,11 +151,13 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 	rowH := listCoreRowHeightEstimate(
 		cfg.TextStyle, PaddingTwoFive, w)
 	scrollID := ScopeID(id, "scroll")
-	var scrollY float32
-	if cfg.Scrollable {
-		// Default 0: unscrolled list before first scroll event.
-		scrollY = w.scrollY().GetOr(scrollID, 0)
-	}
+	// The results viewport is always Scrollable (see the layout below),
+	// so the virtualized window must always follow the real offset.
+	// Reading it only when Cfg.Scrollable was set left the window
+	// pinned at index 0 while the viewport scrolled, so a scrolled
+	// palette showed the trailing spacer instead of rows.
+	// Default 0: unscrolled list before first scroll event.
+	scrollY := w.scrollY().GetOr(scrollID, 0)
 	first, last := listCoreVisibleRange(len(filtered), rowH, cfg.MaxHeight, scrollY)
 	// Index space: the *filtered* items, so it moves with the query.
 	listHeightRegisterUniform(w, scrollID, len(filtered), rowH, 0, 0)

--- a/gui/view_command_palette_test.go
+++ b/gui/view_command_palette_test.go
@@ -1,6 +1,10 @@
 package gui
 
-import "testing"
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
 
 func TestCommandPaletteHidden(t *testing.T) {
 	w := &Window{}
@@ -439,4 +443,104 @@ func TestPaletteFloatZIndexDefault(t *testing.T) {
 	if cfg.FloatZIndex != 1000 {
 		t.Errorf("FloatZIndex = %d, want 1000", cfg.FloatZIndex)
 	}
+}
+
+// The results viewport is always Scrollable, so the virtualized
+// window has to follow the real scroll offset. It used to be read
+// only when Cfg.Scrollable was set, which pinned the window at index
+// 0: the viewport scrolled but the rows did not, so a scrolled
+// palette showed the trailing transparent spacer instead of items.
+// Cfg.Scrollable is left unset here on purpose — that is the case
+// that used to break.
+func TestCommandPaletteScrollFollowsOffset(t *testing.T) {
+	w := &Window{}
+	const id = "cp-scroll-follow"
+	commandPaletteShow(id, w)
+
+	items := make([]CommandPaletteItem, 200)
+	for i := range items {
+		items[i] = CommandPaletteItem{
+			ID:    "cmd-" + itoa(i),
+			Label: "Command " + itoa(i),
+		}
+	}
+	cfg := CommandPaletteCfg{
+		ID:        id,
+		Items:     items,
+		MaxHeight: 200,
+		OnAction:  func(_ string, _ EventCtx) {},
+	}
+
+	// Unscrolled: the window starts at the top.
+	if first, _ := paletteRowRange(t, w, cfg); first != 0 {
+		t.Fatalf("unscrolled palette: first row = %d, want 0", first)
+	}
+
+	// Scroll well past the first screen. Offsets are negative.
+	w.scrollY().Set(ScopeID(id, "scroll"), -1000)
+	first, last := paletteRowRange(t, w, cfg)
+	if first == 0 {
+		t.Error("scrolled palette still renders from row 0; the " +
+			"virtualized window is not following the scroll offset")
+	}
+	if last <= first {
+		t.Errorf("scrolled palette rendered no rows: first=%d last=%d",
+			first, last)
+	}
+
+	// Scrolled past the end: the range clamps to the last index, so the
+	// tail renders. This is the symptom the bug produced -- an offset
+	// beyond the window used to leave only the trailing spacer.
+	w.scrollY().Set(ScopeID(id, "scroll"), -1_000_000)
+	_, last = paletteRowRange(t, w, cfg)
+	if want := len(items) - 1; last != want {
+		t.Errorf("palette scrolled to the bottom: last row = %d, want %d",
+			last, want)
+	}
+}
+
+// paletteRowRange returns the index of the first and last item row
+// the palette actually built, read back from the rendered labels.
+func paletteRowRange(
+	t *testing.T, w *Window, cfg CommandPaletteCfg,
+) (int, int) {
+	t.Helper()
+	layout := generateViewLayout(CommandPalette(cfg), w)
+	first, last := -1, -1
+	var walk func(Layout)
+	walk = func(l Layout) {
+		if l.Shape != nil && l.Shape.shapeType == shapeText &&
+			l.Shape.TC != nil {
+			if idx, ok := paletteLabelIndex(l.Shape.TC.Text); ok {
+				if first < 0 || idx < first {
+					first = idx
+				}
+				if idx > last {
+					last = idx
+				}
+			}
+		}
+		for i := range l.Children {
+			walk(l.Children[i])
+		}
+	}
+	walk(layout)
+	if first < 0 {
+		t.Fatal("palette rendered no item rows")
+	}
+	return first, last
+}
+
+// paletteLabelIndex parses "Command 42" back to 42. Anything else --
+// the placeholder, a detail line -- is not an item row.
+func paletteLabelIndex(text string) (int, bool) {
+	rest, ok := strings.CutPrefix(text, "Command ")
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }


### PR DESCRIPTION
Part of #504, split out because it is a live rendering bug and does not
break the API. The three remaining `Scrollable` removals stay in #504.

## The bug

The palette's results viewport is hardcoded `Scrollable: true`
(`gui/view_command_palette.go:264`), but the virtualized window read the
scroll offset only when the caller had set `CommandPaletteCfg.Scrollable`.

With the flag unset — the common case, since nothing in the API suggests
you need it — `scrollY` stayed 0, so `listCoreVisibleRange` windowed at
index 0 while the viewport scrolled underneath. `listCoreViews` emits a
trailing transparent spacer for everything past the window, so scrolling
past the first screen showed blank rows.

## The fix

Read the offset unconditionally. `CommandPaletteCfg.Scrollable` becomes a
documented no-op, marked `exportaudit:keep` and scheduled for removal with
the other three `Scrollable` opt-ins in #504. Callers can delete the line
now; the field stays until that sweep so this PR is not breaking.

## Checks made while reviewing

- **Keying is correct.** `scrollID` contains `:`, so `resolveShapeIDs`
  treats it as an absolute leaf and never re-joins ancestors. The read key
  equals the scroll container's `effID` even when the palette is nested
  under an ID-bearing panel.
- **`MaxHeight` cannot be 0** at the call site (defaulted at
  `view_command_palette.go:457`), so `listCoreVisibleRange` never hits its
  degenerate `(0, -1)` branch here.
- `w.scrollY().GetOr(...)` matches the pattern already used by combobox,
  table, tree and virtual-list.

## Test

`TestCommandPaletteScrollFollowsOffset` leaves `Cfg.Scrollable` unset on
purpose — that is the case that broke. Verified non-vacuous by reverting
the fix:

```
view_command_palette_test.go:483: scrolled palette still renders from row 0
view_command_palette_test.go:497: palette scrolled to the bottom: last row = 11, want 199
```

`last row = 11` is the symptom exactly: 12 rows built while the viewport
sits at row 199.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues) and
`make check` all pass. Goldens are unchanged — unscrolled output does not
move, so no re-record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
