### PR TITLE
feat(input): NumericInput steps with arrow keys and wheel (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ and this project adheres to
 
 ### Added
 
+- **`NumericInput` steps with the arrow keys** (#503) — Up and Down step by
+  `StepCfg.Step`, with the existing Shift (10x) and Alt (0.1x) multipliers.
+  Stepping is on by default because arrow keys are the spinbox convention; turn
+  it off with `StepCfg.KeyboardDisabled`. The handler consumes the event only
+  when it actually steps, so an arrow that does not step still reaches an
+  enclosing list, and a read-only field declines the key rather than swallowing
+  it. Wheel stepping stays opt-in behind `StepCfg.MouseWheel`, because a field
+  that eats the wheel stops the form under the pointer from scrolling; it is now
+  wired up rather than merely accepted.
+
+### Changed
+
+- **BREAKING: `NumericStepCfg.Keyboard` is now `KeyboardDisabled`** (#503) — the
+  field never did anything: nothing read it, so a `NumericInput` could not step
+  by keyboard whatever the caller set. Now that stepping works it defaults on,
+  and the field spells the opt-out to match the `FocusDisabled` house style.
+  Delete `Keyboard: true`; replace `Keyboard: false` with
+  `KeyboardDisabled: true`.
+
 - **`ergonomics-audit -mode deadcfg`** (#505) — a gate for exported `*Cfg`
   fields nothing consumes. It classifies every read rather than counting
   references, so it catches a field that is only ever copied into a field of the

--- a/Makefile
+++ b/Makefile
@@ -342,12 +342,7 @@ ergonomics-audit:
 	go run ./tools/ergonomics-audit/ -mode theme .
 	go run ./tools/ergonomics-audit/ -mode a11y .
 	go run ./tools/ergonomics-audit/ -mode visual .
-# deadcfg is ADVISORY until its findings clear. The mode itself gates
-# (exit non-zero on any unmarked finding), but the two fields it
-# currently reports -- NumericStepCfg.MouseWheel and .Keyboard -- are
-# known and tracked as #503. Delete the `|| true` in the PR that removes
-# them -- leaving it there turns a gate into decoration.
-	go run ./tools/ergonomics-audit/ -mode deadcfg . || true
+	go run ./tools/ergonomics-audit/ -mode deadcfg .
 
 # Insert a generated ID into every broken literal in this repo's tests
 # and examples. Scoped away from gui/ deliberately: go-gui's own widget

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -398,6 +398,30 @@ func goldenCases() []goldenCase {
 			},
 		},
 		{
+			// Arrow-key stepping (#503) changes no pixel by itself, but
+			// it makes the field interactive, so both the resting and
+			// focused appearances are now worth pinning.
+			name: "numericinput",
+			build: func(_ *Window) View {
+				return NumericInput(NumericInputCfg{
+					ID:      "num",
+					Text:    "42.5",
+					StepCfg: NumericStepCfg{Step: 1, ShowButtons: true},
+				})
+			},
+		},
+		{
+			name:    "numericinput_focused",
+			focusID: "num",
+			build: func(_ *Window) View {
+				return NumericInput(NumericInputCfg{
+					ID:      "num",
+					Text:    "42.5",
+					StepCfg: NumericStepCfg{Step: 1, ShowButtons: true},
+				})
+			},
+		},
+		{
 			name: "numericinput_disabled",
 			build: func(_ *Window) View {
 				return NumericInput(NumericInputCfg{

--- a/gui/input_numeric.go
+++ b/gui/input_numeric.go
@@ -50,12 +50,18 @@ type NumericStepCfg struct {
 	// exportaudit:keep — caller-facing config (issue #372)
 	AltMultiplier float64
 	// MouseWheel enables stepping via the mouse wheel over the field.
+	// Opt-in, not default-on: a wheel that steps is a wheel that no
+	// longer scrolls the page under the pointer, and a numeric field
+	// inside a long form is the common case (issue #503).
 	// exportaudit:keep — caller-facing config (issue #372)
 	MouseWheel bool
-	// Keyboard enables stepping via Up/Down arrow keys.
+	// KeyboardDisabled turns off Up/Down arrow stepping, which is
+	// otherwise on: arrow keys are the spinbox convention, so opting
+	// out is the rare choice. Named for the opt-out to match the
+	// FocusDisabled house style.
 	// exportaudit:keep — caller-facing config (issue #372)
-	Keyboard    bool
-	ShowButtons bool
+	KeyboardDisabled bool
+	ShowButtons      bool
 }
 
 // NumericCurrencyModeCfg defines currency symbol placement.
@@ -135,25 +141,30 @@ func numericLocaleNormalize(cfg NumericLocaleCfg) NumericLocaleCfg {
 }
 
 func numericStepCfgNormalize(cfg NumericStepCfg) NumericStepCfg {
+	// !(x > 0) rather than x <= 0: NaN fails every comparison,
+	// so the naive form passes a NaN step through and the field
+	// commits "NaN" on the next arrow key (issue #503 made
+	// stepping default-on, so every NumericInput is exposed).
+	// Inf is likewise unsteppable: it clamps straight to Min/Max.
 	step := cfg.Step
-	if step <= 0 {
+	if !(step > 0) || math.IsInf(step, 0) {
 		step = 1.0
 	}
 	shift := cfg.ShiftMultiplier
-	if shift <= 0 {
+	if !(shift > 0) || math.IsInf(shift, 0) {
 		shift = 10.0
 	}
 	alt := cfg.AltMultiplier
-	if alt <= 0 {
+	if !(alt > 0) || math.IsInf(alt, 0) {
 		alt = 0.1
 	}
 	return NumericStepCfg{
-		Step:            step,
-		ShiftMultiplier: shift,
-		AltMultiplier:   alt,
-		MouseWheel:      cfg.MouseWheel,
-		Keyboard:        cfg.Keyboard,
-		ShowButtons:     cfg.ShowButtons,
+		Step:             step,
+		ShiftMultiplier:  shift,
+		AltMultiplier:    alt,
+		MouseWheel:       cfg.MouseWheel,
+		KeyboardDisabled: cfg.KeyboardDisabled,
+		ShowButtons:      cfg.ShowButtons,
 	}
 }
 
@@ -347,14 +358,15 @@ func numericParse(raw string, loc NumericLocaleCfg) (float64, bool) {
 }
 
 // numericClamp clamps value between optional min and max. Unset
-// Opt means unbounded.
+// Opt means unbounded, and so does a NaN bound: NaN fails every
+// comparison, so letting it through silently disables that side.
 func numericClamp(value float64, minVal, maxVal Opt[float64]) float64 {
 	lo := math.Inf(-1)
 	hi := math.Inf(1)
-	if v, ok := minVal.Value(); ok {
+	if v, ok := minVal.Value(); ok && !math.IsNaN(v) {
 		lo = v
 	}
-	if v, ok := maxVal.Value(); ok {
+	if v, ok := maxVal.Value(); ok && !math.IsNaN(v) {
 		hi = v
 	}
 	if lo > hi {
@@ -556,13 +568,15 @@ func numericStepDelta(cfg NumericStepCfg, modifiers Modifier) float64 {
 }
 
 func numericStepSeedMode(text string, value, minVal Opt[float64], decimals int, loc NumericLocaleCfg, mc numericModeCfg) float64 {
-	if v, ok := value.Value(); ok {
+	// A NaN Value or Min is caller garbage, not a seed: NaN
+	// poisons the addition below and the field commits "NaN".
+	if v, ok := value.Value(); ok && !math.IsNaN(v) {
 		return v
 	}
 	if parsed, ok := numericModeParseValue(text, decimals, loc, mc); ok {
 		return parsed
 	}
-	if v, ok := minVal.Value(); ok {
+	if v, ok := minVal.Value(); ok && !math.IsNaN(v) {
 		return v
 	}
 	return 0.0
@@ -578,7 +592,7 @@ func numericInputCommitResultMode(text string, value, minVal, maxVal Opt[float64
 		clamped := numericClamp(parsed, minVal, maxVal)
 		return Some(clamped), numericModeFormatValue(clamped, decimals, loc, mc)
 	}
-	if v, ok := value.Value(); ok {
+	if v, ok := value.Value(); ok && !math.IsNaN(v) {
 		clamped := numericClamp(v, minVal, maxVal)
 		return Some(clamped), numericModeFormatValue(clamped, decimals, loc, mc)
 	}

--- a/gui/input_numeric_test.go
+++ b/gui/input_numeric_test.go
@@ -410,3 +410,52 @@ func TestNumericEmptyPrefixSpacing(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, "$")
 	}
 }
+
+func TestNumericClampNaNBoundsIgnored(t *testing.T) {
+	t.Parallel()
+	// A NaN bound is caller garbage, not a constraint: NaN fails
+	// every comparison, so it must behave as unset.
+	nan := Some(math.NaN())
+	if got := numericClamp(5, nan, Opt[float64]{}); got != 5 {
+		t.Errorf("NaN min clamped 5 to %v", got)
+	}
+	if got := numericClamp(-500, nan, Some(10.0)); got != -500 {
+		t.Errorf("NaN min clamped -500 to %v", got)
+	}
+	if got := numericClamp(500, Some(5.0), nan); got != 500 {
+		t.Errorf("NaN max clamped 500 to %v", got)
+	}
+	if got := numericClamp(3, Some(5.0), Some(10.0)); got != 5 {
+		t.Errorf("real bounds clamped 3 to %v, want 5", got)
+	}
+}
+
+func TestNumericStepNaNSeedsFallBack(t *testing.T) {
+	t.Parallel()
+	// Unparseable text forces the seed onto Value/Min. NaN there
+	// must fall through to 0 rather than committing "NaN".
+	_, s := numericInputStepResult("abc", Some(math.NaN()),
+		Opt[float64]{}, Opt[float64]{}, 0,
+		NumericStepCfg{Step: 1}, NumericLocaleCfg{}, 1, ModNone)
+	if s != "1" {
+		t.Errorf("NaN value seeded %q, want \"1\"", s)
+	}
+	_, s = numericInputStepResult("abc", Opt[float64]{},
+		Some(math.NaN()), Opt[float64]{}, 0,
+		NumericStepCfg{Step: 1}, NumericLocaleCfg{}, 1, ModNone)
+	if s != "1" {
+		t.Errorf("NaN min seeded %q, want \"1\"", s)
+	}
+}
+
+func TestNumericCommitNaNValueStaysUnset(t *testing.T) {
+	t.Parallel()
+	v, s := numericInputCommitResult("abc", Some(math.NaN()),
+		Opt[float64]{}, Opt[float64]{}, 0, NumericLocaleCfg{})
+	if _, ok := v.Value(); ok {
+		t.Errorf("NaN value fallback committed %v, want unset", v)
+	}
+	if s != "" {
+		t.Errorf("NaN value fallback formatted %q, want \"\"", s)
+	}
+}

--- a/gui/testdata/numericinput.dark.golden
+++ b/gui/testdata/numericinput.dark.golden
@@ -1,0 +1,11 @@
+Rect xy=15.00,15.00 wh=160.00,33.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=160.00,33.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=16.00,16.00 wh=158.00,31.60
+Clip xy=27.00,22.00 wh=122.00,19.60
+Text xy=27.00,22.99 wh=0.00,0.00 color=#e6e8ebff text="42.5" size=14.00
+Clip xy=16.00,16.00 wh=158.00,31.60
+Rect xy=161.00,17.00 wh=6.00,14.80 color=#262a2fff fill
+Text xy=161.00,18.29 wh=0.00,0.00 color=#e6e8ebff text="▲" size=10.00
+Rect xy=161.00,31.80 wh=6.00,14.80 color=#262a2fff fill
+Text xy=161.00,33.09 wh=0.00,0.00 color=#e6e8ebff text="▼" size=10.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/numericinput.light.golden
+++ b/gui/testdata/numericinput.light.golden
@@ -1,0 +1,10 @@
+Rect xy=14.00,14.00 wh=160.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=14.00,14.00 wh=160.00,29.60
+Clip xy=24.00,19.00 wh=128.00,19.60
+Text xy=24.00,19.99 wh=0.00,0.00 color=#1a1d21ff text="42.5" size=14.00
+Clip xy=14.00,14.00 wh=160.00,29.60
+Rect xy=162.00,14.00 wh=6.00,14.80 color=#ffffffff fill
+Text xy=162.00,15.29 wh=0.00,0.00 color=#1a1d21ff text="▲" size=10.00
+Rect xy=162.00,28.80 wh=6.00,14.80 color=#ffffffff fill
+Text xy=162.00,30.09 wh=0.00,0.00 color=#1a1d21ff text="▼" size=10.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/numericinput_focused.dark.golden
+++ b/gui/testdata/numericinput_focused.dark.golden
@@ -1,0 +1,12 @@
+Shadow xy=15.00,15.00 wh=160.00,33.60 color=#4d82f03f radius=6.00 blur=2.00 offset=0.00,0.00
+Rect xy=15.00,15.00 wh=160.00,33.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=160.00,33.60 color=#4d82f0ff radius=6.00 thickness=1.00
+Clip xy=16.00,16.00 wh=158.00,31.60
+Clip xy=27.00,22.00 wh=122.00,19.60
+Text xy=27.00,22.99 wh=0.00,0.00 color=#e6e8ebff text="42.5" size=14.00
+Clip xy=16.00,16.00 wh=158.00,31.60
+Rect xy=161.00,17.00 wh=6.00,14.80 color=#262a2fff fill
+Text xy=161.00,18.29 wh=0.00,0.00 color=#e6e8ebff text="▲" size=10.00
+Rect xy=161.00,31.80 wh=6.00,14.80 color=#262a2fff fill
+Text xy=161.00,33.09 wh=0.00,0.00 color=#e6e8ebff text="▼" size=10.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/numericinput_focused.light.golden
+++ b/gui/testdata/numericinput_focused.light.golden
@@ -1,0 +1,11 @@
+Shadow xy=14.00,14.00 wh=160.00,29.60 color=#2f6fe03f radius=6.00 blur=2.00 offset=0.00,0.00
+Rect xy=14.00,14.00 wh=160.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=14.00,14.00 wh=160.00,29.60
+Clip xy=24.00,19.00 wh=128.00,19.60
+Text xy=24.00,19.99 wh=0.00,0.00 color=#1a1d21ff text="42.5" size=14.00
+Clip xy=14.00,14.00 wh=160.00,29.60
+Rect xy=162.00,14.00 wh=6.00,14.80 color=#ffffffff fill
+Text xy=162.00,15.29 wh=0.00,0.00 color=#1a1d21ff text="▲" size=10.00
+Rect xy=162.00,28.80 wh=6.00,14.80 color=#ffffffff fill
+Text xy=162.00,30.09 wh=0.00,0.00 color=#1a1d21ff text="▼" size=10.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -156,6 +156,14 @@ type InputCfg struct {
 	// the whole control wider than the theme asked for.
 	noMinWidthFloor bool
 
+	// onMouseScroll attaches a wheel handler to the field's own shape.
+	// Set only by widgets that wrap an Input and give the wheel a
+	// meaning of their own -- NumericInput's wheel stepping. Private
+	// because the general case is wrong: an Input that eats the wheel
+	// stops the page under it from scrolling, so this is opt-in per
+	// wrapping widget rather than a caller-facing field.
+	onMouseScroll func(EventCtx)
+
 	// SpellCheck enables platform spell checking. Mac only.
 	SpellCheck bool
 
@@ -341,7 +349,7 @@ func Input(cfg InputCfg) View {
 			}
 		},
 		AmendLayout: inputAmendLayout(hcfg, focusID,
-			colorBorderFocus, spellChk, onBlur),
+			colorBorderFocus, spellChk, onBlur, cfg.onMouseScroll),
 		Content: []View{inner},
 	})
 	return labelledField(cfg.Label, cfg.TextStyle, HAlignLeft, cfg.Sizing, field)
@@ -613,11 +621,20 @@ func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 func inputAmendLayout(
 	hcfg inputHandlerCfg, focusID string,
 	colorBorderFocus Color, spellChk bool,
-	onBlur func(EventCtx),
+	onBlur func(EventCtx), onMouseScroll func(EventCtx),
 ) func(EventCtx) {
 	// Captured at generation; see focusRingAmend.
 	ring := guiTheme.focusRing
 	return func(ctx EventCtx) {
+		// Attached ahead of the focus gate below: the wheel does not
+		// need focus, and a FocusDisabled numeric field should still
+		// step under the pointer if its wrapper asked for it.
+		if onMouseScroll != nil {
+			if ctx.Layout.Shape.events == nil {
+				ctx.Layout.Shape.events = &eventHandlers{}
+			}
+			ctx.Layout.Shape.events.OnMouseScroll = onMouseScroll
+		}
 		if !ctx.Layout.Shape.Focusable || ctx.Layout.Shape.ID == "" {
 			return
 		}

--- a/gui/view_input_numeric.go
+++ b/gui/view_input_numeric.go
@@ -151,7 +151,10 @@ func NumericInput(cfg NumericInputCfg) View {
 	return labelledField(cfg.Label, cfg.TextStyle, HAlignLeft, cfg.Sizing, control)
 }
 
-func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericStepCfg, fillParent bool) View {
+func numericInputField(
+	cfg NumericInputCfg, locale NumericLocaleCfg,
+	stepCfg NumericStepCfg, fillParent bool,
+) View {
 	sizing := cfg.Sizing
 	var width, height, minWidth, maxWidth, minHeight, maxHeight float32
 	if fillParent {
@@ -219,6 +222,8 @@ func numericInputField(cfg NumericInputCfg, locale NumericLocaleCfg, _ NumericSt
 		Disabled:           cfg.Disabled,
 		Invisible:          cfg.Invisible,
 		OnTextChanged:      cfg.OnTextChanged,
+		OnKeyDown:          numericInputOnKeyDown(cfg, locale, stepCfg),
+		onMouseScroll:      numericInputOnWheel(cfg, locale, stepCfg),
 		PreTextChange: func(current, proposed string) (string, bool) {
 			return numericInputPreCommitTransformMode(
 				current, proposed, cfg.Decimals, locale, modeCfg)
@@ -339,6 +344,73 @@ func numericInputStepButtons(cfg NumericInputCfg, locale NumericLocaleCfg, stepC
 	})
 }
 
+// numericInputOnKeyDown returns the Up/Down stepping handler, or nil
+// when the caller opted out. Stepping is default-on because arrow keys
+// are the spinbox convention (issue #503); before this the field
+// carried a Keyboard flag that nothing read.
+func numericInputOnKeyDown(
+	cfg NumericInputCfg, locale NumericLocaleCfg, stepCfg NumericStepCfg,
+) func(EventCtx) {
+	if stepCfg.KeyboardDisabled {
+		return nil
+	}
+	return func(ctx EventCtx) {
+		if ctx.Event == nil {
+			return
+		}
+		var dir float64
+		switch ctx.Event.KeyCode {
+		case KeyUp:
+			dir = 1
+		case KeyDown:
+			dir = -1
+		default:
+			return
+		}
+		// A read-only field declines the key rather than swallowing it,
+		// so an enclosing list still moves its selection. Consume only
+		// on the paths that actually step.
+		if cfg.ReadOnly {
+			return
+		}
+		numericInputApplyStep(ctx.Layout, cfg, locale, stepCfg,
+			dir, ctx.Event, ctx.Window)
+		ctx.Consume()
+	}
+}
+
+// numericInputOnWheel returns the wheel stepping handler, or nil unless
+// the caller opted in. Opt-in by design: a field that eats the wheel
+// stops the form under the pointer from scrolling.
+func numericInputOnWheel(
+	cfg NumericInputCfg, locale NumericLocaleCfg, stepCfg NumericStepCfg,
+) func(EventCtx) {
+	if !stepCfg.MouseWheel || cfg.ReadOnly {
+		return nil
+	}
+	return func(ctx EventCtx) {
+		if ctx.Event == nil {
+			return
+		}
+		// ScrollY carries lines for a wheel and points for a trackpad
+		// (see the Event doc), so only the sign is portable here: one
+		// step per event, with Shift/Alt applying their multipliers
+		// through numericInputStepResultClamped.
+		var dir float64
+		switch {
+		case ctx.Event.ScrollY > 0:
+			dir = 1
+		case ctx.Event.ScrollY < 0:
+			dir = -1
+		default:
+			return
+		}
+		numericInputApplyStep(ctx.Layout, cfg, locale, stepCfg,
+			dir, ctx.Event, ctx.Window)
+		ctx.Consume()
+	}
+}
+
 func numericInputApplyStep(
 	layout *Layout,
 	cfg NumericInputCfg,
@@ -355,10 +427,14 @@ func numericInputApplyStep(
 		return
 	}
 	modeCfg := numericModeCfgFromInput(cfg)
+	modifiers := ModNone
+	if e != nil {
+		modifiers = e.Modifiers
+	}
 	value, committed, clamped := numericInputStepResultClamped(
 		cfg.Text, cfg.Value, cfg.Min, cfg.Max,
 		cfg.Decimals, stepCfg, locale, dir,
-		e.Modifiers, modeCfg)
+		modifiers, modeCfg)
 	if clamped {
 		// The step was understood but the value could not move: it
 		// already sat at Min or Max. The button's own click cue, if

--- a/gui/view_input_numeric_test.go
+++ b/gui/view_input_numeric_test.go
@@ -1,6 +1,9 @@
 package gui
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 // TestNumericInputStepTriangleBounds locks the named bounds of the step
 // triangle (issue #335 §2): it sits 4pt below the field text, never
@@ -227,5 +230,272 @@ func TestNumericInputReadOnlyStepButtonsGated(t *testing.T) {
 	}
 	if step(true) {
 		t.Error("read-only numeric input stepped the value")
+	}
+}
+
+// numericStepProbe builds a NumericInput and returns its handlers plus a
+// recorder for the committed value. It drives the factories directly:
+// the inner Input reaches them through makeInputOnKeyDown's
+// unhandled-key delegation, which TestNumericInputWiresStepHandlers
+// covers separately.
+func numericStepProbe(
+	t *testing.T, cfg NumericInputCfg,
+) (onKey, onWheel func(EventCtx), got *string, w *Window, ly *Layout) {
+	t.Helper()
+	committed := ""
+	got = &committed
+	cfg.OnValueCommit = func(_ Opt[float64], text string, _ EventCtx) {
+		committed = text
+	}
+	applyNumericInputDefaults(&cfg)
+	locale := numericLocaleNormalize(cfg.Locale)
+	stepCfg := numericStepCfgNormalize(cfg.StepCfg)
+
+	w = &Window{}
+	layout := generateViewLayout(NumericInput(cfg), w)
+	ly = &layout
+	return numericInputOnKeyDown(cfg, locale, stepCfg),
+		numericInputOnWheel(cfg, locale, stepCfg), got, w, ly
+}
+
+func TestNumericInputArrowKeysStepByDefault(t *testing.T) {
+	// StepCfg carries no Keyboard flag at all: stepping is on because
+	// it is the spinbox convention, which is the whole point of #503.
+	onKey, _, got, w, ly := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-arrows",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1},
+	})
+	if onKey == nil {
+		t.Fatal("arrow stepping should be on by default")
+	}
+
+	up := &Event{KeyCode: KeyUp}
+	onKey(EventCtx{ly, up, w})
+	if *got != "6" {
+		t.Errorf("Up stepped to %q, want \"6\"", *got)
+	}
+	if !up.IsHandled {
+		t.Error("a key that stepped must be consumed")
+	}
+
+	down := &Event{KeyCode: KeyDown}
+	onKey(EventCtx{ly, down, w})
+	if *got != "4" {
+		t.Errorf("Down stepped to %q, want \"4\"", *got)
+	}
+}
+
+func TestNumericInputNonArrowKeyBubbles(t *testing.T) {
+	// The acceptance criterion from #503: an unhandled arrow still
+	// reaches an enclosing list, so consume only on the stepping paths.
+	onKey, _, got, w, ly := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-bubble",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1},
+	})
+	e := &Event{KeyCode: KeyLeft}
+	onKey(EventCtx{ly, e, w})
+	if e.IsHandled {
+		t.Error("a key that did not step must not be consumed")
+	}
+	if *got != "" {
+		t.Errorf("KeyLeft committed %q, want no commit", *got)
+	}
+}
+
+func TestNumericInputKeyboardDisabledOptsOut(t *testing.T) {
+	onKey, _, _, _, _ := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-nokeys",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1, KeyboardDisabled: true},
+	})
+	if onKey != nil {
+		t.Error("KeyboardDisabled should leave no key handler")
+	}
+}
+
+func TestNumericInputReadOnlyDeclinesArrows(t *testing.T) {
+	onKey, _, got, w, ly := numericStepProbe(t, NumericInputCfg{
+		ID:       "ni-ro-keys",
+		Text:     "5",
+		ReadOnly: true,
+		StepCfg:  NumericStepCfg{Step: 1},
+	})
+	e := &Event{KeyCode: KeyUp}
+	onKey(EventCtx{ly, e, w})
+	if *got != "" {
+		t.Errorf("read-only field stepped to %q, want no commit", *got)
+	}
+	if e.IsHandled {
+		t.Error("read-only field must decline the key, not swallow it")
+	}
+}
+
+func TestNumericInputWheelIsOptIn(t *testing.T) {
+	_, off, _, _, _ := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-nowheel",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1},
+	})
+	if off != nil {
+		t.Fatal("wheel stepping must stay opt-in")
+	}
+
+	_, on, got, w, ly := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-wheel",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1, MouseWheel: true},
+	})
+	if on == nil {
+		t.Fatal("MouseWheel should install a wheel handler")
+	}
+	// Only the sign of ScrollY is portable: lines for a wheel, points
+	// for a trackpad. A large delta is still one step.
+	e := &Event{ScrollY: 12}
+	on(EventCtx{ly, e, w})
+	if *got != "6" {
+		t.Errorf("wheel up stepped to %q, want \"6\"", *got)
+	}
+	if !e.IsHandled {
+		t.Error("a wheel event that stepped must be consumed")
+	}
+
+	zero := &Event{ScrollY: 0}
+	on(EventCtx{ly, zero, w})
+	if zero.IsHandled {
+		t.Error("a zero-delta wheel event must not be consumed")
+	}
+}
+
+func TestNumericInputWiresStepHandlers(t *testing.T) {
+	// Proves the handlers actually reach the field's shape, which the
+	// factory tests above cannot show.
+	w := &Window{}
+	committed := ""
+	v := NumericInput(NumericInputCfg{
+		ID:      "ni-wired",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1, MouseWheel: true},
+		OnValueCommit: func(_ Opt[float64], text string, _ EventCtx) {
+			committed = text
+		},
+	})
+	layout := generateViewLayout(v, w)
+	layoutArrange(&layout, w)
+
+	field := findShapeByID(&layout, "ni-wired")
+	if field == nil {
+		t.Fatal("numeric field not found")
+	}
+	if field.Shape.events == nil {
+		t.Fatal("field shape carries no events")
+	}
+	if field.Shape.events.OnMouseScroll == nil {
+		t.Error("field shape carries no OnMouseScroll")
+	}
+
+	// Asserting OnKeyDown is non-nil would prove nothing -- Input always
+	// installs one. What has to hold is that an arrow reaches the step
+	// path THROUGH it, by makeInputOnKeyDown's unhandled-key delegation.
+	// Stepping is focus-gated there, so focus the field first.
+	w.SetFocus(field.Shape.idKey())
+	e := &Event{KeyCode: KeyUp}
+	field.Shape.events.OnKeyDown(EventCtx{field, e, w})
+	if committed != "6" {
+		t.Errorf("arrow through the real handler committed %q, want \"6\"",
+			committed)
+	}
+}
+
+func TestNumericInputNaNInfStepFallsBackToOne(t *testing.T) {
+	// NaN fails every comparison, so a naive <= 0 check passes it
+	// through and the field commits "NaN" on the next arrow key.
+	for _, step := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		got := numericStepCfgNormalize(NumericStepCfg{Step: step})
+		if got.Step != 1 {
+			t.Errorf("Step %v normalized to %v, want 1", step, got.Step)
+		}
+	}
+	for _, m := range []float64{math.NaN(), math.Inf(1)} {
+		got := numericStepCfgNormalize(NumericStepCfg{
+			Step: 1, ShiftMultiplier: m, AltMultiplier: m,
+		})
+		if got.ShiftMultiplier != 10.0 {
+			t.Errorf("Shift %v normalized to %v, want 10", m, got.ShiftMultiplier)
+		}
+		if got.AltMultiplier != 0.1 {
+			t.Errorf("Alt %v normalized to %v, want 0.1", m, got.AltMultiplier)
+		}
+	}
+
+	// End to end: a NaN step still steps by one through the key path.
+	onKey, _, got, w, ly := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-nan",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: math.NaN()},
+	})
+	e := &Event{KeyCode: KeyUp}
+	onKey(EventCtx{ly, e, w})
+	if *got != "6" {
+		t.Errorf("NaN step committed %q, want \"6\"", *got)
+	}
+}
+
+func TestNumericInputStepHandlersNilEventNoPanic(t *testing.T) {
+	onKey, onWheel, got, w, ly := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-nilev",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1, MouseWheel: true},
+	})
+	// Handlers run on dispatch events, which are never nil, but a
+	// synthesized call must decline rather than panic.
+	onKey(EventCtx{ly, nil, w})
+	onWheel(EventCtx{ly, nil, w})
+	if *got != "" {
+		t.Errorf("nil event committed %q, want no commit", *got)
+	}
+
+	// The shared apply path takes the raw click event, which a
+	// programmatic click may leave nil; modifiers default to none.
+	committed := ""
+	cfg := NumericInputCfg{ID: "ni-nilapply", Text: "5"}
+	cfg.OnValueCommit = func(_ Opt[float64], text string, _ EventCtx) {
+		committed = text
+	}
+	applyNumericInputDefaults(&cfg)
+	numericInputApplyStep(nil, cfg,
+		numericLocaleNormalize(cfg.Locale),
+		numericStepCfgNormalize(cfg.StepCfg), 1, nil, w)
+	if committed != "6" {
+		t.Errorf("nil-event apply committed %q, want \"6\"", committed)
+	}
+}
+
+func TestNumericInputWheelReadOnlyNoHandler(t *testing.T) {
+	_, on, _, _, _ := numericStepProbe(t, NumericInputCfg{
+		ID:       "ni-rowheel",
+		Text:     "5",
+		ReadOnly: true,
+		StepCfg:  NumericStepCfg{Step: 1, MouseWheel: true},
+	})
+	if on != nil {
+		t.Error("read-only field with MouseWheel should install no handler")
+	}
+}
+
+func TestNumericInputArrowShiftStepsTenfold(t *testing.T) {
+	onKey, _, got, w, ly := numericStepProbe(t, NumericInputCfg{
+		ID:      "ni-shift",
+		Text:    "5",
+		StepCfg: NumericStepCfg{Step: 1},
+	})
+	e := &Event{KeyCode: KeyUp, Modifiers: ModShift}
+	onKey(EventCtx{ly, e, w})
+	if *got != "15" {
+		t.Errorf("Shift+Up committed %q, want \"15\"", *got)
+	}
+	if !e.IsHandled {
+		t.Error("a Shift step that moved must be consumed")
 	}
 }


### PR DESCRIPTION
Closes #503.

## What

`NumericInput` now steps by `StepCfg.Step` on Up/Down, with the existing
Shift (10x) and Alt (0.1x) multipliers. Wheel stepping works behind
`StepCfg.MouseWheel`. Both flags previously did nothing —
`numericStepCfgNormalize` copied them from one `NumericStepCfg` into the
next, forever, with no code acting on the value.

## Design

- **Keyboard defaults on, `KeyboardDisabled` opts out** — arrow keys are the
  spinbox convention, matching the `FocusDisabled` house style used
  elsewhere in this repo.
- **Wheel stays opt-in** behind `MouseWheel` — a field that eats the wheel
  stops the form under it from scrolling.
- **Consume only on the paths that step.** A non-arrow key, a zero-delta
  wheel event, and a read-only field all decline, so an unhandled arrow
  still reaches an enclosing list — the acceptance criterion in #503.

## Wiring

`InputCfg` gains a private `onMouseScroll` seam, attached in
`inputAmendLayout` ahead of the focus gate (wheel stepping should not
require focus), following the `view_slider.go:288` precedent of attaching
directly to the shape's own events rather than adding a caller-facing
field. Keyboard stepping reaches the field through
`makeInputOnKeyDown`'s existing unhandled-key delegation:
`inputKeyVertical` returns `false` for a non-multiline `Input`, so
Up/Down fall through to `hcfg.OnKeyDown`.

## Breaking change

`NumericStepCfg.Keyboard` → `KeyboardDisabled` (rename, inverted
polarity). Nothing in this repo sets either flag. Folds into the v0.69.0
sibling sync alongside #504.

## Verification

Two new golden cases (`numericinput`, `numericinput_focused`) pin the
interactive appearance — no existing golden moved, confirming this is
behaviour-only. `ergonomics-audit -mode deadcfg` now reports 0 findings
(both fields were its motivating case from #505), so the Makefile's
`|| true` is dropped — the gate is live.

`make prepush` green. New tests proven non-vacuous: reverting the two
wiring lines fails `TestNumericInputWiresStepHandlers` on both assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
