### PR TITLE
feat(widgets)!: remove Scrollable from list widgets; always scroll (#504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,29 @@ and this project adheres to
 
 ### Changed
 
+- **BREAKING: `Scrollable` is removed from `ListBoxCfg`, `TreeCfg`, `TableCfg`
+  and `CommandPaletteCfg`; these widgets always scroll** (#504) — following
+  `ComboboxCfg` in v0.68.0. A list that does not scroll is not a choice anyone
+  makes, and the flag also gated virtualization, so a 10k-row `ListBox` without
+  it built every row: a performance cliff hidden behind an ergonomics flag. On
+  `CommandPalette` the flag was worse than useless — the results column was
+  hardcoded scrollable while the flag only gated reading the offset, so a
+  scrolled palette rendered blank rows (fixed separately in v0.68.1). Delete the
+  line; scroll state is still keyed by `Cfg.ID`. Content that fits gains an
+  inert scroll region: `scrollVertical` clamps and returns false when the offset
+  does not move, so the wheel event still bubbles to the page.
+- **`TableCfg.FreezeHeader` now works on its own** (#504) — it used to require
+  `Scrollable` as well (`freeze := cfg.FreezeHeader && cfg.Scrollable && ...`),
+  so a caller who set only `FreezeHeader` got nothing, with no report. Removing
+  `Scrollable` dissolves the dependency. **This is a visible layout change in
+  code you did not touch:** a table that set `FreezeHeader` without `Scrollable`
+  renders as a header zone plus a body zone instead of one flat column, and its
+  scroll key becomes `ScopeID(Cfg.ID, "scroll")`.
+- **A `Table` with no `ID` no longer joins the scroll system** (#504) — scroll
+  state is keyed by ID, so there is nothing to key. `TableCfg.ID` is
+  `gui:"required"`, so `go vet` already rejects this; `gui.Debug` reports it at
+  runtime. The alternative was `requireScrollID` panicking on a decision the
+  caller never made.
 - **BREAKING: `NumericStepCfg.Keyboard` is now `KeyboardDisabled`** (#503) — the
   field never did anything: nothing read it, so a `NumericInput` could not step
   by keyboard whatever the caller set. Now that stepping works it defaults on,

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -134,7 +134,8 @@ per-shape opt-in.
 ## Virtualized lists
 
 `ListBox`, `Table`, `Tree` and `Combobox` virtualize automatically when the
-scroll container has a bounded height. That means `Scrollable` plus `Height` or
+scroll container has a bounded height. They always scroll — there is no
+`Scrollable` opt-in — so a bounded height is the whole requirement: `Height` or
 `MaxHeight`, or — `ListBox` only — a height Fill sizing resolved last frame.
 Every row is the same height there, which is exact because the widget owns the
 row shape.

--- a/examples/command_demo/main.go
+++ b/examples/command_demo/main.go
@@ -147,11 +147,10 @@ func mainView(w *gui.Window) gui.View {
 			body(app, theme),
 			statusBar(app, theme),
 			gui.CommandPalette(gui.CommandPaletteCfg{
-				ID:         "palette",
-				Scrollable: true,
-				Items:      w.CommandPaletteItems(),
-				OnAction:   paletteAction,
-				OnDismiss:  func(_ *gui.Window) {},
+				ID:        "palette",
+				Items:     w.CommandPaletteItems(),
+				OnAction:  paletteAction,
+				OnDismiss: func(_ *gui.Window) {},
 			}),
 		},
 	})

--- a/examples/listbox/main.go
+++ b/examples/listbox/main.go
@@ -80,8 +80,7 @@ func mainView(w *gui.Window) gui.View {
 				TextStyle: theme.N5,
 			}),
 			gui.ListBox(gui.ListBoxCfg{
-				ID:         "virtual-listbox-10k",
-				Scrollable: true,
+				ID: "virtual-listbox-10k",
 				// Fill takes whatever the two labels above leave, so no
 				// "window height minus 70" guess to keep in sync.
 				Sizing:      gui.FillFill,

--- a/examples/showcase/demo_data.go
+++ b/examples/showcase/demo_data.go
@@ -30,7 +30,6 @@ func demoTable(w *gui.Window) gui.View {
 	rows := showcaseTableRowsSorted(app.TableSortBy)
 	cfg := gui.TableCfgFromData(rows)
 	cfg.ID = "catalog-table"
-	cfg.Scrollable = true
 	cfg.Sizing = gui.FitFit
 	cfg.MaxHeight = 260
 	cfg.SizeBorder = 1
@@ -296,12 +295,11 @@ func demoTree(w *gui.Window) gui.View {
 			}),
 			gui.Text(gui.TextCfg{Text: "Virtualized tree (scroll)", TextStyle: gui.CurrentTheme().B3}),
 			gui.Tree(gui.TreeCfg{
-				ID:         "showcase-tree-virtual",
-				Scrollable: true,
-				Sizing:     gui.FillFit,
-				MaxHeight:  200,
-				OnSelect:   showcaseTreeOnSelect,
-				Nodes:      showcaseBigTreeNodes(),
+				ID:        "showcase-tree-virtual",
+				Sizing:    gui.FillFit,
+				MaxHeight: 200,
+				OnSelect:  showcaseTreeOnSelect,
+				Nodes:     showcaseBigTreeNodes(),
 			}),
 			gui.Text(gui.TextCfg{Text: "Lazy-loading tree", TextStyle: gui.CurrentTheme().B3}),
 			gui.Tree(gui.TreeCfg{

--- a/examples/showcase/demo_selection.go
+++ b/examples/showcase/demo_selection.go
@@ -173,7 +173,6 @@ func demoListBox(w *gui.Window) gui.View {
 			gui.Text(gui.TextCfg{Text: "Virtualized list (scroll)", TextStyle: t.B3}),
 			gui.ListBox(gui.ListBoxCfg{
 				ID:          "listbox-demo",
-				Scrollable:  true,
 				Sizing:      gui.FillFit,
 				MaxHeight:   200,
 				Multiple:    true,
@@ -264,7 +263,6 @@ func demoDragReorder(w *gui.Window) gui.View {
 				ID:          "drag-listbox",
 				Sizing:      gui.FillFit,
 				MaxHeight:   200,
-				Scrollable:  true,
 				Data:        app.DragListItems,
 				Reorderable: true,
 				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
@@ -304,7 +302,6 @@ func demoDragReorder(w *gui.Window) gui.View {
 				Nodes:       app.DragTreeNodes,
 				Sizing:      gui.FillFit,
 				MaxHeight:   250,
-				Scrollable:  true,
 				Reorderable: true,
 				OnReorder: func(movedID string, beforeID string, ctx gui.EventCtx) {
 					a := appState(ctx.Window)

--- a/examples/showcase/docs/commands.md
+++ b/examples/showcase/docs/commands.md
@@ -181,9 +181,8 @@ Include the palette view in the view tree (hidden by default):
 
 ```go
 gui.CommandPalette(gui.CommandPaletteCfg{
-    ID:         "palette",
-    Scrollable: true,
-    Items:      w.CommandPaletteItems(),
+    ID:        "palette",
+    Items:     w.CommandPaletteItems(),
     OnAction:   paletteAction,
     OnDismiss:  func(_ *gui.Window) {},
 })
@@ -233,25 +232,24 @@ the first item on each keystroke.
 
 ### CommandPaletteCfg Fields
 
-| Field            | Type                     | Description                                       |
-| ---------------- | ------------------------ | ------------------------------------------------- |
-| `ID`             | `string`                 | Palette instance ID                               |
-| `Items`          | `[]CommandPaletteItem`   | Items to display                                  |
-| `OnAction`       | `func(string, EventCtx)` | Called with selected item ID                      |
-| `OnDismiss`      | `func(*Window)`          | Called when palette closes                        |
-| `Placeholder`    | `string`                 | Input placeholder text                            |
-| `TextStyle`      | `TextStyle`              | Item label style                                  |
-| `DetailStyle`    | `TextStyle`              | Shortcut hint style                               |
-| `Color`          | `Color`                  | Panel background                                  |
-| `ColorBorder`    | `Color`                  | Panel border                                      |
-| `ColorHighlight` | `Color`                  | Highlight/hover color                             |
-| `SizeBorder`     | `Opt[float32]`           | Border thickness                                  |
-| `Radius`         | `Opt[float32]`           | Corner radius                                     |
-| `Width`          | `float32`                | Panel width (default 500)                         |
-| `MaxHeight`      | `float32`                | Max list height (default 400)                     |
-| `BackdropColor`  | `Color`                  | Semi-transparent overlay                          |
-| `Scrollable`     | `bool`                   | Opt results list into scroll (key `ID+":scroll"`) |
-| `FloatZIndex`    | `int`                    | Z-order (default 1000)                            |
+| Field            | Type                     | Description                   |
+| ---------------- | ------------------------ | ----------------------------- |
+| `ID`             | `string`                 | Palette instance ID           |
+| `Items`          | `[]CommandPaletteItem`   | Items to display              |
+| `OnAction`       | `func(string, EventCtx)` | Called with selected item ID  |
+| `OnDismiss`      | `func(*Window)`          | Called when palette closes    |
+| `Placeholder`    | `string`                 | Input placeholder text        |
+| `TextStyle`      | `TextStyle`              | Item label style              |
+| `DetailStyle`    | `TextStyle`              | Shortcut hint style           |
+| `Color`          | `Color`                  | Panel background              |
+| `ColorBorder`    | `Color`                  | Panel border                  |
+| `ColorHighlight` | `Color`                  | Highlight/hover color         |
+| `SizeBorder`     | `Opt[float32]`           | Border thickness              |
+| `Radius`         | `Opt[float32]`           | Corner radius                 |
+| `Width`          | `float32`                | Panel width (default 500)     |
+| `MaxHeight`      | `float32`                | Max list height (default 400) |
+| `BackdropColor`  | `Color`                  | Semi-transparent overlay      |
+| `FloatZIndex`    | `int`                    | Z-order (default 1000)        |
 
 ### CommandPaletteItem
 

--- a/examples/showcase/docs/widget_command_palette.md
+++ b/examples/showcase/docs/widget_command_palette.md
@@ -6,9 +6,8 @@ results list.
 
 ```go
 gui.CommandPalette(gui.CommandPaletteCfg{
-    ID:         "cmd",
-    Scrollable: true,
-    Items:      items,
+    ID:    "cmd",
+    Items: items,
     OnAction: func(id string, ctx gui.EventCtx) {
         // handle action
     },
@@ -29,15 +28,14 @@ gui.CommandPaletteToggle("cmd", w)
 
 ## Key Properties
 
-| Property    | Type                 | Description                                    |
-| ----------- | -------------------- | ---------------------------------------------- |
-| ID          | string               | Unique identifier                              |
-| Items       | []CommandPaletteItem | Available commands                             |
-| Placeholder | string               | Search input hint text                         |
-| Width       | float32              | Palette width                                  |
-| MaxHeight   | float32              | Maximum dropdown height                        |
-| Scrollable  | bool                 | Opt into the scroll system (state keyed by ID) |
-| FloatZIndex | int                  | Z-index for float layering                     |
+| Property    | Type                 | Description                |
+| ----------- | -------------------- | -------------------------- |
+| ID          | string               | Unique identifier          |
+| Items       | []CommandPaletteItem | Available commands         |
+| Placeholder | string               | Search input hint text     |
+| Width       | float32              | Palette width              |
+| MaxHeight   | float32              | Maximum dropdown height    |
+| FloatZIndex | int                  | Z-index for float layering |
 
 ## Appearance
 

--- a/examples/showcase/docs/widget_listbox.md
+++ b/examples/showcase/docs/widget_listbox.md
@@ -35,16 +35,15 @@ gui.ListBox(gui.ListBoxCfg{
 
 ## Virtualization
 
-Renders only visible rows when height is constrained. Requires
-`Scrollable: true` and `Height` or `MaxHeight > 0`. Scroll state is keyed by the
-widget's string ID.
+Renders only visible rows when height is constrained. The list always scrolls,
+so `Height` or `MaxHeight > 0` is the only requirement. Scroll state is keyed by
+the widget's string ID.
 
 ```go
 gui.ListBox(gui.ListBoxCfg{
-    ID:         "virt-lb",
-    Scrollable: true,
-    MaxHeight:  200,
-    Data:       items,
+    ID:        "virt-lb",
+    MaxHeight: 200,
+    Data:      items,
 })
 ```
 
@@ -66,22 +65,21 @@ When `Items` is set, `Data` is ignored.
 
 ## Key Properties
 
-| Property    | Type            | Description                                    |
-| ----------- | --------------- | ---------------------------------------------- |
-| SelectedIDs | []string        | Selected item IDs                              |
-| Items       | []string        | Simple string list (alt. to Data)              |
-| Data        | []ListBoxOption | Items (ID, Name, Value, IsSubhead)             |
-| Multiple    | bool            | Allow multi-select                             |
-| Height      | float32         | Fixed height (activates virtualization)        |
-| MinWidth    | float32         | Minimum width                                  |
-| MaxWidth    | float32         | Maximum width                                  |
-| MinHeight   | float32         | Minimum height                                 |
-| MaxHeight   | float32         | Maximum height                                 |
-| Scrollable  | bool            | Opt into the scroll system (state keyed by ID) |
-| Reorderable | bool            | Enable drag-reorder                            |
-| Sizing      | Sizing          | Combined axis sizing mode                      |
-| Disabled    | bool            | Disable interaction                            |
-| Invisible   | bool            | Hide without removing from layout              |
+| Property    | Type            | Description                             |
+| ----------- | --------------- | --------------------------------------- |
+| SelectedIDs | []string        | Selected item IDs                       |
+| Items       | []string        | Simple string list (alt. to Data)       |
+| Data        | []ListBoxOption | Items (ID, Name, Value, IsSubhead)      |
+| Multiple    | bool            | Allow multi-select                      |
+| Height      | float32         | Fixed height (activates virtualization) |
+| MinWidth    | float32         | Minimum width                           |
+| MaxWidth    | float32         | Maximum width                           |
+| MinHeight   | float32         | Minimum height                          |
+| MaxHeight   | float32         | Maximum height                          |
+| Reorderable | bool            | Enable drag-reorder                     |
+| Sizing      | Sizing          | Combined axis sizing mode               |
+| Disabled    | bool            | Disable interaction                     |
+| Invisible   | bool            | Hide without removing from layout       |
 
 ## Appearance
 

--- a/examples/showcase/docs/widget_table.md
+++ b/examples/showcase/docs/widget_table.md
@@ -45,12 +45,11 @@ w.Table(gui.TableCfg{
 
 ## Virtualization
 
-Renders only visible rows when scrolling is enabled. Requires `Scrollable: true`
-and `Height` or `MaxHeight > 0`. Scroll state is keyed by `cfg.ID`, or
+Renders only visible rows. The table always scrolls, so `Height` or
+`MaxHeight > 0` is the only requirement. Scroll state is keyed by `cfg.ID`, or
 `cfg.ID + ":scroll"` when `FreezeHeader` is set.
 
 ```go
-cfg.Scrollable = true
 cfg.MaxHeight = 260
 ```
 
@@ -82,26 +81,25 @@ When `RawData` is set, `Data` is ignored.
 
 ## Key Properties
 
-| Property           | Type              | Description                                    |
-| ------------------ | ----------------- | ---------------------------------------------- |
-| RawData            | [][]string        | CSV-style data (alt. to Data)                  |
-| Data               | []TableRowCfg     | Row data with cells                            |
-| ColumnAlignments   | []HorizontalAlign | Per-column alignment                           |
-| ColumnWidthDefault | float32           | Default column width                           |
-| ColumnWidthMin     | float32           | Minimum column width                           |
-| AlignHead          | HorizontalAlign   | Header row alignment                           |
-| MultiSelect        | bool              | Allow multi-row selection                      |
-| Selected           | map[int]bool      | Selected row indices                           |
-| Scrollable         | bool              | Opt into the scroll system (state keyed by ID) |
-| Scrollbar          | ScrollbarOverflow | Scrollbar overflow mode                        |
-| BorderStyle        | TableBorderStyle  | Cell border style                              |
-| Sizing             | Sizing            | Combined axis sizing mode                      |
-| Width              | float32           | Fixed width                                    |
-| Height             | float32           | Fixed height                                   |
-| MinWidth           | float32           | Minimum width                                  |
-| MaxWidth           | float32           | Maximum width                                  |
-| MinHeight          | float32           | Minimum height                                 |
-| MaxHeight          | float32           | Maximum height                                 |
+| Property           | Type              | Description                   |
+| ------------------ | ----------------- | ----------------------------- |
+| RawData            | [][]string        | CSV-style data (alt. to Data) |
+| Data               | []TableRowCfg     | Row data with cells           |
+| ColumnAlignments   | []HorizontalAlign | Per-column alignment          |
+| ColumnWidthDefault | float32           | Default column width          |
+| ColumnWidthMin     | float32           | Minimum column width          |
+| AlignHead          | HorizontalAlign   | Header row alignment          |
+| MultiSelect        | bool              | Allow multi-row selection     |
+| Selected           | map[int]bool      | Selected row indices          |
+| Scrollbar          | ScrollbarOverflow | Scrollbar overflow mode       |
+| BorderStyle        | TableBorderStyle  | Cell border style             |
+| Sizing             | Sizing            | Combined axis sizing mode     |
+| Width              | float32           | Fixed width                   |
+| Height             | float32           | Fixed height                  |
+| MinWidth           | float32           | Minimum width                 |
+| MaxWidth           | float32           | Maximum width                 |
+| MinHeight          | float32           | Minimum height                |
+| MaxHeight          | float32           | Maximum height                |
 
 ## Appearance
 

--- a/examples/showcase/docs/widget_tree.md
+++ b/examples/showcase/docs/widget_tree.md
@@ -5,8 +5,7 @@ navigation, and drag-reorder support.
 
 ```go
 gui.Tree(gui.TreeCfg{
-    ID:         "project-tree",
-    Scrollable: true,
+    ID:        "project-tree",
     MaxHeight: 240,
     OnSelect: func(nodeID string, ctx gui.EventCtx) {
         gui.State[AppState](ctx.Window).SelectedNode = nodeID
@@ -44,10 +43,10 @@ a tree.
 
 ## Virtualization
 
-Renders only visible nodes (flattened) when height is constrained. Requires
-`Scrollable: true` and `Height` or `MaxHeight > 0`. Scroll state is keyed by the
-widget's string ID. The main usage example above shows the required
-configuration.
+Renders only visible nodes (flattened) when height is constrained. The tree
+always scrolls, so `Height` or `MaxHeight > 0` is the only requirement. Scroll
+state is keyed by the widget's string ID. The main usage example above shows the
+required configuration.
 
 ## Keyboard Navigation
 
@@ -71,23 +70,22 @@ When `ItemPaths` is set, `Nodes` is ignored.
 
 ## Key Properties
 
-| Property    | Type          | Description                                    |
-| ----------- | ------------- | ---------------------------------------------- |
-| ItemPaths   | []string      | Flat slash-separated paths (alt.)              |
-| Nodes       | []TreeNodeCfg | Root-level tree nodes                          |
-| Indent      | float32       | Indent per nesting level                       |
-| Spacing     | Opt[float32]  | Vertical spacing between rows                  |
-| Scrollable  | bool          | Opt into the scroll system (state keyed by ID) |
-| Reorderable | bool          | Enable drag-reorder of siblings                |
-| Disabled    | bool          | Disable interaction                            |
-| Invisible   | bool          | Hide without removing from layout              |
-| Sizing      | Sizing        | Combined axis sizing mode                      |
-| Width       | float32       | Fixed width                                    |
-| Height      | float32       | Fixed height                                   |
-| MinWidth    | float32       | Minimum width                                  |
-| MaxWidth    | float32       | Maximum width                                  |
-| MinHeight   | float32       | Minimum height                                 |
-| MaxHeight   | float32       | Maximum height                                 |
+| Property    | Type          | Description                       |
+| ----------- | ------------- | --------------------------------- |
+| ItemPaths   | []string      | Flat slash-separated paths (alt.) |
+| Nodes       | []TreeNodeCfg | Root-level tree nodes             |
+| Indent      | float32       | Indent per nesting level          |
+| Spacing     | Opt[float32]  | Vertical spacing between rows     |
+| Reorderable | bool          | Enable drag-reorder of siblings   |
+| Disabled    | bool          | Disable interaction               |
+| Invisible   | bool          | Hide without removing from layout |
+| Sizing      | Sizing        | Combined axis sizing mode         |
+| Width       | float32       | Fixed width                       |
+| Height      | float32       | Fixed height                      |
+| MinWidth    | float32       | Minimum width                     |
+| MaxWidth    | float32       | Maximum width                     |
+| MinHeight   | float32       | Minimum height                    |
+| MaxHeight   | float32       | Maximum height                    |
 
 ## TreeNodeCfg
 

--- a/gui/backend/soft/render_test.go
+++ b/gui/backend/soft/render_test.go
@@ -464,10 +464,9 @@ func TestListBoxVirtualizedFillsViewport(t *testing.T) {
 			Sizing:     gui.FillFill,
 			Content: []gui.View{
 				gui.ListBox(gui.ListBoxCfg{
-					ID:         "lb",
-					Scrollable: true,
-					Height:     listH,
-					Data:       items,
+					ID:     "lb",
+					Height: listH,
+					Data:   items,
 				}),
 			},
 		})

--- a/gui/list_core_alloc_bench_test.go
+++ b/gui/list_core_alloc_bench_test.go
@@ -95,10 +95,9 @@ func BenchmarkCommandPaletteGenerateLayout(b *testing.B) {
 		Set(id, "49")
 
 	v := CommandPalette(CommandPaletteCfg{
-		ID:         id,
-		Items:      items,
-		OnAction:   func(_ string, ctx EventCtx) {},
-		Scrollable: true,
+		ID:       id,
+		Items:    items,
+		OnAction: func(_ string, ctx EventCtx) {},
 	})
 
 	b.ReportAllocs()
@@ -143,7 +142,6 @@ func BenchmarkListBoxGenerateLayout(b *testing.B) {
 		w.scrollY().Set(scrollID, 1000)
 		v := ListBox(ListBoxCfg{
 			ID:          "bench-lb-v",
-			Scrollable:  true,
 			MaxHeight:   220,
 			Data:        data,
 			SelectedIDs: selected,
@@ -165,11 +163,10 @@ func BenchmarkListBoxGenerateLayout(b *testing.B) {
 		big := listBoxTestData(10_000)
 		w := newTestWindow()
 		cfg := ListBoxCfg{
-			ID:         "bench-lb-fill",
-			Scrollable: true,
-			Sizing:     FillFill,
-			Data:       big,
-			OnSelect:   func(_ []string, ctx EventCtx) {},
+			ID:       "bench-lb-fill",
+			Sizing:   FillFill,
+			Data:     big,
+			OnSelect: func(_ []string, ctx EventCtx) {},
 		}
 		cache := listBoxEnsureCache(&cfg, w)
 		cache.resolvedH = 300

--- a/gui/scroll_index_test.go
+++ b/gui/scroll_index_test.go
@@ -14,11 +14,10 @@ func scrollIndexListWindow(id string, n int) *Window {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{ListBox(ListBoxCfg{
-				ID:         id,
-				Scrollable: true,
-				Height:     200,
-				Sizing:     FillFixed,
-				Data:       listBoxTestData(n),
+				ID:     id,
+				Height: 200,
+				Sizing: FillFixed,
+				Data:   listBoxTestData(n),
 			})},
 		})
 	}
@@ -218,7 +217,6 @@ func TestScrollToIndexOnTableRespectsFreeze(t *testing.T) {
 			Sizing: FillFill,
 			Content: []View{Table(TableCfg{
 				ID:           "tbl",
-				Scrollable:   true,
 				FreezeHeader: true,
 				Height:       200,
 				Sizing:       FillFixed,

--- a/gui/testdata/listbox.dark.golden
+++ b/gui/testdata/listbox.dark.golden
@@ -1,6 +1,12 @@
 Rect xy=15.00,15.00 wh=82.00,100.80 color=#262a2fff radius=6.00 fill
 StrokeRect xy=15.00,15.00 wh=82.00,100.80 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=30.00,30.00 wh=52.00,70.80
 Text xy=35.00,32.00 wh=0.00,0.00 color=#e6e8ebff text="one" size=14.00
 Rect xy=30.00,53.60 wh=52.00,23.60 color=#4d82f028 radius=6.00 fill
 Text xy=35.00,55.60 wh=0.00,0.00 color=#e6e8ebff text="two" size=14.00
 Text xy=35.00,79.20 wh=0.00,0.00 color=#e6e8ebff text="three" size=14.00
+Clip xy=30.00,105.80 wh=52.00,7.00
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=87.00,30.00 wh=7.00,70.80
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/listbox.light.golden
+++ b/gui/testdata/listbox.light.golden
@@ -1,5 +1,11 @@
 Rect xy=14.00,14.00 wh=80.00,98.80 color=#ffffffff radius=6.00 fill
+Clip xy=28.00,28.00 wh=52.00,70.80
 Text xy=33.00,30.00 wh=0.00,0.00 color=#1a1d21ff text="one" size=14.00
 Rect xy=28.00,51.60 wh=52.00,23.60 color=#2f6fe01e radius=6.00 fill
 Text xy=33.00,53.60 wh=0.00,0.00 color=#1a1d21ff text="two" size=14.00
 Text xy=33.00,77.20 wh=0.00,0.00 color=#1a1d21ff text="three" size=14.00
+Clip xy=28.00,102.80 wh=52.00,7.00
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=84.00,28.00 wh=7.00,70.80
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/listbox_disabled.dark.golden
+++ b/gui/testdata/listbox_disabled.dark.golden
@@ -1,6 +1,12 @@
 Rect xy=15.00,15.00 wh=82.00,100.80 color=#262a2f7f radius=6.00 fill
 StrokeRect xy=15.00,15.00 wh=82.00,100.80 color=#ffffff0e radius=6.00 thickness=1.00
+Clip xy=30.00,30.00 wh=52.00,70.80
 Text xy=35.00,32.00 wh=0.00,0.00 color=#e6e8eb80 text="one" size=14.00
 Rect xy=30.00,53.60 wh=52.00,23.60 color=#4d82f014 radius=6.00 fill
 Text xy=35.00,55.60 wh=0.00,0.00 color=#e6e8eb80 text="two" size=14.00
 Text xy=35.00,79.20 wh=0.00,0.00 color=#e6e8eb80 text="three" size=14.00
+Clip xy=30.00,105.80 wh=52.00,7.00
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=87.00,30.00 wh=7.00,70.80
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/listbox_disabled.light.golden
+++ b/gui/testdata/listbox_disabled.light.golden
@@ -1,5 +1,11 @@
 Rect xy=14.00,14.00 wh=80.00,98.80 color=#ffffff7f radius=6.00 fill
+Clip xy=28.00,28.00 wh=52.00,70.80
 Text xy=33.00,30.00 wh=0.00,0.00 color=#1a1d2195 text="one" size=14.00
 Rect xy=28.00,51.60 wh=52.00,23.60 color=#2f6fe00f radius=6.00 fill
 Text xy=33.00,53.60 wh=0.00,0.00 color=#1a1d2195 text="two" size=14.00
 Text xy=33.00,77.20 wh=0.00,0.00 color=#1a1d2195 text="three" size=14.00
+Clip xy=28.00,102.80 wh=52.00,7.00
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=84.00,28.00 wh=7.00,70.80
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/listbox_focused.dark.golden
+++ b/gui/testdata/listbox_focused.dark.golden
@@ -1,8 +1,14 @@
 Shadow xy=15.00,15.00 wh=82.00,100.80 color=#4d82f03f radius=6.00 blur=2.00 offset=0.00,0.00
 Rect xy=15.00,15.00 wh=82.00,100.80 color=#262a2fff radius=6.00 fill
 StrokeRect xy=15.00,15.00 wh=82.00,100.80 color=#4d82f0ff radius=6.00 thickness=1.00
+Clip xy=30.00,30.00 wh=52.00,70.80
 StrokeRect xy=30.00,30.00 wh=52.00,23.60 color=#4d82f0ff radius=6.00 thickness=1.00
 Text xy=35.00,32.00 wh=0.00,0.00 color=#e6e8ebff text="one" size=14.00
 Rect xy=30.00,53.60 wh=52.00,23.60 color=#4d82f028 radius=6.00 fill
 Text xy=35.00,55.60 wh=0.00,0.00 color=#e6e8ebff text="two" size=14.00
 Text xy=35.00,79.20 wh=0.00,0.00 color=#e6e8ebff text="three" size=14.00
+Clip xy=30.00,105.80 wh=52.00,7.00
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=87.00,30.00 wh=7.00,70.80
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/listbox_focused.light.golden
+++ b/gui/testdata/listbox_focused.light.golden
@@ -1,7 +1,13 @@
 Shadow xy=14.00,14.00 wh=80.00,98.80 color=#2f6fe03f radius=6.00 blur=2.00 offset=0.00,0.00
 Rect xy=14.00,14.00 wh=80.00,98.80 color=#ffffffff radius=6.00 fill
+Clip xy=28.00,28.00 wh=52.00,70.80
 StrokeRect xy=28.00,28.00 wh=52.00,23.60 color=#2f6fe0ff radius=6.00 thickness=1.00
 Text xy=33.00,30.00 wh=0.00,0.00 color=#1a1d21ff text="one" size=14.00
 Rect xy=28.00,51.60 wh=52.00,23.60 color=#2f6fe01e radius=6.00 fill
 Text xy=33.00,53.60 wh=0.00,0.00 color=#1a1d21ff text="two" size=14.00
 Text xy=33.00,77.20 wh=0.00,0.00 color=#1a1d21ff text="three" size=14.00
+Clip xy=28.00,102.80 wh=52.00,7.00
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=84.00,28.00 wh=7.00,70.80
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/listbox_reorder_focused.dark.golden
+++ b/gui/testdata/listbox_reorder_focused.dark.golden
@@ -1,8 +1,14 @@
 Shadow xy=15.00,15.00 wh=82.00,100.80 color=#4d82f03f radius=6.00 blur=2.00 offset=0.00,0.00
 Rect xy=15.00,15.00 wh=82.00,100.80 color=#262a2fff radius=6.00 fill
 StrokeRect xy=15.00,15.00 wh=82.00,100.80 color=#4d82f0ff radius=6.00 thickness=1.00
+Clip xy=30.00,30.00 wh=52.00,70.80
 StrokeRect xy=30.00,30.00 wh=52.00,23.60 color=#4d82f0ff radius=6.00 thickness=1.00
 Text xy=35.00,32.00 wh=0.00,0.00 color=#e6e8ebff text="one" size=14.00
 Rect xy=30.00,53.60 wh=52.00,23.60 color=#4d82f028 radius=6.00 fill
 Text xy=35.00,55.60 wh=0.00,0.00 color=#e6e8ebff text="two" size=14.00
 Text xy=35.00,79.20 wh=0.00,0.00 color=#e6e8ebff text="three" size=14.00
+Clip xy=30.00,105.80 wh=52.00,7.00
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=87.00,30.00 wh=7.00,70.80
+Clip xy=30.00,30.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/listbox_reorder_focused.light.golden
+++ b/gui/testdata/listbox_reorder_focused.light.golden
@@ -1,7 +1,13 @@
 Shadow xy=14.00,14.00 wh=80.00,98.80 color=#2f6fe03f radius=6.00 blur=2.00 offset=0.00,0.00
 Rect xy=14.00,14.00 wh=80.00,98.80 color=#ffffffff radius=6.00 fill
+Clip xy=28.00,28.00 wh=52.00,70.80
 StrokeRect xy=28.00,28.00 wh=52.00,23.60 color=#2f6fe0ff radius=6.00 thickness=1.00
 Text xy=33.00,30.00 wh=0.00,0.00 color=#1a1d21ff text="one" size=14.00
 Rect xy=28.00,51.60 wh=52.00,23.60 color=#2f6fe01e radius=6.00 fill
 Text xy=33.00,53.60 wh=0.00,0.00 color=#1a1d21ff text="two" size=14.00
 Text xy=33.00,77.20 wh=0.00,0.00 color=#1a1d21ff text="three" size=14.00
+Clip xy=28.00,102.80 wh=52.00,7.00
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=84.00,28.00 wh=7.00,70.80
+Clip xy=28.00,28.00 wh=52.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/table.dark.golden
+++ b/gui/testdata/table.dark.golden
@@ -1,4 +1,8 @@
+Clip xy=16.00,16.00 wh=277.00,47.20
 Text xy=29.20,18.00 wh=0.00,0.00 color=#e6e8ebff text="Name" size=14.00
 Text xy=89.20,18.00 wh=0.00,0.00 color=#e6e8ebff text="Size" size=14.00
 Text xy=21.00,41.60 wh=0.00,0.00 color=#e6e8ebff text="alpha" size=14.00
 Text xy=81.00,41.60 wh=0.00,0.00 color=#e6e8ebff text="12" size=14.00
+Clip xy=295.00,16.00 wh=7.00,47.20
+Clip xy=16.00,16.00 wh=277.00,47.20
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/table.light.golden
+++ b/gui/testdata/table.light.golden
@@ -1,4 +1,8 @@
+Clip xy=14.00,14.00 wh=281.00,47.20
 Text xy=27.20,16.00 wh=0.00,0.00 color=#1a1d21ff text="Name" size=14.00
 Text xy=87.20,16.00 wh=0.00,0.00 color=#1a1d21ff text="Size" size=14.00
 Text xy=19.00,39.60 wh=0.00,0.00 color=#1a1d21ff text="alpha" size=14.00
 Text xy=79.00,39.60 wh=0.00,0.00 color=#1a1d21ff text="12" size=14.00
+Clip xy=296.00,14.00 wh=7.00,47.20
+Clip xy=14.00,14.00 wh=281.00,47.20
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/table_focused.dark.golden
+++ b/gui/testdata/table_focused.dark.golden
@@ -1,5 +1,6 @@
 Shadow xy=15.00,15.00 wh=290.00,72.80 color=#4d82f03f blur=2.00 offset=0.00,0.00
 StrokeRect xy=15.00,15.00 wh=290.00,72.80 color=#4d82f0ff thickness=1.00
+Clip xy=16.00,16.00 wh=277.00,70.80
 Rect xy=16.00,16.00 wh=120.00,23.60 color=#2f343aff radius=6.00 fill
 Text xy=29.20,18.00 wh=0.00,0.00 color=#e6e8ebff text="Name" size=14.00
 Text xy=89.20,18.00 wh=0.00,0.00 color=#e6e8ebff text="Size" size=14.00
@@ -7,3 +8,6 @@ Text xy=21.00,41.60 wh=0.00,0.00 color=#e6e8ebff text="alpha" size=14.00
 Text xy=81.00,41.60 wh=0.00,0.00 color=#e6e8ebff text="12" size=14.00
 Text xy=21.00,65.20 wh=0.00,0.00 color=#e6e8ebff text="beta" size=14.00
 Text xy=81.00,65.20 wh=0.00,0.00 color=#e6e8ebff text="9" size=14.00
+Clip xy=295.00,16.00 wh=7.00,70.80
+Clip xy=16.00,16.00 wh=277.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/table_focused.light.golden
+++ b/gui/testdata/table_focused.light.golden
@@ -1,4 +1,5 @@
 Shadow xy=14.00,14.00 wh=292.00,70.80 color=#2f6fe03f blur=2.00 offset=0.00,0.00
+Clip xy=14.00,14.00 wh=281.00,70.80
 Rect xy=14.00,14.00 wh=120.00,23.60 color=#edf0f4ff radius=6.00 fill
 Text xy=27.20,16.00 wh=0.00,0.00 color=#1a1d21ff text="Name" size=14.00
 Text xy=87.20,16.00 wh=0.00,0.00 color=#1a1d21ff text="Size" size=14.00
@@ -6,3 +7,6 @@ Text xy=19.00,39.60 wh=0.00,0.00 color=#1a1d21ff text="alpha" size=14.00
 Text xy=79.00,39.60 wh=0.00,0.00 color=#1a1d21ff text="12" size=14.00
 Text xy=19.00,63.20 wh=0.00,0.00 color=#1a1d21ff text="beta" size=14.00
 Text xy=79.00,63.20 wh=0.00,0.00 color=#1a1d21ff text="9" size=14.00
+Clip xy=296.00,14.00 wh=7.00,70.80
+Clip xy=14.00,14.00 wh=281.00,70.80
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/tree_disabled.dark.golden
+++ b/gui/testdata/tree_disabled.dark.golden
@@ -1,6 +1,12 @@
+Clip xy=16.00,16.00 wh=86.00,51.20
 Text xy=22.00,19.00 wh=0.00,0.00 color=#e6e8eb80 text="  " size=12.00
 Text xy=38.00,19.00 wh=0.00,0.00 color=#e6e8eb80 text=" " size=12.00
 Text xy=54.00,19.00 wh=0.00,0.00 color=#e6e8eb80 text="Alpha" size=14.00
 Text xy=22.00,44.60 wh=0.00,0.00 color=#e6e8eb80 text="  " size=12.00
 Text xy=38.00,44.60 wh=0.00,0.00 color=#e6e8eb80 text=" " size=12.00
 Text xy=54.00,44.60 wh=0.00,0.00 color=#e6e8eb80 text="Beta" size=14.00
+Clip xy=16.00,58.20 wh=86.00,7.00
+Clip xy=16.00,16.00 wh=86.00,51.20
+Clip xy=93.00,16.00 wh=7.00,51.20
+Clip xy=16.00,16.00 wh=86.00,51.20
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/tree_disabled.light.golden
+++ b/gui/testdata/tree_disabled.light.golden
@@ -1,6 +1,12 @@
+Clip xy=14.00,14.00 wh=84.00,47.20
 Text xy=19.00,16.00 wh=0.00,0.00 color=#1a1d2195 text="  " size=12.00
 Text xy=35.00,16.00 wh=0.00,0.00 color=#1a1d2195 text=" " size=12.00
 Text xy=51.00,16.00 wh=0.00,0.00 color=#1a1d2195 text="Alpha" size=14.00
 Text xy=19.00,39.60 wh=0.00,0.00 color=#1a1d2195 text="  " size=12.00
 Text xy=35.00,39.60 wh=0.00,0.00 color=#1a1d2195 text=" " size=12.00
 Text xy=51.00,39.60 wh=0.00,0.00 color=#1a1d2195 text="Beta" size=14.00
+Clip xy=14.00,51.20 wh=84.00,7.00
+Clip xy=14.00,14.00 wh=84.00,47.20
+Clip xy=88.00,14.00 wh=7.00,47.20
+Clip xy=14.00,14.00 wh=84.00,47.20
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -49,11 +49,6 @@ type CommandPaletteCfg struct {
 	Width       float32
 	MaxHeight   float32
 
-	// Scrollable is a no-op and is scheduled for removal (issue #504).
-	// The results list always scrolls; scroll state is keyed by
-	// ScopeID(Cfg.ID, "scroll").
-	// exportaudit:keep — deprecated caller-facing config (issue #504)
-	Scrollable     bool
 	Color          Color
 	ColorBorder    Color
 	ColorHighlight Color
@@ -152,10 +147,8 @@ func (cp *commandPaletteView) GenerateLayout(w *Window) Layout {
 		cfg.TextStyle, PaddingTwoFive, w)
 	scrollID := ScopeID(id, "scroll")
 	// The results viewport is always Scrollable (see the layout below),
-	// so the virtualized window must always follow the real offset.
-	// Reading it only when Cfg.Scrollable was set left the window
-	// pinned at index 0 while the viewport scrolled, so a scrolled
-	// palette showed the trailing spacer instead of rows.
+	// so the virtualized window must always follow the real offset
+	// (issue #504).
 	// Default 0: unscrolled list before first scroll event.
 	scrollY := w.scrollY().GetOr(scrollID, 0)
 	first, last := listCoreVisibleRange(len(filtered), rowH, cfg.MaxHeight, scrollY)

--- a/gui/view_command_palette_test.go
+++ b/gui/view_command_palette_test.go
@@ -396,8 +396,7 @@ func TestPaletteKeyboardDispatchIntegration(t *testing.T) {
 
 	selected := ""
 	v := CommandPalette(CommandPaletteCfg{
-		ID:         id,
-		Scrollable: true,
+		ID: id,
 		Items: []CommandPaletteItem{
 			{ID: "alpha", Label: "Alpha"},
 			{ID: "beta", Label: "Beta"},

--- a/gui/view_listbox.go
+++ b/gui/view_listbox.go
@@ -63,12 +63,6 @@ type ListBoxCfg struct {
 	// MaxHeight caps the list's height. Like Height, it resolves the
 	// height virtualization needs.
 	MaxHeight float32
-	// Scrollable opts the list into the scroll system. Scroll state
-	// is keyed by Cfg.ID — pass that same id to Window.ScrollVerticalTo.
-	// Virtualization is automatic; it requires a resolved height, so
-	// pair Scrollable with Height or MaxHeight, or rely on Fill
-	// sizing (which virtualizes from the second frame).
-	Scrollable bool
 	// FocusDisabled opts out of the default-on focus. Focus also
 	// requires a non-empty ID; without one the control is inert.
 	FocusDisabled bool
@@ -174,7 +168,7 @@ func ListBox(cfg ListBoxCfg) View {
 			A11YDescription: cfg.A11YDescription,
 		},
 		Focusable:   !cfg.FocusDisabled,
-		Scrollable:  cfg.Scrollable,
+		Scrollable:  true,
 		AmendLayout: focusRingAmend(Color{}, cfg.ColorBorderFocus),
 		OnKeyDown: func(ctx EventCtx) {
 			listBoxOnKeyDown(listBoxID, itemIDs,
@@ -201,11 +195,11 @@ func ListBox(cfg ListBoxCfg) View {
 }
 
 // listBoxCanVirtualize reports whether the list takes the
-// virtualizing path. Scrollable alone qualifies: with no configured
-// height, virtualization starts on the second frame once Arrange has
-// resolved one.
+// virtualizing path. Every list qualifies since #504 removed the
+// Scrollable opt-in: with no configured height, virtualization starts
+// on the second frame once Arrange has resolved one.
 func listBoxCanVirtualize(cfg *ListBoxCfg) bool {
-	return cfg != nil && cfg.Scrollable
+	return cfg != nil
 }
 
 func (lv *listBoxView) GenerateLayout(w *Window) Layout {
@@ -285,7 +279,7 @@ func (lv *listBoxView) GenerateLayout(w *Window) Layout {
 			A11YDescription: cfg.A11YDescription,
 		},
 		Focusable:  !cfg.FocusDisabled,
-		Scrollable: cfg.Scrollable,
+		Scrollable: true,
 		AmendLayout: amendAll(
 			listBoxAmendLayout(cache),
 			focusRingAmend(Color{}, cfg.ColorBorderFocus)),
@@ -370,7 +364,7 @@ func listBoxVisibleRange(
 ) (first, last int, virtualize bool, listH, rowH float32) {
 	first = 0
 	last = len(cfg.Data) - 1
-	virtualize = cfg.Scrollable
+	virtualize = true
 	listH = cfg.Height
 	if listH <= 0 {
 		listH = cfg.MaxHeight
@@ -390,8 +384,7 @@ func listBoxVisibleRange(
 		listHeightRegisterUniform(w, cfg.ID, len(cfg.Data), rowH, 0, 0)
 	} else {
 		virtualize = false
-		if cfg.Scrollable && cache.hSeen &&
-			len(cfg.Data) > 0 && DebugEnabled() {
+		if cache.hSeen && len(cfg.Data) > 0 && DebugEnabled() {
 			// The layout has run at least once and still gave the
 			// list no height, so every row builds each frame.
 			w.debugWarn(debugCheckListBoxNoHeight, cfg.ID,

--- a/gui/view_listbox_test.go
+++ b/gui/view_listbox_test.go
@@ -6,6 +6,21 @@ import (
 	"testing"
 )
 
+// listBoxRows returns a rendered ListBox's row children, dropping the
+// scrollbar pair. Every list joins the scroll system since #504 removed
+// the Scrollable opt-in, so the container always carries scrollbars;
+// they are OverDraw children, which is what marks them as not rows.
+func listBoxRows(layout *Layout) []Layout {
+	rows := make([]Layout, 0, len(layout.Children))
+	for _, c := range layout.Children {
+		if c.Shape.OverDraw {
+			continue
+		}
+		rows = append(rows, c)
+	}
+	return rows
+}
+
 func TestListBoxIDPassthrough(t *testing.T) {
 	w := &Window{}
 	layout := generateViewLayout(ListBox(ListBoxCfg{
@@ -27,8 +42,8 @@ func TestListBoxChildCount(t *testing.T) {
 			{ID: "c", Name: "Gamma"},
 		},
 	}), w)
-	if len(layout.Children) != 3 {
-		t.Errorf("children: got %d, want 3", len(layout.Children))
+	if got := len(listBoxRows(&layout)); got != 3 {
+		t.Errorf("rows: got %d, want 3", got)
 	}
 }
 
@@ -107,8 +122,8 @@ func TestListBoxItems(t *testing.T) {
 		ID:    "lb-items",
 		Items: []string{"Go", "Rust", "Zig"},
 	}), w)
-	if len(layout.Children) != 3 {
-		t.Fatalf("children = %d, want 3", len(layout.Children))
+	if len(listBoxRows(&layout)) != 3 {
+		t.Fatalf("rows = %d, want 3", len(listBoxRows(&layout)))
 	}
 }
 
@@ -120,8 +135,8 @@ func TestListBoxItemsPrecedence(t *testing.T) {
 		Items: []string{"Alpha", "Beta"},
 		Data:  []ListBoxOption{{ID: "ignored", Name: "Ignored"}},
 	}), w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("children = %d, want 2", len(layout.Children))
+	if got := len(listBoxRows(&layout)); got != 2 {
+		t.Fatalf("rows = %d, want 2", got)
 	}
 }
 
@@ -156,8 +171,8 @@ func TestListBoxItemsEmptyKeepsData(t *testing.T) {
 		Items: []string{},
 		Data:  []ListBoxOption{{ID: "a", Name: "Alpha"}},
 	}), w)
-	if len(layout.Children) != 1 {
-		t.Fatalf("children = %d, want 1 (Data preserved)", len(layout.Children))
+	if len(listBoxRows(&layout)) != 1 {
+		t.Fatalf("rows = %d, want 1 (Data preserved)", len(listBoxRows(&layout)))
 	}
 }
 
@@ -170,8 +185,8 @@ func TestListBoxSubheadingCount(t *testing.T) {
 			{ID: "a", Name: "Alpha"},
 		},
 	}), w)
-	if len(layout.Children) != 2 {
-		t.Errorf("children: got %d, want 2", len(layout.Children))
+	if got := len(listBoxRows(&layout)); got != 2 {
+		t.Errorf("rows: got %d, want 2", got)
 	}
 }
 
@@ -191,10 +206,9 @@ func TestListBoxFillVirtualizesNextFrame(t *testing.T) {
 	// hook), the view phase builds only the visible rows.
 	w := newTestWindow()
 	cfg := ListBoxCfg{
-		ID:         "lb-fill",
-		Scrollable: true,
-		Sizing:     FillFill,
-		Data:       listBoxTestData(10_000),
+		ID:     "lb-fill",
+		Sizing: FillFill,
+		Data:   listBoxTestData(10_000),
 	}
 	v := ListBox(cfg)
 	if _, ok := v.(*listBoxView); !ok {
@@ -236,9 +250,8 @@ func TestListBoxFillVirtualizesNextFrame(t *testing.T) {
 func TestListBoxAmendStoresResolvedHeight(t *testing.T) {
 	w := newTestWindow()
 	cfg := ListBoxCfg{
-		ID:         "lb-amend",
-		Scrollable: true,
-		Data:       listBoxTestData(10),
+		ID:   "lb-amend",
+		Data: listBoxTestData(10),
 	}
 	v := ListBox(cfg)
 	layout := generateViewLayout(v, w)
@@ -297,11 +310,10 @@ func TestListBoxVisibleRangeHeightPriority(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := ListBoxCfg{
-				ID:         "lb-prio-" + tc.name,
-				Scrollable: true,
-				Height:     tc.height,
-				MaxHeight:  tc.maxHeight,
-				Data:       data,
+				ID:        "lb-prio-" + tc.name,
+				Height:    tc.height,
+				MaxHeight: tc.maxHeight,
+				Data:      data,
 			}
 			cache := &listBoxCache{resolvedH: tc.resolvedH, hSeen: true}
 			first, last, virtualize, listH, _ :=
@@ -382,9 +394,8 @@ func TestListBoxNoHeightWarning(t *testing.T) {
 	var found []string
 	w.debug.collect = &found
 	cfg := ListBoxCfg{
-		ID:         "lb-warn",
-		Scrollable: true,
-		Data:       listBoxTestData(500),
+		ID:   "lb-warn",
+		Data: listBoxTestData(500),
 	}
 	v := ListBox(cfg)
 
@@ -416,9 +427,8 @@ func TestListBoxNoHeightGatedByCategory(t *testing.T) {
 	defer DebugCategories(prevMask)
 	w := newTestWindow()
 	cfg := ListBoxCfg{
-		ID:         "lb-cat",
-		Scrollable: true,
-		Data:       listBoxTestData(500),
+		ID:   "lb-cat",
+		Data: listBoxTestData(500),
 	}
 	v := ListBox(cfg)
 
@@ -839,5 +849,50 @@ func TestListBoxReorderClickMovesKeyboardFocus(t *testing.T) {
 
 	if got := StateReadOr(w, nsListBoxFocus, "lb-reo-click", -1); got != 1 {
 		t.Errorf("focus index = %d, want 1", got)
+	}
+}
+
+func TestListBoxAlwaysScrollable(t *testing.T) {
+	// #504: the Scrollable opt-in is gone, so a plain list joins the
+	// scroll system with no flag. Previously this shape carried
+	// Scrollable=false and its wheel events went nowhere.
+	w := &Window{}
+	layout := generateViewLayout(ListBox(ListBoxCfg{
+		ID:        "lb-always",
+		MaxHeight: 60,
+		Data: []ListBoxOption{
+			{ID: "a", Name: "Alpha"},
+			{ID: "b", Name: "Beta"},
+			{ID: "c", Name: "Gamma"},
+		},
+	}), w)
+	if !layout.Shape.Scrollable {
+		t.Error("a list must be scrollable without being asked")
+	}
+}
+
+func TestListBoxZeroHeightSkipsVirtualization(t *testing.T) {
+	// The edge #504 calls out: with no resolved height there is nothing
+	// to window against, so virtualization stays off and every row
+	// builds. It must degrade quietly, not panic or drop rows.
+	w := &Window{}
+	cfg := &ListBoxCfg{
+		ID: "lb-zero",
+		Data: []ListBoxOption{
+			{ID: "a", Name: "Alpha"},
+			{ID: "b", Name: "Beta"},
+		},
+	}
+	cache := &listBoxCache{}
+	first, last, virtualize, listH, _ := listBoxVisibleRange(cfg, cache, w)
+	if virtualize {
+		t.Error("virtualization must stay off with no resolved height")
+	}
+	if listH != 0 {
+		t.Errorf("listH = %v, want 0", listH)
+	}
+	if first != 0 || last != len(cfg.Data)-1 {
+		t.Errorf("range = (%d,%d), want all rows (0,%d)",
+			first, last, len(cfg.Data)-1)
 	}
 }

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -77,11 +77,6 @@ type TableCfg struct {
 	SizeBorder       float32 // ergonomics-audit:opt-plain — 0 = no borders, applied as-is; public API kept plain
 	SizeBorderHeader float32 // ergonomics-audit:opt-plain — 0 = no header separator; public API kept plain
 
-	// Scrollable enables scrolling. When set with Height or
-	// MaxHeight, virtualization renders only visible rows. Scroll
-	// state is keyed by Cfg.ID, or ScopeID(Cfg.ID, "scroll") when
-	// FreezeHeader is set — pass that to Window.ScrollVerticalTo.
-	Scrollable  bool
 	Width       float32
 	Height      float32
 	MinWidth    float32
@@ -265,7 +260,10 @@ func tableView(cfg TableCfg, w *Window) View {
 	}
 
 	columnWidths := tableColumnWidths(&cfg, w)
-	freeze := cfg.FreezeHeader && cfg.Scrollable && len(cfg.Data) > 1
+	// FreezeHeader no longer depends on a Scrollable opt-in (#504): the
+	// table always scrolls, so the caller's intent is the whole
+	// condition. A header still needs a body row to freeze above.
+	freeze := cfg.FreezeHeader && len(cfg.Data) > 1
 	// Derived once per view: the freeze path's concatenation must not
 	// be repeated at each use (virtualization read + bodyCfg literal).
 	scrollID := tableScrollID(&cfg, freeze)
@@ -289,8 +287,7 @@ func tableView(cfg TableCfg, w *Window) View {
 		dataCount = len(cfg.Data) - 1
 	}
 
-	virtualize := cfg.Scrollable && listHeight > 0 &&
-		dataCount > 0 && w != nil
+	virtualize := listHeight > 0 && dataCount > 0 && w != nil
 	rowHeight := float32(0)
 	first, last := dataStart, lastRowIdx
 	if virtualize {
@@ -346,16 +343,21 @@ func tableView(cfg TableCfg, w *Window) View {
 	// state carries false/nil/nil, which is what outerCfg already is.
 	tableWireFocus(&outerCfg, fw)
 
-	if cfg.Scrollable {
-		outerCfg.Scrollable = true
-		outerCfg.Padding = NewPadding(0, DefaultScrollbarStyle.Size+PadXSmall, 0, 0)
-		outerCfg.ScrollbarCfgX = &ScrollbarCfg{
-			Overflow: ScrollbarHidden,
-		}
-		if cfg.Scrollbar != ScrollbarAuto {
-			outerCfg.ScrollbarCfgY = &ScrollbarCfg{
-				Overflow: cfg.Scrollbar,
-			}
+	// The table always scrolls now that #504 removed the Scrollable
+	// opt-in -- but scroll state is keyed by ID, so an ID-less table has
+	// nothing to key and must not join the scroll system. Cfg.ID is
+	// gui:"required", so this is the un-vetted path (and the library's
+	// own tableCfgFromCSV / tableCfgError build one); gui.Debug reports
+	// it under the scrollable-without-ID check. Declining here beats
+	// requireScrollID panicking on a decision the caller did not make.
+	outerCfg.Scrollable = cfg.ID != ""
+	outerCfg.Padding = NewPadding(0, DefaultScrollbarStyle.Size+PadXSmall, 0, 0)
+	outerCfg.ScrollbarCfgX = &ScrollbarCfg{
+		Overflow: ScrollbarHidden,
+	}
+	if cfg.Scrollbar != ScrollbarAuto {
+		outerCfg.ScrollbarCfgY = &ScrollbarCfg{
+			Overflow: cfg.Scrollbar,
 		}
 	}
 

--- a/gui/view_table_keys_test.go
+++ b/gui/view_table_keys_test.go
@@ -334,7 +334,6 @@ func TestTableFreezeFocusWiring(t *testing.T) {
 	l := generateViewLayout(Table(TableCfg{
 		ID:           "ft",
 		Focusable:    true,
-		Scrollable:   true,
 		MaxHeight:    100,
 		FreezeHeader: true,
 		Data:         tableTestRows(),

--- a/gui/view_table_test.go
+++ b/gui/view_table_test.go
@@ -6,6 +6,22 @@ import (
 	"github.com/go-gui-org/go-glyph"
 )
 
+// tableRows returns a rendered Table's row children, dropping the
+// scrollbar. Every table joins the scroll system since #504 removed the
+// Scrollable opt-in, so the outer container always carries one; it is
+// an OverDraw child, which is what marks it as not a row. (The
+// horizontal bar is ScrollbarHidden, so only the vertical one appears.)
+func tableRows(layout *Layout) []Layout {
+	rows := make([]Layout, 0, len(layout.Children))
+	for _, c := range layout.Children {
+		if c.Shape.OverDraw {
+			continue
+		}
+		rows = append(rows, c)
+	}
+	return rows
+}
+
 func TestTableBasic(t *testing.T) {
 	v := Table(TableCfg{
 		ID: "tbl-test",
@@ -17,8 +33,8 @@ func TestTableBasic(t *testing.T) {
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 3 {
-		t.Fatalf("rows = %d, want 3", len(layout.Children))
+	if len(tableRows(&layout)) != 3 {
+		t.Fatalf("rows = %d, want 3", len(tableRows(&layout)))
 	}
 }
 
@@ -26,8 +42,8 @@ func TestTableEmpty(t *testing.T) {
 	v := Table(TableCfg{ID: "tbl-test"})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 0 {
-		t.Errorf("children = %d, want 0", len(layout.Children))
+	if len(tableRows(&layout)) != 0 {
+		t.Errorf("children = %d, want 0", len(tableRows(&layout)))
 	}
 }
 
@@ -43,7 +59,6 @@ func TestTableA11Y(t *testing.T) {
 		{name: "plain"},
 		{name: "freeze", cfg: TableCfg{
 			FreezeHeader: true,
-			Scrollable:   true,
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -85,8 +100,8 @@ func TestTableBorderAll(t *testing.T) {
 	w := &Window{}
 	layout := generateViewLayout(v, w)
 	// 2 rows (cell borders with negative spacing, no separators).
-	if len(layout.Children) != 2 {
-		t.Errorf("children = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) != 2 {
+		t.Errorf("children = %d, want 2", len(tableRows(&layout)))
 	}
 	// Each cell should have a border.
 	row := layout.Children[0]
@@ -110,8 +125,8 @@ func TestTableBorderHorizontal(t *testing.T) {
 	w := &Window{}
 	layout := generateViewLayout(v, w)
 	// 3 rows + 2 separators (between 0-1 and 1-2; not after last).
-	if len(layout.Children) != 5 {
-		t.Errorf("children = %d, want 5", len(layout.Children))
+	if len(tableRows(&layout)) != 5 {
+		t.Errorf("children = %d, want 5", len(tableRows(&layout)))
 	}
 }
 
@@ -129,8 +144,8 @@ func TestTableBorderHeaderOnly(t *testing.T) {
 	w := &Window{}
 	layout := generateViewLayout(v, w)
 	// 3 rows + 1 separator (after header only).
-	if len(layout.Children) != 4 {
-		t.Errorf("children = %d, want 4", len(layout.Children))
+	if len(tableRows(&layout)) != 4 {
+		t.Errorf("children = %d, want 4", len(tableRows(&layout)))
 	}
 }
 
@@ -145,8 +160,8 @@ func TestTableRawData(t *testing.T) {
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 3 {
-		t.Fatalf("rows = %d, want 3", len(layout.Children))
+	if len(tableRows(&layout)) != 3 {
+		t.Fatalf("rows = %d, want 3", len(tableRows(&layout)))
 	}
 }
 
@@ -164,9 +179,9 @@ func TestTableRawDataPrecedence(t *testing.T) {
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 2 {
+	if len(tableRows(&layout)) != 2 {
 		t.Fatalf("rows = %d, want 2 (RawData)",
-			len(layout.Children))
+			len(tableRows(&layout)))
 	}
 }
 
@@ -182,8 +197,8 @@ func TestTableRawDataHeaderRow(t *testing.T) {
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("rows = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) != 2 {
+		t.Fatalf("rows = %d, want 2", len(tableRows(&layout)))
 	}
 }
 
@@ -197,8 +212,8 @@ func TestTableRawDataHeaderOnly(t *testing.T) {
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 1 {
-		t.Fatalf("rows = %d, want 1 (header-only)", len(layout.Children))
+	if len(tableRows(&layout)) != 1 {
+		t.Fatalf("rows = %d, want 1 (header-only)", len(tableRows(&layout)))
 	}
 }
 
@@ -289,8 +304,8 @@ func TestTableSelectedRowTextColor(t *testing.T) {
 		},
 		Selected: map[int]bool{1: true},
 	}), w)
-	if len(layout.Children) < 2 {
-		t.Fatalf("rows = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) < 2 {
+		t.Fatalf("rows = %d, want 2", len(tableRows(&layout)))
 	}
 	unselected := layout.Children[0].Children[0].Children[0].Shape.TC
 	selected := layout.Children[1].Children[0].Children[0].Shape.TC
@@ -402,8 +417,8 @@ func TestWindowTable(t *testing.T) {
 		},
 	})
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("rows = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) != 2 {
+		t.Fatalf("rows = %d, want 2", len(tableRows(&layout)))
 	}
 }
 
@@ -424,8 +439,8 @@ func TestTableColumnWidthCaching(t *testing.T) {
 	// Second call should hit cache.
 	v2 := w.Table(cfg)
 	layout2 := generateViewLayout(v2, w)
-	if len(layout2.Children) != 2 {
-		t.Fatalf("rows = %d, want 2", len(layout2.Children))
+	if got := len(tableRows(&layout2)); got != 2 {
+		t.Fatalf("rows = %d, want 2", got)
 	}
 }
 
@@ -462,17 +477,16 @@ func TestTableVirtualization(t *testing.T) {
 	}
 
 	v := w.Table(TableCfg{
-		ID:         "virtual-test",
-		Scrollable: true,
-		MaxHeight:  200,
-		Data:       data,
+		ID:        "virtual-test",
+		MaxHeight: 200,
+		Data:      data,
 	})
 	layout := generateViewLayout(v, w)
 	// Should have fewer children than total rows due to
 	// virtualization (visible rows + spacers).
-	if len(layout.Children) >= 101 {
+	if len(tableRows(&layout)) >= 101 {
 		t.Errorf("expected virtualized children < 101, got %d",
-			len(layout.Children))
+			len(tableRows(&layout)))
 	}
 }
 
@@ -497,8 +511,8 @@ func TestTableFromCSV(t *testing.T) {
 	w := &Window{}
 	v := w.tableFromCSV("A,B\n1,2\n")
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("rows = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) != 2 {
+		t.Fatalf("rows = %d, want 2", len(tableRows(&layout)))
 	}
 }
 
@@ -507,8 +521,8 @@ func TestTableFromCSVError(t *testing.T) {
 	v := w.tableFromCSV("\"unclosed")
 	layout := generateViewLayout(v, w)
 	// Should produce error table with 1 row.
-	if len(layout.Children) != 1 {
-		t.Fatalf("rows = %d, want 1", len(layout.Children))
+	if len(tableRows(&layout)) != 1 {
+		t.Fatalf("rows = %d, want 1", len(tableRows(&layout)))
 	}
 }
 
@@ -517,7 +531,6 @@ func TestTableFreezeHeader(t *testing.T) {
 	w.textMeasurer = &tableTestMeasurer{}
 	v := w.Table(TableCfg{
 		ID:           "freeze-test",
-		Scrollable:   true,
 		MaxHeight:    200,
 		FreezeHeader: true,
 		Data: []TableRowCfg{
@@ -528,8 +541,8 @@ func TestTableFreezeHeader(t *testing.T) {
 	})
 	layout := generateViewLayout(v, w)
 	// Outer has 2 children: header zone, body zone.
-	if len(layout.Children) != 2 {
-		t.Fatalf("outer children = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) != 2 {
+		t.Fatalf("outer children = %d, want 2", len(tableRows(&layout)))
 	}
 	headerZone := layout.Children[0]
 	bodyZone := layout.Children[1]
@@ -550,7 +563,6 @@ func TestTableFreezeHeaderWithSeparator(t *testing.T) {
 	w.textMeasurer = &tableTestMeasurer{}
 	v := w.Table(TableCfg{
 		ID:           "freeze-sep-test",
-		Scrollable:   true,
 		MaxHeight:    200,
 		FreezeHeader: true,
 		BorderStyle:  TableBorderHeaderOnly,
@@ -562,8 +574,8 @@ func TestTableFreezeHeaderWithSeparator(t *testing.T) {
 		},
 	})
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("outer children = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) != 2 {
+		t.Fatalf("outer children = %d, want 2", len(tableRows(&layout)))
 	}
 	headerZone := layout.Children[0]
 	bodyZone := layout.Children[1]
@@ -579,8 +591,11 @@ func TestTableFreezeHeaderWithSeparator(t *testing.T) {
 	}
 }
 
-func TestTableFreezeHeaderNoScroll(t *testing.T) {
-	// FreezeHeader=true but Scrollable=false → falls back to single Column.
+func TestTableFreezeHeaderNeedsNoScrollableFlag(t *testing.T) {
+	// #504 item 2: FreezeHeader used to require Scrollable as well, so
+	// setting it alone silently did nothing. The table always scrolls
+	// now, so the caller's intent is the whole condition -- this same
+	// config used to render one flat Column of 3 rows.
 	v := Table(TableCfg{
 		ID:           "tbl-test",
 		FreezeHeader: true,
@@ -592,9 +607,15 @@ func TestTableFreezeHeaderNoScroll(t *testing.T) {
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	// Same as non-frozen: 3 rows, single Column.
-	if len(layout.Children) != 3 {
-		t.Errorf("children = %d, want 3", len(layout.Children))
+	// Frozen shape: a header zone and a body zone, not a flat row list.
+	if got := len(tableRows(&layout)); got != 2 {
+		t.Fatalf("outer children = %d, want 2 (header zone + body zone)",
+			got)
+	}
+	headerZone := layout.Children[0]
+	if len(headerZone.Children) != 1 {
+		t.Errorf("header zone children = %d, want 1 (the header row)",
+			len(headerZone.Children))
 	}
 }
 
@@ -610,14 +631,13 @@ func TestTableFreezeHeaderVirtualization(t *testing.T) {
 
 	v := w.Table(TableCfg{
 		ID:           "freeze-virtual-test",
-		Scrollable:   true,
 		MaxHeight:    200,
 		FreezeHeader: true,
 		Data:         data,
 	})
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("outer children = %d, want 2", len(layout.Children))
+	if len(tableRows(&layout)) != 2 {
+		t.Fatalf("outer children = %d, want 2", len(tableRows(&layout)))
 	}
 	bodyZone := layout.Children[1]
 	// Body should have fewer than 100 children due to virtualization.
@@ -643,8 +663,8 @@ func TestTableRichTextCell(t *testing.T) {
 	})
 	w := &Window{}
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 1 {
-		t.Fatalf("rows = %d, want 1", len(layout.Children))
+	if len(tableRows(&layout)) != 1 {
+		t.Fatalf("rows = %d, want 1", len(tableRows(&layout)))
 	}
 }
 

--- a/gui/view_theme_picker.go
+++ b/gui/view_theme_picker.go
@@ -74,7 +74,6 @@ func (tv *themePickerView) GenerateLayout(w *Window) Layout {
 			Content: []View{
 				ListBox(ListBoxCfg{
 					ID:          lbID,
-					Scrollable:  true,
 					MinWidth:    140,
 					MaxHeight:   300,
 					Data:        data,

--- a/gui/view_tree.go
+++ b/gui/view_tree.go
@@ -39,10 +39,6 @@ type TreeCfg struct {
 	// requires a non-empty ID; without one the control is inert.
 	FocusDisabled bool
 
-	// Scrollable opts the tree into the scroll system. Scroll state
-	// is keyed by Cfg.ID - pass that same id to Window.ScrollVerticalTo.
-	Scrollable bool
-
 	Width     float32
 	Height    float32
 	MinWidth  float32
@@ -201,7 +197,7 @@ func (tv *treeView) GenerateLayout(w *Window) Layout {
 	if listHeight <= 0 {
 		listHeight = cfg.MaxHeight
 	}
-	virtualize := cfg.Scrollable && listHeight > 0 && len(flatRows) > 0
+	virtualize := listHeight > 0 && len(flatRows) > 0
 	rowHeight := float32(0)
 	first, last := 0, len(flatRows)-1
 	if virtualize {
@@ -266,7 +262,7 @@ func (tv *treeView) GenerateLayout(w *Window) Layout {
 		// caller's description with the label.
 		a11Y:       cfg.a11yInfo(cfg.ID),
 		Focusable:  !cfg.FocusDisabled,
-		Scrollable: cfg.Scrollable,
+		Scrollable: true,
 		OnKeyDown: func(ctx EventCtx) {
 			if canReorder {
 				if dragReorderEscape(cfg.ID, ctx.Event.KeyCode, ctx.Window) {

--- a/gui/view_tree_test.go
+++ b/gui/view_tree_test.go
@@ -2,6 +2,21 @@ package gui
 
 import "testing"
 
+// treeRows returns a rendered Tree's row children, dropping the
+// scrollbar pair. Every tree joins the scroll system since #504 removed
+// the Scrollable opt-in; scrollbars are OverDraw children, which is
+// what marks them as not rows.
+func treeRows(layout *Layout) []Layout {
+	rows := make([]Layout, 0, len(layout.Children))
+	for _, c := range layout.Children {
+		if c.Shape.OverDraw {
+			continue
+		}
+		rows = append(rows, c)
+	}
+	return rows
+}
+
 func TestTreeNodeIDFallback(t *testing.T) {
 	if got := treeNodeID(TreeNodeCfg{Text: "alpha"}); got != "alpha" {
 		t.Errorf("treeNodeID(Text=alpha) = %q, want %q", got, "alpha")
@@ -392,8 +407,8 @@ func TestTreeGenerateLayoutA11Y(t *testing.T) {
 	if layout.Shape.A11YRole != AccessRoleTree {
 		t.Fatalf("layout.Shape.A11YRole = %d, want %d", layout.Shape.A11YRole, AccessRoleTree)
 	}
-	if got := len(layout.Children); got != 2 {
-		t.Fatalf("len(layout.Children) = %d, want 2", got)
+	if got := len(treeRows(&layout)); got != 2 {
+		t.Fatalf("len(treeRows(&layout)) = %d, want 2", got)
 	}
 
 	rootRow := layout.Children[0]
@@ -470,8 +485,8 @@ func TestTreeItemPaths(t *testing.T) {
 		ID:        "tree-paths",
 		ItemPaths: []string{"src/main.go", "src/lib.go", "docs/readme.md"},
 	}), w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("children = %d, want 2", len(layout.Children))
+	if len(treeRows(&layout)) != 2 {
+		t.Fatalf("children = %d, want 2", len(treeRows(&layout)))
 	}
 }
 
@@ -506,9 +521,9 @@ func TestTreeItemPathsPrecedence(t *testing.T) {
 			{ID: "ignored", Text: "Ignored"},
 		},
 	}), w)
-	if len(layout.Children) != 2 {
+	if len(treeRows(&layout)) != 2 {
 		t.Fatalf("children = %d, want 2 (ItemPaths)",
-			len(layout.Children))
+			len(treeRows(&layout)))
 	}
 }
 
@@ -692,7 +707,7 @@ func TestTreeGenerateLayoutReorderable(t *testing.T) {
 			{ID: "b", Text: "B"},
 		},
 	}), w)
-	if got := len(layout.Children); got != 2 {
+	if got := len(treeRows(&layout)); got != 2 {
 		t.Fatalf("children = %d, want 2", got)
 	}
 	if got := layout.Children[0].Shape.ID; got != "tree-reo:row:a" {

--- a/gui/view_widget_test.go
+++ b/gui/view_widget_test.go
@@ -581,8 +581,8 @@ func TestListBoxGeneratesLayout(t *testing.T) {
 	if layout.Shape.A11YRole != AccessRoleList {
 		t.Fatalf("got role %d, want List", layout.Shape.A11YRole)
 	}
-	if len(layout.Children) != 3 {
-		t.Fatalf("got %d children, want 3", len(layout.Children))
+	if got := len(listBoxRows(&layout)); got != 3 {
+		t.Fatalf("got %d rows, want 3", got)
 	}
 }
 
@@ -639,8 +639,8 @@ func TestListBoxSubheading(t *testing.T) {
 		OnSelect: func(_ []string, ctx EventCtx) {},
 	})
 	layout := generateViewLayout(v, w)
-	if len(layout.Children) != 2 {
-		t.Fatalf("got %d children, want 2", len(layout.Children))
+	if got := len(listBoxRows(&layout)); got != 2 {
+		t.Fatalf("got %d rows, want 2", got)
 	}
 }
 


### PR DESCRIPTION
Addresses #504 items 1 and 2. Item 3 (flag polarity) is deliberately deferred —
see the bottom.

## What

`Scrollable` is removed from `ListBoxCfg`, `TreeCfg`, `TableCfg` and
`CommandPaletteCfg`. These widgets always scroll, following `ComboboxCfg` in
v0.68.0. Callers delete the line; scroll state is still keyed by `Cfg.ID`.

## Why the flag was worse than an ergonomics wart

- **It gated virtualization.** A 10k-row `ListBox` without it built every row —
  a performance cliff hidden behind an ergonomics flag.
- **On `CommandPalette` it was a half-switch.** The results column was hardcoded
  scrollable while the flag only gated *reading* the offset, so a scrolled
  palette rendered blank rows. Fixed separately in #506; this removes the trap.

## Non-risk, verified

Content that fits gains an *inert* scroll region rather than stealing the wheel:
`scrollVertical` clamps and returns `false` when the offset does not move, and
`event_handlers.go` assigns that straight to `e.IsHandled`, so the event bubbles
to the page. New test `TestListBoxZeroHeightSkipsVirtualization` covers the
zero-height edge the issue calls out.

## Behaviour change worth reviewing

`TableCfg.FreezeHeader` now works on its own — it used to read
`cfg.FreezeHeader && cfg.Scrollable && len(cfg.Data) > 1`, so setting it alone
silently did nothing. **This is a visible layout change in code nobody touched:**
such a table now renders a header zone plus a body zone instead of one flat
column. It has its own CHANGELOG entry.

The old test asserted the silent no-op, so it is replaced by
`TestTableFreezeHeaderNeedsNoScrollableFlag`, proven non-vacuous (forcing
`freeze` false gives back the 3 flat rows).

## One judgement call

An ID-less `Table` panicked, because `requireScrollID` fires on `Scrollable`
with an empty ID — and the library's own `tableCfgFromCSV` / `tableCfgError`
build ID-less tables, so the library crashed itself. Now an ID-less table
declines the scroll system instead. That guard exists to catch a *caller* who
wrote `Scrollable: true` without an ID; it should not punish them for a choice
the library makes internally. `TableCfg.ID` is `gui:"required"`, so `go vet`
rejects this statically and `gui.Debug` reports it at runtime. Own CHANGELOG
entry. **Say if you would rather it panic.**

## Goldens

14 files re-recorded: **76 insertions, 0 deletions**. Every text row survives at
identical coordinates; only `Clip` commands are added, and no scrollbar thumb is
drawn because content fits and `ScrollbarAuto` hides it. Diff read before
accepting, per the repo rule.

Test child counts moved because scrollbars are now children. Rather than
hardcode `+2`, `listBoxRows` / `tableRows` / `treeRows` filter `OverDraw`
children so the assertions still read as row counts.

## Sibling consumers

Breaking. Needs the `sync-siblings` pass at v0.69.0 — tier 1 (go-charts,
go-edit, go-kite, go-term, go-map), then tier 2 (go-speedtest, which needs tier
1 tagged).

## Deferred

Item 3 of #504 — the flag-polarity renames (`HideHex`, `HideTodayIndicator`) —
is a naming decision that needs each struct's default settled first. Separate
PR, same release.

## Verification

`make prepush` green. `make ergonomics-audit`, `make export-audit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
