### PR TITLE
docs(datepicker): state flag polarity on today/adjacent-month flags (#504)

### DIFF
--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -93,14 +93,21 @@ type DatePickerCfg struct {
 	// ColorTextOnSelect is the text color drawn over the selected
 	// day's fill. Unset takes the theme's.
 	// exportaudit:keep — caller-facing config (issue #372)
-	ColorTextOnSelect    Color
-	WeekdaysLen          DatePickerWeekdayLen
-	Disabled             bool
-	Invisible            bool
-	SelectMultiple       bool
+	ColorTextOnSelect Color
+	WeekdaysLen       DatePickerWeekdayLen
+	Disabled          bool
+	Invisible         bool
+	SelectMultiple    bool
+	// HideTodayIndicator turns off the border drawn around today's cell,
+	// which is otherwise on. Named for the opt-out because the indicator is
+	// the default: a calendar that does not mark today is the rare choice
+	// (issue #504).
 	HideTodayIndicator   bool
 	MondayFirstDayOfWeek bool
-	ShowAdjacentMonths   bool
+	// ShowAdjacentMonths fills the grid's leading and trailing cells with
+	// the neighboring months' days, which is otherwise off. Named for the
+	// opt-in because the plain grid is the default (issue #504).
+	ShowAdjacentMonths bool
 
 	// Sound overrides the theme's selection cue for a day cell.
 	// SoundNone (the zero value) takes Theme.Sounds.Selection, which

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -50,15 +50,22 @@ type InputDateCfg struct {
 	// ColorTextOnSelect is the text color drawn over the selected
 	// day's fill. Unset takes the theme's.
 	// exportaudit:keep — caller-facing config (issue #372)
-	ColorTextOnSelect    Color
-	Sizing               Sizing
-	WeekdaysLen          DatePickerWeekdayLen
-	Disabled             bool
-	Invisible            bool
-	SelectMultiple       bool
+	ColorTextOnSelect Color
+	Sizing            Sizing
+	WeekdaysLen       DatePickerWeekdayLen
+	Disabled          bool
+	Invisible         bool
+	SelectMultiple    bool
+	// HideTodayIndicator turns off the border drawn around today's cell,
+	// which is otherwise on. Named for the opt-out because the indicator is
+	// the default: a calendar that does not mark today is the rare choice
+	// (issue #504).
 	HideTodayIndicator   bool
 	MondayFirstDayOfWeek bool
-	ShowAdjacentMonths   bool
+	// ShowAdjacentMonths fills the grid's leading and trailing cells with
+	// the neighboring months' days, which is otherwise off. Named for the
+	// opt-in because the plain grid is the default (issue #504).
+	ShowAdjacentMonths bool
 
 	// ReadOnly blocks date edits while the field stays focusable and
 	// selectable, mirroring InputCfg.ReadOnly. Typing is blocked on the


### PR DESCRIPTION
Item 3 of #504, resolved as documentation rather than renames.

## Why no renames

The issue's rule: default on spells the opt-out (`HideX`), default off spells
the opt-in (`ShowX`). Every flag it named already obeys it.

| Field | Consuming read | Default |
|---|---|---|
| `ShowHSL` | `gui/view_color_fields.go:107` | off |
| `ShowSwatch` | `gui/view_color_fields.go` | off |
| `HideHex` | `gui/view_color_fields.go:103` — `if !cfg.HideHex` | **on** |
| `ShowAdjacentMonths` | `gui/view_date_picker_calendar.go:100` | off |
| `HideTodayIndicator` | `gui/view_date_picker_calendar.go:146` | **on** |

Mixed `Show`/`Hide` in one struct is not an inconsistency here — it is two
different defaults, each correctly named. Renaming would require flipping a
default, so a zero-value `ColorFieldsCfg` loses its hex field and a zero-value
`DatePickerCfg` stops marking today. That is a behaviour break plus a sibling
sync, in exchange for symmetry.

## What this changes

`HideTodayIndicator` and `ShowAdjacentMonths` had no doc comment on either
`DatePickerCfg` (`gui/view_date_picker.go`) or `InputDateCfg`
(`gui/view_input_date.go`). Each now states its default and why it is named for
the opt-out or the opt-in. The `ColorFieldsCfg` flags were already documented
and are untouched.

Comment-only. gofmt re-aligned the field block above each insertion; no
behaviour change, no golden re-record, no CHANGELOG entry.

Verified: `go build ./...`, `go vet ./gui/`, `go test ./gui/` all clean.

Closes #504