### PR TITLE
fix(ids): resolve Sidebar, InputDate and Table IDs at generation time (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,42 @@ and this project adheres to
   transparent instead of the opaque theme background. See
   `examples/transparent/` and `docs/specs/transparent-windows.md`.
 
+- **`gui.DebugUnresolvedKeys` and `(*Window).TestFindings`** (#518) — a dev-mode
+  gate for the quietest identity mistake: a widget that keys its internal state
+  on the raw `cfg.ID` while `resolveShapeIDs` gives its shape a scoped effective
+  ID, so state is written and read under different strings. The audit runs once
+  per frame from the existing debug walk, over the identities the walk already
+  collected, and does not instrument the state store. It reports only when an
+  ancestor join really rewrote a shape of that leaf, so a cache keyed by a file
+  name stays quiet. Like `DebugUnscopedIDs` it is **not** in `DebugAll`, because
+  `gui/datagrid` is window-global by decision (#519); ask for it by name.
+  `(*Window).TestFindings(mask)` is the general assertable form of
+  `TestDuplicateIDs`: it takes the categories to run, so an opt-in category is
+  testable as data instead of stderr-only.
+
+  ```go
+  found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys)
+  ```
+
+### Fixed
+
+- **Sidebar, InputDate and Table now resolve their IDs at generation time**
+  (#518) — all three built eagerly in the `(*Window)` factory, which runs
+  _before_ `generateViewLayout` descends the View tree. The ID scope stack is
+  empty there, so `w.EffID` returned the leaf unchanged and the widget keyed
+  scroll offset, focus, open state and row heights on a name that is
+  window-global. One instance worked; a second instance of the same `cfg.ID`
+  under another panel shared its state. Each now defers the build, so the
+  resolve happens with the scope live.
+
+  **Behavior change.** A Sidebar, InputDate or Table inside an ID-bearing
+  ancestor now carries the effective ID it always should have. Public APIs take
+  the effective ID, so a hand-spelled call must follow: a table with
+  `ID: "catalog"` inside a panel with `ID: "detail"` moves from
+  `w.SetFocus("catalog")` to `w.SetFocus("detail:catalog")`. Compose it with
+  `gui.ScopeID`, never by hand. Unscoped widgets are unaffected. Turn on
+  `DebugUnresolvedKeys` to find the rest.
+
 ## [v0.69.0] - 2026-09-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,8 +271,22 @@ explicitly when auditing a screen for reusability:
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
 ```
 
+**`DebugUnresolvedKeys` is not in `DebugAll` either.** It reports a `StateMap`
+key that is a bare leaf while an ancestor join rewrote the shape of that name —
+the widget closed over the raw `cfg.ID` instead of resolving it, so its state
+key and its identity are different strings. Latent, not broken: it works until a
+second instance of the same `cfg.ID` appears under another scope, and
+`gui/datagrid` is window-global by decision. Remedy is `w.EffID(cfg.ID)` in
+`GenerateLayout` or `ctx.EffID(leaf)` in a handler. See issue #518.
+
 Assertable forms for tests, which return findings as data:
 `(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.
+`(*Window).TestFindings(mask)` is the general form: it takes the categories to
+run, so an opt-in category is assertable instead of stderr-only.
+
+```go
+found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys)
+```
 
 ## Coding Conventions
 

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -47,9 +47,22 @@ with `ScopeID` or `ScopeIDN`, never by hand. Public APIs — `SetFocus`,
 
 A part (a row key, a heading slug) must not contain `:`. A composite widget's
 inner shape sets `Shape.focusOwner` to the owner's leaf instead of repeating its
-`ID`. Duplicates are loud: `gui.Debug` reports them, and
-`(*Window).TestDuplicateIDs` asserts a clean window. See
-`docs/specs/widget-id-scoping.md` and
+`ID`.
+
+Two accessors read the identity, and they answer different questions:
+
+- `shape.idKey()` — the identity of this shape. Read it at every keying site,
+  never the bare `Shape.ID`. It returns the resolved `effID`, and falls back to
+  the leaf only on a tree that `resolveShapeIDs` has not walked, such as a
+  hand-built `Layout` in a test.
+- `shape.focusKey()` — the identity whose focus, input and spell-check state
+  this shape renders. It returns `focusOwner` when the shape belongs to a
+  composite widget, and `idKey()` when it does not. It is empty for a shape that
+  participates in neither, which is the signal to draw no caret and no
+  selection.
+
+Duplicates are loud: `gui.Debug` reports them, and `(*Window).TestDuplicateIDs`
+asserts a clean window. See `docs/specs/widget-id-scoping.md` and
 `docs/specs/widget-id-per-scope-uniqueness.md`.
 
 ## `Opt[T]` vs plain fields
@@ -287,4 +300,26 @@ panel as it stands. When you plan to reuse a screen, ask for it:
 
 ```go
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
+```
+
+`DebugUnresolvedKeys` is opt-in for the same reason. It reports per-widget state
+stored under a leaf ID that an ancestor join rewrote, so the widget's state key
+and its shape's identity are different strings. Such a widget works while it is
+the only instance of its `cfg.ID`, and two of them under different scopes share
+one state slot. Ask for it with the same call:
+
+```go
+gui.DebugCategories(gui.DebugAll | gui.DebugUnresolvedKeys)
+```
+
+The remedy is a resolved key: `w.EffID(cfg.ID)` during `GenerateLayout`, or
+`ctx.EffID(leaf)` in a handler.
+
+`DebugCategories` prints to stderr. To assert an opt-in category in a test, use
+`(*Window).TestFindings(mask)`, which returns the findings as data:
+
+```go
+if found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys); len(found) > 0 {
+	t.Fatalf("unresolved state keys: %v", found)
+}
 ```

--- a/gui/bounded_map.go
+++ b/gui/bounded_map.go
@@ -224,3 +224,29 @@ func (m *BoundedMap[K, V]) compactOrder() {
 	m.order = m.order[:dst]
 	m.head = 0
 }
+
+// stringKeys returns the map's keys when they are strings, and nil
+// otherwise. The signature names no type parameter, so a caller
+// holding a BoundedMap boxed in an `any` can ask for its keys through
+// an interface assertion without knowing K.
+//
+// Only the dev-mode state-key audit calls it (see
+// debug_state_keys.go), so the per-key type assertion is not on a
+// frame path.
+func (m *BoundedMap[K, V]) stringKeys() []string {
+	if m == nil {
+		return nil
+	}
+	var out []string
+	m.rangeKeys(func(k K) bool {
+		s, ok := any(k).(string)
+		if !ok {
+			// A non-string key type: the whole map is uninteresting,
+			// and one key is enough to establish that.
+			return false
+		}
+		out = append(out, s)
+		return true
+	})
+	return out
+}

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -113,9 +113,38 @@ const (
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugUnscopedIDs
 
-	// DebugAll is every category [Debug] turns on. [DebugUnscopedIDs] is
-	// deliberately absent: it reports a design property, not a bug, and
-	// would fire on most widgets in a small app.
+	// DebugUnresolvedKeys reports per-widget state stored under a leaf
+	// ID that an ancestor join rewrote, so the widget's state key and
+	// its shape's identity are different strings.
+	//
+	// A factory that closes over the raw cfg.ID and keys StateMap on it
+	// works while the widget sits at the top level, where the scope is
+	// empty and the leaf is already the identity. Put the same widget
+	// under an ID-bearing ancestor and its shape resolves to
+	// "panel:leaf" while its state still lives at "leaf". Nothing
+	// panics and nothing looks wrong; the widget stops responding. The
+	// two EffID seams exist to prevent this, and neither is required by
+	// the compiler.
+	//
+	// The finding is raised when a state key names no shape in the
+	// window and an ancestor join rewrote a shape of that leaf, which
+	// is the signature of a missed resolve rather than of an unrelated
+	// key that happens to collide.
+	//
+	// Latent rather than broken, which is why [Debug] does not turn it
+	// on: a widget that keys both the write and the read on the same
+	// unresolved leaf works, and fails only when a second instance of
+	// it appears under a different scope with the same cfg.ID. Some
+	// widgets are also window-global by decision — gui/datagrid is the
+	// documented case. Ask for the category explicitly when auditing a
+	// screen for reuse, alongside [DebugUnscopedIDs].
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugUnresolvedKeys
+
+	// DebugAll is every category [Debug] turns on. [DebugUnscopedIDs]
+	// and [DebugUnresolvedKeys] are deliberately absent: both report a
+	// design property rather than a present defect, and both fire on
+	// widgets that work today.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
 		DebugListBoxNoHeight | DebugGradientResampled | DebugWrapOverflow |
@@ -259,6 +288,10 @@ const (
 	// debugCheckWindowTransparency fires from a backend's window
 	// creation when WindowCfg.Transparent could not be honoured.
 	debugCheckWindowTransparency
+	// debugCheckUnresolvedKey fires from the state-key audit when a
+	// StateMap key is a bare leaf that the resolve pass scoped; see
+	// debug_state_keys.go.
+	debugCheckUnresolvedKey
 )
 
 // checkCategory maps an internal check to the public category that
@@ -285,6 +318,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugCallbacks
 	case debugCheckWindowTransparency:
 		return DebugWindowDegraded
+	case debugCheckUnresolvedKey:
+		return DebugUnresolvedKeys
 	}
 	return 0
 }
@@ -311,8 +346,8 @@ type debugState struct {
 // debugAudit runs the dev-mode checks over one frame's composed
 // layout tree. No-op unless an audit category is on.
 //
-// The tree walk is skipped unless a category that audits the frame —
-// duplicates or missing IDs — is on; the unconsumed check runs from
+// The tree walk is skipped unless a category that reads the frame is
+// on; walkCategories below lists them. The unconsumed check runs from
 // dispatch and the listbox check from the view phase, so they gate
 // themselves.
 //
@@ -320,22 +355,24 @@ type debugState struct {
 // same tree the renderer does, including floating and overlay layers.
 func (w *Window) debugAudit(root *Layout) {
 	const walkCategories = DebugDuplicates | DebugMissingIDs |
-		DebugUnscopedIDs
+		DebugUnscopedIDs | DebugUnresolvedKeys
 	if DebugCategory(debugMask.Load())&walkCategories == 0 {
 		return
 	}
-	// ids maps an ID to the path of the shape that claimed it first,
-	// so a duplicate can name both sites. Frame-scoped, unlike
-	// w.debug.warned.
-	ids := make(map[string]string)
+	// ids is frame-scoped, unlike w.debug.warned.
+	ids := &debugIDs{claimed: make(map[string]string)}
 	var path []int
 	w.debugWalk(root, &path, ids)
+	// The state-key audit compares the identities this walk collected
+	// against the keys the state maps hold, so it runs after the walk
+	// and gates itself.
+	w.debugCheckStateKeys(ids)
 }
 
 // debugWalk is the depth-first audit. path is the index chain from
 // the root to layout, maintained in place to keep the walk to one
 // allocation.
-func (w *Window) debugWalk(layout *Layout, path *[]int, ids map[string]string) {
+func (w *Window) debugWalk(layout *Layout, path *[]int, ids *debugIDs) {
 	if s := layout.Shape; s != nil {
 		w.debugCheckShape(s, *path, ids)
 	}
@@ -346,24 +383,53 @@ func (w *Window) debugWalk(layout *Layout, path *[]int, ids map[string]string) {
 	}
 }
 
+// debugIDs is what the audit walk collects about identity, shared by
+// the checks that need the whole frame rather than one shape.
+type debugIDs struct {
+	// claimed maps an effective ID to the path of the shape that
+	// claimed it first, so a duplicate can name both sites.
+	claimed map[string]string
+	// scoped maps a leaf to the effective ID an ancestor join gave it.
+	// Only shapes whose identity actually changed under the join
+	// appear, so a widget that composes its own absolute ID is absent.
+	// The state-key audit reads it; see debug_state_keys.go.
+	scoped map[string]string
+}
+
+// noteScoped records a leaf that an ancestor join rewrote. The first
+// claim wins, which keeps the finding stable across runs.
+func (d *debugIDs) noteScoped(leaf, effID string) {
+	if leaf == "" || leaf == effID {
+		return
+	}
+	if _, seen := d.scoped[leaf]; seen {
+		return
+	}
+	if d.scoped == nil {
+		d.scoped = make(map[string]string)
+	}
+	d.scoped[leaf] = effID
+}
+
 // debugCheckShape runs the per-shape checks. path is the shape's
 // index chain from the root; ids records which path first claimed
 // each ID this frame.
-func (w *Window) debugCheckShape(s *Shape, path []int, ids map[string]string) {
+func (w *Window) debugCheckShape(s *Shape, path []int, ids *debugIDs) {
 	if s.ID != "" {
 		// Uniqueness is on the *effective* ID: the same leaf under two
 		// different ID-bearing ancestors is two identities and is not a
 		// duplicate. The message names the effective path, since that is
 		// the string the stores and the public APIs use.
 		key := s.idKey()
-		if first, dup := ids[key]; dup {
+		ids.noteScoped(s.ID, key)
+		if first, dup := ids.claimed[key]; dup {
 			w.debugWarn(debugCheckDupID, key,
 				"duplicate ID %q at %s, first claimed at %s; ID is the "+
 					"identity key for focus, scroll, and per-widget state, so "+
 					"the two collapse to one tab stop and one state slot",
 				key, debugPath(path), first)
 		} else {
-			ids[key] = debugPath(path)
+			ids.claimed[key] = debugPath(path)
 		}
 		// An identity that resolves to itself has no ID-bearing ancestor
 		// to scope it, so the leaf is still a window-global name and the
@@ -426,20 +492,47 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids map[string]string) {
 //
 // The debug gate is turned on for the duration and restored after.
 func (w *Window) TestDuplicateIDs() []string {
+	return w.TestFindings(DebugAll)
+}
+
+// TestFindings renders the window and returns, as data, every finding
+// the given categories report. An empty result means the categories
+// found nothing in the frame.
+//
+// [Window.TestDuplicateIDs] is this call with [DebugAll]. Use this form
+// to reach a category that [Debug] leaves off, which is otherwise
+// reported only on stderr:
+//
+//	found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys)
+//
+// The mask replaces the process gate for the duration of the call, and
+// the previous mask is restored after. That gate is process-wide, so
+// this is not safe to call from a parallel test. Like
+// [Window.TestDuplicateIDs] it dispatches nothing and fires no
+// callbacks, and it covers the window as rendered, not the app: drive
+// the app into each interesting state and check again.
+// exportaudit:keep — dev-diagnostic API for app authors
+func (w *Window) TestFindings(mask DebugCategory) []string {
 	root := w.TestRender(nil)
 	if root == nil {
 		return nil
 	}
 	var found []string
-	prevOn := DebugEnabled()
+	// Restore the exact mask, not just on/off: a caller may have a
+	// narrower gate installed that this call must not widen for good.
+	prevMask := DebugCategory(debugMask.Load())
 	// A fresh warn-once map: a sweep should report the window in front
 	// of it, not skip what an earlier sweep or a stray frame reported.
 	prevWarned := w.debug.warned
 	w.debug.warned = nil
 	w.debug.collect = &found
-	Debug(true)
+	DebugCategories(mask)
+	// The generation only moves on an off -> on transition, so widening
+	// an already-on gate would keep stale warn-once memory. The nil map
+	// above covers that; this keeps the two in step.
+	w.debug.gen = debugGen.Load()
 	defer func() {
-		Debug(prevOn)
+		DebugCategories(prevMask)
 		w.debug.collect = nil
 		w.debug.warned = prevWarned
 	}()

--- a/gui/debug_state_keys.go
+++ b/gui/debug_state_keys.go
@@ -1,0 +1,109 @@
+package gui
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+// Dev-mode audit for per-widget state stored under an unresolved ID.
+//
+// Every other identity mistake in this library has a gate: a duplicate
+// effective ID, a focusable or scrollable shape with no ID, and
+// hand-rolled ID composition are all reported. A state key that was
+// never resolved is the one that was not, and it is the quietest of
+// them: the widget renders, the state is written, and the read never
+// sees it.
+//
+// The audit does not instrument the store. It runs once per frame from
+// debugAudit, over the identities the layout walk already collected,
+// and compares them with the keys the string-keyed state maps hold.
+
+// stringKeyed is the seam onto a BoundedMap whose keys are strings.
+// The registry stores maps boxed in `any` with the key type erased, so
+// the audit asks through this interface rather than knowing K; a map
+// keyed by anything else answers nil.
+type stringKeyed interface {
+	stringKeys() []string
+}
+
+// debugCheckStateKeys reports a state key that is a bare leaf while
+// the shape of that name resolved under a scope.
+//
+// A key is a finding when all three hold:
+//
+//   - it is a bare leaf: non-empty and free of IDSep, so it was never
+//     joined to a scope and is not absolute;
+//   - no shape in the window carries it as an identity, so it is not
+//     the legitimate key of an unscoped top-level widget;
+//   - an ancestor join rewrote a shape of that leaf, which is the
+//     shape whose state this key was meant to be.
+//
+// The third condition is what keeps the audit quiet. It reads
+// debugIDs.scoped, which holds only the leaves the resolve pass
+// actually changed, so a widget that builds its own absolute ID —
+// Form composes "form:login" from cfg.ID "login" — is absent from the
+// index and keys its state on cfg.ID without a finding. A cache keyed
+// by a file name or a URL satisfies the first two conditions and is
+// reported only if a widget in the same window resolved from that
+// exact leaf.
+func (w *Window) debugCheckStateKeys(ids *debugIDs) {
+	if DebugCategory(debugMask.Load())&DebugUnresolvedKeys == 0 {
+		return
+	}
+	if len(ids.scoped) == 0 {
+		// No shape in this window was rewritten by a join, so no key
+		// can be the unresolved form of one.
+		return
+	}
+	// Namespaces in sorted order, so a window with several findings
+	// reports them the same way on every run.
+	for _, ns := range slices.Sorted(maps.Keys(w.viewState.registry.maps)) {
+		w.debugScanKeys(ns, w.viewState.registry.maps[ns], ids)
+	}
+	// The hot namespaces are cached fields rather than registry
+	// entries, and they are the ones most often keyed by a widget ID.
+	w.debugScanKeys(nsDebugScrollX, w.scrollXMap, ids)
+	w.debugScanKeys(nsDebugScrollY, w.scrollYMap, ids)
+	w.debugScanKeys(nsDebugOverflow, w.overflowMap, ids)
+	w.debugScanKeys(nsDebugHoverInside, w.hoverInsideMap, ids)
+}
+
+// Names for the hot maps, which have no registry namespace of their
+// own but must still be nameable in a finding.
+const (
+	nsDebugScrollX     = "scrollX"
+	nsDebugScrollY     = "scrollY"
+	nsDebugOverflow    = "overflow"
+	nsDebugHoverInside = "hoverInside"
+)
+
+// debugScanKeys reports the findings in one namespace. m is a
+// BoundedMap boxed in `any`; a map with a non-string key type, a nil
+// map and a value that is not a BoundedMap at all are all skipped.
+func (w *Window) debugScanKeys(ns string, m any, ids *debugIDs) {
+	sk, ok := m.(stringKeyed)
+	if !ok {
+		return
+	}
+	for _, key := range sk.stringKeys() {
+		if key == "" || strings.Contains(key, IDSep) {
+			continue
+		}
+		if _, claimed := ids.claimed[key]; claimed {
+			// A shape really is named by this key.
+			continue
+		}
+		effID, ok := ids.scoped[key]
+		if !ok {
+			continue
+		}
+		w.debugWarn(debugCheckUnresolvedKey, ns+"/"+key,
+			"state key %q in namespace %q is an unresolved leaf; "+
+				"the shape of that name resolved to %q, so state is "+
+				"written and read under different keys. Resolve the "+
+				"leaf with w.EffID during GenerateLayout, or with "+
+				"ctx.EffID in a handler.",
+			key, ns, effID)
+	}
+}

--- a/gui/debug_state_keys_test.go
+++ b/gui/debug_state_keys_test.go
@@ -1,0 +1,119 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+)
+
+// stateKeyTree builds a tree whose single leaf carries the given
+// effective ID, which is what resolveShapeIDs would have stamped.
+func stateKeyTree(effID string) Layout {
+	s := &Shape{ID: "name"}
+	s.effID = effID
+	return debugTree(s)
+}
+
+// The defect: state written under the bare leaf while the shape it
+// belongs to resolved under a scope.
+func TestDebugStateKeysUnresolvedLeaf(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll|DebugUnresolvedKeys)
+	w := &Window{}
+	StateMap[string, bool](w, "test", capModerate).Set("name", true)
+	tree := stateKeyTree("settings:name")
+
+	w.debugAudit(&tree)
+
+	got := buf.String()
+	if !strings.Contains(got, `state key "name"`) ||
+		!strings.Contains(got, `"settings:name"`) {
+		t.Fatalf("want unresolved-key finding naming both, got %q", got)
+	}
+}
+
+// The correct spelling: the key matches what the resolve pass stamped.
+func TestDebugStateKeysResolvedIsQuiet(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll|DebugUnresolvedKeys)
+	w := &Window{}
+	StateMap[string, bool](w, "test", capModerate).Set("settings:name", true)
+	tree := stateKeyTree("settings:name")
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+// A top-level widget has an empty scope, so its leaf *is* its
+// identity. Keying state on it is correct and must stay quiet.
+func TestDebugStateKeysUnscopedWidgetIsQuiet(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll|DebugUnresolvedKeys)
+	w := &Window{}
+	StateMap[string, bool](w, "test", capModerate).Set("name", true)
+	tree := stateKeyTree("name")
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+// A cache keyed by something that is not a widget ID names no shape in
+// the window, so it is not a finding.
+func TestDebugStateKeysUnrelatedKeyIsQuiet(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll|DebugUnresolvedKeys)
+	w := &Window{}
+	StateMap[string, bool](w, "svg", capModerate).Set("icon.svg", true)
+	tree := stateKeyTree("settings:name")
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+// The hot maps are cached fields rather than registry entries and are
+// the ones most often keyed by a widget ID, so they are scanned too.
+func TestDebugStateKeysScansHotMaps(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll|DebugUnresolvedKeys)
+	w := &Window{}
+	w.scrollY().Set("name", 12)
+	tree := stateKeyTree("panel:name")
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); !strings.Contains(got, `namespace "scrollY"`) {
+		t.Fatalf("want scrollY finding, got %q", got)
+	}
+}
+
+// A map with non-string keys answers nil and is skipped rather than
+// panicking on the type assertion.
+func TestDebugStateKeysIgnoresNonStringKeys(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll|DebugUnresolvedKeys)
+	w := &Window{}
+	StateMap[int, bool](w, "ints", capModerate).Set(7, true)
+	tree := stateKeyTree("settings:name")
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+// The category gates independently of the rest.
+func TestDebugStateKeysGatedByCategory(t *testing.T) {
+	buf := captureDebugMask(t, DebugDuplicates)
+	w := &Window{}
+	StateMap[string, bool](w, "test", capModerate).Set("name", true)
+	tree := stateKeyTree("settings:name")
+
+	w.debugAudit(&tree)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings with category off, got %q", got)
+	}
+}

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -258,6 +258,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckWrapOverflow, DebugWrapOverflow},
 		{debugCheckDeferredLoop, DebugCallbacks},
 		{debugCheckWindowTransparency, DebugWindowDegraded},
+		{debugCheckUnresolvedKey, DebugUnresolvedKeys},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
@@ -272,6 +273,9 @@ func TestCheckCategoryMapping(t *testing.T) {
 	}
 	if DebugAll&DebugUnscopedIDs != 0 {
 		t.Fatal("DebugUnscopedIDs must stay opt-in, outside DebugAll")
+	}
+	if DebugAll&DebugUnresolvedKeys != 0 {
+		t.Fatal("DebugUnresolvedKeys must stay opt-in, outside DebugAll")
 	}
 }
 
@@ -736,5 +740,43 @@ func TestWrapOverflowGatedByCategory(t *testing.T) {
 	layoutOverflow(layout, w)
 	if got := buf.String(); got != "" {
 		t.Fatalf("mask without DebugWrapOverflow reported %q", got)
+	}
+}
+
+// The point of the seam: an opt-in category is invisible through
+// TestDuplicateIDs, which asks for DebugAll, and reachable by naming
+// it. DebugUnscopedIDs is the case — a window-global ID is a design
+// property, not a defect, so the default sweep stays quiet on it.
+func TestTestFindingsReachesOptInCategory(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(_ *Window) View {
+		return Column(ContainerCfg{
+			Sizing:  FillFill,
+			Content: []View{Button(ButtonCfg{ID: "bare", Label: "Save"})},
+		})
+	})
+
+	if got := w.TestDuplicateIDs(); len(got) != 0 {
+		t.Fatalf("DebugAll must stay quiet on an unscoped ID, got %q", got)
+	}
+	got := w.TestFindings(DebugAll | DebugUnscopedIDs)
+	if len(got) != 1 || !strings.Contains(got[0], `"bare"`) {
+		t.Fatalf("want one unscoped-ID finding naming the ID, got %q", got)
+	}
+}
+
+// The call installs its mask only for its own duration. A narrower
+// gate a caller had installed must survive it unwidened.
+func TestTestFindingsRestoresMask(t *testing.T) {
+	captureDebugMask(t, DebugMissingIDs)
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(_ *Window) View {
+		return Column(ContainerCfg{Sizing: FillFill})
+	})
+
+	w.TestFindings(DebugAll | DebugUnresolvedKeys)
+
+	if got := DebugCategory(debugMask.Load()); got != DebugMissingIDs {
+		t.Fatalf("want the caller's mask restored, got %v", got)
 	}
 }

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -92,11 +92,17 @@ func InputDate(cfg InputDateCfg) View {
 func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 	cfg := &idv.cfg
 
+	// Resolve once, here: every state key and every inner ID below is
+	// built from cfgID, and only generation time knows the ID scope the
+	// field sits in. A resolve in the InputDate factory would be a
+	// no-op — the factory runs before generateViewLayout descends the
+	// View tree, so the scope stack is still empty there. See issue
+	// #518.
+	cfgID := w.EffID(cfg.ID)
 	// A read-only date field never opens the calendar popup, closing
 	// the picker's OnSelect mutation path structurally regardless of any
 	// stored open state.
-	isOpen := StateReadOr(w, nsInputDate, cfg.ID, false) && !cfg.ReadOnly
-	cfgID := cfg.ID
+	isOpen := StateReadOr(w, nsInputDate, cfgID, false) && !cfg.ReadOnly
 
 	// Format date for display.
 	dates := cfg.Dates

--- a/gui/view_sidebar.go
+++ b/gui/view_sidebar.go
@@ -39,8 +39,28 @@ type SidebarCfg struct {
 	Invisible bool
 }
 
+// sidebarView defers the sidebar's construction to layout-generation
+// time.
+//
+// The deferral is load-bearing, not a style choice. A factory body runs
+// while the application builds its View tree, before generateViewLayout
+// descends it, so the generation-time ID scope is still empty there and
+// (*Window).EffID would answer with the bare leaf. The animation state
+// below is keyed by the sidebar's identity, so it must resolve that
+// identity in the phase that knows the scope. See issue #518.
+type sidebarView struct {
+	cfg SidebarCfg
+}
+
 // Sidebar creates an animated panel that slides in/out.
 func (w *Window) Sidebar(cfg SidebarCfg) View {
+	return &sidebarView{cfg: cfg}
+}
+
+func (sv *sidebarView) GenerateLayout(w *Window) Layout {
+	// A copy, because the defaults and the resolved ID below are
+	// per-generation values and the view outlives none of them.
+	cfg := sv.cfg
 	if cfg.Width == 0 {
 		cfg.Width = 250
 	}
@@ -60,10 +80,11 @@ func (w *Window) Sidebar(cfg SidebarCfg) View {
 	}
 
 	if cfg.Invisible {
-		return invisibleContainerView()
+		return generateViewLayout(invisibleContainerView(), w)
 	}
 
 	// One resolved identity for every key below; see (*Window).EffID.
+	// This runs during generation, so the scope is live.
 	cfg.ID = w.EffID(cfg.ID)
 
 	animW := sidebarAnimatedWidth(w, cfg)
@@ -84,7 +105,7 @@ func (w *Window) Sidebar(cfg SidebarCfg) View {
 		content = nil
 	}
 
-	return Column(ContainerCfg{
+	return generateViewLayout(Column(ContainerCfg{
 		ID:       cfg.ID,
 		Sizing:   cfg.Sizing,
 		Width:    animW,
@@ -100,7 +121,7 @@ func (w *Window) Sidebar(cfg SidebarCfg) View {
 			A11YDescription: cfg.A11YDescription,
 		},
 		Content: content,
-	})
+	}), w)
 }
 
 func sidebarAnimatedWidth(w *Window, cfg SidebarCfg) float32 {

--- a/gui/view_sidebar_test.go
+++ b/gui/view_sidebar_test.go
@@ -1,6 +1,9 @@
 package gui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSidebarOpenWidth(t *testing.T) {
 	w := &Window{}
@@ -95,12 +98,15 @@ func TestSidebarA11YRole(t *testing.T) {
 
 func TestSidebarRuntimeStateInit(t *testing.T) {
 	w := &Window{}
-	_ = w.Sidebar(SidebarCfg{
+	v := w.Sidebar(SidebarCfg{
 		ID:      "sb",
 		Open:    true,
 		Width:   100,
 		Content: []View{Text(TextCfg{Text: "x"})},
 	})
+	// The state is written during generation, not by the factory call:
+	// only generation knows the ID scope the key must carry.
+	_ = generateViewLayout(v, w)
 	sm := StateMap[string, sidebarRuntimeState](
 		w, nsSidebar, capFew)
 	rt, ok := sm.Get("sb")
@@ -280,5 +286,64 @@ func TestSidebarNoDoubleAnimation(t *testing.T) {
 	rt2, _ := sm.Get("sb")
 	if rt2.prevOpen != false {
 		t.Errorf("PrevOpen after second call = %v, want false", rt2.prevOpen)
+	}
+}
+
+// TestSidebarStateKeyIsScoped pins the fix for the defect
+// DebugUnresolvedKeys reports: the sidebar's animation state must be
+// keyed by the effective ID, so two sidebars written with the same leaf
+// under different panels animate independently.
+//
+// The factory body cannot resolve the key. It runs while the
+// application builds its View tree, before generateViewLayout descends
+// it, so the scope is still empty there. sidebarView.GenerateLayout
+// resolves it in the phase that knows the scope.
+func TestSidebarStateKeyIsScoped(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(w *Window) View {
+		return Column(ContainerCfg{
+			ID:     "detail",
+			Sizing: FillFill,
+			Content: []View{
+				w.Sidebar(SidebarCfg{
+					ID:      "nav",
+					Open:    true,
+					Width:   100,
+					Content: []View{Text(TextCfg{Text: "x"})},
+				}),
+			},
+		})
+	})
+
+	sm := StateMap[string, sidebarRuntimeState](w, nsSidebar, capFew)
+	if _, ok := sm.Get("detail:nav"); !ok {
+		t.Fatalf("want state under the effective ID, keys are %q", sm.Keys())
+	}
+	if _, ok := sm.Get("nav"); ok {
+		t.Error("state must not also live under the bare leaf")
+	}
+}
+
+// The audit that found this defect must now be silent on the widget.
+func TestSidebarNoUnresolvedKeyFinding(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll|DebugUnresolvedKeys)
+	w := NewTestWindow(WindowCfg{})
+	w.TestRender(func(w *Window) View {
+		return Column(ContainerCfg{
+			ID:     "detail",
+			Sizing: FillFill,
+			Content: []View{
+				w.Sidebar(SidebarCfg{
+					ID:      "nav",
+					Open:    true,
+					Width:   100,
+					Content: []View{Text(TextCfg{Text: "x"})},
+				}),
+			},
+		})
+	})
+
+	if got := buf.String(); strings.Contains(got, nsSidebar) {
+		t.Fatalf("want no sidebar finding, got %q", got)
 	}
 }

--- a/gui/view_table.go
+++ b/gui/view_table.go
@@ -184,8 +184,19 @@ func Table(cfg TableCfg) View {
 
 // Table generates a table with text measurement, column width
 // caching, and optional virtualization.
-func (w *Window) Table(cfg TableCfg) View {
-	return tableView(cfg, w)
+//
+// The build is deferred to layout generation, like the package-level
+// [Table]. It is load-bearing rather than a style choice: tableView
+// resolves cfg.ID with (*Window).EffID and keys scroll offset, focus
+// and row heights on the result, and the generation-time ID scope is
+// only live while generateViewLayout descends the View tree. Building
+// here instead would resolve against an empty scope, so a table inside
+// an ID-bearing panel would key its state on the bare leaf. See issue
+// #518.
+func (*Window) Table(cfg TableCfg) View {
+	return viewFunc(func(w *Window) View {
+		return tableView(cfg, w)
+	})
 }
 
 // tableScrollID returns the scroll key for a table. The freeze path


### PR DESCRIPTION
Closes part of #518.

## The bug

`Sidebar`, `InputDate` and `Table` built eagerly in the `(*Window)` factory. That body runs **before** `generateViewLayout` descends the View tree, so the generation-time ID scope stack is still empty and `w.EffID(cfg.ID)` returns the leaf unchanged.

The failure is silent because the wrong answer and the right answer are the same string for a top-level widget. Each of the three keyed scroll offset, focus, open state and row heights on a window-global name. One instance worked. A second instance of the same `cfg.ID` under another panel shared its state.

Each now defers the build (a view struct, or `viewFunc`), so the resolve happens with the scope live.

## The gate

`gui.DebugUnresolvedKeys` reports a `StateMap` key that is a bare leaf while an ancestor join rewrote the shape of that name — state written and read under different strings.

It runs once per frame from the existing debug walk, over identities the walk already collected. It does not instrument the state store. A finding needs all three: the key is a bare leaf, no shape claims it as an identity, and a join actually rewrote a shape of that leaf. That third condition keeps a cache keyed by a file name or URL quiet.

Not in `DebugAll`, like `DebugUnscopedIDs`, while `gui/datagrid` stays window-global by decision (#519). Ask for it by name.

## The test seam

`(*Window).TestFindings(mask)` is the general assertable form of `TestDuplicateIDs`, so an opt-in category is testable as data rather than stderr-only.

```go
found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys)
```

It restores the exact previous mask, not just on/off, and resets warn-once memory so a sweep reports the window in front of it.

## Behavior change

A Sidebar, InputDate or Table inside an ID-bearing ancestor now carries the effective ID it always should have. Public APIs take the effective ID, so a hand-spelled call must follow:

```go
// table ID "catalog" inside a panel with ID "detail"
w.SetFocus("catalog")           // before
w.SetFocus("detail:catalog")    // now — compose with gui.ScopeID
```

Unscoped widgets are unaffected. Sibling scan: only `go-charts` touches any of the three, through the package-level `gui.Table`, which already deferred and is unchanged. No sibling bump needed.

## Verification

- `make prepush` green: race tests, cross-lint 0 issues, cross-compile, coverage 84.9% >= 70% with every per-package floor met, export-audit clean.
- New tests: 7 in `gui/debug_state_keys_test.go`, 2 for the seam in `gui/debug_test.go`, 2 for sidebar scoping.
- Docs: `CLAUDE.md`, `docs/dx-cheat-sheet.md`, `CHANGELOG.md`.

## Follow-ups

- #519 datagrid root-ID migration — lets `DebugUnresolvedKeys` move into `DebugAll`
- #520 `EffID` should report a call made outside layout generation
- #521 an app cannot learn a widget's effective ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)