### PR TITLE
fix(datagrid)!: resolve the grid's own ID at generation time (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,23 @@ and this project adheres to
   `gui.ScopeID`, never by hand. Unscoped widgets are unaffected. Turn on
   `DebugUnresolvedKeys` to find the rest.
 
+- **`datagrid` resolves the grid's own ID** (#519) — `datagrid.New` built
+  eagerly and never resolved `cfg.ID`, so every state slot the grid owns (column
+  widths, presentation cache, CRUD working copy, data-source state) was keyed on
+  the raw leaf while the grid's root shape resolved to its effective ID. Two
+  grids sharing a `cfg.ID` under different panels were distinct shapes with one
+  state slot, and their children collided outright. `New` now returns a deferred
+  view; the build resolves once, at the top, and every state key, child ID and
+  header reverse-parse prefix derives from that one string.
+  `DebugUnresolvedKeys` moves into `DebugAll` as a result, so `gui.Debug(true)`
+  reports an unresolved state key without being asked.
+
+  **Behavior change.** Every ID a scoped grid publishes moves: `catalog:row:3`
+  becomes `detail:catalog:row:3`. An app that spells a grid or one of its parts
+  by hand for `gg.FindByID`, `gg.SetFocus`, `gg.ScrollVerticalTo` or
+  `datagrid.GetSourceStats` must pass the effective form. Compose it with
+  `gg.ScopeID`, never by hand. An unscoped grid is unaffected.
+
 ## [v0.69.0] - 2026-09-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,10 @@ Public APIs (`SetFocus`, `FindByID`, `IsFocus`, `ScrollVerticalTo`, `Test*`)
 take the **effective** ID. Two seams for widget code: `w.EffID(cfg.ID)` for
 state read during `GenerateLayout`, and `ctx.EffID(leaf)` for handlers in
 factories that build eagerly with no `Window`. `gui/datagrid` is the documented
-exception — its child IDs are absolute by design and stay window-global. See
+exception — it spells its child IDs absolutely, built from the grid's own
+resolved ID, because `dataGridHeaderColIDFromLayoutID` recovers a column by
+trimming that prefix back off. The grid root resolves like any other widget
+(#519), so a scoped grid's children are scoped with it. See
 `docs/specs/widget-id-per-scope-uniqueness.md`.
 
 **Compose inner IDs with `gui.ScopeID` / `gui.ScopeIDN`, never by hand.** An ID
@@ -271,13 +274,13 @@ explicitly when auditing a screen for reusability:
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
 ```
 
-**`DebugUnresolvedKeys` is not in `DebugAll` either.** It reports a `StateMap`
-key that is a bare leaf while an ancestor join rewrote the shape of that name —
-the widget closed over the raw `cfg.ID` instead of resolving it, so its state
-key and its identity are different strings. Latent, not broken: it works until a
-second instance of the same `cfg.ID` appears under another scope, and
-`gui/datagrid` is window-global by decision. Remedy is `w.EffID(cfg.ID)` in
-`GenerateLayout` or `ctx.EffID(leaf)` in a handler. See issue #518.
+**`DebugUnresolvedKeys` is in `DebugAll`.** It reports a `StateMap` key that is
+a bare leaf while an ancestor join rewrote the shape of that name — the widget
+closed over the raw `cfg.ID` instead of resolving it, so its state key and its
+identity are different strings. The failure is latent: the widget works until a
+second instance of the same `cfg.ID` appears under another scope, and then both
+share one state slot. Remedy is `w.EffID(cfg.ID)` in `GenerateLayout` or
+`ctx.EffID(leaf)` in a handler. See issues #518 and #519.
 
 Assertable forms for tests, which return findings as data:
 `(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.
@@ -285,7 +288,7 @@ Assertable forms for tests, which return findings as data:
 run, so an opt-in category is assertable instead of stderr-only.
 
 ```go
-found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys)
+found := w.TestFindings(gui.DebugAll | gui.DebugUnscopedIDs)
 ```
 
 ## Coding Conventions

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -302,24 +302,21 @@ panel as it stands. When you plan to reuse a screen, ask for it:
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
 ```
 
-`DebugUnresolvedKeys` is opt-in for the same reason. It reports per-widget state
-stored under a leaf ID that an ancestor join rewrote, so the widget's state key
-and its shape's identity are different strings. Such a widget works while it is
-the only instance of its `cfg.ID`, and two of them under different scopes share
-one state slot. Ask for it with the same call:
-
-```go
-gui.DebugCategories(gui.DebugAll | gui.DebugUnresolvedKeys)
-```
+`DebugUnresolvedKeys` is part of `DebugAll`, so `gui.Debug(true)` already runs
+it. It reports per-widget state stored under a leaf ID that an ancestor join
+rewrote, so the widget's state key and its shape's identity are different
+strings. Such a widget works while it is the only instance of its `cfg.ID`, and
+two of them under different scopes share one state slot.
 
 The remedy is a resolved key: `w.EffID(cfg.ID)` during `GenerateLayout`, or
 `ctx.EffID(leaf)` in a handler.
 
-`DebugCategories` prints to stderr. To assert an opt-in category in a test, use
-`(*Window).TestFindings(mask)`, which returns the findings as data:
+`DebugCategories` prints to stderr. To assert a category in a test, including an
+opt-in one, use `(*Window).TestFindings(mask)`, which returns the findings as
+data:
 
 ```go
-if found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys); len(found) > 0 {
-	t.Fatalf("unresolved state keys: %v", found)
+if found := w.TestFindings(gui.DebugAll | gui.DebugUnscopedIDs); len(found) > 0 {
+	t.Fatalf("ID defects: %v", found)
 }
 ```

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -258,12 +258,18 @@ parses a header cell ID by trimming `dataGridHeaderPrefix(gridID)` off a
 `ScopeID(gridID, "header", col)` leaf (`gui/datagrid/view_data_grid_header.go`),
 and row keys (`ScopeID(cfg.ID, "row", rowID)`) and the scroll child
 (`dataGridScrollID`) are likewise multi-part. Absolute leaves skip the join, so
-two grids with the same `cfg.ID` under different ID'd panels **still collide on
-every child ID** — the composability win does not extend to datagrid, and the
-children must stay absolute because the reverse parse requires it. The grid
-root's own leaf becomes `panel:grid`. Audit its leaf-ID consumers
-(`FindByID(cfg.ID)`, `IsFocus(cfg.ID)`, reverse-parse callers) as migration
-work. A future per-grid prefix fix parses against the grid's `effID`.
+the children can never pick up the surrounding scope from the resolve pass, and
+they must stay absolute because the reverse parse requires it.
+
+**The prefix they are built from is now the grid's resolved ID** (#519).
+`datagrid.New` returns a deferred view; the build resolves `cfg.ID` with
+`w.EffID` once, at the top, and every state key, child ID and reverse-parse
+prefix derives from that one string. So a grid with `cfg.ID` `"grid"` inside a
+panel `"detail"` is `detail:grid` and its rows are `detail:grid:row:<key>`, and
+two grids sharing a `cfg.ID` under different panels no longer collide. The
+exception that remains is the spelling: the children are composed absolutely
+rather than joined by the pass. Leaf-ID consumers take the effective form —
+`FindByID`, `IsFocus`, and `datagrid.GetSourceStats`.
 
 **Dock is the second deliberate absolute composite, for the opposite reason.** A
 dock group container takes `ScopeID(dockID, node.ID)` and a dock splitter takes
@@ -399,7 +405,10 @@ so a miss recomputes identically.
 5. **Widget-state keys read during `GenerateLayout`:** migrate to
    `w.EffID(cfg.ID)` (Decision 7) — the resolve pass alone cannot serve reads
    that happen before it.
-6. **Datagrid:** stays a permanent absolute-leaf exception. The composability
-   claim explicitly excludes it until a per-grid `effID`-based parse exists.
+6. **Datagrid:** stays a permanent absolute-leaf exception in spelling only. Its
+   root resolves like any other widget and every child ID is built from that
+   resolved prefix (#519), so two grids sharing a `cfg.ID` under different
+   scopes are distinct. What stays absolute is how the children are composed,
+   because `dataGridHeaderColIDFromLayoutID` trims the prefix back off.
 7. **Joined vs absolute collision** (`"a:b"` from two spellings): allowed,
    reported loudly by the duplicate-ID check. No escaping, per parent spec.

--- a/gui/datagrid/data_source_grid.go
+++ b/gui/datagrid/data_source_grid.go
@@ -18,6 +18,12 @@ type SourceStats struct {
 }
 
 // GetSourceStats returns async stats for the named grid.
+//
+// gridID is the grid's effective ID, the same form gg.FindByID and
+// gg.SetFocus take: a grid with cfg.ID "catalog" inside a panel with ID
+// "detail" answers to "detail:catalog". Compose it with gg.ScopeID. An
+// unknown ID reads as a grid with no source, so a stale bare leaf
+// returns a zero SourceStats rather than an error (issue #519).
 func GetSourceStats(w *gg.Window, gridID string) SourceStats {
 	dgSrc := gg.StateMapRead[string, dataGridSourceState](w, nsDgSource)
 	if dgSrc == nil {

--- a/gui/datagrid/view_data_grid.go
+++ b/gui/datagrid/view_data_grid.go
@@ -556,10 +556,53 @@ type dataGridCtx struct {
 	scrollID  string
 }
 
+// dataGridView defers the grid build to layout generation.
+//
+// It is load-bearing rather than a style choice. dataGridBuild resolves
+// cfg.ID with (*gg.Window).EffID and derives every state key, every
+// child ID and the header reverse-parse prefix from the result, and the
+// generation-time ID scope is only live while the framework descends
+// the View tree. A build at New time would resolve against an empty
+// scope, so two grids sharing a cfg.ID under different panels would
+// share one set of column widths, presentation cache, CRUD working copy
+// and data-source state. See issue #519.
+type dataGridView struct {
+	cfg DataGridCfg
+}
+
+// GenerateLayout builds the grid under the scope of the panel it sits
+// in, then hands the assembled View back to the framework.
+func (v *dataGridView) GenerateLayout(w *gg.Window) gg.Layout {
+	return gg.GenerateViewLayout(dataGridBuild(w, v.cfg), w)
+}
+
 // New creates a controlled, virtualized data grid view.
+//
+// The grid's identity is its effective ID: the leaf joined to the IDs
+// of its ID-bearing ancestors. Every ID the grid publishes is built
+// from that, so a grid with ID "catalog" inside a panel with ID
+// "detail" answers to "detail:catalog" and its rows to
+// "detail:catalog:row:<key>". Public APIs that name a grid or one of
+// its parts — gg.SetFocus, gg.FindByID, [GetSourceStats] — take that
+// form. Compose it with gg.ScopeID, never by hand.
 func New(w *gg.Window, cfg DataGridCfg) gg.View {
+	// Eager, so an empty ID fails at the call site rather than a frame
+	// later with no clue which grid is at fault.
 	gg.RequireID("DataGrid", cfg.ID)
+	return &dataGridView{cfg: cfg}
+}
+
+// dataGridBuild assembles the grid. It runs at layout generation time,
+// under the ID scope of the enclosing panel.
+func dataGridBuild(w *gg.Window, cfg DataGridCfg) gg.View {
 	applyDataGridDefaults(&cfg)
+	// Resolve once, here, before anything reads cfg.ID. Everything
+	// below flows from this string: the state keys, focusID, scrollID,
+	// the child IDs and the header prefix that
+	// dataGridHeaderColIDFromLayoutID trims back off. Resolving in one
+	// place is what keeps the forward build and the reverse parse
+	// spelling the same name.
+	cfg.ID = w.EffID(cfg.ID)
 	if len(cfg.RowsData) > 0 && cfg.DataSource == nil {
 		n := min(len(cfg.RowsData), maxDataConvLen)
 		// Auto-generate columns from sorted keys of first row

--- a/gui/datagrid/view_data_grid_test.go
+++ b/gui/datagrid/view_data_grid_test.go
@@ -702,3 +702,84 @@ func TestDataGridRowsDataEmptyFirstRow(t *testing.T) {
 		t.Fatal("expected children (empty-first-row)")
 	}
 }
+
+// --- ID scoping (issue #519) ---
+
+// A grid inside an ID-bearing panel keys its state on the effective ID,
+// not the leaf. The check is the audit rather than a hand-read of one
+// namespace: the grid owns column widths, presentation, CRUD and
+// data-source state, and a missed resolve in any of them is the defect.
+func TestDataGridStateKeysResolveUnderScope(t *testing.T) {
+	w := gg.NewTestWindow(gg.WindowCfg{})
+	w.UpdateView(func(_ *gg.Window) gg.View {
+		return gg.Column(gg.ContainerCfg{
+			ID:      "detail",
+			Sizing:  gg.FillFill,
+			Content: []gg.View{scopedTestGrid(w)},
+		})
+	})
+
+	if found := w.TestFindings(gg.DebugAll); len(found) != 0 {
+		t.Fatalf("scoped grid must leave no unresolved state key, got %q", found)
+	}
+}
+
+// The grid's own shape answers to the scoped name, which is what
+// SetFocus and FindByID must be given.
+func TestDataGridRootResolvesToEffectiveID(t *testing.T) {
+	w := gg.NewTestWindow(gg.WindowCfg{})
+	w.UpdateView(func(_ *gg.Window) gg.View {
+		return gg.Column(gg.ContainerCfg{
+			ID:      "detail",
+			Sizing:  gg.FillFill,
+			Content: []gg.View{scopedTestGrid(w)},
+		})
+	})
+	root := w.TestRender(nil)
+	if root == nil {
+		t.Fatal("render produced no layout")
+	}
+
+	if _, ok := root.FindByID("detail:grid"); !ok {
+		t.Fatal("grid must be addressable by its effective ID")
+	}
+	if _, ok := root.FindByID("grid"); ok {
+		t.Fatal("the bare leaf must no longer name the grid")
+	}
+}
+
+// Two grids sharing one cfg.ID under different panels are distinct
+// identities, which is the case the unresolved key silently merged.
+func TestDataGridTwoScopesAreDistinct(t *testing.T) {
+	w := gg.NewTestWindow(gg.WindowCfg{})
+	w.UpdateView(func(_ *gg.Window) gg.View {
+		return gg.Column(gg.ContainerCfg{
+			Sizing: gg.FillFill,
+			Content: []gg.View{
+				gg.Column(gg.ContainerCfg{ID: "left",
+					Content: []gg.View{scopedTestGrid(w)}}),
+				gg.Column(gg.ContainerCfg{ID: "right",
+					Content: []gg.View{scopedTestGrid(w)}}),
+			},
+		})
+	})
+
+	if found := w.TestFindings(gg.DebugAll); len(found) != 0 {
+		t.Fatalf("two scoped grids must not collide, got %q", found)
+	}
+}
+
+// scopedTestGrid builds the same small grid for every scoping test, so
+// a change to the fixture cannot make one of them pass for the wrong
+// reason.
+func scopedTestGrid(w *gg.Window) gg.View {
+	return New(w, DataGridCfg{
+		ID: "grid",
+		Columns: []GridColumnCfg{
+			{ID: "name", Title: "Name"},
+		},
+		Rows: []GridRow{
+			{ID: "r1", Cells: map[string]string{"name": "one"}},
+		},
+	})
+}

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -131,24 +131,21 @@ const (
 	// is the signature of a missed resolve rather than of an unrelated
 	// key that happens to collide.
 	//
-	// Latent rather than broken, which is why [Debug] does not turn it
-	// on: a widget that keys both the write and the read on the same
-	// unresolved leaf works, and fails only when a second instance of
-	// it appears under a different scope with the same cfg.ID. Some
-	// widgets are also window-global by decision — gui/datagrid is the
-	// documented case. Ask for the category explicitly when auditing a
-	// screen for reuse, alongside [DebugUnscopedIDs].
+	// The finding is latent rather than immediate — a widget that keys
+	// both the write and the read on the same unresolved leaf works,
+	// and fails only when a second instance of it appears under a
+	// different scope with the same cfg.ID — but it is a defect either
+	// way, so [Debug] turns it on.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugUnresolvedKeys
 
 	// DebugAll is every category [Debug] turns on. [DebugUnscopedIDs]
-	// and [DebugUnresolvedKeys] are deliberately absent: both report a
-	// design property rather than a present defect, and both fire on
-	// widgets that work today.
+	// is deliberately absent: it reports a design property rather than
+	// a defect, and fires on widgets that are correct as written.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
 		DebugListBoxNoHeight | DebugGradientResampled | DebugWrapOverflow |
-		DebugCallbacks | DebugWindowDegraded
+		DebugCallbacks | DebugWindowDegraded | DebugUnresolvedKeys
 )
 
 func init() {

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -268,14 +268,11 @@ func TestCheckCategoryMapping(t *testing.T) {
 	// DebugAll covers every category Debug(true) turns on.
 	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
 	// a design property, not a defect.
-	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow|DebugCallbacks|DebugWindowDegraded {
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow|DebugCallbacks|DebugWindowDegraded|DebugUnresolvedKeys {
 		t.Fatal("DebugAll must cover every category Debug(true) enables")
 	}
 	if DebugAll&DebugUnscopedIDs != 0 {
 		t.Fatal("DebugUnscopedIDs must stay opt-in, outside DebugAll")
-	}
-	if DebugAll&DebugUnresolvedKeys != 0 {
-		t.Fatal("DebugUnresolvedKeys must stay opt-in, outside DebugAll")
 	}
 }
 


### PR DESCRIPTION
Closes #519. Completes the migration #518 started.

## The bug

`datagrid.New` built eagerly and never called `EffID`. Every state slot the grid owns was keyed on the raw `cfg.ID` while the grid's root shape resolved to its effective ID:

| namespace | what shared a slot |
|---|---|
| `gui.dg.col_widths` | column widths |
| `gui.dg.presentation` | sort/filter/format cache |
| `gui.dg.crud` | CRUD working copy |
| `gui.dg.source` | data-source paging and load state |

One grid per `cfg.ID` worked — the key was wrong but self-consistent. Two grids sharing a `cfg.ID` under different panels were distinct shapes with one state slot, and their children collided outright. The audit shows both halves of that, taken with the fix reverted:

```
duplicate ID "grid:scroll" at 0/1/0/0, first claimed at 0/0/0/0
duplicate ID "grid:header:name" ...
duplicate ID "grid:row:r1" ...
state key "grid" in namespace "gui.dg.col_widths" is an unresolved leaf;
  the shape of that name resolved to "left:grid"
```

## The fix

`New` returns a deferred `dataGridView`; `dataGridBuild` runs under the enclosing panel's ID scope and resolves once, at the top:

```go
cfg.ID = w.EffID(cfg.ID)
```

Everything below flows from that one string — the state keys, `focusID`, `scrollID`, the child IDs and the header prefix that `dataGridHeaderColIDFromLayoutID` trims back off. Resolving in one place is what keeps the forward build and the reverse parse spelling the same name. `RequireID` stays eager, so an empty ID still fails at the call site.

## `DebugUnresolvedKeys` joins `DebugAll`

It was held out only because datagrid produced six known findings. The showcase is now clean across every demo page and its docs view, so `gui.Debug(true)` reports an unresolved state key without being asked, and `TestDemoPagesHaveNoIDDefects` asserts it through the existing `TestDuplicateIDs` call. `DebugUnscopedIDs` stays opt-in — it reports a design property, not a defect.

## Breaking

Every ID a scoped grid publishes moves:

```go
// grid ID "catalog" inside a panel with ID "detail"
"catalog:row:3"          // before
"detail:catalog:row:3"   // now
```

An app that spells a grid or one of its parts by hand for `gg.FindByID`, `gg.SetFocus`, `gg.ScrollVerticalTo` or `datagrid.GetSourceStats` must pass the effective form. Compose it with `gg.ScopeID`, never by hand. An unscoped grid is unaffected.

`GetSourceStats` is the non-obvious one, so its doc now says which form it takes. An unknown ID reads as a grid with no source, so a stale bare leaf returns a zero `SourceStats` rather than an error.

**Sibling scan: clear.** go-charts, go-edit, go-kite, go-term, go-map and go-speedtest have zero references to `datagrid`.

## Verification

- `make prepush` green: race tests, cross-lint 0 issues on 4 platforms, cross-compile, coverage 84.9% >= 70% with every per-package floor met, export-audit clean, changelog-check ok.
- Three new tests in `gui/datagrid/view_data_grid_test.go`. Two of them fail with the resolve reverted, with the output quoted above; the third pins the public addressing form.
- Docs: `CLAUDE.md`, `docs/dx-cheat-sheet.md`, `docs/specs/widget-id-per-scope-uniqueness.md` (Decision 6 is now an exception in spelling only), `CHANGELOG.md`.

## Still open

- #520 `EffID` should report a call made outside layout generation — the check that would have caught this class at the source
- #521 an app cannot learn a widget's effective ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)