### PR TITLE
feat(debug): report a resolve made at the wrong time (#520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,21 @@ and this project adheres to
   testable as data instead of stderr-only.
 
   ```go
-  found := w.TestFindings(gui.DebugAll | gui.DebugUnresolvedKeys)
+  found := w.TestFindings(gui.DebugAll | gui.DebugUnscopedIDs)
   ```
+
+- **`EffID` reports a mistimed resolve** (#520) — `w.EffID` answers with the
+  bare leaf when it is called before the framework descends into the scope the
+  widget belongs to, and that is also the correct answer for a widget with no
+  scope above it. Failure and success were byte-identical, which is why six
+  widgets carried the same bug and no test saw it. `DebugUnresolvedKeys` now
+  reports the call itself: it records what each resolve answered and compares
+  that with where the shape of that leaf actually landed. It fires whatever the
+  widget does with the result — a state key, an inner `ScopeID`, a focus check —
+  rather than only what reaches a scanned state map, and a call made entirely
+  outside layout generation is reported separately with its own message.
+  `(*Window).TestFindings` now installs the categories before it renders, so a
+  check that records during generation is assertable.
 
 ### Fixed
 
@@ -75,6 +88,13 @@ and this project adheres to
   by hand for `gg.FindByID`, `gg.SetFocus`, `gg.ScrollVerticalTo` or
   `datagrid.GetSourceStats` must pass the effective form. Compose it with
   `gg.ScopeID`, never by hand. An unscoped grid is unaffected.
+
+- **`ContextMenu` resolves its ID at generation time** (#520) — the resolve was
+  present but ran in the factory body, before the descent into the panel the
+  menu sits in, so a context menu inside an ID-bearing ancestor keyed its open
+  state, its saved focus and its popup ID on the bare leaf. The build is now
+  deferred. Same behavior change as the widgets above: a scoped context menu
+  carries the effective ID, so a hand-spelled `SetFocus` must follow.
 
 ## [v0.69.0] - 2026-09-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,13 +274,23 @@ explicitly when auditing a screen for reusability:
 gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
 ```
 
-**`DebugUnresolvedKeys` is in `DebugAll`.** It reports a `StateMap` key that is
-a bare leaf while an ancestor join rewrote the shape of that name — the widget
-closed over the raw `cfg.ID` instead of resolving it, so its state key and its
-identity are different strings. The failure is latent: the widget works until a
-second instance of the same `cfg.ID` appears under another scope, and then both
-share one state slot. Remedy is `w.EffID(cfg.ID)` in `GenerateLayout` or
-`ctx.EffID(leaf)` in a handler. See issues #518 and #519.
+**`DebugUnresolvedKeys` is in `DebugAll`.** It reports two things. First, a
+resolve that answered with the bare leaf while the shape of that name landed
+under a scope — the call ran before the descent that opens the scope, which is
+what an eagerly built widget factory does. Second, a `StateMap` key that is a
+bare leaf while an ancestor join rewrote the shape of that name — the widget
+never resolved at all. Either way the widget's state key and its identity are
+different strings. The failure is latent: the widget works until a second
+instance of the same `cfg.ID` appears under another scope, and then both share
+one state slot. Remedy is `w.EffID(cfg.ID)` in `GenerateLayout` or
+`ctx.EffID(leaf)` in a handler. See issues #518, #519 and #520.
+
+**A widget factory that reads window state must defer its build.** A factory
+body runs while the _parent's_ `Content` slice is being built, before the
+framework descends into the container the widget will sit in, so `w.EffID` there
+joins the enclosing scope rather than the widget's own. Return a view struct or
+a `viewFunc` and resolve inside `GenerateLayout`. Six widgets carried this bug
+before anything checked for it.
 
 Assertable forms for tests, which return findings as data:
 `(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -303,13 +303,28 @@ gui.DebugCategories(gui.DebugAll | gui.DebugUnscopedIDs)
 ```
 
 `DebugUnresolvedKeys` is part of `DebugAll`, so `gui.Debug(true)` already runs
-it. It reports per-widget state stored under a leaf ID that an ancestor join
-rewrote, so the widget's state key and its shape's identity are different
-strings. Such a widget works while it is the only instance of its `cfg.ID`, and
-two of them under different scopes share one state slot.
+it. It reports a widget whose state key and whose identity are different strings
+— either because the widget never resolved its `cfg.ID`, or because it resolved
+at the wrong time and got the bare leaf back. Such a widget works while it is
+the only instance of its `cfg.ID`, and two of them under different scopes share
+one state slot.
 
 The remedy is a resolved key: `w.EffID(cfg.ID)` during `GenerateLayout`, or
 `ctx.EffID(leaf)` in a handler.
+
+**Resolve during `GenerateLayout`, never in a factory body.** A factory runs
+while the parent's `Content` slice is being built, which is before the framework
+descends into the container the widget will sit in. `w.EffID` there joins the
+enclosing scope, not the widget's own. The answer it returns for a widget with
+no scope above it is the same string a correct resolve returns, so the mistake
+is invisible until someone puts the widget in a panel. A factory that needs to
+resolve returns a view struct, or defers its body:
+
+```go
+func (w *Window) Thing(cfg ThingCfg) View {
+	return viewFunc(func(vw *Window) View { return thingView(cfg, vw) })
+}
+```
 
 `DebugCategories` prints to stderr. To assert a category in a test, including an
 opt-in one, use `(*Window).TestFindings(mask)`, which returns the findings as

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -289,6 +289,10 @@ const (
 	// StateMap key is a bare leaf that the resolve pass scoped; see
 	// debug_state_keys.go.
 	debugCheckUnresolvedKey
+	// debugCheckEffIDPhase fires from (*Window).EffID when it is called
+	// outside layout generation, where the ID scope is empty and the
+	// call cannot do its job.
+	debugCheckEffIDPhase
 )
 
 // checkCategory maps an internal check to the public category that
@@ -315,7 +319,7 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugCallbacks
 	case debugCheckWindowTransparency:
 		return DebugWindowDegraded
-	case debugCheckUnresolvedKey:
+	case debugCheckUnresolvedKey, debugCheckEffIDPhase:
 		return DebugUnresolvedKeys
 	}
 	return 0
@@ -333,6 +337,11 @@ type debugWarnKey struct {
 // debugState is a window's warn-once memory. Zero value is ready.
 type debugState struct {
 	warned map[debugWarnKey]struct{}
+	// effIDAnswers records what (*Window).EffID returned for each leaf
+	// this frame, so the audit can compare a resolve against the scope
+	// the shape actually landed in. Frame-scoped and filled only while
+	// DebugUnresolvedKeys is on; see debug_state_keys.go.
+	effIDAnswers map[string]string
 	// collect, when non-nil, receives findings instead of debugOut. Set
 	// only by TestUnconsumedEvents, which needs the findings as data
 	// rather than as text on stderr.
@@ -510,10 +519,6 @@ func (w *Window) TestDuplicateIDs() []string {
 // the app into each interesting state and check again.
 // exportaudit:keep — dev-diagnostic API for app authors
 func (w *Window) TestFindings(mask DebugCategory) []string {
-	root := w.TestRender(nil)
-	if root == nil {
-		return nil
-	}
 	var found []string
 	// Restore the exact mask, not just on/off: a caller may have a
 	// narrower gate installed that this call must not widen for good.
@@ -533,6 +538,14 @@ func (w *Window) TestFindings(mask DebugCategory) []string {
 		w.debug.collect = nil
 		w.debug.warned = prevWarned
 	}()
+	// The gate goes on before the render, not after it: a check that
+	// records during layout generation — the EffID phase check — sees
+	// nothing if the frame it is meant to inspect was drawn with the
+	// categories still off.
+	root := w.TestRender(nil)
+	if root == nil {
+		return nil
+	}
 	w.debugAudit(root)
 	return found
 }

--- a/gui/debug_state_keys.go
+++ b/gui/debug_state_keys.go
@@ -51,6 +51,7 @@ func (w *Window) debugCheckStateKeys(ids *debugIDs) {
 	if DebugCategory(debugMask.Load())&DebugUnresolvedKeys == 0 {
 		return
 	}
+	w.debugCheckEffIDAnswers(ids)
 	if len(ids.scoped) == 0 {
 		// No shape in this window was rewritten by a join, so no key
 		// can be the unresolved form of one.
@@ -105,5 +106,71 @@ func (w *Window) debugScanKeys(ns string, m any, ids *debugIDs) {
 				"leaf with w.EffID during GenerateLayout, or with "+
 				"ctx.EffID in a handler.",
 			key, ns, effID)
+	}
+}
+
+// maxEffIDAnswers bounds the per-frame record. A window with more
+// distinct resolves than this in one frame is past the point where
+// naming one more of them helps, and the bound is what keeps a gate
+// left on in a long-running app from growing without limit.
+const maxEffIDAnswers = 4096
+
+// debugNoteEffID records what EffID answered for a leaf this frame.
+// Only the first answer per leaf is kept: a widget that resolves the
+// same leaf twice in one frame gets one finding, not two.
+func (w *Window) debugNoteEffID(leaf, effID string) {
+	if leaf == "" || DebugCategory(debugMask.Load())&DebugUnresolvedKeys == 0 {
+		return
+	}
+	if len(w.debug.effIDAnswers) >= maxEffIDAnswers {
+		return
+	}
+	if w.debug.effIDAnswers == nil {
+		w.debug.effIDAnswers = make(map[string]string)
+	}
+	if _, seen := w.debug.effIDAnswers[leaf]; seen {
+		return
+	}
+	w.debug.effIDAnswers[leaf] = effID
+}
+
+// debugCheckEffIDAnswers reports a resolve that returned the bare leaf
+// while the shape of that leaf landed under a scope.
+//
+// This is the general form of the state-key audit, and it catches the
+// case the depth check cannot. A factory body called while building a
+// parent's Content slice runs at a non-zero generation depth — the
+// framework is descending, just not into the container this widget is
+// about to sit in — so the scope EffID joins to is the enclosing one,
+// not the widget's own. The answer is the bare leaf, the shape resolves
+// to "panel:leaf", and the two disagree.
+//
+// It reports whatever the widget did with the result: a state key, an
+// inner ID composed with ScopeID, a focus check, a value simply stored
+// in a struct. The state-key scan below sees only what reached a
+// scanned map.
+func (w *Window) debugCheckEffIDAnswers(ids *debugIDs) {
+	// Cleared whether or not anything is reported, so the next frame
+	// starts from what that frame actually resolved.
+	defer clear(w.debug.effIDAnswers)
+	for leaf, answered := range w.debug.effIDAnswers {
+		if answered != leaf {
+			// The resolve picked up a scope. Whether it picked up the
+			// right one is the duplicate-ID check's business.
+			continue
+		}
+		effID, ok := ids.scoped[leaf]
+		if !ok {
+			// No shape of this leaf was rewritten by a join, so the
+			// bare answer is the identity.
+			continue
+		}
+		w.debugWarn(debugCheckEffIDPhase, leaf,
+			"EffID(%q) returned the bare leaf, but the shape of that "+
+				"name resolved to %q. The call ran before the descent "+
+				"into the scope it belongs to — a widget factory that "+
+				"builds eagerly resolves against the enclosing scope, "+
+				"not its own. Defer the build to GenerateLayout.",
+			leaf, effID)
 	}
 }

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -777,3 +777,131 @@ func TestTestFindingsRestoresMask(t *testing.T) {
 		t.Fatalf("want the caller's mask restored, got %v", got)
 	}
 }
+
+// EffID outside generation returns the leaf, which is indistinguishable
+// from a correct resolve at the top level. The finding is the only
+// thing that separates them, so it has to fire on the call itself.
+func TestEffIDOutsideGenerationReports(t *testing.T) {
+	buf := captureDebugMask(t, DebugUnresolvedKeys)
+	w := NewTestWindow(WindowCfg{})
+
+	if got := w.EffID("save"); got != "save" {
+		t.Fatalf("EffID must still answer with the leaf, got %q", got)
+	}
+	if !strings.Contains(buf.String(), `EffID("save")`) {
+		t.Fatalf("want a phase finding naming the leaf, got %q", buf.String())
+	}
+}
+
+// A resolve made from GenerateLayout is the supported call and must
+// stay silent, whether or not the widget has a scope above it.
+func TestEffIDDuringGenerationIsQuiet(t *testing.T) {
+	buf := captureDebugMask(t, DebugUnresolvedKeys)
+	w := NewTestWindow(WindowCfg{})
+
+	var scoped, unscoped string
+	w.UpdateView(func(_ *Window) View {
+		return Column(ContainerCfg{
+			ID:     "panel",
+			Sizing: FillFill,
+			Content: []View{viewFunc(func(vw *Window) View {
+				scoped = vw.EffID("save")
+				return Column(ContainerCfg{})
+			})},
+		})
+	})
+	w.TestRender(nil)
+	w.UpdateView(func(vw *Window) View {
+		unscoped = vw.EffID("save")
+		return Column(ContainerCfg{Sizing: FillFill})
+	})
+	w.TestRender(nil)
+
+	if scoped != "panel:save" {
+		t.Errorf("scoped resolve = %q, want %q", scoped, "panel:save")
+	}
+	if unscoped != "save" {
+		t.Errorf("top-level resolve = %q, want %q", unscoped, "save")
+	}
+	if buf.String() != "" {
+		t.Errorf("a resolve at generation time must be quiet, got %q", buf.String())
+	}
+}
+
+// The depth is restored when a view function panics, so one bad frame
+// does not leave every later EffID call looking correctly timed.
+func TestGenDepthUnwindsOnPanic(t *testing.T) {
+	w := NewTestWindow(WindowCfg{})
+	func() {
+		defer func() { _ = recover() }()
+		generateViewLayout(viewFunc(func(_ *Window) View {
+			panic("boom")
+		}), w)
+	}()
+
+	if got := w.viewState.genDepth; got != 0 {
+		t.Fatalf("genDepth = %d after a panic, want 0", got)
+	}
+}
+
+// eagerFactoryParent reproduces the shape all four migrated widgets had
+// (issues #518, #519): a factory body that resolves while the parent's
+// Content slice is being built, which is before the descent into the
+// container the widget will sit in.
+type eagerFactoryParent struct {
+	resolved *string
+}
+
+func (p *eagerFactoryParent) GenerateLayout(w *Window) Layout {
+	return generateViewLayout(Column(ContainerCfg{
+		ID:     "panel",
+		Sizing: FillFill,
+		Content: []View{
+			func() View {
+				*p.resolved = w.EffID("save")
+				return Button(ButtonCfg{ID: "save", Label: "Save"})
+			}(),
+		},
+	}), w)
+}
+
+// The generation depth is non-zero inside a nested GenerateLayout, so
+// the depth check cannot see this one. Comparing the answer with where
+// the shape resolved is what catches it.
+func TestEffIDEagerFactoryUnderPanelReports(t *testing.T) {
+	buf := captureDebugMask(t, DebugUnresolvedKeys)
+	w := NewTestWindow(WindowCfg{})
+
+	var resolved string
+	w.UpdateView(func(_ *Window) View {
+		return &eagerFactoryParent{resolved: &resolved}
+	})
+	w.TestRender(nil)
+
+	if resolved != "save" {
+		t.Fatalf("fixture no longer reproduces the bug: resolved = %q", resolved)
+	}
+	if !strings.Contains(buf.String(), `resolved to "panel:save"`) {
+		t.Fatalf("want a finding naming the scope the shape landed in, got %q",
+			buf.String())
+	}
+}
+
+// The record is per frame. A widget corrected between frames must stop
+// being reported, and a frame that resolves nothing must not inherit
+// the previous frame's answers.
+func TestEffIDAnswersAreFrameScoped(t *testing.T) {
+	captureDebugMask(t, DebugUnresolvedKeys)
+	w := NewTestWindow(WindowCfg{})
+
+	var resolved string
+	w.UpdateView(func(_ *Window) View {
+		return &eagerFactoryParent{resolved: &resolved}
+	})
+	w.TestRender(nil)
+
+	if len(w.debug.effIDAnswers) != 0 {
+		t.Fatalf("the record must be cleared after the audit, got %v",
+			w.debug.effIDAnswers)
+	}
+}

--- a/gui/id_resolve.go
+++ b/gui/id_resolve.go
@@ -122,14 +122,35 @@ func (w *Window) joinLeaf(scope, leaf string) string {
 // as the ancestor IDs above the widget do, and when one of those
 // changes the widget's identity has changed by design.
 //
-// Outside layout generation the scope is empty, so EffID returns the
-// leaf unchanged.
+// Call it during layout generation and nowhere else. The ID scope is
+// only live while the framework descends the View tree, so a call from
+// a widget factory body, an event handler or app code has no scope to
+// join and returns the leaf. That answer is also the correct answer for
+// a top-level widget, so the mistake is invisible until the widget is
+// put inside a panel — which is why [DebugUnresolvedKeys] reports the
+// call rather than letting it pass. Handlers have [EventCtx.EffID],
+// which cannot be called at the wrong time.
 // exportaudit:keep — public seam for widget code (see CLAUDE.md)
 func (w *Window) EffID(leaf string) string {
 	if w == nil {
 		return leaf
 	}
-	return w.joinLeaf(w.viewState.idScope, leaf)
+	if w.viewState.genDepth == 0 {
+		w.debugWarn(debugCheckEffIDPhase, leaf,
+			"EffID(%q) was called outside layout generation, where the "+
+				"ID scope is empty, so it returned the leaf unchanged. "+
+				"That is the right answer only for a top-level widget. "+
+				"Move the call into GenerateLayout — a factory that "+
+				"builds eagerly must defer — or use ctx.EffID in a "+
+				"handler.", leaf)
+	}
+	effID := w.joinLeaf(w.viewState.idScope, leaf)
+	// A call from inside the tree has a non-zero depth and still misses
+	// the scope when the factory body runs before the descent that
+	// opens it. Depth cannot see that; the frame audit can, by
+	// comparing this answer with where the shape resolved.
+	w.debugNoteEffID(leaf, effID)
+	return effID
 }
 
 // childScopeID returns the scope a shape's children generate and

--- a/gui/view.go
+++ b/gui/view.go
@@ -55,6 +55,15 @@ func GenerateViewLayout(view View, w *Window) Layout {
 // GenerateLayout via appendChildViews; the only remaining invariant
 // this function owns is shape normalization.
 func generateViewLayout(view View, w *Window) Layout {
+	// The depth is what lets EffID tell "no scope, top of the tree"
+	// from "no scope, not generating at all". Every generation path
+	// runs through here, so counting in one place covers them all.
+	// Deferred, so a panic in a view function cannot leave the window
+	// looking as if generation were still in progress.
+	if w != nil {
+		w.viewState.genDepth++
+		defer func() { w.viewState.genDepth-- }()
+	}
 	layout := view.GenerateLayout(w)
 	ensureLayoutShape(&layout)
 	return layout

--- a/gui/view_context_menu.go
+++ b/gui/view_context_menu.go
@@ -77,9 +77,28 @@ type ContextMenuCfg struct {
 
 // ContextMenu creates a container that opens a floating menu
 // on right-click at the cursor position.
+//
+// The build is deferred to layout generation. It is load-bearing rather
+// than a style choice: contextMenuBuild resolves cfg.ID with
+// [Window.EffID] and keys the open state, the saved focus and the
+// popup's own ID on the result, and the generation-time ID scope is
+// only live while the framework descends the View tree. Building here
+// would resolve against the enclosing scope, so a context menu inside
+// an ID-bearing panel would key its state on the bare leaf. See issue
+// #520.
 func ContextMenu(w *Window, cfg ContextMenuCfg) View {
+	// Eager, so a missing ID or a duplicate item ID fails at the call
+	// site rather than a frame later.
 	RequireID("ContextMenu", cfg.ID)
 	checkForDuplicateMenuIDs(cfg.Items)
+	return viewFunc(func(vw *Window) View {
+		return contextMenuBuild(vw, cfg)
+	})
+}
+
+// contextMenuBuild assembles the menu under the ID scope of the panel
+// it sits in.
+func contextMenuBuild(w *Window, cfg ContextMenuCfg) View {
 	applyContextMenuDefaults(&cfg)
 
 	// One resolved identity for every key below; see (*Window).EffID.

--- a/gui/window_state.go
+++ b/gui/window_state.go
@@ -115,7 +115,14 @@ type ViewState struct {
 	// idScope is the effective ID of the innermost ID-bearing shape
 	// currently being generated. Maintained by generateViewLayout and
 	// read by (*Window).EffID; empty outside the view phase.
-	idScope                  string
+	idScope string
+
+	// genDepth counts the generateViewLayout frames currently on the
+	// stack, so EffID can tell an empty scope at the top of the tree
+	// from an empty scope because no tree is being generated. The two
+	// produce the same answer, which is why the second went unnoticed
+	// in four widgets; see issue #520.
+	genDepth                 int
 	mousePosX                float32
 	mousePosY                float32
 	mouseButtonHeld          MouseButton

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -315,7 +315,12 @@ func (w *Window) updateLocked() {
 	// access scratch pools (frame-scoped, single-goroutine), atomic
 	// inputCursorOn, and animations (guarded by w.animMu).
 	w.mu.Unlock()
+	// The root view function is generation too, so a resolve made in
+	// its body is correctly timed and must not be reported as a
+	// depth-zero call. The empty scope it sees is the real one.
+	w.viewState.genDepth++
 	view := w.viewGenerator(w)
+	w.viewState.genDepth--
 	rootLayout := generateViewLayout(view, w)
 	w.mu.Lock()
 	defer w.mu.Unlock()


### PR DESCRIPTION
Closes #520.

## The premise in the issue was half right

#520 proposed tracking generation depth and reporting a call at depth zero. I built that first, then tested whether it actually catches the bugs it cites. It does not.

A factory body called while building a parent's `Content` slice runs at a **non-zero** depth — the framework is descending, just not into the container this widget is about to sit in. Probe, with the depth check in place and the historical shape reproduced:

```
resolved="save"  depthFinding=false     // nested factory: missed
resolved="save"  depthFinding=true      // root view fn:   caught
```

`resolved` should be `"panel:save"` in both. Depth alone catches only calls made entirely outside the frame — a real class, but not the one that produced six bugs.

## What actually works

Compare the answer with the outcome. `EffID` records what it returned for each leaf in the frame; the audit checks each recorded answer against `debugIDs.scoped`, which already holds the leaves the resolve pass rewrote. A bare answer against a scoped shape is a mistimed resolve:

```
EffID("save") returned the bare leaf, but the shape of that name resolved to
"panel:save". The call ran before the descent into the scope it belongs to — a
widget factory that builds eagerly resolves against the enclosing scope, not its
own. Defer the build to GenerateLayout.
```

This is a strict superset of what the state-key scan sees. It fires on whatever the widget did with the result — a state key, an inner `ScopeID`, a focus check, a value merely stored in a struct — rather than only on what reached a scanned map.

The depth check is kept, with its own message, for the outside-the-frame case. The root view function is counted as generation, since a resolve there is correctly timed and its empty scope is the real one.

## It found a sixth bug immediately

`ContextMenu` had the resolve in the factory body. A context menu inside an ID-bearing panel keyed its open state, its saved focus and its popup ID on the bare leaf. Build deferred; same class as #518 and #519.

## `TestFindings` ordering

It installed the mask *after* rendering, so a check that records during generation saw a frame drawn with the categories off. The gate now goes on first. That also means render-phase findings reach the returned slice, which is what the method already documents.

## Verification

- `make prepush` green: race tests, cross-lint 0 issues on 4 platforms, cross-compile, coverage 85.0% >= 70% with every per-package floor met, export-audit clean, changelog-check ok.
- Showcase clean across every demo page and its docs view with `DebugAll` on, after the ContextMenu fix and not before it.
- Five new tests: the nested eager factory (fails without the audit), the depth-zero call, a correctly timed resolve staying quiet in both scoped and unscoped positions, frame-scoping of the record, and depth unwinding on a panic.

## The rule, now written down

`CLAUDE.md` and the cheat sheet say it plainly: a widget factory that reads window state defers its build. That is the property all six violations shared, and it is now checked rather than remembered.

## Still open

- #521 an app cannot learn a widget's effective ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)