### PR TITLE
feat(gui): read an effective ID back instead of spelling it (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to
   ancestor join really rewrote a shape of that leaf, so a cache keyed by a file
   name stays quiet. Like `DebugUnscopedIDs` it is **not** in `DebugAll`, because
   `gui/datagrid` is window-global by decision (#519); ask for it by name.
-  `(*Window).TestFindings(mask)` is the general assertable form of
+  _Superseded below: #519 fixed the datagrid and moved the category into
+  `DebugAll`._ `(*Window).TestFindings(mask)` is the general assertable form of
   `TestDuplicateIDs`: it takes the categories to run, so an opt-in category is
   testable as data instead of stderr-only.
 
@@ -52,6 +53,22 @@ and this project adheres to
   outside layout generation is reported separately with its own message.
   `(*Window).TestFindings` now installs the categories before it renders, so a
   check that records during generation is assertable.
+
+- **`(*Window).EffectiveIDs`, `(*Window).ResolveID` and
+  `gui.DebugUnknownFocus`** (#521) — the effective ID is what every addressing
+  API takes, and until now an app could not learn one. It had to spell the
+  string by hand from the join rule and its own View tree, and a wrong spelling
+  failed in silence: `SetFocus` on an unknown ID focuses nothing,
+  `ScrollVerticalTo` writes an offset no scrollable reads. `ResolveID("nav")`
+  now answers with the identities the last frame stamped for that leaf —
+  `["detail:nav"]` under a panel with `ID: "detail"` — and `EffectiveIDs()`
+  lists the whole frame. Both read the arranged tree, so the answer is what the
+  addressing APIs expect rather than a second implementation of the rule.
+  `DebugUnknownFocus`, in `DebugAll`, closes the other half: a frame that ends
+  with a focus ID nothing focusable claims is reported, and the message offers
+  the spelling that would have worked. It runs from the frame audit rather than
+  from `SetFocus`, because focusing a widget the current frame has not built yet
+  is legitimate. Every public API that takes an effective ID now says so.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ trimming that prefix back off. The grid root resolves like any other widget
 (#519), so a scoped grid's children are scoped with it. See
 `docs/specs/widget-id-per-scope-uniqueness.md`.
 
+**Read an effective ID back rather than spelling it.** `w.ResolveID("nav")`
+returns the identities the last frame stamped for that leaf (`["detail:nav"]`);
+`w.EffectiveIDs()` lists the whole frame. Both read the arranged tree, so they
+answer what the addressing APIs take (#521).
+
 **Compose inner IDs with `gui.ScopeID` / `gui.ScopeIDN`, never by hand.** An ID
 is a `:`-joined path (`grid:header:name:resize`); composition is associative.
 `ScopeIDN` appends a numeric segment without allocating for the number — use it
@@ -284,6 +289,13 @@ different strings. The failure is latent: the widget works until a second
 instance of the same `cfg.ID` appears under another scope, and then both share
 one state slot. Remedy is `w.EffID(cfg.ID)` in `GenerateLayout` or
 `ctx.EffID(leaf)` in a handler. See issues #518, #519 and #520.
+
+**`DebugUnknownFocus` is in `DebugAll`.** It reports a frame that ended with a
+focus ID no focusable shape claims, which is what `SetFocus` on a misspelled or
+unscoped ID leaves behind: the call is accepted, stored, and never matched. The
+message names the spelling the frame did stamp. It runs from the frame audit,
+not from `SetFocus`, because focusing a widget the current frame has not built
+yet is legitimate (#521).
 
 **A widget factory that reads window state must defer its build.** A factory
 body runs while the _parent's_ `Content` slice is being built, before the

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -45,6 +45,17 @@ Two panels can contain the same leaf ID. Each is a different widget. Compose IDs
 with `ScopeID` or `ScopeIDN`, never by hand. Public APIs — `SetFocus`,
 `FindByID`, `IsFocus`, `ScrollVerticalTo`, `Test*` — take the effective ID.
 
+Do not spell one by hand. Ask the frame:
+
+```go
+ids := w.ResolveID("nav")  // ["detail:nav"] under Panel{ID:"detail"}
+w.SetFocus(ids[0])
+all := w.EffectiveIDs()    // every identity in the frame, tree order
+```
+
+An empty answer means no widget of that name is in the current frame: either the
+spelling is wrong or the widget is not rendered.
+
 A part (a row key, a heading slug) must not contain `:`. A composite widget's
 inner shape sets `Shape.focusOwner` to the owner's leaf instead of repeating its
 `ID`.
@@ -325,6 +336,13 @@ func (w *Window) Thing(cfg ThingCfg) View {
 	return viewFunc(func(vw *Window) View { return thingView(cfg, vw) })
 }
 ```
+
+`DebugUnknownFocus` is also part of `DebugAll`. It reports the same mistake from
+the other side: a frame that finished with a focus ID nothing focusable claims,
+which is what `SetFocus("nav")` leaves behind when the frame stamped
+`"detail:nav"`. The finding names the spelling that would have worked. It fires
+from the frame audit, not from `SetFocus`, because a view function may
+legitimately focus a control it is still returning.
 
 `DebugCategories` prints to stderr. To assert a category in a test, including an
 opt-in one, use `(*Window).TestFindings(mask)`, which returns the findings as

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -41,6 +41,15 @@ implementation, and the code is the authority.
    deliberately **outside** `DebugAll` — it reports a design property, not a
    defect, and fires on most widgets in a small app. Enable it with
    `gui.DebugCategories(gui.DebugUnscopedIDs)`.
+4. **A read-back seam was added** (#521). The spec made effective IDs the form
+   every addressing API takes but gave an app no way to learn one: the author
+   had to apply the join rule to their own View tree by hand, and a wrong
+   spelling failed silently. `(*Window).ResolveID(leaf)` answers with the
+   identities the last frame stamped for that leaf, and
+   `(*Window).EffectiveIDs()` lists the frame. Both read the arranged tree
+   rather than re-deriving the rule, so they cannot drift from it.
+   `gui.DebugUnknownFocus` reports the other half — a frame that finished with a
+   focus ID nothing focusable claims.
 
 Phase A.4 (producer simplification) was applied where a composite's own nesting
 already mirrors `ScopeID(cfg.ID, part)` — combobox and select now set a plain

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -139,13 +140,36 @@ const (
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugUnresolvedKeys
 
+	// DebugUnknownFocus reports a window whose focus ID names no
+	// focusable shape in the frame, so the keyboard has nowhere to go.
+	//
+	// [Window.SetFocus] takes the *effective* ID and accepts any
+	// string. A leaf spelled without the scope its widget sits under —
+	// "nav" where the frame stamped "detail:nav" — is accepted, stored
+	// and never matched, which is the same silent shape the resolve
+	// checks report from the other side.
+	//
+	// The check runs from the frame audit rather than from SetFocus,
+	// because setting focus on a widget the current frame has not built
+	// yet is legitimate and common: a view function may focus a control
+	// it is in the middle of returning. Only a frame that finished with
+	// nothing focusable under that name is a finding.
+	//
+	// It also fires when the focused widget leaves the tree — a tab
+	// switch, a closed dialog — which is a real dangling focus rather
+	// than a false alarm: the keyboard is dead until something takes
+	// focus back. [Window.ClearFocus] is how a view drops it on purpose.
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugUnknownFocus
+
 	// DebugAll is every category [Debug] turns on. [DebugUnscopedIDs]
 	// is deliberately absent: it reports a design property rather than
 	// a defect, and fires on widgets that are correct as written.
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
 		DebugListBoxNoHeight | DebugGradientResampled | DebugWrapOverflow |
-		DebugCallbacks | DebugWindowDegraded | DebugUnresolvedKeys
+		DebugCallbacks | DebugWindowDegraded | DebugUnresolvedKeys |
+		DebugUnknownFocus
 )
 
 func init() {
@@ -293,6 +317,9 @@ const (
 	// outside layout generation, where the ID scope is empty and the
 	// call cannot do its job.
 	debugCheckEffIDPhase
+	// debugCheckUnknownFocus fires from the frame audit when the
+	// window's focus ID names no focusable shape in the frame.
+	debugCheckUnknownFocus
 )
 
 // checkCategory maps an internal check to the public category that
@@ -321,6 +348,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugWindowDegraded
 	case debugCheckUnresolvedKey, debugCheckEffIDPhase:
 		return DebugUnresolvedKeys
+	case debugCheckUnknownFocus:
+		return DebugUnknownFocus
 	}
 	return 0
 }
@@ -361,7 +390,7 @@ type debugState struct {
 // same tree the renderer does, including floating and overlay layers.
 func (w *Window) debugAudit(root *Layout) {
 	const walkCategories = DebugDuplicates | DebugMissingIDs |
-		DebugUnscopedIDs | DebugUnresolvedKeys
+		DebugUnscopedIDs | DebugUnresolvedKeys | DebugUnknownFocus
 	if DebugCategory(debugMask.Load())&walkCategories == 0 {
 		return
 	}
@@ -373,6 +402,54 @@ func (w *Window) debugAudit(root *Layout) {
 	// against the keys the state maps hold, so it runs after the walk
 	// and gates itself.
 	w.debugCheckStateKeys(ids)
+	// Reads the identities the walk collected, so it runs after it.
+	w.debugCheckFocusTarget(ids)
+}
+
+// focusableByLeaf returns the identities of the focusable shapes this
+// frame stamped for one leaf, sorted so the message is the same on
+// every run. It reads what the audit walk collected rather than the
+// window's tree, so the finding describes the frame it inspected.
+func focusableByLeaf(ids *debugIDs, leaf string) []string {
+	var out []string
+	for id := range ids.focusable {
+		if lastIDSegment(id) == leaf {
+			out = append(out, id)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// debugCheckFocusTarget reports a focus ID that names no focusable
+// shape in the frame.
+//
+// The message offers the effective IDs the frame did stamp for the
+// same leaf, because the usual cause is a leaf spelled without its
+// scope and the right answer is one short string away.
+func (w *Window) debugCheckFocusTarget(ids *debugIDs) {
+	if DebugCategory(debugMask.Load())&DebugUnknownFocus == 0 {
+		return
+	}
+	id := w.viewState.focusID
+	if id == "" {
+		return
+	}
+	if _, ok := ids.focusable[id]; ok {
+		return
+	}
+	hint := "no widget of that name is in this frame"
+	if _, claimed := ids.claimed[id]; claimed {
+		hint = "a shape of that name is in this frame but is not focusable"
+	} else if near := focusableByLeaf(ids, lastIDSegment(id)); len(near) > 0 {
+		hint = "the frame stamped " + strings.Join(near, ", ") +
+			" for that leaf"
+	}
+	w.debugWarn(debugCheckUnknownFocus, id,
+		"focus is set to %q but nothing focusable in the frame claims "+
+			"it, so the keyboard has nowhere to go; %s. SetFocus takes "+
+			"the effective ID — read it back with (*Window).ResolveID.",
+		id, hint)
 }
 
 // debugWalk is the depth-first audit. path is the index chain from
@@ -400,6 +477,10 @@ type debugIDs struct {
 	// appear, so a widget that composes its own absolute ID is absent.
 	// The state-key audit reads it; see debug_state_keys.go.
 	scoped map[string]string
+	// focusable holds the identity of every shape the focus system can
+	// land on, so the focus-target check can tell "no such widget" from
+	// "a widget of that name exists but cannot take focus".
+	focusable map[string]struct{}
 }
 
 // noteScoped records a leaf that an ancestor join rewrote. The first
@@ -428,6 +509,12 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids *debugIDs) {
 		// the string the stores and the public APIs use.
 		key := s.idKey()
 		ids.noteScoped(s.ID, key)
+		if s.Focusable {
+			if ids.focusable == nil {
+				ids.focusable = make(map[string]struct{})
+			}
+			ids.focusable[key] = struct{}{}
+		}
 		if first, dup := ids.claimed[key]; dup {
 			w.debugWarn(debugCheckDupID, key,
 				"duplicate ID %q at %s, first claimed at %s; ID is the "+

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -259,6 +259,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckDeferredLoop, DebugCallbacks},
 		{debugCheckWindowTransparency, DebugWindowDegraded},
 		{debugCheckUnresolvedKey, DebugUnresolvedKeys},
+		{debugCheckUnknownFocus, DebugUnknownFocus},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
@@ -268,7 +269,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 	// DebugAll covers every category Debug(true) turns on.
 	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
 	// a design property, not a defect.
-	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow|DebugCallbacks|DebugWindowDegraded|DebugUnresolvedKeys {
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow|DebugCallbacks|DebugWindowDegraded|DebugUnresolvedKeys|DebugUnknownFocus {
 		t.Fatal("DebugAll must cover every category Debug(true) enables")
 	}
 	if DebugAll&DebugUnscopedIDs != 0 {

--- a/gui/id_query.go
+++ b/gui/id_query.go
@@ -1,0 +1,98 @@
+package gui
+
+import "strings"
+
+// Reading effective IDs back out of a frame.
+//
+// Every public API that addresses a widget — SetFocus, FindByID,
+// ScrollVerticalTo, the Test* helpers — takes the *effective* ID, and
+// an app author writes only the leaf. The join rule is documented and
+// deterministic, but spelling the result by hand means reading one's
+// own View tree for the ID-bearing ancestors, and a wrong spelling
+// fails in silence: SetFocus on an unknown ID focuses nothing and
+// ScrollVerticalTo writes an offset no scrollable reads.
+//
+// These two functions answer from the frame instead. They read the
+// arranged tree, which carries the identity the resolve pass actually
+// stamped, so the answer is what the addressing APIs expect rather
+// than a second implementation of the rule. See issue #521.
+
+// EffectiveIDs returns every effective ID in the last laid-out frame,
+// in tree order, with duplicates kept.
+//
+// Use it to see what a window is addressable by. Duplicates are kept
+// because two shapes sharing an identity is a defect the addressing
+// APIs cannot express — [Window.TestDuplicateIDs] reports it — and
+// hiding it here would make this the one view that looks clean.
+//
+// The list is empty before the first frame is laid out: identities are
+// stamped during arrange, so a window that has never rendered has
+// none.
+// exportaudit:keep — dev-diagnostic API for app authors (issue #521)
+func (w *Window) EffectiveIDs() []string {
+	if w == nil {
+		return nil
+	}
+	var ids []string
+	collectEffectiveIDs(&w.layout, &ids)
+	return ids
+}
+
+// ResolveID returns the effective IDs the last laid-out frame stamped
+// for a widget written with the given leaf.
+//
+// It is the direct answer to "I wrote ID: \"nav\", what do I pass to
+// SetFocus?". A leaf under a panel with ID "detail" answers
+// ["detail:nav"]; a top-level one answers ["nav"].
+//
+// A shape matches when its identity is the leaf itself, or when the
+// last segment of its identity is the leaf. The second form is needed
+// because a widget that resolves its own ID — the datagrid, and every
+// factory that writes cfg.ID = w.EffID(cfg.ID) — puts the already
+// joined string on the shape, so there is no bare leaf left to compare
+// against.
+//
+// More than one answer means the leaf is used under more than one
+// scope, which is legal, and the caller must pick the scope it meant.
+// No answer means no widget of that name is in the current frame:
+// either the spelling is wrong or the widget is not rendered.
+// exportaudit:keep — dev-diagnostic API for app authors (issue #521)
+func (w *Window) ResolveID(leaf string) []string {
+	if w == nil || leaf == "" {
+		return nil
+	}
+	var out []string
+	for _, id := range w.EffectiveIDs() {
+		if id == leaf || lastIDSegment(id) == leaf {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// lastIDSegment returns the part of an effective ID after the final
+// IDSep, which is the leaf its Cfg was written with.
+func lastIDSegment(id string) string {
+	if i := strings.LastIndex(id, IDSep); i >= 0 {
+		return id[i+len(IDSep):]
+	}
+	return id
+}
+
+// collectEffectiveIDs appends the identity of every ID-bearing shape
+// in one tree. An ID-less shape has no identity and is skipped, but
+// its children are still walked: an ID-less container adds no scope
+// and does not hide what is under it.
+func collectEffectiveIDs(layout *Layout, out *[]string) {
+	if layout == nil {
+		return
+	}
+	if layout.Shape != nil {
+		if key := layout.Shape.idKey(); key != "" {
+			*out = append(*out, key)
+		}
+	}
+	for i := range layout.Children {
+		collectEffectiveIDs(&layout.Children[i], out)
+	}
+}

--- a/gui/id_query_test.go
+++ b/gui/id_query_test.go
@@ -1,0 +1,161 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+)
+
+// scopedIDTree builds an arranged-looking tree: a panel with an ID and
+// one focusable leaf under it, resolved the way layoutArrange would
+// have resolved them.
+func scopedIDTree() Layout {
+	leaf := &Shape{ID: "nav", Focusable: true}
+	leaf.effID = "detail:nav"
+	panel := &Shape{ID: "detail"}
+	panel.effID = "detail"
+	root := Layout{Shape: &Shape{}}
+	root.Children = append(root.Children, Layout{
+		Shape:    panel,
+		Children: []Layout{{Shape: leaf}},
+	})
+	return root
+}
+
+// The identities the frame stamped, in tree order, with the ID-less
+// root left out.
+func TestEffectiveIDsListsTheFrame(t *testing.T) {
+	w := &Window{}
+	w.layout = scopedIDTree()
+
+	got := w.EffectiveIDs()
+	want := []string{"detail", "detail:nav"}
+	if len(got) != len(want) {
+		t.Fatalf("EffectiveIDs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("EffectiveIDs() = %v, want %v", got, want)
+		}
+	}
+}
+
+// A window that has never rendered has no identities to report, and
+// must answer with an empty list rather than panic on a nil tree.
+func TestEffectiveIDsBeforeFirstFrame(t *testing.T) {
+	w := &Window{}
+	if got := w.EffectiveIDs(); len(got) != 0 {
+		t.Fatalf("want no identities before the first frame, got %v", got)
+	}
+}
+
+// The question the API exists for: the app wrote ID "nav", and needs
+// the string SetFocus takes.
+func TestResolveIDAnswersTheScopedSpelling(t *testing.T) {
+	w := &Window{}
+	w.layout = scopedIDTree()
+
+	got := w.ResolveID("nav")
+	if len(got) != 1 || got[0] != "detail:nav" {
+		t.Fatalf(`ResolveID("nav") = %v, want ["detail:nav"]`, got)
+	}
+}
+
+// A widget that resolved its own ID puts the joined string on the
+// shape, so there is no bare leaf on the tree to match. The trailing
+// segment is what makes the lookup work anyway.
+func TestResolveIDMatchesASelfResolvedWidget(t *testing.T) {
+	s := &Shape{ID: "detail:grid"}
+	s.effID = "detail:grid"
+	w := &Window{}
+	w.layout = debugTree(s)
+
+	got := w.ResolveID("grid")
+	if len(got) != 1 || got[0] != "detail:grid" {
+		t.Fatalf(`ResolveID("grid") = %v, want ["detail:grid"]`, got)
+	}
+}
+
+// A leaf used under two scopes has two answers, and the caller picks.
+func TestResolveIDReportsEveryScope(t *testing.T) {
+	a := &Shape{ID: "name"}
+	a.effID = "settings:name"
+	b := &Shape{ID: "name"}
+	b.effID = "profile:name"
+	w := &Window{}
+	w.layout = debugTree(a, b)
+
+	got := w.ResolveID("name")
+	if len(got) != 2 || got[0] != "settings:name" || got[1] != "profile:name" {
+		t.Fatalf("ResolveID(\"name\") = %v, want both scopes", got)
+	}
+}
+
+// A name no widget carries answers with nothing rather than a guess.
+func TestResolveIDUnknownLeafIsEmpty(t *testing.T) {
+	w := &Window{}
+	w.layout = scopedIDTree()
+
+	if got := w.ResolveID("missing"); len(got) != 0 {
+		t.Fatalf("want no answer for an unknown leaf, got %v", got)
+	}
+}
+
+// The defect this reports: focus set to the unscoped spelling of a
+// scoped widget. The finding must name the string that would work.
+func TestUnknownFocusReportsTheScopedSpelling(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll)
+	w := &Window{}
+	w.layout = scopedIDTree()
+	w.viewState.focusID = "nav"
+
+	w.debugAudit(&w.layout)
+
+	got := buf.String()
+	if !strings.Contains(got, `focus is set to "nav"`) ||
+		!strings.Contains(got, "detail:nav") {
+		t.Fatalf("want a finding naming both spellings, got %q", got)
+	}
+}
+
+// The correct spelling is silent.
+func TestUnknownFocusCorrectSpellingIsQuiet(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll)
+	w := &Window{}
+	w.layout = scopedIDTree()
+	w.viewState.focusID = "detail:nav"
+
+	w.debugAudit(&w.layout)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}
+
+// A shape of that name exists but cannot take focus. That is a
+// different mistake from a misspelling, so it gets its own wording.
+func TestUnknownFocusNamesANonFocusableShape(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll)
+	w := &Window{}
+	w.layout = scopedIDTree()
+	w.viewState.focusID = "detail"
+
+	w.debugAudit(&w.layout)
+
+	if got := buf.String(); !strings.Contains(got, "is not focusable") {
+		t.Fatalf("want the not-focusable wording, got %q", got)
+	}
+}
+
+// No focus is not a finding: a window with nothing focused is the
+// normal state at startup.
+func TestUnknownFocusEmptyFocusIsQuiet(t *testing.T) {
+	buf := captureDebugMask(t, DebugAll)
+	w := &Window{}
+	w.layout = scopedIDTree()
+
+	w.debugAudit(&w.layout)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("want no findings, got %q", got)
+	}
+}

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -284,6 +284,10 @@ func (w *Window) scrollHorizontalBy(id string, delta float32) {
 
 // ScrollHorizontalTo scrolls the given scrollable to offset
 // (negative).
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollHorizontalTo(id string, offset float32) {
 	scrollSmoothCancel(w, id, scrollAxisX)
 	sx := w.scrollX()
@@ -362,6 +366,10 @@ func (w *Window) scrollVerticalBy(id string, delta float32) {
 
 // ScrollVerticalTo scrolls the given scrollable to offset
 // (negative).
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollVerticalTo(id string, offset float32) {
 	scrollSmoothCancel(w, id, scrollAxisY)
 	sy := w.scrollY()
@@ -388,6 +396,10 @@ func (w *Window) scrollVerticalToSmooth(id string, offset float32) {
 // ScrollVerticalToPct scrolls to a vertical percentage.
 // pct: 0.0 = top, 1.0 = bottom. Clamped to [0, 1].
 // No-op if the scroll id is not found or content fits viewport.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollVerticalToPct(id string, pct float32) {
 	ly, ok := findLayoutByScrollID(&w.layout, id)
 	if !ok {
@@ -405,6 +417,10 @@ func (w *Window) ScrollVerticalToPct(id string, pct float32) {
 // ScrollVerticalOffset returns the current vertical scroll offset of
 // the given scrollable: <= 0, where 0 is the top. Unknown ids read
 // as 0 (unscrolled).
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollVerticalOffset(id string) float32 {
 	// Default 0: unscrolled position when no offset recorded yet.
 	return w.scrollY().GetOr(id, 0)
@@ -413,6 +429,10 @@ func (w *Window) ScrollVerticalOffset(id string) float32 {
 // ScrollVerticalPct returns the current vertical scroll
 // position as a percentage (0.0 = top, 1.0 = bottom).
 // Returns 0 if not found or content fits viewport.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollVerticalPct(id string) float32 {
 	ly, ok := findLayoutByScrollID(&w.layout, id)
 	if !ok {

--- a/gui/scroll_index.go
+++ b/gui/scroll_index.go
@@ -61,6 +61,10 @@ func (w *Window) ScrollToIndex(id string, index int) {
 
 // ScrollToIndexAt scrolls the given list so item index lands at frac
 // of the viewport: 0 top, 0.5 middle, 1 bottom. Main goroutine only.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollToIndexAt(id string, index int, frac float32) {
 	w.scrollIndexRequest(id, index, virtualScrollAt,
 		f32Clamp(frac, 0, 1))
@@ -70,6 +74,10 @@ func (w *Window) ScrollToIndexAt(id string, index int, frac float32) {
 // brings item index fully into the viewport, and does nothing when it
 // is already visible. This is the one to call when moving a selection
 // with the arrow keys. Main goroutine only.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 // exportaudit:keep — the selection-following form of the index API
 func (w *Window) ScrollIndexIntoView(id string, index int) {
 	w.scrollIndexRequest(id, index, virtualScrollIntoView, 0)
@@ -79,6 +87,10 @@ func (w *Window) ScrollIndexIntoView(id string, index int) {
 // differs from ScrollVerticalToPct(id, 1) under virtualization, where
 // the content height is assembled from spacers over an estimated row
 // height and a percentage therefore drifts. Main goroutine only.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollToEnd(id string) {
 	w.scrollIndexRequest(id, 0, virtualScrollEnd, 0)
 }

--- a/gui/testing.go
+++ b/gui/testing.go
@@ -210,6 +210,10 @@ func testHitPoint(ly *Layout, id string) (x, y float32, err error) {
 // Returns ErrTestNoHandler when the widget has neither an OnClick, an
 // OnMouseDown nor focusability, since a click on such a widget cannot
 // have any effect worth asserting on.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) TestClick(id string) error {
 	ly, err := w.testTarget(id)
 	if err != nil {
@@ -283,6 +287,10 @@ func (w *Window) testFocus(id string) error {
 // global commands, tab traversal and container scrolling — "nothing
 // consumed it" is normal, not a defect. Assert on the state change
 // instead.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) TestKey(id string, key KeyCode, mods Modifier) error {
 	if err := w.testFocus(id); err != nil {
 		return err
@@ -302,6 +310,10 @@ func (w *Window) TestKey(id string, key KeyCode, mods Modifier) error {
 // Character events, not key events: typing is EventChar, and an input
 // that only handled EventKeyDown would wrongly appear to work if this
 // sent key codes. Empty text focuses the widget and delivers nothing.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) TestType(id string, text string) error {
 	if err := w.testFocus(id); err != nil {
 		return err
@@ -364,6 +376,10 @@ func (w *Window) testTab(dir TabDirection) (focusedID string, err error) {
 // container whose content already fits, and ErrTestUnhandled when the
 // event reached no one — including the case where it fell through to a
 // scrollable already pinned at its limit.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) TestScroll(id string, dx, dy float32) error {
 	ly, err := w.testTarget(id)
 	if err != nil {
@@ -438,6 +454,10 @@ func testScrollRoomErr(ly *Layout, id string, dx, dy float32) error {
 // non-scrollable widget has no offset rather than an offset of zero, and
 // silently reporting 0 would make an over-scroll assertion pass for the
 // wrong reason.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) TestScrollOffset(id string) (x, y float32, err error) {
 	ly, err := w.testTarget(id)
 	if err != nil {

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -254,6 +254,10 @@ func datePickerGetState(w *Window, cfg *DatePickerCfg) datePickerState {
 }
 
 // DatePickerReset clears the state for a date picker instance.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) DatePickerReset(id string) {
 	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
 	sm.Delete(id)

--- a/gui/view_virtual_list_build.go
+++ b/gui/view_virtual_list_build.go
@@ -261,12 +261,20 @@ func virtualListMeasure(m *listHeightModel) func(EventCtx) {
 // keyboard navigation currently sits on. ItemView reads it to render
 // the focused row — an unbuilt row has no shape to hold focus, so the
 // focus lives on the list and is expressed as an index.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) VirtualListFocusedIndex(id string) int {
 	return StateReadOr(w, nsVirtualListFocus, id, 0)
 }
 
 // SetVirtualListFocusedIndex moves a virtual list's keyboard focus to
 // index and scrolls it into view. Main goroutine only.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 // exportaudit:keep — the write half of the focused-index pair
 func (w *Window) SetVirtualListFocusedIndex(id string, index int) {
 	StateMap[string, int](w, nsVirtualListFocus, capModerate).

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -4,7 +4,9 @@ import "time"
 
 // window_focus.go — keyboard focus management.
 
-// FocusID returns the current focus ID.
+// FocusID returns the current focus ID. The value is an effective ID,
+// so it is already in the form [Window.SetFocus] and [Layout.FindByID]
+// take.
 func (w *Window) FocusID() string {
 	return w.viewState.focusID
 }
@@ -15,6 +17,10 @@ func (w *Window) FocusID() string {
 // (focusID); the caret-blink animation is managed from the render
 // pass, not here (see syncBlinkCursor). Use ClearFocus to remove
 // focus.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) SetFocus(id string) {
 	w.lockForAPI("SetFocus")
 	defer w.mu.Unlock()
@@ -73,6 +79,10 @@ func resetBlinkCursorVisible(w *Window) {
 }
 
 // IsFocus tests if the given focus id equals the window's focus id.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) IsFocus(id string) bool {
 	return w.viewState.focusID != "" && w.viewState.focusID == id
 }


### PR DESCRIPTION
## Summary

Closes #521. Last item in the effective-ID chain (#518 → #519 → #520 → #521).

Every addressing API (`SetFocus`, `FindByID`, `ScrollVerticalTo`, `Test*`)
takes the **effective** ID, but an app author writes only the leaf. The
join rule is documented and deterministic, but spelling the result by
hand means reading the View tree for ID-bearing ancestors, and a wrong
spelling fails silently: `SetFocus` on an unknown ID focuses nothing.

- **`(*Window).ResolveID(leaf)`** answers with the identities the last
  frame stamped for that leaf (`ResolveID("nav")` → `["detail:nav"]`).
  Matches on the trailing segment too, so it works for a widget that
  already resolved its own ID (datagrid, deferred factories).
- **`(*Window).EffectiveIDs()`** lists every identity in the frame, tree
  order. Both read the arranged tree, so they can't drift from the join
  rule — they're not a second implementation of it.
- **`gui.DebugUnknownFocus`** (added to `DebugAll`): reports a frame that
  ends with a focus ID nothing focusable claims. Runs from the frame
  audit, not from `SetFocus`, because focusing a widget the current frame
  is still building is legitimate. The message names the spelling the
  frame did stamp for that leaf.
- Doc line added to 19 public ID-taking APIs pointing at `ResolveID`.

**Scope decision:** the issue's item 3 also considered an unknown-ID
report from `ScrollVerticalTo`. Left out deliberately — a scroll offset
legitimately outlives the widget it belongs to (a list scrolls, then
unmounts), so an equivalent scroll audit would fire on correct code.
Scroll gets the doc line instead of a check.

## Test plan

- [x] 10 new tests in `gui/id_query_test.go`; verified to discriminate
      (stubbing the check body reds exactly the two focus-check tests)
- [x] `make prepush`: 0 lint issues on 4 platforms, coverage 84.9% ≥ 70%,
      all per-package floors met, export-audit clean
- [x] Sibling repos (go-charts, go-edit, go-kite, go-term, go-map,
      go-speedtest) grepped for `TestFindings|DebugAll`: 0 hits, so
      widening `DebugAll` cannot red a sibling's tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)