### PR TITLE
fix(gui): resolve WithTooltip and Menubar IDs at generation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,22 @@ and this project adheres to
 
 ### Fixed
 
+- **WithTooltip and Menubar now resolve their IDs at generation time** (#528) —
+  the last two widgets of the class #518, #519 and #520 fixed. Both took a
+  `*Window` and built eagerly in the factory body, which runs while the parent's
+  `Content` slice is assembled — before the framework descends into the
+  container the widget will sit in. `WithTooltip` therefore called `w.EffID`
+  against the enclosing scope, so the same tooltip text in two ID-bearing panels
+  shared one hover entry, and `Menubar` never resolved at all, keying selection,
+  focus and its AmendLayout closure on the bare leaf while its own shape
+  resolved under the panel. Each now defers the build behind the documented
+  pattern, so the resolve happens with the scope live.
+
+  **Behavior change.** A tooltip or menubar inside an ID-bearing ancestor now
+  carries the effective ID it always should have, so a hand-spelled
+  `SetFocus("bar")` on a scoped menubar must become `SetFocus("panel:bar")`.
+  Both are window-global in the common case, where nothing changes.
+
 - **Sidebar, InputDate and Table now resolve their IDs at generation time**
   (#518) — all three built eagerly in the `(*Window)` factory, which runs
   _before_ `generateViewLayout` descends the View tree. The ID scope stack is

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -81,9 +81,23 @@ implementation, and the code is the authority.
    `(*Window).EffID` is unchanged and still necessary: a widget that reads its
    own state inside `GenerateLayout` cannot wait for its own shape to be
    stamped. It joins the same ambient scope through the same `resolveLeaf`. The
-   eager-factory failure (#528) is also unchanged — a factory body runs before
-   the descent that opens its scope, so there is nothing to stamp yet, and
-   `DebugUnresolvedKeys` still reports it.
+   eager-factory failure is also unchanged — a factory body runs before the
+   descent that opens its scope, so there is nothing to stamp yet, and
+   `DebugUnresolvedKeys` still reports it (see point 6).
+
+6. **The last two eager factories are gone** (#528, 2026-09-06). `WithTooltip`
+   and `Menubar` were the remainder of the class #518, #519 and #520 addressed,
+   found by auditing every `w.EffID` call site against its enclosing function.
+   `WithTooltip` resolved in the factory body, which runs while the parent's
+   `Content` slice is built, so the tip ID joined the enclosing scope while the
+   popup's shape landed under the panel — two tooltips with the same text in two
+   panels shared one hover entry. `Menubar` resolved nowhere at all: every key
+   was the bare leaf while the `Row` it returns carried an ID that generation
+   joined. Both now defer behind `viewFunc` and resolve inside the deferred
+   build, which is the remedy this spec already prescribes and the one
+   `ContextMenu` and `Table` use. Every remaining `EffID` call site in `gui/`
+   either sits in a `GenerateLayout` method or in a helper that is itself
+   deferred.
 
 Phase A.4 (producer simplification) was applied where a composite's own nesting
 already mirrors `ScopeID(cfg.ID, part)` — combobox and select now set a plain

--- a/gui/view_menubar.go
+++ b/gui/view_menubar.go
@@ -90,10 +90,31 @@ type MenubarCfg struct {
 
 // Menubar creates a horizontal menubar with keyboard
 // navigation.
-func Menubar(w *Window, cfg MenubarCfg) View {
-	applyMenubarDefaults(&cfg)
+//
+// The build is deferred to layout generation, like [ContextMenu]. It is
+// load-bearing rather than a style choice: menubarBuild resolves cfg.ID
+// with [Window.EffID] and keys the selection, the focus check and the
+// AmendLayout closure on the result, and the generation-time ID scope
+// is only live while the framework descends the View tree. Building
+// here would leave those keys as the bare leaf while the bar's own
+// shape resolved under the panel it sits in. See issue #528.
+func Menubar(_ *Window, cfg MenubarCfg) View {
+	// Eager, so a missing ID or a duplicate item ID fails at the call
+	// site rather than a frame later.
 	RequireID("Menubar", cfg.ID)
 	checkForDuplicateMenuIDs(cfg.Items)
+	return viewFunc(func(vw *Window) View {
+		return menubarBuild(vw, cfg)
+	})
+}
+
+// menubarBuild assembles the bar under the ID scope of the panel it
+// sits in.
+func menubarBuild(w *Window, cfg MenubarCfg) View {
+	applyMenubarDefaults(&cfg)
+
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
 
 	// On focus with no selection, select first item.
 	if w.IsFocus(cfg.ID) {

--- a/gui/view_menubar_test.go
+++ b/gui/view_menubar_test.go
@@ -137,3 +137,129 @@ func TestFindMenuByID(t *testing.T) {
 		t.Error("should not find z")
 	}
 }
+
+// menubarInPanels renders one menubar, all named "bar", inside each of
+// the given ID-bearing panels. The bar's identity is therefore
+// "<panel>:bar", which is what every assertion below is about.
+func menubarInPanels(panelIDs ...string) *Window {
+	w := NewTestWindow(WindowCfg{})
+	w.UpdateView(func(vw *Window) View {
+		panels := make([]View, 0, len(panelIDs))
+		for _, id := range panelIDs {
+			panels = append(panels, Column(ContainerCfg{
+				ID: id,
+				Content: []View{
+					// Called while the panel's Content slice is built,
+					// which is the eager-factory position issue #528 is
+					// about.
+					Menubar(vw, MenubarCfg{
+						ID: "bar",
+						Items: []MenuItemCfg{
+							MenuItemText("file", "File"),
+							MenuItemText("edit", "Edit"),
+						},
+					}),
+				},
+			}))
+		}
+		return Column(ContainerCfg{Sizing: FillFill, Content: panels})
+	})
+	return w
+}
+
+// A menubar inside an ID-bearing panel keys its selection on the
+// identity its shape resolves to. Window-global is the common case, not
+// the only one (issue #528).
+func TestMenubarScopesSelectionToPanel(t *testing.T) {
+	w := menubarInPanels("panel")
+	// Focus drives the auto-select branch, which is the write this test
+	// is about.
+	w.SetFocus("panel:bar")
+	root := w.TestRender(nil)
+
+	if _, ok := root.FindByID("panel:bar"); !ok {
+		t.Fatalf("FindByID(%q) = false", "panel:bar")
+	}
+	sm := StateMapRead[string, string](w, nsMenu)
+	if sm == nil {
+		t.Fatal("no menu state written")
+	}
+	if _, stale := sm.Get("bar"); stale {
+		t.Error("selection keyed on the bare leaf \"bar\"")
+	}
+	sel, ok := sm.Get("panel:bar")
+	if !ok || sel != "file" {
+		t.Fatalf("selection under %q = (%q, %v), want (%q, true)",
+			"panel:bar", sel, ok, "file")
+	}
+}
+
+// The same leaf in two panels is two menubars, in one window. Pre-fix
+// both keyed selection on the bare "bar", so the focused bar's
+// auto-select and the unfocused bar's AmendLayout cleanup fought over
+// one entry.
+func TestMenubarSameIDInTwoPanelsIsTwoKeys(t *testing.T) {
+	w := menubarInPanels("a", "b")
+	w.SetFocus("a:bar")
+	w.TestRender(nil)
+
+	sm := StateMapRead[string, string](w, nsMenu)
+	if sm == nil {
+		t.Fatal("no menu state written")
+	}
+	if sel, ok := sm.Get("a:bar"); !ok || sel != "file" {
+		t.Errorf("selection under %q = (%q, %v), want (%q, true)",
+			"a:bar", sel, ok, "file")
+	}
+	// The unfocused twin must not have been given a selection, and
+	// neither bar may key on the bare leaf.
+	if _, ok := sm.Get("b:bar"); ok {
+		t.Error("unfocused menubar in panel b holds a selection")
+	}
+	if _, stale := sm.Get("bar"); stale {
+		t.Error("selection keyed on the bare leaf \"bar\"")
+	}
+}
+
+// The dev-mode gate that reports an unresolved state key must stay quiet
+// for the fixed widget.
+func TestMenubarUnderPanelIsQuiet(t *testing.T) {
+	w := menubarInPanels("panel")
+	w.SetFocus("panel:bar")
+	if found := w.TestFindings(DebugAll); len(found) != 0 {
+		t.Fatalf("findings = %v, want none", found)
+	}
+}
+
+// The build is deferred, but validation is not: a missing ID or a
+// duplicate item ID must still fail where the app wrote the call, not a
+// frame later inside generation. Asserted by never generating.
+func TestMenubarValidatesAtCallSite(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  MenubarCfg
+	}{
+		{"missing ID", MenubarCfg{
+			Items: []MenuItemCfg{MenuItemText("file", "File")},
+		}},
+		{"duplicate item ID", MenubarCfg{
+			ID: "bar",
+			Items: []MenuItemCfg{
+				MenuItemText("file", "File"),
+				MenuItemText("file", "Again"),
+			},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatal("no panic; validation is no longer eager")
+				}
+			}()
+			// The window is unused by the eager half, so a nil one is
+			// enough to show nothing was deferred.
+			Menubar(nil, tc.cfg)
+		})
+	}
+}

--- a/gui/view_tooltip.go
+++ b/gui/view_tooltip.go
@@ -134,7 +134,24 @@ type WithTooltipCfg struct {
 
 // WithTooltip wraps content and shows a tooltip on hover after
 // a delay. Tooltip state is managed via AmendLayout.
-func WithTooltip(w *Window, cfg WithTooltipCfg) View {
+//
+// The build is deferred to layout generation. It is load-bearing
+// rather than a style choice: withTooltipBuild resolves the tip ID
+// with [Window.EffID] and keys the hover state, the popup's own ID and
+// the AmendLayout closure on the result, and the generation-time ID
+// scope is only live while the framework descends the View tree.
+// Building here would resolve against the enclosing scope, so the same
+// label in two ID-bearing panels would share one hover entry. See
+// issue #528.
+func WithTooltip(_ *Window, cfg WithTooltipCfg) View {
+	return viewFunc(func(w *Window) View {
+		return withTooltipBuild(w, cfg)
+	})
+}
+
+// withTooltipBuild assembles the wrapper under the ID scope of the
+// panel it sits in.
+func withTooltipBuild(w *Window, cfg WithTooltipCfg) View {
 	tipID := cfg.ID
 	if tipID == "" {
 		tipID = cfg.Text

--- a/gui/view_tooltip_test.go
+++ b/gui/view_tooltip_test.go
@@ -343,3 +343,99 @@ func TestTooltipExplicitTopLeft(t *testing.T) {
 			layout.Shape.FloatAnchor)
 	}
 }
+
+// tooltipPanel names one panel and the tooltip inside it. An empty
+// tipID exercises the fallback to the label text as the leaf.
+type tooltipPanel struct {
+	panelID string
+	tipID   string
+	text    string
+}
+
+// tooltipsInPanels renders one tooltip wrapper inside each ID-bearing
+// panel, with the mouse parked inside the first panel's trigger so that
+// wrapper's AmendLayout runs hovered and every later one runs outside.
+// The trigger is a fixed-size rectangle so the hit test does not depend
+// on text measurement, which is a nil-measurer approximation in tests.
+func tooltipsInPanels(panels ...tooltipPanel) *Window {
+	w := NewTestWindow(WindowCfg{})
+	w.viewState.mousePosX = 60
+	w.viewState.mousePosY = 60
+	w.UpdateView(func(vw *Window) View {
+		views := make([]View, 0, len(panels))
+		for _, p := range panels {
+			views = append(views, Column(ContainerCfg{
+				ID: p.panelID,
+				Content: []View{
+					// Called while the panel's Content slice is built,
+					// which is the eager-factory position issue #528 is
+					// about.
+					WithTooltip(vw, WithTooltipCfg{
+						ID:   p.tipID,
+						Text: p.text,
+						Content: []View{
+							Rectangle(RectangleCfg{
+								Width:  100,
+								Height: 50,
+								Sizing: FixedFixed,
+							}),
+						},
+					}),
+				},
+			}))
+		}
+		return Column(ContainerCfg{Sizing: FillFill, Content: views})
+	})
+	return w
+}
+
+// A tooltip built inside an ID-bearing panel must key its hover state on
+// the identity its own shape resolves to, not on the scope of whatever
+// was being built when the factory ran (issue #528).
+func TestWithTooltipScopesHoverStateToPanel(t *testing.T) {
+	w := tooltipsInPanels(tooltipPanel{"panel", "tip1", "hello"})
+	w.TestRender(nil)
+
+	if got := w.viewState.tooltip.hoverID; got != "panel:tip1" {
+		t.Fatalf("hover key = %q, want %q", got, "panel:tip1")
+	}
+}
+
+// The same label in two panels is two tooltips, in one window. Pre-fix
+// both wrappers keyed hover on the bare "hello": the second wrapper saw
+// its own tipID in ts.hoverID while the mouse was outside it and cleared
+// the first wrapper's hover. The observable result is that hovering a
+// tooltip did nothing whenever a same-labelled twin existed elsewhere.
+func TestWithTooltipSameTextInTwoPanelsIsTwoKeys(t *testing.T) {
+	w := tooltipsInPanels(
+		tooltipPanel{panelID: "a", text: "hello"},
+		tooltipPanel{panelID: "b", text: "hello"},
+	)
+	w.TestRender(nil)
+
+	if got := w.viewState.tooltip.hoverID; got != "a:hello" {
+		t.Fatalf("hover key = %q, want %q", got, "a:hello")
+	}
+}
+
+// The popup's own shape resolves under the panel too, so the identity
+// and the state key are one string.
+func TestWithTooltipPopupIDResolvesUnderPanel(t *testing.T) {
+	w := tooltipsInPanels(tooltipPanel{"panel", "tip1", "hello"})
+	w.viewState.tooltip.id = "panel:tip1"
+	w.viewState.tooltip.popupID = ScopeID("panel:tip1", "popup")
+	root := w.TestRender(nil)
+
+	if _, ok := root.FindByID("panel:tip1:popup"); !ok {
+		t.Fatalf("FindByID(%q) = false", "panel:tip1:popup")
+	}
+}
+
+// The dev-mode gate that reports an eagerly resolved key must stay quiet
+// for the fixed widget.
+func TestWithTooltipUnderPanelIsQuiet(t *testing.T) {
+	w := tooltipsInPanels(tooltipPanel{"panel", "tip1", "hello"})
+	if found := w.TestFindings(DebugAll); len(found) != 0 {
+		t.Fatalf("findings = %v, want none", found)
+	}
+}


### PR DESCRIPTION
## Summary

`WithTooltip` and `Menubar` build eagerly in the factory body, before the
framework descends into the panel they sit in. `WithTooltip` calls
`w.EffID(tipID)` too early, joining the enclosing scope instead of its
own; `Menubar` never calls `EffID` at all. Same class of bug as #518,
#519, #520 — the last two eager-factory sites in `gui/`.

Fix: defer the build behind `viewFunc` and resolve inside it, matching
the existing `ContextMenu`/`Table` pattern.

Fixes #528

## Test plan

- [x] `TestMenubarScopesSelectionToPanel`, `TestMenubarSameIDInTwoPanelsIsTwoKeys`, `TestMenubarUnderPanelIsQuiet`, `TestMenubarValidatesAtCallSite` (new)
- [x] `TestWithTooltipScopesHoverStateToPanel`, `TestWithTooltipSameTextInTwoPanelsIsTwoKeys`, `TestWithTooltipPopupIDResolvesUnderPanel`, `TestWithTooltipUnderPanelIsQuiet` (new)
- [x] Regressions recorded pre-fix (state written on bare leaf / findings present), confirmed fixed post-fix
- [x] `go build ./...`, `go test ./...`, `golangci-lint run ./...` clean
- [x] `make prepush` full gate green (race tests, lint, vet, cross-compile, coverage, export audit)
- [x] No golden test churn
- [x] Live `GOGUI_DEBUG=1` check on `examples/showcase/` — no `EffID(` findings on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)