### PR TITLE
docs(gui): record that ctx.EffID keeps its argument (#526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ and this project adheres to
 
 ### Changed
 
+- **`EventCtx.EffID` keeps its argument** (#526) — documentation only, no API
+  change. #518 left open a `ctx.Key()` that would read the handler's own stamped
+  identity and retire `ctx.EffID(leaf)`. An audit of every call site shows the
+  seam never resolves the handler's own shape: it resolves a leaf naming a shape
+  at or above the handler, and the handler's shape is often ID-less, so
+  `ctx.Key()` would have replaced nothing. A rename was rejected as well — the
+  seam is a kept public export, and the fallback branch joins a scope rather
+  than finding an ancestor. The doc comment now states that contract, and
+  `docs/specs/widget-id-per-scope-uniqueness.md` records the decision.
+
 - **Effective IDs are stamped once, during layout generation** (#527) — identity
   used to be computed twice from the same information: `appendChildViews` knew a
   shape's exact scope while generating it and threw the answer away, then

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -323,6 +323,13 @@ one state slot.
 The remedy is a resolved key: `w.EffID(cfg.ID)` during `GenerateLayout`, or
 `ctx.EffID(leaf)` in a handler.
 
+The two seams are not interchangeable. `w.EffID(cfg.ID)` takes a leaf in the
+**current** scope and joins it. `ctx.EffID(leaf)` takes a leaf captured at build
+time that names a shape **at or above** the handler, and searches the ancestor
+chain for it — which is why a handler attached to an ID-less shape can still
+resolve its owner's key. Pass the leaf the owner was written with, not the
+handler's own (issue #526).
+
 **Resolve during `GenerateLayout`, never in a factory body.** A factory runs
 while the parent's `Content` slice is being built, which is before the framework
 descends into the container the widget will sit in. `w.EffID` there joins the

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -99,6 +99,24 @@ implementation, and the code is the authority.
    either sits in a `GenerateLayout` method or in a helper that is itself
    deferred.
 
+7. **`EventCtx.EffID` keeps its argument** (#526, 2026-09-06). #518 left a
+   second option open: stamp the resolved ID on the shape and give handlers a
+   `ctx.Key()` that reads it, retiring `ctx.EffID(leaf)` "for the common case
+   where the leaf names the handler's own shape". That case does not exist. All
+   ten non-test call sites resolve a leaf naming a shape **at or above** the
+   handler — a scrollbar resolves the scrollable ancestor it drives, and
+   `inputOnClick` sits on an ID-less inner row and resolves the outer
+   container's leaf — so `ctx.Key()` would have replaced none of them and would
+   have become a second seam beside the one it was meant to retire. A rename was
+   rejected too: the seam is `exportaudit:keep`, so it costs either a break for
+   third-party widget code or a deprecated alias, and a name like
+   `ResolveAncestorID` would misdescribe the fallback branch, which joins the
+   nearest scope for a leaf that names no ancestor at all. The trap the option
+   was meant to close is now covered by `DebugUnresolvedKeys` (#520) and
+   `DebugUnknownFocus` (#521), which report the bare-leaf key and the unclaimed
+   focus ID respectively. The doc comment on `EffID` states the contract
+   instead.
+
 Phase A.4 (producer simplification) was applied where a composite's own nesting
 already mirrors `ScopeID(cfg.ID, part)` — combobox and select now set a plain
 `"dropdown"` leaf. Composites whose inner IDs are reverse-parsed or whose owner

--- a/gui/event_ctx.go
+++ b/gui/event_ctx.go
@@ -41,6 +41,14 @@ func (c EventCtx) handled() bool {
 // EffID resolves a leaf ID a handler closed over to the effective ID
 // the framework's stores are keyed by (see gui/id_resolve.go).
 //
+// This is not "resolve my own ID", and there is no argument-free form of it.
+// The leaf names a shape at or above the handler, and the handler's own shape
+// frequently carries no ID at all: Input attaches its click handler to an
+// ID-less inner row and resolves the leaf of the outer container, and a
+// scrollbar resolves the leaf of the scrollable ancestor it drives. Reading an
+// identity off ctx.Layout would answer "" in both cases, so the argument is
+// load-bearing (issue #526).
+//
 // A widget factory that builds its tree eagerly — Input, for one — has
 // no Window when it captures cfg.ID, so it cannot call
 // [Window.EffID] at generation time. Its handlers resolve here instead:


### PR DESCRIPTION
## Summary

Closes #526 with a "record and close" outcome — no API change.

#518 left a follow-up option open: replace `ctx.EffID(leaf)` with a
`ctx.Key()` that reads the handler's own stamped `Shape.effID`,
deprecating `ctx.EffID` "for the common case where the leaf names the
handler's own shape."

An audit of every non-test `ctx.EffID` call site (10, across
`view_scrollbar.go`, `view_input.go`, `view_input_handlers.go`) shows
that case does not exist: every site resolves a leaf naming a shape
**at or above** the handler (a scrollbar resolves the scrollable
ancestor it drives; `inputOnClick` sits on an ID-less inner row and
resolves the outer container's leaf). `ctx.Key()` would replace zero
of them.

A rename was also considered and rejected: `EventCtx.EffID` is
`exportaudit:keep`, so a rename costs either a break for third-party
widget code or a permanent second name, and a candidate like
`ResolveAncestorID` would misdescribe the fallback branch, which joins
the nearest scope for a leaf naming no ancestor at all.

## Changes (docs + comment only, no logic)

- `gui/event_ctx.go` — tightens the `EffID` doc comment to state the
  contract plainly: not "resolve my own ID", the argument is
  load-bearing, there's no zero-arg form.
- `docs/specs/widget-id-per-scope-uniqueness.md` — new item 7 recording
  the decision and why.
- `docs/dx-cheat-sheet.md` — distinguishes `w.EffID` (current scope)
  from `ctx.EffID` (leaf naming an ancestor, searched at dispatch time).
- `CHANGELOG.md` — Unreleased → Changed entry.

## Verification

- `make prepush` — full gate (race tests, lint, vet, cross-compile,
  coverage, export audit) — clean.
- `git diff --stat` — 4 files, +43/-0, no `.go` logic changed (comment
  lines only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)