### PR TITLE
docs: fix stale and missing content across all docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@ Guidance for Claude Code (claude.ai/code) in this repo.
 ```
 go run ./examples/get_started/  # run the example app
 make prepush                    # full gate (race, cross-lint, cross-compile, coverage, export audit)
-make check-all                  # test + lint + vet (what .githooks/pre-push runs)
-make check                      # fast subset (vet, deps-doc, large-files, generate/tidy/fmt-md checks)
+make check-all                  # test + lint + check (.githooks/pre-push runs this)
+make check                      # fast gate (vet, deps-doc, large-files, generate/tidy/fmt-md/changelog checks)
 make test / lint / vet          # individually
 make fmt-md                     # Prettier over tracked .md (.prettierrc holds the flags)
-make ergonomics-audit           # focus/callbacks inventory + ID/a11y/theme/visual/literals/deadcfg gates
+make ergonomics-audit           # focus/callbacks/opt/ids/literals/theme/a11y/visual/deadcfg gates
 make export-audit               # exported surface (advisory in-repo)
 ./scripts/large-files.sh        # Go files >800 lines in gui/
 git config core.hooksPath .githooks  # enable tracked hooks
@@ -63,9 +63,10 @@ silent no-op. The `requiredid` analyzer flags it; `gui.Debug` reports it at
 runtime.
 
 **Input controls are focusable by default; opt out with `FocusDisabled`, never
-with `Focusable: false`.** Sixteen input Cfgs default on (Button, Input, Select,
-Slider, Tree, …); everything else is opt-in via `Focusable: true`. Current
-inventory: `ergonomics-audit -mode focus`. See
+with `Focusable: false`.** Twenty Cfgs default on (Button, Input, Select,
+Slider, Tree, Combobox, DatePicker, ListBox, … — full list in
+`docs/architecture.md`); everything else is opt-in via `Focusable: true`.
+Current inventory: `ergonomics-audit -mode focus`. See
 `docs/specs/focusable-default-input.md`.
 
 **`Shape.ID` is a leaf; identity is the effective ID.** Layout **generation**
@@ -269,6 +270,11 @@ walks the composed tree every frame and reports to stderr (`gui/debug.go`):
 - `OnMouseLeave` with no `ID` (callback never fires)
 - a scrollable listbox that resolved to height 0
 - a container setting both `Wrap` and `Overflow` (wrap wins)
+- a fill gradient with more stops than the GPU shader limit (silently resampled)
+- a window-level feature the platform refused (no ARGB visual, no compositor,
+  refused opacity)
+- a shape whose stamp disagrees with its scope, or an ID-bearing shape with no
+  stamp (`DebugStampDrift` — a hand-built `Layout` in a generated tree)
 - a callback that acted without `ctx.Consume()` while an ancestor also handles
 - a link the user activated that opened nothing (unknown anchor, relative link,
   failed platform opener)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,27 +111,22 @@ the bare read is also what makes `gui.Themed` subtree scoping work.
 
 1. Fork, create a feature branch, make focused commits.
 2. Add or update tests.
-3. Run `make prepush` (fast subset: `make check`).
+3. Run `make check-all` (test + lint + the `make check` gate). Run
+   `make prepush` once per branch for the full gate (race, cross-lint,
+   cross-compile, coverage, export audit).
 4. Open a pull request against `main`.
-5. Once review and CI pass, add the PR to the merge queue — the web UI's "Merge
-   when ready" button, or `gh pr merge --auto --squash`.
+5. Once review and CI pass, squash-merge — `gh pr merge --squash` — after
+   rebasing on the current `main` if it moved.
 
-### Merge queue
+### Merging
 
-`main` merges through a queue rather than directly. The queue rebuilds each
-candidate against the state it will actually land on, so branches no longer need
-to be up to date before merging: an unrelated PR landing first does not make
-yours stale, and independent PRs land together in one CI cycle instead of one
-each.
+`main` merges directly — the merge queue was removed, so rebase the branch on
+the current `main` before merging and let CI run on the result:
 
-Practical consequences:
-
-- Do not rebase just because `main` moved. The queue does that, and a force-push
-  drops your entry and restarts its checks.
-- CI runs a second time on the merge-group commit. That run is the one that
-  gates the merge; the PR run is the early signal.
-- A failure evicts only the entry that caused it. The rest of the batch
-  continues.
+- Do not merge a branch that is behind `main`. Rebase first; a force-push is
+  expected there, unlike in the queue era.
+- CI runs on the PR and again after the merge. The post-merge run is the one
+  that catches integration breaks; watch it land.
 
 ## Claude Code hooks
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ work.
 Set `GOGUI_DEBUG=1` (or `gui.Debug(true)`) to audit every frame for duplicate
 widget IDs and focusable widgets without IDs. `gui.DebugCategories` enables each
 class of finding — duplicates, missing IDs, unconsumed events, listbox
-virtualization — independently. See the
+virtualization, over-stop gradients, unresolved state keys, unclaimed focus IDs,
+stamp drift, dropped callbacks and links, refused window features —
+independently. See the
 [Debugging](https://github.com/go-gui-org/go-gui/wiki/Debugging) wiki page.
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ frame rebuilds the entire UI from the view function.
 │                                                      ▼              │
 │  ┌───────────────────────────────────────────────────────────────┐  │
 │  │ layoutArrange()                                               │  │
-│  │  ├─ resolve Sizing (Fit/Fixed/Grow per axis)                  │  │
+│  │  ├─ resolve Sizing (Fit/Fixed/Fill per axis)                  │  │
 │  │  ├─ layoutFillWidths / layoutFillHeights                      │  │
 │  │  ├─ spacing() — visible-children-only gap calc                │  │
 │  │  └─ AmendLayout hooks (overlay repositioning)                 │  │
@@ -75,7 +75,8 @@ frame rebuilds the entire UI from the view function.
 │  ├─ SvgParser (SVG parse + tessellate)                              │
 │  ├─ NativeDialogs (filedialog / printdialog)                        │
 │  └─ NativePlatform (a11y, IME, tray, menubar, spellcheck,           │
-│       notifications, bookmarks, URI opening)                        │
+│       notifications, bookmarks, URI opening, window opacity,        │
+│       frameless drag/resize)                                        │
 │                                                                     │
 │  ┌──────────────────────────────────────────────────────┐           │
 │  │ Tests: nil injected interfaces — no backend needed   │           │
@@ -100,7 +101,7 @@ frame rebuilds the entire UI from the view function.
 │  ├─ Parent   *Layout        ← pointer up                         │
 │  ├─ Children []Layout       ← values down (no pointer cycles)    │
 │  ├─ Axis     AxisType       ← Row / Column / None                │
-│  └─ Sizing   SizingType     ← Fit/Fixed/Grow per axis            │
+ │  └─ Sizing   SizingType     ← Fit/Fixed/Fill per axis           │
 ├──────────────────────────────────────────────────────────────────┤
 │ Shape                                                            │
 │  ├─ Pos, Size              ← absolute coordinates                │
@@ -166,7 +167,7 @@ frame rebuilds the entire UI from the view function.
 
 ```
 go-gui/
-├── gui/                          ← core (~200 non-test .go files at top level)
+├── gui/                          ← core (~270 non-test .go files at top level)
 │   ├── view*.go                  ← View interface, generateViewLayout
 │   ├── layout*.go                ← Layout tree, arrange, query
 │   ├── shape*.go                 ← Shape type + ShapeTextConfig
@@ -211,10 +212,11 @@ policy from code that drifts.
 ### Frame lifecycle
 
 - Every frame runs on the one main OS thread, in order: `generateViewLayout`
-  (builds the Layout tree) → `layoutArrange` (sizing, ID resolution, float
-  extraction) → `renderLayout` (emits into `w.renderers`) → backend
-  `renderersDraw` (drains read-only). All `*Window` access is main-thread-only.
-  Backends wake the loop from other threads via `SetWakeMainFn`.
+  (builds the Layout tree and stamps each shape's `effID`) → `layoutArrange`
+  (sizing, `focusOwner` resolution, float extraction) → `renderLayout` (emits
+  into `w.renderers`) → backend `renderersDraw` (drains read-only). All
+  `*Window` access is main-thread-only. Backends wake the loop from other
+  threads via `SetWakeMainFn`.
 - Frame-scoped objects come from the `w.scratch` pools (`allocShape`,
   `allocEventHandlers`, `allocEffects`, layer slices). Pointers are valid only
   until the next frame's pool reset — never store them in window/app state.
@@ -309,14 +311,30 @@ policy from code that drifts.
 ### Native platform boundaries
 
 - Backends inject `TextMeasurer` (glyph metrics), `SvgParser`, and
-  `NativePlatform` (dialogs, notifications, print, a11y, IME, titlebar) at
-  startup. All are nil in tests — test code must never require a backend.
+  `NativePlatform` (dialogs, notifications, print, a11y, IME, titlebar, window
+  opacity, frameless drag/resize) at startup. All are nil in tests — test code
+  must never require a backend.
 - `gui/` never imports backend packages. `NativePlatform` is the only seam to
   platform services.
 - **Where to change:** a new platform capability is a new `NativePlatform`
   method implemented per backend, not a direct call from `gui/`.
 - **Catches:** `make test` runs with nil injected interfaces. `make vet` (incl.
   the `requiredid` analyzer) flags structural mistakes.
+
+### Window furniture
+
+- `WindowCfg` carries the frame: `Transparent` (creation-time only, needs a
+  compositor on X11), `BgColor` alpha (read every frame), `Min/MaxWidth/Height`
+  (`FixedSize` pins both), and `Decorations` (frameless needs an app drag handle
+  via `StartWindowDrag`/`StartWindowResize`). Opacity is the runtime setter
+  `SetWindowOpacity` / `WindowOpacity`, refused on a transparent Windows window.
+- **Where to change:** `gui/window_cfg.go` for config, `gui/window_opacity.go`
+  and `gui/window_decoration.go` for runtime, one `NativePlatform` method per
+  capability, implemented per backend.
+- **Catches:** `gui.Debug` (category `DebugWindowDegraded`) reports a refused
+  feature. Specs: `docs/specs/transparent-windows.md`,
+  `docs/specs/window-opacity.md`, `docs/specs/window-size-limits.md`,
+  `docs/specs/frameless-windows.md`.
 
 ### Widget Cfg invariants
 
@@ -355,18 +373,18 @@ policy from code that drifts.
 
 ### Validation map
 
-| Invariant class                    | Local / CI gate                                                                |
-| ---------------------------------- | ------------------------------------------------------------------------------ |
-| Frame lifecycle, concurrency       | `make test-race`, `make bench-gate` (alloc gates)                              |
-| Event consumption                  | `TestUnconsumedEvents`, `gui.Debug` (`DebugUnconsumed`), ergoaudit `callbacks` |
-| Duplicate / mis-scoped IDs         | `TestDuplicateIDs`, `gui.Debug` (`DebugDuplicates`), ergoaudit `ids`           |
-| Render command stream              | `gui/render_layout_test.go`, backend render tests                              |
-| Backend build matrix, threading    | `make cross-compile`, `make lint-cross`, `make test` (`CGO_ENABLED=0` GL)      |
-| Theme single source                | `TestDefaultStylesMirrorThemeDark`, ergoaudit `theme`                          |
-| Native platform seam               | `make test` (nil interfaces), `make vet` (`requiredid`)                        |
-| Focusable + ID, a11y, Opt/literals | `make vet`, ergoaudit `focus`/`a11y`/`opt`/`literals`, `gui.Debug`             |
-| Generated files                    | `make generate-check`                                                          |
-| Exported surface                   | `make export-audit` — see `docs/specs/exportaudit-surface-policy.md`           |
+| Invariant class                    | Local / CI gate                                                                                                                     |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Frame lifecycle, concurrency       | `make test-race`, `make bench-gate` (alloc gates)                                                                                   |
+| Event consumption                  | `TestUnconsumedEvents`, `gui.Debug` (`DebugUnconsumed`), ergoaudit `callbacks`                                                      |
+| Duplicate / mis-scoped IDs         | `TestDuplicateIDs`, `gui.Debug` (`DebugDuplicates`, `DebugUnresolvedKeys`, `DebugUnknownFocus`, `DebugStampDrift`), ergoaudit `ids` |
+| Render command stream              | `gui/render_layout_test.go`, backend render tests                                                                                   |
+| Backend build matrix, threading    | `make cross-compile`, `make lint-cross`, `make test` (`CGO_ENABLED=0` GL)                                                           |
+| Theme single source                | `TestDefaultStylesMirrorThemeDark`, ergoaudit `theme`                                                                               |
+| Native platform seam               | `make test` (nil interfaces), `make vet` (`requiredid`)                                                                             |
+| Focusable + ID, a11y, Opt/literals | `make vet`, ergoaudit `focus`/`a11y`/`opt`/`literals`, `gui.Debug`                                                                  |
+| Generated files                    | `make generate-check`                                                                                                               |
+| Exported surface                   | `make export-audit` — see `docs/specs/exportaudit-surface-policy.md`                                                                |
 
 ## Future Directions
 

--- a/docs/cookbook-add-widget.md
+++ b/docs/cookbook-add-widget.md
@@ -23,7 +23,8 @@ Every widget has a `*Cfg` struct. Conventions:
   Slider, Select). Focus always requires a non-empty `ID`. Without one, the
   control never joins the tab order. Container-like widgets add `Sizing Sizing`,
   `Float bool`, `FloatAnchor FloatAttach`, `FloatTieOff FloatAttach`,
-  `Padding Padding`, `Radius Opt[float32]`, `SizeBorder Opt[float32]`.
+  `Padding Padding`, `Radius Opt[float32]`, `SizeBorder Opt[float32]` (`Table`
+  is the exception: its `SizeBorder` is a plain `float32` applied as-is).
 - **Callbacks** — one func field per event. Sig: `func(EventCtx)`. One rule for
   all of them: call `ctx.Consume()` on any path that acts on the event. On any
   path that means "not mine", call nothing. Nothing is marked handled for you. A
@@ -179,7 +180,8 @@ ClickOnSpace: true,
 
 **Hover/focus feedback** — use `OnHover` for mouse hover, `AmendLayout` for
 keyboard focus. `AmendLayout` runs every frame after sizing. Use it to update
-child colors based on `w.IsFocus(layout.Shape.ID)`.
+child colors based on `w.IsFocus(layout.Shape.idKey())` — never the bare
+`Shape.ID`, which is the leaf, not the identity.
 
 **Inner IDs** — a composite widget's inner shapes need their own IDs. Compose
 them with `gui.ScopeID(cfg.ID, "part")`, or `gui.ScopeIDN(cfg.ID, "row", i)`
@@ -237,7 +239,7 @@ func applyToggleDefaults(cfg *ToggleCfg) {
         cfg.TextSelect = "✓"
     }
     if !cfg.Padding.IsSet() {
-        cfg.Padding = Some(d.Padding)
+        cfg.Padding = d.Padding
     }
     if cfg.TextStyle == (TextStyle{}) {
         cfg.TextStyle = d.TextStyleNormal
@@ -303,7 +305,7 @@ In `examples/showcase/`, create a demo function and register it:
 // examples/showcase/demo_toggle.go
 func demoToggle(_ *gui.Window) gui.View {
     return gui.Column(gui.ContainerCfg{
-        Padding: gui.Some(gui.PaddingMedium),
+        Padding: gui.PadAll(8),
         Spacing: gui.SomeF(8),
         Content: []gui.View{
             gui.Toggle(gui.ToggleCfg{

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,6 +40,11 @@ becomes the installed program name (the `Exec=` line on Linux, the file inside
 the `.zip` on Windows, `Contents/MacOS/<name>` on macOS). `myapp-linux` in means
 `Exec=myapp-linux` out.
 
+On Linux/X11, transparent and translucent windows need a running compositing
+manager at runtime — without one the window renders black, which `gui.Debug`
+reports. Either depend on one in the package or document it for the user. See
+`docs/specs/transparent-windows.md`.
+
 ## Step 2: package with buildapp
 
 A `.png` icon works on every platform. macOS also accepts `.icns`, Windows also

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -21,7 +21,7 @@ Input{ID: "name", FocusDisabled: true} // not in the tab order
 
 Most input controls are focusable by default. They are `Button`,
 `ColorChannelSlider`, `ColorPicker`, `ColorPlane`, `ColorWheel`, `Combobox`,
-`DatePicker`, `Input`, `InputDate`, `ListBox`, `NumericInput`,
+`DatePicker`, `ExpandPanel`, `Input`, `InputDate`, `ListBox`, `NumericInput`,
 `RadioButtonGroup`, `Radio`, `Select`, `Slider`, `Switch`, `Toggle`, `Tree`,
 `VirtualList`. Everything else opts in with `Focusable: true`. If a control
 never answers the keyboard, the usual cause is a missing `ID`. The `requiredid`
@@ -54,7 +54,8 @@ all := w.EffectiveIDs()    // every identity in the frame, tree order
 ```
 
 An empty answer means no widget of that name is in the current frame: either the
-spelling is wrong or the widget is not rendered.
+spelling is wrong or the widget is not rendered. More than one answer means the
+leaf is used under more than one scope, which is legal — pick the scope meant.
 
 A part (a row key, a heading slug) must not contain `:`. A composite widget's
 inner shape sets `Shape.focusOwner` to the owner's leaf instead of repeating its
@@ -87,7 +88,9 @@ is a real choice:
 
 `SizeBorder` is the example: `0` means "no border", so a plain `float32` cannot
 tell that from "not specified". `Color` and `Padding` carry their own set flag
-and stay plain.
+and stay plain. `ScrollbarCfg.GapEdge`/`GapEnd` are the same case — `0` is a
+real inset — so they are `Opt[float32]` defaulting to the theme's
+`SizeScrollbarGap`/`SizeScrollbarGapEnd` (write `gui.SomeF(4)`).
 
 ## Colors
 
@@ -162,7 +165,8 @@ scroll container has a bounded height. They always scroll — there is no
 `Scrollable` opt-in — so a bounded height is the whole requirement: `Height` or
 `MaxHeight`, or — `ListBox` only — a height Fill sizing resolved last frame.
 Every row is the same height there, which is exact because the widget owns the
-row shape.
+row shape. `Combobox` additionally clips its label so the arrow stays inside the
+field, and its dropdown scrolls unconditionally.
 
 For rows the app builds, of heights only the layout engine knows, use
 `VirtualList`:
@@ -209,6 +213,19 @@ These work on the uniform widgets too, in each one's own index space (a frozen
 table header is data index 0 but sits outside the scrollable). Call
 `w.InvalidateListHeights(id)` when a row's content changed under a stable key —
 nothing detects that. See `docs/specs/virtualized-variable-height-lists.md`.
+
+## Numeric input steps
+
+`NumericInput` steps on Up/Down by default (`KeyboardDisabled` opts out) and on
+the mouse wheel only when `MouseWheel` is set. Shift scales the step 10x, Alt
+0.1x; `ShiftMultiplier`/`AltMultiplier` override each (zero takes the default).
+
+## Date picker sizing
+
+`DatePicker` is self-sized: `Height` is deliberately not pinned. A cell's height
+comes from the theme font, and the month grid keeps it across months through the
+internal `CalBodyHeight`. `HideTodayIndicator` opts out of the today ring;
+`ShowAdjacentMonths` opts into filling the edge cells.
 
 ## `Wrap` with Fit width
 
@@ -272,6 +289,13 @@ triangle wound against its neighbors cancels along their shared edge and cuts a
 hairline through the mesh. Share vertices between adjacent triangles rather than
 overlapping them. With per-vertex color, an overlap paints twice and shows.
 
+## Canvas transforms
+
+A `DrawContext` carries a transform stack: `Translate(dx, dy)`,
+`ScaleBy(sx, sy)`, `Save()` and `Restore()`. The matrix is batch-stamped, so a
+transform between two fills does not merge them. See
+`docs/specs/draw-canvas-transform.md`.
+
 ## The one-event rule
 
 Nothing is marked handled for you. A callback that acts on an event calls
@@ -298,12 +322,26 @@ into a nested `ButtonCfg` or `ToggleCfg` means passing `SoundDisabled` too —
 those resolve their own precedence, and a resolved `SoundNone` reads there as
 "unset". See `docs/widget-sound.md`.
 
+## Markdown render callback
+
+`MarkdownCfg.RenderBlock(w, el)` overrides rendering per block: return a `View`
+and `true` to replace the block (or nil to drop it), `false` to keep the
+default. The hook runs every frame over cached blocks, so it must be cheap and
+pure — build `View` structs, do not fetch or parse. It runs during
+`GenerateLayout` under the frame lock: no window-mutating calls, `QueueCommand`
+for those. Hook writers own their IDs: compose with `ScopeID(el.DocID, …)`. See
+`docs/specs/markdown-render-callback.md`.
+
 ## Find it early
 
 `gui.Debug(true)`, or `GOGUI_DEBUG=1`, checks the layout every frame. It reports
-duplicate IDs, focusable shapes without IDs, and handlers that act without
-consuming. Findings print once per window. In tests, use
-`(*Window).TestDuplicateIDs` and `(*Window).TestUnconsumedEvents`.
+duplicate IDs, focusable shapes without IDs, handlers that act without
+consuming, and the rest of the sweep: scrollable or `OnMouseLeave` shapes
+without IDs, a height-0 virtualized listbox, an over-stop gradient, a
+`Wrap`+`Overflow` container, unresolved state keys, unclaimed focus IDs, stamp
+drift, dropped callbacks and links, and refused window features. Findings print
+once per window. In tests, use `(*Window).TestDuplicateIDs` and
+`(*Window).TestUnconsumedEvents`.
 
 `DebugUnscopedIDs` is separate and opt-in: it is not part of `DebugAll`. It
 reports an ID with no ID-bearing ancestor — the widget cannot move into a second
@@ -350,6 +388,12 @@ which is what `SetFocus("nav")` leaves behind when the frame stamped
 `"detail:nav"`. The finding names the spelling that would have worked. It fires
 from the frame audit, not from `SetFocus`, because a view function may
 legitimately focus a control it is still returning.
+
+`DebugStampDrift` is also part of `DebugAll`. It reports a shape whose stamp
+disagrees with the scope it was arranged under, or an ID-bearing shape with no
+stamp at all — the signature of a hand-built `Layout` spliced into a generated
+tree. Every store then keys it on its bare leaf, which works until a second
+widget of that leaf appears elsewhere in the window.
 
 `DebugCategories` prints to stderr. To assert a category in a test, including an
 opt-in one, use `(*Window).TestFindings(mask)`, which returns the findings as

--- a/docs/specs/focusable-default-input.md
+++ b/docs/specs/focusable-default-input.md
@@ -4,6 +4,13 @@ Status: **implemented** — Phase 1 shipped v0.36.0 (Input, Select, Slider,
 Toggle, Switch). Phase 2 shipped v0.37.0, dropping `Focusable bool` for
 `FocusDisabled bool` on the remaining nine controls. Both phases in CHANGELOG.
 
+Follow-up landed: the deferred bucket (Decision 8) is empty. `Combobox`,
+`DatePicker`, `ListBox`, `RadioButtonGroup`, `NumericInput` and `InputDate` are
+all focusable by default now, as are `Tree` and `ColorPicker` from the
+borderline set (Decision 9) — twenty Cfgs in total. Only `ThemePicker` (and the
+non-input opt-ins) keeps `Focusable bool`. The table and Decisions 8–9 below
+keep their original verdicts as history; read them as landed.
+
 Base: `main` @ `8522098` Target release: go-gui `v0.36.0` (breaking)
 
 ## Motivation
@@ -70,12 +77,13 @@ at every read, loud break at the call site.
    the same author (matches idfocus-to-focusable decision #5).
 7. **Phase 1 and Phase 2 ship together** as a single `v0.36.0` migration (one
    break for consumers, not two).
-8. **Composites and Input wrappers deferred** (Combobox, DatePicker, Listbox,
-   RadioButtonGroup, **NumericInput, InputDate**) — each either governs focus
-   over internal children or has a focus-model defect the flip exposes (see
-   [Deferred — why](#deferred--why)). Revisit in a follow-up.
-9. **Borderline widgets stay opt-in** (ColorPicker, ThemePicker, Tree) — Tree is
-   navigation, the pickers are composite.
+8. **Composites and Input wrappers deferred, then landed** (Combobox,
+   DatePicker, Listbox, RadioButtonGroup, **NumericInput, InputDate**) — each
+   either governs focus over internal children or had a focus-model defect the
+   flip exposed (see [Deferred — why](#deferred--why)). All six flipped in a
+   follow-up; the bucket is empty.
+9. **Borderline widgets stay opt-in** (ThemePicker) — `Tree` and `ColorPicker`
+   landed in the follow-up; `ThemePicker` keeps `Focusable bool`.
 10. **Analyzer stays silent** on an in-scope input with no `ID`. Inert is a
     valid choice. No positive lint.
 11. **In-scope invariant** — a widget qualifies for the flip only if it (a)
@@ -90,16 +98,16 @@ Only widgets that satisfy the Decision-11 invariant are in scope. Audit against
 the two failure modes (fabricated ID from empty `cfg.ID`, and more than one
 focus candidate):
 
-| Cfg                                                                 | Focus candidates                                           | Fabricates ID? | Verdict                 |
-| ------------------------------------------------------------------- | ---------------------------------------------------------- | -------------- | ----------------------- |
-| `InputCfg`                                                          | 1 (outer `Column`, inner `Text` is `FocusSkip`, same `ID`) | no             | ✅ in — Phase 1         |
-| `SelectCfg`                                                         | 1 (`cfg.ID`, dropdown never focusable)                     | no¹            | ✅ in — Phase 2         |
-| `SliderCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2         |
-| `ToggleCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2         |
-| `SwitchCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2         |
-| `NumericInputCfg`                                                   | **2** (outer Row `cfg.ID` + inner Input `cfg.ID+"_field"`) | no (gated)     | ❌ deferred             |
-| `InputDateCfg`                                                      | 1, but inner Input `ID = cfgID+".input"` **ungated**       | **yes**        | ❌ deferred             |
-| `ComboboxCfg`, `DatePickerCfg`, `ListBoxCfg`, `RadioButtonGroupCfg` | focus over internal children                               | —              | ❌ deferred (composite) |
+| Cfg                                                                 | Focus candidates                                           | Fabricates ID? | Verdict               |
+| ------------------------------------------------------------------- | ---------------------------------------------------------- | -------------- | --------------------- |
+| `InputCfg`                                                          | 1 (outer `Column`, inner `Text` is `FocusSkip`, same `ID`) | no             | ✅ in — Phase 1       |
+| `SelectCfg`                                                         | 1 (`cfg.ID`, dropdown never focusable)                     | no¹            | ✅ in — Phase 2       |
+| `SliderCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2       |
+| `ToggleCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2       |
+| `SwitchCfg`                                                         | 1 (`cfg.ID`)                                               | no             | ✅ in — Phase 2       |
+| `NumericInputCfg`                                                   | **2** (outer Row `cfg.ID` + inner Input `cfg.ID+"_field"`) | no (gated)     | ✅ landed (follow-up) |
+| `InputDateCfg`                                                      | 1, but inner Input `ID = cfgID+".input"` **ungated**       | **yes**        | ✅ landed (follow-up) |
+| `ComboboxCfg`, `DatePickerCfg`, `ListBoxCfg`, `RadioButtonGroupCfg` | focus over internal children                               | —              | ✅ landed (follow-up) |
 
 ¹ `SelectCfg.ID` is optional. An empty `ID` yields one _inert_ focus target but
 its open-state (`nsSelect`) is keyed on `""` and thus shared across ID-less
@@ -109,10 +117,11 @@ recommended in practice, not required for the flip.
 **Phase 1:** `InputCfg` (single-line + multiline, the 96% case). **Phase 2:**
 `SelectCfg`, `SliderCfg` (`gui:"required"` ID), `ToggleCfg`, `SwitchCfg`.
 
-### Deferred — why
+### Deferred — why (landed; kept as the defect record)
 
-The two Input **wrappers** each break the Decision-11 invariant and need a
-dedicated focus-model fix before they can flip:
+The two Input **wrappers** each broke the Decision-11 invariant and needed a
+dedicated focus-model fix before they could flip. The fixes landed in the
+follow-up; what follows is the defect record, not open work:
 
 - **`InputDate`** — `inputDateTextField` sets the inner Input's `ID` to
   `cfgID + ".input"` unconditionally (`view_input_date.go:233`). With an empty

--- a/docs/specs/frameless-windows.md
+++ b/docs/specs/frameless-windows.md
@@ -98,8 +98,6 @@ coordinates, which the Go-side event no longer carries.
 
 ## Not included
 
-- `FixedSize` is still ignored on X11 (no `WM_NORMAL_HINTS`). A pre-existing
-  gap, left alone to keep this change scoped.
 - No `gui.TitleBar` widget. `examples/frameless` builds its header from a plain
   `Row` and a `Button`.
 - Web, software, iOS and Android backends are no-ops.

--- a/docs/specs/widget-id-per-scope-uniqueness.md
+++ b/docs/specs/widget-id-per-scope-uniqueness.md
@@ -26,15 +26,15 @@ implementation, and the code is the authority.
    menus injected from outside the tree holds.
 2. **`EventCtx.EffID` was added.** Decision 7 assumed a stateful widget always
    has a `*Window` while it composes. Several do not: `Input`, `Slider`,
-   `Splitter`, `ProgressBar`, `Skeleton` and `Scrollbar` build their trees in
-   plain factories and capture `cfg.ID` as a leaf. Their handlers resolve at
-   dispatch time instead, walking the ancestor chain for the shape that carries
-   the leaf. Same `resolveLeaf`, so the two paths cannot drift. `Splitter` is
-   now converted (issue #264): it is a struct view whose `GenerateLayout`
-   resolves the effective ID once (`id := w.EffID(cfg.ID)`) and composes every
-   inner ID (panes, handle, collapse buttons) from that path — the root shape
-   stays on the plain leaf and the framework joins it to the same string, while
-   the composed children are absolute.
+   `ProgressBar`, `Skeleton` and `Scrollbar` build their trees in plain
+   factories and capture `cfg.ID` as a leaf. Their handlers resolve at dispatch
+   time instead, walking the ancestor chain for the shape that carries the leaf.
+   Same `resolveLeaf`, so the two paths cannot drift. `Splitter` was one of
+   these and is now converted (issue #264): it is a struct view whose
+   `GenerateLayout` resolves the effective ID once (`id := w.EffID(cfg.ID)`) and
+   composes every inner ID (panes, handle, collapse buttons) from that path —
+   the root shape stays on the plain leaf and the framework joins it to the same
+   string, while the composed children are absolute.
 3. **The "still globally competing" warning is a debug category, not an
    ergonomics-audit mode.** "Has no ID-bearing ancestor" is a property of the
    composed tree, which the AST does not have. It is `gui.DebugUnscopedIDs`,
@@ -214,9 +214,9 @@ Rules:
   loud, as today.
 - An absolute ancestor still contributes its full `effID` as the join prefix:
   leaf `"name"` under `"app:settings"` → `"app:settings:name"`.
-- A leaf that already contains `:` is an **absolute** identity. The resolution
-  pass does not join further. That is the compatibility path for today's
-  `ScopeID` results.
+- A leaf that already contains `:` is an **absolute** identity. Generation does
+  not join it further. That is the compatibility path for today's `ScopeID`
+  results.
 - Absolute (`:`) is not an opt-out that keeps a bare global leaf under an ID'd
   ancestor. Under an ID'd ancestor, a plain leaf always becomes `ancestor:leaf`.
   There is no "stay bare `ok` under panel `p`" mode.
@@ -233,11 +233,13 @@ These supersede parent Decisions 1–2 for identity resolution. The `:` grammar
 and no-escaping rules stay.
 
 This is **not** a widget-side ID stack inside `GenerateLayout`. Widget factories
-still set leaf `Shape.ID` (plain or absolute). Scope is the framework's job. A
-post-build resolve pass stamps `effID` before any ID-keyed store or match that
-runs after layout generation. Widget-internal state read **during**
-`GenerateLayout` cannot wait for that pass — Decision 7 gives widgets their
-scope at generation time instead.
+still set leaf `Shape.ID` (plain or absolute). Scope is the framework's job.
+Identity is stamped **once, during generation** (`stampEffID`, called from
+`generateViewLayout` and `appendChildViews` — point 5 above), so there is no
+second pass for a widget to wait for. Widget-internal state read **during**
+`GenerateLayout` cannot wait for its own shape to be stamped — Decision 7 gives
+widgets their scope at generation time instead, through the same `resolveLeaf`
+the stamp uses.
 
 1. **Framework join on ID-bearing ancestors.** Containers with an ID push a
    namespace for descendants that use plain leaf IDs. Moving a widget under a
@@ -269,17 +271,18 @@ scope at generation time instead.
    input-state / spell-check maps hold `effID`.
 7. **Generation-time scope for widget-state keys.** Widgets that read `StateMap`
    inside `GenerateLayout` (combobox open/query/highlight/items, theme-picker
-   select, tree / sidebar / listbox state, …) cannot wait for the resolve pass —
-   their tree shape depends on the read. `generateViewLayout` maintains a
-   framework-side scope: before recursing into a child it pushes the child's
-   `effID`. `w.EffID(leaf)` joins the current scope with the leaf (absolute `:`
-   leaves pass through unchanged). Stateful widgets key every `ns*` map on
-   `w.EffID(cfg.ID)`, reads and writes alike (event handlers close the key over
-   at generation. It stays valid while ancestor IDs do). The float boundary
-   resets scope to `""` at each float root during generation, matching the
-   resolve pass. One `resolveLeaf(scope, leaf)` helper implements both paths so
-   they cannot drift. Cost: one `:`-join per stateful widget per frame — Phase
-   C's memo is shared with this path.
+   select, tree / sidebar / listbox state, …) cannot wait for their own shape to
+   be stamped — their tree shape depends on the read. `appendChildViews`
+   maintains a framework-side scope: on its way to pushing a parent's scope it
+   stamps the parent, so `w.EffID(leaf)` joins the current scope with the leaf
+   (absolute `:` leaves pass through unchanged). Stateful widgets key every
+   `ns*` map on `w.EffID(cfg.ID)`, reads and writes alike (event handlers close
+   the key over at generation. It stays valid while ancestor IDs do). A float is
+   not a scope boundary: it is stamped where it was written, so the
+   generation-time scope and the stamp agree with no float special case. One
+   `resolveLeaf(scope, leaf)` helper implements both paths so they cannot drift.
+   Cost: one `:`-join per stateful widget per frame — Phase C's memo is shared
+   with this path.
 
 ## Worked examples
 
@@ -304,12 +307,11 @@ Panel{ID: "profile",  Content: ColorPicker{ID: "palette"}} // owner → profile:
 ```
 
 A composite whose own container nesting already mirrors `ScopeID(owner, part)`
-**must** drop that `ScopeID` and set a plain leaf (no `:`) once
-`resolveShapeIDs` exists. Until those producers simplify, reuse under ID'd
-ancestors is **not** safe for that widget — `TestDuplicateIDs` will still report
-the absolute children. Leave absolute only when the leaf needs `:` (`ScopeIDN`)
-or the owner is not an ancestor ID (synthetic prefixes, toast, command-button
-scopes).
+**must** drop that `ScopeID` and set a plain leaf (no `:`) now that generation
+stamps `effID`. Until those producers simplify, reuse under ID'd ancestors is
+**not** safe for that widget — `TestDuplicateIDs` will still report the absolute
+children. Leave absolute only when the leaf needs `:` (`ScopeIDN`) or the owner
+is not an ancestor ID (synthetic prefixes, toast, command-button scopes).
 
 ```go
 // App content under ID'd panels — the composability win
@@ -362,26 +364,24 @@ not `IDSep`: a node ID is tree data fed into `ScopeID` as a **part**, and an
 `IDSep` in a part makes the composed leaf absolute in the wrong way —
 window-global, outside the dock scope.
 
-## Resolution pass
+## Identity stamping (was: resolution pass)
 
-`resolveShapeIDs(layout, scope string)` runs **first** in every `layoutPipeline`
-call (`gui/layout_pipeline.go`) — before width/height passes and before
-`applyLayoutTransition` / `applyHeroTransition`. It stamps `effID` on every
-shape before any ID-keyed store or match that runs after layout generation.
+Identity is stamped during generation, not by a pass over the built tree (point
+5 above): `generateViewLayout` stamps whatever a view returned and
+`appendChildViews` stamps a parent on its way to pushing that parent's scope.
+What is left of the pass this section originally described is
+`resolveFocusOwners`, run from `layoutArrange`, which rewrites `focusOwner`
+references in place. Injected overlays (toast, dialog, inspector) arrange as
+their own roots with an empty scope.
 
-Wire it for **every root** `layoutArrange` feeds the pipeline
-(`gui/layout_arrange.go`): main layout and each floating layout. A miss on any
-root is a silent break.
+**Float scope boundary:** a float is stamped where it was written, so it keeps
+the scope of the ID-bearing ancestors around its write site — a combobox
+dropdown or popover inside a panel carries that panel's scope, and extraction
+cannot move it. Injected tooltips/menus only pick up scope from ID'd ancestors
+**inside their own tree**.
 
-**Float scope boundary:** each float/dialog is its own pipeline root with an
-empty initial scope. It does **not** inherit ID-bearing ancestors from the main
-tree. Injected tooltips/menus only pick up scope from ID'd ancestors **inside
-their own tree**. Authors who need the triggering panel's prefix must set an
-absolute ID (or put an ID'd ancestor in the float tree).
-
-The Decision 7 generation-time scope resets identically: a `Float` layout's
-subtree generates with empty scope, so a widget inside a float reads the same
-keys the resolve pass produces. Both rules go through the shared
+The Decision 7 generation-time scope agrees by construction: a widget inside a
+float reads the same keys the stamp produces. Both go through the shared
 `resolveLeaf(scope, leaf)` helper.
 
 ## Migrate keying and match sites
@@ -412,9 +412,8 @@ one commit each with a test:
   spell-check). After the change those stores hold `effID`. "Already a full path
   string" is not enough once producers emit plain leaves. Fix `focusKey()` per
   Decision 6 so Input's inner text keeps working. Note the `AmendLayout`
-  `IsFocus` call sites that pass the leaf today — for example the combobox's
-  `AmendLayout` uses `ctx.Layout.Shape.ID` (`gui/view_combobox.go`) — they
-  become `effID` (or `w.EffID`).
+  `IsFocus` call sites that pass the leaf today — they become `effID` (or
+  `w.EffID`), read back with `shape.idKey()` rather than the bare `Shape.ID`.
 
 ## Implementation phases
 
@@ -431,9 +430,10 @@ one commit each with a test:
    `ScopeID(cfg.ID, part)` producer to a plain leaf. Leave absolute leaves that
    cannot simplify. Until this lands, two instances of the same composite under
    different ID'd panels still collide on absolute children.
-5. ergonomics-audit `ids` mode: warn on state-keyed shapes (focusable /
-   scrollable / stateful) with a plain leaf and no ID-bearing ancestor (still
-   globally competing).
+5. Warn on state-keyed shapes (focusable / scrollable / stateful) with a plain
+   leaf and no ID-bearing ancestor (still globally competing) — landed as
+   `gui.DebugUnscopedIDs`, deliberately outside `DebugAll` (point 3 above), not
+   as an ergonomics-audit mode.
 6. Docs: CLAUDE.md Focus section, parent Remaining work pointer, showcase
    regression. Showcase win requires ID-bearing demo/panel ancestors.
 
@@ -463,11 +463,11 @@ so a miss recomputes identically.
 
 ## Relation to `widget-id-scoping.md`
 
-| Parent                                                      | This spec                                                                                                                                                         |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Decision 1: helper only, containers do not push a namespace | Superseded for plain leaves under ID-bearing ancestors — via post-build resolve plus a framework-side generation-time scope (Decision 7), not a widget-side stack |
-| Decision 2: flat window-global strings, per-scope deferred  | Effective IDs stay flat strings. Uniqueness is on `effID`. Leaf reuse across scopes is allowed                                                                    |
-| Grammar / no escaping / `ScopeID`                           | Unchanged. Absolute leaves are today's composed strings                                                                                                           |
+| Parent                                                      | This spec                                                                                                                                              |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Decision 1: helper only, containers do not push a namespace | Superseded for plain leaves under ID-bearing ancestors — generation stamps the join (Decision 7 gives widgets the same scope), not a widget-side stack |
+| Decision 2: flat window-global strings, per-scope deferred  | Effective IDs stay flat strings. Uniqueness is on `effID`. Leaf reuse across scopes is allowed                                                         |
+| Grammar / no escaping / `ScopeID`                           | Unchanged. Absolute leaves are today's composed strings                                                                                                |
 
 ## Closed questions
 
@@ -480,8 +480,8 @@ so a miss recomputes identically.
    during resolve or `*Shape` reference. Bare leaf `focusKey` is invalid after
    stores migrate.
 5. **Widget-state keys read during `GenerateLayout`:** migrate to
-   `w.EffID(cfg.ID)` (Decision 7) — the resolve pass alone cannot serve reads
-   that happen before it.
+   `w.EffID(cfg.ID)` (Decision 7) — the widget's own shape is not stamped yet at
+   that point, so only the ambient scope answers.
 6. **Datagrid:** stays a permanent absolute-leaf exception in spelling only. Its
    root resolves like any other widget and every child ID is built from that
    resolved prefix (#519), so two grids sharing a `cfg.ID` under different

--- a/docs/subpackage-analysis.md
+++ b/docs/subpackage-analysis.md
@@ -5,16 +5,15 @@ root `gui` package into subpackages (`gui/layout/`, `gui/animation/`, and more).
 
 ## Current state
 
-- Root `gui/` package: ~200 non-test .go files at top level (~400 including
-  tests)
-- 25 library packages under `gui/` (16 under `backend/`). 82 total in the module
-  including examples and tools
+- Root `gui/` package: ~270 non-test .go files at top level
+- 31 library packages under `gui/` (21 under `backend/`). 104 total in the
+  module including examples and tools
 - Compile time: 0.28s — not a problem
 - File naming convention: `layout_*.go`, `render_*.go`, `view_*.go`,
   `animation_*.go` — provides grep-level discoverability
 - Existing subpackages: `datagrid`, `markdown`, `svg`, `svg/css`, `highlight`,
-  `audio`, `shader` — leaf subsystems that import `gui` but are not imported by
-  it
+  `audio`, `shader`, `backend`, `internal`, `locales`, `assets` — leaf
+  subsystems that import `gui` but are not imported by it
 
 ## Why core subsystems can't move
 

--- a/examples/showcase/docs/commands.md
+++ b/examples/showcase/docs/commands.md
@@ -205,15 +205,17 @@ gui.Command{
 Handle palette selection:
 
 ```go
-func paletteAction(id string, e *gui.Event, w *gui.Window) {
-    cmd, ok := w.CommandByID(id)
+func paletteAction(id string, ctx gui.EventCtx) {
+    cmd, ok := ctx.Window.CommandByID(id)
     if ok && cmd.Execute != nil {
-        cmd.Execute(e, w)
+        cmd.Execute(ctx.Event, ctx.Window)
     }
 }
 ```
 
 ### Visibility Functions
+
+Only toggling is public — show, dismiss and visibility read are unexported:
 
 | Function                      | Description       |
 | ----------------------------- | ----------------- |

--- a/examples/showcase/docs/widget_command_palette.md
+++ b/examples/showcase/docs/widget_command_palette.md
@@ -19,36 +19,39 @@ gui.CommandPaletteToggle("cmd", w)
 
 ## API
 
-| Function                            | Description            |
-| ----------------------------------- | ---------------------- |
-| CommandPaletteShow(id, w)           | Show and focus palette |
-| CommandPaletteDismiss(id, w)        | Hide palette           |
-| CommandPaletteToggle(id, w)         | Toggle visibility      |
-| CommandPaletteIsVisible(id, w) bool | Check if visible       |
+| Function                    | Description       |
+| --------------------------- | ----------------- |
+| CommandPaletteToggle(id, w) | Toggle visibility |
+
+Show, dismiss and visibility read are unexported; `Toggle` is the only public
+control.
 
 ## Key Properties
 
-| Property    | Type                 | Description                |
-| ----------- | -------------------- | -------------------------- |
-| ID          | string               | Unique identifier          |
-| Items       | []CommandPaletteItem | Available commands         |
-| Placeholder | string               | Search input hint text     |
-| Width       | float32              | Palette width              |
-| MaxHeight   | float32              | Maximum dropdown height    |
-| FloatZIndex | int                  | Z-index for float layering |
+| Property      | Type                 | Description                |
+| ------------- | -------------------- | -------------------------- |
+| ID            | string               | Unique identifier          |
+| Items         | []CommandPaletteItem | Available commands         |
+| Placeholder   | string               | Search input hint text     |
+| Width         | float32              | Palette width              |
+| MaxHeight     | float32              | Maximum dropdown height    |
+| FloatZIndex   | int                  | Z-index for float layering |
+| Sound         | SoundCue             | Backdrop-dismiss cue       |
+| SoundDisabled | bool                 | Suppress backdrop sound    |
 
 ## Appearance
 
-| Property       | Type         | Description               |
-| -------------- | ------------ | ------------------------- |
-| Color          | Color        | Card background color     |
-| ColorBorder    | Color        | Card border color         |
-| ColorHighlight | Color        | Highlighted item color    |
-| BackdropColor  | Color        | Semi-transparent backdrop |
-| SizeBorder     | Opt[float32] | Border width              |
-| Radius         | Opt[float32] | Corner radius             |
-| TextStyle      | TextStyle    | Item label text styling   |
-| DetailStyle    | TextStyle    | Item detail text styling  |
+| Property             | Type         | Description                 |
+| -------------------- | ------------ | --------------------------- |
+| Color                | Color        | Card background color       |
+| ColorBorder          | Color        | Card border color           |
+| ColorHighlight       | Color        | Highlighted item color      |
+| ColorHighlightSubtle | Color        | Tint behind highlighted row |
+| BackdropColor        | Color        | Semi-transparent backdrop   |
+| SizeBorder           | Opt[float32] | Border width                |
+| Radius               | Opt[float32] | Corner radius               |
+| TextStyle            | TextStyle    | Item label text styling     |
+| DetailStyle          | TextStyle    | Item detail text styling    |
 
 ## CommandPaletteItem
 

--- a/examples/showcase/docs/widget_listbox.md
+++ b/examples/showcase/docs/widget_listbox.md
@@ -65,27 +65,30 @@ When `Items` is set, `Data` is ignored.
 
 ## Key Properties
 
-| Property    | Type            | Description                             |
-| ----------- | --------------- | --------------------------------------- |
-| SelectedIDs | []string        | Selected item IDs                       |
-| Items       | []string        | Simple string list (alt. to Data)       |
-| Data        | []ListBoxOption | Items (ID, Name, Value, IsSubhead)      |
-| Multiple    | bool            | Allow multi-select                      |
-| Height      | float32         | Fixed height (activates virtualization) |
-| MinWidth    | float32         | Minimum width                           |
-| MaxWidth    | float32         | Maximum width                           |
-| MinHeight   | float32         | Minimum height                          |
-| MaxHeight   | float32         | Maximum height                          |
-| Reorderable | bool            | Enable drag-reorder                     |
-| Sizing      | Sizing          | Combined axis sizing mode               |
-| Disabled    | bool            | Disable interaction                     |
-| Invisible   | bool            | Hide without removing from layout       |
+| Property      | Type            | Description                             |
+| ------------- | --------------- | --------------------------------------- |
+| SelectedIDs   | []string        | Selected item IDs                       |
+| Items         | []string        | Simple string list (alt. to Data)       |
+| Data          | []ListBoxOption | Items (ID, Name, Value, IsSubhead)      |
+| Multiple      | bool            | Allow multi-select                      |
+| Height        | float32         | Fixed height (activates virtualization) |
+| MinWidth      | float32         | Minimum width                           |
+| MaxWidth      | float32         | Maximum width                           |
+| MinHeight     | float32         | Minimum height                          |
+| MaxHeight     | float32         | Maximum height                          |
+| Reorderable   | bool            | Enable drag-reorder                     |
+| Sizing        | Sizing          | Combined axis sizing mode               |
+| Disabled      | bool            | Disable interaction                     |
+| Invisible     | bool            | Hide without removing from layout       |
+| FocusDisabled | bool            | Opt out of default-on focus             |
+| Sound         | SoundCue        | Row-activation cue                      |
+| SoundDisabled | bool            | Suppress row sounds                     |
 
 ## Appearance
 
 | Property        | Type         | Description             |
 | --------------- | ------------ | ----------------------- |
-| Padding         | Opt[Padding] | Inner padding           |
+| Padding         | Padding      | Inner padding           |
 | Radius          | Opt[float32] | Corner radius           |
 | SizeBorder      | Opt[float32] | Border width            |
 | Color           | Color        | Background color        |

--- a/examples/showcase/docs/widget_table.md
+++ b/examples/showcase/docs/widget_table.md
@@ -100,6 +100,10 @@ When `RawData` is set, `Data` is ignored.
 | MaxWidth           | float32           | Maximum width                 |
 | MinHeight          | float32           | Minimum height                |
 | MaxHeight          | float32           | Maximum height                |
+| FreezeHeader       | bool              | Pin header outside the scroll |
+| Focusable          | bool              | Opt in to keyboard focus      |
+| Sound              | SoundCue          | Row-activation cue            |
+| SoundDisabled      | bool              | Suppress row sounds           |
 
 ## Appearance
 

--- a/examples/showcase/docs/widget_tree.md
+++ b/examples/showcase/docs/widget_tree.md
@@ -70,22 +70,25 @@ When `ItemPaths` is set, `Nodes` is ignored.
 
 ## Key Properties
 
-| Property    | Type          | Description                       |
-| ----------- | ------------- | --------------------------------- |
-| ItemPaths   | []string      | Flat slash-separated paths (alt.) |
-| Nodes       | []TreeNodeCfg | Root-level tree nodes             |
-| Indent      | float32       | Indent per nesting level          |
-| Spacing     | Opt[float32]  | Vertical spacing between rows     |
-| Reorderable | bool          | Enable drag-reorder of siblings   |
-| Disabled    | bool          | Disable interaction               |
-| Invisible   | bool          | Hide without removing from layout |
-| Sizing      | Sizing        | Combined axis sizing mode         |
-| Width       | float32       | Fixed width                       |
-| Height      | float32       | Fixed height                      |
-| MinWidth    | float32       | Minimum width                     |
-| MaxWidth    | float32       | Maximum width                     |
-| MinHeight   | float32       | Minimum height                    |
-| MaxHeight   | float32       | Maximum height                    |
+| Property      | Type          | Description                       |
+| ------------- | ------------- | --------------------------------- |
+| ItemPaths     | []string      | Flat slash-separated paths (alt.) |
+| Nodes         | []TreeNodeCfg | Root-level tree nodes             |
+| Indent        | float32       | Indent per nesting level          |
+| Spacing       | Opt[float32]  | Vertical spacing between rows     |
+| Reorderable   | bool          | Enable drag-reorder of siblings   |
+| Disabled      | bool          | Disable interaction               |
+| Invisible     | bool          | Hide without removing from layout |
+| Sizing        | Sizing        | Combined axis sizing mode         |
+| Width         | float32       | Fixed width                       |
+| Height        | float32       | Fixed height                      |
+| MinWidth      | float32       | Minimum width                     |
+| MaxWidth      | float32       | Maximum width                     |
+| MinHeight     | float32       | Minimum height                    |
+| MaxHeight     | float32       | Maximum height                    |
+| FocusDisabled | bool          | Opt out of default-on focus       |
+| Sound         | SoundCue      | Row-activation cue                |
+| SoundDisabled | bool          | Suppress row sounds               |
 
 ## TreeNodeCfg
 
@@ -107,7 +110,7 @@ When `ItemPaths` is set, `Nodes` is ignored.
 | ColorHover  | Color        | Hover background        |
 | ColorFocus  | Color        | Focused node background |
 | ColorBorder | Color        | Border color            |
-| Padding     | Opt[Padding] | Inner padding           |
+| Padding     | Padding      | Inner padding           |
 | SizeBorder  | Opt[float32] | Border width            |
 | Radius      | Opt[float32] | Corner radius           |
 

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -215,7 +215,7 @@ func envTruthy(name string) bool {
 // Debug turns dev-mode diagnostics on or off. When on, every category
 // of finding is checked:
 //
-//   - two shapes sharing one ID
+//   - two shapes sharing one effective ID
 //   - a focusable shape with no ID (never keyboard-reachable)
 //   - a scrollable shape with no ID (scroll offset shared with every
 //     other ID-less scrollable in the window)
@@ -226,12 +226,19 @@ func envTruthy(name string) bool {
 //     (silently resampled down to the limit on GPU backends)
 //   - a container that sets both Wrap and Overflow (wrap wins, overflow
 //     is ignored)
+//   - a state key that is a bare leaf while an ancestor join rewrote
+//     the shape of that name (the widget never resolved its cfg.ID, or
+//     resolved at the wrong time)
+//   - a frame that finished with a focus ID no focusable shape claims
+//   - a shape whose stamp disagrees with the scope it was arranged
+//     under, or an ID-bearing shape with no stamp at all
+//   - a window-level feature the platform could not deliver
 //
-// It also reports, from dispatch rather than from the frame audit, any
-// consume-class callback that relies on automatic handling while an
-// ancestor would also have received the event — the sites that would
-// silently start firing twice under the one-rule event model. See
-// debug_event.go.
+// It also reports, from dispatch rather than from the frame audit, a
+// callback that acted on an event without consuming it while an
+// ancestor also received it; deferred callbacks that kept re-queueing
+// themselves until the frame bounded the loop; and a link activation
+// that resolved to nothing. See debug_event.go.
 //
 // [DebugCategories] enables these classes independently; Debug is the
 // same API with both extremes (all on, all off).

--- a/gui/debug_state_keys.go
+++ b/gui/debug_state_keys.go
@@ -40,8 +40,8 @@ type stringKeyed interface {
 //     shape whose state this key was meant to be.
 //
 // The third condition is what keeps the audit quiet. It reads
-// debugIDs.scoped, which holds only the leaves the resolve pass
-// actually changed, so a widget that builds its own absolute ID —
+// debugIDs.scoped, which holds only the leaves an ancestor join
+// actually rewrote, so a widget that builds its own absolute ID —
 // Form composes "form:login" from cfg.ID "login" — is absent from the
 // index and keys its state on cfg.ID without a finding. A cache keyed
 // by a file name or a URL satisfies the first two conditions and is

--- a/gui/id_query.go
+++ b/gui/id_query.go
@@ -13,9 +13,9 @@ import "strings"
 // ScrollVerticalTo writes an offset no scrollable reads.
 //
 // These two functions answer from the frame instead. They read the
-// arranged tree, which carries the identity the resolve pass actually
-// stamped, so the answer is what the addressing APIs expect rather
-// than a second implementation of the rule. See issue #521.
+// arranged tree, which carries the identity generation stamped, so the
+// answer is what the addressing APIs expect rather than a second
+// implementation of the rule. See issue #521.
 
 // EffectiveIDs returns every effective ID in the last laid-out frame,
 // in tree order, with duplicates kept.
@@ -26,7 +26,7 @@ import "strings"
 // hiding it here would make this the one view that looks clean.
 //
 // The list is empty before the first frame is laid out: identities are
-// stamped during arrange, so a window that has never rendered has
+// stamped during generation, so a window that has never rendered has
 // none.
 // exportaudit:keep — dev-diagnostic API for app authors (issue #521)
 func (w *Window) EffectiveIDs() []string {

--- a/gui/view_command_palette.go
+++ b/gui/view_command_palette.go
@@ -83,7 +83,7 @@ type commandPaletteView struct {
 }
 
 // CommandPalette creates the palette view. Include in view tree;
-// hidden unless CommandPaletteShow was called.
+// hidden until shown with CommandPaletteToggle.
 func CommandPalette(cfg CommandPaletteCfg) View {
 	RequireID("CommandPalette", cfg.ID)
 	applyCommandPaletteDefaults(&cfg)

--- a/gui/window_cfg.go
+++ b/gui/window_cfg.go
@@ -53,7 +53,7 @@ type WindowCfg struct {
 	// the window to, in logical pixels. Zero means no ceiling. A
 	// ceiling below its floor is raised to the floor. On Windows and
 	// macOS the ceiling also caps the maximize button, not only the
-	// drag.
+	// drag. FixedSize wins over both, pinning the ceiling too.
 	// exportaudit:keep — caller-facing config (issue #494)
 	MaxWidth int
 	// exportaudit:keep — caller-facing config (issue #494)


### PR DESCRIPTION
Review pass over every doc against recent ID-scoping (#518-#531), window (#515/#516/#494/#473), and widget-behavior (#510/#509/#498/#496/#495/#486/#485/#476/#470-480) changes.

Stale fixed: uniqueness spec resolve-pass sections, focusable deferred bucket + 16/19/20 count split, architecture Grow/files/arrange, cookbook Padding/IsFocus/SizeBorder, CONTRIBUTING merge queue + prepush, frameless FixedSize bullet, MaxWidth comment, commands.md paletteAction signature, palette API table (only Toggle is public), Padding types in showcase docs, resolve-pass wording in code comments.

Missing filled: StampDrift + full Debug sweep in cheat-sheet/README/CLAUDE, ResolveID multi-answer, ScrollbarCfg Opt instance, NumericInput steps, DatePicker sizing, Canvas transforms, Markdown RenderBlock, deployment compositor note, subpackage counts, Sound/Focus rows in showcase docs.

Local gate: make prepush green.