### PR TITLE
fix(gui): Input follows the cursor horizontally (#534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,23 @@ and this project adheres to
 
 ### Fixed
 
+- **Input now scrolls horizontally to follow the caret** (#534) — text wider
+  than the field was clipped with no way to reach it, so the caret went
+  invisible as soon as typing passed the right edge. Both modes are fixed.
+  Single-line always follows the caret, the way a conventional text field does.
+  Multiline wraps as before, but a run with no break opportunity is wider than
+  the width it was wrapped to, and that overflow is now recorded on the shape
+  (`Shape.inkOverflowW`) and counted by `computeContentWidth`, so the field can
+  scroll to reach it and a `Scrollable` multiline input shows its horizontal bar
+  — hidden until needed, like the vertical one. A field that is not a scroll
+  container gets the offset applied to its text shape alone: making a
+  single-line field `Scrollable` would trip two sizing rules that treat any
+  `Scrollable` `Fill` container as elastic, resizing Inputs in a `Row` and
+  collapsing data grid cells. Drag-to-select auto-scrolls on both axes now, and
+  a password field's caret geometry and measured width are read against the
+  bullets it renders rather than the raw text, which had put the caret at the
+  wrong offset.
+
 - **WithTooltip and Menubar now resolve their IDs at generation time** (#528) —
   the last two widgets of the class #518, #519 and #520 fixed. Both took a
   `*Window` and built eagerly in the factory body, which runs while the parent's

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -71,6 +71,63 @@ func goldenCases() []goldenCase {
 			},
 		},
 		{
+			// Issue #534: a single-line field scrolled horizontally.
+			// The offset is set here rather than driven, the way
+			// virtual_list pins its scroll — a golden records
+			// appearance, and a fixed offset is the same every run.
+			// This case needs no measurer: the shift is arithmetic in
+			// AmendLayout, so it records headlessly.
+			name:    "input_scrolled_x",
+			focusID: "in",
+			build: func(w *Window) View {
+				w.scrollX().Set("in", -60)
+				return Input(InputCfg{
+					ID: "in",
+					// Fixed width, long text: the field cannot hug its
+					// content, so the golden records the shift itself
+					// rather than the end of the scroll range.
+					Width:  200,
+					Sizing: FixedFit,
+					Text: "a long value that runs a very long way " +
+						"past the right edge of the field it sits in",
+				})
+			},
+		},
+		{
+			// Pins that a placeholder is never shifted, however the
+			// field was left scrolled: it is not the user's text.
+			name: "input_scrolled_x_placeholder",
+			build: func(w *Window) View {
+				w.scrollX().Set("in", -60)
+				return Input(InputCfg{
+					ID:          "in",
+					Placeholder: "enter a value",
+				})
+			},
+		},
+		{
+			// Pins that the horizontal bar of a scrollable multiline
+			// input stays invisible while nothing overflows.
+			//
+			// Only the hidden state is recordable here. Ink overflow is
+			// discovered from a glyph layout, and layoutPlainText
+			// returns before that path when there is no measurer, so a
+			// headless frame can never make the bar appear. The visible
+			// case is covered by the unit tests in
+			// view_input_scroll_test.go.
+			name: "input_multiline_hscroll_hidden",
+			build: func(_ *Window) View {
+				return Input(InputCfg{
+					ID:         "in",
+					Mode:       InputMultiline,
+					Scrollable: true,
+					Height:     80,
+					Sizing:     FillFixed,
+					Text:       "one two three four five six seven",
+				})
+			},
+		},
+		{
 			name: "input_disabled",
 			build: func(_ *Window) View {
 				return Input(InputCfg{

--- a/gui/layout.go
+++ b/gui/layout.go
@@ -59,6 +59,9 @@ func layoutPlaceholder() Layout {
 // skipLayoutChild reports whether a child should be excluded
 // from spacing, content-size, and overflow calculations.
 func skipLayoutChild(s *Shape) bool {
+	if s == nil {
+		return true
+	}
 	return s.Float || s.shapeType == shapeNone || s.OverDraw
 }
 
@@ -84,11 +87,31 @@ func contentWidth(layout *Layout) float32 {
 	return computeContentWidth(layout)
 }
 
+// childExtentW is how far one child reaches on the X axis: its Width,
+// or Shape.inkOverflowW where painted ink reaches further. Only text
+// that cannot wrap sets that field (see Shape.inkOverflowW), so for
+// every other child this is just Width. A non-finite overflow is
+// ignored rather than poisoning the sum.
+func childExtentW(s *Shape) float32 {
+	ink := s.inkOverflowW
+	if !f32IsFinite(ink) {
+		return s.Width
+	}
+	return f32Max(s.Width, ink)
+}
+
 // computeContentWidth iterates children to calculate total content
 // width. Called during the fill pass to populate the cache and as a
-// fallback when no cached value exists.
+// fallback when no cached value exists. Each child's extent comes
+// from childExtentW.
 func computeContentWidth(layout *Layout) float32 {
 	var width float32
+	if layout == nil || layout.Shape == nil {
+		return 0
+	}
+	// Both axes measure a child the same way; only the combining
+	// operator differs. See childExtentW.
+
 	if layout.Shape.Axis == axisLeftToRight {
 		width += layout.spacing()
 		for i := range layout.Children {
@@ -96,7 +119,7 @@ func computeContentWidth(layout *Layout) float32 {
 			if skipLayoutChild(c.Shape) {
 				continue
 			}
-			width += c.Shape.Width
+			width += childExtentW(c.Shape)
 		}
 	} else {
 		for i := range layout.Children {
@@ -104,7 +127,7 @@ func computeContentWidth(layout *Layout) float32 {
 			if skipLayoutChild(c.Shape) {
 				continue
 			}
-			width = f32Max(width, c.Shape.Width)
+			width = f32Max(width, childExtentW(c.Shape))
 		}
 	}
 	return width

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -191,6 +191,48 @@ func layoutWrapTextWalk(layout *Layout, w *Window) {
 			return
 		}
 		layoutPlainText(shape, tc, style, w)
+		if shape.inkOverflowW > 0 {
+			propagateInkOverflow(layout)
+		}
+	}
+}
+
+// propagateInkOverflow tells the ancestors of an overflowing text shape
+// how far its ink actually reaches, so a scroll container above it can
+// scroll to the ink instead of stopping at the box.
+//
+// Two things happen per ancestor. Its contentW cache is refreshed,
+// because layoutFillWidths cached it one pass before the glyph layout
+// existed (refitFitAncestors in layout_wrap.go does the same for the
+// wrap pass). And the overflow is carried one level further up, unless
+// this ancestor is a viewport — a Clip or Scrollable node is where the
+// ink stops being visible, so it takes the refreshed contentW (that is
+// what makes scrolling possible) but does not leak the overflow to its
+// own parent, which would widen the whole page.
+//
+// Ordering: called from layoutWrapTextWalk, which runs after the fill
+// widths and before layoutAdjustScrollOffsets, so a width discovered
+// here still reaches the scroll clamp, positioning and the scrollbar
+// thumb in the same frame. Parent pointers are set by layoutParents at
+// the top of layoutArrange, and shapes are rebuilt every frame, so
+// inkOverflowW needs no reset.
+func propagateInkOverflow(node *Layout) {
+	if node == nil || node.Shape == nil {
+		return
+	}
+	ink := node.Shape.inkOverflowW
+	if !f32IsFinite(ink) || ink <= 0 {
+		return
+	}
+	for p := node.Parent; p != nil; p = p.Parent {
+		if p.Shape == nil {
+			return
+		}
+		p.Shape.contentW = computeContentWidth(p)
+		if p.Shape.Clip || p.Shape.Scrollable {
+			return
+		}
+		p.Shape.inkOverflowW = f32Max(p.Shape.inkOverflowW, ink)
 	}
 }
 
@@ -326,5 +368,21 @@ func layoutPlainText(
 	if tc.TextMode == TextModeMultiline &&
 		shape.Sizing.Width != sizingFixed && l.Width > 0 {
 		shape.Width = l.Width
+	}
+	// A wrapped run with no break opportunity is wider than the width it
+	// was wrapped to. Record the excess rather than growing the shape:
+	// the shape's width IS the wrap width, so growing it would re-wrap
+	// the text and undo the overflow that is being measured.
+	if tc.overflowScrollX && f32IsFinite(l.Width) &&
+		l.Width > shape.Width+f32Tolerance &&
+		(tc.TextMode == TextModeWrap ||
+			tc.TextMode == TextModeWrapKeepSpaces) {
+		// Plus the caret: it is painted ink too, and the extent recorded
+		// here is what layoutAdjustScrollOffsets clamps the field's
+		// horizontal offset against. Without it the pipeline clamps the
+		// caret's own width back off and the caret at the end of the run
+		// is never quite reachable. Only Input's text sets
+		// overflowScrollX, so no other shape pays for the caret.
+		shape.inkOverflowW = l.Width + inputCaretW
 	}
 }

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -40,7 +40,16 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 		}
 		return
 	}
-	if !rectsOverlap(shapeBounds(shape), clip) {
+	// Cull against the ink, not just the box. A run that could not wrap
+	// paints past its shape's right edge (see Shape.inkOverflowW), and
+	// once the field is scrolled the box can sit entirely left of the
+	// clip while the visible part of the text does not.
+	bounds := shapeBounds(shape)
+	if f32IsFinite(shape.inkOverflowW) &&
+		shape.inkOverflowW > bounds.Width {
+		bounds.Width = shape.inkOverflowW
+	}
+	if !rectsOverlap(bounds, clip) {
 		return
 	}
 	c := tc.TextStyle.Color
@@ -222,7 +231,7 @@ func renderInputCursor(shape *Shape, text string, baseX, baseY float32,
 
 	style := textStyleOrDefault(shape)
 	byteIdx := runeToByteIndex(text, pos)
-	cursorW := float32(1.5)
+	cursorW := inputCaretW
 
 	layout := preLayout
 	ok := hasPreLayout
@@ -494,7 +503,7 @@ func textWidthFallback(text string, runePos int, tc *shapeTextConfig, style Text
 	runePos = min(runePos, runeLen)
 	prefix := text[:runeToByteIndex(text, runePos)]
 	if tc != nil && tc.textIsPassword {
-		prefix = passwordMask(prefix)
+		prefix = maskPassword(prefix)
 	}
 	if w.textMeasurer != nil {
 		return w.textMeasurer.TextWidth(prefix, style)

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -39,24 +39,23 @@ func adjustCursorTrailing(
 	}
 }
 
-// inputScrollCursorIntoView adjusts the vertical scroll of a
-// multiline input so the cursor remains visible.
-// layout must be the outer scroll container (Column with a scroll ID).
+// inputCaretW is the painted width of the text caret. Shared with
+// renderInputCursor so the horizontal follow below scrolls the whole
+// caret into view, not just the edge the glyph layout reports.
+const inputCaretW = float32(1.5)
+
+// inputScrollCursorIntoView adjusts an input's scroll so the cursor
+// stays visible: vertically for a multiline input, and horizontally in
+// both modes.
+// layout must be the outer field container (the Column holding cfg.ID).
 func inputScrollCursorIntoView(
 	id string, text string, layout *Layout, w *Window,
 ) {
 	if id == "" || w.textMeasurer == nil {
 		return
 	}
-	if len(layout.Children) == 0 {
-		return
-	}
-	inner := &layout.Children[0]
-	if len(inner.Children) == 0 {
-		return
-	}
-	txtShape := inner.Children[0].Shape
-	if txtShape == nil || txtShape.TC == nil {
+	txtShape := inputTextShapeFromLayout(layout)
+	if txtShape == nil {
 		return
 	}
 	style := textStyleOrDefault(txtShape)
@@ -70,13 +69,25 @@ func inputScrollCursorIntoView(
 	runeLen := utf8RuneCount(text)
 	pos := is.CursorPos
 	pos = min(pos, runeLen)
-	byteIdx := runeToByteIndex(text, pos)
+	// The glyph layout above was built from the masked text for a
+	// password field (inputGlyphLayoutResolved masks internally), so the
+	// byte index has to be taken against that same string. A bullet and
+	// the rune it hides are different byte lengths, so indexing the raw
+	// text lands the caret in the wrong place.
+	idxText := text
+	if txtShape.TC.textIsPassword {
+		idxText = maskPassword(text)
+		pos = min(pos, utf8RuneCount(idxText))
+	}
+	byteIdx := runeToByteIndex(idxText, pos)
 
 	cp, ok := gl.GetCursorPos(byteIdx)
 	if !ok {
 		return
 	}
 	adjustCursorTrailing(&cp, gl.Lines, byteIdx, is.cursorTrailing)
+
+	inputScrollCursorIntoViewX(id, layout, txtShape, cp, w)
 
 	// Default 0: unscrolled position when no offset recorded yet.
 	sy := w.scrollY()
@@ -94,6 +105,58 @@ func inputScrollCursorIntoView(
 	} else if cursorBot > visibleBot {
 		sy.Set(id, -(cursorBot - viewportH))
 		scrollSmoothCancel(w, id, scrollAxisY)
+	}
+}
+
+// inputScrollCursorIntoViewX is the horizontal half of the follow. It
+// runs for both modes: single-line text never wraps, and a multiline
+// run with no break opportunity overflows the wrap width, so either can
+// put the caret outside the field.
+//
+// Unlike the vertical branch, the offset is clamped here at the write.
+// A single-line field is deliberately not Scrollable (see
+// inputAmendLayout), so layoutAdjustScrollOffsets never sees it and
+// would not clamp a stale offset for it. For a multiline field this is
+// the same clamp the pipeline applies, so doing it twice is harmless.
+func inputScrollCursorIntoViewX(
+	id string, layout *Layout, txtShape *Shape,
+	cp glyph.CursorPosition, w *Window,
+) {
+	if layout == nil || layout.Shape == nil || txtShape == nil {
+		return
+	}
+	viewportW := layout.Shape.Width - layout.Shape.paddingWidth()
+	if viewportW <= 0 || !f32IsFinite(viewportW) {
+		return
+	}
+	if !f32IsFinite(cp.X) {
+		return
+	}
+	// The caret is painted ink, so the extent the offset is clamped
+	// against has to include it. That is not pedantry: this runs from a
+	// key handler, so layout still holds the arrangement of the frame
+	// before the keystroke and inputScrollContentW is one character
+	// short, while cp comes from a glyph layout built on the new text.
+	// Clamping to the stale extent alone parks the caret exactly one
+	// character past the right edge and keeps it there.
+	maxNegX := f32Min(0, viewportW-f32Max(
+		inputScrollContentW(layout, txtShape), cp.X+inputCaretW))
+
+	// Default 0: unscrolled position when no offset recorded yet.
+	sx := w.scrollX()
+	offset := sx.GetOr(id, 0)
+	cursorLeft := cp.X
+	cursorRight := cp.X + inputCaretW
+	visibleLeft := -offset
+	visibleRight := visibleLeft + viewportW
+
+	switch {
+	case cursorLeft < visibleLeft:
+		sx.Set(id, f32Clamp(-cursorLeft, maxNegX, 0))
+		scrollSmoothCancel(w, id, scrollAxisX)
+	case cursorRight > visibleRight:
+		sx.Set(id, f32Clamp(-(cursorRight-viewportW), maxNegX, 0))
+		scrollSmoothCancel(w, id, scrollAxisX)
 	}
 }
 
@@ -446,4 +509,52 @@ func (w *Window) ScrollVerticalPct(id string) float32 {
 	// Default 0: unscrolled position when no offset recorded yet.
 	current := sy.GetOr(id, 0)
 	return f32Clamp(current/maxOffset, 0, 1)
+}
+
+// inputScrollContentW returns how far an input's content reaches on the
+// X axis, which is what its horizontal offset is clamped against.
+//
+// The two modes reach past the viewport by opposite routes, and each
+// one's measure is the other's noise, so this picks rather than maxes.
+//
+// Multiline wraps, so its text shape is pinned to the wrap width and is
+// always exactly the viewport — it says nothing. What reaches past is
+// the ink recorded for a run that could not wrap, carried up to the
+// field by propagateInkOverflow and read back through contentWidth.
+// That figure already includes the caret (see layoutPlainText).
+//
+// Single-line never wraps, so the full text width is its intrinsic
+// width — but read that from MinWidth, not Width. Text pins its
+// measurement as a minimum and its Fill parent then stretches it, so
+// for text that fits, Width is the viewport and says nothing, exactly
+// like the container's content width. Plus the caret, painted just past
+// the last glyph: without it a caret at the end of the text sits
+// exactly on the clamp and renders half-clipped.
+//
+// Taking the max of every candidate instead would floor every input at
+// the viewport plus a caret, so even a field whose text fits would
+// report 1.5px of scrollable range and could paint itself shifted.
+func inputScrollContentW(layout *Layout, txtShape *Shape) float32 {
+	if layout == nil || txtShape == nil {
+		return 0
+	}
+	if txtShape.TC != nil && txtShape.TC.overflowScrollX {
+		content := contentWidth(layout)
+		ink := txtShape.inkOverflowW
+		if !f32IsFinite(content) {
+			content = 0
+		}
+		if !f32IsFinite(ink) {
+			ink = 0
+		}
+		return f32Max(content, ink)
+	}
+	intrinsic := txtShape.MinWidth
+	if intrinsic <= 0 {
+		intrinsic = txtShape.Width
+	}
+	if !f32IsFinite(intrinsic) || intrinsic < 0 {
+		intrinsic = 0
+	}
+	return intrinsic + inputCaretW
 }

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -213,6 +213,17 @@ type Shape struct {
 	// child-tree summation in position and scroll passes.
 	contentW, contentH float32
 
+	// inkOverflowW is how far painted ink reaches past Shape.Width on
+	// the X axis. Text that cannot wrap (an unbreakable run wider than
+	// the wrap width) overflows its box instead of growing it, because
+	// the wrap width and Shape.Width are the same number and widening
+	// the shape would re-wrap the text. Recording the overflow here
+	// instead lets computeContentWidth report the true extent, so a
+	// scroll container above the text can scroll to reach it. Set in
+	// layoutPlainText, propagated upward by propagateInkOverflow, and
+	// zero for everything that does not overflow.
+	inkOverflowW float32
+
 	// siblingSumGen matches scratchPools.fillGen when
 	// siblingSumW and siblingSumH are valid for the current
 	// frame. Separate from fillGen because sibling sums are
@@ -406,6 +417,12 @@ type shapeTextConfig struct {
 	wrapCacheValid  bool
 	textLayoutValid bool
 	textLayoutMode  textMode
+	// overflowScrollX opts this shape into ink-overflow accounting:
+	// layoutPlainText records how far an unbreakable run reaches past
+	// the wrap width in Shape.inkOverflowW so an ancestor scroll
+	// container can reach it. Only Input's text shape sets it, which
+	// keeps the content-width change off every other wrapped text.
+	overflowScrollX bool
 }
 
 // hasRtfLayout returns true if the shape has an RTF layout.

--- a/gui/testdata/input_multiline_hscroll_hidden.dark.golden
+++ b/gui/testdata/input_multiline_hscroll_hidden.dark.golden
@@ -1,0 +1,9 @@
+Rect xy=15.00,15.00 wh=290.00,80.00 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=290.00,80.00 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,21.00 wh=268.00,68.00
+Text xy=26.00,21.00 wh=268.00,0.00 color=#e6e8ebff text="one two three four five six seven" size=14.00
+Clip xy=26.00,85.00 wh=268.00,7.00
+Clip xy=26.00,21.00 wh=268.00,68.00
+Clip xy=295.00,21.00 wh=7.00,68.00
+Clip xy=26.00,21.00 wh=268.00,68.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_multiline_hscroll_hidden.light.golden
+++ b/gui/testdata/input_multiline_hscroll_hidden.light.golden
@@ -1,0 +1,8 @@
+Rect xy=14.00,14.00 wh=292.00,80.00 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,19.00 wh=272.00,70.00
+Text xy=24.00,19.00 wh=272.00,0.00 color=#1a1d21ff text="one two three four five six seven" size=14.00
+Clip xy=24.00,84.00 wh=272.00,7.00
+Clip xy=24.00,19.00 wh=272.00,70.00
+Clip xy=296.00,19.00 wh=7.00,70.00
+Clip xy=24.00,19.00 wh=272.00,70.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_scrolled_x.dark.golden
+++ b/gui/testdata/input_scrolled_x.dark.golden
@@ -1,0 +1,7 @@
+Shadow xy=15.00,15.00 wh=200.00,31.60 color=#4d82f03f radius=6.00 blur=2.00 offset=0.00,0.00
+Rect xy=15.00,15.00 wh=200.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=200.00,31.60 color=#4d82f0ff radius=6.00 thickness=1.00
+Clip xy=26.00,21.00 wh=178.00,19.60
+Text xy=-34.00,21.00 wh=0.00,0.00 color=#e6e8ebff text="a long value that runs a very long way past the right edge of the field it sits in" size=14.00
+Rect xy=-34.00,21.00 wh=1.50,16.80 color=#e6e8ebff fill
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_scrolled_x.light.golden
+++ b/gui/testdata/input_scrolled_x.light.golden
@@ -1,0 +1,6 @@
+Shadow xy=14.00,14.00 wh=200.00,29.60 color=#2f6fe03f radius=6.00 blur=2.00 offset=0.00,0.00
+Rect xy=14.00,14.00 wh=200.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,19.00 wh=180.00,19.60
+Text xy=-36.00,19.00 wh=0.00,0.00 color=#1a1d21ff text="a long value that runs a very long way past the right edge of the field it sits in" size=14.00
+Rect xy=-36.00,19.00 wh=1.50,16.80 color=#1a1d21ff fill
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_scrolled_x_placeholder.dark.golden
+++ b/gui/testdata/input_scrolled_x_placeholder.dark.golden
@@ -1,0 +1,5 @@
+Rect xy=15.00,15.00 wh=160.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=160.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,21.00 wh=138.00,19.60
+Text xy=26.00,21.00 wh=0.00,0.00 color=#e6e8eb64 text="enter a value" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_scrolled_x_placeholder.light.golden
+++ b/gui/testdata/input_scrolled_x_placeholder.light.golden
@@ -1,0 +1,4 @@
+Rect xy=14.00,14.00 wh=160.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,19.00 wh=140.00,19.60
+Text xy=24.00,19.00 wh=0.00,0.00 color=#1a1d217c text="enter a value" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -259,6 +259,12 @@ func Input(cfg InputCfg) View {
 			IsPassword:        cfg.IsPassword,
 			placeholderActive: placeholderActive,
 			readOnly:          cfg.ReadOnly,
+			// Multiline wraps, so a run with no break opportunity is
+			// the only thing that can reach past the field. Record it
+			// so the field's horizontal scroll can follow the cursor
+			// into it. Single-line never wraps, so its text shape is
+			// already full width and needs no overflow accounting.
+			scrollOverflowX: cfg.Mode == InputMultiline,
 		}),
 	}
 
@@ -485,14 +491,18 @@ func (h *inputHandlerCfg) compiledMask() *CompiledInputMask {
 	return &c
 }
 
-// inputScrollIDFor returns the scroll key for a multiline input, or
-// "" when the input does not opt into scrolling. Multiline-only:
-// single-line inputs never scroll vertically.
+// inputScrollIDFor returns the key an input's scroll offsets are stored
+// under, or "" for an input with no identity to key them by.
+//
+// Every input follows the caret horizontally, which is what a
+// conventional text field does, so every input needs a key. What
+// cfg.Scrollable decides is only how the offset is applied: a
+// Scrollable multiline field is a real scroll container, with
+// scrollbars and the pipeline folding the offset into its children;
+// anything else has the offset applied to its text shape alone, in
+// inputApplyScrollX.
 func inputScrollIDFor(cfg *InputCfg) string {
-	if cfg.Mode == InputMultiline && cfg.Scrollable {
-		return cfg.ID
-	}
-	return ""
+	return cfg.ID
 }
 
 // inputOnClick handles a click on the inner row that wraps the text
@@ -550,7 +560,7 @@ func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 		byteIdx := gl.GetClosestOffset(relX, relY)
 		displayText := text
 		if ly.Shape.TC.textIsPassword {
-			displayText = passwordMask(text)
+			displayText = maskPassword(text)
 		}
 		runePos := byteToRuneIndex(displayText, byteIdx)
 		imap := StateMap[string, inputState](
@@ -613,6 +623,16 @@ func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 			ds.viewBot = ds.viewTop + viewH
 			ds.maxScrollNeg = f32Min(0,
 				viewH-ctx.Layout.Shape.Height)
+
+			// Same frame on X, clamped against the same extent the
+			// follow writes against (see inputScrollContentW).
+			sx := ctx.Window.scrollX()
+			ds.scrollX0 = sx.GetOr(scrollID, 0)
+			ds.viewLeft = p.X + p.Padding.Left
+			viewW := p.Width - p.paddingWidth()
+			ds.viewRight = ds.viewLeft + viewW
+			ds.maxScrollNegX = f32Min(0, viewW-inputScrollContentW(
+				ctx.Layout.Parent, ly.Shape))
 		}
 		startInputDrag(ds, ctx.Window)
 	}
@@ -635,6 +655,7 @@ func inputAmendLayout(
 			}
 			ctx.Layout.Shape.events.OnMouseScroll = onMouseScroll
 		}
+		inputApplyScrollX(hcfg, ctx.Layout, ctx.Window)
 		if !ctx.Layout.Shape.Focusable || ctx.Layout.Shape.ID == "" {
 			return
 		}

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -10,21 +10,34 @@ import (
 // inputTextFromLayout extracts the current text from the input's
 // inner layout structure (Column → Row → Text).
 func inputTextFromLayout(layout *Layout) string {
-	if len(layout.Children) == 0 {
+	txt := inputTextShapeFromLayout(layout)
+	if txt == nil {
 		return ""
+	}
+	if txt.TC.textIsPlaceholder {
+		return ""
+	}
+	return txt.TC.Text
+}
+
+// inputTextShapeFromLayout returns an input's inner text shape
+// (Column -> Row/Column -> Text), or nil when the tree is not the shape
+// this expects. Every caller that reaches the text leaf has to descend
+// the same way and move together if the widget's structure changes;
+// one helper is what keeps them together.
+func inputTextShapeFromLayout(layout *Layout) *Shape {
+	if layout == nil || len(layout.Children) == 0 {
+		return nil
 	}
 	row := &layout.Children[0]
 	if len(row.Children) == 0 {
-		return ""
+		return nil
 	}
-	txt := &row.Children[0]
-	if txt.Shape.TC == nil {
-		return ""
+	txt := row.Children[0].Shape
+	if txt == nil || txt.TC == nil {
+		return nil
 	}
-	if txt.Shape.TC.textIsPlaceholder {
-		return ""
-	}
-	return txt.Shape.TC.Text
+	return txt
 }
 
 // inputSetTextInLayout writes mutated text back into the input's
@@ -37,21 +50,14 @@ func inputTextFromLayout(layout *Layout) string {
 // from app state before the next render, so this echo only feeds
 // intra-batch event reads — it never reaches the screen.
 func inputSetTextInLayout(layout *Layout, text string) {
-	if len(layout.Children) == 0 {
+	txt := inputTextShapeFromLayout(layout)
+	if txt == nil {
 		return
 	}
-	row := &layout.Children[0]
-	if len(row.Children) == 0 {
-		return
-	}
-	txt := &row.Children[0]
-	if txt.Shape == nil || txt.Shape.TC == nil {
-		return
-	}
-	txt.Shape.TC.Text = text
+	txt.TC.Text = text
 	// Clear the placeholder flag so a follow-up read returns the
 	// typed text rather than treating it as placeholder content.
-	txt.Shape.TC.textIsPlaceholder = false
+	txt.TC.textIsPlaceholder = false
 }
 
 // inputGlyphLayoutFor navigates to the inner text shape of an
@@ -70,19 +76,12 @@ func inputGlyphLayoutWithText(
 	if w.textMeasurer == nil {
 		return glyph.Layout{}, false
 	}
-	if len(layout.Children) == 0 {
+	txt := inputTextShapeFromLayout(layout)
+	if txt == nil {
 		return glyph.Layout{}, false
 	}
-	row := &layout.Children[0]
-	if len(row.Children) == 0 {
-		return glyph.Layout{}, false
-	}
-	txt := &row.Children[0]
-	if txt.Shape == nil || txt.Shape.TC == nil {
-		return glyph.Layout{}, false
-	}
-	style := textStyleOrDefault(txt.Shape)
-	return inputGlyphLayout(text, txt.Shape, style, w)
+	style := textStyleOrDefault(txt)
+	return inputGlyphLayout(text, txt, style, w)
 }
 
 // trailingLineStart returns the start of the previous visual line
@@ -182,24 +181,32 @@ type inputDragState struct {
 	scrollY0               float32
 	viewTop, viewBot       float32
 	maxScrollNeg           float32
+	// Horizontal mirror of the four fields above. The offset can move
+	// mid-drag on either axis, so both are captured at drag start and
+	// re-read as a delta in computeRunePos.
+	scrollX0            float32
+	viewLeft, viewRight float32
+	maxScrollNegX       float32
 }
 
 func (d *inputDragState) computeRunePos(
 	mx, my float32, w *Window,
 ) int {
-	scrollDelta := float32(0)
+	scrollDelta, scrollDeltaX := float32(0), float32(0)
 	if d.scrollID != "" {
 		sy := w.scrollY()
 		// Default 0: absent entry means unscrolled initial position.
 		sNow := sy.GetOr(d.scrollID, 0)
 		scrollDelta = sNow - d.scrollY0
+		sNowX := w.scrollX().GetOr(d.scrollID, 0)
+		scrollDeltaX = sNowX - d.scrollX0
 	}
 	relY := my - (d.txtOffY + scrollDelta)
 	// A drag carried above or below the text selects to the line's
 	// edge rather than stopping at the pointer's column; see
 	// textDragEdgeX.
 	top, bot := glyphTextBand(&d.gl)
-	relX := textDragEdgeX(mx-d.txtOffX, relY, top, bot)
+	relX := textDragEdgeX(mx-(d.txtOffX+scrollDeltaX), relY, top, bot)
 	byteIdx := d.gl.GetClosestOffset(relX, relY)
 	return byteToRuneIndex(d.displayText, byteIdx)
 }
@@ -235,25 +242,68 @@ func (d *inputDragState) updateSelection(rp int, w *Window) {
 func (d *inputDragState) scrollCallback(
 	_ *Animate, w *Window,
 ) {
-	var delta float32
-	if d.lastMouseY < d.viewTop {
-		delta = (d.viewTop - d.lastMouseY) * 0.3
-	} else if d.lastMouseY > d.viewBot {
-		delta = -((d.lastMouseY - d.viewBot) * 0.3)
-	} else {
+	// Both axes are computed before anything is decided. Returning as
+	// soon as one axis is inside its band would stop the auto-scroll
+	// while the pointer is still dragging past the other edge.
+	delta := dragScrollDelta(d.lastMouseY, d.viewTop, d.viewBot)
+	deltaX := float32(0)
+	if d.viewRight > d.viewLeft {
+		// An unseeded X band (both zero) would read as "outside" for
+		// every pointer position; only a real band takes part.
+		deltaX = dragScrollDelta(d.lastMouseX, d.viewLeft, d.viewRight)
+	}
+	if delta == 0 && deltaX == 0 {
 		w.AnimationRemove(animIDDragScroll)
 		return
 	}
-	sy := w.scrollY()
-	// Default 0: unscrolled position when no offset recorded yet.
-	cur := sy.GetOr(d.scrollID, 0)
-	newScroll := f32Clamp(cur+delta, d.maxScrollNeg, 0)
-	if newScroll == cur {
+	// Both calls run: || would skip the second axis once the first has
+	// moved, and the drag has to advance on each independently.
+	movedY := applyDragScroll(
+		w.scrollY(), d.scrollID, delta, d.maxScrollNeg)
+	movedX := applyDragScroll(
+		w.scrollX(), d.scrollID, deltaX, d.maxScrollNegX)
+	if !movedY && !movedX {
 		return
 	}
-	sy.Set(d.scrollID, newScroll)
 	rp := d.computeRunePos(d.lastMouseX, d.lastMouseY, w)
 	d.updateSelection(rp, w)
+}
+
+// applyDragScroll advances one axis of a drag auto-scroll by delta and
+// reports whether the stored offset actually moved. It does not move
+// when the axis is already scrolled as far as it goes, which is what
+// stops a drag held past the end from re-selecting every frame.
+func applyDragScroll(
+	m *BoundedMap[string, float32], id string, delta, maxNeg float32,
+) bool {
+	if delta == 0 || !f32IsFinite(delta) {
+		return false
+	}
+	if !f32IsFinite(maxNeg) || maxNeg > 0 {
+		maxNeg = 0
+	}
+	// Default 0: unscrolled position when no offset recorded yet.
+	cur := m.GetOr(id, 0)
+	next := f32Clamp(cur+delta, maxNeg, 0)
+	if next == cur {
+		return false
+	}
+	m.Set(id, next)
+	return true
+}
+
+// dragScrollDelta returns the auto-scroll step for a pointer dragged
+// past one edge of the viewport band, or 0 while it is inside. The
+// step is proportional to the overshoot, so the further out the drag
+// is carried the faster the field scrolls.
+func dragScrollDelta(pos, lo, hi float32) float32 {
+	switch {
+	case pos < lo:
+		return (lo - pos) * 0.3
+	case pos > hi:
+		return -((pos - hi) * 0.3)
+	}
+	return 0
 }
 
 // startInputDrag sets up MouseLock drag-to-select for an input.
@@ -266,7 +316,10 @@ func startInputDrag(d *inputDragState, w *Window) {
 			d.updateSelection(rp, ctx.Window)
 			if d.scrollID != "" {
 				outside := ctx.Event.MouseY < d.viewTop ||
-					ctx.Event.MouseY > d.viewBot
+					ctx.Event.MouseY > d.viewBot ||
+					(d.viewRight > d.viewLeft &&
+						(ctx.Event.MouseX < d.viewLeft ||
+							ctx.Event.MouseX > d.viewRight))
 				if outside && !ctx.Window.HasAnimation(
 					animIDDragScroll) {
 					ctx.Window.AnimationAdd(&Animate{
@@ -298,4 +351,78 @@ func startInputDrag(d *inputDragState, w *Window) {
 			imap.Set(d.focusID, is)
 		},
 	})
+}
+
+// inputApplyScrollX shifts an input's text shape by its horizontal
+// scroll offset, which is what makes the field follow the caret.
+// A Scrollable field is skipped: it is a real scroll container, so
+// layoutPositions has already folded the offset into its children.
+//
+// The offset lives in w.scrollX() under the field's own identity even
+// though such a field is deliberately NOT Scrollable — marking a
+// single-line field scrollable would trip two sizing rules that treat
+// any Scrollable Fill container as elastic (layout_sizing.go,
+// layoutFillCrossAxis and the MinHeight floor), resizing Inputs in a
+// Row and collapsing data grid cells. Sharing the storage instead keeps
+// one follow function for every input.
+//
+// Only the text leaf moves. The inner row keeps its position, so the
+// click target still covers the whole field, and the caret, hit test
+// and drag all read the text shape's own X, so they move with it.
+// Running from AmendLayout puts this before layoutSetShapeClips and
+// before event dispatch: the shifted ink is still clipped to the field
+// and hit testing sees the shifted rect.
+func inputApplyScrollX(
+	hcfg inputHandlerCfg, layout *Layout, w *Window,
+) {
+	if layout == nil || layout.Shape == nil {
+		return
+	}
+	if layout.Shape.Scrollable || hcfg.scrollID == "" {
+		return
+	}
+	key := layout.Shape.idKey()
+	if key == "" {
+		return
+	}
+	txt := inputTextShapeFromLayout(layout)
+	if txt == nil || txt.TC.textIsPlaceholder {
+		// A placeholder is never scrolled: it is not the user's text
+		// and the caret sits at its start.
+		return
+	}
+	// Default 0: no entry means the field has never scrolled.
+	offset := w.scrollX().GetOr(key, 0)
+	if offset == 0 {
+		return
+	}
+	if !f32IsFinite(offset) {
+		w.scrollX().Set(key, 0)
+		return
+	}
+	// Re-clamp against this frame's geometry. The offset was written
+	// against the previous frame, so a field that grew or text that
+	// shrank can leave it stale, and nothing else clamps it: the field
+	// is not Scrollable, so layoutAdjustScrollOffsets never sees it.
+	viewW := layout.Shape.Width - layout.Shape.paddingWidth()
+	if viewW <= 0 || !f32IsFinite(viewW) {
+		// Degenerate geometry: a field sized to nothing this frame (a
+		// collapsed pane, a hidden tab). Clamping against it would be
+		// arithmetic on a negative viewport, so leave the stored offset
+		// alone and paint unshifted until the field has a real width.
+		// Matches the same guard at the write site.
+		return
+	}
+	// Same extent the write site clamps against.
+	clamped := f32Clamp(offset,
+		f32Min(0, viewW-inputScrollContentW(layout, txt)), 0)
+	if clamped != offset {
+		// Store it back, the way layoutAdjustScrollOffsets does for a
+		// real scroll container. Painting the clamped value while the
+		// map keeps the stale one would leave every reader of the
+		// offset (ScrollHorizontalPct, the next follow, a drag seed)
+		// disagreeing with what is on screen.
+		w.scrollX().Set(key, clamped)
+	}
+	txt.X += clamped
 }

--- a/gui/view_input_scroll_test.go
+++ b/gui/view_input_scroll_test.go
@@ -1,0 +1,765 @@
+package gui
+
+import (
+	"math"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+// caretStubMeasurer is a fixed-advance measurer that returns a fully
+// populated glyph.Layout: lines, per-rune rects and cursor attributes.
+// stubTextMeasurer only fills Height, which is enough for the wrap
+// passes but not for GetCursorPos, and the horizontal follow is built
+// entirely out of cursor geometry.
+//
+// Wrapping matches glyph.WrapWord, which is the only mode go-gui asks
+// for: breaks happen at spaces, and a word wider than the wrap width
+// is left to overflow rather than broken. That overflow is the multiline
+// half of issue #534.
+type caretStubMeasurer struct {
+	charWidth  float32
+	fontHeight float32
+	// measured records every string TextWidth was asked about, so a
+	// test can assert which spelling of the text was sized.
+	measured []string
+}
+
+func (m *caretStubMeasurer) TextWidth(text string, _ TextStyle) float32 {
+	m.measured = append(m.measured, text)
+	return float32(len([]rune(text))) * m.charWidth
+}
+
+func (m *caretStubMeasurer) TextHeight(_ string, _ TextStyle) float32 {
+	return m.fontHeight
+}
+
+func (m *caretStubMeasurer) FontAscent(s TextStyle) float32 {
+	return s.Size * 0.8
+}
+
+func (m *caretStubMeasurer) FontHeight(_ TextStyle) float32 {
+	return m.fontHeight
+}
+
+// caretStubLine is one wrapped line: byte range plus rune count.
+type caretStubLine struct {
+	start, end, runes int
+}
+
+// wrapWords splits text into lines the way WrapWord does.
+func (m *caretStubMeasurer) wrapWords(
+	text string, wrapWidth float32,
+) []caretStubLine {
+	if wrapWidth <= 0 {
+		return []caretStubLine{{0, len(text), len([]rune(text))}}
+	}
+	var lines []caretStubLine
+	var cur caretStubLine
+	pos, first := 0, true
+	for word := range strings.SplitSeq(text, " ") {
+		runes := len([]rune(word))
+		if first {
+			cur = caretStubLine{0, len(word), runes}
+			pos, first = len(word), false
+			continue
+		}
+		// The joining space counts toward the line it stays on.
+		if float32(cur.runes+1+runes)*m.charWidth > wrapWidth {
+			lines = append(lines, cur)
+			cur = caretStubLine{pos + 1, pos + 1 + len(word), runes}
+		} else {
+			cur.runes += 1 + runes
+			cur.end = pos + 1 + len(word)
+		}
+		pos += 1 + len(word)
+	}
+	return append(lines, cur)
+}
+
+func (m *caretStubMeasurer) LayoutText(
+	text string, _ TextStyle, wrapWidth float32,
+) (glyph.Layout, error) {
+	l := glyph.Layout{
+		Text:            text,
+		CharRectByIndex: map[int]int{},
+		LogAttrByIndex:  map[int]int{},
+	}
+	if text == "" {
+		l.Height = m.fontHeight
+		return l, nil
+	}
+	// Every byte that starts a rune is a valid cursor position; nothing
+	// inside a rune is. This is what makes a byte index taken against
+	// the wrong string (raw text vs password bullets) fail loudly.
+	for byteIdx := range text {
+		l.LogAttrByIndex[byteIdx] = len(l.LogAttrs)
+		l.LogAttrs = append(l.LogAttrs,
+			glyph.LogAttr{IsCursorPosition: true})
+	}
+	l.LogAttrByIndex[len(text)] = len(l.LogAttrs)
+	l.LogAttrs = append(l.LogAttrs, glyph.LogAttr{IsCursorPosition: true})
+
+	for row, line := range m.wrapWords(text, wrapWidth) {
+		y := float32(row) * m.fontHeight
+		col := 0
+		for byteIdx := range text[line.start:line.end] {
+			abs := line.start + byteIdx
+			l.CharRectByIndex[abs] = len(l.CharRects)
+			l.CharRects = append(l.CharRects, glyph.CharRect{
+				Index: abs,
+				Rect: glyph.Rect{
+					X: float32(col) * m.charWidth, Y: y,
+					Width: m.charWidth, Height: m.fontHeight,
+				},
+			})
+			col++
+		}
+		lineW := float32(line.runes) * m.charWidth
+		l.Lines = append(l.Lines, glyph.Line{
+			StartIndex: line.start,
+			Length:     line.end - line.start,
+			Rect: glyph.Rect{
+				Y: y, Width: lineW, Height: m.fontHeight,
+			},
+		})
+		l.Width = f32Max(l.Width, lineW)
+		l.Height = y + m.fontHeight
+	}
+	l.VisualWidth, l.VisualHeight = l.Width, l.Height
+	return l, nil
+}
+
+// arrangeInput builds and arranges one Input filling a fixed window,
+// and returns the arranged field layout (the container claiming cfg.ID).
+func arrangeInput(
+	t *testing.T, w *Window, cfg InputCfg,
+) (*Layout, *Layout) {
+	t.Helper()
+	// A default Input hugs its content, which would make the field as
+	// wide as the text and leave nothing to scroll. Pin it to the
+	// window, the way a real form's Fill-width field resolves.
+	if !cfg.Sizing.IsSet() {
+		cfg.Sizing = FixedFixed
+		cfg.Width = float32(w.windowWidth)
+		cfg.Height = float32(w.windowHeight)
+		cfg.noMinWidthFloor = true
+	}
+	// Fixed, not FillFill: only updateLayout seeds a FillFill root from
+	// the window rect, and these tests arrange the tree directly.
+	root := generateViewLayout(Column(ContainerCfg{
+		Sizing:     FixedFixed,
+		Width:      float32(w.windowWidth),
+		Height:     float32(w.windowHeight),
+		Padding:    NoPadding,
+		SizeBorder: NoBorder,
+		Content:    []View{Input(cfg)},
+	}), w)
+	layoutArrange(&root, w)
+	field := findLayoutByID(&root, cfg.ID)
+	if field == nil {
+		t.Fatalf("no layout with ID %q after arrange", cfg.ID)
+	}
+	return &root, field
+}
+
+// findLayoutByID returns the first layout whose effective identity is
+// key, or nil.
+func findLayoutByID(layout *Layout, key string) *Layout {
+	if layout.Shape != nil && layout.Shape.idKey() == key {
+		return layout
+	}
+	for i := range layout.Children {
+		if found := findLayoutByID(&layout.Children[i], key); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func caretTestWindow(width, height int) *Window {
+	w := &Window{windowWidth: width, windowHeight: height, focused: true}
+	w.SetTextMeasurer(&caretStubMeasurer{charWidth: 10, fontHeight: 20})
+	return w
+}
+
+// --- Single line ---
+
+// TestInputSingleLineScrollFollowsCursorRight is the core of the
+// single-line half of #534: a caret past the right edge pulls the view
+// after it instead of disappearing.
+func TestInputSingleLineScrollFollowsCursorRight(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	text := strings.Repeat("a", 60)
+	_, field := arrangeInput(t, w, InputCfg{ID: "in", Text: text})
+	setInputState(w, "in", inputState{CursorPos: len(text)})
+
+	inputScrollCursorIntoView("in", text, field, w)
+
+	offset := w.scrollX().GetOr("in", 0)
+	if offset >= 0 {
+		t.Fatalf("scrollX = %v, want negative (view follows the caret)", offset)
+	}
+	viewportW := field.Shape.Width - field.Shape.paddingWidth()
+	want := -(float32(len(text))*10 + inputCaretW - viewportW)
+	if !floatNear(offset, want, 0.01) {
+		t.Errorf("scrollX = %v, want %v (caret flush at the right edge)",
+			offset, want)
+	}
+}
+
+// TestInputSingleLineScrollFollowsCursorLeft pins the return trip:
+// moving the caret home scrolls all the way back to 0.
+func TestInputSingleLineScrollFollowsCursorLeft(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	text := strings.Repeat("a", 60)
+	_, field := arrangeInput(t, w, InputCfg{ID: "in", Text: text})
+	w.scrollX().Set("in", -400)
+	setInputState(w, "in", inputState{CursorPos: 0})
+
+	inputScrollCursorIntoView("in", text, field, w)
+
+	if got := w.scrollX().GetOr("in", 0); got != 0 {
+		t.Errorf("scrollX = %v, want 0 (caret at the start)", got)
+	}
+}
+
+// TestInputSingleLineScrollZeroWhenTextFits asserts a field wider than
+// its text never scrolls, so short inputs are untouched by the change.
+func TestInputSingleLineScrollZeroWhenTextFits(t *testing.T) {
+	w := caretTestWindow(400, 60)
+	text := "abc"
+	_, field := arrangeInput(t, w, InputCfg{ID: "in", Text: text})
+	setInputState(w, "in", inputState{CursorPos: len(text)})
+
+	inputScrollCursorIntoView("in", text, field, w)
+
+	if got := w.scrollX().GetOr("in", 0); got != 0 {
+		t.Errorf("scrollX = %v, want 0 (text fits)", got)
+	}
+}
+
+// TestInputScrollXShiftsTextShapeOnly pins the mechanism: the offset
+// moves the text leaf and nothing else, so the click target still
+// covers the whole field.
+func TestInputScrollXShiftsTextShapeOnly(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	text := strings.Repeat("a", 60)
+
+	_, before := arrangeInput(t, w, InputCfg{ID: "in", Text: text})
+	rowX := before.Children[0].Shape.X
+	txtX := inputTextShape(t, before).X
+
+	w.scrollX().Set("in", -30)
+	_, after := arrangeInput(t, w, InputCfg{ID: "in", Text: text})
+
+	if got := after.Children[0].Shape.X; !floatNear(got, rowX, 0.01) {
+		t.Errorf("inner row X = %v, want %v (must not move)", got, rowX)
+	}
+	if got := inputTextShape(t, after).X; !floatNear(got, txtX-30, 0.01) {
+		t.Errorf("text X = %v, want %v", got, txtX-30)
+	}
+}
+
+// TestInputScrollXIgnoresPlaceholder pins that placeholder text is
+// never shifted: it is not the user's text, and the caret sits at its
+// start.
+func TestInputScrollXIgnoresPlaceholder(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	_, before := arrangeInput(t, w, InputCfg{
+		ID: "in", Placeholder: strings.Repeat("p", 60),
+	})
+	txtX := inputTextShape(t, before).X
+
+	w.scrollX().Set("in", -30)
+	_, after := arrangeInput(t, w, InputCfg{
+		ID: "in", Placeholder: strings.Repeat("p", 60),
+	})
+
+	if got := inputTextShape(t, after).X; !floatNear(got, txtX, 0.01) {
+		t.Errorf("placeholder X = %v, want %v (unshifted)", got, txtX)
+	}
+}
+
+// TestInputSingleLineInjectsNoScrollbars asserts the single-line field
+// stays a plain container: no scrollbar children, and not Scrollable —
+// which two sizing rules would otherwise treat as elastic.
+func TestInputSingleLineInjectsNoScrollbars(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	_, field := arrangeInput(t, w, InputCfg{
+		ID: "in", Text: strings.Repeat("a", 60),
+	})
+	if got := len(field.Children); got != 1 {
+		t.Errorf("field has %d children, want 1 (no scrollbars)", got)
+	}
+	if field.Shape.Scrollable {
+		t.Error("single-line field must not be Scrollable")
+	}
+}
+
+// TestInputSingleLineStaleOffsetReclamped pins the re-clamp in
+// inputApplyScrollX: nothing else clamps a single-line offset, because
+// the field is not Scrollable.
+func TestInputSingleLineStaleOffsetReclamped(t *testing.T) {
+	w := caretTestWindow(400, 60)
+	w.scrollX().Set("in", -900)
+	_, field := arrangeInput(t, w, InputCfg{ID: "in", Text: "abc"})
+
+	txt := inputTextShape(t, field)
+	if txt.X < field.Shape.X {
+		t.Errorf("text X = %v, left of the field at %v: stale offset "+
+			"was applied unclamped", txt.X, field.Shape.X)
+	}
+	// The clamp is stored, not just painted. Leaving -900 in the map
+	// would keep every later reader of the offset (the next follow, a
+	// drag seed, ScrollHorizontalPct) disagreeing with the screen.
+	if got := w.scrollX().GetOr("in", 0); got != 0 {
+		t.Errorf("stored scrollX = %v, want 0: the re-clamp must be "+
+			"written back, not only applied to the shape", got)
+	}
+}
+
+// TestInputPasswordScrollUsesMaskedByteIndex pins the password fix.
+// The glyph layout is built from bullets, so the caret's byte index has
+// to be taken against the mask: a two-byte rune and its three-byte
+// bullet do not line up, and the raw index lands mid-rune, where
+// GetCursorPos refuses and the follow silently does nothing.
+func TestInputPasswordScrollUsesMaskedByteIndex(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	text := strings.Repeat("é", 40) // 2 bytes per rune, 3 per bullet
+	_, field := arrangeInput(t, w, InputCfg{
+		ID: "in", Text: text, IsPassword: true,
+	})
+	setInputState(w, "in", inputState{CursorPos: 40})
+
+	inputScrollCursorIntoView("in", text, field, w)
+
+	if got := w.scrollX().GetOr("in", 0); got >= 0 {
+		t.Errorf("scrollX = %v, want negative: the caret is past the "+
+			"right edge of a masked 40-bullet field", got)
+	}
+}
+
+// --- Multiline ---
+
+func multilineCfg(id, text string) InputCfg {
+	return InputCfg{
+		ID: id, Text: text, Mode: InputMultiline, Scrollable: true,
+	}
+}
+
+// TestInputMultilineInkOverflowWidensContent is the multiline half of
+// #534: a run with no break opportunity overflows the wrap width, and
+// the field must be able to scroll to reach it.
+func TestInputMultilineInkOverflowWidensContent(t *testing.T) {
+	w := caretTestWindow(200, 200)
+	text := strings.Repeat("a", 60) // no space: nowhere to break
+	_, field := arrangeInput(t, w, multilineCfg("in", text))
+
+	txt := inputTextShape(t, field)
+	if txt.inkOverflowW <= txt.Width {
+		t.Fatalf("inkOverflowW = %v, want > text width %v",
+			txt.inkOverflowW, txt.Width)
+	}
+	if got := contentWidth(field); got < txt.inkOverflowW {
+		t.Errorf("contentWidth(field) = %v, want >= ink %v",
+			got, txt.inkOverflowW)
+	}
+	if got := scrollMaxOffsetX(field); got >= 0 {
+		t.Errorf("scrollMaxOffsetX = %v, want negative (scrollable)", got)
+	}
+}
+
+// TestInputMultilineWrapWidthUnchangedByInkOverflow pins the reason the
+// overflow is recorded rather than added to Shape.Width: the shape's
+// width IS the wrap width, so growing it would re-wrap the text.
+func TestInputMultilineWrapWidthUnchangedByInkOverflow(t *testing.T) {
+	w := caretTestWindow(200, 200)
+	text := strings.Repeat("a", 60)
+	_, field := arrangeInput(t, w, multilineCfg("in", text))
+
+	txt := inputTextShape(t, field)
+	widthArg := txt.TC.textLayoutWidth
+	if !floatNear(widthArg, txt.Width, 0.01) {
+		t.Errorf("cached wrap width %v != shape width %v",
+			widthArg, txt.Width)
+	}
+	style := textStyleOrDefault(txt)
+	if _, ok := plainTextLayoutResolved(text, txt, style, w); !ok {
+		t.Fatal("second layout resolve failed")
+	}
+	if !floatNear(txt.TC.textLayoutWidth, widthArg, 0.01) {
+		t.Errorf("wrap width moved to %v after a re-resolve, want %v: "+
+			"the text would re-wrap every frame",
+			txt.TC.textLayoutWidth, widthArg)
+	}
+}
+
+// TestInputMultilineWrappedTextDoesNotOverflow asserts ordinary text
+// with break opportunities claims no overflow, so the horizontal bar
+// stays hidden for the common case.
+func TestInputMultilineWrappedTextDoesNotOverflow(t *testing.T) {
+	w := caretTestWindow(200, 200)
+	text := strings.Repeat("ab cd ", 20)
+	_, field := arrangeInput(t, w, multilineCfg("in", text))
+
+	txt := inputTextShape(t, field)
+	if txt.inkOverflowW != 0 {
+		t.Errorf("inkOverflowW = %v, want 0 (text wraps)", txt.inkOverflowW)
+	}
+	if got := scrollMaxOffsetX(field); got != 0 {
+		t.Errorf("scrollMaxOffsetX = %v, want 0 (nothing to scroll)", got)
+	}
+}
+
+// TestInputMultilineVerticalFollowUnchanged is a regression pin: the
+// vertical follow that already worked must keep working now that the
+// same function also handles X.
+func TestInputMultilineVerticalFollowUnchanged(t *testing.T) {
+	w := caretTestWindow(200, 80)
+	text := strings.Repeat("ab cd ", 40)
+	_, field := arrangeInput(t, w, multilineCfg("in", text))
+	setInputState(w, "in", inputState{CursorPos: len([]rune(text))})
+
+	inputScrollCursorIntoView("in", text, field, w)
+
+	if got := w.scrollY().GetOr("in", 0); got >= 0 {
+		t.Errorf("scrollY = %v, want negative (caret on a lower line)", got)
+	}
+}
+
+// --- Drag ---
+
+// TestInputDragAutoScrollHorizontal pins the X half of the drag
+// auto-scroll: a pointer carried past the right edge keeps the field
+// scrolling under it.
+func TestInputDragAutoScrollHorizontal(t *testing.T) {
+	w := newTestWindow()
+	text := "abcd"
+	gl := glyph.Layout{
+		Text:            text,
+		CharRectByIndex: map[int]int{0: 0, 1: 1, 2: 2, 3: 3},
+		Lines: []glyph.Line{{
+			StartIndex: 0, Length: 4,
+			Rect: glyph.Rect{Width: 40, Height: 10},
+		}},
+		CharRects: []glyph.CharRect{
+			{Index: 0, Rect: glyph.Rect{X: 0, Width: 10, Height: 10}},
+			{Index: 1, Rect: glyph.Rect{X: 10, Width: 10, Height: 10}},
+			{Index: 2, Rect: glyph.Rect{X: 20, Width: 10, Height: 10}},
+			{Index: 3, Rect: glyph.Rect{X: 30, Width: 10, Height: 10}},
+		},
+	}
+	d := &inputDragState{
+		displayText: text,
+		gl:          gl,
+		focusID:     "f",
+		scrollID:    "inp",
+		lastMouseX:  150, // past viewRight
+		lastMouseY:  50,  // inside the vertical band
+		viewTop:     0, viewBot: 100,
+		viewLeft: 0, viewRight: 100,
+		maxScrollNegX: -200,
+	}
+	d.scrollCallback(nil, w)
+
+	if got := w.scrollX().GetOr("inp", 0); got >= 0 {
+		t.Errorf("scrollX = %v, want negative (dragged past the right "+
+			"edge)", got)
+	}
+	if got := w.scrollY().GetOr("inp", 0); got != 0 {
+		t.Errorf("scrollY = %v, want 0 (pointer inside the band)", got)
+	}
+}
+
+// TestInputDragAutoScrollStopsWhenBothAxesInside pins the restructured
+// stop condition: the animation ends only when neither axis is still
+// dragging past an edge.
+func TestInputDragAutoScrollStopsWhenBothAxesInside(t *testing.T) {
+	w := newTestWindow()
+	d := &inputDragState{
+		focusID: "f", scrollID: "inp",
+		lastMouseX: 50, lastMouseY: 50,
+		viewTop: 0, viewBot: 100,
+		viewLeft: 0, viewRight: 100,
+	}
+	w.AnimationAdd(&Animate{AnimID: animIDDragScroll, Delay: 1})
+	d.scrollCallback(nil, w)
+	if w.HasAnimation(animIDDragScroll) {
+		t.Error("animation must stop once both axes are inside")
+	}
+
+	// Still outside on X alone: the animation must survive.
+	d.lastMouseX = 150
+	w.AnimationAdd(&Animate{AnimID: animIDDragScroll, Delay: 1})
+	d.scrollCallback(nil, w)
+	if !w.HasAnimation(animIDDragScroll) {
+		t.Error("animation must continue while X is still outside")
+	}
+}
+
+// --- Render ---
+
+// TestRenderTextInkOverflowNotCulled pins the cull fix that goes with
+// the scroll: a run that could not wrap paints past its shape's right
+// edge, so once the field is scrolled the box can sit entirely left of
+// the clip while the visible part of the text does not. Culling on the
+// box alone drew nothing at all.
+func TestRenderTextInkOverflowNotCulled(t *testing.T) {
+	w := makeWindowWithScratch()
+	style := TextStyle{Color: RGB(255, 255, 255), Size: 16}
+	shape := &Shape{
+		shapeType: shapeText,
+		X:         -300, Y: 0,
+		Width: 100, Height: 20,
+		inkOverflowW: 600,
+		Opacity:      1.0,
+		TC: &shapeTextConfig{
+			Text: "wide", TextStyle: &style,
+			TextMode: TextModeWrapKeepSpaces,
+		},
+	}
+	renderText(shape, makeClip(0, 0, 200, 100), w)
+
+	if len(w.renderers) == 0 {
+		t.Error("no render commands: the ink reaches into the clip " +
+			"at x 0..300, only the box does not")
+	}
+}
+
+// TestInputMultilineNotScrollableFollowsCaret is the issue's own
+// multiline repro: the field opts into no scrolling at all, so the
+// offset is applied to the text shape the same way a single-line
+// field's is.
+func TestInputMultilineNotScrollableFollowsCaret(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	text := strings.Repeat("a", 60) // unbreakable: cannot wrap
+	_, field := arrangeInput(t, w, InputCfg{
+		ID: "in", Mode: InputMultiline, Text: text,
+	})
+	setInputState(w, "in", inputState{CursorPos: len(text)})
+
+	inputScrollCursorIntoView("in", text, field, w)
+
+	offset := w.scrollX().GetOr("in", 0)
+	if offset >= 0 {
+		t.Fatalf("scrollX = %v, want negative", offset)
+	}
+	if field.Shape.Scrollable {
+		t.Fatal("field must not be Scrollable in this case")
+	}
+
+	// The offset only reaches the screen through AmendLayout, so
+	// re-arrange and check the text shape actually moved.
+	_, after := arrangeInput(t, w, InputCfg{
+		ID: "in", Mode: InputMultiline, Text: text,
+	})
+	txt := inputTextShape(t, after)
+	if txt.X >= after.Shape.X {
+		t.Errorf("text X = %v, want left of the field at %v",
+			txt.X, after.Shape.X)
+	}
+}
+
+// TestInputScrollFollowsCaretOnStaleLayout pins the one-frame lag the
+// follow has to survive. The handlers call inputScrollCursorIntoView
+// with the text the keystroke just produced, but ctx.Layout is still
+// the arrangement of the frame before it, so the text shape and the
+// field's content width are one character short. Clamping the offset
+// against that stale extent alone parks the caret exactly one character
+// past the right edge and leaves it there for every keystroke after.
+func TestInputScrollFollowsCaretOnStaleLayout(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	arranged := strings.Repeat("a", 60)
+	_, field := arrangeInput(t, w, InputCfg{ID: "in", Text: arranged})
+
+	// One character more than the layout above was built from.
+	typed := arranged + "a"
+	setInputState(w, "in", inputState{CursorPos: len(typed)})
+
+	inputScrollCursorIntoView("in", typed, field, w)
+
+	viewportW := field.Shape.Width - field.Shape.paddingWidth()
+	want := -(float32(len(typed))*10 + inputCaretW - viewportW)
+	if got := w.scrollX().GetOr("in", 0); !floatNear(got, want, 0.01) {
+		t.Errorf("scrollX = %v, want %v (caret of the new character "+
+			"visible, not clamped to the previous frame's width)",
+			got, want)
+	}
+}
+
+// TestInputMultilineInkOverflowReservesCaret pins the caret width in the
+// recorded ink extent. A multiline field is a real scroll container, so
+// layoutAdjustScrollOffsets re-clamps whatever the follow wrote against
+// contentWidth. Without the caret in that extent the pipeline trims the
+// caret's own width back off and the caret at the end of an unbreakable
+// run can never be fully reached.
+func TestInputMultilineInkOverflowReservesCaret(t *testing.T) {
+	w := caretTestWindow(200, 80)
+	text := strings.Repeat("a", 60)
+	_, field := arrangeInput(t, w, multilineCfg("in", text))
+
+	txt := inputTextShape(t, field)
+	wantInk := float32(len(text))*10 + inputCaretW
+	if !floatNear(txt.inkOverflowW, wantInk, 0.01) {
+		t.Fatalf("inkOverflowW = %v, want %v (run plus the caret)",
+			txt.inkOverflowW, wantInk)
+	}
+	viewportW := field.Shape.Width - field.Shape.paddingWidth()
+	if got := scrollMaxOffsetX(field); !floatNear(got, viewportW-wantInk, 0.5) {
+		t.Errorf("scrollMaxOffsetX = %v, want %v (caret reachable)",
+			got, viewportW-wantInk)
+	}
+}
+
+// TestInputPasswordWidthMeasuresPaintedMask pins that a password field
+// is sized on the string renderText paints, not on a different mask.
+// maskPassword keeps newlines and passwordMask does not, so measuring
+// the wrong one collapses a multiline password to a single line's worth
+// of bullets and parks the horizontal scroll at the wrong maximum.
+func TestInputPasswordWidthMeasuresPaintedMask(t *testing.T) {
+	m := &caretStubMeasurer{charWidth: 10, fontHeight: 20}
+	w := &Window{windowWidth: 200, windowHeight: 200, focused: true}
+	w.SetTextMeasurer(m)
+	text := "ab\ncd"
+	arrangeInput(t, w, InputCfg{
+		ID: "in", Text: text, IsPassword: true, Mode: InputMultiline,
+	})
+
+	painted, wrong := maskPassword(text), passwordMask(text)
+	if !slices.Contains(m.measured, painted) {
+		t.Errorf("measured %q, none of them the painted mask %q",
+			m.measured, painted)
+	}
+	if slices.Contains(m.measured, wrong) {
+		t.Errorf("measured %q, the newline-flattening mask, instead of "+
+			"the painted %q", wrong, painted)
+	}
+}
+
+// TestInputApplyScrollXIgnoresZeroWidthField pins the degenerate-
+// geometry guard. A field sized to nothing this frame (a collapsed
+// pane, a hidden tab) has a negative viewport once padding is taken
+// off; clamping against that is arithmetic on nonsense, so the stored
+// offset must be left alone until the field has a real width.
+func TestInputApplyScrollXIgnoresZeroWidthField(t *testing.T) {
+	w := caretTestWindow(400, 60)
+	_, field := arrangeInput(t, w, InputCfg{
+		ID: "in", Text: strings.Repeat("a", 60),
+	})
+	txt := inputTextShape(t, field)
+
+	// Collapse the field after arrange: a real one gets here by sitting
+	// in a pane the user dragged shut, which no headless Cfg reproduces.
+	field.Shape.Width = 0
+	w.scrollX().Set("in", -50)
+	before := txt.X
+
+	inputApplyScrollX(inputHandlerCfg{scrollID: "in"}, field, w)
+
+	if got := w.scrollX().GetOr("in", 0); got != -50 {
+		t.Errorf("stored scrollX = %v, want -50 untouched: a zero-width "+
+			"field must not re-clamp the offset", got)
+	}
+	if txt.X != before {
+		t.Errorf("text X = %v, want %v: nothing should shift against a "+
+			"negative viewport", txt.X, before)
+	}
+}
+
+// TestInputInkOverflowStopsAtViewport pins that the overflow is not
+// leaked past the scroll container. propagateInkOverflow refreshes a
+// viewport's content width, which is what makes scrolling possible, but
+// must not carry the ink to that viewport's own parent — doing so would
+// widen the whole page around an input holding one long word.
+func TestInputInkOverflowStopsAtViewport(t *testing.T) {
+	w := caretTestWindow(200, 200)
+	root, field := arrangeInput(t, w, multilineCfg("in",
+		strings.Repeat("a", 60)))
+
+	if txt := inputTextShape(t, field); txt.inkOverflowW == 0 {
+		t.Fatal("text shape recorded no ink overflow: the run did not " +
+			"overflow, so this test proves nothing")
+	}
+	if got := field.Shape.inkOverflowW; got != 0 {
+		t.Errorf("field inkOverflowW = %v, want 0: a Scrollable node is "+
+			"the viewport and absorbs the overflow", got)
+	}
+	if got := root.Shape.inkOverflowW; got != 0 {
+		t.Errorf("root inkOverflowW = %v, want 0: the overflow escaped "+
+			"the scroll container and widened the page", got)
+	}
+}
+
+// TestDragScrollDeltaBoundaries pins the auto-scroll ramp, including
+// the two edges: a pointer exactly on a band edge is inside, not out,
+// so a drag that stops at the edge stops scrolling.
+func TestDragScrollDeltaBoundaries(t *testing.T) {
+	const lo, hi = 100, 300
+	cases := []struct {
+		name string
+		pos  float32
+		want float32
+	}{
+		{"inside", 200, 0},
+		{"on the low edge", lo, 0},
+		{"on the high edge", hi, 0},
+		{"past the low edge scrolls forward", 90, 3},
+		{"past the high edge scrolls back", 310, -3},
+		{"further out scrolls faster", 50, 15},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := dragScrollDelta(c.pos, lo, hi); !floatNear(
+				got, c.want, 0.001) {
+				t.Errorf("dragScrollDelta(%v) = %v, want %v",
+					c.pos, got, c.want)
+			}
+		})
+	}
+}
+
+// TestComputeContentWidthIgnoresNaNInk pins the harden guard: a NaN
+// ink extent from a faulty measurer must not poison the content width.
+func TestComputeContentWidthIgnoresNaNInk(t *testing.T) {
+	lay := &Layout{Shape: &Shape{shapeType: shapeRectangle, Axis: axisTopToBottom}}
+	lay.Children = []Layout{{Shape: &Shape{shapeType: shapeRectangle, Width: 50, inkOverflowW: 50}}}
+	if got := computeContentWidth(lay); got != 50 {
+		t.Fatalf("contentWidth = %v, want 50", got)
+	}
+	lay.Children[0].Shape.inkOverflowW =
+		float32(math.NaN())
+	if got := computeContentWidth(lay); got != 50 {
+		t.Errorf("contentWidth with NaN ink = %v, want 50", got)
+	}
+}
+
+// TestInputApplyScrollXResetsNaNOffset pins that a poisoned scroll
+// entry is cleared rather than painted: NaN would shift the text to
+// nowhere and disagree with every later reader of the offset.
+func TestInputApplyScrollXResetsNaNOffset(t *testing.T) {
+	w := caretTestWindow(200, 60)
+	_, field := arrangeInput(t, w, InputCfg{
+		ID: "in", Text: strings.Repeat("a", 60),
+	})
+	w.scrollX().Set("in", float32(math.NaN()))
+	inputApplyScrollX(inputHandlerCfg{scrollID: "in"}, field, w)
+	if got := w.scrollX().GetOr("in", 0); got != 0 {
+		t.Errorf("stored scrollX = %v, want 0 after NaN reset", got)
+	}
+}
+
+// TestApplyDragScrollRejectsNaNDelta pins that a NaN auto-scroll step
+// moves nothing and writes nothing back to the scroll map.
+func TestApplyDragScrollRejectsNaNDelta(t *testing.T) {
+	w := newTestWindow()
+	if applyDragScroll(w.scrollX(), "inp",
+		float32(math.NaN()), -200) {
+		t.Error("applyDragScroll(NaN) = true, want false")
+	}
+	if got := w.scrollX().GetOr("inp", 0); got != 0 {
+		t.Errorf("scrollX = %v, want 0 untouched", got)
+	}
+}

--- a/gui/view_text.go
+++ b/gui/view_text.go
@@ -46,6 +46,12 @@ type TextCfg struct {
 	// renders from. See Shape.focusOwner. Unexported: a standalone
 	// Text owns its identity through ID.
 	focusOwner string
+
+	// scrollOverflowX opts this text into ink-overflow accounting, so a
+	// run too wide to wrap can be reached by an ancestor scroll
+	// container. See Shape.inkOverflowW. Set by Input; unexported
+	// because a standalone Text has no scroll container to reach it.
+	scrollOverflowX bool
 }
 
 // textView implements View for text rendering.
@@ -74,6 +80,7 @@ func (tv *textView) GenerateLayout(w *Window) Layout {
 		TextMode:          c.Mode,
 		TextTabSize:       c.TabSize,
 		textReadOnly:      c.readOnly,
+		overflowScrollX:   c.scrollOverflowX,
 	}
 
 	layout := Layout{
@@ -95,7 +102,17 @@ func (tv *textView) GenerateLayout(w *Window) Layout {
 		}),
 	}
 
-	layout.Shape.Width = w.TextWidth(c.Text, *ts)
+	// Measure what is painted, not what is stored: a password renders
+	// as bullets, whose advance differs from the raw text's. Measuring
+	// the raw text would size the box wrong and, for an Input, park the
+	// horizontal scroll at the wrong maximum offset. maskPassword is
+	// the same helper renderText masks with, so the measured string and
+	// the painted one agree, newlines included.
+	measured := c.Text
+	if c.IsPassword {
+		measured = maskPassword(measured)
+	}
+	layout.Shape.Width = w.TextWidth(measured, *ts)
 	if w.textMeasurer != nil {
 		layout.Shape.Height = w.textMeasurer.FontHeight(*ts)
 	} else {


### PR DESCRIPTION
## Summary

Fixes #534: text wider than an `Input` field neither wrapped nor scrolled
horizontally in either mode — content was silently clipped and the caret
became invisible.

- **Single-line**: horizontal cursor-follow is always on (not gated on
  `Scrollable`). The offset is applied to the text shape in `AmendLayout`;
  no visible scrollbar.
- **Multiline**: an unbreakable run's ink overflow is recorded on
  `Shape.inkOverflowW` and propagated to ancestor content-width
  accounting, so the horizontal scrollbar appears exactly when an
  unbreakable run overflows — without re-wrapping the text.
- **Password fields**: measurement and hit-testing now read the painted
  mask (`maskPassword`) instead of the raw text, so caret geometry agrees
  with what's on screen when the mask contains newlines.
- Stale horizontal scroll offsets are re-clamped against the current
  frame's geometry and written back, not just painted.
- NaN/Inf and nil-geometry guards (`f32IsFinite`, the repo's existing
  idiom) added throughout the new scroll paths.

## Testing

- New `gui/view_input_scroll_test.go` (single-line/multiline follow,
  drag auto-scroll, password masking, stale-offset reclamping, NaN
  hardening).
- New goldens: `input_scrolled_x`, `input_scrolled_x_placeholder`,
  `input_multiline_hscroll_hidden`.
- `make prepush` green (race tests, lint, cross-GOOS lint, cross-compiles,
  coverage gate, export audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)