### PR TITLE
build: strip dead system deps, package both arches from shared targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,17 +34,9 @@ jobs:
           go-version: stable
           cache: false
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            pkg-config \
-            libfreetype6-dev \
-            libharfbuzz-dev \
-            libpango1.0-dev \
-            libfontconfig1-dev \
-            libhunspell-dev
-
+      # No system packages. `go test -fuzz` builds the module cgo-free:
+      # go-glyph shapes in pure Go, and the Linux spellcheck backend that
+      # wants hunspell is behind -tags hunspell, which no job sets.
       - name: Add go-glyph replace
         working-directory: go-gui
         run: go mod edit -replace=github.com/go-gui-org/go-glyph=../go-glyph

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,45 +27,24 @@ jobs:
         with:
           go-version: stable
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libgl1-mesa-dev \
-            libfreetype6-dev libharfbuzz-dev libpango1.0-dev \
-            libfontconfig1-dev libglib2.0-dev \
-            libx11-dev libxext-dev libxcursor-dev libxinerama-dev \
-            libxi-dev libxrandr-dev libxfixes-dev libxkbcommon-dev \
-            libwayland-dev libdbus-1-dev libpulse-dev libasound2-dev
-
+      # No system packages. `make build-linux` is CGO_ENABLED=0, so the
+      # showcase links no C at all: X11 is jezek/xgb over a socket, GL is
+      # dlopened through purego, and audio defaults to the pure-Go
+      # PulseAudio sink. None of the headers installed here had a caller.
       - name: Add go-glyph replace
         working-directory: go-gui
         run: go mod edit -replace=github.com/go-gui-org/go-glyph=../go-glyph
 
-      - name: Build showcase
+      # Same target a developer runs locally, so a release can be
+      # rehearsed with `make release` before the tag is pushed.
+      - name: Package amd64 and arm64
         working-directory: go-gui
-        run: make build-linux
-
-      - name: Verify static linking
-        working-directory: go-gui
-        run: |
-          echo "OK: binary built successfully"
-
-      - name: Package
-        working-directory: go-gui
-        run: |
-          VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          # buildapp names the installed executable after the file's
-          # basename, so stage it as plain "showcase" first.
-          mkdir -p build/pkg && cp build/showcase-linux build/pkg/showcase
-          go run ./cmd/buildapp -platform linux -o . \
-            -version "${VERSION}" -name "Go-Gui Showcase" \
-            -icon gui/default_icon.png build/pkg/showcase
+        run: make package-linux
 
       - uses: actions/upload-artifact@v7
         with:
           name: linux-asset
-          path: go-gui/go-gui-showcase-*.tar.gz
+          path: go-gui/dist/go-gui-showcase-*.tar.gz
 
   macos:
     name: macOS
@@ -88,25 +67,17 @@ jobs:
         working-directory: go-gui
         run: go mod edit -replace=github.com/go-gui-org/go-glyph=../go-glyph
 
-      - name: Build showcase
+      # Builds arm64 and amd64, fuses them with lipo, bundles the result
+      # as Go-Gui Showcase.app and writes an ad-hoc signed .dmg.  One
+      # download serves Apple silicon and Intel.
+      - name: Package universal .dmg
         working-directory: go-gui
-        run: make build-macos
-
-      - name: Package
-        working-directory: go-gui
-        run: |
-          VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          go run ./cmd/buildapp -version "${VERSION#v}" \
-            -bundle-deps -name "Go-Gui Showcase" build/showcase-macos
-          hdiutil create -srcfolder "Go-Gui Showcase.app" \
-            -volname "Go-Gui Showcase ${VERSION}" \
-            -format UDZO "Go-Gui-Showcase-${VERSION}.dmg"
-          codesign -s - --force "Go-Gui-Showcase-${VERSION}.dmg"
+        run: make package-macos
 
       - uses: actions/upload-artifact@v7
         with:
           name: macos-asset
-          path: go-gui/Go-Gui-Showcase-*.dmg
+          path: go-gui/dist/Go-Gui-Showcase-*.dmg
 
   windows:
     name: Windows
@@ -145,23 +116,16 @@ jobs:
         working-directory: go-gui
         run: go mod edit -replace=github.com/go-gui-org/go-glyph=../go-glyph
 
-      - name: Build showcase
+      # Each .exe is linked -H windowsgui, so no console window opens
+      # behind the showcase.
+      - name: Package amd64 and arm64
         working-directory: go-gui
-        run: make build-windows
-
-      - name: Package
-        working-directory: go-gui
-        run: |
-          VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          mkdir -p build/pkg && cp build/showcase-windows.exe build/pkg/showcase.exe
-          go run ./cmd/buildapp -platform windows -o . \
-            -version "${VERSION}" -name "Go-Gui Showcase" \
-            -icon gui/default_icon.png build/pkg/showcase.exe
+        run: make package-windows
 
       - uses: actions/upload-artifact@v7
         with:
           name: windows-asset
-          path: go-gui/go-gui-showcase-*.zip
+          path: go-gui/dist/go-gui-showcase-*.zip
 
   ios:
     name: iOS
@@ -299,7 +263,11 @@ jobs:
           merge-multiple: true
           path: assets
 
+      # Pinned to a commit rather than the v3 tag: a tag can be moved to
+      # point at different code, a commit cannot.  This commit is release
+      # 3.0.3, which is what refs/tags/v3 dereferenced to when it was
+      # written.  Bump it deliberately, after reading the diff.
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64
         with:
           files: assets/*

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ Thumbs.db
 
 # Build output
 build/
+# Release archives written by `make package-*`.
+dist/
 
 # Serena
 .serena/

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,23 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS  = -X github.com/go-gui-org/go-gui/gui.Version=$(VERSION) \
            -X github.com/go-gui-org/go-gui/gui.Commit=$(COMMIT)
 
+# CFBundleShortVersionString must be a bare dotted number, so drop the
+# leading v that `git describe` puts on a tag.
+BUNDLE_VER = $(patsubst v%,%,$(VERSION))
+
+# Finished archives land here, separate from the loose binaries and
+# staging directories under build/. The release workflow uploads from
+# this directory.
+DIST = dist
+
 # Repo-local bin for the pinned linter. The pinned VERSION itself lives in
 # tools/lint/go.mod -- see the $(LINT_BIN) rule below.
 LINT_DIR = $(CURDIR)/.bin
 LINT_BIN = $(LINT_DIR)/golangci-lint
 LINT_ARGS ?=
 
-.PHONY: build-linux build-windows build-macos build-wasm build-ios build-android build-examples release clean test test-race vet lint lint-bin lint-cross cross-compile coverage-gate prepush check bench bench-gate deps-doc deps-doc-check security gosec govulncheck large-files deadcode generate-check tidy-check workflow-audit cov-report license-check ergonomics-audit ergonomics-audit-fix ergonomics-audit-fix-dry fmt-md fmt-md-check
+.PHONY: build-linux build-windows build-macos build-wasm build-ios build-android build-examples \
+	package-linux package-windows package-macos release clean test test-race vet lint lint-bin lint-cross cross-compile coverage-gate prepush check bench bench-gate deps-doc deps-doc-check security gosec govulncheck large-files deadcode generate-check tidy-check workflow-audit cov-report license-check ergonomics-audit ergonomics-audit-fix ergonomics-audit-fix-dry fmt-md fmt-md-check
 
 # Desktop builds are cgo-free since the purego GL bindings (#155): the
 # backend/gl uses X11/xgb + purego EGL on Linux and Win32 syscalls on
@@ -21,23 +31,53 @@ LINT_ARGS ?=
 # `make release` gets a Mach-O binary in the "linux" tarball.  The
 # purego backend cross-compiles cleanly, so this costs nothing on a
 # Linux host either.
+# Both architectures on every desktop platform.  The cgo-free
+# cross-compile costs almost nothing and it covers arm64 Linux servers
+# and Windows on ARM, which amd64-only archives left with nothing to
+# download.
 build-linux:
+	@mkdir -p build
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 	go build -ldflags "$(LDFLAGS)" \
-	  -o build/showcase-linux ./examples/showcase/
+	  -o build/showcase-linux-amd64 ./examples/showcase/
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+	go build -ldflags "$(LDFLAGS)" \
+	  -o build/showcase-linux-arm64 ./examples/showcase/
 
 # -H windowsgui marks the PE as a GUI-subsystem image.  Without it the
 # Windows loader allocates a console for the process, so every launch
 # shows an empty terminal window behind the app window.
 build-windows:
+	@mkdir -p build
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
 	go build -ldflags "$(LDFLAGS) -H windowsgui" \
-	  -o build/showcase-windows.exe ./examples/showcase/
+	  -o build/showcase-windows-amd64.exe ./examples/showcase/
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 \
+	go build -ldflags "$(LDFLAGS) -H windowsgui" \
+	  -o build/showcase-windows-arm64.exe ./examples/showcase/
 
+# Universal binary, so one .dmg serves Apple silicon and Intel.  A bare
+# `go build` here inherits the host arch, which on a macos-latest runner
+# meant the release .dmg would not run on an Intel Mac at all.
+#
+# Each half is a separate cgo build -- the Metal backend is ObjC -- and
+# needs its own -arch in CGO_CFLAGS/CGO_LDFLAGS, because the C compiler
+# does not read GOARCH.  lipo then fuses the two Mach-O files.  macOS
+# only: cross-compiling this from Linux would need the macOS SDK.
 build-macos:
-	CGO_LDFLAGS="-Wl,-no_warn_duplicate_libraries" \
-	go build -ldflags "$(LDFLAGS)" \
-	  -o build/showcase-macos ./examples/showcase/
+	@mkdir -p build
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 \
+	  CGO_CFLAGS="-arch arm64" \
+	  CGO_LDFLAGS="-arch arm64 -Wl,-no_warn_duplicate_libraries" \
+	  go build -ldflags "$(LDFLAGS)" \
+	  -o build/showcase-darwin-arm64 ./examples/showcase/
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \
+	  CGO_CFLAGS="-arch x86_64" \
+	  CGO_LDFLAGS="-arch x86_64 -Wl,-no_warn_duplicate_libraries" \
+	  go build -ldflags "$(LDFLAGS)" \
+	  -o build/showcase-darwin-amd64 ./examples/showcase/
+	lipo -create -output build/showcase-macos \
+	  build/showcase-darwin-arm64 build/showcase-darwin-amd64
 
 build-wasm:
 	GOOS=js GOARCH=wasm \
@@ -85,23 +125,61 @@ build-examples:
 # Packaging goes through cmd/buildapp on all three desktop targets, so
 # each archive carries what its platform needs to look like an
 # application: a .desktop entry and icon on Linux, an icon resource on
-# Windows, a signed .app on macOS.  The binary is staged under
-# build/pkg/ first because buildapp takes the installed executable's
-# name from the file's basename, and "showcase-linux" would end up in
-# the Exec= line of the desktop entry.
-release: build-linux build-windows build-macos build-wasm
-	mkdir -p build/pkg
-	cp build/showcase-linux build/pkg/showcase
-	cp build/showcase-windows.exe build/pkg/showcase.exe
-	go run ./cmd/buildapp -platform linux -o build -version $(VERSION) \
-	  -name "Go-Gui Showcase" -icon gui/default_icon.png build/pkg/showcase
-	go run ./cmd/buildapp -platform windows -o build -version $(VERSION) \
-	  -name "Go-Gui Showcase" -icon gui/default_icon.png build/pkg/showcase.exe
-	cd build && go run ../cmd/buildapp -version $(VERSION) \
-	  -name "Go-Gui Showcase" showcase-macos
+# Windows, a signed .app on macOS.
+#
+# Each binary is staged under its own build/pkg-* directory as plain
+# "showcase" first, because buildapp takes the installed executable's
+# name from the file's basename -- package it as "showcase-linux-amd64"
+# and that string lands in the desktop entry's Exec= line.  buildapp
+# reads the target architecture from the ELF/PE machine field, not from
+# the name, so the two archives per platform get distinct names on their
+# own.
+#
+# The release workflow calls these same targets, so CI and a local
+# `make release` cannot drift apart.
+
+package-linux: build-linux
+	@mkdir -p build/pkg-linux-amd64 build/pkg-linux-arm64 $(DIST)
+	cp build/showcase-linux-amd64 build/pkg-linux-amd64/showcase
+	cp build/showcase-linux-arm64 build/pkg-linux-arm64/showcase
+	go run ./cmd/buildapp -platform linux -o $(DIST) -version $(VERSION) \
+	  -name "Go-Gui Showcase" -icon gui/default_icon.png \
+	  build/pkg-linux-amd64/showcase
+	go run ./cmd/buildapp -platform linux -o $(DIST) -version $(VERSION) \
+	  -name "Go-Gui Showcase" -icon gui/default_icon.png \
+	  build/pkg-linux-arm64/showcase
+
+package-windows: build-windows
+	@mkdir -p build/pkg-windows-amd64 build/pkg-windows-arm64 $(DIST)
+	cp build/showcase-windows-amd64.exe build/pkg-windows-amd64/showcase.exe
+	cp build/showcase-windows-arm64.exe build/pkg-windows-arm64/showcase.exe
+	go run ./cmd/buildapp -platform windows -o $(DIST) -version $(VERSION) \
+	  -name "Go-Gui Showcase" -icon gui/default_icon.png \
+	  build/pkg-windows-amd64/showcase.exe
+	go run ./cmd/buildapp -platform windows -o $(DIST) -version $(VERSION) \
+	  -name "Go-Gui Showcase" -icon gui/default_icon.png \
+	  build/pkg-windows-arm64/showcase.exe
+
+# No -bundle-deps.  install_name_tool cannot rewrite a load command in a
+# fat Mach-O, so passing it aborts the whole target the moment the
+# binary goes universal.  Nothing is lost: the showcase links only
+# /System and /usr/lib, which every macOS already has.
+package-macos: build-macos
+	@mkdir -p build/pkg-macos $(DIST)
+	cp build/showcase-macos build/pkg-macos/showcase
+	rm -rf "build/Go-Gui Showcase.app"
+	go run ./cmd/buildapp -o build -version $(BUNDLE_VER) \
+	  -name "Go-Gui Showcase" build/pkg-macos/showcase
+	rm -f "$(DIST)/Go-Gui-Showcase-$(VERSION).dmg"
 	hdiutil create -srcfolder "build/Go-Gui Showcase.app" \
 	  -volname "Go-Gui Showcase $(VERSION)" \
-	  -format UDZO "build/Go-Gui-Showcase-$(VERSION).dmg"
+	  -format UDZO "$(DIST)/Go-Gui-Showcase-$(VERSION).dmg"
+	codesign -s - --force "$(DIST)/Go-Gui-Showcase-$(VERSION).dmg"
+
+# Every desktop artifact the release workflow attaches.  package-macos
+# needs a Mac; on Linux run package-linux and package-windows only.
+release: package-linux package-windows package-macos build-wasm
+	@ls -la $(DIST)
 
 # Run all benchmarks with allocation reporting (matching CI baseline job).
 bench:
@@ -119,6 +197,7 @@ bench-gate:
 # binaries belong in build/ or examples/bin/, never the repo root.
 clean:
 	rm -rf build/
+	rm -rf $(DIST)
 	rm -rf $(LINT_DIR)
 	rm -rf examples/bin/
 	rm -f showcase fontviewer listbox get_started command_demo \

--- a/scripts/install-ubuntu-deps.sh
+++ b/scripts/install-ubuntu-deps.sh
@@ -1,26 +1,33 @@
 #!/usr/bin/env bash
-# Install Ubuntu system dependencies required to build go-gui with CGO.
-# libegl1 is a runtime dependency, not a build one: gui/backend/gl dlopens
-# libEGL.so.1 by soname. No GL headers are needed since the backend dropped
-# github.com/go-gl/gl for the purego binding in gui/backend/internal/glbind.
+# Install the Ubuntu packages go-gui's CI actually links against.
+#
+# The list is short because the Linux build is cgo-free: X11 goes through
+# jezek/xgb over a socket, GL through purego's dlopen, and go-glyph shapes
+# text in pure Go. That leaves exactly two opt-in cgo paths, and only the
+# first is built by any job:
+#
+#   -tags otoaudio   oto v3's ALSA driver, #cgo pkg-config: alsa
+#   -tags hunspell   gui/backend/spellcheck on Linux, #cgo pkg-config: hunspell
+#
+# libhunspell-dev is therefore NOT installed. Add it here, and install
+# pkg-config alongside, if a job ever starts building -tags hunspell.
+#
+# Everything else this script used to install -- FreeType, HarfBuzz,
+# Pango, fontconfig, and the libx11/libxext/libxcursor/libxinerama/libxi/
+# libxrandr/libxfixes/libxkbcommon headers -- had no caller. They were
+# left from the era when go-glyph shaped through cgo and the GL backend
+# used go-gl.
+#
+# libegl1 is the exception to all of the above: it is a runtime package,
+# not a build one. gui/backend/gl dlopens libEGL.so.1 by soname, so no
+# headers are wanted -- only the shared object, for any test that reaches
+# the GL backend.
+#
 # Usage: ./scripts/install-ubuntu-deps.sh
 set -euo pipefail
 
 sudo apt-get update
 sudo apt-get install -y \
   pkg-config \
-  libfreetype6-dev \
-  libharfbuzz-dev \
-  libpango1.0-dev \
-  libfontconfig1-dev \
-  libhunspell-dev \
-  libegl1 \
-  libx11-dev \
-  libxext-dev \
-  libxcursor-dev \
-  libxinerama-dev \
-  libxi-dev \
-  libxrandr-dev \
-  libxfixes-dev \
-  libxkbcommon-dev \
-  libasound2-dev
+  libasound2-dev \
+  libegl1


### PR DESCRIPTION
## Dead dependencies

The Linux build has been cgo-free since X11 moved to `jezek/xgb` and GL
moved to purego, and go-glyph now shapes in pure Go. The CI dependency
list never caught up.

`scripts/install-ubuntu-deps.sh` drops from 16 packages to 3:

| Package | Why it stays |
| --- | --- |
| `pkg-config`, `libasound2-dev` | oto v3's ALSA driver, built by `-tags otoaudio` |
| `libegl1` | `gui/backend/gl` dlopens `libEGL.so.1` by soname -- runtime package, not headers |

FreeType, HarfBuzz, Pango, fontconfig and every `libx*-dev` header had no
caller. `libhunspell-dev` is gone too: the declaration that wants it, in
`gui/backend/spellcheck`, sits behind `-tags hunspell`, which no job
sets. The script records how to restore it correctly if that changes.

`fuzz.yml` installed five of the same dead packages and now installs
none.

## Packaging

Packaging moves into the Makefile as `package-linux`, `package-windows`
and `package-macos`, and `release.yml` calls those same targets. A
release can now be rehearsed with `make release` before the tag is
pushed, and CI cannot drift from a local build.

- **Both architectures on every platform.** amd64-only archives left
  arm64 Linux and Windows on ARM with nothing to download.
- **macOS is a universal binary.** Each half is a separate cgo build
  with its own `-arch`, since the C compiler does not read `GOARCH`;
  `lipo` fuses them. A bare `go build` inherited the runner's
  architecture, so the release `.dmg` would not have run on an Intel Mac
  at all.
- **`-H windowsgui`**, so no console window opens behind the app.
- **`-bundle-deps` dropped.** `install_name_tool` cannot rewrite a load
  command in a fat Mach-O, so it aborts the target the moment the binary
  goes universal. Nothing is lost -- the showcase links only `/System`
  and `/usr/lib`.

`action-gh-release` is pinned to the 3.0.3 commit rather than the `v3`
tag. A tag can be moved, and `v3` did move during this work.

## Verification

Built all artifacts locally. `lipo -info` reports `x86_64 arm64`;
`otool -L` shows nothing outside `/System` and `/usr/lib`; both PEs
report subsystem 2 with `.rsrc` present; the Linux archives carry
x86-64 and aarch64 ELFs; `Info.plist` carries a bare dotted version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)