### PR TITLE
fix(gui): re-export DialogCfg.DefaultButton, dialog StartDir, AccessiblePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **`DialogCfg.DefaultButton` is exported again (#19)** — the field and its
+  `DialogButtonNo`/`DialogButtonYes` constants were unexported by the #230 sweep
+  with no caller to keep them alive. A confirm dialog reached only by a
+  deliberate gesture (a quit prompt, for instance) wants Enter on "Yes"; the
+  behaviour was already implemented, only unreachable from outside the package.
+  Any value other than `DialogButtonYes` keeps the safe "No" default.
+- **Native file dialogs take a `StartDir` again (#372)** — `StartDir` on
+  `NativeOpenDialogCfg`, `NativeSaveDialogCfg` and `NativeFolderDialogCfg` was
+  unexported by the #230 sweep, so every picker passed an empty directory to the
+  platform no matter what the app set. The backends already honoured the value.
+  An empty `StartDir` still means "platform default", and so does a value that
+  cannot name a directory: the Linux backend spends the path as an argv element
+  for zenity/kdialog, so a value starting with `-` or holding a NUL is screened
+  back to the default rather than reaching the tool as an option.
+- **`AccessiblePath` is exported (#372)** — the element type of
+  `NativeDialogResult.Paths`. Callers could read `.Path` and `.Grant` inline but
+  could not name the type, so a helper taking one, or a slice of their own, was
+  impossible. `PathStrings()` is unchanged.
+
 ## [v0.70.0] - 2026-09-07
 
 ### Added

--- a/gui/file_access.go
+++ b/gui/file_access.go
@@ -9,11 +9,17 @@ type Grant struct {
 	ID uint64 // 0 = no grant (no-op on release)
 }
 
-// accessiblePath pairs a filesystem path with an optional
+// AccessiblePath pairs a filesystem path with an optional
 // security-scoped grant. On macOS sandboxed apps the grant
 // keeps the path accessible across relaunches.
-type accessiblePath struct {
-	Path  string
+// exportaudit:keep — caller-facing config (issue #372)
+type AccessiblePath struct {
+	// Path is the filesystem path the user chose.
+	// exportaudit:keep — caller-facing config (issue #372)
+	Path string
+	// Grant is the security-scoped grant that keeps Path reachable on a
+	// sandboxed macOS app. The zero Grant means no scope was needed.
+	// exportaudit:keep — caller-facing config (issue #372)
 	Grant Grant
 }
 

--- a/gui/file_access_test.go
+++ b/gui/file_access_test.go
@@ -96,7 +96,7 @@ func TestGrantZeroID(t *testing.T) {
 }
 
 func TestAccessiblePathFields(t *testing.T) {
-	ap := accessiblePath{Path: "/file", Grant: Grant{ID: 42}}
+	ap := AccessiblePath{Path: "/file", Grant: Grant{ID: 42}}
 	if ap.Path != "/file" || ap.Grant.ID != 42 {
 		t.Errorf("fields: %+v", ap)
 	}

--- a/gui/native_dialog.go
+++ b/gui/native_dialog.go
@@ -21,7 +21,7 @@ const (
 type NativeDialogResult struct {
 	ErrorCode    string
 	ErrorMessage string
-	Paths        []accessiblePath
+	Paths        []AccessiblePath
 	Status       NativeDialogStatus
 }
 
@@ -42,18 +42,28 @@ type NativeFileFilter struct {
 
 // NativeOpenDialogCfg configures the native open-file dialog.
 type NativeOpenDialogCfg struct {
-	OnDone        func(NativeDialogResult, *Window)
-	Title         string
-	startDir      string
+	OnDone func(NativeDialogResult, *Window)
+	Title  string
+	// StartDir is the directory the picker opens in. Empty (the zero
+	// value) takes the platform default — the last-used directory on
+	// most desktops. A value that cannot name a directory (one starting
+	// with "-", or holding a NUL) is screened back to that default; see
+	// safeStartDir.
+	// exportaudit:keep — caller-facing config (issue #372)
+	StartDir      string
 	Filters       []NativeFileFilter
 	AllowMultiple bool
 }
 
 // NativeSaveDialogCfg configures the native save-file dialog.
 type NativeSaveDialogCfg struct {
-	OnDone           func(NativeDialogResult, *Window)
-	Title            string
-	startDir         string
+	OnDone func(NativeDialogResult, *Window)
+	Title  string
+	// StartDir is the directory the picker opens in. Empty (the zero
+	// value) takes the platform default, as does a value screened out by
+	// safeStartDir.
+	// exportaudit:keep — caller-facing config (issue #372)
+	StartDir         string
 	DefaultName      string
 	DefaultExtension string
 	Filters          []NativeFileFilter
@@ -62,9 +72,13 @@ type NativeSaveDialogCfg struct {
 
 // NativeFolderDialogCfg configures the native folder picker.
 type NativeFolderDialogCfg struct {
-	OnDone   func(NativeDialogResult, *Window)
-	Title    string
-	startDir string
+	OnDone func(NativeDialogResult, *Window)
+	Title  string
+	// StartDir is the directory the picker opens in. Empty (the zero
+	// value) takes the platform default, as does a value screened out by
+	// safeStartDir.
+	// exportaudit:keep — caller-facing config (issue #372)
+	StartDir string
 }
 
 // NativeAlertLevel controls the severity icon of a message/confirm dialog.
@@ -177,7 +191,7 @@ func nativeOpenDialogImpl(w *Window, cfg NativeOpenDialogCfg) {
 		return
 	}
 	defer markNativeDialogVisible(w)()
-	pr := w.nativePlatform.ShowOpenDialog(cfg.Title, cfg.startDir, extensions, cfg.AllowMultiple)
+	pr := w.nativePlatform.ShowOpenDialog(cfg.Title, safeStartDir(cfg.StartDir), extensions, cfg.AllowMultiple)
 	dispatchDialogDone(w, cfg.OnDone, nativeResultFromPlatform(pr, w))
 }
 
@@ -197,7 +211,7 @@ func nativeSaveDialogImpl(w *Window, cfg NativeSaveDialogCfg) {
 		return
 	}
 	defer markNativeDialogVisible(w)()
-	pr := w.nativePlatform.ShowSaveDialog(cfg.Title, cfg.startDir, cfg.DefaultName, defaultExt, extensions, cfg.ConfirmOverwrite)
+	pr := w.nativePlatform.ShowSaveDialog(cfg.Title, safeStartDir(cfg.StartDir), cfg.DefaultName, defaultExt, extensions, cfg.ConfirmOverwrite)
 	dispatchDialogDone(w, cfg.OnDone, nativeResultFromPlatform(pr, w))
 }
 
@@ -207,7 +221,7 @@ func nativeFolderDialogImpl(w *Window, cfg NativeFolderDialogCfg) {
 		return
 	}
 	defer markNativeDialogVisible(w)()
-	pr := w.nativePlatform.ShowFolderDialog(cfg.Title, cfg.startDir)
+	pr := w.nativePlatform.ShowFolderDialog(cfg.Title, safeStartDir(cfg.StartDir))
 	dispatchDialogDone(w, cfg.OnDone, nativeResultFromPlatform(pr, w))
 }
 
@@ -263,14 +277,31 @@ func nativeAlertErrorResult(code, message string) NativeAlertResult {
 	return NativeAlertResult{Status: DialogError, ErrorCode: code, ErrorMessage: message}
 }
 
+// safeStartDir screens a caller-supplied StartDir before it reaches a
+// platform backend. StartDir became caller-settable with issue #372, and the
+// Linux backend spends it as an argv element for zenity/kdialog — kdialog
+// takes the directory positionally, so a value that begins with "-" is read
+// as an option rather than a path. A NUL byte is rejected for the same class
+// of reason: exec refuses it and the Cocoa path would truncate at it.
+//
+// Neither case is worth an error. The documented meaning of an empty
+// StartDir is "platform default", so an unusable value degrades to exactly
+// that instead of failing a dialog the user asked for.
+func safeStartDir(dir string) string {
+	if strings.HasPrefix(dir, "-") || strings.ContainsRune(dir, 0) {
+		return ""
+	}
+	return dir
+}
+
 func nativeResultFromPlatform(pr PlatformDialogResult, w *Window) NativeDialogResult {
-	paths := make([]accessiblePath, len(pr.Paths))
+	paths := make([]AccessiblePath, len(pr.Paths))
 	for i, pp := range pr.Paths {
 		var grant Grant
 		if len(pp.BookmarkData) > 0 {
 			grant = w.storeBookmark(pp.Path, pp.BookmarkData)
 		}
-		paths[i] = accessiblePath{Path: pp.Path, Grant: grant}
+		paths[i] = AccessiblePath{Path: pp.Path, Grant: grant}
 	}
 	return NativeDialogResult{
 		Status:       pr.Status,

--- a/gui/native_dialog_test.go
+++ b/gui/native_dialog_test.go
@@ -118,7 +118,7 @@ func TestNativeSaveExtensionsNoDuplicate(t *testing.T) {
 
 func TestNativeDialogResultPathStrings(t *testing.T) {
 	r := NativeDialogResult{
-		Paths: []accessiblePath{
+		Paths: []AccessiblePath{
 			{Path: "/a/b.txt"},
 			{Path: "/c/d.pdf", Grant: Grant{ID: 1}},
 		},
@@ -509,5 +509,133 @@ func TestNativeOpenDialogPlatformError(t *testing.T) {
 	}
 	if result.ErrorMessage != "disk full" {
 		t.Errorf("ErrorMessage: got %q", result.ErrorMessage)
+	}
+}
+
+// startDirRecorder captures the startDir argument each dialog entry point
+// hands the platform, so the tests below can assert the Cfg field actually
+// reaches the backend rather than being dropped on the way (issue #372).
+type startDirRecorder struct {
+	noopNativePlatform
+	got string
+}
+
+func (r *startDirRecorder) ShowOpenDialog(_, startDir string, _ []string, _ bool) PlatformDialogResult {
+	r.got = startDir
+	return PlatformDialogResult{Status: DialogCancel}
+}
+
+func (r *startDirRecorder) ShowSaveDialog(_, startDir, _, _ string, _ []string, _ bool) PlatformDialogResult {
+	r.got = startDir
+	return PlatformDialogResult{Status: DialogCancel}
+}
+
+func (r *startDirRecorder) ShowFolderDialog(_, startDir string) PlatformDialogResult {
+	r.got = startDir
+	return PlatformDialogResult{Status: DialogCancel}
+}
+
+// TestNativeDialogStartDirReachesPlatform pins the exported StartDir field on
+// all three file-dialog Cfgs. The field was unexported by the #230 sweep, so
+// every dialog passed "" no matter what the app wanted; these three arms fail
+// if that regresses.
+func TestNativeDialogStartDirReachesPlatform(t *testing.T) {
+	const want = "/tmp/projects"
+	tests := []struct {
+		name string
+		show func(w *Window)
+	}{
+		{"open", func(w *Window) {
+			nativeOpenDialogImpl(w, NativeOpenDialogCfg{StartDir: want})
+		}},
+		{"save", func(w *Window) {
+			nativeSaveDialogImpl(w, NativeSaveDialogCfg{StartDir: want, DefaultName: "n.txt"})
+		}},
+		{"folder", func(w *Window) {
+			nativeFolderDialogImpl(w, NativeFolderDialogCfg{StartDir: want})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &startDirRecorder{}
+			w := &Window{}
+			w.nativePlatform = rec
+			tt.show(w)
+			if rec.got != want {
+				t.Fatalf("startDir = %q, want %q", rec.got, want)
+			}
+		})
+	}
+}
+
+// TestNativeDialogStartDirEmptyByDefault records the safe default: an unset
+// StartDir stays empty, which every backend reads as "platform default
+// directory" rather than as a path to resolve.
+func TestNativeDialogStartDirEmptyByDefault(t *testing.T) {
+	rec := &startDirRecorder{}
+	w := &Window{}
+	w.nativePlatform = rec
+	nativeOpenDialogImpl(w, NativeOpenDialogCfg{})
+	if rec.got != "" {
+		t.Fatalf("startDir = %q, want empty", rec.got)
+	}
+}
+
+// TestSafeStartDir covers the screen directly: an ordinary path passes
+// through untouched, and the two shapes that would be misread by a backend
+// degrade to "" (the documented platform default).
+func TestSafeStartDir(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"absolute", "/tmp/projects", "/tmp/projects"},
+		{"relative", "projects/src", "projects/src"},
+		{"empty", "", ""},
+		{"dot", ".", "."},
+		{"leading dash reads as a flag", "--help", ""},
+		{"single dash", "-rf", ""},
+		{"nul byte", "/tmp/a\x00b", ""},
+		{"dash inside is fine", "/tmp/my-dir", "/tmp/my-dir"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safeStartDir(tt.in); got != tt.want {
+				t.Fatalf("safeStartDir(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNativeDialogStartDirScreenedAtEveryEntryPoint pins that all three
+// dialog entry points route StartDir through the screen, not just the open
+// dialog — a backend must never receive a flag-shaped directory.
+func TestNativeDialogStartDirScreenedAtEveryEntryPoint(t *testing.T) {
+	const hostile = "--title=pwn"
+	tests := []struct {
+		name string
+		show func(w *Window)
+	}{
+		{"open", func(w *Window) {
+			nativeOpenDialogImpl(w, NativeOpenDialogCfg{StartDir: hostile})
+		}},
+		{"save", func(w *Window) {
+			nativeSaveDialogImpl(w, NativeSaveDialogCfg{StartDir: hostile, DefaultName: "n.txt"})
+		}},
+		{"folder", func(w *Window) {
+			nativeFolderDialogImpl(w, NativeFolderDialogCfg{StartDir: hostile})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &startDirRecorder{}
+			w := &Window{}
+			w.nativePlatform = rec
+			tt.show(w)
+			if rec.got != "" {
+				t.Fatalf("startDir = %q, want it screened to empty", rec.got)
+			}
+		})
 	}
 }

--- a/gui/view_dialog.go
+++ b/gui/view_dialog.go
@@ -14,12 +14,15 @@ const (
 // DialogButton identifies which button of a confirm dialog receives
 // initial keyboard focus. The zero value (DialogButtonNo) keeps the safe
 // default for destructive actions.
-type dialogButton uint8
+// exportaudit:keep — caller-facing config (issue #372)
+type DialogButton uint8
 
 // DialogButton constants.
 const (
-	dialogButtonNo dialogButton = iota
-	dialogButtonYes
+	// exportaudit:keep — caller-facing config (issue #372)
+	DialogButtonNo DialogButton = iota
+	// exportaudit:keep — caller-facing config (issue #372)
+	DialogButtonYes
 )
 
 const dialogBaseFocusID = "__gui_dialog__"
@@ -67,7 +70,8 @@ type DialogCfg struct {
 	// keyboard focus (so Enter/Space activate it). Defaults to
 	// DialogButtonNo, preserving the safe default for destructive
 	// actions. Ignored for non-confirm dialog types.
-	defaultButton dialogButton
+	// exportaudit:keep — caller-facing config (issue #372)
+	DefaultButton DialogButton
 
 	// Sound overrides the theme's click cue for every dialog button.
 	// SoundNone (the zero value) takes Theme.Sounds.Click, which is
@@ -333,7 +337,7 @@ func applyDialogDefaults(cfg *DialogCfg) {
 // DialogButtonYes, this is the "Yes" button (scoped ":1"); otherwise
 // the base focus ID (the "No"/"OK"/input element).
 func dialogFocusID(cfg DialogCfg) string {
-	if cfg.DialogType == DialogConfirm && cfg.defaultButton == dialogButtonYes {
+	if cfg.DialogType == DialogConfirm && cfg.DefaultButton == DialogButtonYes {
 		return ScopeIDN(cfg.FocusID, "", 1)
 	}
 	return cfg.FocusID

--- a/gui/view_dialog_test.go
+++ b/gui/view_dialog_test.go
@@ -339,12 +339,28 @@ func TestDialogConfirmDefaultButtonYes(t *testing.T) {
 	w.Dialog(DialogCfg{
 		DialogType:    DialogConfirm,
 		Title:         "Quit?",
-		defaultButton: dialogButtonYes,
+		DefaultButton: DialogButtonYes,
 	})
 	// DialogButtonYes focuses IDFocus+1 ("Yes").
 	want := ScopeIDN(w.dialogCfg.FocusID, "", 1)
 	if got := w.FocusID(); got != want {
 		t.Fatalf("focus = %q, want Yes button %q", got, want)
+	}
+}
+
+// TestDialogConfirmDefaultButtonOutOfRange pins the safe fallback now that
+// DefaultButton is exported: the field is a plain uint8, so a caller can hand
+// over a value that names no button. Anything that is not DialogButtonYes
+// focuses the base id ("No"), never a scoped id with no shape behind it.
+func TestDialogConfirmDefaultButtonOutOfRange(t *testing.T) {
+	w := &Window{}
+	w.Dialog(DialogCfg{
+		DialogType:    DialogConfirm,
+		Title:         "Quit?",
+		DefaultButton: DialogButton(200),
+	})
+	if got := w.FocusID(); got != w.dialogCfg.FocusID {
+		t.Fatalf("focus = %q, want base %q", got, w.dialogCfg.FocusID)
 	}
 }
 
@@ -355,7 +371,7 @@ func TestDialogDefaultButtonYesIgnoredForNonConfirm(t *testing.T) {
 	w.Dialog(DialogCfg{
 		DialogType:    DialogMessage,
 		Title:         "Done",
-		defaultButton: dialogButtonYes,
+		DefaultButton: DialogButtonYes,
 	})
 	if got := w.FocusID(); got != w.dialogCfg.FocusID {
 		t.Fatalf("focus = %q, want base %q", got, w.dialogCfg.FocusID)
@@ -370,7 +386,7 @@ func TestRetainDialogFocus_DefaultButtonYes(t *testing.T) {
 	w.Dialog(DialogCfg{
 		DialogType:    DialogConfirm,
 		Title:         "Quit?",
-		defaultButton: dialogButtonYes,
+		DefaultButton: DialogButtonYes,
 	})
 	dialog := generateViewLayout(dialogViewGenerator(w.dialogCfg), w)
 
@@ -450,7 +466,7 @@ func TestDialogFocusTargetIsAddressable(t *testing.T) {
 			DialogType: DialogConfirm,
 			// The Yes button is the ScopeIDN-composed sibling, so this
 			// covers the composed arm of dialogFocusID too.
-			defaultButton: dialogButtonYes,
+			DefaultButton: DialogButtonYes,
 		}},
 		{"prompt", DialogCfg{Title: "t", DialogType: DialogPrompt}},
 		{"caller-supplied focus id", DialogCfg{


### PR DESCRIPTION
## Summary

The #230 sweep unexported three fields/types that had no caller to keep them alive, but each was already fully implemented — just unreachable from outside the package.

- **`DialogCfg.DefaultButton`** (`DialogButtonNo`/`DialogButtonYes`) — lets a confirm dialog reached only by a deliberate gesture (a quit prompt) default focus to "Yes". Any out-of-range value keeps the safe "No" default.
- **`StartDir`** on `NativeOpenDialogCfg`/`NativeSaveDialogCfg`/`NativeFolderDialogCfg` — every native file dialog silently opened in the platform default directory no matter what the app set. Every backend already honoured it. A value that can't name a directory (leading `-`, embedded NUL) is screened back to the default via `safeStartDir`, since the Linux backend spends it as an argv element for zenity/kdialog.
- **`AccessiblePath`** (element type of `NativeDialogResult.Paths`) — callers could read `.Path`/`.Grant` inline but couldn't name the type for a helper signature or a slice of their own.

Issue #372.

## Test plan

- `TestDialogConfirmDefaultButtonOutOfRange` — out-of-range `DefaultButton` falls back to "No"
- `TestNativeDialogStartDirReachesPlatform` / `TestNativeDialogStartDirEmptyByDefault` — StartDir reaches the platform backend, empty stays empty
- `TestSafeStartDir` / `TestNativeDialogStartDirScreenedAtEveryEntryPoint` — hostile StartDir values are screened at all three entry points
- `make prepush` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)