### PR TITLE
changelog: add v0.71.0 (dialog and native-dialog Cfg re-exports)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.71.0] - 2026-09-08
+
 ### Added
 
 - **`DialogCfg.DefaultButton` is exported again (#19)** — the field and its


### PR DESCRIPTION
## Summary

Cuts the `Unreleased` section over to `v0.71.0`.

Minor bump: #541 added exported API surface — `DialogCfg.DefaultButton`, `StartDir` on the three native file-dialog Cfgs, and `AccessiblePath`. All three are additive re-exports of surface the #230 sweep had made unreachable; nothing that compiled before stops compiling, so there is no BREAKING entry.

#540 (build gate + CLAUDE.md rewrite) is internal and carries no changelog entry of its own.

## Test plan

- `make check` green locally (`changelog-check: ok`, Prettier clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)