### PR TITLE
fix(gui): report shaper refusals, gate keypress allocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to
 
 ### Added
 
+- **Shaper refusals are reported instead of degrading silently** — text the
+  glyph shaper refuses, past its 10KB byte budget for example, falls back to
+  approximate metrics: caret placement, selection rectangles and grapheme-aware
+  delete all lose precision with nothing saying why. The new
+  `DebugGlyphLayoutFallback` category (part of `DebugAll`) reports the shape
+  once, with its byte length and the shaper's error.
+
+  Profiling behind this: a keypress reshapes the whole buffer on every
+  keystroke, linear in bytes (about 2.4ms and 7MB of garbage at 10KB of ASCII),
+  because the layout cache keys on the full text and the caret needs character
+  boundaries. Typical fields under 1KB cost about 0.25ms. An allocation gate
+  (`TestInputKeypressAllocBudget`, 10KB field, real shaper) pins the
+  steady-state budget so it cannot regress unnoticed; timing stays out of the
+  gate as machine variance. Windowed or incremental shaping was rejected:
+  shaping is not prefix-stable under wrapping and ligatures, and a wrong caret
+  is worse than a slow one.
+
 - **Canned text animations on `TextCfg.Anim` (#543)** — a `Text` can now animate
   itself. `TextAnimCfg` takes a `Kind` — fade in or out, pulse, slide from any
   of four directions, pop, shake, typewriter, shimmer — plus `Duration`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,28 @@ and this project adheres to
   page to keep the animation loop running, which is what an animated text next
   to a code block now does.
 
+- **Focus follows a widget that loses it** — disabling or removing the focused
+  widget moves focus to the first tab stop (or clears it when none remains) on
+  the next frame, instead of parking it on a dead ID that swallowed keys
+  silently. One shared predicate — focusable, non-empty ID, not disabled — now
+  decides dispatch, tab order, mouse focus, test targeting and the debug gate
+  together, so the five can no longer disagree. Behavior change: `SetFocus` on a
+  disabled or absent ID does not stick past the frame; the blur commit for the
+  old field still fires through the usual `AmendLayout` path.
+
+- **Untrusted text is size-bounded** — the X11 clipboard read stops at 16 MiB,
+  matching the Win32 bound, so a hostile selection owner cannot grow the buffer
+  without bound; `PreTextChange` and `PostCommitNormalize` returns are capped at
+  the keystroke insert budget, so one runaway callback cannot pin unbounded
+  per-window state.
+
+- **Input hardening and cheaper masks** — char/key/click handlers with no
+  originating event decline instead of panicking, negative cursor positions
+  clamp instead of wrapping through the selection casts, event dispatch and
+  focus lookups stop descending past 256 levels, and mask patterns without
+  custom tokens share one compiled instance (an alloc-gate test pins the
+  per-generation budget) instead of recompiling on every frame.
+
 ## [v0.71.0] - 2026-09-08
 
 ### Added

--- a/gui/backend/gl/clipboard_cap.go
+++ b/gui/backend/gl/clipboard_cap.go
@@ -1,0 +1,22 @@
+package gl
+
+// appendClipChunk appends one transfer page to a clipboard buffer
+// while enforcing a total cap: any process can stuff the selection,
+// so a hostile owner must not grow our buffer without bound. Reports
+// false when paging stops — either the buffer reached the cap or the
+// caller decides so from BytesAfter. Kept free of platform calls so
+// it unit-tests on every GOOS, unlike the transfer loops that use it.
+func appendClipChunk(out, page []byte, limit int) ([]byte, bool) {
+	if len(out) >= limit {
+		return out, false
+	}
+	out = append(out, page...)
+	if len(out) > limit {
+		// Truncation can split a trailing multi-byte rune; the
+		// result decodes with a RuneError tail. Acceptable for a
+		// hostile payload that only a cap stops.
+		out = out[:limit]
+		return out, false
+	}
+	return out, true
+}

--- a/gui/backend/gl/clipboard_cap_test.go
+++ b/gui/backend/gl/clipboard_cap_test.go
@@ -1,0 +1,41 @@
+package gl
+
+import (
+	"testing"
+)
+
+func TestAppendClipChunkUnderCap(t *testing.T) {
+	out, ok := appendClipChunk([]byte("ab"), []byte("cd"), 8)
+	if !ok || string(out) != "abcd" {
+		t.Fatalf("got %q, %v; want %q, true", out, ok, "abcd")
+	}
+}
+
+func TestAppendClipChunkExactCapPagesOn(t *testing.T) {
+	out, ok := appendClipChunk([]byte("ab"), []byte("cd"), 4)
+	if !ok || string(out) != "abcd" {
+		t.Fatalf("got %q, %v; want %q, true", out, ok, "abcd")
+	}
+}
+
+func TestAppendClipChunkTruncatesAndStops(t *testing.T) {
+	out, ok := appendClipChunk([]byte("ab"), []byte("cdef"), 4)
+	if ok || string(out) != "abcd" {
+		t.Fatalf("got %q, %v; want %q, false", out, ok, "abcd")
+	}
+}
+
+func TestAppendClipChunkFullBufferIgnoresPage(t *testing.T) {
+	full := []byte("abcd")
+	out, ok := appendClipChunk(full, []byte("e"), 4)
+	if ok || string(out) != "abcd" {
+		t.Fatalf("got %q, %v; want %q, false", out, ok, "abcd")
+	}
+}
+
+func TestAppendClipChunkZeroLimit(t *testing.T) {
+	out, ok := appendClipChunk(nil, []byte("x"), 0)
+	if ok || len(out) != 0 {
+		t.Fatalf("got %q, %v; want empty, false", out, ok)
+	}
+}

--- a/gui/backend/gl/clipboard_x11.go
+++ b/gui/backend/gl/clipboard_x11.go
@@ -13,6 +13,13 @@ import (
 // selection owner cannot hang the UI thread.
 const clipReadTimeout = time.Second
 
+// maxClipboardChars bounds a clipboard read. Any process can place
+// arbitrary data on the selection, so a hostile owner must not grow
+// our buffer past this. Twin of the Win32 bound in platform_win32.go;
+// the two files never compile together, so the constant lives in
+// both rather than behind a third build tag.
+const maxClipboardChars = 16 << 20
+
 // selectionState returns pointers to the cached text and owner flag backing
 // sel, so the set/get/serve paths can treat CLIPBOARD and PRIMARY uniformly.
 // Reports false for any other selection (e.g. SECONDARY), which we neither
@@ -149,8 +156,11 @@ func readClipProperty(conn *xgb.Conn, win xproto.Window, prop xproto.Atom) strin
 		if err != nil || reply == nil || reply.Format == 0 {
 			break
 		}
-		out = append(out, reply.Value...)
-		if reply.BytesAfter == 0 {
+		buf, room := appendClipChunk(out, reply.Value, maxClipboardChars)
+		out = buf
+		// Done when the owner has no more, or when the cap stopped
+		// the buffer: the owner may have more, but we stop.
+		if reply.BytesAfter == 0 || !room {
 			break
 		}
 		// long-offset is in 32-bit units; ValueLen counts Format/8 (=1)

--- a/gui/backend/soft/input_keypress_bench_test.go
+++ b/gui/backend/soft/input_keypress_bench_test.go
@@ -1,0 +1,108 @@
+package soft
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// F2: glyph-per-keypress profile. One keystroke in an Input costs an
+// insert (rune-slice rebuild), a full Update (generate, arrange,
+// render), and — when the caret is visible — a whole-buffer glyph
+// reshape, because renderInputCursor needs character boundaries and
+// the layout cache keys on the full text. These benches measure the
+// whole keypress against the REAL shaper: the gui stubs skip
+// LayoutText entirely and would profile the fallback path.
+//
+// Each iteration re-seeds the same text so size stays fixed (typing
+// "x" into the seed, then rebuilding the view from the seed).
+// Sizes are byte budgets, because the shaper caps input at 10240
+// bytes (go-glyph MaxTextLength) and anything past that measures the
+// fallback path instead of shaping.
+// keypressWindow returns a window holding a focused Input seeded
+// with text, measured by the real shaper, plus a reseed func that
+// rebuilds the view from the seed. Each iteration re-seeds so the
+// size stays fixed while typing "x" into it.
+func keypressWindow(
+	tb testing.TB, seed string,
+) (*gui.Window, func()) {
+	tb.Helper()
+	w := gui.NewWindow(gui.WindowCfg{Width: 800, Height: 600})
+	tm, err := prepare(w, 1)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { tm.textSys.Free() })
+	w.SetTextMeasurer(tm)
+	reseed := func() {
+		w.UpdateView(func(w *gui.Window) gui.View {
+			return gui.Input(gui.InputCfg{
+				ID:     "f",
+				Text:   seed,
+				Sizing: gui.FillFit,
+			})
+		})
+	}
+	reseed()
+	w.Update()
+	w.SetFocus("f")
+	w.Update()
+	return w, reseed
+}
+
+func benchmarkInputKeypress(b *testing.B, seed string) {
+	b.Helper()
+	w, reseed := keypressWindow(b, seed)
+	x := gui.Event{Type: gui.EventChar, CharCode: 'x'}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		reseed()
+		w.EventFn(&x)
+		w.Update()
+	}
+}
+
+func BenchmarkInputKeypress(b *testing.B) {
+	scripts := []struct {
+		name     string
+		unit     string
+		unitSize int
+	}{
+		{"ascii", "a", 1},
+		{"cjk", "中", 3},
+		{"emoji", "🎉", 4},
+	}
+	for _, byteBudget := range []int{1_024, 5_120, 10_000} {
+		for _, sc := range scripts {
+			name := fmt.Sprintf("%s_%dB", sc.name, byteBudget)
+			b.Run(name, func(b *testing.B) {
+				benchmarkInputKeypress(b, strings.Repeat(
+					sc.unit, byteBudget/sc.unitSize))
+			})
+		}
+	}
+}
+
+// The keypress cost scales with the text size (whole-buffer insert
+// copies plus one full reshape per keystroke), so the budget is
+// pinned at the top of the shaper's byte range: a 10KB field must
+// not get heap-hungrier without the bench above showing it first.
+// Timing stays advisory (machine variance); allocations do not.
+func TestInputKeypressAllocBudget(t *testing.T) {
+	w, reseed := keypressWindow(t, strings.Repeat("a", 10_000))
+	x := gui.Event{Type: gui.EventChar, CharCode: 'x'}
+	keypress := func() {
+		reseed()
+		w.EventFn(&x)
+		w.Update()
+	}
+	// Discard the first sweep: font and atlas warmth is one-time,
+	// the gate is on the steady-state keypress.
+	testing.AllocsPerRun(10, keypress)
+	if got := testing.AllocsPerRun(50, keypress); got > 400 {
+		t.Fatalf("keypress allocs = %v, want <= 400", got)
+	}
+}

--- a/gui/backend/soft/input_keypress_bench_test.go
+++ b/gui/backend/soft/input_keypress_bench_test.go
@@ -1,3 +1,9 @@
+//go:build !wasm
+
+// The whole keypress runs against the real shaper, whose construction
+// needs a DOM (syscall/js) the node-based CI harness does not provide
+// — same exclusion as the other text-system tests in this package.
+
 package soft
 
 import (

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -211,6 +211,15 @@ const (
 	// exportaudit:keep — dev-diagnostic API for app authors
 	DebugUnknownLookup
 
+	// DebugGlyphLayoutFallback reports a text shape the glyph shaper
+	// refused — past its byte budget, for example — so the frame fell
+	// back to approximate metrics. Caret placement, selection
+	// rectangles and grapheme-aware delete all lose precision past
+	// that point, silently without this finding: nothing errors, the
+	// text still renders, only the boundaries drift.
+	// exportaudit:keep — dev-diagnostic API for app authors
+	DebugGlyphLayoutFallback
+
 	// DebugAll is every category [Debug] turns on. [DebugUnscopedIDs]
 	// is deliberately absent: it reports a design property rather than
 	// a defect, and fires on widgets that are correct as written.
@@ -218,7 +227,8 @@ const (
 	DebugAll = DebugDuplicates | DebugMissingIDs | DebugUnconsumed |
 		DebugListBoxNoHeight | DebugGradientResampled | DebugWrapOverflow |
 		DebugCallbacks | DebugWindowDegraded | DebugUnresolvedKeys |
-		DebugUnknownFocus | DebugStampDrift | DebugUnknownLookup
+		DebugUnknownFocus | DebugStampDrift | DebugUnknownLookup |
+		DebugGlyphLayoutFallback
 )
 
 func init() {

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -522,7 +522,7 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids *debugIDs) {
 		// the string the stores and the public APIs use.
 		key := s.idKey()
 		ids.noteScoped(s.ID, key)
-		if s.Focusable {
+		if s.canTakeFocus() {
 			if ids.focusable == nil {
 				ids.focusable = make(map[string]struct{})
 			}

--- a/gui/debug_checks.go
+++ b/gui/debug_checks.go
@@ -69,6 +69,11 @@ const (
 	// asks for an animation but carries no ID; the animation and its
 	// progress are keyed by identity, so there is nothing to key on.
 	debugCheckTextAnimNoID
+	// debugCheckGlyphLayoutFallback fires from plainTextLayoutResolved
+	// when the shaper refuses a text, so the frame falls back to
+	// approximate metrics with degraded caret, selection and delete
+	// precision.
+	debugCheckGlyphLayoutFallback
 )
 
 // checkCategory maps an internal check to the public category that
@@ -102,6 +107,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugStampDrift
 	case debugCheckUnknownFocus:
 		return DebugUnknownFocus
+	case debugCheckGlyphLayoutFallback:
+		return DebugGlyphLayoutFallback
 	}
 	return 0
 }

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -274,6 +274,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckUnresolvedKey, DebugUnresolvedKeys},
 		{debugCheckStampDrift, DebugStampDrift},
 		{debugCheckUnknownFocus, DebugUnknownFocus},
+		{debugCheckGlyphLayoutFallback, DebugGlyphLayoutFallback},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {
@@ -283,7 +284,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 	// DebugAll covers every category Debug(true) turns on.
 	// DebugUnscopedIDs is opt-in and deliberately outside it: it reports
 	// a design property, not a defect.
-	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow|DebugCallbacks|DebugWindowDegraded|DebugUnresolvedKeys|DebugStampDrift|DebugUnknownFocus|DebugUnknownLookup {
+	if DebugAll != DebugDuplicates|DebugMissingIDs|DebugUnconsumed|DebugListBoxNoHeight|DebugGradientResampled|DebugWrapOverflow|DebugCallbacks|DebugWindowDegraded|DebugUnresolvedKeys|DebugStampDrift|DebugUnknownFocus|DebugUnknownLookup|DebugGlyphLayoutFallback {
 		t.Fatal("DebugAll must cover every category Debug(true) enables")
 	}
 	if DebugAll&DebugUnscopedIDs != 0 {

--- a/gui/event_depth_test.go
+++ b/gui/event_depth_test.go
@@ -1,0 +1,78 @@
+package gui
+
+import (
+	"testing"
+)
+
+// The breadth guard (maxEventChildren) cannot see a chain of
+// single-child layouts. These tests pin the depth budget
+// (maxEventDepth): walks stop descending past it instead of recursing
+// until the stack gives out, and ordinary-depth trees are unaffected.
+
+// deepChain builds a single-child chain n levels deep with a
+// focusable leaf. Hand-built, so idKey falls back to the leaf ID.
+func deepChain(n int) *Layout {
+	root := &Layout{Shape: &Shape{}}
+	cur := root
+	for range n {
+		cur.Children = []Layout{{Shape: &Shape{}}}
+		cur = &cur.Children[0]
+	}
+	cur.Shape.Focusable = true
+	cur.Shape.ID = "deep"
+	return root
+}
+
+func TestFindByIDStopsAtDepthCap(t *testing.T) {
+	if _, ok := deepChain(100).findByID("deep"); !ok {
+		t.Error("findByID missed a leaf at depth 100")
+	}
+	if _, ok := deepChain(maxEventDepth + 50).findByID("deep"); ok {
+		t.Errorf("findByID reached past maxEventDepth (%d)",
+			maxEventDepth)
+	}
+}
+
+func TestFindByIDDepthBoundary(t *testing.T) {
+	// The budget is depth > maxEventDepth: a leaf sitting exactly
+	// on the line is still reachable, one step past is not.
+	if _, ok := deepChain(maxEventDepth).findByID("deep"); !ok {
+		t.Errorf("findByID missed a leaf at depth %d", maxEventDepth)
+	}
+	if _, ok := deepChain(maxEventDepth + 1).findByID("deep"); ok {
+		t.Errorf("findByID reached a leaf at depth %d",
+			maxEventDepth+1)
+	}
+}
+
+func TestFocusCandidatesStopAtDepthCap(t *testing.T) {
+	var candidates []focusCandidate
+	collectFocusCandidates(deepChain(maxEventDepth+50),
+		&candidates, make(map[string]struct{}))
+	if len(candidates) != 0 {
+		t.Errorf("collected %d candidates past maxEventDepth, want 0",
+			len(candidates))
+	}
+}
+
+func TestCharHandlerDeepChainTerminates(t *testing.T) {
+	root := deepChain(10000)
+	w := newTestWindow()
+	w.SetFocus("deep")
+	e := &Event{Type: EventChar, CharCode: 'x'}
+	charHandler(root, e, w)
+	// Past the budget the leaf is never reached: the event travels
+	// on unhandled instead of recursing without bound.
+	if e.IsHandled {
+		t.Error("charHandler reached past maxEventDepth")
+	}
+}
+
+func TestMouseDownDeepChainTerminates(t *testing.T) {
+	root := deepChain(10000)
+	e := &Event{Type: EventMouseDown, MouseButton: MouseLeft}
+	mouseDownHandler(root, false, e, &Window{})
+	if e.IsHandled {
+		t.Error("mouseDownHandler reached past maxEventDepth")
+	}
+}

--- a/gui/event_handlers.go
+++ b/gui/event_handlers.go
@@ -2,18 +2,46 @@ package gui
 
 import "slices"
 
+// Event consumption convention, stated once because the two spellings
+// look interchangeable and are not. A shape callback holding an
+// EventCtx reports by calling ctx.Consume(); one that does not lets
+// the event travel on, and there is no ctx.Bubble. Dispatch internals
+// and (e, w) helpers below them hold no ctx, so they set e.IsHandled
+// directly — including the spacebar/enter-to-click pre-marks, which
+// claim the key for click activation before the callback runs.
+
 // maxEventChildren caps traversal depth to prevent DoS from
 // maliciously deep or wide layout trees.
 const maxEventChildren = 10000
+
+// maxEventDepth caps recursion depth for the tree walks below. The
+// breadth guard above cannot see a chain of single-child layouts,
+// which would otherwise recurse until the stack gives out. Real trees
+// nest dozens deep at most; past this the walk stops descending, so
+// the frame drops input rather than the process.
+const maxEventDepth = 256
 
 // overMaxChildren reports whether layout has excessive children.
 func overMaxChildren(layout *Layout) bool {
 	return len(layout.Children) > maxEventChildren
 }
 
+// overMaxDepth reports whether a tree walk has descended past the
+// depth budget.
+func overMaxDepth(depth int) bool {
+	return depth > maxEventDepth
+}
+
 // charHandler handles character input events (typing).
 // Traverses forward (depth-first) and delivers to focused element.
 func charHandler(layout *Layout, e *Event, w *Window) {
+	charHandlerDepth(layout, e, w, 0)
+}
+
+func charHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	if overMaxChildren(layout) {
 		return
 	}
@@ -21,7 +49,7 @@ func charHandler(layout *Layout, e *Event, w *Window) {
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		charHandler(&layout.Children[i], e, w)
+		charHandlerDepth(&layout.Children[i], e, w, depth+1)
 		if e.IsHandled {
 			return
 		}
@@ -35,15 +63,15 @@ func charHandler(layout *Layout, e *Event, w *Window) {
 		onChar = layout.Shape.events.OnChar
 		events = layout.Shape.events
 	}
-	// OnChar is consume-class: pre-marked handled before the callback.
+	// Delivers to the focused target, which consumes explicitly.
 	if executeFocusCallback(layout, e, w, onChar, evChar) {
 		return
 	}
 	// Spacebar-to-click: when ClickOnSpace is set, fire OnClick
 	// on spacebar instead of requiring a separate OnChar wrapper.
-	// OnClick is consume-class, so pre-mark before the call rather
-	// than marking after — marking after would override a
-	// ctx.Bubble() the callback made.
+	// The space is claimed for click activation before the call, so
+	// it never also types; an OnClick that declines cannot release
+	// it back to the character path.
 	if events != nil &&
 		events.clickOnSpace &&
 		e.CharCode == charSpace &&
@@ -67,6 +95,13 @@ func imeCompositionHandler(_ *Layout, e *Event, w *Window) {
 // Traverses forward and delivers to focused element. Falls back to
 // keyboard scroll if the focused scroll container has no handler.
 func keydownHandler(layout *Layout, e *Event, w *Window) {
+	keydownHandlerDepth(layout, e, w, 0)
+}
+
+func keydownHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 
 	// Guard against excessive children count to prevent DoS.
 	if overMaxChildren(layout) {
@@ -77,7 +112,7 @@ func keydownHandler(layout *Layout, e *Event, w *Window) {
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		keydownHandler(&layout.Children[i], e, w)
+		keydownHandlerDepth(&layout.Children[i], e, w, depth+1)
 		if e.IsHandled {
 			return
 		}
@@ -91,17 +126,17 @@ func keydownHandler(layout *Layout, e *Event, w *Window) {
 		onKeyDown = layout.Shape.events.OnKeyDown
 		events = layout.Shape.events
 	}
-	// OnKeyDown is notify-class: it receives every key, so auto-consume
-	// would silently kill tab traversal and accelerators in any widget
-	// that has a key handler.
+	// Nothing is pre-marked: OnKeyDown receives every key, so an
+	// implicit claim here would silently kill tab traversal and
+	// accelerators in any widget that has a key handler.
 	executeFocusCallback(layout, e, w, onKeyDown, evNotify)
 	if e.IsHandled {
 		return
 	}
 	// Enter-to-click: when ClickOnEnter is set, fire OnClick on
 	// Enter key instead of requiring a separate OnKeyDown wrapper.
-	// OnClick is consume-class, so pre-mark here — the surrounding
-	// OnKeyDown dispatch does not.
+	// Claimed here, the way the spacebar path above claims its key:
+	// the surrounding OnKeyDown dispatch never pre-marks.
 	if events != nil &&
 		events.clickOnEnter &&
 		e.KeyCode == KeyEnter &&
@@ -119,8 +154,16 @@ func keydownHandler(layout *Layout, e *Event, w *Window) {
 // keyupHandler handles key up events.
 // Traverses forward and delivers to focused element.
 func keyupHandler(layout *Layout, e *Event, w *Window) {
+	keyupHandlerDepth(layout, e, w, 0)
+}
+
+func keyupHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
 	// Guard against nil layout to prevent panic
 	if layout == nil {
+		return
+	}
+
+	if overMaxDepth(depth) {
 		return
 	}
 
@@ -133,7 +176,7 @@ func keyupHandler(layout *Layout, e *Event, w *Window) {
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		keyupHandler(&layout.Children[i], e, w)
+		keyupHandlerDepth(&layout.Children[i], e, w, depth+1)
 		if e.IsHandled {
 			return
 		}
@@ -145,7 +188,7 @@ func keyupHandler(layout *Layout, e *Event, w *Window) {
 	if layout.Shape.hasEvents() {
 		onKeyUp = layout.Shape.events.OnKeyUp
 	}
-	// OnKeyUp is notify-class, like OnKeyDown.
+	// OnKeyUp, like OnKeyDown, is never pre-marked.
 	executeFocusCallback(layout, e, w, onKeyUp, evNotify)
 }
 
@@ -194,6 +237,15 @@ func keyDownScrollHandler(layout *Layout, e *Event, w *Window) {
 func mouseDownHandler(
 	layout *Layout, inHandler bool, e *Event, w *Window,
 ) {
+	mouseDownHandlerDepth(layout, inHandler, e, w, 0)
+}
+
+func mouseDownHandlerDepth(
+	layout *Layout, inHandler bool, e *Event, w *Window, depth int,
+) {
+	if overMaxDepth(depth) {
+		return
+	}
 	// Check mouse lock (only at top level).
 	if !inHandler {
 		if w.viewState.mouseLock.mouseDown != nil {
@@ -207,7 +259,7 @@ func mouseDownHandler(
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		mouseDownHandler(&layout.Children[i], true, e, w)
+		mouseDownHandlerDepth(&layout.Children[i], true, e, w, depth+1)
 		if e.IsHandled {
 			e.MouseX, e.MouseY = ox, oy
 			return
@@ -218,7 +270,7 @@ func mouseDownHandler(
 		return
 	}
 	if layout.Shape.PointInShape(e.MouseX, e.MouseY) {
-		if layout.Shape.Focusable && layout.Shape.ID != "" &&
+		if layout.Shape.canTakeFocus() &&
 			e.MouseButton != MouseRight {
 			w.SetFocus(layout.Shape.idKey())
 			e.IsHandled = true
@@ -227,7 +279,8 @@ func mouseDownHandler(
 		if layout.Shape.hasEvents() {
 			onMouseDown = layout.Shape.events.OnMouseDown
 		}
-		// OnMouseDown is consume-class.
+		// evMouseDown names the event for the unconsumed-event debug
+		// check; the callback itself consumes explicitly.
 		executeMouseCallback(layout, e, w, onMouseDown, evMouseDown)
 		var onClick shapeCallback
 		if layout.Shape.hasEvents() {
@@ -237,7 +290,8 @@ func mouseDownHandler(
 				onClick = events.OnClick
 			}
 		}
-		// OnClick is consume-class.
+		// evClick additionally plays the shape's click cue before
+		// the callback, independently of whether it consumes.
 		executeMouseCallback(layout, e, w, onClick, evClick)
 	}
 }
@@ -245,6 +299,13 @@ func mouseDownHandler(
 // mouseMoveHandler handles mouse movement events.
 // Traverses reverse (topmost first).
 func mouseMoveHandler(layout *Layout, e *Event, w *Window) {
+	mouseMoveHandlerDepth(layout, e, w, 0)
+}
+
+func mouseMoveHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	if w.viewState.mouseLock.MouseMove != nil {
 		w.viewState.mouseLock.MouseMove(EventCtx{layout, e, w})
 		return
@@ -257,7 +318,7 @@ func mouseMoveHandler(layout *Layout, e *Event, w *Window) {
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		mouseMoveHandler(&layout.Children[i], e, w)
+		mouseMoveHandlerDepth(&layout.Children[i], e, w, depth+1)
 		if e.IsHandled {
 			e.MouseX, e.MouseY = ox, oy
 			return
@@ -271,14 +332,21 @@ func mouseMoveHandler(layout *Layout, e *Event, w *Window) {
 	if layout.Shape.hasEvents() {
 		onMouseMove = layout.Shape.events.OnMouseMove
 	}
-	// OnMouseMove is notify-class: nested shapes legitimately all
-	// want move notifications.
+	// evNotify carries no ancestor rule, so nested shapes
+	// legitimately all want move notifications.
 	executeMouseCallback(layout, e, w, onMouseMove, evNotify)
 }
 
 // mouseUpHandler handles mouse button release events.
 // Traverses reverse (topmost first).
 func mouseUpHandler(layout *Layout, e *Event, w *Window) {
+	mouseUpHandlerDepth(layout, e, w, 0)
+}
+
+func mouseUpHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	if w.viewState.mouseLock.MouseUp != nil {
 		w.viewState.mouseLock.MouseUp(EventCtx{layout, e, w})
 		return
@@ -288,7 +356,7 @@ func mouseUpHandler(layout *Layout, e *Event, w *Window) {
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		mouseUpHandler(&layout.Children[i], e, w)
+		mouseUpHandlerDepth(&layout.Children[i], e, w, depth+1)
 		if e.IsHandled {
 			e.MouseX, e.MouseY = ox, oy
 			return
@@ -302,7 +370,8 @@ func mouseUpHandler(layout *Layout, e *Event, w *Window) {
 	if layout.Shape.hasEvents() {
 		onMouseUp = layout.Shape.events.OnMouseUp
 	}
-	// OnMouseUp is consume-class.
+	// evMouseUp names the event for the unconsumed-event debug
+	// check; the callback itself consumes explicitly.
 	executeMouseCallback(layout, e, w, onMouseUp, evMouseUp)
 }
 
@@ -328,8 +397,9 @@ func focusedScrollTarget(layout *Layout, w *Window) *Layout {
 // and falls back to the scroll container under cursor.
 func mouseScrollHandler(layout *Layout, e *Event, w *Window) {
 	if ly := focusedScrollTarget(layout, w); ly != nil {
-		// OnMouseScroll is notify-class: cascade-on-unhandled is the
-		// designed contract, so there is no pre-mark here.
+		// Cascade-on-unhandled is the designed contract, so there
+		// is no pre-mark here: an unhandled scroll falls through to
+		// the container below.
 		if callRelative(ly, e, w, ly.Shape.events.OnMouseScroll, evNotify) {
 			return
 		}
@@ -338,12 +408,19 @@ func mouseScrollHandler(layout *Layout, e *Event, w *Window) {
 }
 
 func mouseScrollFallbackHandler(layout *Layout, e *Event, w *Window) {
+	mouseScrollFallbackHandlerDepth(layout, e, w, 0)
+}
+
+func mouseScrollFallbackHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	ox, oy := rotateMouseInverse(layout.Shape, e)
 	for i := range slices.Backward(layout.Children) {
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		mouseScrollFallbackHandler(&layout.Children[i], e, w)
+		mouseScrollFallbackHandlerDepth(&layout.Children[i], e, w, depth+1)
 		if e.IsHandled {
 			e.MouseX, e.MouseY = ox, oy
 			return
@@ -357,8 +434,8 @@ func mouseScrollFallbackHandler(layout *Layout, e *Event, w *Window) {
 	if layout.Shape.hasEvents() &&
 		layout.Shape.events.OnMouseScroll != nil {
 		if layout.Shape.PointInShape(e.MouseX, e.MouseY) {
-			// Notify-class: no pre-mark, so an unhandled scroll falls
-			// through to the scroll container below.
+			// No pre-mark, so an unhandled scroll falls through to
+			// the scroll container below.
 			layout.Shape.events.OnMouseScroll(EventCtx{layout, e, w})
 			if e.IsHandled {
 				return
@@ -391,12 +468,19 @@ func mouseScrollFallbackHandler(layout *Layout, e *Event, w *Window) {
 
 // fileDropHandler handles file-drop events. Does not change focus.
 func fileDropHandler(layout *Layout, e *Event, w *Window) {
+	fileDropHandlerDepth(layout, e, w, 0)
+}
+
+func fileDropHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	ox, oy := rotateMouseInverse(layout.Shape, e)
 	for i := range slices.Backward(layout.Children) {
 		if !isChildEnabled(&layout.Children[i]) {
 			continue
 		}
-		fileDropHandler(&layout.Children[i], e, w)
+		fileDropHandlerDepth(&layout.Children[i], e, w, depth+1)
 		if e.IsHandled {
 			e.MouseX, e.MouseY = ox, oy
 			return
@@ -410,6 +494,7 @@ func fileDropHandler(layout *Layout, e *Event, w *Window) {
 	if layout.Shape.hasEvents() {
 		onFileDrop = layout.Shape.events.OnFileDrop
 	}
-	// OnFileDrop is consume-class.
+	// evFileDrop names the event for the unconsumed-event debug
+	// check; the callback itself consumes explicitly.
 	executeMouseCallback(layout, e, w, onFileDrop, evFileDrop)
 }

--- a/gui/event_traversal.go
+++ b/gui/event_traversal.go
@@ -14,7 +14,7 @@ func isFocusedTarget(layout *Layout, w *Window) bool {
 	if layout.Shape.ID == reservedDialogID {
 		return true
 	}
-	if !layout.Shape.Focusable || layout.Shape.ID == "" {
+	if !layout.Shape.canTakeFocus() {
 		return false
 	}
 	// The focus store holds effective IDs, so compare on idKey, not on
@@ -81,9 +81,9 @@ func callRelative(
 
 // executeMouseCallback executes a callback if the mouse is
 // within shape bounds. Coordinates are made relative before
-// calling. Returns true if handled. class is passed through to
-// callRelative — this helper serves both classes (OnClick/OnMouseUp/
-// OnFileDrop consume, OnMouseMove notifies).
+// calling. Returns true if handled. class names the event for the
+// unconsumed-event debug check, nothing more: the callback itself
+// decides consumption with ctx.Consume().
 func executeMouseCallback(
 	layout *Layout, e *Event, w *Window,
 	callback shapeCallback, class evClass,

--- a/gui/focus_defects_test.go
+++ b/gui/focus_defects_test.go
@@ -40,7 +40,7 @@ func focusableIDs(layout *Layout) []string {
 	var out []string
 	var walk func(*Layout)
 	walk = func(l *Layout) {
-		if s := l.Shape; s != nil && s.Focusable && !s.FocusSkip && !s.Disabled {
+		if s := l.Shape; s != nil && s.canTakeFocus() && !s.FocusSkip {
 			out = append(out, s.ID)
 		}
 		for i := range l.Children {

--- a/gui/focus_take_test.go
+++ b/gui/focus_take_test.go
@@ -1,0 +1,157 @@
+package gui
+
+import (
+	"testing"
+)
+
+// Regression tests for the take-focus predicate (Shape.canTakeFocus)
+// and the per-frame focus fixup (fixupFocusLocked). Every widget maps
+// an invisible Cfg to the disabled invisibleContainerView singleton,
+// so invisibility never reaches a shape — these tests pin that
+// invariant — and a widget disabled or removed while focused loses
+// focus to the first tab stop instead of parking it in the void.
+
+// focusFixupWindow builds a two-input window whose second input the
+// test can disable by flipping *disabled and re-running Update.
+func focusFixupWindow(disabled *bool) *Window {
+	w := newTestWindow()
+	w.viewGenerator = func(_ *Window) View {
+		return Column(ContainerCfg{
+			Content: []View{
+				Input(InputCfg{ID: "fix-a", Sizing: FillFit}),
+				Input(InputCfg{
+					ID:       "fix-b",
+					Sizing:   FillFit,
+					Disabled: *disabled,
+				}),
+			},
+		})
+	}
+	return w
+}
+
+func TestCanTakeFocusPredicate(t *testing.T) {
+	cases := []struct {
+		name  string
+		shape Shape
+		want  bool
+	}{
+		{"focusable with ID", Shape{Focusable: true, ID: "a"},
+			true},
+		{"no ID", Shape{Focusable: true}, false},
+		{"not focusable", Shape{ID: "a"}, false},
+		{"disabled", Shape{Focusable: true, ID: "a", Disabled: true},
+			false},
+		// FocusSkip is tab-order-only: the widget still takes
+		// click-focus, so the predicate stays true.
+		{"focus skip", Shape{Focusable: true, ID: "a", FocusSkip: true},
+			true},
+	}
+	for _, tc := range cases {
+		if got := tc.shape.canTakeFocus(); got != tc.want {
+			t.Errorf("%s: canTakeFocus() = %v, want %v",
+				tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestValidFocusSurvivesFrame(t *testing.T) {
+	disabled := false
+	w := focusFixupWindow(&disabled)
+	w.SetFocus("fix-b")
+	w.Update()
+	if got := w.FocusID(); got != "fix-b" {
+		t.Fatalf("FocusID() = %q, want %q", got, "fix-b")
+	}
+}
+
+func TestDisabledFocusMovesToFirstTabStop(t *testing.T) {
+	disabled := false
+	w := focusFixupWindow(&disabled)
+	w.SetFocus("fix-b")
+	w.Update()
+	if got := w.FocusID(); got != "fix-b" {
+		t.Fatalf("setup: FocusID() = %q, want %q", got, "fix-b")
+	}
+	disabled = true
+	w.refreshLayout = true
+	w.Update()
+	if got := w.FocusID(); got != "fix-a" {
+		t.Fatalf("FocusID() = %q, want %q", got, "fix-a")
+	}
+}
+
+func TestFocusClearedWhenNothingFocusable(t *testing.T) {
+	disabled := false
+	w := focusFixupWindow(&disabled)
+	w.SetFocus("fix-a")
+	w.Update()
+	w.viewGenerator = func(_ *Window) View {
+		return Column(ContainerCfg{
+			Content: []View{
+				Input(InputCfg{
+					ID:       "fix-a",
+					Sizing:   FillFit,
+					Disabled: true,
+				}),
+				Input(InputCfg{
+					ID:       "fix-b",
+					Sizing:   FillFit,
+					Disabled: true,
+				}),
+			},
+		})
+	}
+	w.refreshLayout = true
+	w.Update()
+	if got := w.FocusID(); got != "" {
+		t.Fatalf("FocusID() = %q, want empty", got)
+	}
+}
+
+func TestInvisibleInputTakesNoFocus(t *testing.T) {
+	w := newTestWindow()
+	w.viewGenerator = func(_ *Window) View {
+		return Column(ContainerCfg{
+			Content: []View{
+				Input(InputCfg{ID: "vis", Sizing: FillFit}),
+				Input(InputCfg{ID: "hid", Sizing: FillFit, Invisible: true}),
+			},
+		})
+	}
+	w.Update()
+	// The invisible input collapses to the disabled singleton: it
+	// joins no tab stop.
+	var candidates []focusCandidate
+	seen := make(map[string]struct{})
+	collectFocusCandidates(&w.layout, &candidates, seen)
+	if len(candidates) != 1 || candidates[0].id != "vis" {
+		t.Fatalf("tab stops = %v, want [vis]", candidates)
+	}
+	// Parking focus on the hidden leaf does not stick: the fixup
+	// moves it to the visible field on the next frame.
+	w.SetFocus("hid")
+	w.Update()
+	if got := w.FocusID(); got != "vis" {
+		t.Fatalf("FocusID() = %q, want %q", got, "vis")
+	}
+}
+
+func TestRemovedFocusMovesToFirstTabStop(t *testing.T) {
+	disabled := false
+	w := focusFixupWindow(&disabled)
+	w.SetFocus("fix-b")
+	w.Update()
+	w.viewGenerator = func(_ *Window) View {
+		return Column(ContainerCfg{
+			Content: []View{
+				Input(InputCfg{ID: "fix-a", Sizing: FillFit}),
+			},
+		})
+	}
+	w.refreshLayout = true
+	w.Update()
+	if got := w.FocusID(); got != "fix-a" {
+		t.Fatalf("FocusID() = %q, want %q", got, "fix-a")
+	}
+}

--- a/gui/input_mask.go
+++ b/gui/input_mask.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"errors"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -73,6 +74,39 @@ func inputMaskDefaultTokens() []MaskTokenDef {
 	}
 }
 
+// defaultMaskTokens is the shared default table compileInputMask
+// reads from. Package-level because the mask compiles on every Input
+// generation — once per field per frame — and rebuilding the table
+// each time is pure garbage. Read-only after init; never mutated.
+var defaultMaskTokens = inputMaskDefaultTokens()
+
+// compiledMaskCache shares compiled masks across generations. A mask
+// is read-only after compile, so one instance serves every field
+// using the pattern. Keyed by pattern only when no custom tokens are
+// in play: custom tables make the key unbounded, and those fields
+// compile fresh. Patterns are static app strings, so the map settles
+// at a handful of entries and never grows per frame.
+var compiledMaskCache = struct {
+	sync.RWMutex
+	m map[string]*CompiledInputMask
+}{m: make(map[string]*CompiledInputMask)}
+
+// cachedCompiledMask returns the shared instance for pattern, or nil
+// when no custom tokens apply and the pattern is not cached yet.
+func cachedCompiledMask(pattern string) *CompiledInputMask {
+	compiledMaskCache.RLock()
+	c := compiledMaskCache.m[pattern]
+	compiledMaskCache.RUnlock()
+	return c
+}
+
+// storeCompiledMaskCache records a compiled mask for reuse.
+func storeCompiledMaskCache(pattern string, c *CompiledInputMask) {
+	compiledMaskCache.Lock()
+	compiledMaskCache.m[pattern] = c
+	compiledMaskCache.Unlock()
+}
+
 // InputMaskFromPreset returns the mask pattern for a preset.
 func inputMaskFromPreset(preset InputMaskPreset) string {
 	switch preset {
@@ -99,7 +133,7 @@ func compileInputMask(mask string, custom []MaskTokenDef) (CompiledInputMask, er
 	}
 
 	tokenMap := make(map[rune]MaskTokenDef)
-	for _, def := range inputMaskDefaultTokens() {
+	for _, def := range defaultMaskTokens {
 		tokenMap[def.Symbol] = def
 	}
 	for _, def := range custom {

--- a/gui/input_mask_alloc_test.go
+++ b/gui/input_mask_alloc_test.go
@@ -1,0 +1,70 @@
+package gui
+
+import (
+	"testing"
+)
+
+// The mask compiles on every Input generation — once per field per
+// frame — so its allocation budget matters. These tests pin it: the
+// default-token table is shared, and token-less patterns compile once
+// and read back from a cache.
+func TestCompiledMaskAllocBudget(t *testing.T) {
+	hcfg := inputHandlerCfg{Mask: "(999) 999-9999"}
+	if got := testing.AllocsPerRun(100, func() {
+		_ = hcfg.compiledMask()
+	}); got > 3 {
+		t.Fatalf("compiledMask allocs = %v, want <= 3", got)
+	}
+}
+
+func TestCompiledMaskCustomTokensCompileFresh(t *testing.T) {
+	digits := []MaskTokenDef{{
+		Symbol:  '#',
+		matcher: isASCIIDigit,
+	}}
+	letters := []MaskTokenDef{{
+		Symbol:  '#',
+		matcher: isMaskLetter,
+	}}
+	// Same pattern, different token tables: the cache must not
+	// serve one for the other.
+	if _, err := compileInputMask("##", digits); err != nil {
+		t.Fatal(err)
+	}
+	got, err := compileInputMask("##", letters)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := inputMaskInsert("", 0, 0, 0, "ab", &got)
+	if !res.Changed || res.Text != "ab" {
+		t.Fatalf("custom letters mask insert = %q, want %q",
+			res.Text, "ab")
+	}
+}
+
+func TestCompiledMaskCacheSharesInstances(t *testing.T) {
+	hcfg := inputHandlerCfg{Mask: "99/99"}
+	a := hcfg.compiledMask()
+	b := hcfg.compiledMask()
+	if a != b {
+		t.Fatal("expected the pattern cache to share one instance")
+	}
+}
+
+func TestCompiledMaskCustomTokensSkipCache(t *testing.T) {
+	custom := []MaskTokenDef{{
+		Symbol:  '#',
+		matcher: isASCIIDigit,
+	}}
+	hcfg := inputHandlerCfg{Mask: "##", maskTokens: custom}
+	a := hcfg.compiledMask()
+	b := hcfg.compiledMask()
+	if a == nil || b == nil {
+		t.Fatal("expected custom-token masks to compile")
+	}
+	// Custom tables make the key unbounded, so each generation
+	// compiles fresh rather than sharing.
+	if a == b {
+		t.Fatal("expected custom-token masks to compile fresh")
+	}
+}

--- a/gui/input_nil_event_test.go
+++ b/gui/input_nil_event_test.go
@@ -1,0 +1,131 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The input and combobox event handlers close over window state and
+// read ctx.Event unconditionally. A synthetic dispatch with no
+// originating event must decline cleanly instead of panicking.
+
+// nilEventCtx builds a context with no event and no layout: the
+// least any handler may assume.
+func nilEventCtx(w *Window) EventCtx {
+	return EventCtx{Layout: nil, Event: nil, Window: w}
+}
+
+func TestInputOnCharNilEventDeclines(t *testing.T) {
+	w := newTestWindow()
+	makeInputOnChar(inputHandlerCfg{})(nilEventCtx(w))
+}
+
+func TestInputOnKeyDownNilEventDeclines(t *testing.T) {
+	w := newTestWindow()
+	makeInputOnKeyDown(inputHandlerCfg{})(nilEventCtx(w))
+}
+
+func TestInputOnKeyUpNilEventDeclines(t *testing.T) {
+	w := newTestWindow()
+	makeInputOnKeyUp(inputHandlerCfg{})(nilEventCtx(w))
+}
+
+func TestInputOnClickNilEventDeclines(t *testing.T) {
+	w := newTestWindow()
+	inputOnClick("leaf", "scroll", true)(nilEventCtx(w))
+}
+
+func TestInputOnClickNilLayoutDeclines(t *testing.T) {
+	w := newTestWindow()
+	e := &Event{Type: EventMouseDown, MouseButton: MouseLeft}
+	inputOnClick("leaf", "scroll", true)(EventCtx{nil, e, w})
+}
+
+func TestComboboxOnCharNilEventDeclines(t *testing.T) {
+	w := newTestWindow()
+	makeComboboxOnChar("cb")(nilEventCtx(w))
+}
+
+func TestComboboxOnKeyDownNilEventDeclines(t *testing.T) {
+	w := newTestWindow()
+	makeComboboxOnKeyDown("cb", nil, "cb", nil, "", 0, 0)(
+		nilEventCtx(w))
+}
+
+// Declining leaves the event unhandled so it travels on.
+func TestInputOnCharNoFocusLeavesUnhandled(t *testing.T) {
+	w := newTestWindow()
+	layout := generateViewLayout(Input(InputCfg{
+		ID: "nil-evt", Sizing: FillFit,
+	}), w)
+	e := &Event{Type: EventChar, CharCode: 'x'}
+	layout.Shape.events.OnChar(EventCtx{&layout, e, w})
+	if e.IsHandled {
+		t.Error("unfocused input must not consume the character")
+	}
+}
+
+func TestUpdateCursorAndSelectionClampsNegative(t *testing.T) {
+	w := newTestWindow()
+	imap := StateMap[string, inputState](w, nsInput, capMany)
+	updateCursorAndSelection(imap, "neg", inputState{CursorPos: -3},
+		-5, true)
+	got := imap.GetOr("neg", inputState{CursorPos: -99})
+	if got.CursorPos != 0 {
+		t.Errorf("CursorPos = %d, want 0", got.CursorPos)
+	}
+	if got.selectBeg != 0 || got.selectEnd != 0 {
+		t.Errorf("selection = (%d, %d), want (0, 0)",
+			got.selectBeg, got.selectEnd)
+	}
+}
+
+func TestPreTextChangeOversizedAdjustedCapped(t *testing.T) {
+	w := newTestWindow()
+	big := make([]rune, inputMaxInsertRunes+1000)
+	for i := range big {
+		big[i] = 'x'
+	}
+	hcfg := inputHandlerCfg{
+		preTextChange: func(_, _ string) (string, bool) {
+			return string(big), true
+		},
+	}
+	text, changed := inputTextChange(hcfg, nil, "", "a", "cap-pre", w)
+	if !changed {
+		t.Fatal("expected the adjusted text to apply")
+	}
+	if n := utf8RuneCount(text); n != inputMaxInsertRunes {
+		t.Fatalf("adjusted runes = %d, want %d", n, inputMaxInsertRunes)
+	}
+}
+
+func TestNormalizeOnCommitOversizedCapped(t *testing.T) {
+	hcfg := inputHandlerCfg{
+		postCommitNormalize: func(text string, _ InputCommitReason) string {
+			return text + string(make([]rune, inputMaxInsertRunes))
+		},
+	}
+	got := hcfg.normalizeOnCommit("hi", InputCommitEnter)
+	if n := utf8RuneCount(got); n != inputMaxInsertRunes {
+		t.Fatalf("normalized runes = %d, want %d", n, inputMaxInsertRunes)
+	}
+}
+
+func TestCapCallbackTextBoundaries(t *testing.T) {
+	if got := capCallbackText(""); got != "" {
+		t.Fatalf("capCallbackText(\"\") = %q, want empty", got)
+	}
+	// Exactly at budget: passes through untouched, not truncated
+	// and re-sliced.
+	exact := strings.Repeat("x", inputMaxInsertRunes)
+	if got := capCallbackText(exact); got != exact {
+		t.Fatalf("at-budget text = %d runes, want %d",
+			utf8RuneCount(got), inputMaxInsertRunes)
+	}
+	over := strings.Repeat("y", inputMaxInsertRunes+1)
+	if got := capCallbackText(over); utf8RuneCount(got) != inputMaxInsertRunes {
+		t.Fatalf("over-budget text = %d runes, want %d",
+			utf8RuneCount(got), inputMaxInsertRunes)
+	}
+}

--- a/gui/input_state.go
+++ b/gui/input_state.go
@@ -201,6 +201,18 @@ func inputInsert(text string, insertText string, focusID string, w *Window) stri
 	return nextText
 }
 
+// capCallbackText bounds text an app callback returns (PreTextChange
+// adjusted, PostCommitNormalize output). The callback is trusted code
+// but not size-checked code: without a bound one runaway return pins
+// unbounded memory in per-window state. inputMaxInsertRunes is the
+// same budget keystroke inserts get.
+func capCallbackText(s string) string {
+	if utf8RuneCount(s) <= inputMaxInsertRunes {
+		return s
+	}
+	return s[:runeToByteIndex(s, inputMaxInsertRunes)]
+}
+
 // inputSetTextAndCursorAtEnd pushes undo and places cursor at end
 // of newText. Used when PreTextChange returns adjusted text where
 // positional cursor mapping is unreliable.
@@ -369,7 +381,9 @@ func inputSelectAll(text string, focusID string, w *Window) {
 }
 
 // updateCursorAndSelection moves cursor to newPos, extending
-// or resetting selection based on shift modifier.
+// or resetting selection based on shift modifier. Negative positions
+// (corrupt state, never produced by the cursor functions) clamp to
+// zero rather than wrapping through the uint32 selection casts below.
 func updateCursorAndSelection(
 	imap *BoundedMap[string, inputState],
 	focusID string,
@@ -377,14 +391,16 @@ func updateCursorAndSelection(
 	newPos int,
 	isShift bool,
 ) {
+	newPos = max(newPos, 0)
+	anchor := max(is.CursorPos, 0)
 	if isShift {
 		if is.selectBeg == is.selectEnd {
 			// Start new selection from current cursor.
-			is.selectBeg = uint32(is.CursorPos)
+			is.selectBeg = uint32(anchor)
 			is.selectEnd = uint32(newPos)
 		} else {
 			// Extend: move the end that matches current cursor.
-			if uint32(is.CursorPos) == is.selectEnd {
+			if uint32(anchor) == is.selectEnd {
 				is.selectEnd = uint32(newPos)
 			} else {
 				is.selectBeg = uint32(newPos)

--- a/gui/layout_query.go
+++ b/gui/layout_query.go
@@ -32,11 +32,18 @@ func (layout *Layout) FindLayout(predicate func(Layout) bool) (*Layout, bool) {
 // resolves to under its ID-bearing ancestors, which is what the focus
 // store holds.
 func findLayoutByFocusID(layout *Layout, id string) (*Layout, bool) {
+	return findLayoutByFocusIDDepth(layout, id, 0)
+}
+
+func findLayoutByFocusIDDepth(layout *Layout, id string, depth int) (*Layout, bool) {
+	if overMaxDepth(depth) {
+		return nil, false
+	}
 	if id != "" && layout.Shape.Focusable && layout.Shape.idKey() == id {
 		return layout, true
 	}
 	for i := range layout.Children {
-		if ly, ok := findLayoutByFocusID(&layout.Children[i], id); ok {
+		if ly, ok := findLayoutByFocusIDDepth(&layout.Children[i], id, depth+1); ok {
 			return ly, true
 		}
 	}
@@ -47,11 +54,18 @@ func findLayoutByFocusID(layout *Layout, id string) (*Layout, bool) {
 // with matching scroll ID. An empty id never matches. id is an
 // effective ID, as in [FindLayoutByFocusID].
 func findLayoutByScrollID(layout *Layout, id string) (*Layout, bool) {
+	return findLayoutByScrollIDDepth(layout, id, 0)
+}
+
+func findLayoutByScrollIDDepth(layout *Layout, id string, depth int) (*Layout, bool) {
+	if overMaxDepth(depth) {
+		return nil, false
+	}
 	if id != "" && layout.Shape.Scrollable && layout.Shape.idKey() == id {
 		return layout, true
 	}
 	for i := range layout.Children {
-		if ly, ok := findLayoutByScrollID(&layout.Children[i], id); ok {
+		if ly, ok := findLayoutByScrollIDDepth(&layout.Children[i], id, depth+1); ok {
 			return ly, true
 		}
 	}
@@ -88,6 +102,13 @@ func (layout *Layout) FindByID(id string) (*Layout, bool) {
 // for callers whose miss is a legitimate answer rather than a
 // misspelling.
 func (layout *Layout) findByID(id string) (*Layout, bool) {
+	return layout.findByIDDepth(id, 0)
+}
+
+func (layout *Layout) findByIDDepth(id string, depth int) (*Layout, bool) {
+	if overMaxDepth(depth) {
+		return nil, false
+	}
 	if id == "" {
 		return nil, false
 	}
@@ -98,7 +119,7 @@ func (layout *Layout) findByID(id string) (*Layout, bool) {
 		return layout, true
 	}
 	for i := range layout.Children {
-		if res, ok := layout.Children[i].findByID(id); ok {
+		if res, ok := layout.Children[i].findByIDDepth(id, depth+1); ok {
 			return res, true
 		}
 	}
@@ -111,8 +132,15 @@ type focusCandidate struct {
 }
 
 func collectFocusCandidates(layout *Layout, candidates *[]focusCandidate, seen map[string]struct{}) {
+	collectFocusCandidatesDepth(layout, candidates, seen, 0)
+}
+
+func collectFocusCandidatesDepth(layout *Layout, candidates *[]focusCandidate, seen map[string]struct{}, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	s := layout.Shape
-	if s.Focusable && !s.FocusSkip && !s.Disabled && s.ID != "" {
+	if s.canTakeFocus() && !s.FocusSkip {
 		// Candidates carry the effective ID: it is what the focus store
 		// holds, so it is what focusFindNext/Previous compare against.
 		//
@@ -129,7 +157,7 @@ func collectFocusCandidates(layout *Layout, candidates *[]focusCandidate, seen m
 		}
 	}
 	for i := range layout.Children {
-		collectFocusCandidates(&layout.Children[i], candidates, seen)
+		collectFocusCandidatesDepth(&layout.Children[i], candidates, seen, depth+1)
 	}
 }
 

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -608,6 +608,20 @@ func (s *Shape) focusKey() string {
 	return s.idKey()
 }
 
+// canTakeFocus reports whether a shape is eligible to hold keyboard
+// focus: focusable, addressed by a non-empty ID, and not disabled.
+// FocusSkip is deliberately absent: a skipped widget is out of tab
+// order but still takes click-focus. There is no Invisible arm:
+// invisibility never reaches a shape, because every widget maps an
+// invisible Cfg to the disabled invisibleContainerView singleton, so
+// an invisible widget is already disabled here. The single predicate
+// keeps dispatch (isFocusedTarget), tab order
+// (collectFocusCandidates), mouse focus (mouseDownHandler) and the
+// debug gate's focusable set from drifting apart again.
+func (s *Shape) canTakeFocus() bool {
+	return s.Focusable && s.ID != "" && !s.Disabled
+}
+
 // rendersFocusState reports whether this shape draws caret, selection
 // or spell-check state for some widget: for itself when Focusable, or
 // for the owner named by focusOwner. False for ordinary text, which

--- a/gui/testing.go
+++ b/gui/testing.go
@@ -252,15 +252,16 @@ func (w *Window) TestClick(id string) error {
 }
 
 // testFocusable resolves id and rejects it unless it can actually hold
-// focus. Both conditions are required by isFocusedTarget; a widget with
-// Focusable set but no ID is the silent no-op the requiredid analyzer
-// and the RequireID panic exist to prevent.
+// focus. Decided by Shape.canTakeFocus, the same predicate dispatch
+// and tab order use; a widget with Focusable set but no ID is the
+// silent no-op the requiredid analyzer and the RequireID panic exist
+// to prevent.
 func (w *Window) testFocusable(id string) (*Layout, error) {
 	ly, err := w.testTarget(id)
 	if err != nil {
 		return nil, err
 	}
-	if !ly.Shape.Focusable {
+	if !ly.Shape.canTakeFocus() {
 		return nil, fmt.Errorf("%w: %q", errTestNotFocusable, id)
 	}
 	return ly, nil

--- a/gui/text_cursor.go
+++ b/gui/text_cursor.go
@@ -79,11 +79,3 @@ func truncatePreview(s string, maxRunes int) string {
 	byteIdx := runeToByteIndex(s, maxRunes)
 	return s[:byteIdx] + "..."
 }
-
-// selectionRange returns (beg, end) with beg <= end.
-func selectionRange(a, b int) (uint32, uint32) {
-	if a <= b {
-		return uint32(a), uint32(b)
-	}
-	return uint32(b), uint32(a)
-}

--- a/gui/text_cursor_test.go
+++ b/gui/text_cursor_test.go
@@ -69,12 +69,6 @@ func TestByteToRuneIndex(t *testing.T) {
 	assertEqual(t, byteToRuneIndex(text, 4), 2)
 }
 
-func TestSelectionRange(t *testing.T) {
-	beg, end := selectionRange(5, 2)
-	assertEqual(t, int(beg), 2)
-	assertEqual(t, int(end), 5)
-}
-
 func assertEqual(t *testing.T, got, want int) {
 	t.Helper()
 	if got != want {

--- a/gui/text_layout.go
+++ b/gui/text_layout.go
@@ -129,6 +129,16 @@ func plainTextLayoutResolved(
 	}
 	layout, err := w.textMeasurer.LayoutText(text, style, widthArg)
 	if err != nil {
+		// The shaper refused the text — past its byte budget, for
+		// example — so the frame falls back to approximate metrics.
+		// Report once per identity: without this the caret,
+		// selection and grapheme delete silently lose precision,
+		// and nothing else in the frame says why.
+		w.debugWarn(debugCheckGlyphLayoutFallback, shape.idKey(),
+			"glyph layout failed for %q (%d bytes): %v; "+
+				"using approximate metrics with degraded caret, "+
+				"selection and delete precision",
+			shape.idKey(), len(text), err)
 		return glyph.Layout{}, false
 	}
 	tc.textLayout = &layout

--- a/gui/text_layout_fallback_test.go
+++ b/gui/text_layout_fallback_test.go
@@ -1,0 +1,74 @@
+package gui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+// A shaper refusal — past the byte budget, for example — must not
+// degrade the caret, selection and grapheme delete in silence. These
+// tests pin the DebugGlyphLayoutFallback finding: reported once per
+// shape while the category is on, silent otherwise.
+
+// failMeasurer refuses every layout the way an over-budget text is
+// refused, without needing a 10KB string in a unit test.
+type failMeasurer struct{ *stubTextMeasurer }
+
+func (failMeasurer) LayoutText(
+	string, TextStyle, float32,
+) (glyph.Layout, error) {
+	return glyph.Layout{}, errors.New("text exceeds max length")
+}
+
+func TestGlyphLayoutFallbackFinding(t *testing.T) {
+	w := newTestWindow()
+	w.textMeasurer = &failMeasurer{&stubTextMeasurer{charWidth: 10}}
+	w.viewGenerator = func(_ *Window) View {
+		return Column(ContainerCfg{
+			Content: []View{
+				// Wrap mode resolves the glyph layout during
+				// arrange; single-line text only shapes on the
+				// render paths that need boundaries.
+				Text(TextCfg{ID: "long", Text: "hello",
+					Mode: TextModeWrap}),
+			},
+		})
+	}
+	found := w.TestFindings(DebugGlyphLayoutFallback)
+	joined := strings.Join(found, "\n")
+	if !strings.Contains(joined, `"long"`) {
+		t.Fatalf("want finding naming the shape, got %q", found)
+	}
+	if !strings.Contains(joined, "approximate metrics") {
+		t.Fatalf("want fallback message, got %q", found)
+	}
+}
+
+func TestGlyphLayoutFallbackWarnOnce(t *testing.T) {
+	buf := captureDebugMask(t, DebugGlyphLayoutFallback)
+	w := &Window{}
+	w.textMeasurer = &failMeasurer{&stubTextMeasurer{}}
+	shape := &Shape{ID: "once", TC: &shapeTextConfig{Text: "hello"}}
+	style := DefaultTextStyle
+	plainTextLayoutResolved("hello", shape, style, w)
+	plainTextLayoutResolved("hello world", shape, style, w)
+	if n := strings.Count(buf.String(), "approximate metrics"); n != 1 {
+		t.Fatalf("warn-once: want 1 finding, got %d (%q)",
+			n, buf.String())
+	}
+}
+
+func TestGlyphLayoutFallbackCategoryGate(t *testing.T) {
+	buf := captureDebug(t)
+	DebugCategories(DebugMissingIDs)
+	w := &Window{}
+	w.textMeasurer = &failMeasurer{&stubTextMeasurer{}}
+	shape := &Shape{ID: "gated", TC: &shapeTextConfig{Text: "hello"}}
+	plainTextLayoutResolved("hello", shape, DefaultTextStyle, w)
+	if got := buf.String(); got != "" {
+		t.Fatalf("category off must be silent, got %q", got)
+	}
+}

--- a/gui/view_combobox.go
+++ b/gui/view_combobox.go
@@ -357,6 +357,10 @@ func comboboxClose(id string, w *Window) {
 
 func makeComboboxOnChar(cfgID string) func(EventCtx) {
 	return func(ctx EventCtx) {
+		// No originating event: no character to append, so decline.
+		if ctx.Event == nil {
+			return
+		}
 		ss := StateMap[string, bool](ctx.Window, nsCombobox, capModerate)
 		// Default false: absent entry means "not open".
 		isOpen := ss.GetOr(cfgID, false)
@@ -383,6 +387,10 @@ func makeComboboxOnChar(cfgID string) func(EventCtx) {
 
 func makeComboboxOnKeyDown(cfgID string, onSelect func(string, EventCtx), focusID string, filteredIDs []string, scrollID string, rowH, listH float32) func(EventCtx) {
 	return func(ctx EventCtx) {
+		// No originating event: no key to act on, so decline.
+		if ctx.Event == nil {
+			return
+		}
 		comboboxOnKeyDown(cfgID, onSelect, focusID, filteredIDs, scrollID, rowH, listH, ctx.Event, ctx.Window)
 	}
 }

--- a/gui/view_input.go
+++ b/gui/view_input.go
@@ -43,13 +43,15 @@ type InputCfg struct {
 	// proposed), or ("", false) to reject. Undo/redo bypass this
 	// callback by design — if security invariants (max length,
 	// forbidden chars) must be enforced unconditionally, use
-	// OnTextChanged instead.
+	// OnTextChanged instead. Adjusted text is capped at
+	// inputMaxInsertRunes runes.
 	// exportaudit:keep — caller-facing config (issue #372)
 	PreTextChange func(current, proposed string) (string, bool)
 
 	// PostCommitNormalize transforms the final text before
 	// OnTextCommit fires. Use for trimming whitespace,
-	// normalizing case, or formatting.
+	// normalizing case, or formatting. Returned text is capped at
+	// inputMaxInsertRunes runes.
 	// exportaudit:keep — caller-facing config (issue #372)
 	PostCommitNormalize func(text string, reason InputCommitReason) string
 
@@ -470,7 +472,7 @@ func (h *inputHandlerCfg) normalizeOnCommit(
 	if h.ReadOnly || h.postCommitNormalize == nil {
 		return text
 	}
-	return h.postCommitNormalize(text, reason)
+	return capCallbackText(h.postCommitNormalize(text, reason))
 }
 
 // compiledMask returns a non-nil *CompiledInputMask if the
@@ -483,10 +485,22 @@ func (h *inputHandlerCfg) compiledMask() *CompiledInputMask {
 	if pattern == "" {
 		return nil
 	}
+	// No custom tokens: share one compiled instance per pattern
+	// across every field and frame, because a mask is read-only
+	// after compile and recompiling per generation is pure garbage.
+	if len(h.maskTokens) == 0 {
+		if c := cachedCompiledMask(pattern); c != nil {
+			return c
+		}
+	}
 	c, err := compileInputMask(pattern, h.maskTokens)
 	if err != nil {
 		log.Printf("input: mask compile failed: %v", err)
 		return nil
+	}
+	if len(h.maskTokens) == 0 {
+		storeCompiledMaskCache(pattern, &c)
+		return &c
 	}
 	return &c
 }
@@ -513,6 +527,11 @@ func inputScrollIDFor(cfg *InputCfg) string {
 // of its own (see Shape.focusOwner).
 func inputOnClick(leafID, leafScrollID string, canFocus bool) func(EventCtx) {
 	return func(ctx EventCtx) {
+		// Cursor placement needs the click coordinates and the inner
+		// tree; without either there is nothing to place.
+		if ctx.Event == nil || ctx.Layout == nil {
+			return
+		}
 		if len(ctx.Layout.Children) < 1 {
 			// No inner text shape: not ours
 			return

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -39,6 +39,7 @@ func inputTextChange(hcfg inputHandlerCfg, layout *Layout, text, ins string, id 
 			if adjusted == proposed {
 				text = inputInsert(text, ins, id, w)
 			} else {
+				adjusted = capCallbackText(adjusted)
 				inputSetTextAndCursorAtEnd(
 					text, adjusted, id, w)
 				text = adjusted
@@ -59,6 +60,11 @@ func inputTextChange(hcfg inputHandlerCfg, layout *Layout, text, ins string, id 
 
 func makeInputOnChar(hcfg inputHandlerCfg) func(EventCtx) {
 	return func(ctx EventCtx) {
+		// No originating event (a synthetic dispatch): there is no
+		// character to insert, so decline and let it travel on.
+		if ctx.Event == nil {
+			return
+		}
 		// The captured IDs are leaves (Input builds its tree with no
 		// Window in hand); ctx.EffID turns them into the identities the
 		// focus and state stores hold.
@@ -123,6 +129,10 @@ func inputKeyMutatesText(e *Event, mode inputMode) bool {
 func makeInputOnKeyDown(hcfg inputHandlerCfg) func(EventCtx) {
 	mask := hcfg.CompiledMask
 	return func(ctx EventCtx) {
+		// No originating event: no key to act on, so decline.
+		if ctx.Event == nil {
+			return
+		}
 		id := ctx.EffID(hcfg.FocusID)
 		if id == "" || !ctx.Window.IsFocus(id) {
 			return
@@ -226,6 +236,10 @@ func makeInputOnKeyDown(hcfg inputHandlerCfg) func(EventCtx) {
 
 func makeInputOnKeyUp(hcfg inputHandlerCfg) func(EventCtx) {
 	return func(ctx EventCtx) {
+		// No originating event: nothing to forward, so decline.
+		if ctx.Event == nil {
+			return
+		}
 		id := ctx.EffID(hcfg.FocusID)
 		if id == "" || !ctx.Window.IsFocus(id) {
 			return

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -239,6 +239,7 @@ func inputKeyPaste(
 		if adjusted == proposed {
 			return inputInsert(text, clip, id, w), true
 		}
+		adjusted = capCallbackText(adjusted)
 		inputSetTextAndCursorAtEnd(text, adjusted, id, w)
 		return adjusted, true
 	}

--- a/gui/view_input_layout.go
+++ b/gui/view_input_layout.go
@@ -310,6 +310,10 @@ func dragScrollDelta(pos, lo, hi float32) float32 {
 func startInputDrag(d *inputDragState, w *Window) {
 	w.MouseLock(MouseLockCfg{
 		MouseMove: func(ctx EventCtx) {
+			// No originating event: no pointer position, so decline.
+			if ctx.Event == nil {
+				return
+			}
 			d.lastMouseX = ctx.Event.MouseX
 			d.lastMouseY = ctx.Event.MouseY
 			rp := d.computeRunePos(ctx.Event.MouseX, ctx.Event.MouseY, ctx.Window)

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -21,6 +21,11 @@ func (w *Window) FocusID() string {
 // id is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
+// No existence check runs here — a View function may set focus before
+// the widget exists — so a misspelled or stale ID parks focus in the
+// void until the next frame's fixup moves it on. Turn on gui.Debug to
+// hear about it (DebugUnknownFocus), or assert with
+// (*Window).TestFindings in tests.
 func (w *Window) SetFocus(id string) {
 	w.lockForAPI("SetFocus")
 	defer w.mu.Unlock()
@@ -65,6 +70,33 @@ func (w *Window) setFocusLocked(id string) {
 	// input method may be activated for — may claim it. syncIMEEditContext
 	// decides that from the arranged tree each frame (gui/ime_context.go,
 	// issue #393).
+}
+
+// fixupFocusLocked moves focus off a widget that can no longer take
+// it: disabled since the last frame, or gone from the tree entirely.
+// Runs once per full Update, after the arranged tree is composed and
+// before renderers build, so the frame never draws a focus ring for a
+// widget that cannot be reached, and the blur commit for the old field
+// fires on the following frame through the usual AmendLayout path.
+// A surviving focus ID is untouched: this is a repair pass, not a
+// traversal, and costs one findByID walk only while something holds
+// focus. Must run under w.mu; use SetFocus outside the frame pass.
+func (w *Window) fixupFocusLocked() {
+	id := w.viewState.focusID
+	if id == "" {
+		return
+	}
+	if ly, ok := w.layout.findByID(id); ok && ly.Shape.canTakeFocus() {
+		return
+	}
+	// The invalid ID is not among the tab candidates, so this lands on
+	// the first tab stop in DFS order; with no candidates at all the
+	// window ends unfocused rather than parked on a dead ID.
+	if next, ok := w.layout.nextFocusable(w); ok {
+		w.setFocusLocked(next.idKey())
+		return
+	}
+	w.setFocusLocked("")
 }
 
 // resetBlinkCursorVisible resets the blink timer so the cursor

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -353,6 +353,11 @@ func (w *Window) updateLocked() {
 	}
 
 	w.layout = composeLayout(layers, w)
+	// Repair focus before anything reads it: a widget disabled or
+	// removed since the last frame cannot keep holding it. Runs under
+	// w.mu, ahead of the debug audit and renderer build, so neither
+	// sees the dead ID.
+	w.fixupFocusLocked()
 	// Dev-mode identity checks. One atomic load when the gate is off.
 	w.debugAudit(&w.layout)
 	w.buildRenderers(w.Config.BgColor, w.windowRect())


### PR DESCRIPTION
F2 glyph-per-keypress follow-up (approved A+D).

**D — shaper refusals report loudly.** Text the shaper refuses (past its 10KB byte budget) falls back to approximate metrics: caret, selection and grapheme delete lose precision with nothing saying why. New DebugGlyphLayoutFallback category (in DebugAll) reports the shape once per identity with byte length and the shaper error.

**A — keypress alloc gate.** A keypress reshapes the whole buffer every keystroke, linear in bytes (~2.4ms / 7MB garbage at 10KB ASCII, ~0.25ms under 1KB). TestInputKeypressAllocBudget pins steady-state allocs at <= 400 with the real shaper; timing stays advisory. Bench matrix (1/5/10KB x ascii/cjk/emoji) alongside.

Windowed/incremental shaping rejected: shaping is not prefix-stable under wrapping and ligatures; a wrong caret is worse than a slow one.

Local gate: make prepush green.