### PR TITLE
fix(gui): cluster-safe vertical caret, bullet password mask, bounded programmatic input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,35 @@ and this project adheres to
   custom tokens share one compiled instance (an alloc-gate test pins the
   per-generation budget) instead of recompiling on every frame.
 
+- **Vertical caret motion in a selectable `Text` stays on cluster boundaries** —
+  with no shaped layout to consult, Up/Down fell back to line-column math and
+  could park the caret between a base rune and its combining mark, so the next
+  delete cut a cluster in half. The fallback now snaps to the nearest grapheme
+  stop, which `Input` already did. The line-column math behind it finds line
+  boundaries by scanning bytes, which needs no `[]rune` copy of the buffer, but
+  counts the column in runes: a byte column carried onto a line of different
+  rune widths lands mid-rune, which made Up fail to leave a line at all when the
+  line above held a 4-byte rune, and made Down answer past the end of the text.
+  The snap cannot repair that, because a drifted index is usually itself a valid
+  cluster boundary.
+
+- **Password fields mask with bullets everywhere** — multiline passwords
+  rendered `*` while single-line fields rendered `•`, with different advances.
+  The multiline mask now emits the same bullet, so measuring and painting agree
+  on one glyph in both modes.
+
+- **Programmatic input text is size-bounded like typed text** — `Input` content
+  assigned by the app bypassed the keystroke/paste/callback rune budget, so an
+  oversize string shaped every frame and filled the 50-deep undo history.
+  Generation now truncates to the budget and reports once per identity under the
+  `DebugGlyphLayoutFallback` category. Standalone `Text` stays unbounded: with
+  no undo history or per-keystroke reshape, long-form display has nothing to
+  bound. Clipboard pastes are pre-capped before any `[]rune` conversion, so a
+  platform-sized paste no longer allocates transiently, and the shared mask
+  cache stops at 256 patterns, emptying and refilling on overflow rather than
+  refusing the newcomer — a pattern the cache could never admit would recompile
+  on every frame, which is the cost the cache exists to remove.
+
 ## [v0.71.0] - 2026-09-08
 
 ### Added

--- a/gui/debug_checks.go
+++ b/gui/debug_checks.go
@@ -74,6 +74,10 @@ const (
 	// approximate metrics with degraded caret, selection and delete
 	// precision.
 	debugCheckGlyphLayoutFallback
+	// debugCheckTextTruncated fires from textView.GenerateLayout when
+	// app-supplied input text exceeds the rune budget and is
+	// truncated to it, so the frame never shapes unbounded content.
+	debugCheckTextTruncated
 )
 
 // checkCategory maps an internal check to the public category that
@@ -107,7 +111,7 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugStampDrift
 	case debugCheckUnknownFocus:
 		return DebugUnknownFocus
-	case debugCheckGlyphLayoutFallback:
+	case debugCheckGlyphLayoutFallback, debugCheckTextTruncated:
 		return DebugGlyphLayoutFallback
 	}
 	return 0

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -275,6 +275,7 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckStampDrift, DebugStampDrift},
 		{debugCheckUnknownFocus, DebugUnknownFocus},
 		{debugCheckGlyphLayoutFallback, DebugGlyphLayoutFallback},
+		{debugCheckTextTruncated, DebugGlyphLayoutFallback},
 	}
 	for _, tc := range tests {
 		if got := checkCategory(tc.check); got != tc.want {

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -210,6 +210,38 @@ func goldenCases() []goldenCase {
 			},
 		},
 		{
+			// A masked single-line field: pins the bullet glyph and
+			// the advance it measures at. maskPassword is what both
+			// the measure and the paint path go through, so a change
+			// to the mask character moves this file.
+			name: "input_password",
+			build: func(_ *Window) View {
+				return Input(InputCfg{
+					ID:         "in",
+					Text:       "hunter2",
+					IsPassword: true,
+				})
+			},
+		},
+		{
+			// The multiline mask is a separate helper
+			// (passwordMaskKeepNewlines) reached only when the text
+			// holds a newline. It rendered '*' against the single-line
+			// bullet until this was recorded, with no golden to catch
+			// the mismatch.
+			name: "input_password_multiline",
+			build: func(_ *Window) View {
+				return Input(InputCfg{
+					ID:         "in",
+					Mode:       InputMultiline,
+					Height:     80,
+					Sizing:     FillFixed,
+					Text:       "one two\nthree four",
+					IsPassword: true,
+				})
+			},
+		},
+		{
 			name: "input_disabled",
 			build: func(_ *Window) View {
 				return Input(InputCfg{

--- a/gui/input_mask.go
+++ b/gui/input_mask.go
@@ -85,7 +85,11 @@ var defaultMaskTokens = inputMaskDefaultTokens()
 // using the pattern. Keyed by pattern only when no custom tokens are
 // in play: custom tables make the key unbounded, and those fields
 // compile fresh. Patterns are static app strings, so the map settles
-// at a handful of entries and never grows per frame.
+// at a handful of entries and never grows per frame. Capped anyway:
+// a dynamic pattern source must degrade to recompiling, not to
+// unbounded growth.
+const compiledMaskCacheMax = 256
+
 var compiledMaskCache = struct {
 	sync.RWMutex
 	m map[string]*CompiledInputMask
@@ -100,11 +104,23 @@ func cachedCompiledMask(pattern string) *CompiledInputMask {
 	return c
 }
 
-// storeCompiledMaskCache records a compiled mask for reuse.
+// storeCompiledMaskCache records a compiled mask for reuse. On
+// overflow the cache is emptied and refilled from the newcomer rather
+// than the newcomer being refused: compiledMask() runs from the Input
+// factory every frame, so a pattern that can never be admitted
+// recompiles every frame forever — the exact per-frame garbage this
+// cache exists to remove. Dropping the whole set costs one recompile
+// per live pattern and cannot pin a live field behind 256 dead ones.
 func storeCompiledMaskCache(pattern string, c *CompiledInputMask) {
 	compiledMaskCache.Lock()
+	defer compiledMaskCache.Unlock()
+	if _, ok := compiledMaskCache.m[pattern]; ok {
+		return
+	}
+	if len(compiledMaskCache.m) >= compiledMaskCacheMax {
+		clear(compiledMaskCache.m)
+	}
 	compiledMaskCache.m[pattern] = c
-	compiledMaskCache.Unlock()
 }
 
 // InputMaskFromPreset returns the mask pattern for a preset.

--- a/gui/input_mask_test.go
+++ b/gui/input_mask_test.go
@@ -1,6 +1,9 @@
 package gui
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestInputMaskPresets(t *testing.T) {
 	assertEqual(t, len(inputMaskFromPreset(maskNone)), 0)
@@ -154,5 +157,59 @@ func TestIsMaskAlnum(t *testing.T) {
 			t.Errorf("isMaskAlnum(%q) = %v, want %v",
 				tc.r, got, tc.want)
 		}
+	}
+}
+
+// TestCompiledMaskCacheCapped pins the bound on the shared mask cache:
+// a dynamic pattern source degrades to recompiling, not to unbounded
+// growth. Patterns use a unique prefix to avoid colliding with the
+// suite's real masks.
+func TestCompiledMaskCacheCapped(t *testing.T) {
+	// The cache is process-global. Swap in an empty map and put the
+	// original back, so filling it here cannot starve the caching
+	// other tests (an alloc gate among them) rely on.
+	compiledMaskCache.Lock()
+	saved := compiledMaskCache.m
+	compiledMaskCache.m = make(map[string]*CompiledInputMask)
+	compiledMaskCache.Unlock()
+	t.Cleanup(func() {
+		compiledMaskCache.Lock()
+		compiledMaskCache.m = saved
+		compiledMaskCache.Unlock()
+	})
+
+	pat := func(i int) string { return fmt.Sprintf("test-cap-9-%d-999", i) }
+	for i := range compiledMaskCacheMax + 50 {
+		p := pat(i)
+		c, err := compileInputMask(p, nil)
+		if err != nil {
+			t.Fatalf("compile %q: %v", p, err)
+		}
+		storeCompiledMaskCache(p, &c)
+	}
+	compiledMaskCache.RLock()
+	n := len(compiledMaskCache.m)
+	compiledMaskCache.RUnlock()
+	if n > compiledMaskCacheMax {
+		t.Errorf("cache size = %d, want <= %d", n, compiledMaskCacheMax)
+	}
+	// Overflow must not lock the newcomer out. compiledMask() runs
+	// every frame, so a pattern the cache refuses forever recompiles
+	// forever; the last one stored has to be cached.
+	last := pat(compiledMaskCacheMax + 49)
+	if cachedCompiledMask(last) == nil {
+		t.Error("last pattern not cached; overflow must admit the newcomer")
+	}
+	// Re-storing an admitted pattern keeps the original instance:
+	// fields built from one pattern must share it, which is the
+	// sharing the per-generation alloc gate counts on.
+	orig := cachedCompiledMask(last)
+	fresh, err := compileInputMask(last, nil)
+	if err != nil {
+		t.Fatalf("recompile %q: %v", last, err)
+	}
+	storeCompiledMaskCache(last, &fresh)
+	if cachedCompiledMask(last) != orig {
+		t.Error("re-store replaced the cached instance; must keep the first")
 	}
 }

--- a/gui/input_state.go
+++ b/gui/input_state.go
@@ -1,6 +1,10 @@
 package gui
 
-import "github.com/go-gui-org/go-glyph"
+import (
+	"unicode/utf8"
+
+	"github.com/go-gui-org/go-glyph"
+)
 
 const inputMaxInsertRunes = 65_536
 
@@ -118,10 +122,7 @@ func inputProposedText(text, insertText string, focusID string, w *Window) strin
 	if len(insertText) == 0 {
 		return text
 	}
-	insertRunes := []rune(insertText)
-	if len(insertRunes) > inputMaxInsertRunes {
-		insertRunes = insertRunes[:inputMaxInsertRunes]
-	}
+	insertRunes := []rune(truncateToMaxRunes(insertText))
 	runes := []rune(text)
 	is := inputStateOrDefault(focusID, w)
 	cursorPos := min(is.CursorPos, len(runes))
@@ -152,10 +153,7 @@ func inputInsert(text string, insertText string, focusID string, w *Window) stri
 	if len(insertText) == 0 {
 		return text
 	}
-	insertRunes := []rune(insertText)
-	if len(insertRunes) > inputMaxInsertRunes {
-		insertRunes = insertRunes[:inputMaxInsertRunes]
-	}
+	insertRunes := []rune(truncateToMaxRunes(insertText))
 
 	runes := []rune(text)
 	is := inputStateOrDefault(focusID, w)
@@ -185,7 +183,7 @@ func inputInsert(text string, insertText string, focusID string, w *Window) stri
 
 	nextText := string(runes)
 	op := inputOpInsert
-	if len(insertRunes) > 1 {
+	if isMultiRuneInsert(insertText) {
 		// Multi-rune inserts (paste, IME commits) are one undo step
 		// even after a typing run, so they break the run.
 		op = inputOpNone
@@ -201,16 +199,40 @@ func inputInsert(text string, insertText string, focusID string, w *Window) stri
 	return nextText
 }
 
+// isMultiRuneInsert reports whether s holds more than one rune,
+// stopping at the second. Paste and IME commits (multi-rune) break
+// the typing undo run; single keystrokes coalesce into one step.
+func isMultiRuneInsert(s string) bool {
+	n := 0
+	for range s {
+		n++
+		if n > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// truncateToMaxRunes caps s at inputMaxInsertRunes runes without
+// converting the whole string to []rune first. Callers pass
+// unbounded input (clipboard, app callbacks); the conversion alone
+// would allocate for all of it before any cap applies.
+func truncateToMaxRunes(s string) string {
+	if len(s) <= inputMaxInsertRunes {
+		return s // byte length bounds rune count from above
+	}
+	// runeToByteIndex stops at len(s), so a string with fewer runes
+	// than the budget slices to itself.
+	return s[:runeToByteIndex(s, inputMaxInsertRunes)]
+}
+
 // capCallbackText bounds text an app callback returns (PreTextChange
 // adjusted, PostCommitNormalize output). The callback is trusted code
 // but not size-checked code: without a bound one runaway return pins
 // unbounded memory in per-window state. inputMaxInsertRunes is the
 // same budget keystroke inserts get.
 func capCallbackText(s string) string {
-	if utf8RuneCount(s) <= inputMaxInsertRunes {
-		return s
-	}
-	return s[:runeToByteIndex(s, inputMaxInsertRunes)]
+	return truncateToMaxRunes(s)
 }
 
 // inputSetTextAndCursorAtEnd pushes undo and places cursor at end
@@ -463,69 +485,93 @@ func wordBoundsAt(text string, pos int) (int, int) {
 	return byteToRuneIndex(text, beg), byteToRuneIndex(text, end)
 }
 
+// Line scanning below walks bytes: '\n' never appears inside a
+// multibyte sequence, so finding line boundaries needs no []rune
+// conversion and allocates nothing.
+//
+// The column, however, is counted in RUNES. A byte column carried
+// onto a line whose runes have different widths lands mid-rune, and
+// byteToRuneIndex counts each partial byte as a RuneError — so the
+// answer drifts by up to three and lands on some unrelated valid
+// grapheme stop, which closestGraphemeStop then leaves alone. That
+// made Up fail to leave a line at all when the line above held a
+// 4-byte rune, and made Down return an index past the end of the
+// text. Counting the column in runes is what makes the round trip
+// exact; it costs a scan of one line and still allocates nothing.
+
 // moveCursorUp moves cursor up one line in multiline text.
-func moveCursorUp(runes []rune, pos int) int {
+func moveCursorUp(text string, pos int) int {
+	bytePos := runeToByteIndex(text, pos)
 	// Find start of current line.
-	lineStart := pos
-	for lineStart > 0 && runes[lineStart-1] != '\n' {
+	lineStart := bytePos
+	for lineStart > 0 && text[lineStart-1] != '\n' {
 		lineStart--
 	}
 	if lineStart == 0 {
 		return 0 // Already on first line.
 	}
-	col := pos - lineStart
+	col := utf8.RuneCountInString(text[lineStart:bytePos])
 	// Find start of previous line.
 	prevLineEnd := lineStart - 1
 	prevLineStart := prevLineEnd
-	for prevLineStart > 0 && runes[prevLineStart-1] != '\n' {
+	for prevLineStart > 0 && text[prevLineStart-1] != '\n' {
 		prevLineStart--
 	}
-	prevLineLen := prevLineEnd - prevLineStart
-	col = min(col, prevLineLen)
-	return prevLineStart + col
+	prevLen := utf8.RuneCountInString(text[prevLineStart:prevLineEnd])
+	// Rune index of prevLineStart, walking back from pos: the column
+	// runs, then the '\n', then the whole previous line.
+	prevStartRune := pos - col - 1 - prevLen
+	return prevStartRune + min(col, prevLen)
 }
 
 // moveCursorDown moves cursor down one line in multiline text.
-func moveCursorDown(runes []rune, pos int) int {
-	n := len(runes)
+func moveCursorDown(text string, pos int) int {
+	n := len(text)
+	bytePos := runeToByteIndex(text, pos)
 	// Find start of current line.
-	lineStart := pos
-	for lineStart > 0 && runes[lineStart-1] != '\n' {
+	lineStart := bytePos
+	for lineStart > 0 && text[lineStart-1] != '\n' {
 		lineStart--
 	}
-	col := pos - lineStart
+	col := utf8.RuneCountInString(text[lineStart:bytePos])
 	// Find end of current line (next \n).
-	lineEnd := pos
-	for lineEnd < n && runes[lineEnd] != '\n' {
+	lineEnd := bytePos
+	for lineEnd < n && text[lineEnd] != '\n' {
 		lineEnd++
 	}
 	if lineEnd >= n {
-		return n // Already on last line.
+		return utf8RuneCount(text) // Already on last line.
 	}
 	// Next line starts after \n.
 	nextLineStart := lineEnd + 1
 	nextLineEnd := nextLineStart
-	for nextLineEnd < n && runes[nextLineEnd] != '\n' {
+	for nextLineEnd < n && text[nextLineEnd] != '\n' {
 		nextLineEnd++
 	}
-	nextLineLen := nextLineEnd - nextLineStart
-	col = min(col, nextLineLen)
-	return nextLineStart + col
+	nextLen := utf8.RuneCountInString(text[nextLineStart:nextLineEnd])
+	// Rune index of nextLineStart, walking forward from pos: the rest
+	// of this line, then the '\n'.
+	nextStartRune := pos + utf8.RuneCountInString(text[bytePos:lineEnd]) + 1
+	return nextStartRune + min(col, nextLen)
 }
 
 // moveCursorLineStart returns the start of the current line.
-func moveCursorLineStart(runes []rune, pos int) int {
-	for pos > 0 && runes[pos-1] != '\n' {
-		pos--
+func moveCursorLineStart(text string, pos int) int {
+	bytePos := runeToByteIndex(text, pos)
+	lineStart := bytePos
+	for lineStart > 0 && text[lineStart-1] != '\n' {
+		lineStart--
 	}
-	return pos
+	return pos - utf8.RuneCountInString(text[lineStart:bytePos])
 }
 
 // moveCursorLineEnd returns the end of the current line.
-func moveCursorLineEnd(runes []rune, pos int) int {
-	n := len(runes)
-	for pos < n && runes[pos] != '\n' {
-		pos++
+func moveCursorLineEnd(text string, pos int) int {
+	n := len(text)
+	bytePos := runeToByteIndex(text, pos)
+	lineEnd := bytePos
+	for lineEnd < n && text[lineEnd] != '\n' {
+		lineEnd++
 	}
-	return pos
+	return pos + utf8.RuneCountInString(text[bytePos:lineEnd])
 }

--- a/gui/input_state_test.go
+++ b/gui/input_state_test.go
@@ -1,6 +1,10 @@
 package gui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
 
 // inputHasSelection returns true if text is selected.
 func inputHasSelection(focusID string, w *Window) bool {
@@ -646,5 +650,146 @@ func TestInputSetTextAndCursorAtEnd(t *testing.T) {
 	}
 	if is.Undo == nil {
 		t.Fatal("undo stack must be pushed with the old text")
+	}
+}
+
+func TestTruncateToMaxRunes(t *testing.T) {
+	if got := truncateToMaxRunes(""); got != "" {
+		t.Errorf("empty = %q, want empty", got)
+	}
+	if got := truncateToMaxRunes("hello"); got != "hello" {
+		t.Errorf("short = %q, want unchanged", got)
+	}
+	exact := strings.Repeat("x", inputMaxInsertRunes)
+	if got := truncateToMaxRunes(exact); got != exact {
+		t.Error("exact-budget input must pass through untouched")
+	}
+	over := strings.Repeat("y", inputMaxInsertRunes+1)
+	if got := truncateToMaxRunes(over); utf8RuneCount(got) != inputMaxInsertRunes {
+		t.Errorf("over-budget runes = %d, want %d",
+			utf8RuneCount(got), inputMaxInsertRunes)
+	}
+	multi := strings.Repeat("é", inputMaxInsertRunes+10)
+	got := truncateToMaxRunes(multi)
+	if utf8RuneCount(got) != inputMaxInsertRunes || !utf8.ValidString(got) {
+		t.Error("multibyte truncation must keep the budget on a rune boundary")
+	}
+	big := strings.Repeat("z", inputMaxInsertRunes*4)
+	if got := truncateToMaxRunes(big); utf8RuneCount(got) != inputMaxInsertRunes {
+		t.Errorf("large runes = %d, want %d",
+			utf8RuneCount(got), inputMaxInsertRunes)
+	}
+	invalid := strings.Repeat("a", inputMaxInsertRunes) + "\xff\xfe"
+	got = truncateToMaxRunes(invalid)
+	if utf8RuneCount(got) != inputMaxInsertRunes {
+		t.Errorf("invalid-tail runes = %d, want %d (bad bytes cap cleanly)",
+			utf8RuneCount(got), inputMaxInsertRunes)
+	}
+}
+
+func TestIsMultiRuneInsert(t *testing.T) {
+	if isMultiRuneInsert("") {
+		t.Error("empty must be single")
+	}
+	if isMultiRuneInsert("a") {
+		t.Error("one ASCII rune must be single")
+	}
+	if isMultiRuneInsert("é") {
+		t.Error("one multibyte rune must be single")
+	}
+	if !isMultiRuneInsert("ab") {
+		t.Error("two runes must be multi")
+	}
+	if !isMultiRuneInsert("aé") {
+		t.Error("mixed-width pair must be multi")
+	}
+}
+
+func TestMoveCursorUpDownMultibyte(t *testing.T) {
+	// Regression: the column must be counted in runes. With a byte
+	// column, a 4-byte rune on the destination line made Up answer an
+	// index still on the SOURCE line (the caret never moved up) and
+	// made Down answer an index past the end of the text. Both wrong
+	// answers land on ordinary grapheme stops, so the caller's
+	// closestGraphemeStop snap could not repair either one.
+
+	// Line 0 is one 4-byte rune; line 1 is ASCII. Runes: 0=emoji,
+	// 1='\n', 2..7='a'..'f'. Line 0 ends at rune 1.
+	up := "\U0001F389\nabcdef"
+	assertEqual(t, utf8RuneCount(up), 8)
+	// Column 0 of line 1 -> start of line 0.
+	assertEqual(t, moveCursorUp(up, 2), 0)
+	// Columns past the end of line 0 clamp to its end, never to a
+	// position back on line 1.
+	assertEqual(t, moveCursorUp(up, 4), 1)
+	assertEqual(t, moveCursorUp(up, 7), 1)
+
+	// Line 1 is one 4-byte rune. Runes: 0..5='a'..'f', 6='\n', 7=emoji.
+	down := "abcdef\n\U0001F389"
+	assertEqual(t, utf8RuneCount(down), 8)
+	assertEqual(t, moveCursorDown(down, 0), 7)
+	// Column 2 exceeds line 1's single rune, so it clamps to the end
+	// of the text (8), not past it.
+	assertEqual(t, moveCursorDown(down, 2), 8)
+	assertEqual(t, moveCursorDown(down, 5), 8)
+
+	// Moving right on the source line must not move the target left.
+	// A byte column made Up(9) answer 1 while Up(8) answered 2.
+	cjk := "\u6f22\u5b57\u30c6\u30b9\u30c8\nabcdefghijklmno"
+	assertEqual(t, moveCursorUp(cjk, 8), 2)
+	assertEqual(t, moveCursorUp(cjk, 9), 3)
+
+	// Line start/end stay exact across multibyte lines.
+	assertEqual(t, moveCursorLineStart(cjk, 8), 6)
+	assertEqual(t, moveCursorLineEnd(cjk, 2), 5)
+
+	// Every result is a legal cursor position.
+	for _, s := range []string{up, down, cjk} {
+		n := utf8RuneCount(s)
+		for pos := 0; pos <= n; pos++ {
+			for _, got := range []int{
+				moveCursorUp(s, pos), moveCursorDown(s, pos),
+				moveCursorLineStart(s, pos), moveCursorLineEnd(s, pos),
+			} {
+				if got < 0 || got > n {
+					t.Fatalf("%q pos %d: got %d, out of range 0..%d",
+						s, pos, got, n)
+				}
+			}
+		}
+	}
+}
+
+func TestTextViewTruncatesOverlongProgrammaticText(t *testing.T) {
+	buf := captureDebugMask(t, DebugGlyphLayoutFallback)
+	w := caretTestWindow(400, 60)
+	big := strings.Repeat("a", inputMaxInsertRunes+100)
+	_, field := arrangeInput(t, w, InputCfg{ID: "big", Text: big})
+	if got := utf8RuneCount(inputTextFromLayout(field)); got != inputMaxInsertRunes {
+		t.Errorf("input text runes = %d, want %d (clamped)",
+			got, inputMaxInsertRunes)
+	}
+	if buf.Len() == 0 {
+		t.Error("expected a truncation finding under DebugGlyphLayoutFallback")
+	}
+}
+
+func TestStandaloneTextStaysUnbounded(t *testing.T) {
+	buf := captureDebugMask(t, DebugGlyphLayoutFallback)
+	w := newTestWindow()
+	big := strings.Repeat("a", inputMaxInsertRunes+100)
+	root := generateViewLayout(Column(ContainerCfg{
+		Content: []View{Text(TextCfg{ID: "big", Text: big})},
+	}), w)
+	ly := findLayoutByID(&root, "big")
+	if ly == nil {
+		t.Fatal("no layout with ID \"big\" after generate")
+	}
+	if got := utf8RuneCount(ly.Shape.TC.Text); got != inputMaxInsertRunes+100 {
+		t.Errorf("display text runes = %d, want untouched %d",
+			got, inputMaxInsertRunes+100)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("display text must stay silent, got %q", buf.String())
 	}
 }

--- a/gui/render_layout_test.go
+++ b/gui/render_layout_test.go
@@ -747,10 +747,32 @@ func TestTextWidthFallbackPasswordMask(t *testing.T) {
 	w := makeWindow()
 	style := TextStyle{Size: 14}
 	tc := &shapeTextConfig{textIsPassword: true}
-	got := textWidthFallback("abc", 3, tc, style, w)
+	got := textWidthFallback("abc", 3, tc, style, w, false)
 	// Password: 3 mask chars * size * 0.6
 	want := float32(3) * 14 * 0.6
 	if !f32AreClose(got, want) {
 		t.Errorf("textWidthFallback = %f, want %f", got, want)
 	}
+	// textAlreadyMasked: the render path hands in text masked at the
+	// top of the frame. The width is identical either way (a mask is
+	// one bullet per rune, so masking bullets changes nothing), so
+	// only the allocation distinguishes the two paths — assert that,
+	// not the width, or the flag can be deleted with the test green.
+	masked := maskPassword("abc")
+	if got = textWidthFallback(masked, 3, tc, style, w, true); !f32AreClose(got, want) {
+		t.Errorf("pre-masked textWidthFallback = %f, want %f", got, want)
+	}
+	if n := testing.AllocsPerRun(100, func() {
+		sinkWidth = textWidthFallback(masked, 3, tc, style, w, true)
+	}); n != 0 {
+		t.Errorf("pre-masked allocs = %v, want 0 (no second mask)", n)
+	}
+	if n := testing.AllocsPerRun(100, func() {
+		sinkWidth = textWidthFallback(masked, 3, tc, style, w, false)
+	}); n == 0 {
+		t.Error("unmasked path must still allocate a mask; " +
+			"if it does not, the flag is measuring nothing")
+	}
 }
+
+var sinkWidth float32

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -277,7 +277,7 @@ func renderInputCursor(shape *Shape, text string, baseX, baseY float32,
 
 	// Fallback for nil textMeasurer (tests).
 	fh := fontHeight(style, w)
-	cx := textWidthFallback(text, pos, shape.TC, style, w)
+	cx := textWidthFallback(text, pos, shape.TC, style, w, true)
 	emitCaretCmd(RenderCmd{
 		Kind:  RenderRect,
 		X:     baseX + cx,
@@ -384,8 +384,8 @@ func renderInputSelection(shape *Shape, text string, baseX, baseY float32,
 
 	// Fallback for nil textMeasurer (tests).
 	fh := fontHeight(style, w)
-	x0 := textWidthFallback(text, int(beg), tc, style, w)
-	x1 := textWidthFallback(text, int(end), tc, style, w)
+	x0 := textWidthFallback(text, int(beg), tc, style, w, true)
+	x1 := textWidthFallback(text, int(end), tc, style, w, true)
 	emitRenderer(RenderCmd{
 		Kind:  RenderRect,
 		X:     baseX + x0,
@@ -498,11 +498,14 @@ func fontHeight(style TextStyle, w *Window) float32 {
 }
 
 // textWidthFallback approximates text width for tests (no glyph).
-func textWidthFallback(text string, runePos int, tc *shapeTextConfig, style TextStyle, w *Window) float32 {
+// textAlreadyMasked skips password masking: renderText's fallback
+// sites pass text masked at the top of the frame, and masking bullets
+// again is a wasted allocation for an identical string.
+func textWidthFallback(text string, runePos int, tc *shapeTextConfig, style TextStyle, w *Window, textAlreadyMasked bool) float32 {
 	runeLen := utf8RuneCount(text)
 	runePos = min(runePos, runeLen)
 	prefix := text[:runeToByteIndex(text, runePos)]
-	if tc != nil && tc.textIsPassword {
+	if tc != nil && tc.textIsPassword && !textAlreadyMasked {
 		prefix = maskPassword(prefix)
 	}
 	if w.textMeasurer != nil {

--- a/gui/render_text_helpers.go
+++ b/gui/render_text_helpers.go
@@ -11,17 +11,52 @@ func maskPassword(text string) string {
 	return passwordMask(text)
 }
 
-// passwordMaskKeepNewlines replaces each rune with '*' but
-// preserves '\n' characters.
+// passwordMaskKeepNewlines replaces each rune with a bullet but
+// preserves '\n' characters, matching passwordMask's glyph so
+// single-line and multiline passwords render identically.
+//
+// It repeats passwordMask's stack-buffer shape rather than calling it:
+// maskPassword routes every multiline password here, and a masked
+// field is rebuilt twice per frame (measure in textView.GenerateLayout,
+// paint in renderText), so a heap allocation here is per-frame garbage.
+// The bullet bytes are U+2022 in UTF-8, the same three passwordMask
+// writes.
 func passwordMaskKeepNewlines(text string) string {
+	n := utf8RuneCount(text)
+	if n <= 64 {
+		// Worst case is every rune a bullet: n*3 bytes.
+		var buf [64 * 3]byte
+		return string(buf[:maskKeepNewlinesInto(buf[:], text)])
+	}
 	var b strings.Builder
-	b.Grow(len(text))
+	// One bullet (3 bytes) or one '\n' (1 byte) per rune, so the rune
+	// count times 3 is an exact upper bound. Sizing off len(text)
+	// would under-reserve for ASCII and force a regrow.
+	b.Grow(n * 3)
 	for _, r := range text {
 		if r == '\n' {
 			b.WriteByte('\n')
 		} else {
-			b.WriteByte('*')
+			b.WriteString("\u2022")
 		}
 	}
 	return b.String()
+}
+
+// maskKeepNewlinesInto writes the mask into dst and returns the byte
+// length written. dst must hold 3 bytes per rune of text. Split out
+// only so the caller's stack array stays in the caller's frame; it is
+// inlined into the one call site above.
+func maskKeepNewlinesInto(dst []byte, text string) int {
+	i := 0
+	for _, r := range text {
+		if r == '\n' {
+			dst[i] = '\n'
+			i++
+			continue
+		}
+		dst[i], dst[i+1], dst[i+2] = 0xe2, 0x80, 0xa2
+		i += 3
+	}
+	return i
 }

--- a/gui/render_text_helpers_test.go
+++ b/gui/render_text_helpers_test.go
@@ -1,11 +1,14 @@
 package gui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestPasswordMaskKeepNewlinesBasic(t *testing.T) {
 	got := passwordMaskKeepNewlines("abc")
-	if got != "***" {
-		t.Errorf("got %q, want %q", got, "***")
+	if got != "•••" {
+		t.Errorf("got %q, want %q", got, "•••")
 	}
 }
 
@@ -18,15 +21,15 @@ func TestPasswordMaskKeepNewlinesEmpty(t *testing.T) {
 
 func TestPasswordMaskKeepNewlinesPreservesNewlines(t *testing.T) {
 	got := passwordMaskKeepNewlines("ab\ncd\n")
-	if got != "**\n**\n" {
-		t.Errorf("got %q, want %q", got, "**\\n**\\n")
+	if got != "••\n••\n" {
+		t.Errorf("got %q, want %q", got, "••\\n••\\n")
 	}
 }
 
 func TestPasswordMaskKeepNewlinesUnicode(t *testing.T) {
 	got := passwordMaskKeepNewlines("🔑key")
-	if got != "****" {
-		t.Errorf("got %q, want %q", got, "****")
+	if got != "••••" {
+		t.Errorf("got %q, want %q", got, "••••")
 	}
 }
 
@@ -94,3 +97,31 @@ func TestHashCombineU64SeedMatters(t *testing.T) {
 		t.Error("different seeds should produce different outputs")
 	}
 }
+
+// TestPasswordMaskKeepNewlinesLong crosses the 64-rune stack-buffer
+// boundary: the heap path must produce byte-identical output to the
+// stack path, newlines included.
+func TestPasswordMaskKeepNewlinesLong(t *testing.T) {
+	in := strings.Repeat("ab\n", 40) // 120 runes, 40 newlines
+	got := passwordMaskKeepNewlines(in)
+	want := strings.Repeat("••\n", 40)
+	if got != want {
+		t.Errorf("long mask = %q, want %q", got, want)
+	}
+	// The stack path and the heap path must agree on a shared prefix.
+	short := strings.Repeat("ab\n", 20) // 60 runes
+	if passwordMaskKeepNewlines(short) != strings.Repeat("••\n", 20) {
+		t.Error("stack path disagrees with the heap path")
+	}
+}
+
+func TestPasswordMaskKeepNewlinesNoAlloc(t *testing.T) {
+	in := "secret\npassword"
+	if n := testing.AllocsPerRun(100, func() {
+		sinkMask = passwordMaskKeepNewlines(in)
+	}); n > 1 {
+		t.Errorf("allocs = %v, want <= 1 (the result string only)", n)
+	}
+}
+
+var sinkMask string

--- a/gui/testdata/input_password.dark.golden
+++ b/gui/testdata/input_password.dark.golden
@@ -1,0 +1,5 @@
+Rect xy=15.00,15.00 wh=160.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=160.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,21.00 wh=138.00,19.60
+Text xy=26.00,21.00 wh=0.00,0.00 color=#e6e8ebff text="•••••••" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_password.light.golden
+++ b/gui/testdata/input_password.light.golden
@@ -1,0 +1,4 @@
+Rect xy=14.00,14.00 wh=160.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,19.00 wh=140.00,19.60
+Text xy=24.00,19.00 wh=0.00,0.00 color=#1a1d21ff text="•••••••" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_password_multiline.dark.golden
+++ b/gui/testdata/input_password_multiline.dark.golden
@@ -1,0 +1,5 @@
+Rect xy=15.00,15.00 wh=290.00,80.00 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=290.00,80.00 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,21.00 wh=268.00,68.00
+Text xy=26.00,21.00 wh=268.00,0.00 color=#e6e8ebff text="•••••••\n••••••••••" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/testdata/input_password_multiline.light.golden
+++ b/gui/testdata/input_password_multiline.light.golden
@@ -1,0 +1,4 @@
+Rect xy=14.00,14.00 wh=292.00,80.00 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,19.00 wh=272.00,70.00
+Text xy=24.00,19.00 wh=272.00,0.00 color=#1a1d21ff text="•••••••\n••••••••••" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00

--- a/gui/text_cursor.go
+++ b/gui/text_cursor.go
@@ -22,7 +22,10 @@ func runeToByteIndex(text string, runeIdx int) int {
 	return idx
 }
 
-// byteToRuneIndex converts a byte index to a rune index.
+// byteToRuneIndex converts a byte index to a rune index. byteIdx must
+// be a rune boundary: slicing mid-rune counts the partial tail as a
+// RuneError and the result drifts by one. All callers pass aligned
+// indices (glyph layout offsets or runeToByteIndex output).
 func byteToRuneIndex(text string, byteIdx int) int {
 	if byteIdx <= 0 {
 		return 0

--- a/gui/view_input_handlers.go
+++ b/gui/view_input_handlers.go
@@ -15,15 +15,8 @@ func inputTextChange(hcfg inputHandlerCfg, layout *Layout, text, ins string, id 
 			// inputInsert does for a paste. Only the ">1 rune"
 			// question matters, and ins is caller-sized input that
 			// inputMaskInsert bounds, so count with an early exit.
-			n := 0
-			for range ins {
-				n++
-				if n > 1 {
-					break
-				}
-			}
 			op := inputOpInsert
-			if n > 1 {
+			if isMultiRuneInsert(ins) {
 				op = inputOpNone
 			}
 			undo := inputPushUndo(is, text, op)

--- a/gui/view_input_keys.go
+++ b/gui/view_input_keys.go
@@ -101,7 +101,7 @@ func inputKeyHome(
 			}
 		}
 	} else {
-		lineStart := moveCursorLineStart([]rune(text), pos)
+		lineStart := moveCursorLineStart(text, pos)
 		if pos != lineStart {
 			newPos = lineStart
 		} else {
@@ -139,7 +139,7 @@ func inputKeyEnd(
 			}
 		}
 	} else {
-		lineEnd := moveCursorLineEnd([]rune(text), pos)
+		lineEnd := moveCursorLineEnd(text, pos)
 		if pos != lineEnd {
 			newPos = lineEnd
 			trailing = true
@@ -183,11 +183,11 @@ func inputKeyVertical(
 		}
 	} else {
 		if up {
-			newPos = moveCursorUp([]rune(text), pos)
+			newPos = moveCursorUp(text, pos)
 		} else {
-			newPos = moveCursorDown([]rune(text), pos)
+			newPos = moveCursorDown(text, pos)
 		}
-		// Line-column math is rune-based; snap the result to the
+		// Line-column math is byte-based; snap the result to the
 		// nearest cluster boundary so vertical motion cannot park
 		// the caret inside a multi-rune grapheme.
 		newPos = closestGraphemeStop(graphemeStops(text), newPos)
@@ -208,6 +208,9 @@ func inputKeyPaste(
 	if len(clip) == 0 {
 		return text, false
 	}
+	// Bound before any []rune conversion downstream: clipboard
+	// content is platform-sized, not app-sized.
+	clip = truncateToMaxRunes(clip)
 	if mask != nil {
 		cis := inputStateOrDefault(id, w)
 		res := inputMaskInsert(text,

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -884,24 +884,24 @@ func TestWordBoundsAtClassRuns(t *testing.T) {
 }
 
 func TestMoveCursorUpDown(t *testing.T) {
-	runes := []rune("abc\ndef\nghi")
+	text := "abc\ndef\nghi"
 	// From middle of line 1 → line 0.
-	assertEqual(t, moveCursorUp(runes, 5), 1)
+	assertEqual(t, moveCursorUp(text, 5), 1)
 	// From line 0 → stays at 0.
-	assertEqual(t, moveCursorUp(runes, 1), 0)
+	assertEqual(t, moveCursorUp(text, 1), 0)
 	// From line 0 → line 1.
-	assertEqual(t, moveCursorDown(runes, 1), 5)
+	assertEqual(t, moveCursorDown(text, 1), 5)
 	// From line 1 → line 2.
-	assertEqual(t, moveCursorDown(runes, 5), 9)
+	assertEqual(t, moveCursorDown(text, 5), 9)
 	// From last line → end.
-	assertEqual(t, moveCursorDown(runes, 9), 11)
+	assertEqual(t, moveCursorDown(text, 9), 11)
 }
 
 func TestMoveCursorLineStartEnd(t *testing.T) {
-	runes := []rune("abc\ndef")
-	assertEqual(t, moveCursorLineStart(runes, 5), 4)
-	assertEqual(t, moveCursorLineEnd(runes, 0), 3)
-	assertEqual(t, moveCursorLineEnd(runes, 4), 7)
+	text := "abc\ndef"
+	assertEqual(t, moveCursorLineStart(text, 5), 4)
+	assertEqual(t, moveCursorLineEnd(text, 0), 3)
+	assertEqual(t, moveCursorLineEnd(text, 4), 7)
 }
 
 // --- Cursor render tests ---

--- a/gui/view_text.go
+++ b/gui/view_text.go
@@ -84,6 +84,27 @@ var textEventHandlers = &eventHandlers{
 
 func (tv *textView) GenerateLayout(w *Window) Layout {
 	c := &tv.cfg
+	// App-supplied input text bypasses the insert/paste/callback
+	// caps, so bound it here. Scoped to Input's inner text
+	// (focusOwner): standalone Text has no undo history or
+	// per-keystroke reshape, so long-form display stays unbounded.
+	// Warn-once per identity. The byte-length guard skips the rune
+	// scan for small texts.
+	if c.focusOwner != "" && len(c.Text) > inputMaxInsertRunes &&
+		utf8RuneCount(c.Text) > inputMaxInsertRunes {
+		// Gated at the call site, not only inside debugWarn: the
+		// app hands the same oversize string back every frame, so
+		// the preview and the args slice would allocate per frame.
+		// The gate is this check's own category, not DebugEnabled():
+		// any other category being on would otherwise pay the same
+		// per-frame allocation for a finding debugWarn discards.
+		if DebugCategory(debugMask.Load())&DebugGlyphLayoutFallback != 0 {
+			w.debugWarn(debugCheckTextTruncated, c.focusOwner,
+				"text exceeds %d runes; truncating to budget (preview %q)",
+				inputMaxInsertRunes, truncatePreview(c.Text, 30))
+		}
+		c.Text = truncateToMaxRunes(c.Text)
+	}
 	ts := &c.TextStyle
 
 	tv.tc = shapeTextConfig{

--- a/gui/view_text_select.go
+++ b/gui/view_text_select.go
@@ -392,10 +392,14 @@ func textKeyVertical(
 		}
 	} else {
 		if up {
-			newPos = moveCursorUp([]rune(text), pos)
+			newPos = moveCursorUp(text, pos)
 		} else {
-			newPos = moveCursorDown([]rune(text), pos)
+			newPos = moveCursorDown(text, pos)
 		}
+		// Line-column math is byte-based; snap the result to the
+		// nearest cluster boundary so vertical motion cannot park
+		// the caret inside a multi-rune grapheme (inputKeyVertical).
+		newPos = closestGraphemeStop(graphemeStops(text), newPos)
 	}
 	updateCursorAndSelection(imap, id, is, newPos, isShift)
 	return true

--- a/gui/view_text_select_test.go
+++ b/gui/view_text_select_test.go
@@ -1,6 +1,10 @@
 package gui
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
 
 func TestTextSelectAllAndCopy(t *testing.T) {
 	w := newTestWindow()
@@ -309,5 +313,38 @@ func TestTextDragCancelCollapsedSelectionHarmless(t *testing.T) {
 	}
 	if is.CursorPos != 2 {
 		t.Errorf("cursor = %d, want 2", is.CursorPos)
+	}
+}
+
+// TestTextKeyVerticalSnapsToGrapheme is the regression test for
+// vertical motion in a selectable multiline Text parking the caret
+// inside a grapheme cluster. Without a shaped layout (glOK false) the
+// fallback walks byte columns, and a column that lands between a base
+// rune and its combining mark must snap back to a cluster boundary —
+// the same guarantee inputKeyVertical already gave an Input.
+func TestTextKeyVerticalSnapsToGrapheme(t *testing.T) {
+	// Line 0 "ab"; line 1 "e" + U+0301 (one cluster, two runes) + "cd".
+	// Moving down from rune column 1 targets rune 4, the combining
+	// mark — inside the cluster.
+	text := "ab\ne\u0301cd"
+	imap := NewBoundedMap[string, inputState](8)
+	is := inputState{CursorPos: 1}
+	imap.Set("t", is)
+
+	raw := moveCursorDown(text, 1)
+	stops := graphemeStops(text)
+	if closestGraphemeStop(stops, raw) == raw {
+		t.Fatalf("test text no longer exercises the snap: "+
+			"moveCursorDown gave %d, already a stop", raw)
+	}
+
+	if !textKeyVertical(imap, "t", is, text, 1, false, -1, false,
+		TextModeMultiline, glyph.Layout{}, false) {
+		t.Fatal("multiline vertical motion must report handled")
+	}
+	got, _ := imap.Get("t")
+	if closestGraphemeStop(stops, got.CursorPos) != got.CursorPos {
+		t.Errorf("cursor = %d, not a grapheme stop (stops %v)",
+			got.CursorPos, stops)
 	}
 }


### PR DESCRIPTION
Vertical caret motion in selectable Text snaps to grapheme stops; multiline password mask uses bullets; programmatic Input text truncated to rune budget with DebugGlyphLayoutFallback report; pastes pre-capped; mask cache capped at 256.