### PR TITLE
feat(gui): query scroll overflow on both axes (#546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Scroll overflow is queryable, on both axes (#546)** — `ScrollOverflowX` and
+  `ScrollOverflowY` report how much content a scrollable currently hides, as a
+  positive number of pixels, and 0 when the content fits. Nothing exported
+  answered this before: `ScrollVerticalPct` reads 0 both at the top of a long
+  list and when there is nothing to scroll at all, so it cannot be used as the
+  test. An application can now react to overflow appearing, for example to
+  reserve space so an overlay scrollbar stops covering the last pixels of
+  content.
+
+  Both return `(float32, bool)`. The bool is false before the first frame is
+  arranged and for an id nothing stamped, because the width alone cannot carry
+  it — a miss and a scrollable with nothing to scroll both read 0, and a caller
+  sizing a reservation from that would silently reserve nothing. A miss is a
+  routine startup condition rather than a failure, so this is a bool and not an
+  error; a misspelled id is additionally named by the `DebugUnknownLookup` gate.
+
+  The value reports overflow, not scrollbar visibility — a scrollbar set to
+  `ScrollbarVisible` paints over content that fits. It also describes the frame
+  that was last arranged, so sizing a reservation from it feeds back into the
+  measurement that produced it; reserve unconditionally, or hold a reservation
+  once taken, rather than following the value every frame.
+
+  Growing a scrollable by the scrollbar's thickness automatically was rejected:
+  sizing resolves before overflow is known, so it is a fixed point, and Fixed
+  and Fill sizing cannot grow at all. A change callback was rejected too — the
+  state is recomputed every frame and would have to fire from the arrange pass
+  under the frame lock, while a view function reading the getter is already the
+  poll.
+
+- **`ScrollHorizontalOffset` and `ScrollHorizontalPct` (#546)** — the horizontal
+  getters were missing while their vertical twins were exported, so an
+  application could set a horizontal offset but never read one back.
+
+### Fixed
+
+- **Scroll percentage APIs no longer crash before the first frame (#546)** —
+  `ScrollVerticalPct` and `ScrollVerticalToPct` walked the layout tree without
+  checking that a frame had been arranged, so calling either on a window whose
+  first frame has not run — during setup, or from a command that fires before
+  the view does — dereferenced a nil root shape and crashed the process. Both
+  now take the same guard the rest of the scroll API already used and answer 0
+  (or do nothing) instead. The newly exported `ScrollHorizontalPct` carried the
+  same fault and is fixed with them.
+
 ## [v0.72.0] - 2026-09-09
 
 ### Added

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -378,7 +378,8 @@ func (w *Window) scrollHorizontalToSmooth(id string, offset float32) {
 // pct: 0.0 = left, 1.0 = right. Clamped to [0, 1].
 // No-op if the scroll id is not found or content fits viewport.
 func (w *Window) scrollHorizontalToPct(id string, pct float32) {
-	ly, ok := findLayoutByScrollID(&w.layout, id)
+	// See ScrollHorizontalPct: the walk faults on an un-arranged tree.
+	ly, ok := findScrollLayout(w, id)
 	if !ok {
 		return
 	}
@@ -389,24 +390,6 @@ func (w *Window) scrollHorizontalToPct(id string, pct float32) {
 	sx := w.scrollX()
 	sx.Set(id, maxOffset*f32Clamp(pct, 0, 1))
 	scrollSmoothCancel(w, id, scrollAxisX)
-}
-
-// ScrollHorizontalPct returns the current horizontal scroll
-// position as a percentage (0.0 = left, 1.0 = right).
-// Returns 0 if not found or content fits viewport.
-func (w *Window) scrollHorizontalPct(id string) float32 {
-	ly, ok := findLayoutByScrollID(&w.layout, id)
-	if !ok {
-		return 0
-	}
-	maxOffset := scrollMaxOffsetX(ly)
-	if maxOffset == 0 {
-		return 0
-	}
-	sx := w.scrollX()
-	// Default 0: unscrolled position when no offset recorded yet.
-	current := sx.GetOr(id, 0)
-	return f32Clamp(current/maxOffset, 0, 1)
 }
 
 // ScrollVerticalBy scrolls the given scrollable by delta. id is
@@ -469,7 +452,8 @@ func (w *Window) scrollVerticalToSmooth(id string, offset float32) {
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollVerticalToPct(id string, pct float32) {
-	ly, ok := findLayoutByScrollID(&w.layout, id)
+	// See ScrollHorizontalPct: the walk faults on an un-arranged tree.
+	ly, ok := findScrollLayout(w, id)
 	if !ok {
 		debugLookupMiss(&w.layout, "ScrollVerticalToPct", id)
 		return
@@ -503,7 +487,9 @@ func (w *Window) ScrollVerticalOffset(id string) float32 {
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 func (w *Window) ScrollVerticalPct(id string) float32 {
-	ly, ok := findLayoutByScrollID(&w.layout, id)
+	// See ScrollHorizontalPct: guard the un-arranged tree before the
+	// walk dereferences the root Shape.
+	ly, ok := findScrollLayout(w, id)
 	if !ok {
 		return 0
 	}
@@ -515,6 +501,126 @@ func (w *Window) ScrollVerticalPct(id string) float32 {
 	// Default 0: unscrolled position when no offset recorded yet.
 	current := sy.GetOr(id, 0)
 	return f32Clamp(current/maxOffset, 0, 1)
+}
+
+// ScrollHorizontalOffset returns the current horizontal scroll offset
+// of the given scrollable: <= 0, where 0 is the left edge. Unknown ids
+// read as 0 (unscrolled).
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// exportaudit:keep — caller-facing scroll query, axis twin of
+// ScrollVerticalOffset (issue #546)
+func (w *Window) ScrollHorizontalOffset(id string) float32 {
+	// Read-only accessor: a query must not allocate the state map as a
+	// side effect of being asked about a container that never scrolled.
+	sx := w.scrollXRead()
+	if sx == nil {
+		return 0
+	}
+	// Default 0: unscrolled position when no offset recorded yet.
+	return sx.GetOr(id, 0)
+}
+
+// ScrollHorizontalPct returns the current horizontal scroll
+// position as a percentage (0.0 = left, 1.0 = right).
+// Returns 0 if not found or content fits viewport.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// exportaudit:keep — caller-facing scroll query, axis twin of
+// ScrollVerticalPct (issue #546)
+func (w *Window) ScrollHorizontalPct(id string) float32 {
+	// findScrollLayout, not findLayoutByScrollID: the walk reads
+	// Shape.Scrollable, so a window whose first frame has not been
+	// arranged yet has a nil root Shape and would fault.
+	ly, ok := findScrollLayout(w, id)
+	if !ok {
+		debugLookupMiss(&w.layout, "ScrollHorizontalPct", id)
+		return 0
+	}
+	maxOffset := scrollMaxOffsetX(ly)
+	if maxOffset == 0 {
+		return 0
+	}
+	sx := w.scrollX()
+	// Default 0: unscrolled position when no offset recorded yet.
+	current := sx.GetOr(id, 0)
+	return f32Clamp(current/maxOffset, 0, 1)
+}
+
+// ScrollOverflowX reports how much content the given scrollable hides
+// on the X axis, as a positive width in pixels, and whether the
+// scrollable was found. The width is 0 when the content fits.
+//
+// ok is false before the first frame is arranged and for an id
+// nothing stamped. It is reported separately because the width alone
+// cannot carry it: a miss and a scrollable with nothing to scroll both
+// read 0, and a caller sizing a reservation from that would silently
+// reserve nothing. Callers that only ask "is there overflow" may
+// discard it.
+//
+// This answers "is there anything to scroll", which no other getter
+// does: ScrollHorizontalPct reads 0 both at the left edge with content
+// still to the right and when there is nothing to scroll at all.
+//
+// It does not report whether a scrollbar is drawn. A scrollbar's
+// visibility also depends on ScrollbarCfg.Overflow, and
+// ScrollbarVisible paints a bar over content that fits.
+//
+// The figure describes the frame that was last arranged. Sizing a
+// reservation from it therefore feeds back into the measurement that
+// produced it: reserve space, the content narrows, the overflow
+// changes, and the layout can flip between the two states every frame.
+// Reserve on an axis unconditionally, or hold the reservation once
+// taken, rather than tracking this value directly.
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// exportaudit:keep — caller-facing overflow query (issue #546)
+func (w *Window) ScrollOverflowX(id string) (float32, bool) {
+	ly, ok := findScrollLayout(w, id)
+	if !ok {
+		// A leaf spelled without its scope reaches here, and ok alone
+		// does not say which mistake it was. Name the spelling the
+		// frame stamped.
+		debugLookupMiss(&w.layout, "ScrollOverflowX", id)
+		return 0, false
+	}
+	// scrollMaxOffsetX is the most-negative reachable offset, so its
+	// magnitude is the hidden width.
+	return -scrollMaxOffsetX(ly), true
+}
+
+// ScrollOverflowY reports how much content the given scrollable hides
+// on the Y axis, as a positive height in pixels, and whether the
+// scrollable was found. The height is 0 when the content fits.
+//
+// The ok result, the reservation feedback loop and the
+// scrollbar-visibility caveat are all as described on
+// [Window.ScrollOverflowX].
+//
+// id is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// exportaudit:keep — caller-facing overflow query (issue #546)
+func (w *Window) ScrollOverflowY(id string) (float32, bool) {
+	ly, ok := findScrollLayout(w, id)
+	if !ok {
+		// See ScrollOverflowX.
+		debugLookupMiss(&w.layout, "ScrollOverflowY", id)
+		return 0, false
+	}
+	// scrollMaxOffsetY is the most-negative reachable offset, so its
+	// magnitude is the hidden height.
+	return -scrollMaxOffsetY(ly), true
 }
 
 // inputScrollContentW returns how far an input's content reaches on the

--- a/gui/scroll_overflow_test.go
+++ b/gui/scroll_overflow_test.go
@@ -1,0 +1,223 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+)
+
+// makeHScrollLayout builds a left-to-right scrollable so the X axis
+// carries the overflow. makeScrollLayout stacks top-to-bottom, which
+// leaves contentWidth pinned to the widest child and says nothing
+// about horizontal reach.
+func makeHScrollLayout(idScroll string, width, height float32, contentW, contentH float32) (*Layout, *Window) {
+	w := &Window{}
+	pinScrollMultiplier(w, 1)
+	child := Layout{
+		Shape: &Shape{
+			shapeType: shapeRectangle,
+			Width:     contentW,
+			Height:    contentH,
+		},
+	}
+	layout := Layout{
+		Shape: &Shape{
+			shapeType:  shapeRectangle,
+			Scrollable: true,
+			ID:         idScroll,
+			Width:      width,
+			Height:     height,
+			Axis:       axisLeftToRight,
+		},
+		Children: []Layout{child},
+	}
+	w.layout = Layout{
+		Shape:    &Shape{shapeType: shapeRectangle},
+		Children: []Layout{layout},
+	}
+	return &w.layout.Children[0], w
+}
+
+// TestScrollOverflowReportsHiddenExtent asserts the query answers with
+// the hidden extent as a positive magnitude, and that the axis with no
+// overflow stays at 0 rather than borrowing the other axis's figure.
+func TestScrollOverflowReportsHiddenExtent(t *testing.T) {
+	t.Parallel()
+	t.Run("vertical", func(t *testing.T) {
+		_, w := makeScrollLayout("v", 100, 100, 100, 300)
+		got, ok := w.ScrollOverflowY("v")
+		if got != 200 || !ok {
+			t.Errorf("ScrollOverflowY = %v, %v, want 200, true", got, ok)
+		}
+		got, ok = w.ScrollOverflowX("v")
+		if got != 0 || !ok {
+			t.Errorf("ScrollOverflowX = %v, %v, want 0, true (fits)", got, ok)
+		}
+	})
+	t.Run("horizontal", func(t *testing.T) {
+		_, w := makeHScrollLayout("h", 100, 50, 400, 50)
+		got, ok := w.ScrollOverflowX("h")
+		if got != 300 || !ok {
+			t.Errorf("ScrollOverflowX = %v, %v, want 300, true", got, ok)
+		}
+		got, ok = w.ScrollOverflowY("h")
+		if got != 0 || !ok {
+			t.Errorf("ScrollOverflowY = %v, %v, want 0, true (fits)", got, ok)
+		}
+	})
+}
+
+// TestScrollOverflowZeroWhenContentFits pins the distinction the issue
+// asked for: content that fits reads 0, which ScrollVerticalPct cannot
+// tell apart from being scrolled to the top.
+func TestScrollOverflowZeroWhenContentFits(t *testing.T) {
+	t.Parallel()
+	_, w := makeScrollLayout("fits", 200, 200, 100, 100)
+	// The pair the bool exists to separate: found, but nothing to
+	// scroll. A miss reports the same 0 with ok false.
+	got, ok := w.ScrollOverflowY("fits")
+	if got != 0 || !ok {
+		t.Errorf("ScrollOverflowY = %v, %v, want 0, true", got, ok)
+	}
+	got, ok = w.ScrollOverflowX("fits")
+	if got != 0 || !ok {
+		t.Errorf("ScrollOverflowX = %v, %v, want 0, true", got, ok)
+	}
+}
+
+// TestScrollOverflowUnknownID covers the two cold paths: an id nothing
+// stamped, and a window whose layout tree was never built.
+func TestScrollOverflowUnknownID(t *testing.T) {
+	t.Parallel()
+	_, w := makeScrollLayout("known", 100, 100, 100, 300)
+	got, ok := w.ScrollOverflowY("missing")
+	if got != 0 || ok {
+		t.Errorf("ScrollOverflowY(missing) = %v, %v, want 0, false", got, ok)
+	}
+	got, ok = w.ScrollOverflowX("missing")
+	if got != 0 || ok {
+		t.Errorf("ScrollOverflowX(missing) = %v, %v, want 0, false", got, ok)
+	}
+
+	// No frame arranged yet: the routine startup miss, which is why
+	// this is a bool and not an error.
+	empty := &Window{}
+	got, ok = empty.ScrollOverflowY("any")
+	if got != 0 || ok {
+		t.Errorf("ScrollOverflowY on empty window = %v, %v, want 0, false", got, ok)
+	}
+	got, ok = empty.ScrollOverflowX("any")
+	if got != 0 || ok {
+		t.Errorf("ScrollOverflowX on empty window = %v, %v, want 0, false", got, ok)
+	}
+}
+
+// TestScrollHorizontalOffsetMirrorsVertical asserts the newly exported
+// horizontal getter reads back what the setter clamped, matching
+// ScrollVerticalOffset's semantics on the other axis.
+func TestScrollHorizontalOffsetMirrorsVertical(t *testing.T) {
+	t.Parallel()
+	_, w := makeHScrollLayout("hx", 100, 50, 400, 50)
+
+	if got := w.ScrollHorizontalOffset("hx"); got != 0 {
+		t.Errorf("initial ScrollHorizontalOffset = %v, want 0", got)
+	}
+
+	w.ScrollHorizontalTo("hx", -120)
+	if got := w.ScrollHorizontalOffset("hx"); got != -120 {
+		t.Errorf("ScrollHorizontalOffset = %v, want -120", got)
+	}
+
+	// Past the end: the setter clamps to the max offset, so the
+	// getter must report the clamped value, not the request.
+	w.ScrollHorizontalTo("hx", -9999)
+	if got := w.ScrollHorizontalOffset("hx"); got != -300 {
+		t.Errorf("clamped ScrollHorizontalOffset = %v, want -300", got)
+	}
+
+	if got := w.ScrollHorizontalOffset("missing"); got != 0 {
+		t.Errorf("ScrollHorizontalOffset(missing) = %v, want 0", got)
+	}
+}
+
+// A miss returns the same 0 that "content fits" returns, so a leaf
+// spelled without its scope would otherwise read as a confident wrong
+// answer. Both axes report the identity the frame stamped.
+func TestScrollOverflowUnscopedLeafReports(t *testing.T) {
+	for _, tc := range []struct {
+		api  string
+		call func(*Window, string) (float32, bool)
+	}{
+		{"ScrollOverflowY", (*Window).ScrollOverflowY},
+		{"ScrollOverflowX", (*Window).ScrollOverflowX},
+	} {
+		t.Run(tc.api, func(t *testing.T) {
+			buf := captureDebugMask(t, DebugUnknownLookup)
+			resetLookupWarnings(t)
+			w := scopedScrollTree()
+
+			if got, ok := tc.call(w, "list"); got != 0 || ok {
+				t.Fatalf("%s = %v, %v, want 0, false (bare leaf misses)",
+					tc.api, got, ok)
+			}
+
+			got := buf.String()
+			if !strings.Contains(got, tc.api+`("list") found nothing`) ||
+				!strings.Contains(got, `"detail:list"`) {
+				t.Fatalf("want a near-miss finding naming detail:list, got %q", got)
+			}
+		})
+	}
+}
+
+// The effective ID resolves, so nothing is reported.
+func TestScrollOverflowHitStaysSilent(t *testing.T) {
+	buf := captureDebugMask(t, DebugUnknownLookup)
+	resetLookupWarnings(t)
+	w := scopedScrollTree()
+
+	if got, ok := w.ScrollOverflowY("detail:list"); got != 200 || !ok {
+		t.Fatalf("ScrollOverflowY = %v, %v, want 200, true", got, ok)
+	}
+	if got, ok := w.ScrollOverflowX("detail:list"); got != 0 || !ok {
+		t.Fatalf("ScrollOverflowX = %v, %v, want 0, true (fits)", got, ok)
+	}
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("a hit must stay silent, got %q", got)
+	}
+}
+
+// ScrollHorizontalPct joins the same gate as its vertical setter twin.
+func TestScrollHorizontalPctUnscopedLeafReports(t *testing.T) {
+	buf := captureDebugMask(t, DebugUnknownLookup)
+	resetLookupWarnings(t)
+	w := scopedScrollTree()
+
+	w.ScrollHorizontalPct("list")
+
+	got := buf.String()
+	if !strings.Contains(got, `ScrollHorizontalPct("list") found nothing`) {
+		t.Fatalf("want a near-miss finding for the bare leaf, got %q", got)
+	}
+}
+
+// TestScrollPctBeforeFirstArrangeDoesNotPanic pins the guard the
+// exported percentage getters and ScrollVerticalToPct need: the
+// scroll-id walk reads Shape.Scrollable, so a window whose first frame
+// has not been arranged has a nil root Shape and faults without it.
+// Exporting ScrollHorizontalPct (#546) put that path in reach of an
+// application asking about scroll state during startup.
+func TestScrollPctBeforeFirstArrangeDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	w := &Window{}
+
+	if got := w.ScrollHorizontalPct("any"); got != 0 {
+		t.Errorf("ScrollHorizontalPct = %v, want 0", got)
+	}
+	if got := w.ScrollVerticalPct("any"); got != 0 {
+		t.Errorf("ScrollVerticalPct = %v, want 0", got)
+	}
+	// Setters take the same walk; a no-op is the whole assertion.
+	w.ScrollVerticalToPct("any", 0.5)
+	w.scrollHorizontalToPct("any", 0.5)
+}

--- a/gui/scroll_test.go
+++ b/gui/scroll_test.go
@@ -244,7 +244,7 @@ func TestScrollToPctAndPct(t *testing.T) {
 		if v != -300 {
 			t.Errorf("expected -300, got %v", v)
 		}
-		pct := w.scrollHorizontalPct("4")
+		pct := w.ScrollHorizontalPct("4")
 		if math.Abs(float64(pct-1.0)) > 0.01 {
 			t.Errorf("expected ~1.0, got %v", pct)
 		}
@@ -258,7 +258,7 @@ func TestScrollPctNoScrollNeeded(t *testing.T) {
 	if pct != 0 {
 		t.Errorf("expected 0, got %v", pct)
 	}
-	pct = w.scrollHorizontalPct("6")
+	pct = w.ScrollHorizontalPct("6")
 	if pct != 0 {
 		t.Errorf("expected 0, got %v", pct)
 	}


### PR DESCRIPTION
Closes #546.

## What

`ScrollOverflowX` / `ScrollOverflowY` report how much content a scrollable currently hides, as a positive number of pixels, and 0 when the content fits. Nothing exported answered this before — `ScrollVerticalPct` reads 0 both at the top of a long list and when there is nothing to scroll at all.

Both return `(float32, bool)`. The bool is false before the first frame is arranged and for an id nothing stamped: a miss and a scrollable with nothing to scroll both read 0, and a caller sizing a reservation from the width alone would silently reserve nothing. A miss is a routine startup condition rather than a test-authoring bug, so this is comma-ok and not an error; a misspelled id is additionally named by the `DebugUnknownLookup` gate.

Also exports `ScrollHorizontalOffset` and `ScrollHorizontalPct`, which were missing while their vertical twins were public.

## Crash fixed

Exporting `ScrollHorizontalPct` uncovered a live one. `ScrollVerticalPct`, `ScrollVerticalToPct` and `scrollHorizontalToPct` called `findLayoutByScrollID` directly rather than `findScrollLayout`, skipping the arranged-frame guard — the walk reads `Shape.Scrollable`, so a call before the first frame dereferenced a nil root shape and killed the process. All four sites now take the guard. `TestScrollPctBeforeFirstArrangeDoesNotPanic` covers it; it segfaults without the fix.

## Rejected

- **`ContainerCfg.ScrollbarReservesSpace`** — sizing resolves in `layoutArrange` before overflow is known, so "grow by the scrollbar's thickness exactly when a bar appears" is a fixed point. Fixed and Fill sizing cannot grow at all, so the flag would work under Fit and silently do nothing elsewhere.
- **An overflow-change callback** — the state is recomputed every frame, so firing it means dispatching from the arrange pass under `w.mu`, needing `deferCallback` and handing a nil `ctx.Layout`. A view function reading the getter is already the poll.

## Verification

`make prepush` green: coverage 85.3%, export-audit surface clean, all four new exports carry `exportaudit:keep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)