### PR TITLE
Name the parameter effectiveID on the APIs that take one (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to
   getters were missing while their vertical twins were exported, so an
   application could set a horizontal offset but never read one back.
 
+### Changed
+
+- **Addressing APIs name the parameter `effectiveID` (#550)** — every API that
+  takes a stamped layout identity (`SetFocus`, `IsFocus`, `FindByID`, the
+  `Scroll*` family, the `Test*` helpers, `VirtualListFocusedIndex`,
+  `SetVirtualListFocusedIndex`, `DatePickerReset`, `InvalidateListHeights`) now
+  names its first parameter `effectiveID` instead of `id`, so autocomplete and
+  the godoc signature line show the rule the doc comment already stated: a leaf
+  under an ID-bearing ancestor is addressed by its full path (`"detail:nav"`),
+  not by the leaf its `Cfg` was written with. Go callers pass positionally, so
+  nothing recompiles differently and no migration is needed.
+
 ### Fixed
 
 - **Scroll percentage APIs no longer crash before the first frame (#546)** —

--- a/gui/debug_lookup.go
+++ b/gui/debug_lookup.go
@@ -53,8 +53,8 @@ var (
 //
 // Called only from a miss path, so a lookup that finds its target
 // costs nothing beyond the branch it was already taking.
-func debugLookupMiss(layout *Layout, api, id string) {
-	if id == "" || layout == nil {
+func debugLookupMiss(layout *Layout, api, effectiveID string) {
+	if effectiveID == "" || layout == nil {
 		return
 	}
 	if DebugCategory(debugMask.Load())&DebugUnknownLookup == 0 {
@@ -64,20 +64,20 @@ func debugLookupMiss(layout *Layout, api, id string) {
 	// the frame rate, and the finding is printed once, so the second
 	// frame onwards must not pay for a tree walk whose result is
 	// already known.
-	if lookupWarnSeen(api, id, false) {
+	if lookupWarnSeen(api, effectiveID, false) {
 		return
 	}
 	root := layout
 	for root.Parent != nil {
 		root = root.Parent
 	}
-	near := lookupNearMisses(root, id)
+	near := lookupNearMisses(root, effectiveID)
 	if len(near) == 0 {
 		// Nothing to report *yet*: the widget may be built by a later
 		// frame, so the pair stays unmarked and can still report then.
 		return
 	}
-	if lookupWarnSeen(api, id, true) {
+	if lookupWarnSeen(api, effectiveID, true) {
 		return
 	}
 	// Diagnostics are best-effort; a failed write to stderr is not
@@ -86,19 +86,19 @@ func debugLookupMiss(layout *Layout, api, id string) {
 		"gui: %s(%q) found nothing, but the frame stamped %s for that "+
 			"leaf; %s takes the effective ID — read it back with "+
 			"(*Window).ResolveID.\n",
-		api, id, quoteJoin(near), api)
+		api, effectiveID, quoteJoin(near), api)
 }
 
 // lookupNearMisses returns the identities in one frame whose last
-// segment is the leaf of id, excluding id itself. Sorted and
-// deduplicated so the message is the same on every run.
-func lookupNearMisses(root *Layout, id string) []string {
-	leaf := lastIDSegment(id)
+// segment is the leaf of effectiveID, excluding effectiveID itself.
+// Sorted and deduplicated so the message is the same on every run.
+func lookupNearMisses(root *Layout, effectiveID string) []string {
+	leaf := lastIDSegment(effectiveID)
 	var ids []string
 	collectEffectiveIDs(root, &ids)
 	out := ids[:0]
 	for _, got := range ids {
-		if got != id && lastIDSegment(got) == leaf {
+		if got != effectiveID && lastIDSegment(got) == leaf {
 			out = append(out, got)
 		}
 	}
@@ -106,15 +106,15 @@ func lookupNearMisses(root *Layout, id string) []string {
 	return slices.Compact(out)
 }
 
-// lookupWarnSeen reports whether this (api, id) pair has already been
-// reported under the current generation of the gate. When mark is set
-// and the pair is new, it is remembered before returning, so the next
-// call answers true.
+// lookupWarnSeen reports whether this (api, effectiveID) pair has
+// already been reported under the current generation of the gate.
+// When mark is set and the pair is new, it is remembered before
+// returning, so the next call answers true.
 //
 // Split from the report itself so debugLookupMiss can ask the cheap
 // question (peek) before the expensive one (walk the frame for near
 // misses) and mark only what it actually printed.
-func lookupWarnSeen(api, id string, mark bool) bool {
+func lookupWarnSeen(api, effectiveID string, mark bool) bool {
 	lookupWarnMu.Lock()
 	defer lookupWarnMu.Unlock()
 	// Discard memory built under an older generation, so Debug(false)
@@ -123,7 +123,7 @@ func lookupWarnSeen(api, id string, mark bool) bool {
 		lookupWarnGen = gen
 		lookupWarned = nil
 	}
-	key := debugLookupKey{api: api, id: id}
+	key := debugLookupKey{api: api, id: effectiveID}
 	if _, seen := lookupWarned[key]; seen {
 		return true
 	}

--- a/gui/layout_query.go
+++ b/gui/layout_query.go
@@ -28,22 +28,22 @@ func (layout *Layout) FindLayout(predicate func(Layout) bool) (*Layout, bool) {
 
 // FindLayoutByFocusID recursively searches for a layout with matching focus ID.
 //
-// id is an effective ID (see gui/id_resolve.go): the full path a widget
-// resolves to under its ID-bearing ancestors, which is what the focus
-// store holds.
-func findLayoutByFocusID(layout *Layout, id string) (*Layout, bool) {
-	return findLayoutByFocusIDDepth(layout, id, 0)
+// effectiveID is an effective ID (see gui/id_resolve.go): the full path
+// a widget resolves to under its ID-bearing ancestors, which is what
+// the focus store holds.
+func findLayoutByFocusID(layout *Layout, effectiveID string) (*Layout, bool) {
+	return findLayoutByFocusIDDepth(layout, effectiveID, 0)
 }
 
-func findLayoutByFocusIDDepth(layout *Layout, id string, depth int) (*Layout, bool) {
+func findLayoutByFocusIDDepth(layout *Layout, effectiveID string, depth int) (*Layout, bool) {
 	if overMaxDepth(depth) {
 		return nil, false
 	}
-	if id != "" && layout.Shape.Focusable && layout.Shape.idKey() == id {
+	if effectiveID != "" && layout.Shape.Focusable && layout.Shape.idKey() == effectiveID {
 		return layout, true
 	}
 	for i := range layout.Children {
-		if ly, ok := findLayoutByFocusIDDepth(&layout.Children[i], id, depth+1); ok {
+		if ly, ok := findLayoutByFocusIDDepth(&layout.Children[i], effectiveID, depth+1); ok {
 			return ly, true
 		}
 	}
@@ -51,21 +51,21 @@ func findLayoutByFocusIDDepth(layout *Layout, id string, depth int) (*Layout, bo
 }
 
 // FindLayoutByScrollID recursively searches for a Scrollable layout
-// with matching scroll ID. An empty id never matches. id is an
-// effective ID, as in [FindLayoutByFocusID].
-func findLayoutByScrollID(layout *Layout, id string) (*Layout, bool) {
-	return findLayoutByScrollIDDepth(layout, id, 0)
+// with matching scroll ID. An empty ID never matches. effectiveID is
+// an effective ID, as in [FindLayoutByFocusID].
+func findLayoutByScrollID(layout *Layout, effectiveID string) (*Layout, bool) {
+	return findLayoutByScrollIDDepth(layout, effectiveID, 0)
 }
 
-func findLayoutByScrollIDDepth(layout *Layout, id string, depth int) (*Layout, bool) {
+func findLayoutByScrollIDDepth(layout *Layout, effectiveID string, depth int) (*Layout, bool) {
 	if overMaxDepth(depth) {
 		return nil, false
 	}
-	if id != "" && layout.Shape.Scrollable && layout.Shape.idKey() == id {
+	if effectiveID != "" && layout.Shape.Scrollable && layout.Shape.idKey() == effectiveID {
 		return layout, true
 	}
 	for i := range layout.Children {
-		if ly, ok := findLayoutByScrollIDDepth(&layout.Children[i], id, depth+1); ok {
+		if ly, ok := findLayoutByScrollIDDepth(&layout.Children[i], effectiveID, depth+1); ok {
 			return ly, true
 		}
 	}
@@ -73,11 +73,11 @@ func findLayoutByScrollIDDepth(layout *Layout, id string, depth int) (*Layout, b
 }
 
 // FindByID searches the layout tree for a layout with the given ID.
-// An empty id never matches — a widget without an ID cannot be
-// addressed — matching the id != "" guards in FindLayoutByScrollID and
-// FindLayoutByFocusID.
+// An empty effectiveID never matches — a widget without an ID cannot
+// be addressed — matching the effectiveID != "" guards in
+// FindLayoutByScrollID and FindLayoutByFocusID.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing ancestor
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing ancestor
 // is addressed by its full path ("settings:name"), not by the leaf its
 // Cfg was written with. See gui/id_resolve.go.
 // A nil Shape means the layout tree has not been built yet (no frame
@@ -90,10 +90,10 @@ func findLayoutByScrollIDDepth(layout *Layout, id string, depth int) (*Layout, b
 // here looks like from the outside. Library code that probes for a
 // widget which may legitimately be absent calls findByID instead; see
 // debug_lookup.go.
-func (layout *Layout) FindByID(id string) (*Layout, bool) {
-	res, ok := layout.findByID(id)
+func (layout *Layout) FindByID(effectiveID string) (*Layout, bool) {
+	res, ok := layout.findByID(effectiveID)
 	if !ok {
-		debugLookupMiss(layout, "FindByID", id)
+		debugLookupMiss(layout, "FindByID", effectiveID)
 	}
 	return res, ok
 }
@@ -101,25 +101,25 @@ func (layout *Layout) FindByID(id string) (*Layout, bool) {
 // findByID is FindByID without the debug report: the lookup itself,
 // for callers whose miss is a legitimate answer rather than a
 // misspelling.
-func (layout *Layout) findByID(id string) (*Layout, bool) {
-	return layout.findByIDDepth(id, 0)
+func (layout *Layout) findByID(effectiveID string) (*Layout, bool) {
+	return layout.findByIDDepth(effectiveID, 0)
 }
 
-func (layout *Layout) findByIDDepth(id string, depth int) (*Layout, bool) {
+func (layout *Layout) findByIDDepth(effectiveID string, depth int) (*Layout, bool) {
 	if overMaxDepth(depth) {
 		return nil, false
 	}
-	if id == "" {
+	if effectiveID == "" {
 		return nil, false
 	}
 	if layout.Shape == nil {
 		return nil, false
 	}
-	if layout.Shape.idKey() == id {
+	if layout.Shape.idKey() == effectiveID {
 		return layout, true
 	}
 	for i := range layout.Children {
-		if res, ok := layout.Children[i].findByIDDepth(id, depth+1); ok {
+		if res, ok := layout.Children[i].findByIDDepth(effectiveID, depth+1); ok {
 			return res, true
 		}
 	}

--- a/gui/list_height_registry.go
+++ b/gui/list_height_registry.go
@@ -211,21 +211,21 @@ func listHeightEnsureVariable(
 // InvalidateListHeights drops every measured height for the given
 // list, so the next frames re-measure from the estimate. Call it when
 // a row's content changed under a stable key — nothing detects that,
-// because the model keys on identity, not on content. id is the
-// effective scroll ID. Main goroutine only.
+// because the model keys on identity, not on content. effectiveID is
+// the widget's effective ID. Main goroutine only.
 // exportaudit:keep — the only escape hatch for content edited under a
 // stable key; nothing detects that case
-func (w *Window) InvalidateListHeights(id string) {
-	m, ok := listHeightLookup(w, id)
+func (w *Window) InvalidateListHeights(effectiveID string) {
+	m, ok := listHeightLookup(w, effectiveID)
 	if !ok || m.uniform {
 		return
 	}
 	sy := w.scrollY()
 	// Default 0: absent entry means the list has not been scrolled.
-	anchor := listHeightCaptureAnchor(m, sy.GetOr(id, 0))
+	anchor := listHeightCaptureAnchor(m, sy.GetOr(effectiveID, 0))
 	m.ResetToEstimate(m.estimate)
 	if off, restored := listHeightRestoreAnchor(m, anchor); restored {
-		sy.Set(id, off)
+		sy.Set(effectiveID, off)
 	}
 	w.UpdateWindow()
 }

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -4,11 +4,11 @@ import "github.com/go-gui-org/go-glyph"
 
 // findScrollLayout returns the layout for the scroll id, or false
 // if the layout tree is not yet built or the id is not found.
-func findScrollLayout(w *Window, id string) (*Layout, bool) {
+func findScrollLayout(w *Window, effectiveID string) (*Layout, bool) {
 	if w.layout.Shape == nil {
 		return nil, false
 	}
-	return findLayoutByScrollID(&w.layout, id)
+	return findLayoutByScrollID(&w.layout, effectiveID)
 }
 
 // fireOnScroll fires the OnScroll callback if set.
@@ -301,8 +301,8 @@ func scrollVertical(layout *Layout, delta float32, w *Window) bool {
 
 // ScrollToView scrolls the parent scroll container to make
 // the view with the given id visible.
-func (w *Window) scrollToView(id string) {
-	target, ok := w.layout.FindByID(id)
+func (w *Window) scrollToView(effectiveID string) {
+	target, ok := w.layout.FindByID(effectiveID)
 	if !ok {
 		return
 	}
@@ -327,40 +327,40 @@ func (w *Window) scrollToView(id string) {
 	}
 }
 
-// ScrollHorizontalBy scrolls the given scrollable by delta. id is
+// ScrollHorizontalBy scrolls the given scrollable by delta. effectiveID is
 // the scrollable's scroll key (see the Scrollable doc on each Cfg).
-func (w *Window) scrollHorizontalBy(id string, delta float32) {
-	scrollSmoothCancel(w, id, scrollAxisX)
+func (w *Window) scrollHorizontalBy(effectiveID string, delta float32) {
+	scrollSmoothCancel(w, effectiveID, scrollAxisX)
 	sx := w.scrollX()
 	// Default 0: unscrolled position when no offset recorded yet.
-	current := sx.GetOr(id, 0)
+	current := sx.GetOr(effectiveID, 0)
 	newVal := current + delta
-	if ly, ok := findScrollLayout(w, id); ok {
+	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		maxOffset := scrollMaxOffsetX(ly)
 		newVal = f32Clamp(newVal, maxOffset, 0)
-		sx.Set(id, newVal)
+		sx.Set(effectiveID, newVal)
 		fireOnScroll(ly, w)
 		return
 	}
-	sx.Set(id, newVal)
+	sx.Set(effectiveID, newVal)
 }
 
 // ScrollHorizontalTo scrolls the given scrollable to offset
 // (negative).
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) ScrollHorizontalTo(id string, offset float32) {
-	scrollSmoothCancel(w, id, scrollAxisX)
+func (w *Window) ScrollHorizontalTo(effectiveID string, offset float32) {
+	scrollSmoothCancel(w, effectiveID, scrollAxisX)
 	sx := w.scrollX()
-	if ly, ok := findScrollLayout(w, id); ok {
+	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		maxOffset := scrollMaxOffsetX(ly)
-		sx.Set(id, f32Clamp(offset, maxOffset, 0))
+		sx.Set(effectiveID, f32Clamp(offset, maxOffset, 0))
 		fireOnScroll(ly, w)
 		return
 	}
-	sx.Set(id, offset)
+	sx.Set(effectiveID, offset)
 }
 
 // ScrollHorizontalToSmooth eases the given scrollable to offset
@@ -368,8 +368,8 @@ func (w *Window) ScrollHorizontalTo(id string, offset float32) {
 // mouse-wheel scrolling. No-op if the scroll id is not found or the
 // target equals the current offset. Use ScrollHorizontalTo for an
 // instant jump.
-func (w *Window) scrollHorizontalToSmooth(id string, offset float32) {
-	if ly, ok := findScrollLayout(w, id); ok {
+func (w *Window) scrollHorizontalToSmooth(effectiveID string, offset float32) {
+	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		scrollSmoothTo(w, ly, scrollAxisX, offset)
 	}
 }
@@ -377,9 +377,9 @@ func (w *Window) scrollHorizontalToSmooth(id string, offset float32) {
 // ScrollHorizontalToPct scrolls to a horizontal percentage.
 // pct: 0.0 = left, 1.0 = right. Clamped to [0, 1].
 // No-op if the scroll id is not found or content fits viewport.
-func (w *Window) scrollHorizontalToPct(id string, pct float32) {
+func (w *Window) scrollHorizontalToPct(effectiveID string, pct float32) {
 	// See ScrollHorizontalPct: the walk faults on an un-arranged tree.
-	ly, ok := findScrollLayout(w, id)
+	ly, ok := findScrollLayout(w, effectiveID)
 	if !ok {
 		return
 	}
@@ -388,40 +388,40 @@ func (w *Window) scrollHorizontalToPct(id string, pct float32) {
 		return
 	}
 	sx := w.scrollX()
-	sx.Set(id, maxOffset*f32Clamp(pct, 0, 1))
-	scrollSmoothCancel(w, id, scrollAxisX)
+	sx.Set(effectiveID, maxOffset*f32Clamp(pct, 0, 1))
+	scrollSmoothCancel(w, effectiveID, scrollAxisX)
 }
 
-// ScrollVerticalBy scrolls the given scrollable by delta. id is
+// ScrollVerticalBy scrolls the given scrollable by delta. effectiveID is
 // the scrollable's scroll key (see the Scrollable doc on each Cfg).
-func (w *Window) scrollVerticalBy(id string, delta float32) {
-	scrollSmoothCancel(w, id, scrollAxisY)
+func (w *Window) scrollVerticalBy(effectiveID string, delta float32) {
+	scrollSmoothCancel(w, effectiveID, scrollAxisY)
 	sy := w.scrollY()
 	// Default 0: unscrolled position when no offset recorded yet.
-	current := sy.GetOr(id, 0)
+	current := sy.GetOr(effectiveID, 0)
 	newVal := current + delta
-	if ly, ok := findScrollLayout(w, id); ok {
+	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		maxOffset := scrollMaxOffsetY(ly)
 		newVal = f32Clamp(newVal, maxOffset, 0)
-		sy.Set(id, newVal)
+		sy.Set(effectiveID, newVal)
 		fireOnScroll(ly, w)
 		return
 	}
-	sy.Set(id, newVal)
+	sy.Set(effectiveID, newVal)
 }
 
 // ScrollVerticalTo scrolls the given scrollable to offset
 // (negative).
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) ScrollVerticalTo(id string, offset float32) {
-	scrollSmoothCancel(w, id, scrollAxisY)
+func (w *Window) ScrollVerticalTo(effectiveID string, offset float32) {
+	scrollSmoothCancel(w, effectiveID, scrollAxisY)
 	sy := w.scrollY()
-	if ly, ok := findScrollLayout(w, id); ok {
+	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		maxOffset := scrollMaxOffsetY(ly)
-		sy.Set(id, f32Clamp(offset, maxOffset, 0))
+		sy.Set(effectiveID, f32Clamp(offset, maxOffset, 0))
 		fireOnScroll(ly, w)
 		return
 	}
@@ -429,8 +429,8 @@ func (w *Window) ScrollVerticalTo(id string, offset float32) {
 	// is built is legitimate, and the next frame reads it. The gate
 	// reports only the case that is not — a leaf spelled without the
 	// scope the frame stamped it under.
-	debugLookupMiss(&w.layout, "ScrollVerticalTo", id)
-	sy.Set(id, offset)
+	debugLookupMiss(&w.layout, "ScrollVerticalTo", effectiveID)
+	sy.Set(effectiveID, offset)
 }
 
 // ScrollVerticalToSmooth eases the given scrollable to offset
@@ -438,8 +438,8 @@ func (w *Window) ScrollVerticalTo(id string, offset float32) {
 // mouse-wheel scrolling. No-op if the scroll id is not found or the
 // target equals the current offset. Use ScrollVerticalTo for an
 // instant jump.
-func (w *Window) scrollVerticalToSmooth(id string, offset float32) {
-	if ly, ok := findScrollLayout(w, id); ok {
+func (w *Window) scrollVerticalToSmooth(effectiveID string, offset float32) {
+	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		scrollSmoothTo(w, ly, scrollAxisY, offset)
 	}
 }
@@ -448,14 +448,14 @@ func (w *Window) scrollVerticalToSmooth(id string, offset float32) {
 // pct: 0.0 = top, 1.0 = bottom. Clamped to [0, 1].
 // No-op if the scroll id is not found or content fits viewport.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) ScrollVerticalToPct(id string, pct float32) {
+func (w *Window) ScrollVerticalToPct(effectiveID string, pct float32) {
 	// See ScrollHorizontalPct: the walk faults on an un-arranged tree.
-	ly, ok := findScrollLayout(w, id)
+	ly, ok := findScrollLayout(w, effectiveID)
 	if !ok {
-		debugLookupMiss(&w.layout, "ScrollVerticalToPct", id)
+		debugLookupMiss(&w.layout, "ScrollVerticalToPct", effectiveID)
 		return
 	}
 	maxOffset := scrollMaxOffsetY(ly)
@@ -463,33 +463,33 @@ func (w *Window) ScrollVerticalToPct(id string, pct float32) {
 		return
 	}
 	sy := w.scrollY()
-	sy.Set(id, maxOffset*f32Clamp(pct, 0, 1))
-	scrollSmoothCancel(w, id, scrollAxisY)
+	sy.Set(effectiveID, maxOffset*f32Clamp(pct, 0, 1))
+	scrollSmoothCancel(w, effectiveID, scrollAxisY)
 }
 
 // ScrollVerticalOffset returns the current vertical scroll offset of
 // the given scrollable: <= 0, where 0 is the top. Unknown ids read
 // as 0 (unscrolled).
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) ScrollVerticalOffset(id string) float32 {
+func (w *Window) ScrollVerticalOffset(effectiveID string) float32 {
 	// Default 0: unscrolled position when no offset recorded yet.
-	return w.scrollY().GetOr(id, 0)
+	return w.scrollY().GetOr(effectiveID, 0)
 }
 
 // ScrollVerticalPct returns the current vertical scroll
 // position as a percentage (0.0 = top, 1.0 = bottom).
 // Returns 0 if not found or content fits viewport.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) ScrollVerticalPct(id string) float32 {
+func (w *Window) ScrollVerticalPct(effectiveID string) float32 {
 	// See ScrollHorizontalPct: guard the un-arranged tree before the
 	// walk dereferences the root Shape.
-	ly, ok := findScrollLayout(w, id)
+	ly, ok := findScrollLayout(w, effectiveID)
 	if !ok {
 		return 0
 	}
@@ -499,7 +499,7 @@ func (w *Window) ScrollVerticalPct(id string) float32 {
 	}
 	sy := w.scrollY()
 	// Default 0: unscrolled position when no offset recorded yet.
-	current := sy.GetOr(id, 0)
+	current := sy.GetOr(effectiveID, 0)
 	return f32Clamp(current/maxOffset, 0, 1)
 }
 
@@ -507,13 +507,13 @@ func (w *Window) ScrollVerticalPct(id string) float32 {
 // of the given scrollable: <= 0, where 0 is the left edge. Unknown ids
 // read as 0 (unscrolled).
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 //
 // exportaudit:keep — caller-facing scroll query, axis twin of
 // ScrollVerticalOffset (issue #546)
-func (w *Window) ScrollHorizontalOffset(id string) float32 {
+func (w *Window) ScrollHorizontalOffset(effectiveID string) float32 {
 	// Read-only accessor: a query must not allocate the state map as a
 	// side effect of being asked about a container that never scrolled.
 	sx := w.scrollXRead()
@@ -521,26 +521,26 @@ func (w *Window) ScrollHorizontalOffset(id string) float32 {
 		return 0
 	}
 	// Default 0: unscrolled position when no offset recorded yet.
-	return sx.GetOr(id, 0)
+	return sx.GetOr(effectiveID, 0)
 }
 
 // ScrollHorizontalPct returns the current horizontal scroll
 // position as a percentage (0.0 = left, 1.0 = right).
 // Returns 0 if not found or content fits viewport.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 //
 // exportaudit:keep — caller-facing scroll query, axis twin of
 // ScrollVerticalPct (issue #546)
-func (w *Window) ScrollHorizontalPct(id string) float32 {
+func (w *Window) ScrollHorizontalPct(effectiveID string) float32 {
 	// findScrollLayout, not findLayoutByScrollID: the walk reads
 	// Shape.Scrollable, so a window whose first frame has not been
 	// arranged yet has a nil root Shape and would fault.
-	ly, ok := findScrollLayout(w, id)
+	ly, ok := findScrollLayout(w, effectiveID)
 	if !ok {
-		debugLookupMiss(&w.layout, "ScrollHorizontalPct", id)
+		debugLookupMiss(&w.layout, "ScrollHorizontalPct", effectiveID)
 		return 0
 	}
 	maxOffset := scrollMaxOffsetX(ly)
@@ -549,7 +549,7 @@ func (w *Window) ScrollHorizontalPct(id string) float32 {
 	}
 	sx := w.scrollX()
 	// Default 0: unscrolled position when no offset recorded yet.
-	current := sx.GetOr(id, 0)
+	current := sx.GetOr(effectiveID, 0)
 	return f32Clamp(current/maxOffset, 0, 1)
 }
 
@@ -579,18 +579,18 @@ func (w *Window) ScrollHorizontalPct(id string) float32 {
 // Reserve on an axis unconditionally, or hold the reservation once
 // taken, rather than tracking this value directly.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 //
 // exportaudit:keep — caller-facing overflow query (issue #546)
-func (w *Window) ScrollOverflowX(id string) (float32, bool) {
-	ly, ok := findScrollLayout(w, id)
+func (w *Window) ScrollOverflowX(effectiveID string) (float32, bool) {
+	ly, ok := findScrollLayout(w, effectiveID)
 	if !ok {
 		// A leaf spelled without its scope reaches here, and ok alone
 		// does not say which mistake it was. Name the spelling the
 		// frame stamped.
-		debugLookupMiss(&w.layout, "ScrollOverflowX", id)
+		debugLookupMiss(&w.layout, "ScrollOverflowX", effectiveID)
 		return 0, false
 	}
 	// scrollMaxOffsetX is the most-negative reachable offset, so its
@@ -606,16 +606,16 @@ func (w *Window) ScrollOverflowX(id string) (float32, bool) {
 // scrollbar-visibility caveat are all as described on
 // [Window.ScrollOverflowX].
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 //
 // exportaudit:keep — caller-facing overflow query (issue #546)
-func (w *Window) ScrollOverflowY(id string) (float32, bool) {
-	ly, ok := findScrollLayout(w, id)
+func (w *Window) ScrollOverflowY(effectiveID string) (float32, bool) {
+	ly, ok := findScrollLayout(w, effectiveID)
 	if !ok {
 		// See ScrollOverflowX.
-		debugLookupMiss(&w.layout, "ScrollOverflowY", id)
+		debugLookupMiss(&w.layout, "ScrollOverflowY", effectiveID)
 		return 0, false
 	}
 	// scrollMaxOffsetY is the most-negative reachable offset, so its

--- a/gui/scroll_index.go
+++ b/gui/scroll_index.go
@@ -50,23 +50,23 @@ type virtualScrollReq struct {
 const virtualScrollMaxAge = 4
 
 // ScrollToIndex scrolls the given list so item index sits at the top
-// of the viewport. id is the list's effective scroll ID; index is in
+// of the viewport. effectiveID is the list's effective ID; index is in
 // the widget's own index space (see the retrofit table in
 // docs/specs/virtualized-variable-height-lists.md — a frozen table
 // header, for instance, is data index 0 but sits outside the
 // scrollable). Main goroutine only.
-func (w *Window) ScrollToIndex(id string, index int) {
-	w.scrollIndexRequest(id, index, virtualScrollAt, 0)
+func (w *Window) ScrollToIndex(effectiveID string, index int) {
+	w.scrollIndexRequest(effectiveID, index, virtualScrollAt, 0)
 }
 
 // ScrollToIndexAt scrolls the given list so item index lands at frac
 // of the viewport: 0 top, 0.5 middle, 1 bottom. Main goroutine only.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) ScrollToIndexAt(id string, index int, frac float32) {
-	w.scrollIndexRequest(id, index, virtualScrollAt,
+func (w *Window) ScrollToIndexAt(effectiveID string, index int, frac float32) {
+	w.scrollIndexRequest(effectiveID, index, virtualScrollAt,
 		f32Clamp(frac, 0, 1))
 }
 
@@ -75,12 +75,12 @@ func (w *Window) ScrollToIndexAt(id string, index int, frac float32) {
 // is already visible. This is the one to call when moving a selection
 // with the arrow keys. Main goroutine only.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 // exportaudit:keep — the selection-following form of the index API
-func (w *Window) ScrollIndexIntoView(id string, index int) {
-	w.scrollIndexRequest(id, index, virtualScrollIntoView, 0)
+func (w *Window) ScrollIndexIntoView(effectiveID string, index int) {
+	w.scrollIndexRequest(effectiveID, index, virtualScrollIntoView, 0)
 }
 
 // ScrollToEnd pins the given list to the bottom of its content. It
@@ -88,24 +88,24 @@ func (w *Window) ScrollIndexIntoView(id string, index int) {
 // the content height is assembled from spacers over an estimated row
 // height and a percentage therefore drifts. Main goroutine only.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) ScrollToEnd(id string) {
-	w.scrollIndexRequest(id, 0, virtualScrollEnd, 0)
+func (w *Window) ScrollToEnd(effectiveID string) {
+	w.scrollIndexRequest(effectiveID, 0, virtualScrollEnd, 0)
 }
 
 // scrollIndexRequest applies the request against the current layout
 // when it can, and queues it either way so later passes converge it
 // as rows are measured.
 func (w *Window) scrollIndexRequest(
-	id string, index int, mode virtualScrollMode, frac float32,
+	effectiveID string, index int, mode virtualScrollMode, frac float32,
 ) {
-	if w == nil || id == "" {
+	if w == nil || effectiveID == "" {
 		return
 	}
 	r := virtualScrollReq{
-		scrollID: id,
+		scrollID: effectiveID,
 		index:    index,
 		frac:     frac,
 		frame:    w.frameCount,
@@ -113,10 +113,10 @@ func (w *Window) scrollIndexRequest(
 	}
 	// A jump and a pending anchor both write the same offset; the
 	// explicit jump is the later intent, so drop the anchor.
-	w.dropScrollAnchor(id)
-	scrollSmoothCancel(w, id, scrollAxisY)
+	w.dropScrollAnchor(effectiveID)
+	scrollSmoothCancel(w, effectiveID, scrollAxisY)
 
-	if sc, ok := findScrollLayout(w, id); ok {
+	if sc, ok := findScrollLayout(w, effectiveID); ok {
 		applyVirtualScroll(r, sc, w, false)
 	}
 	w.queueVirtualScroll(r)

--- a/gui/testing.go
+++ b/gui/testing.go
@@ -156,18 +156,18 @@ func (w *Window) settle() {
 	}
 }
 
-// testTarget resolves id to a layout and rejects the two states in
-// which dispatching any event is meaningless.
-func (w *Window) testTarget(id string) (*Layout, error) {
-	ly, ok := w.layout.FindByID(id)
+// testTarget resolves effectiveID to a layout and rejects the two
+// states in which dispatching any event is meaningless.
+func (w *Window) testTarget(effectiveID string) (*Layout, error) {
+	ly, ok := w.layout.FindByID(effectiveID)
 	if !ok {
-		return nil, fmt.Errorf("%w: %q", errTestNoSuchID, id)
+		return nil, fmt.Errorf("%w: %q", errTestNoSuchID, effectiveID)
 	}
 	if ly.Shape == nil {
-		return nil, fmt.Errorf("%w: %q", errTestNoSuchID, id)
+		return nil, fmt.Errorf("%w: %q", errTestNoSuchID, effectiveID)
 	}
 	if ly.Shape.Disabled {
-		return nil, fmt.Errorf("%w: %q", errTestDisabled, id)
+		return nil, fmt.Errorf("%w: %q", errTestDisabled, effectiveID)
 	}
 	return ly, nil
 }
@@ -178,10 +178,10 @@ func (w *Window) testTarget(id string) (*Layout, error) {
 // The center of shapeClip, not of the shape: PointInShape tests the
 // clip rectangle, so a widget partly scrolled out of its container has
 // a shape center that misses and a clip center that does not.
-func testHitPoint(ly *Layout, id string) (x, y float32, err error) {
+func testHitPoint(ly *Layout, effectiveID string) (x, y float32, err error) {
 	c := ly.Shape.shapeClip
 	if c.Width <= 0 || c.Height <= 0 {
-		return 0, 0, fmt.Errorf("%w: %q", errTestNotVisible, id)
+		return 0, 0, fmt.Errorf("%w: %q", errTestNotVisible, effectiveID)
 	}
 	return c.X + c.Width/2, c.Y + c.Height/2, nil
 }
@@ -211,11 +211,11 @@ func testHitPoint(ly *Layout, id string) (x, y float32, err error) {
 // OnMouseDown nor focusability, since a click on such a widget cannot
 // have any effect worth asserting on.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) TestClick(id string) error {
-	ly, err := w.testTarget(id)
+func (w *Window) TestClick(effectiveID string) error {
+	ly, err := w.testTarget(effectiveID)
 	if err != nil {
 		return err
 	}
@@ -224,9 +224,9 @@ func (w *Window) TestClick(id string) error {
 		(ev.OnClick != nil || ev.OnMouseDown != nil)
 	if !hasClick && !ly.Shape.Focusable {
 		return fmt.Errorf("%w: %q has no click handler and is not focusable",
-			errTestNoHandler, id)
+			errTestNoHandler, effectiveID)
 	}
-	x, y, err := testHitPoint(ly, id)
+	x, y, err := testHitPoint(ly, effectiveID)
 	if err != nil {
 		return err
 	}
@@ -246,23 +246,23 @@ func (w *Window) TestClick(id string) error {
 	w.EventFn(&up)
 	w.settle()
 	if !down.IsHandled {
-		return fmt.Errorf("%w: click on %q", errTestUnhandled, id)
+		return fmt.Errorf("%w: click on %q", errTestUnhandled, effectiveID)
 	}
 	return nil
 }
 
-// testFocusable resolves id and rejects it unless it can actually hold
+// testFocusable resolves effectiveID and rejects it unless it can actually hold
 // focus. Decided by Shape.canTakeFocus, the same predicate dispatch
 // and tab order use; a widget with Focusable set but no ID is the
 // silent no-op the requiredid analyzer and the RequireID panic exist
 // to prevent.
-func (w *Window) testFocusable(id string) (*Layout, error) {
-	ly, err := w.testTarget(id)
+func (w *Window) testFocusable(effectiveID string) (*Layout, error) {
+	ly, err := w.testTarget(effectiveID)
 	if err != nil {
 		return nil, err
 	}
 	if !ly.Shape.canTakeFocus() {
-		return nil, fmt.Errorf("%w: %q", errTestNotFocusable, id)
+		return nil, fmt.Errorf("%w: %q", errTestNotFocusable, effectiveID)
 	}
 	return ly, nil
 }
@@ -272,11 +272,11 @@ func (w *Window) testFocusable(id string) (*Layout, error) {
 //
 // FocusSkip is not rejected: a skipped widget is out of tab order but
 // can still be focused programmatically, which is what this does.
-func (w *Window) testFocus(id string) error {
-	if _, err := w.testFocusable(id); err != nil {
+func (w *Window) testFocus(effectiveID string) error {
+	if _, err := w.testFocusable(effectiveID); err != nil {
 		return err
 	}
-	w.SetFocus(id)
+	w.SetFocus(effectiveID)
 	w.settle()
 	return nil
 }
@@ -289,11 +289,11 @@ func (w *Window) testFocus(id string) error {
 // consumed it" is normal, not a defect. Assert on the state change
 // instead.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) TestKey(id string, key KeyCode, mods Modifier) error {
-	if err := w.testFocus(id); err != nil {
+func (w *Window) TestKey(effectiveID string, key KeyCode, mods Modifier) error {
+	if err := w.testFocus(effectiveID); err != nil {
 		return err
 	}
 	down := Event{Type: EventKeyDown, KeyCode: key, Modifiers: mods}
@@ -312,11 +312,11 @@ func (w *Window) TestKey(id string, key KeyCode, mods Modifier) error {
 // that only handled EventKeyDown would wrongly appear to work if this
 // sent key codes. Empty text focuses the widget and delivers nothing.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) TestType(id string, text string) error {
-	if err := w.testFocus(id); err != nil {
+func (w *Window) TestType(effectiveID string, text string) error {
+	if err := w.testFocus(effectiveID); err != nil {
 		return err
 	}
 	for _, r := range text {
@@ -378,20 +378,20 @@ func (w *Window) testTab(dir TabDirection) (focusedID string, err error) {
 // event reached no one — including the case where it fell through to a
 // scrollable already pinned at its limit.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) TestScroll(id string, dx, dy float32) error {
-	ly, err := w.testTarget(id)
+func (w *Window) TestScroll(effectiveID string, dx, dy float32) error {
+	ly, err := w.testTarget(effectiveID)
 	if err != nil {
 		return err
 	}
 	hasScroll := ly.Shape.hasEvents() && ly.Shape.events.OnMouseScroll != nil
 	if !ly.Shape.Scrollable && !hasScroll {
 		return fmt.Errorf("%w: %q is not Scrollable and has no OnMouseScroll",
-			errTestNoHandler, id)
+			errTestNoHandler, effectiveID)
 	}
-	x, y, err := testHitPoint(ly, id)
+	x, y, err := testHitPoint(ly, effectiveID)
 	if err != nil {
 		return err
 	}
@@ -405,12 +405,12 @@ func (w *Window) TestScroll(id string, dx, dy float32) error {
 	if !e.IsHandled {
 		// Re-resolve: settle() rebuilt the tree, so the ly captured
 		// above is stale (see TestRender's doc comment).
-		if cur, rerr := w.testTarget(id); rerr == nil {
-			if err = testScrollRoomErr(cur, id, dx, dy); err != nil {
+		if cur, rerr := w.testTarget(effectiveID); rerr == nil {
+			if err = testScrollRoomErr(cur, effectiveID, dx, dy); err != nil {
 				return err
 			}
 		}
-		return fmt.Errorf("%w: scroll on %q", errTestUnhandled, id)
+		return fmt.Errorf("%w: scroll on %q", errTestUnhandled, effectiveID)
 	}
 	return nil
 }
@@ -423,7 +423,7 @@ func (w *Window) TestScroll(id string, dx, dy float32) error {
 // Room is measured the same way layoutAdjustScrollOffsets clamps —
 // viewport minus content — so this cannot disagree with the clamp that
 // actually swallowed the scroll.
-func testScrollRoomErr(ly *Layout, id string, dx, dy float32) error {
+func testScrollRoomErr(ly *Layout, effectiveID string, dx, dy float32) error {
 	if !ly.Shape.Scrollable {
 		return nil
 	}
@@ -437,7 +437,7 @@ func testScrollRoomErr(ly *Layout, id string, dx, dy float32) error {
 	}
 	return fmt.Errorf(
 		"%w: %q content is %.0fx%.0f inside a %.0fx%.0f viewport",
-		errTestNoScrollRoom, id,
+		errTestNoScrollRoom, effectiveID,
 		contentWidth(ly), contentHeight(ly),
 		ly.Shape.Width-ly.Shape.paddingWidth(),
 		ly.Shape.Height-ly.Shape.paddingHeight(),
@@ -456,24 +456,24 @@ func testScrollRoomErr(ly *Layout, id string, dx, dy float32) error {
 // silently reporting 0 would make an over-scroll assertion pass for the
 // wrong reason.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) TestScrollOffset(id string) (x, y float32, err error) {
-	ly, err := w.testTarget(id)
+func (w *Window) TestScrollOffset(effectiveID string) (x, y float32, err error) {
+	ly, err := w.testTarget(effectiveID)
 	if err != nil {
 		return 0, 0, err
 	}
 	if !ly.Shape.Scrollable {
-		return 0, 0, fmt.Errorf("%w: %q is not Scrollable", errTestNoHandler, id)
+		return 0, 0, fmt.Errorf("%w: %q is not Scrollable", errTestNoHandler, effectiveID)
 	}
 	// Read-only accessors: a query must not allocate the state maps as a
 	// side effect of being asked about a container that never scrolled.
 	if sx := w.scrollXRead(); sx != nil {
-		x = sx.GetOr(id, 0)
+		x = sx.GetOr(effectiveID, 0)
 	}
 	if sy := w.scrollYRead(); sy != nil {
-		y = sy.GetOr(id, 0)
+		y = sy.GetOr(effectiveID, 0)
 	}
 	return x, y, nil
 }

--- a/gui/view_date_picker.go
+++ b/gui/view_date_picker.go
@@ -255,12 +255,12 @@ func datePickerGetState(w *Window, cfg *DatePickerCfg) datePickerState {
 
 // DatePickerReset clears the state for a date picker instance.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) DatePickerReset(id string) {
+func (w *Window) DatePickerReset(effectiveID string) {
 	sm := StateMap[string, datePickerState](w, nsDatePicker, capModerate)
-	sm.Delete(id)
+	sm.Delete(effectiveID)
 	w.UpdateWindow()
 }
 

--- a/gui/view_virtual_list_build.go
+++ b/gui/view_virtual_list_build.go
@@ -141,7 +141,7 @@ const virtualListWidthRatchetRuns = 4
 // a width change invalidates the wrap, re-wraps and re-measures every
 // frame too. Nothing about it looks like a failure from inside; the
 // list just never settles.
-func virtualListNoteWidth(w *Window, m *listHeightModel, id string, iw float32) {
+func virtualListNoteWidth(w *Window, m *listHeightModel, effectiveID string, iw float32) {
 	// Only growth with the window standing still counts: that is what
 	// separates the ratchet from a resize the user asked for.
 	if iw > m.measuredW+listHeightEps && m.lastWinW == w.windowWidth {
@@ -151,12 +151,12 @@ func virtualListNoteWidth(w *Window, m *listHeightModel, id string, iw float32) 
 	}
 	m.measuredW, m.lastWinW = iw, w.windowWidth
 	if m.widthRun >= virtualListWidthRatchetRuns && DebugEnabled() {
-		w.debugWarn(debugCheckListWidthRatchet, id,
+		w.debugWarn(debugCheckListWidthRatchet, effectiveID,
 			"list %q has widened on %d consecutive frames with the "+
 				"window unchanged (now %.0f px): a row is demanding the "+
 				"width ItemView handed it — MinWidth taken from that "+
 				"argument ratchets, and each width change re-wraps every "+
-				"row", id, m.widthRun, iw)
+				"row", effectiveID, m.widthRun, iw)
 	}
 }
 
@@ -262,24 +262,24 @@ func virtualListMeasure(m *listHeightModel) func(EventCtx) {
 // the focused row — an unbuilt row has no shape to hold focus, so the
 // focus lives on the list and is expressed as an index.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) VirtualListFocusedIndex(id string) int {
-	return StateReadOr(w, nsVirtualListFocus, id, 0)
+func (w *Window) VirtualListFocusedIndex(effectiveID string) int {
+	return StateReadOr(w, nsVirtualListFocus, effectiveID, 0)
 }
 
 // SetVirtualListFocusedIndex moves a virtual list's keyboard focus to
 // index and scrolls it into view. Main goroutine only.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 // exportaudit:keep — the write half of the focused-index pair
-func (w *Window) SetVirtualListFocusedIndex(id string, index int) {
+func (w *Window) SetVirtualListFocusedIndex(effectiveID string, index int) {
 	StateMap[string, int](w, nsVirtualListFocus, capModerate).
-		Set(id, max(index, 0))
-	w.ScrollIndexIntoView(id, index)
+		Set(effectiveID, max(index, 0))
+	w.ScrollIndexIntoView(effectiveID, index)
 }
 
 // virtualListKeyDown moves the focused index and keeps it in view.

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -18,7 +18,7 @@ func (w *Window) FocusID() string {
 // pass, not here (see syncBlinkCursor). Use ClearFocus to remove
 // focus.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
 // No existence check runs here — a View function may set focus before
@@ -26,10 +26,10 @@ func (w *Window) FocusID() string {
 // void until the next frame's fixup moves it on. Turn on gui.Debug to
 // hear about it (DebugUnknownFocus), or assert with
 // (*Window).TestFindings in tests.
-func (w *Window) SetFocus(id string) {
+func (w *Window) SetFocus(effectiveID string) {
 	w.lockForAPI("SetFocus")
 	defer w.mu.Unlock()
-	w.setFocusLocked(id)
+	w.setFocusLocked(effectiveID)
 }
 
 // ClearFocus removes keyboard focus from any widget.
@@ -37,7 +37,7 @@ func (w *Window) ClearFocus() {
 	w.SetFocus("")
 }
 
-func (w *Window) setFocusLocked(id string) {
+func (w *Window) setFocusLocked(effectiveID string) {
 	prev := w.viewState.focusID
 	// Only a real focus *change* drops selections and clears the IME.
 	// Re-asserting focus on the widget that already holds it must leave
@@ -46,7 +46,7 @@ func (w *Window) setFocusLocked(id string) {
 	// inside their View function, which runs on every layout rebuild,
 	// so an unconditional selection clear wiped every nsInput selection
 	// window-wide on each re-assert. Real transitions still clear both.
-	if id != prev {
+	if effectiveID != prev {
 		w.clearInputSelections()
 		w.imeClear()
 		// The a11y snapshot carries the focused index but no layout
@@ -54,8 +54,8 @@ func (w *Window) setFocusLocked(id string) {
 		// here or syncA11y would skip the push (issue #407).
 		w.a11y.dirty = true
 	}
-	w.viewState.focusID = id
-	if id != "" {
+	w.viewState.focusID = effectiveID
+	if effectiveID != "" {
 		w.viewState.inputCursorOn.Store(true)
 	}
 	// The caret-blink animation is not started here. Whether the new
@@ -112,11 +112,11 @@ func resetBlinkCursorVisible(w *Window) {
 
 // IsFocus tests if the given focus id equals the window's focus id.
 //
-// id is the widget's effective ID: a leaf under an ID-bearing
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
-func (w *Window) IsFocus(id string) bool {
-	return w.viewState.focusID != "" && w.viewState.focusID == id
+func (w *Window) IsFocus(effectiveID string) bool {
+	return w.viewState.focusID != "" && w.viewState.focusID == effectiveID
 }
 
 // hasFocus returns true if the window has focus.


### PR DESCRIPTION
Every addressing API takes an effective ID but named the parameter `id`, so autocomplete and godoc hid the one rule callers need at the call site. This renames the parameter to `effectiveID` on the 25 exported APIs in the family (scroll, scroll-index, testing helpers, focus, virtual list, date picker, list heights, FindByID) plus the private helpers threading the same value, updates the doc-comment lead words, and normalises the two 'effective scroll ID' outliers. Positional calls are unaffected — no migration, no sibling bump. Closes #550.