### PR TITLE
Public scroll setters and ScopeID colon-part audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to
   getters were missing while their vertical twins were exported, so an
   application could set a horizontal offset but never read one back.
 
+- **Horizontal percentage scrolling and eased scrolling are public** —
+  `ScrollHorizontalToPct` joins its already-public vertical twin
+  `ScrollVerticalToPct`, and `ScrollHorizontalToSmooth` /
+  `ScrollVerticalToSmooth` expose the same exponential ease the mouse wheel uses
+  for programmatic jumps. `ScrollHorizontalToPct` also reports an unscoped-leaf
+  miss through the `DebugUnknownLookup` gate, matching the vertical form.
+
 ### Changed
 
 - **Addressing APIs name the parameter `effectiveID` (#550)** — every API that

--- a/docs/specs/scopeid-literal-colon-audit.md
+++ b/docs/specs/scopeid-literal-colon-audit.md
@@ -1,0 +1,73 @@
+# ScopeID literal colon audit
+
+Status: implemented. No issue was filed; implemented directly from the proposal.
+First run over `gui/`: 0 findings.
+
+## Problem
+
+`ScopeID` parts must not contain `IDSep` (`gui/id_scope.go:27`), and "nothing
+enforces that". The only content-level guard in the repo is
+`TestDockMintedNodeIDsHaveNoIDSep` (`gui/dock_layout_identity_test.go:121`),
+which covers minted dock node IDs only. Everywhere else a colon in a part is
+silent until it collides (duplicate ID) or re-scopes (leaf promoted to absolute,
+drops out of its scope, state key diverges) — both detected by consequence, not
+by cause.
+
+## Decision
+
+Extend `ergonomics-audit -mode ids` (`tools/ergonomics-audit/ids.go`) with one
+new rule: flag a `ScopeID` / `ScopeIDN` call whose **part** argument is a string
+literal containing `":"`.
+
+- The **owner** (first argument) is exempt: it may itself be composed, which is
+  how nesting works (`ScopeID(base, "resize")` in `gui/id_scope.go:24`).
+- `ScopeIDN`'s numeric argument cannot contain a separator; only its string
+  parts are checked.
+- Matching is on the selector name (`Sel.Name == "ScopeID"` / `"ScopeIDN"`),
+  regardless of package qualifier, so `gui.ScopeID` and the datagrid's
+  `gg.ScopeID` both count.
+- Non-literal parts (variables, row keys, slugs) stay out of scope: invisible
+  statically, and the one runtime hook (`ScopeID` itself) is pure with no
+  findings channel — see Rejected Approaches.
+
+A literal part containing `":"` is always rewritable (drop the colon or use `-`
+/ `_`, per the parts rule in `docs/specs/widget-id-scoping.md`), so findings are
+fixed, not marked: no new marker. If a legitimate literal exception ever
+appears, that is a spec amendment, not a quiet marker.
+
+## Implementation steps
+
+1. Add the rule to `inspectIDs` in `tools/ergonomics-audit/ids.go`: on
+   `*ast.CallExpr` with a `*ast.SelectorExpr` fun named `ScopeID` or `ScopeIDN`,
+   unquote each part argument (skip index 0) and report literals containing
+   `":"`. Reuse `shortExpr` and the existing `seen`/`exempt` dedup in `scanIDs`.
+2. Add table tests in `tools/ergonomics-audit/ids_test.go` through `scanSrc`,
+   following the file's case-as-source convention: flags
+   `ScopeID(cfg.ID, "row:x")`; quiet on `ScopeID(base, "resize")`,
+   `ScopeIDN(cfg.ID, "opt", i)`, and a variable part.
+3. Run `make ergonomics-audit` over the repo; fix any findings in the same pass
+   (each is a literal rewrite).
+4. No `CHANGELOG.md` entry: audit-only, no exported surface or observable
+   behaviour change.
+
+## Rejected Approaches
+
+- **Panic in `ScopeID` on a colon-bearing part.** Fail-fast fits the repo ethos,
+  but `ScopeID` is pure — no `*Window`, no findings channel — so panic is its
+  only signal, and it fires on data-derived input: a row key containing `":"`
+  becomes a crash instead of a diagnostic. Adds a per-part scan to a per-frame
+  path.
+- **Sanitize in `ScopeID` (strip/replace `:`).** Silent identity change with new
+  collision shapes; trades a loud failure for a quiet one, the exact hazard
+  `widget-id-scoping.md` rejects for implicit IDs.
+- **A `Debug` category for absolute leaves under a scope.** The stamp pass
+  cannot distinguish misuse from the documented absolute-leaf exception
+  (`gui/datagrid` children, `form:<id>`), so the category is either noisy or
+  allowlist-driven. Left as future work, not this spec.
+
+## Unresolved questions
+
+- Should the rule also cover `+ IDSep +` hand-joins (already flagged as
+  hand-rolled composition today — confirm no double-report)?
+- Does the datagrid's absolute-spelling exception need any literal colon-bearing
+  part that this rule would flag?

--- a/gui/scroll.go
+++ b/gui/scroll.go
@@ -368,7 +368,14 @@ func (w *Window) ScrollHorizontalTo(effectiveID string, offset float32) {
 // mouse-wheel scrolling. No-op if the scroll id is not found or the
 // target equals the current offset. Use ScrollHorizontalTo for an
 // instant jump.
-func (w *Window) scrollHorizontalToSmooth(effectiveID string, offset float32) {
+//
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// exportaudit:keep — caller-facing scroll setter, axis twin of
+// ScrollVerticalToSmooth
+func (w *Window) ScrollHorizontalToSmooth(effectiveID string, offset float32) {
 	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		scrollSmoothTo(w, ly, scrollAxisX, offset)
 	}
@@ -377,10 +384,18 @@ func (w *Window) scrollHorizontalToSmooth(effectiveID string, offset float32) {
 // ScrollHorizontalToPct scrolls to a horizontal percentage.
 // pct: 0.0 = left, 1.0 = right. Clamped to [0, 1].
 // No-op if the scroll id is not found or content fits viewport.
-func (w *Window) scrollHorizontalToPct(effectiveID string, pct float32) {
+//
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// exportaudit:keep — caller-facing scroll setter, axis twin of
+// ScrollVerticalToPct
+func (w *Window) ScrollHorizontalToPct(effectiveID string, pct float32) {
 	// See ScrollHorizontalPct: the walk faults on an un-arranged tree.
 	ly, ok := findScrollLayout(w, effectiveID)
 	if !ok {
+		debugLookupMiss(&w.layout, "ScrollHorizontalToPct", effectiveID)
 		return
 	}
 	maxOffset := scrollMaxOffsetX(ly)
@@ -438,7 +453,14 @@ func (w *Window) ScrollVerticalTo(effectiveID string, offset float32) {
 // mouse-wheel scrolling. No-op if the scroll id is not found or the
 // target equals the current offset. Use ScrollVerticalTo for an
 // instant jump.
-func (w *Window) scrollVerticalToSmooth(effectiveID string, offset float32) {
+//
+// effectiveID is the widget's effective ID: a leaf under an ID-bearing
+// ancestor is addressed by its full path ("detail:nav"), not by the
+// leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// exportaudit:keep — caller-facing scroll setter, axis twin of
+// ScrollHorizontalToSmooth
+func (w *Window) ScrollVerticalToSmooth(effectiveID string, offset float32) {
 	if ly, ok := findScrollLayout(w, effectiveID); ok {
 		scrollSmoothTo(w, ly, scrollAxisY, offset)
 	}

--- a/gui/scroll_overflow_test.go
+++ b/gui/scroll_overflow_test.go
@@ -219,5 +219,5 @@ func TestScrollPctBeforeFirstArrangeDoesNotPanic(t *testing.T) {
 	}
 	// Setters take the same walk; a no-op is the whole assertion.
 	w.ScrollVerticalToPct("any", 0.5)
-	w.scrollHorizontalToPct("any", 0.5)
+	w.ScrollHorizontalToPct("any", 0.5)
 }

--- a/gui/scroll_smooth_test.go
+++ b/gui/scroll_smooth_test.go
@@ -331,7 +331,7 @@ func TestScrollVerticalToSmoothEasesToAbsoluteTarget(t *testing.T) {
 	_, w := makeScrollLayout("14", 100, 100, 100, 300)
 	w.scrollY().Set("14", -100)
 
-	w.scrollVerticalToSmooth("14", 0)
+	w.ScrollVerticalToSmooth("14", 0)
 
 	e := w.scrollSmooth.findEntry("14", scrollAxisY)
 	if e == nil || !e.active {
@@ -344,7 +344,7 @@ func TestScrollVerticalToSmoothEasesToAbsoluteTarget(t *testing.T) {
 		t.Errorf("current = %v, want -100 (displayed offset)", e.current)
 	}
 	// Absolute target must not accumulate on repeat calls.
-	w.scrollVerticalToSmooth("14", 0)
+	w.ScrollVerticalToSmooth("14", 0)
 	if e.target != 0 {
 		t.Errorf("target after repeat call = %v, want 0", e.target)
 	}
@@ -357,7 +357,7 @@ func TestScrollVerticalToSmoothEasesToAbsoluteTarget(t *testing.T) {
 func TestScrollVerticalToSmoothClampsAtBounds(t *testing.T) {
 	_, w := makeScrollLayout("15", 100, 100, 100, 300) // maxOffset -200
 
-	w.scrollVerticalToSmooth("15", -9999)
+	w.ScrollVerticalToSmooth("15", -9999)
 	e := w.scrollSmooth.findEntry("15", scrollAxisY)
 	if e == nil || e.target != -200 {
 		t.Fatalf("target = %v, want -200 (clamped)", e.target)
@@ -372,7 +372,7 @@ func TestScrollVerticalToSmoothNoOpAtTarget(t *testing.T) {
 	_, w := makeScrollLayout("16", 100, 100, 100, 300)
 
 	// Already at offset 0: nothing to ease, no entry armed.
-	w.scrollVerticalToSmooth("16", 0)
+	w.ScrollVerticalToSmooth("16", 0)
 	if w.scrollSmooth != nil {
 		if e := w.scrollSmooth.findEntry("16", scrollAxisY); e != nil && e.active {
 			t.Error("expected no active entry when already at target")
@@ -383,7 +383,7 @@ func TestScrollVerticalToSmoothNoOpAtTarget(t *testing.T) {
 func TestScrollVerticalToSmoothUnknownID(t *testing.T) {
 	_, w := makeScrollLayout("17", 100, 100, 100, 300)
 
-	w.scrollVerticalToSmooth("nope", -50) // must not panic or arm
+	w.ScrollVerticalToSmooth("nope", -50) // must not panic or arm
 	if w.scrollSmooth != nil && w.scrollSmooth.findEntry("nope", scrollAxisY) != nil {
 		t.Error("unknown scroll id must not create an entry")
 	}
@@ -409,7 +409,7 @@ func TestScrollHorizontalToSmoothEases(t *testing.T) {
 		Children: []Layout{layout},
 	}
 
-	w.scrollHorizontalToSmooth("18", -50)
+	w.ScrollHorizontalToSmooth("18", -50)
 	driveScrollSmooth(w, 200)
 	if v, _ := w.scrollX().Get("18"); v != -50 {
 		t.Errorf("horizontal settled = %v, want -50", v)
@@ -420,7 +420,7 @@ func TestScrollVerticalToSmoothCanceledByInstantScroll(t *testing.T) {
 	_, w := makeScrollLayout("19", 100, 100, 100, 300)
 	w.scrollY().Set("19", -100)
 
-	w.scrollVerticalToSmooth("19", 0)
+	w.ScrollVerticalToSmooth("19", 0)
 	if e := w.scrollSmooth.findEntry("19", scrollAxisY); e == nil || !e.active {
 		t.Fatal("expected active entry before instant scroll")
 	}
@@ -456,7 +456,7 @@ func TestScrollHorizontalToSmoothCanceledByInstantScroll(t *testing.T) {
 	}
 	w.scrollX().Set("20", -100)
 
-	w.scrollHorizontalToSmooth("20", 0)
+	w.ScrollHorizontalToSmooth("20", 0)
 	if e := w.scrollSmooth.findEntry("20", scrollAxisX); e == nil || !e.active {
 		t.Fatal("expected active entry before instant scroll")
 	}
@@ -474,7 +474,7 @@ func TestScrollHorizontalToSmoothCanceledByInstantScroll(t *testing.T) {
 func TestScrollVerticalToSmoothRejectsNaN(t *testing.T) {
 	_, w := makeScrollLayout("21", 100, 100, 100, 300)
 
-	w.scrollVerticalToSmooth("21", float32(math.NaN()))
+	w.ScrollVerticalToSmooth("21", float32(math.NaN()))
 	if w.scrollSmooth != nil {
 		if e := w.scrollSmooth.findEntry("21", scrollAxisY); e != nil && e.active {
 			t.Error("NaN offset must not arm an entry")

--- a/gui/scroll_test.go
+++ b/gui/scroll_test.go
@@ -238,7 +238,7 @@ func TestScrollToPctAndPct(t *testing.T) {
 			Children: []Layout{layout},
 		}
 
-		w.scrollHorizontalToPct("4", 1.0)
+		w.ScrollHorizontalToPct("4", 1.0)
 		sx := w.scrollX()
 		v, _ := sx.Get("4")
 		if v != -300 {

--- a/tools/ergonomics-audit/ids.go
+++ b/tools/ergonomics-audit/ids.go
@@ -31,6 +31,13 @@ package main
 //     than a leftover.
 //   - "ergonomics-audit:not-an-id" — the string is not a widget ID at all. An
 //     export filename or a spreadsheet column name only looks like one.
+//
+// A third rule covers the composition helper itself: a ScopeID /
+// ScopeIDN call whose *part* argument is a string literal containing
+// ":" is flagged. The owner (first argument) may itself be composed,
+// which is how nesting works, so it is exempt. Non-literal parts are
+// invisible statically and stay quiet. A literal part is always
+// rewritable, so these findings carry no marker — fix the literal.
 
 import (
 	"fmt"
@@ -55,6 +62,11 @@ const idNotAnIDMarker = "ergonomics-audit:not-an-id"
 // with. A concatenation mentioning none of them is not composing an ID
 // path (a label, a message, a URL), so it is left alone.
 const idSeparators = ":._-/"
+
+// scopeIDSep is the only separator that is illegal inside a ScopeID
+// part. The other idSeparators are legal part spelling ("opt_2",
+// "row-3"); only ":" re-scopes, promoting the leaf to absolute.
+const scopeIDSep = ":"
 
 // idFinding is one hand-rolled composition in an ID position.
 type idFinding struct {
@@ -218,6 +230,33 @@ func hasSeparator(expr ast.Expr) bool {
 	return strings.ContainsAny(s, idSeparators)
 }
 
+// isScopeIDCall reports whether fun is a call to the ScopeID /
+// ScopeIDN composition helper, qualified (gui.ScopeID) or bare
+// (test stubs, dot imports).
+func isScopeIDCall(fun ast.Expr) bool {
+	if sel, ok := fun.(*ast.SelectorExpr); ok {
+		return sel.Sel.Name == "ScopeID" || sel.Sel.Name == "ScopeIDN"
+	}
+	if id, ok := fun.(*ast.Ident); ok {
+		return id.Name == "ScopeID" || id.Name == "ScopeIDN"
+	}
+	return false
+}
+
+// hasScopeIDSep reports whether expr is a string literal containing
+// the ID separator, which a ScopeID part must not hold.
+func hasScopeIDSep(expr ast.Expr) bool {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(s, scopeIDSep)
+}
+
 // markedLines returns the set of source lines carrying marker in a
 // comment, so a deliberate exception can be annotated where it lives.
 func markedLines(fset *token.FileSet, f *ast.File, markers ...string) map[int]bool {
@@ -315,6 +354,21 @@ func inspectIDs(
 				}
 				return true
 			})
+		case *ast.CallExpr:
+			// ScopeID(cfg.ID, "row:x") — a literal part containing the
+			// separator. The owner (first argument) may itself be
+			// composed, which is how nesting works, so only the parts
+			// are checked. Non-literal parts are invisible statically
+			// and stay quiet. Both gui.ScopeID and a bare ScopeID
+			// (test stubs, dot imports) count.
+			if !isScopeIDCall(node.Fun) {
+				return true
+			}
+			for _, arg := range node.Args[1:] {
+				if hasScopeIDSep(arg) {
+					report("ScopeID part containing "+strconv.Quote(scopeIDSep), arg)
+				}
+			}
 		}
 		return true
 	})

--- a/tools/ergonomics-audit/ids_test.go
+++ b/tools/ergonomics-audit/ids_test.go
@@ -177,6 +177,51 @@ func colName(i int) string {
 	}
 }
 
+// A literal ScopeID part containing the separator re-scopes the leaf,
+// so it is flagged. Only ":" counts: the other separators are legal
+// part spelling.
+func TestIDsFlagsScopeIDLiteralColon(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+
+func f(cfg struct{ ID string }) {
+	_ = ScopeID(cfg.ID, "row:x")
+	_ = ScopeIDN(cfg.ID, "opt:y", 2)
+}
+
+func ScopeID(string, ...string) string { return "" }
+
+func ScopeIDN(string, string, int) string { return "" }
+`
+	got := scanSrc(t, src)
+	if len(got) != 2 {
+		t.Errorf("got %d findings, want 2:\n%s", len(got), strings.Join(got, "\n"))
+	}
+}
+
+// A composed owner is nesting, not a violation; a clean part, a
+// numeric segment and a variable part all stay quiet. The variable
+// case is invisible statically by design.
+func TestIDsIgnoresScopeIDCleanParts(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+
+func f(cfg struct{ ID string }, base, key string, i int) {
+	_ = ScopeID(cfg.ID, "handle")
+	_ = ScopeID(base, "resize")
+	_ = ScopeIDN(cfg.ID, "opt", i)
+	_ = ScopeID(cfg.ID, key)
+}
+
+func ScopeID(string, ...string) string { return "" }
+
+func ScopeIDN(string, string, int) string { return "" }
+`
+	if got := scanSrc(t, src); len(got) != 0 {
+		t.Errorf("want no findings, got:\n%s", strings.Join(got, "\n"))
+	}
+}
+
 func TestIsIDName(t *testing.T) {
 	t.Parallel()
 	cases := map[string]bool{


### PR DESCRIPTION
Two commits:

1. feat(gui): make horizontal pct and eased scroll setters public — promotes scrollHorizontalToPct, scrollHorizontalToSmooth, scrollVerticalToSmooth to ScrollHorizontalToPct, ScrollHorizontalToSmooth, ScrollVerticalToSmooth with effectiveID docs and exportaudit markers. Horizontal Pct now reports unscoped-leaf misses via DebugUnknownLookup, matching vertical.
2. feat(tools): flag ScopeID literal parts containing the ID separator — new ergonomics-audit -mode ids rule plus spec docs/specs/scopeid-literal-colon-audit.md. First repo run: 0 findings.

Local gate: make prepush green.