### PR TITLE
fix(showcase): resolve palette ID at generation time so toggle hits scoped state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,15 @@ and this project adheres to
 
 ### Fixed
 
+- **Showcase "Open Command Palette" button opens the palette** — the demo
+  toggled the palette by its bare leaf (`"cmd-palette"`) while the palette reads
+  its visibility state by effective ID (`"detail:cmd-palette"` under the detail
+  panel), so the toggle wrote a key no frame ever read and the button silently
+  did nothing. The demo now defers its build to generation time, resolves the ID
+  with `w.EffID` in the panel's scope, and closes the button handler over that
+  key — the documented pattern for a factory that addresses a widget it does not
+  itself own.
+
 - **Scroll percentage APIs no longer crash before the first frame (#546)** —
   `ScrollVerticalPct` and `ScrollVerticalToPct` walked the layout tree without
   checking that a frame had been arranged, so calling either on a window whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to
 
 ### Fixed
 
-- **Showcase "Open Command Palette" button opens the palette** — the demo
+- **Showcase "Open Command Palette" button opens the palette (#554)** — the demo
   toggled the palette by its bare leaf (`"cmd-palette"`) while the palette reads
   its visibility state by effective ID (`"detail:cmd-palette"` under the detail
   panel), so the toggle wrote a key no frame ever read and the button silently

--- a/examples/showcase/demo_navigation.go
+++ b/examples/showcase/demo_navigation.go
@@ -200,12 +200,27 @@ func demoMenus(w *gui.Window) gui.View {
 }
 
 func demoCommandPalette(w *gui.Window) gui.View {
+	// Deferred: the button closes over the palette's effective ID,
+	// which is only known inside GenerateLayout under the detail
+	// panel's scope. Resolving in the factory body (or via
+	// ctx.EffID from the sibling button) keys the wrong state slot
+	// and the toggle silently misses.
+	return commandPaletteDemoView{}
+}
+
+// commandPaletteDemoView defers the demo build to generation time so
+// w.EffID joins "cmd-palette" against the enclosing panel scope.
+// The OnClick handler closes over that resolved key, which stays
+// valid while the ancestor IDs above it do.
+type commandPaletteDemoView struct{}
+
+func (v commandPaletteDemoView) GenerateLayout(w *gui.Window) gui.Layout {
 	t := gui.CurrentTheme()
 	app := appState(w)
 
-	const paletteID = "cmd-palette"
+	id := w.EffID("cmd-palette")
 
-	return gui.Column(gui.ContainerCfg{
+	return gui.GenerateViewLayout(gui.Column(gui.ContainerCfg{
 		Sizing:  gui.FillFit,
 		Spacing: gui.SomeF(12),
 		Padding: gui.NoPadding,
@@ -217,7 +232,7 @@ func demoCommandPalette(w *gui.Window) gui.View {
 					gui.Text(gui.TextCfg{Text: "Open Command Palette", TextStyle: t.N3}),
 				},
 				OnClick: func(ctx gui.EventCtx) {
-					gui.CommandPaletteToggle(paletteID, ctx.Window)
+					gui.CommandPaletteToggle(id, ctx.Window)
 				},
 			}),
 			gui.Text(gui.TextCfg{
@@ -225,7 +240,7 @@ func demoCommandPalette(w *gui.Window) gui.View {
 				TextStyle: t.N3,
 			}),
 			gui.CommandPalette(gui.CommandPaletteCfg{
-				ID:          paletteID,
+				ID:          id,
 				Placeholder: "Type a command...",
 				Items: []gui.CommandPaletteItem{
 					{ID: "new-file", Label: "New File", Icon: gui.IconPlus, Group: "File"},
@@ -239,5 +254,5 @@ func demoCommandPalette(w *gui.Window) gui.View {
 				},
 			}),
 		},
-	})
+	}), w)
 }


### PR DESCRIPTION
Showcase "Open Command Palette" button did nothing: it toggled by bare leaf ("cmd-palette") while the palette reads visibility state by effective ID ("detail:cmd-palette"), so the toggle wrote a key no frame read. The demo now defers its build to generation time, resolves with w.EffID in the panel scope, and closes the handler over that key. Adds the CHANGELOG entry the entry-check gate requires.