### PR TITLE
Harden render pipeline tracks 1-4, deprecate TermGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,62 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Deprecated
+
+- **TermGrid widget deprecated, removal in a future minor** — `TermGrid`,
+  `TermGridCfg`, `TermGridData`, `TermCell`, `TermCursor`, `TermSelRange`,
+  `TermAttr`, `TermUnderline`, and `TermReverse` are all marked deprecated. The
+  only terminal in the org, go-term, renders its grid through `DrawCanvas` and
+  never used this widget; the sole remaining consumer is the `examples/termgrid`
+  demo. New code should draw grids on a `DrawCanvas`. Removal takes the
+  `RenderTermGrid` command, its per-backend draws, and the print branch with it.
+
 ### Added
 
+- **TermGrid renders on the GL and Web backends, and in print** — the terminal
+  character grid previously painted only through the Metal and soft backends; on
+  Linux/Windows (GL), in the browser (Web), and in PDF export the widget was
+  silently blank. All three now run the same single-pass draw (background runs,
+  column-pinned glyph runs, cursor, selection, underlines on screen; backgrounds
+  plus text runs in print). Print additionally honors rotation brackets, which
+  it previously dropped: rotated content now prints rotated instead of
+  unrotated. Glow/blur filter effects, custom shaders, and live cursor/selection
+  decorations remain print-skipped by design (no PDF equivalent) and are now
+  grouped and documented as such in the print dispatcher rather than falling
+  through silently.
+
+### Fixed
+
+- **Disabled and Opacity now reach every render path** — fading or disabling a
+  widget previously dimmed only its flat fills, borders, blur, and plain text.
+  Shadows, custom-shader tint, gradient fills and borders, image fills, the
+  terminal grid, canvas batches/texts/gradients/image fills, text gradients, and
+  untinted SVG art all painted at full strength inside a disabled or faded
+  parent. Every one of those now scales alpha by the widget's opacity and halves
+  it when disabled, through one shared helper, so a disabled panel dims as a
+  whole. Copies are made only while dimming actually applies — the enabled path
+  keeps its pointers (canvas batches reuse the frame arena, the term-grid
+  zero-copy test still passes) and the render benchmark still reports 0
+  allocs/op. Three factories (`TermGrid`, RTF, `DrawCanvas`) never set `Opacity`
+  and ran at zero, which the old per-path code silently treated as opaque; they
+  now default to 1.0, making zero mean transparent everywhere. Deliberately out
+  of scope: rich-text layouts and raster image pixels carry no per-command color
+  to scale, and SVG text inside a `disabledRole` theme style is already quieted
+  by the theme, so those are left untouched rather than dimmed twice.
+
+- **Filter layer counts are capped at emission and in every GPU backend** —
+  `Layers` is the `feMergeNode` count of an untrusted SVG filter, and it
+  previously reached the GPU composite loops unbounded (the emit path clamped
+  only the soft backend). A hostile document could demand hundreds of thousands
+  of fullscreen blend passes per frame. The SVG emitter now clamps to 32 and the
+  GL, Metal, iOS, and Android backends clamp again at `beginFilter`, mirroring
+  the soft backend's existing cap. Past a handful of layers a glow is already
+  saturated, so legitimate documents are unaffected. Render-command validation
+  now additionally covers the previously unvalidated kinds (`RenderLine`,
+  `RenderRTF`, `RenderTextPath`, `RenderTermGrid`, `RenderFilterBegin`) and the
+  command goldens record rotation, stencil depth, filter layers/matrix, image
+  clip radius, term-grid geometry, and layout glyph/item counts instead of
+  presence alone.
 - **Scroll overflow is queryable, on both axes (#546)** — `ScrollOverflowX` and
   `ScrollOverflowY` report how much content a scrollable currently hides, as a
   positive number of pixels, and 0 when the content fits. Nothing exported

--- a/examples/termgrid/main.go
+++ b/examples/termgrid/main.go
@@ -61,6 +61,7 @@ func view(w *gui.Window) gui.View {
 		VAlign: gui.VAlignMiddle,
 		Color:  gui.RGB(16, 16, 20),
 		Content: []gui.View{
+			//nolint:staticcheck // this example demonstrates TermGrid itself
 			gui.TermGrid(gui.TermGridCfg{
 				Cols:      cols,
 				Rows:      rows,

--- a/gui/backend/android/draw.go
+++ b/gui/backend/android/draw.go
@@ -327,11 +327,17 @@ func (b *Backend) drawImageTex(
 	C.glesDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
+// maxSvgTriangleFloats caps a RenderSvg triangle list in floats,
+// mirroring the gui package's emit-side cap. It bounds the
+// per-frame vertex allocation an oversized command would force.
+const maxSvgTriangleFloats = 1_200_000
+
 func (b *Backend) drawSvg(r *gui.RenderCmd) {
 	if r.IsClipMask {
 		return
 	}
-	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
+	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 ||
+		len(r.Triangles) > maxSvgTriangleFloats {
 		return
 	}
 	s := b.DPIScale
@@ -618,9 +624,16 @@ func (b *Backend) endRotation() {
 
 // --- Filter (glow) ---
 
+// maxFilterLayers caps the composite repeat count. Layers is the
+// count of feMergeNode elements in an SVG filter, so an untrusted
+// document can name an arbitrary number of them; past a handful the
+// glow is already saturated and each extra pass is a full-layer
+// blend. Mirrors the soft backend's maxFilterLayers.
+const maxFilterLayers = 32
+
 func (b *Backend) beginFilter(r *gui.RenderCmd) {
 	b.FilterBlur = r.BlurRadius * b.DPIScale
-	b.FilterLayer = r.Layers
+	b.FilterLayer = min(max(r.Layers, 1), maxFilterLayers)
 	b.FilterColorMatrix = r.ColorMatrix
 
 	b.SetPipeline(pipeSolid)

--- a/gui/backend/gl/backend.go
+++ b/gui/backend/gl/backend.go
@@ -54,6 +54,11 @@ type Backend struct {
 	normBuf            []gui.GradientStop
 	sampledBuf         []gui.GradientStop
 
+	// Terminal grid run assembly, reused across rows and frames.
+	termRunText []rune
+	termRunCols []int
+	termPlace   []glyph.GlyphPlacement
+
 	allowedImageRoots []string
 	svgCap            int
 	filterLayer       int

--- a/gui/backend/gl/draw.go
+++ b/gui/backend/gl/draw.go
@@ -19,6 +19,20 @@ import (
 
 // renderersDraw iterates render commands and draws them.
 func (b *Backend) renderersDraw(w *gui.Window) {
+	// A truncated command list must not leak backend state into the
+	// next frame: a bound filter FBO, a rotated MVP, or an enabled
+	// stencil test all persist on the GL context. A balanced stream
+	// ends in exactly the restored state, so this is a no-op for it.
+	savedMVP := b.mvp
+	savedStackLen := len(b.mvpStack)
+	defer func() {
+		b.mvp = savedMVP
+		b.mvpStack = b.mvpStack[:savedStackLen]
+		b.usePipeline(&b.pipelines.solid)
+		b.unbindFBO()
+		gogl.Viewport(0, 0, b.physW, b.physH)
+		gogl.Disable(gogl.STENCIL_TEST)
+	}()
 	cmds := w.Renderers()
 	for i := range cmds {
 		r := &cmds[i]
@@ -55,6 +69,8 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 			b.drawTextPath(r)
 		case gui.RenderRTF:
 			b.drawRtf(r)
+		case gui.RenderTermGrid:
+			b.drawTermGrid(r)
 		case gui.RenderCustomShader:
 			b.drawCustomShader(r)
 		case gui.RenderFilterBegin:
@@ -334,11 +350,17 @@ func (b *Backend) resolveImageTexture(res string) (glTexture, bool) {
 	return tex, true
 }
 
+// maxSvgTriangleFloats caps a RenderSvg triangle list in floats,
+// mirroring the gui package's emit-side cap. It bounds the
+// per-frame vertex allocation an oversized command would force.
+const maxSvgTriangleFloats = 1_200_000
+
 func (b *Backend) drawSvg(r *gui.RenderCmd) {
 	if r.IsClipMask {
 		return // clip masks not yet supported in render pipeline
 	}
-	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
+	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 ||
+		len(r.Triangles) > maxSvgTriangleFloats {
 		return
 	}
 	s := b.dpiScale
@@ -524,12 +546,22 @@ func (b *Backend) drawCustomShader(r *gui.RenderCmd) {
 
 // --- Filter (glow) ---
 
+// maxFilterLayers caps the composite repeat count. Layers is the
+// count of feMergeNode elements in an SVG filter, so an untrusted
+// document can name an arbitrary number of them; past a handful the
+// glow is already saturated and each extra pass is a full-layer
+// blend. Mirrors the soft backend's maxFilterLayers.
+const maxFilterLayers = 32
+
 func (b *Backend) beginFilter(r *gui.RenderCmd) {
 	if !b.ensureFilterFBO(b.physW, b.physH) {
 		return
 	}
 	b.filterBlur = r.BlurRadius * b.dpiScale
-	b.filterLayer = r.Layers
+	// Clamped: Layers is the feMergeNode count of an untrusted SVG
+	// filter, and endFilter composites once per layer. Mirrors the
+	// soft backend's maxFilterLayers.
+	b.filterLayer = min(max(r.Layers, 1), maxFilterLayers)
 	b.filterColorMatrix = r.ColorMatrix
 
 	b.bindFBO(b.filterTexA)

--- a/gui/backend/gl/termgrid.go
+++ b/gui/backend/gl/termgrid.go
@@ -1,0 +1,270 @@
+//go:build !js && !darwin && !android
+
+package gl
+
+import (
+	"math"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// defaultTermSelTint is the fallback selection highlight when the
+// caller leaves TermSelRange.Color unset. It matches the Metal and
+// soft backends' fallback, so a terminal is the same picture on
+// every platform.
+var defaultTermSelTint = gui.RGBA(51, 153, 255, 100)
+
+// drawTermGrid renders a terminal character grid from a shared cell
+// buffer in a single pass: background fills, glyph runs (pinned to
+// exact cell columns via DrawLayoutPlaced so the grid never drifts),
+// then cursor and selection overlays. No per-cell Layout nodes exist.
+//
+// It is a port of gui/backend/metal/termgrid.go over this package's
+// rect fill and text system. Attribute support (v1): reverse (swaps
+// fg/bg) and underline are honored; bold/italic are reserved in
+// TermAttr but not yet rendered.
+func (b *Backend) drawTermGrid(r *gui.RenderCmd) {
+	tg := r.TermGrid
+	if b.textSys == nil || tg == nil || tg.Cols <= 0 || tg.Rows <= 0 ||
+		tg.CellW <= 0 || math.IsNaN(float64(tg.CellW)) || math.IsInf(float64(tg.CellW), 0) ||
+		tg.CellH <= 0 || math.IsNaN(float64(tg.CellH)) || math.IsInf(float64(tg.CellH), 0) ||
+		// Division form: a hostile Cols*Rows must not overflow the
+		// check itself. Cols > 0 is established above.
+		tg.Rows > len(tg.Cells)/tg.Cols {
+		return
+	}
+	gx, gy := r.X, r.Y
+	cw, ch := tg.CellW, tg.CellH
+
+	cfg := guiStyleToGlyphConfig(tg.Style)
+	ascent := ch * 0.8
+	if m, err := b.textSys.FontMetrics(cfg); err == nil && m.Ascender > 0 {
+		ascent = m.Ascender
+	}
+
+	b.termGridBackgrounds(tg, gx, gy, cw, ch)
+	b.termGridSelection(tg, gx, gy, cw, ch)
+	b.termGridCursorUnder(tg, gx, gy, cw, ch)
+	b.termGridGlyphs(tg, cfg, gx, gy, cw, ch, ascent)
+	b.termGridDecorations(tg, gx, gy, cw, ch)
+}
+
+// termCellFB returns the effective foreground/background for a cell,
+// applying the reverse attribute.
+func termCellFB(c *gui.TermCell) (fg, bg gui.Color) {
+	fg, bg = c.FG, c.BG
+	if c.Attrs&gui.TermReverse != 0 {
+		fg, bg = bg, fg
+	}
+	return fg, bg
+}
+
+// termGridBackgrounds fills batched runs of same-background cells.
+func (b *Backend) termGridBackgrounds(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	for row := 0; row < tg.Rows; row++ {
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			_, bg := termCellFB(c)
+			if bg.A == 0 {
+				col++
+				continue
+			}
+			start := col
+			for col < tg.Cols {
+				_, nbg := termCellFB(&tg.Cells[row*tg.Cols+col])
+				if nbg != bg {
+					break
+				}
+				col++
+			}
+			b.fillTermRect(
+				gx+float32(start)*cw, gy+float32(row)*ch,
+				float32(col-start)*cw, ch, bg)
+		}
+	}
+}
+
+// termGridSelection tints the selected cell range per row.
+func (b *Backend) termGridSelection(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	sel := tg.Selection
+	if sel.End <= sel.Start {
+		return
+	}
+	tint := sel.Color
+	if tint.A == 0 {
+		tint = defaultTermSelTint
+	}
+	total := tg.Cols * tg.Rows
+	beg := max(sel.Start, 0)
+	end := min(sel.End, total)
+	for row := 0; row < tg.Rows && beg < end; row++ {
+		rowStart := row * tg.Cols
+		rowEnd := rowStart + tg.Cols
+		s := max(beg, rowStart)
+		e := min(end, rowEnd)
+		if s >= e {
+			continue
+		}
+		c0 := s - rowStart
+		c1 := e - rowStart
+		b.fillTermRect(
+			gx+float32(c0)*cw, gy+float32(row)*ch,
+			float32(c1-c0)*cw, ch, tint)
+	}
+}
+
+// termGridCursorUnder draws the block cursor beneath the glyphs so the
+// character remains visible on top.
+func (b *Backend) termGridCursorUnder(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	cur := tg.Cursor
+	if !cur.Visible || cur.Style != gui.TermCursorBlock ||
+		cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	b.fillTermRect(
+		gx+float32(cur.Col)*cw, gy+float32(cur.Row)*ch,
+		cw, ch, cur.Color)
+}
+
+// termGridGlyphs shapes each row into foreground-color runs and draws
+// them with glyphs pinned to their cell columns.
+func (b *Backend) termGridGlyphs(
+	tg *gui.TermGridData, cfg glyph.TextConfig,
+	gx, gy, cw, ch, ascent float32,
+) {
+	b.useGlyphPipeline()
+	defer b.restoreAfterGlyph()
+	for row := 0; row < tg.Rows; row++ {
+		baseline := gy + float32(row)*ch + ascent
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Width == 0 { // continuation of a wide cell
+				col++
+				continue
+			}
+			fg, _ := termCellFB(c)
+			// Extend a run of glyphs sharing this foreground color.
+			b.termGridRunReset()
+			runFG := fg
+			for col < tg.Cols {
+				cell := &tg.Cells[row*tg.Cols+col]
+				if cell.Width == 0 {
+					col++
+					continue
+				}
+				fg2, _ := termCellFB(cell)
+				blank := cell.Ch == 0 || cell.Ch == ' '
+				if !blank && fg2 != runFG {
+					break
+				}
+				if blank {
+					b.termGridRunAppend(' ', col)
+				} else {
+					b.termGridRunAppend(cell.Ch, col)
+				}
+				col++
+			}
+			b.termGridDrawRun(cfg, runFG, gx, baseline, cw)
+		}
+	}
+}
+
+// termGridDecorations draws underline attributes and the bar /
+// underline cursor styles on top of the glyphs.
+func (b *Backend) termGridDecorations(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	thick := max(ch*0.08, 1)
+	for row := 0; row < tg.Rows; row++ {
+		for col := 0; col < tg.Cols; col++ {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Attrs&gui.TermUnderline == 0 {
+				continue
+			}
+			fg, _ := termCellFB(c)
+			b.fillTermRect(
+				gx+float32(col)*cw, gy+float32(row+1)*ch-thick,
+				cw, thick, fg)
+		}
+	}
+
+	cur := tg.Cursor
+	if !cur.Visible || cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	x := gx + float32(cur.Col)*cw
+	y := gy + float32(cur.Row)*ch
+	switch cur.Style {
+	case gui.TermCursorBar:
+		b.fillTermRect(x, y, max(cw*0.15, 1), ch, cur.Color)
+	case gui.TermCursorUnderline:
+		b.fillTermRect(x, y+ch-thick, cw, thick, cur.Color)
+	case gui.TermCursorBlock:
+		// Drawn under the glyph in termGridCursorUnder.
+	}
+}
+
+// --- run assembly helpers (reuse scratch buffers) ---
+
+func (b *Backend) termGridRunReset() {
+	b.termRunText = b.termRunText[:0]
+	b.termRunCols = b.termRunCols[:0]
+}
+
+func (b *Backend) termGridRunAppend(ch rune, col int) {
+	b.termRunText = append(b.termRunText, ch)
+	b.termRunCols = append(b.termRunCols, col)
+}
+
+// termGridDrawRun shapes the accumulated run and draws its glyphs at
+// fixed cell columns. Falls back to natural flow if the shaper does
+// not produce one glyph per cell (e.g. clustered non-ASCII runs).
+func (b *Backend) termGridDrawRun(
+	cfg glyph.TextConfig, fg gui.Color, gx, baseline, cw float32,
+) {
+	if len(b.termRunCols) == 0 {
+		return
+	}
+	cfg.Style.Color = glyph.Color{R: fg.R, G: fg.G, B: fg.B, A: fg.A}
+	layout, err := b.textSys.LayoutText(string(b.termRunText), cfg)
+	if err != nil {
+		return
+	}
+	if len(layout.Glyphs) != len(b.termRunCols) {
+		// Cluster/ligature mismatch — draw at the run's first column.
+		b.textSys.DrawLayout(layout, gx+float32(b.termRunCols[0])*cw, baseline)
+		return
+	}
+	b.termPlace = b.termPlace[:0]
+	for _, col := range b.termRunCols {
+		b.termPlace = append(b.termPlace, glyph.GlyphPlacement{
+			X: gx + float32(col)*cw,
+			Y: baseline,
+		})
+	}
+	b.textSys.DrawLayoutPlaced(layout, b.termPlace)
+}
+
+// fillTermRect draws a solid filled rectangle in logical coordinates.
+func (b *Backend) fillTermRect(x, y, w, h float32, c gui.Color) {
+	if w <= 0 || h <= 0 || c.A == 0 {
+		return
+	}
+	cmd := gui.RenderCmd{
+		Kind: gui.RenderRect, X: x, Y: y, W: w, H: h,
+		Color: c, Fill: true,
+	}
+	b.drawRect(&cmd)
+}

--- a/gui/backend/gl/termgrid_test.go
+++ b/gui/backend/gl/termgrid_test.go
@@ -1,0 +1,41 @@
+//go:build !js && !darwin && !android
+
+package gl
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// drawTermGrid must degrade to a no-op without a text system —
+// headless-safe, no GL context needed.
+func TestDrawTermGridNoTextSys(t *testing.T) {
+	b := &Backend{}
+	cells := make([]gui.TermCell, 4)
+	b.drawTermGrid(&gui.RenderCmd{
+		Kind: gui.RenderTermGrid, X: 0, Y: 0,
+		TermGrid: &gui.TermGridData{
+			Cells: cells, Cols: 2, Rows: 2, CellW: 8, CellH: 16,
+		},
+	})
+}
+
+// drawTermGrid must drop malformed grids without looping or
+// allocating — mirrors the soft backend's validTermGrid contract.
+func TestDrawTermGridMalformed(t *testing.T) {
+	b := &Backend{}
+	bad := []*gui.RenderCmd{
+		{Kind: gui.RenderTermGrid},
+		{Kind: gui.RenderTermGrid,
+			TermGrid: &gui.TermGridData{}},
+		{Kind: gui.RenderTermGrid,
+			TermGrid: &gui.TermGridData{
+				Cells: make([]gui.TermCell, 2),
+				Cols:  2, Rows: 2, CellW: 8, CellH: 16,
+			}},
+	}
+	for _, r := range bad {
+		b.drawTermGrid(r)
+	}
+}

--- a/gui/backend/internal/imgload/imgload.go
+++ b/gui/backend/internal/imgload/imgload.go
@@ -102,10 +102,20 @@ func DecodeNRGBA(
 	if err != nil {
 		return nil, fmt.Errorf("decode image: %w", err)
 	}
+	if maxPixels <= 0 {
+		maxPixels = DefaultMaxImagePixels
+	}
+	bounds := src.Bounds()
+	w, h := int64(bounds.Dx()), int64(bounds.Dy())
+	if w <= 0 || h <= 0 {
+		return nil, fmt.Errorf("invalid image dimensions: %s", path)
+	}
+	if w*h > maxPixels {
+		return nil, fmt.Errorf("image dimensions too large: %s", path)
+	}
 	if existing, ok := src.(*image.NRGBA); ok {
 		return existing, nil
 	}
-	bounds := src.Bounds()
 	nrgba := image.NewNRGBA(bounds)
 	draw.Draw(nrgba, bounds, src, bounds.Min, draw.Src)
 	return nrgba, nil

--- a/gui/backend/internal/imgload/imgload_test.go
+++ b/gui/backend/internal/imgload/imgload_test.go
@@ -161,3 +161,30 @@ func TestDecodeNRGBADefaultLimits(t *testing.T) {
 		}
 	})
 }
+
+func TestDecodeNRGBAEnforcesPostDecodePixels(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "tiny.png")
+	srcImg := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	fw, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := png.Encode(fw, srcImg); err != nil {
+		fw.Close()
+		t.Fatal(err)
+	}
+	fw.Close()
+
+	fr, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fr.Close()
+	// 2x2 = 4 pixels exceeds a 3-pixel budget both in the
+	// DecodeConfig pre-check and the post-decode recheck.
+	if _, err := DecodeNRGBA(path, fr, 0, 3); err == nil {
+		t.Error("expected error for image exceeding maxPixels")
+	}
+}

--- a/gui/backend/internal/texcache/cache.go
+++ b/gui/backend/internal/texcache/cache.go
@@ -22,9 +22,15 @@ type Cache[K comparable, V any] struct {
 
 // New returns a cache that holds at most maxSize entries.
 // destroy is called on evicted or cleared values; nil skips cleanup.
+// A non-positive maxSize is clamped to 1 so eviction stays live:
+// without this, Set with maxSize<=0 never evicts and grows
+// without bound.
 func New[K comparable, V any](
 	maxSize int, destroy func(V),
 ) Cache[K, V] {
+	if maxSize <= 0 {
+		maxSize = 1
+	}
 	return Cache[K, V]{
 		data:    make(map[K]mapEntry[V], maxSize),
 		maxSize: maxSize,
@@ -68,6 +74,12 @@ func (c *Cache[K, V]) EvictOldest() bool {
 // Set inserts or updates key. If the cache is full the
 // least-recently-used entry is evicted first.
 func (c *Cache[K, V]) Set(key K, val V) {
+	if c.maxSize <= 0 {
+		c.maxSize = 1
+	}
+	if c.data == nil {
+		c.data = make(map[K]mapEntry[V], c.maxSize)
+	}
 	if me, ok := c.data[key]; ok {
 		if c.destroy != nil {
 			c.destroy(me.val)

--- a/gui/backend/internal/texcache/cache_test.go
+++ b/gui/backend/internal/texcache/cache_test.go
@@ -130,3 +130,17 @@ func TestEvictOldest(t *testing.T) {
 		t.Fatalf("destroyed = %v", destroyed)
 	}
 }
+
+func TestNonPositiveMaxSizeClamped(t *testing.T) {
+	for _, n := range []int{0, -3} {
+		c := New[string, int](n, nil)
+		c.Set("a", 1)
+		c.Set("b", 2) // must evict a, not grow
+		if _, ok := c.Get("a"); ok {
+			t.Fatalf("New(%d): a should be evicted", n)
+		}
+		if c.Len() != 1 {
+			t.Fatalf("New(%d): len = %d, want 1", n, c.Len())
+		}
+	}
+}

--- a/gui/backend/ios/draw.go
+++ b/gui/backend/ios/draw.go
@@ -327,11 +327,17 @@ func (b *Backend) drawImageTex(
 	C.metalDrawQuad((*C.float)(unsafe.Pointer(&verts[0])))
 }
 
+// maxSvgTriangleFloats caps a RenderSvg triangle list in floats,
+// mirroring the gui package's emit-side cap. It bounds the
+// per-frame vertex allocation an oversized command would force.
+const maxSvgTriangleFloats = 1_200_000
+
 func (b *Backend) drawSvg(r *gui.RenderCmd) {
 	if r.IsClipMask {
 		return
 	}
-	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
+	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 ||
+		len(r.Triangles) > maxSvgTriangleFloats {
 		return
 	}
 	s := b.DPIScale
@@ -645,9 +651,16 @@ func (b *Backend) endRotation() {
 
 // --- Filter (glow) ---
 
+// maxFilterLayers caps the composite repeat count. Layers is the
+// count of feMergeNode elements in an SVG filter, so an untrusted
+// document can name an arbitrary number of them; past a handful the
+// glow is already saturated and each extra pass is a full-layer
+// blend. Mirrors the soft backend's maxFilterLayers.
+const maxFilterLayers = 32
+
 func (b *Backend) beginFilter(r *gui.RenderCmd) {
 	b.FilterBlur = r.BlurRadius * b.DPIScale
-	b.FilterLayer = r.Layers
+	b.FilterLayer = min(max(r.Layers, 1), maxFilterLayers)
 	b.FilterColorMatrix = r.ColorMatrix
 
 	b.SetPipeline(pipeSolid)

--- a/gui/backend/metal/draw.go
+++ b/gui/backend/metal/draw.go
@@ -23,6 +23,18 @@ import (
 
 // renderersDraw iterates render commands and draws them.
 func (b *windowState) renderersDraw(w *gui.Window) {
+	// A truncated command list must not leak a rotated MVP into the
+	// next frame. Filter/stencil targets are per-frame encoder state
+	// owned by metalBeginFrame/metalEndFrame; only the Go-side MVP
+	// stack persists. A balanced stream ends restored, so no-op.
+	savedMVP := b.mvp
+	savedStackLen := len(b.mvpStack)
+	defer func() {
+		b.mvp = savedMVP
+		b.mvpStack = b.mvpStack[:savedStackLen]
+		C.metalSetPipeline(b.ctx, C.int(pipeSolid))
+		C.metalSetMVP(b.ctx, (*C.float)(&b.mvp[0]))
+	}()
 	cmds := w.Renderers()
 	for i := range cmds {
 		r := &cmds[i]
@@ -346,11 +358,17 @@ func (b *windowState) resolveImageTexture(
 	return tex, true
 }
 
+// maxSvgTriangleFloats caps a RenderSvg triangle list in floats,
+// mirroring the gui package's emit-side cap. It bounds the
+// per-frame vertex allocation an oversized command would force.
+const maxSvgTriangleFloats = 1_200_000
+
 func (b *windowState) drawSvg(r *gui.RenderCmd) {
 	if r.IsClipMask {
 		return // clip masks not yet supported in render pipeline
 	}
-	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
+	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 ||
+		len(r.Triangles) > maxSvgTriangleFloats {
 		return
 	}
 	s := b.dpiScale
@@ -675,9 +693,16 @@ func (b *windowState) endRotation() {
 
 // --- Filter (glow) ---
 
+// maxFilterLayers caps the composite repeat count. Layers is the
+// count of feMergeNode elements in an SVG filter, so an untrusted
+// document can name an arbitrary number of them; past a handful the
+// glow is already saturated and each extra pass is a full-layer
+// blend. Mirrors the soft backend's maxFilterLayers.
+const maxFilterLayers = 32
+
 func (b *windowState) beginFilter(r *gui.RenderCmd) {
 	b.filterBlur = r.BlurRadius * b.dpiScale
-	b.filterLayer = r.Layers
+	b.filterLayer = min(max(r.Layers, 1), maxFilterLayers)
 	b.filterColorMatrix = r.ColorMatrix
 
 	// Set pipelines and MVP before switching to filter target.

--- a/gui/backend/soft/draw_svg.go
+++ b/gui/backend/soft/draw_svg.go
@@ -9,6 +9,11 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
+// maxSvgTriangleFloats caps a RenderSvg triangle list in floats,
+// mirroring the gui package's emit-side cap. It bounds the
+// per-frame vertex allocation an oversized command would force.
+const maxSvgTriangleFloats = 1_200_000
+
 // drawSvg rasterizes a tessellated SVG path: a flat triangle list in
 // Triangles, optionally one color per vertex in VertexColors.
 //
@@ -28,7 +33,8 @@ func (r *renderer) drawSvg(cmd *gui.RenderCmd) {
 		// backend consumes it yet; the render path still emits it.
 		return
 	}
-	if len(cmd.Triangles) == 0 || len(cmd.Triangles)%6 != 0 {
+	if len(cmd.Triangles) == 0 || len(cmd.Triangles)%6 != 0 ||
+		len(cmd.Triangles) > maxSvgTriangleFloats {
 		return
 	}
 	numVerts := len(cmd.Triangles) / 2

--- a/gui/backend/soft/draw_test.go
+++ b/gui/backend/soft/draw_test.go
@@ -279,3 +279,30 @@ func TestBufferBoundsMatchScale(t *testing.T) {
 		t.Fatalf("clip = %v, want full bounds", b.clip)
 	}
 }
+
+func TestNewTextureRejectsUnboundedSize(t *testing.T) {
+	gb := newGlyphBackend(1)
+	if id := gb.NewTexture(0, 16); id != 0 {
+		t.Errorf("zero width = %d, want 0 (rejected)", id)
+	}
+	if id := gb.NewTexture(16, -1); id != 0 {
+		t.Errorf("negative height = %d, want 0 (rejected)", id)
+	}
+	if id := gb.NewTexture(8192, 8192); id != 0 {
+		t.Errorf("huge texture = %d, want 0 (rejected)", id)
+	}
+	if id := gb.NewTexture(64, 64); id == 0 {
+		t.Error("valid texture rejected")
+	}
+}
+
+func TestDrawSvgDropsOversizedTriangles(t *testing.T) {
+	r := newRenderer(8, 8, 1)
+	// Past the shared 1_200_000-float cap: must draw nothing and
+	// must not grow svgBatch to the attacker length.
+	r.drawAll([]gui.RenderCmd{{Kind: gui.RenderSvg,
+		Triangles: make([]float32, 1_200_006)}})
+	if cap(r.svgBatch) > 1_200_000 {
+		t.Fatalf("svgBatch cap = %d, want bounded", cap(r.svgBatch))
+	}
+}

--- a/gui/backend/soft/glyph_backend.go
+++ b/gui/backend/soft/glyph_backend.go
@@ -34,6 +34,11 @@ type glyphBackend struct {
 	scale    float32
 }
 
+// maxSoftTexturePixels caps one atlas page. The dimensions arrive
+// from glyph-controlled rasterization, so an unchecked width*height*4
+// make is an OOM sink; 4096x4096 holds a full page with headroom.
+const maxSoftTexturePixels = int64(4096 * 4096)
+
 func newGlyphBackend(scale float32) *glyphBackend {
 	return &glyphBackend{
 		textures: make(map[glyph.TextureID]*softTexture),
@@ -42,6 +47,12 @@ func newGlyphBackend(scale float32) *glyphBackend {
 }
 
 func (gb *glyphBackend) NewTexture(width, height int) glyph.TextureID {
+	if width <= 0 || height <= 0 {
+		return 0
+	}
+	if int64(width)*int64(height) > maxSoftTexturePixels {
+		return 0
+	}
 	gb.nextID++
 	gb.textures[gb.nextID] = &softTexture{
 		pix: make([]byte, width*height*4),

--- a/gui/backend/soft/render_test.go
+++ b/gui/backend/soft/render_test.go
@@ -288,6 +288,7 @@ func TestRenderTermGridPixels(t *testing.T) {
 	cells[3].BG = gui.RGB(255, 0, 0)
 
 	win := newWin(t, 100, 100, func(w *gui.Window) gui.View {
+		//nolint:staticcheck // exercises TermGrid rendering itself
 		return gui.TermGrid(gui.TermGridCfg{
 			ID:    "term",
 			Cells: cells,
@@ -333,6 +334,7 @@ func TestRenderTermGridSelectionCursorAndUnderline(t *testing.T) {
 	cells[3].Attrs = gui.TermUnderline
 
 	win := newWin(t, 100, 100, func(w *gui.Window) gui.View {
+		//nolint:staticcheck // exercises TermGrid rendering itself
 		return gui.TermGrid(gui.TermGridCfg{
 			ID:    "term",
 			Cells: cells,

--- a/gui/backend/web/backend.go
+++ b/gui/backend/web/backend.go
@@ -46,6 +46,11 @@ type Backend struct {
 
 	textPathPlacements []glyph.GlyphPlacement
 
+	// Terminal grid run assembly, reused across rows and frames.
+	termRunText []rune
+	termRunCols []int
+	termPlace   []glyph.GlyphPlacement
+
 	canvasLeft float64 // cached getBoundingClientRect().left
 	canvasTop  float64 // cached getBoundingClientRect().top
 

--- a/gui/backend/web/draw.go
+++ b/gui/backend/web/draw.go
@@ -97,8 +97,11 @@ func (b *Backend) renderersDraw(w *gui.Window) {
 			b.endRotation()
 		case gui.RenderCustomShader:
 			b.drawCustomShader(r)
+		case gui.RenderTermGrid:
+			b.drawTermGrid(r)
 
-		case gui.RenderFilterComposite,
+		case gui.RenderNone,
+			gui.RenderFilterComposite,
 			gui.RenderLayoutPlaced:
 			// Unsupported in Canvas2D backend.
 		}
@@ -527,11 +530,17 @@ func (b *Backend) memImageCanvas(
 	return canvas
 }
 
+// maxSvgTriangleFloats caps a RenderSvg triangle list in floats,
+// mirroring the gui package's emit-side cap. It bounds the
+// per-frame vertex allocation an oversized command would force.
+const maxSvgTriangleFloats = 1_200_000
+
 func (b *Backend) drawSvg(r *gui.RenderCmd) {
 	if r.IsClipMask {
 		return
 	}
-	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
+	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 ||
+		len(r.Triangles) > maxSvgTriangleFloats {
 		return
 	}
 	numVerts := len(r.Triangles) / 2

--- a/gui/backend/web/termgrid.go
+++ b/gui/backend/web/termgrid.go
@@ -1,0 +1,269 @@
+//go:build js && wasm
+
+package web
+
+import (
+	"math"
+
+	"github.com/go-gui-org/go-glyph"
+
+	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/internal/glyphconv"
+)
+
+// defaultTermSelTint is the fallback selection highlight when the
+// caller leaves TermSelRange.Color unset. It matches the other
+// backends' fallback, so a terminal is the same picture on every
+// platform.
+var defaultTermSelTint = gui.RGBA(51, 153, 255, 100)
+
+// drawTermGrid renders a terminal character grid from a shared cell
+// buffer in a single pass: background fills, glyph runs (pinned to
+// exact cell columns via DrawLayoutPlaced so the grid never drifts),
+// then cursor and selection overlays. No per-cell Layout nodes exist.
+//
+// It is a port of gui/backend/metal/termgrid.go over this package's
+// Canvas2D rect fill and text system. Attribute support (v1):
+// reverse (swaps fg/bg) and underline are honored; bold/italic are
+// reserved in TermAttr but not yet rendered.
+func (b *Backend) drawTermGrid(r *gui.RenderCmd) {
+	tg := r.TermGrid
+	if b.textSys == nil || tg == nil || tg.Cols <= 0 || tg.Rows <= 0 ||
+		tg.CellW <= 0 || math.IsNaN(float64(tg.CellW)) || math.IsInf(float64(tg.CellW), 0) ||
+		tg.CellH <= 0 || math.IsNaN(float64(tg.CellH)) || math.IsInf(float64(tg.CellH), 0) ||
+		// Division form: a hostile Cols*Rows must not overflow the
+		// check itself. Cols > 0 is established above.
+		tg.Rows > len(tg.Cells)/tg.Cols {
+		return
+	}
+	gx, gy := r.X, r.Y
+	cw, ch := tg.CellW, tg.CellH
+
+	cfg := glyphconv.GuiStyleToGlyphConfig(tg.Style)
+	ascent := ch * 0.8
+	if m, err := b.textSys.FontMetrics(cfg); err == nil && m.Ascender > 0 {
+		ascent = m.Ascender
+	}
+
+	b.termGridBackgrounds(tg, gx, gy, cw, ch)
+	b.termGridSelection(tg, gx, gy, cw, ch)
+	b.termGridCursorUnder(tg, gx, gy, cw, ch)
+	b.termGridGlyphs(tg, cfg, gx, gy, cw, ch, ascent)
+	b.termGridDecorations(tg, gx, gy, cw, ch)
+}
+
+// termCellFB returns the effective foreground/background for a cell,
+// applying the reverse attribute.
+func termCellFB(c *gui.TermCell) (fg, bg gui.Color) {
+	fg, bg = c.FG, c.BG
+	if c.Attrs&gui.TermReverse != 0 {
+		fg, bg = bg, fg
+	}
+	return fg, bg
+}
+
+// termGridBackgrounds fills batched runs of same-background cells.
+func (b *Backend) termGridBackgrounds(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	for row := 0; row < tg.Rows; row++ {
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			_, bg := termCellFB(c)
+			if bg.A == 0 {
+				col++
+				continue
+			}
+			start := col
+			for col < tg.Cols {
+				_, nbg := termCellFB(&tg.Cells[row*tg.Cols+col])
+				if nbg != bg {
+					break
+				}
+				col++
+			}
+			b.fillTermRect(
+				gx+float32(start)*cw, gy+float32(row)*ch,
+				float32(col-start)*cw, ch, bg)
+		}
+	}
+}
+
+// termGridSelection tints the selected cell range per row.
+func (b *Backend) termGridSelection(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	sel := tg.Selection
+	if sel.End <= sel.Start {
+		return
+	}
+	tint := sel.Color
+	if tint.A == 0 {
+		tint = defaultTermSelTint
+	}
+	total := tg.Cols * tg.Rows
+	beg := max(sel.Start, 0)
+	end := min(sel.End, total)
+	for row := 0; row < tg.Rows && beg < end; row++ {
+		rowStart := row * tg.Cols
+		rowEnd := rowStart + tg.Cols
+		s := max(beg, rowStart)
+		e := min(end, rowEnd)
+		if s >= e {
+			continue
+		}
+		c0 := s - rowStart
+		c1 := e - rowStart
+		b.fillTermRect(
+			gx+float32(c0)*cw, gy+float32(row)*ch,
+			float32(c1-c0)*cw, ch, tint)
+	}
+}
+
+// termGridCursorUnder draws the block cursor beneath the glyphs so the
+// character remains visible on top.
+func (b *Backend) termGridCursorUnder(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	cur := tg.Cursor
+	if !cur.Visible || cur.Style != gui.TermCursorBlock ||
+		cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	b.fillTermRect(
+		gx+float32(cur.Col)*cw, gy+float32(cur.Row)*ch,
+		cw, ch, cur.Color)
+}
+
+// termGridGlyphs shapes each row into foreground-color runs and draws
+// them with glyphs pinned to their cell columns.
+func (b *Backend) termGridGlyphs(
+	tg *gui.TermGridData, cfg glyph.TextConfig,
+	gx, gy, cw, ch, ascent float32,
+) {
+	for row := 0; row < tg.Rows; row++ {
+		baseline := gy + float32(row)*ch + ascent
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Width == 0 { // continuation of a wide cell
+				col++
+				continue
+			}
+			fg, _ := termCellFB(c)
+			// Extend a run of glyphs sharing this foreground color.
+			b.termGridRunReset()
+			runFG := fg
+			for col < tg.Cols {
+				cell := &tg.Cells[row*tg.Cols+col]
+				if cell.Width == 0 {
+					col++
+					continue
+				}
+				fg2, _ := termCellFB(cell)
+				blank := cell.Ch == 0 || cell.Ch == ' '
+				if !blank && fg2 != runFG {
+					break
+				}
+				if blank {
+					b.termGridRunAppend(' ', col)
+				} else {
+					b.termGridRunAppend(cell.Ch, col)
+				}
+				col++
+			}
+			b.termGridDrawRun(cfg, runFG, gx, baseline, cw)
+		}
+	}
+}
+
+// termGridDecorations draws underline attributes and the bar /
+// underline cursor styles on top of the glyphs.
+func (b *Backend) termGridDecorations(
+	tg *gui.TermGridData, gx, gy, cw, ch float32,
+) {
+	thick := max(ch*0.08, 1)
+	for row := 0; row < tg.Rows; row++ {
+		for col := 0; col < tg.Cols; col++ {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Attrs&gui.TermUnderline == 0 {
+				continue
+			}
+			fg, _ := termCellFB(c)
+			b.fillTermRect(
+				gx+float32(col)*cw, gy+float32(row+1)*ch-thick,
+				cw, thick, fg)
+		}
+	}
+
+	cur := tg.Cursor
+	if !cur.Visible || cur.Col < 0 || cur.Col >= tg.Cols ||
+		cur.Row < 0 || cur.Row >= tg.Rows {
+		return
+	}
+	x := gx + float32(cur.Col)*cw
+	y := gy + float32(cur.Row)*ch
+	switch cur.Style {
+	case gui.TermCursorBar:
+		b.fillTermRect(x, y, max(cw*0.15, 1), ch, cur.Color)
+	case gui.TermCursorUnderline:
+		b.fillTermRect(x, y+ch-thick, cw, thick, cur.Color)
+	case gui.TermCursorBlock:
+		// Drawn under the glyph in termGridCursorUnder.
+	}
+}
+
+// --- run assembly helpers (reuse scratch buffers) ---
+
+func (b *Backend) termGridRunReset() {
+	b.termRunText = b.termRunText[:0]
+	b.termRunCols = b.termRunCols[:0]
+}
+
+func (b *Backend) termGridRunAppend(ch rune, col int) {
+	b.termRunText = append(b.termRunText, ch)
+	b.termRunCols = append(b.termRunCols, col)
+}
+
+// termGridDrawRun shapes the accumulated run and draws its glyphs at
+// fixed cell columns. Falls back to natural flow if the shaper does
+// not produce one glyph per cell (e.g. clustered non-ASCII runs).
+func (b *Backend) termGridDrawRun(
+	cfg glyph.TextConfig, fg gui.Color, gx, baseline, cw float32,
+) {
+	if len(b.termRunCols) == 0 {
+		return
+	}
+	cfg.Style.Color = glyph.Color{R: fg.R, G: fg.G, B: fg.B, A: fg.A}
+	layout, err := b.textSys.LayoutText(string(b.termRunText), cfg)
+	if err != nil {
+		return
+	}
+	if len(layout.Glyphs) != len(b.termRunCols) {
+		// Cluster/ligature mismatch — draw at the run's first column.
+		b.textSys.DrawLayout(layout, gx+float32(b.termRunCols[0])*cw, baseline)
+		return
+	}
+	b.termPlace = b.termPlace[:0]
+	for _, col := range b.termRunCols {
+		b.termPlace = append(b.termPlace, glyph.GlyphPlacement{
+			X: gx + float32(col)*cw,
+			Y: baseline,
+		})
+	}
+	b.textSys.DrawLayoutPlaced(layout, b.termPlace)
+}
+
+// fillTermRect fills one solid rect given in logical coordinates.
+func (b *Backend) fillTermRect(x, y, w, h float32, c gui.Color) {
+	if w <= 0 || h <= 0 || c.A == 0 {
+		return
+	}
+	cmd := gui.RenderCmd{
+		Kind: gui.RenderRect, X: x, Y: y, W: w, H: h,
+		Color: c, Fill: true,
+	}
+	b.drawRect(&cmd)
+}

--- a/gui/canvas_draw_image_test.go
+++ b/gui/canvas_draw_image_test.go
@@ -24,7 +24,7 @@ func TestEmitDrawCanvasImagesLocalPath(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: path,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, &Shape{Opacity: 1}, w)
 
 	found := false
 	for _, r := range w.renderers {
@@ -63,7 +63,7 @@ func TestEmitDrawCanvasImagesHTTPInFlight(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: url,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, &Shape{Opacity: 1}, w)
 
 	for _, r := range w.renderers {
 		if r.Kind == RenderImage {
@@ -95,7 +95,7 @@ func TestEmitDrawCanvasImagesHTTPCached(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: url,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, &Shape{Opacity: 1}, w)
 
 	found := false
 	for _, r := range w.renderers {
@@ -117,7 +117,7 @@ func TestEmitDrawCanvasImagesDataURL(t *testing.T) {
 		X: 0, Y: 0, W: 10, H: 10,
 		Src: src,
 	}}
-	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, &Shape{Opacity: 1}, w)
 
 	found := false
 	for _, r := range w.renderers {
@@ -152,7 +152,7 @@ func TestEmitDrawCanvasImagesClipped(t *testing.T) {
 		},
 		{X: 0, Y: 0, W: 100, H: 100, Src: path},
 	}
-	emitDrawCanvasImages(entries, 5, 5, testFullClip, w)
+	emitDrawCanvasImages(entries, 5, 5, testFullClip, &Shape{Opacity: 1}, w)
 
 	var kinds []renderKind
 	var clips []RenderCmd
@@ -257,7 +257,7 @@ func TestEmitDrawCanvasImagesConsecutiveClipped(t *testing.T) {
 			ClipX: 20, ClipY: 20, ClipW: 30, ClipH: 30, Clipped: true,
 		},
 	}
-	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, &Shape{Opacity: 1}, w)
 
 	var kinds []renderKind
 	for _, r := range w.renderers {
@@ -290,7 +290,7 @@ func TestEmitDrawCanvasImagesAllClippedRestoreAtEnd(t *testing.T) {
 			ClipX: 0, ClipY: 0, ClipW: 40, ClipH: 40, Clipped: true,
 		},
 	}
-	emitDrawCanvasImages(entries, 0, 0, testFullClip, w)
+	emitDrawCanvasImages(entries, 0, 0, testFullClip, &Shape{Opacity: 1}, w)
 
 	nClips := 0
 	for _, r := range w.renderers {
@@ -319,7 +319,7 @@ func TestEmitDrawCanvasImagesClippedAway(t *testing.T) {
 		ClipX: 500, ClipY: 500, ClipW: 10, ClipH: 10, Clipped: true,
 	}}
 	emitDrawCanvasImages(entries, 0, 0,
-		drawClip{X: 0, Y: 0, Width: 100, Height: 100}, w)
+		drawClip{X: 0, Y: 0, Width: 100, Height: 100}, &Shape{Opacity: 1}, w)
 
 	for _, r := range w.renderers {
 		if r.Kind == RenderImage {

--- a/gui/golden_test.go
+++ b/gui/golden_test.go
@@ -202,6 +202,22 @@ func colorStr(c Color) string {
 	return fmt.Sprintf("#%02x%02x%02x%02x", c.R, c.G, c.B, c.A)
 }
 
+// matrixStr renders a 4x4 color matrix as a diffable token. A filter
+// bracket with the wrong matrix paints the wrong glow, and presence
+// alone cannot see it.
+func matrixStr(m *[16]float32) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, v := range m {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(f2(v))
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
 // serializeCmd renders one command as a single line. Only fields
 // meaningful for the kind are emitted, so a golden stays readable and
 // a diff points at what actually changed.
@@ -244,6 +260,9 @@ func serializeCmd(c RenderCmd) string {
 		}
 	case RenderImage:
 		fmt.Fprintf(&b, " res=%q", c.Resource)
+		if c.ClipRadius != 0 {
+			b.WriteString(" cradius=" + f2(c.ClipRadius))
+		}
 	case RenderSvg:
 		fmt.Fprintf(&b, " tris=%d", len(c.Triangles))
 		// A vertex-colored batch is a gradient fill. Record the count
@@ -275,6 +294,25 @@ func serializeCmd(c RenderCmd) string {
 		if c.Spread != 0 {
 			b.WriteString(" spread=" + f2(c.Spread))
 		}
+	case RenderRotateBegin:
+		fmt.Fprintf(&b, " rot=%s@%s,%s",
+			f2(c.RotAngle), f2(c.RotCX), f2(c.RotCY))
+	case RenderStencilBegin, RenderStencilEnd:
+		fmt.Fprintf(&b, " sdepth=%d", c.StencilDepth)
+	case RenderFilterBegin, RenderFilterComposite:
+		fmt.Fprintf(&b, " layers=%d", c.Layers)
+		if c.ColorMatrix != nil {
+			b.WriteString(" cmatrix=" + matrixStr(c.ColorMatrix))
+		}
+	case RenderTermGrid:
+		if c.TermGrid != nil {
+			tg := c.TermGrid
+			fmt.Fprintf(&b, " grid=%dx%d cell=%s,%s cells=%d",
+				tg.Cols, tg.Rows,
+				f2(tg.CellW), f2(tg.CellH), len(tg.Cells))
+		} else {
+			b.WriteString(" grid=nil")
+		}
 	}
 
 	// Pointers are fingerprinted by presence. Dereferencing them
@@ -287,7 +325,8 @@ func serializeCmd(c RenderCmd) string {
 		b.WriteString(" +shader")
 	}
 	if c.LayoutPtr != nil {
-		b.WriteString(" +glyphlayout")
+		fmt.Fprintf(&b, " +glyphlayout glyphs=%d items=%d",
+			len(c.LayoutPtr.Glyphs), len(c.LayoutPtr.Items))
 	}
 	if c.LayoutTransform != nil && c.Kind != RenderText {
 		t := c.LayoutTransform

--- a/gui/print_pdf.go
+++ b/gui/print_pdf.go
@@ -6,13 +6,10 @@ import (
 	"fmt"
 	"image"
 	"image/png"
-	"math"
 	"os"
 	"strings"
 	"time"
-	"unicode"
 
-	"github.com/go-gui-org/go-glyph"
 	"github.com/go-pdf/fpdf"
 )
 
@@ -37,6 +34,8 @@ func (c *pdfCtx) ph(h float32) float64 { return float64(h * c.scale) }
 // renderToPDF renders a slice of RenderCmd to a PDF file at
 // job.OutputPath. sourceW and sourceH are the source viewport
 // dimensions in pixels (points).
+//
+//nolint:gocyclo // render command kind dispatch
 func renderToPDF(renderers []RenderCmd, job PrintJob,
 	sourceW, sourceH float32) error {
 
@@ -99,6 +98,7 @@ func renderToPDF(renderers []RenderCmd, job PrintJob,
 
 	var clipStack []clipEntry
 	var stencilClipDepth int
+	var rotateDepth int
 
 	for _, cmd := range renderers {
 		switch cmd.Kind {
@@ -126,14 +126,34 @@ func renderToPDF(renderers []RenderCmd, job PrintJob,
 			pdfRenderLayout(&ctx, cmd)
 		case RenderTextPath:
 			pdfRenderTextPath(&ctx, cmd)
+		case RenderTermGrid:
+			pdfRenderTermGrid(&ctx, cmd)
 		case RenderStencilBegin:
 			pdfRenderStencilBegin(&ctx, cmd, &stencilClipDepth)
 		case RenderStencilEnd:
 			pdfRenderStencilEnd(&ctx, &stencilClipDepth)
+		case RenderRotateBegin:
+			pdf.TransformBegin()
+			// Screen turns are clockwise (RotatedBoxCfg);
+			// fpdf measures counter-clockwise.
+			pdf.TransformRotate(-float64(cmd.RotAngle),
+				ctx.px(cmd.RotCX), ctx.py(cmd.RotCY))
+			rotateDepth++
+		case RenderRotateEnd:
+			if rotateDepth > 0 {
+				rotateDepth--
+				pdf.TransformEnd()
+			}
+		case RenderNone:
+			// Marker only.
+			continue
 		case RenderShadow, RenderBlur, RenderFilterBegin,
 			RenderFilterEnd, RenderFilterComposite,
-			RenderCustomShader,
-			RenderLayoutPlaced, RenderNone:
+			RenderCustomShader, RenderLayoutPlaced:
+			// No PDF equivalent: glow/blur need raster
+			// compositing, shaders need GLSL, and placed
+			// layouts are positioning metadata. Skipped
+			// rather than approximated.
 			continue
 		}
 	}
@@ -144,6 +164,9 @@ func renderToPDF(renderers []RenderCmd, job PrintJob,
 	}
 	for range clipStack {
 		pdf.ClipEnd()
+	}
+	for range rotateDepth {
+		pdf.TransformEnd()
 	}
 
 	if pdf.Err() {
@@ -182,101 +205,6 @@ func pdfRenderStrokeRect(ctx *pdfCtx, cmd RenderCmd) {
 	} else {
 		ctx.pdf.Rect(ctx.px(cmd.X), ctx.py(cmd.Y),
 			ctx.pw(cmd.W), ctx.ph(cmd.H), "D")
-	}
-	if alphaSet {
-		resetAlpha(ctx.pdf)
-	}
-}
-
-func pdfRenderText(ctx *pdfCtx, cmd RenderCmd) {
-	text := ctx.tr(stripUnprintable(cmd.Text))
-	if text == "" {
-		return
-	}
-	tc := cmd.Color
-	// Gradient text: use first stop color as fallback
-	// (true gradient fill not supported in built-in PDF
-	// fonts).
-	if cmd.TextGradient != nil &&
-		len(cmd.TextGradient.Stops) > 0 {
-		gc := cmd.TextGradient.Stops[0].Color
-		tc = RGBA(gc.R, gc.G, gc.B, gc.A)
-	}
-	r, g, b := tc.R, tc.G, tc.B
-	ctx.pdf.SetTextColor(int(r), int(g), int(b))
-	alphaSet := setAlpha(ctx.pdf, tc)
-	family := pdfFontName(cmd.FontName)
-	style := pdfFontStyle(cmd.TextStylePtr)
-	size := float64(cmd.FontSize * ctx.scale / ptToMM)
-	ctx.pdf.SetFont(family, style, size)
-
-	// Scale font so PDF text width matches source.
-	// Built-in PDF fonts have different metrics than
-	// the system font used by glyph.
-	if cmd.TextWidth > 0 && !strings.Contains(text, "\n") {
-		wantW := float64(cmd.TextWidth) * float64(ctx.scale)
-		pdfW := ctx.pdf.GetStringWidth(text)
-		if pdfW > 0 && wantW > 0 {
-			size *= wantW / pdfW
-			ctx.pdf.SetFont(family, style, size)
-		}
-	}
-
-	// Y is top of text box; fpdf expects baseline.
-	// Use actual font ascent when available; fall back
-	// to 75% of em for SVG text and other paths that
-	// don't populate FontAscent.
-	fa := cmd.FontAscent
-	if fa == 0 {
-		fa = cmd.FontSize * 0.75
-	}
-	ascent := float64(fa * ctx.scale)
-	lineH := size * ptToMM64() * 1.2
-	lines := strings.Split(text, "\n")
-	// Affine canvas text: apply the same transform the
-	// screen backends see. Keep the transform around the
-	// text origin so a skew around (X,Y) does not skew
-	// around the page origin. The generic matrix is
-	// sufficient; per-glyph curvature is out of scope.
-	hasXform := cmd.LayoutTransform != nil
-	if hasXform {
-		t := *cmd.LayoutTransform
-		mx := ctx.px(cmd.X)
-		my := ctx.py(cmd.Y)
-		ctx.pdf.TransformBegin()
-		// T(mx,my) * Affine * T(-mx,-my) in PDF
-		// coordinates (Y already flipped in mx/my).
-		// For the common case (XX/YY near 1, XY/YX
-		// skew), this keeps the text at its origin.
-		// X0/Y0 are in logical px; scale to mm.
-		e := mx*(1-float64(t.XX)) - my*float64(t.XY) +
-			float64(t.X0*ctx.scale)
-		f := my*(1-float64(t.YY)) - mx*float64(t.YX) +
-			float64(t.Y0*ctx.scale)
-		ctx.pdf.Transform(fpdf.TransformMatrix{
-			A: float64(t.XX), B: float64(t.YX),
-			C: float64(t.XY), D: float64(t.YY),
-			E: e, F: f,
-		})
-	}
-	for i, line := range lines {
-		ctx.pdf.Text(ctx.px(cmd.X),
-			ctx.py(cmd.Y)+ascent+float64(i)*lineH, line)
-	}
-
-	// Strikethrough — fpdf has no built-in support.
-	if cmd.TextStylePtr != nil && cmd.TextStylePtr.Strikethrough {
-		ctx.pdf.SetDrawColor(int(r), int(g), int(b))
-		lw := max(float64(ctx.scale)*0.5, 0.1)
-		ctx.pdf.SetLineWidth(lw)
-		for i, line := range lines {
-			lineW := ctx.pdf.GetStringWidth(line)
-			sy := ctx.py(cmd.Y) + ascent*0.65 + float64(i)*lineH
-			ctx.pdf.Line(ctx.px(cmd.X), sy, ctx.px(cmd.X)+lineW, sy)
-		}
-	}
-	if hasXform {
-		ctx.pdf.TransformEnd()
 	}
 	if alphaSet {
 		resetAlpha(ctx.pdf)
@@ -545,75 +473,100 @@ func pdfRenderLayout(ctx *pdfCtx, cmd RenderCmd) {
 	}
 }
 
-func pdfRenderTextPath(ctx *pdfCtx, cmd RenderCmd) {
-	tp := cmd.textPath
-	if tp == nil || cmd.TextStylePtr == nil || cmd.Text == "" {
+// pdfTermCellFB returns the effective foreground/background for a
+// cell, applying the reverse attribute. Mirrors the GPU backends'
+// per-cell resolution so print matches the screen.
+func pdfTermCellFB(c *TermCell) (fg, bg Color) {
+	fg, bg = c.FG, c.BG
+	if c.Attrs&TermReverse != 0 {
+		fg, bg = bg, fg
+	}
+	return fg, bg
+}
+
+// pdfRenderTermGrid prints a terminal grid as background rects plus
+// one text run per foreground-color run. Each run is width-pinned
+// via TextWidth, so the PDF matches source columns regardless of
+// built-in font metrics. Selection, cursor and underlines are
+// decorations of a live view and are not printed.
+func pdfRenderTermGrid(ctx *pdfCtx, cmd RenderCmd) {
+	tg := cmd.TermGrid
+	if tg == nil || tg.Cols <= 0 || tg.Rows <= 0 ||
+		tg.CellW <= 0 || tg.CellH <= 0 ||
+		// Division form: a hostile Cols*Rows must not overflow the
+		// check itself. Cols > 0 is established above.
+		tg.Rows > len(tg.Cells)/tg.Cols {
 		return
 	}
-	text := ctx.tr(stripUnprintable(cmd.Text))
-	if text == "" {
-		return
+	sz := tg.Style.Size
+	if sz <= 0 {
+		sz = tg.CellH * 0.75
 	}
-	ts := cmd.TextStylePtr
-	r, g, b := ts.Color.R, ts.Color.G, ts.Color.B
-	ctx.pdf.SetTextColor(int(r), int(g), int(b))
-	alphaSet := setAlpha(ctx.pdf, ts.Color)
-	family := pdfFontName(ts.Family)
-	style := pdfFontStyle(ts)
-	size := float64(ts.Size * ctx.scale / ptToMM)
-	ctx.pdf.SetFont(family, style, size)
-
-	// Measure per-character advances with fpdf.
-	runes := []rune(text)
-	advances := make([]float64, len(runes))
-	var totalAdv float64
-	for i, ch := range runes {
-		advances[i] = ctx.pdf.GetStringWidth(string(ch))
-		totalAdv += advances[i]
-	}
-
-	// Apply text-anchor offset.
-	offset := float64(tp.Offset * ctx.scale)
-	switch tp.Anchor {
-	case SvgTextAnchorMiddle:
-		offset -= totalAdv / 2
-	case SvgTextAnchorEnd:
-		offset -= totalAdv
-	}
-
-	// Method=stretch: scale advances to fill path.
-	advScale := 1.0
-	if tp.method == svgTextPathMethodStretch && totalAdv > 0 {
-		remaining := float64(tp.totalLen*ctx.scale) - offset
-		if remaining > 0 {
-			advScale = remaining / totalAdv
+	// One run buffer for the whole grid: a print walks every cell,
+	// so a per-run append would allocate once per color change.
+	var run []rune
+	for row := range tg.Rows {
+		y := cmd.Y + float32(row)*tg.CellH
+		col := 0
+		for col < tg.Cols {
+			c := &tg.Cells[row*tg.Cols+col]
+			if c.Width == 0 { // continuation of a wide cell
+				col++
+				continue
+			}
+			fg, bg := pdfTermCellFB(c)
+			start := col
+			run = run[:0]
+			for col < tg.Cols {
+				cell := &tg.Cells[row*tg.Cols+col]
+				if cell.Width == 0 {
+					col++
+					continue
+				}
+				fg2, bg2 := pdfTermCellFB(cell)
+				// A background change always ends the run; a
+				// foreground change only ends it on a cell that
+				// paints a glyph, so blanks join either side.
+				if bg2 != bg {
+					break
+				}
+				blank := cell.Ch == 0 || cell.Ch == ' '
+				if !blank && fg2 != fg {
+					break
+				}
+				if blank {
+					run = append(run, ' ')
+				} else {
+					run = append(run, cell.Ch)
+				}
+				col++
+			}
+			w := float32(col-start) * tg.CellW
+			if bg.A > 0 && w > 0 {
+				pdfRenderRect(ctx, RenderCmd{
+					Kind:  RenderRect,
+					X:     cmd.X + float32(start)*tg.CellW,
+					Y:     y,
+					W:     w,
+					H:     tg.CellH,
+					Color: bg,
+					Fill:  true,
+				})
+			}
+			if len(run) > 0 && fg.A > 0 {
+				pdfRenderText(ctx, RenderCmd{
+					Kind:       RenderText,
+					Text:       string(run),
+					X:          cmd.X + float32(start)*tg.CellW,
+					Y:          y,
+					Color:      fg,
+					FontName:   tg.Style.Family,
+					FontSize:   sz,
+					FontAscent: tg.CellH * 0.8,
+					TextWidth:  w,
+				})
+			}
 		}
-	}
-
-	// Place each character along the path.
-	cumAdv := 0.0
-	for i, ch := range runes {
-		adv := advances[i] * advScale
-		centerDist := float32((offset + cumAdv + adv/2) / float64(ctx.scale))
-		pathX, pathY, angle := samplePathAt(
-			tp.Polyline, tp.Table, centerDist)
-		halfAdv := float32(adv / 2 / float64(ctx.scale))
-		cosA := float32(math.Cos(float64(angle)))
-		sinA := float32(math.Sin(float64(angle)))
-		gx := pathX + cmd.X - halfAdv*cosA
-		gy := pathY + cmd.Y - halfAdv*sinA
-
-		angleDeg := float64(angle) * 180 / math.Pi
-		mx := ctx.px(gx)
-		my := ctx.py(gy)
-		ctx.pdf.TransformBegin()
-		ctx.pdf.TransformRotate(-angleDeg, mx, my)
-		ctx.pdf.Text(mx, my, string(ch))
-		ctx.pdf.TransformEnd()
-		cumAdv += adv
-	}
-	if alphaSet {
-		resetAlpha(ctx.pdf)
 	}
 }
 
@@ -632,74 +585,6 @@ func pdfRenderStencilEnd(ctx *pdfCtx, depth *int) {
 		ctx.pdf.ClipEnd()
 		*depth--
 	}
-}
-
-// pdfFontStyle returns an fpdf style string ("B", "I", "BI", "U",
-// etc.) derived from a TextStyle. Returns "" when ts is nil.
-func pdfFontStyle(ts *TextStyle) string {
-	if ts == nil {
-		return ""
-	}
-	bold := ts.Typeface == glyph.TypefaceBold ||
-		ts.Typeface == glyph.TypefaceBoldItalic
-	italic := ts.Typeface == glyph.TypefaceItalic ||
-		ts.Typeface == glyph.TypefaceBoldItalic
-
-	// SVG text encodes weight/style in the Pango font name
-	// (e.g. "Sans Bold") rather than in Typeface.
-	if !bold || !italic {
-		lower := strings.ToLower(ts.Family)
-		if !bold && strings.Contains(lower, "bold") {
-			bold = true
-		}
-		if !italic && strings.Contains(lower, "italic") {
-			italic = true
-		}
-	}
-
-	var s string
-	if bold {
-		s += "B"
-	}
-	if italic {
-		s += "I"
-	}
-	if ts.Underline {
-		s += "U"
-	}
-	return s
-}
-
-// pdfFontName maps a gui font family name to a built-in PDF font.
-func pdfFontName(name string) string {
-	lower := strings.ToLower(name)
-	switch {
-	case strings.Contains(lower, "mono"),
-		strings.Contains(lower, "courier"),
-		strings.Contains(lower, "consol"):
-		return "Courier"
-	case strings.Contains(lower, "serif") &&
-		!strings.Contains(lower, "sans"):
-		return "Times"
-	case strings.Contains(lower, "georgia"),
-		strings.Contains(lower, "times"),
-		strings.Contains(lower, "palatino"),
-		strings.Contains(lower, "garamond"):
-		return "Times"
-	default:
-		return "Helvetica"
-	}
-}
-
-// stripUnprintable removes Private Use Area and other non-printable
-// runes that built-in PDF fonts cannot render.
-func stripUnprintable(s string) string {
-	return strings.Map(func(r rune) rune {
-		if unicode.In(r, unicode.Co) { // Co = Private Use
-			return -1
-		}
-		return r
-	}, s)
 }
 
 // ptToMM64 returns ptToMM as float64 (used for font baseline).

--- a/gui/print_pdf_test.go
+++ b/gui/print_pdf_test.go
@@ -747,3 +747,52 @@ func TestRenderToPDF_SvgTrianglesXform(t *testing.T) {
 	}
 	assertPDFExists(t, j.OutputPath)
 }
+
+func TestRenderToPDF_RotateBracket(t *testing.T) {
+	j := testPrintJob(t)
+	cmds := []RenderCmd{{
+		Kind: RenderRotateBegin, RotAngle: 90, RotCX: 60, RotCY: 35,
+	}, {
+		Kind: RenderRect, X: 10, Y: 10, W: 100, H: 50,
+		Color: RGBA(255, 0, 0, 255),
+	}, {
+		Kind: RenderRotateEnd,
+	}}
+	if err := renderToPDF(cmds, j, 800, 600); err != nil {
+		t.Fatal(err)
+	}
+	assertPDFExists(t, j.OutputPath)
+}
+
+func TestRenderToPDF_TermGrid(t *testing.T) {
+	j := testPrintJob(t)
+	cells := []TermCell{
+		{Ch: 'h', FG: RGBA(0, 0, 0, 255), Width: 1},
+		{Ch: 'i', FG: RGBA(0, 0, 0, 255), Width: 1},
+		{Ch: '!', FG: RGBA(200, 0, 0, 255),
+			BG: RGBA(255, 255, 200, 255), Width: 1},
+		{Ch: ' ', FG: RGBA(0, 0, 0, 255), Width: 1},
+	}
+	cmds := []RenderCmd{{
+		Kind: RenderTermGrid, X: 10, Y: 10, W: 32, H: 16,
+		TermGrid: &TermGridData{
+			Cells: cells, Cols: 4, Rows: 1, CellW: 8, CellH: 16,
+			Style: TextStyle{Family: "monospace", Size: 12},
+		},
+	}}
+	if err := renderToPDF(cmds, j, 800, 600); err != nil {
+		t.Fatal(err)
+	}
+	assertPDFExists(t, j.OutputPath)
+}
+
+func TestRenderToPDF_TermGridNil(t *testing.T) {
+	j := testPrintJob(t)
+	cmds := []RenderCmd{{
+		Kind: RenderTermGrid, X: 10, Y: 10, W: 32, H: 16,
+	}}
+	if err := renderToPDF(cmds, j, 800, 600); err != nil {
+		t.Fatal(err)
+	}
+	assertPDFExists(t, j.OutputPath)
+}

--- a/gui/print_pdf_text.go
+++ b/gui/print_pdf_text.go
@@ -1,0 +1,249 @@
+package gui
+
+import (
+	"math"
+	"strings"
+	"unicode"
+
+	"github.com/go-gui-org/go-glyph"
+	"github.com/go-pdf/fpdf"
+)
+
+// Text rendering for the PDF print backend: run placement, text-on-
+// path flattening, and the font-name/style mapping that turns a
+// TextStyle into one of fpdf's built-in families.
+
+func pdfRenderText(ctx *pdfCtx, cmd RenderCmd) {
+	text := ctx.tr(stripUnprintable(cmd.Text))
+	if text == "" {
+		return
+	}
+	tc := cmd.Color
+	// Gradient text: use first stop color as fallback
+	// (true gradient fill not supported in built-in PDF
+	// fonts).
+	if cmd.TextGradient != nil &&
+		len(cmd.TextGradient.Stops) > 0 {
+		gc := cmd.TextGradient.Stops[0].Color
+		tc = RGBA(gc.R, gc.G, gc.B, gc.A)
+	}
+	r, g, b := tc.R, tc.G, tc.B
+	ctx.pdf.SetTextColor(int(r), int(g), int(b))
+	alphaSet := setAlpha(ctx.pdf, tc)
+	family := pdfFontName(cmd.FontName)
+	style := pdfFontStyle(cmd.TextStylePtr)
+	size := float64(cmd.FontSize * ctx.scale / ptToMM)
+	ctx.pdf.SetFont(family, style, size)
+
+	// Scale font so PDF text width matches source.
+	// Built-in PDF fonts have different metrics than
+	// the system font used by glyph.
+	if cmd.TextWidth > 0 && !strings.Contains(text, "\n") {
+		wantW := float64(cmd.TextWidth) * float64(ctx.scale)
+		pdfW := ctx.pdf.GetStringWidth(text)
+		if pdfW > 0 && wantW > 0 {
+			size *= wantW / pdfW
+			ctx.pdf.SetFont(family, style, size)
+		}
+	}
+
+	// Y is top of text box; fpdf expects baseline.
+	// Use actual font ascent when available; fall back
+	// to 75% of em for SVG text and other paths that
+	// don't populate FontAscent.
+	fa := cmd.FontAscent
+	if fa == 0 {
+		fa = cmd.FontSize * 0.75
+	}
+	ascent := float64(fa * ctx.scale)
+	lineH := size * ptToMM64() * 1.2
+	lines := strings.Split(text, "\n")
+	// Affine canvas text: apply the same transform the
+	// screen backends see. Keep the transform around the
+	// text origin so a skew around (X,Y) does not skew
+	// around the page origin. The generic matrix is
+	// sufficient; per-glyph curvature is out of scope.
+	hasXform := cmd.LayoutTransform != nil
+	if hasXform {
+		t := *cmd.LayoutTransform
+		mx := ctx.px(cmd.X)
+		my := ctx.py(cmd.Y)
+		ctx.pdf.TransformBegin()
+		// T(mx,my) * Affine * T(-mx,-my) in PDF
+		// coordinates (Y already flipped in mx/my).
+		// For the common case (XX/YY near 1, XY/YX
+		// skew), this keeps the text at its origin.
+		// X0/Y0 are in logical px; scale to mm.
+		e := mx*(1-float64(t.XX)) - my*float64(t.XY) +
+			float64(t.X0*ctx.scale)
+		f := my*(1-float64(t.YY)) - mx*float64(t.YX) +
+			float64(t.Y0*ctx.scale)
+		ctx.pdf.Transform(fpdf.TransformMatrix{
+			A: float64(t.XX), B: float64(t.YX),
+			C: float64(t.XY), D: float64(t.YY),
+			E: e, F: f,
+		})
+	}
+	for i, line := range lines {
+		ctx.pdf.Text(ctx.px(cmd.X),
+			ctx.py(cmd.Y)+ascent+float64(i)*lineH, line)
+	}
+
+	// Strikethrough — fpdf has no built-in support.
+	if cmd.TextStylePtr != nil && cmd.TextStylePtr.Strikethrough {
+		ctx.pdf.SetDrawColor(int(r), int(g), int(b))
+		lw := max(float64(ctx.scale)*0.5, 0.1)
+		ctx.pdf.SetLineWidth(lw)
+		for i, line := range lines {
+			lineW := ctx.pdf.GetStringWidth(line)
+			sy := ctx.py(cmd.Y) + ascent*0.65 + float64(i)*lineH
+			ctx.pdf.Line(ctx.px(cmd.X), sy, ctx.px(cmd.X)+lineW, sy)
+		}
+	}
+	if hasXform {
+		ctx.pdf.TransformEnd()
+	}
+	if alphaSet {
+		resetAlpha(ctx.pdf)
+	}
+}
+
+func pdfRenderTextPath(ctx *pdfCtx, cmd RenderCmd) {
+	tp := cmd.textPath
+	if tp == nil || cmd.TextStylePtr == nil || cmd.Text == "" {
+		return
+	}
+	text := ctx.tr(stripUnprintable(cmd.Text))
+	if text == "" {
+		return
+	}
+	ts := cmd.TextStylePtr
+	r, g, b := ts.Color.R, ts.Color.G, ts.Color.B
+	ctx.pdf.SetTextColor(int(r), int(g), int(b))
+	alphaSet := setAlpha(ctx.pdf, ts.Color)
+	family := pdfFontName(ts.Family)
+	style := pdfFontStyle(ts)
+	size := float64(ts.Size * ctx.scale / ptToMM)
+	ctx.pdf.SetFont(family, style, size)
+
+	// Measure per-character advances with fpdf.
+	runes := []rune(text)
+	advances := make([]float64, len(runes))
+	var totalAdv float64
+	for i, ch := range runes {
+		advances[i] = ctx.pdf.GetStringWidth(string(ch))
+		totalAdv += advances[i]
+	}
+
+	// Apply text-anchor offset.
+	offset := float64(tp.Offset * ctx.scale)
+	switch tp.Anchor {
+	case SvgTextAnchorMiddle:
+		offset -= totalAdv / 2
+	case SvgTextAnchorEnd:
+		offset -= totalAdv
+	}
+
+	// Method=stretch: scale advances to fill path.
+	advScale := 1.0
+	if tp.method == svgTextPathMethodStretch && totalAdv > 0 {
+		remaining := float64(tp.totalLen*ctx.scale) - offset
+		if remaining > 0 {
+			advScale = remaining / totalAdv
+		}
+	}
+
+	// Place each character along the path.
+	cumAdv := 0.0
+	for i, ch := range runes {
+		adv := advances[i] * advScale
+		centerDist := float32((offset + cumAdv + adv/2) / float64(ctx.scale))
+		pathX, pathY, angle := samplePathAt(
+			tp.Polyline, tp.Table, centerDist)
+		halfAdv := float32(adv / 2 / float64(ctx.scale))
+		cosA := float32(math.Cos(float64(angle)))
+		sinA := float32(math.Sin(float64(angle)))
+		gx := pathX + cmd.X - halfAdv*cosA
+		gy := pathY + cmd.Y - halfAdv*sinA
+
+		angleDeg := float64(angle) * 180 / math.Pi
+		mx := ctx.px(gx)
+		my := ctx.py(gy)
+		ctx.pdf.TransformBegin()
+		ctx.pdf.TransformRotate(-angleDeg, mx, my)
+		ctx.pdf.Text(mx, my, string(ch))
+		ctx.pdf.TransformEnd()
+		cumAdv += adv
+	}
+	if alphaSet {
+		resetAlpha(ctx.pdf)
+	}
+}
+
+// pdfFontStyle returns an fpdf style string ("B", "I", "BI", "U",
+// etc.) derived from a TextStyle. Returns "" when ts is nil.
+func pdfFontStyle(ts *TextStyle) string {
+	if ts == nil {
+		return ""
+	}
+	bold := ts.Typeface == glyph.TypefaceBold ||
+		ts.Typeface == glyph.TypefaceBoldItalic
+	italic := ts.Typeface == glyph.TypefaceItalic ||
+		ts.Typeface == glyph.TypefaceBoldItalic
+
+	// SVG text encodes weight/style in the Pango font name
+	// (e.g. "Sans Bold") rather than in Typeface.
+	if !bold || !italic {
+		lower := strings.ToLower(ts.Family)
+		if !bold && strings.Contains(lower, "bold") {
+			bold = true
+		}
+		if !italic && strings.Contains(lower, "italic") {
+			italic = true
+		}
+	}
+
+	var s string
+	if bold {
+		s += "B"
+	}
+	if italic {
+		s += "I"
+	}
+	if ts.Underline {
+		s += "U"
+	}
+	return s
+}
+
+// pdfFontName maps a gui font family name to a built-in PDF font.
+func pdfFontName(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.Contains(lower, "mono"),
+		strings.Contains(lower, "courier"),
+		strings.Contains(lower, "consol"):
+		return "Courier"
+	case strings.Contains(lower, "serif") &&
+		!strings.Contains(lower, "sans"):
+		return "Times"
+	case strings.Contains(lower, "georgia"),
+		strings.Contains(lower, "times"),
+		strings.Contains(lower, "palatino"),
+		strings.Contains(lower, "garamond"):
+		return "Times"
+	default:
+		return "Helvetica"
+	}
+}
+
+// stripUnprintable removes Private Use Area and other non-printable
+// runes that built-in PDF fonts cannot render.
+func stripUnprintable(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.In(r, unicode.Co) { // Co = Private Use
+			return -1
+		}
+		return r
+	}, s)
+}

--- a/gui/render_dim_test.go
+++ b/gui/render_dim_test.go
@@ -1,0 +1,352 @@
+package gui
+
+import (
+	"math"
+	"testing"
+
+	"github.com/go-gui-org/go-glyph"
+)
+
+func TestDimColorOrdersOpacityBeforeDisabled(t *testing.T) {
+	c := dimColor(RGBA(10, 20, 30, 200), 0.5, true)
+	// 200*0.5=100, then halved to 50. RGB untouched.
+	if c != RGBA(10, 20, 30, 50) {
+		t.Fatalf("got %v, want alpha 50", c)
+	}
+}
+
+func TestDimColorFastPathIsIdentity(t *testing.T) {
+	c := RGBA(10, 20, 30, 200)
+	if got := dimColor(c, 1.0, false); got != c {
+		t.Fatalf("enabled full-opacity must not touch color: %v", got)
+	}
+	if got := dimColor(c, float32(math.NaN()), false); got != c {
+		t.Fatalf("NaN opacity must apply nothing, like renderShape: %v",
+			got)
+	}
+}
+
+func TestDimmedGradientFastPathKeepsPointer(t *testing.T) {
+	def := &GradientDef{Stops: []GradientStop{
+		{Color: RGBA(255, 0, 0, 255), Pos: 0},
+		{Color: RGBA(0, 0, 255, 255), Pos: 1},
+	}}
+	if dimmedGradient(nil, 0.5, true) != nil {
+		t.Fatal("nil gradient must stay nil")
+	}
+	if got := dimmedGradient(def, 1.0, false); got != def {
+		t.Fatal("enabled gradient must keep its pointer (no copy)")
+	}
+}
+
+func TestDimmedGradientDimsStopsWithoutMutatingSource(t *testing.T) {
+	def := &GradientDef{Stops: []GradientStop{
+		{Color: RGBA(255, 0, 0, 200), Pos: 0},
+	}}
+	got := dimmedGradient(def, 0.5, true)
+	if got == def {
+		t.Fatal("dimmed gradient must be a copy, not the source")
+	}
+	// 200*0.5=100, halved to 50.
+	if got.Stops[0].Color.A != 50 {
+		t.Fatalf("got alpha %d, want 50", got.Stops[0].Color.A)
+	}
+	if def.Stops[0].Color.A != 200 {
+		t.Fatalf("source stops must not mutate: %d",
+			def.Stops[0].Color.A)
+	}
+}
+
+func TestDimmedTermGridFastPathKeepsPointer(t *testing.T) {
+	tg := &TermGridData{Cells: make([]TermCell, 1)}
+	if got := dimmedTermGrid(tg, 1.0, false); got != tg {
+		t.Fatal("enabled grid must keep its pointer (no copy)")
+	}
+}
+
+func TestDimmedTermGridDimsCellsWithoutMutatingSource(t *testing.T) {
+	tg := &TermGridData{
+		Cells: []TermCell{{
+			Ch: 'a', FG: RGBA(255, 255, 255, 200),
+			BG: RGBA(0, 0, 0, 200), Width: 1,
+		}},
+		Cursor:    TermCursor{Color: RGBA(255, 255, 0, 200)},
+		Selection: TermSelRange{Color: RGBA(0, 0, 255, 200)},
+		Cols:      1, Rows: 1, CellW: 8, CellH: 16,
+	}
+	got := dimmedTermGrid(tg, 1.0, true)
+	if got == tg {
+		t.Fatal("dimmed grid must be a copy")
+	}
+	cell := got.Cells[0]
+	if cell.FG.A != 100 || cell.BG.A != 100 {
+		t.Fatalf("cells must halve: FG %d BG %d",
+			cell.FG.A, cell.BG.A)
+	}
+	if got.Cursor.Color.A != 100 || got.Selection.Color.A != 100 {
+		t.Fatal("cursor and selection must dim with the grid")
+	}
+	if tg.Cells[0].FG.A != 200 || tg.Cursor.Color.A != 200 {
+		t.Fatal("source grid buffer must not mutate")
+	}
+}
+
+func TestDimmedVColorsFastPathKeepsSlice(t *testing.T) {
+	w := &Window{}
+	vcols := []Color{RGBA(1, 2, 3, 200)}
+	if got := dimmedVColors(vcols, 1.0, false, w); &got[0] != &vcols[0] {
+		t.Fatal("enabled batches must keep their backing array")
+	}
+}
+
+func TestDimmedTextGradientScalesGlyphAlpha(t *testing.T) {
+	cfg := &glyph.GradientConfig{Stops: []glyph.GradientStop{
+		{Color: glyph.Color{R: 255, A: 200}},
+	}}
+	if dimmedTextGradient(nil, 0.5, true) != nil {
+		t.Fatal("nil text gradient must stay nil")
+	}
+	if got := dimmedTextGradient(cfg, 1.0, false); got != cfg {
+		t.Fatal("enabled text gradient must keep its pointer")
+	}
+	got := dimmedTextGradient(cfg, 0.5, true)
+	if got.Stops[0].Color.A != 50 {
+		t.Fatalf("got alpha %d, want 50", got.Stops[0].Color.A)
+	}
+	if cfg.Stops[0].Color.A != 200 {
+		t.Fatal("source glyph stops must not mutate")
+	}
+}
+
+func TestRenderShapeDisabledDimsShadow(t *testing.T) {
+	w := &Window{}
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		X:         0, Y: 0, Width: 80, Height: 60,
+		Color:   RGBA(200, 200, 200, 255),
+		Opacity: 1.0, Disabled: true,
+		fx: &shapeEffects{
+			Shadow: &BoxShadow{
+				Color:   RGBA(0, 0, 0, 80),
+				OffsetX: 3, OffsetY: 5, BlurRadius: 20,
+			},
+		},
+	}
+	renderShape(shape, ColorTransparent, makeClip(0, 0, 500, 500), w)
+	for _, r := range w.renderers {
+		if r.Kind == RenderShadow && r.Color.A != 40 {
+			t.Fatalf("disabled shadow must halve: got %d", r.Color.A)
+		}
+		if r.Kind == RenderRect && r.Color.A != 127 {
+			t.Fatalf("disabled rect must halve: got %d", r.Color.A)
+		}
+	}
+}
+
+func TestRenderShapeOpacityReachesShadow(t *testing.T) {
+	w := &Window{}
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		X:         0, Y: 0, Width: 80, Height: 60,
+		Color:   RGBA(200, 200, 200, 255),
+		Opacity: 0.5,
+		fx: &shapeEffects{
+			Shadow: &BoxShadow{
+				Color:   RGBA(0, 0, 0, 80),
+				OffsetX: 3, OffsetY: 5, BlurRadius: 20,
+			},
+		},
+	}
+	renderShape(shape, ColorTransparent, makeClip(0, 0, 500, 500), w)
+	for _, r := range w.renderers {
+		if r.Kind == RenderShadow && r.Color.A != 40 {
+			t.Fatalf("faded shadow must scale: got %d", r.Color.A)
+		}
+	}
+}
+
+func TestRenderShapeDisabledDimsImageFill(t *testing.T) {
+	w := &Window{}
+	shape := &Shape{
+		shapeType: shapeImage,
+		X:         10, Y: 20, Width: 100, Height: 80,
+		Color:    RGBA(255, 255, 255, 200),
+		Opacity:  1.0,
+		Disabled: true,
+		Resource: "test.png",
+	}
+	renderShape(shape, ColorTransparent, makeClip(0, 0, 500, 500), w)
+	found := false
+	for _, r := range w.renderers {
+		if r.Kind == RenderImage {
+			found = true
+			if r.Color.A != 100 {
+				t.Fatalf("disabled image fill must halve: got %d",
+					r.Color.A)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no RenderImage emitted")
+	}
+}
+
+// A disabled image must dim its emitted fill without writing the
+// dimmed color back onto the shape: renderShape only restores
+// shape.Color when Opacity < 1, so a write-back would halve again
+// on every later frame the shape survives.
+func TestRenderShapeDisabledImageKeepsShapeColor(t *testing.T) {
+	w := &Window{}
+	orig := RGBA(255, 255, 255, 200)
+	shape := &Shape{
+		shapeType: shapeImage,
+		X:         10, Y: 20, Width: 100, Height: 80,
+		Color:    orig,
+		Opacity:  1.0,
+		Disabled: true,
+		Resource: "test.png",
+	}
+	for frame := range 3 {
+		w.renderers = w.renderers[:0]
+		renderShape(shape, ColorTransparent, makeClip(0, 0, 500, 500), w)
+		if shape.Color != orig {
+			t.Fatalf("frame %d: shape.Color = %v, want %v",
+				frame, shape.Color, orig)
+		}
+		for _, r := range w.renderers {
+			if r.Kind == RenderImage && r.Color.A != 100 {
+				t.Fatalf("frame %d: fill alpha = %d, want 100",
+					frame, r.Color.A)
+			}
+		}
+	}
+}
+
+func TestRenderShapeDisabledDimsGradientFill(t *testing.T) {
+	w := &Window{}
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		X:         0, Y: 0, Width: 80, Height: 60,
+		Color:   RGBA(200, 200, 200, 255),
+		Opacity: 1.0, Disabled: true,
+		fx: &shapeEffects{
+			Gradient: &GradientDef{Stops: []GradientStop{
+				{Color: RGBA(255, 0, 0, 200), Pos: 0},
+			}},
+		},
+	}
+	renderShape(shape, ColorTransparent, makeClip(0, 0, 500, 500), w)
+	found := false
+	for _, r := range w.renderers {
+		if r.Kind == RenderGradient {
+			found = true
+			if r.Gradient.Stops[0].Color.A != 100 {
+				t.Fatalf("disabled gradient must halve: got %d",
+					r.Gradient.Stops[0].Color.A)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no RenderGradient emitted")
+	}
+	if shape.fx.Gradient.Stops[0].Color.A != 200 {
+		t.Fatal("source gradient def must not mutate")
+	}
+}
+
+func TestRenderShapeDisabledDimsTermGrid(t *testing.T) {
+	w := &Window{}
+	tg := &TermGridData{
+		Cells: []TermCell{{
+			Ch: 'a', FG: RGBA(255, 255, 255, 200),
+			BG: RGBA(0, 0, 0, 200), Width: 1,
+		}},
+		Cols: 1, Rows: 1, CellW: 8, CellH: 16,
+	}
+	shape := &Shape{
+		shapeType: shapeTermGrid,
+		X:         0, Y: 0, Width: 8, Height: 16,
+		Opacity: 1.0, Disabled: true, tg: tg,
+	}
+	renderShape(shape, ColorTransparent, makeClip(0, 0, 500, 500), w)
+	found := false
+	for _, r := range w.renderers {
+		if r.Kind == RenderTermGrid {
+			found = true
+			if r.TermGrid.Cells[0].FG.A != 100 {
+				t.Fatalf("disabled grid must halve: got %d",
+					r.TermGrid.Cells[0].FG.A)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no RenderTermGrid emitted")
+	}
+	if tg.Cells[0].FG.A != 200 {
+		t.Fatal("source grid buffer must not mutate")
+	}
+}
+
+func TestEmitSvgPathUntintedOpacityScalesAlphaOnly(t *testing.T) {
+	w := &Window{}
+	path := cachedSvgPath{
+		Triangles: []float32{0, 0, 1, 0, 0, 1},
+		Color:     RGBA(10, 20, 30, 200),
+		VertexColors: []Color{
+			{R: 100, G: 110, B: 120, A: 200},
+			{R: 100, G: 110, B: 120, A: 200},
+			{R: 100, G: 110, B: 120, A: 200},
+		},
+	}
+	shape := &Shape{Opacity: 0.5}
+	emitSvgPathRenderer(path, Color{}, 0, 0, 1, 0, 0,
+		false, nil, shape, w)
+	if len(w.renderers) != 1 {
+		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))
+	}
+	rc := w.renderers[0]
+	// Untinted + faded: flat color scales, vertex RGB preserved.
+	if rc.Color.A != 100 {
+		t.Fatalf("flat path alpha must scale: got %d", rc.Color.A)
+	}
+	if len(rc.VertexColors) != 3 {
+		t.Fatalf("expected 3 vertex colors, got %d",
+			len(rc.VertexColors))
+	}
+	vc := rc.VertexColors[0]
+	if vc.R != 100 || vc.G != 110 || vc.B != 120 || vc.A != 100 {
+		t.Fatalf("vertex RGB must survive, alpha scales: got %v", vc)
+	}
+	if path.VertexColors[0].A != 200 {
+		t.Fatal("cached vertex colors must not mutate")
+	}
+}
+
+func TestEmitDrawCanvasGeometryDisabledDimsBatches(t *testing.T) {
+	w := &Window{}
+	cached := &drawCanvasCache{
+		Batches: []DrawCanvasTriBatch{{
+			Triangles: []float32{0, 0, 1, 0, 0, 1},
+			Color:     RGBA(10, 20, 30, 200),
+			VertexColors: []Color{
+				{R: 1, G: 2, B: 3, A: 200},
+				{R: 1, G: 2, B: 3, A: 200},
+				{R: 1, G: 2, B: 3, A: 200},
+			},
+		}},
+	}
+	shape := &Shape{Opacity: 1.0, Disabled: true}
+	emitDrawCanvasGeometry(cached, 0, 0, shape, w)
+	if len(w.renderers) != 1 {
+		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))
+	}
+	rc := w.renderers[0]
+	if rc.Color.A != 100 || rc.VertexColors[0].A != 100 {
+		t.Fatalf("disabled canvas batch must halve: %v %v",
+			rc.Color, rc.VertexColors[0])
+	}
+	if cached.Batches[0].Color.A != 200 ||
+		cached.Batches[0].VertexColors[0].A != 200 {
+		t.Fatal("cache entry must not mutate")
+	}
+}

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -1,8 +1,33 @@
 package gui
 
-import "math"
+import (
+	"log"
+	"math"
+)
+
+// callOnDrawSafe invokes the app's OnDraw callback, isolating a
+// widget panic so one canvas cannot abort the frame's render walk.
+// Returns false when the callback panicked; the caller then falls
+// back to an empty canvas. Warns once per window.
+func callOnDrawSafe(dc *DrawContext, shape *Shape, w *Window) (ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			ok = false
+			if !w.drawPanicWarned {
+				w.drawPanicWarned = true
+				log.Printf("gui: DrawCanvas OnDraw panicked "+
+					"(id %q) — canvas skipped: %v",
+					shape.idKey(), r)
+			}
+		}
+	}()
+	shape.events.OnDraw(dc)
+	return true
+}
 
 // renderDrawCanvas renders cached draw-canvas triangle batches.
+//
+//nolint:gocyclo // cache states x deferred text/image/gradient emit
 func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	if !rectsOverlap(shapeBounds(shape), clip) {
 		return
@@ -53,19 +78,24 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 			reuse = drawCanvasCache{}
 		}
 		dc.resetFor(cw, ch, scale, w.textMeasurer, reuse)
-		shape.events.OnDraw(dc)
+		// A panic mid-tessellation leaves partial buffers that are
+		// unusable, so the entry keeps its empty content: the canvas
+		// draws nothing and the frame continues. Only a Version bump
+		// (or alwaysRedraw) retries.
 		cached = drawCanvasCache{
 			Version:    shape.Version,
 			pass:       w.renderPass,
 			tessWidth:  cw,
 			tessHeight: ch,
 			Scale:      scale,
-			Batches:    dc.batches,
-			spare:      dc.batchPool,
-			Gradients:  dc.gradients,
-			gradSpare:  dc.gradientPool,
-			Texts:      dc.texts,
-			Images:     dc.images,
+		}
+		if callOnDrawSafe(dc, shape, w) {
+			cached.Batches = dc.batches
+			cached.spare = dc.batchPool
+			cached.Gradients = dc.gradients
+			cached.gradSpare = dc.gradientPool
+			cached.Texts = dc.texts
+			cached.Images = dc.images
 		}
 		if key != "" {
 			sm.Set(key, cached)
@@ -108,7 +138,7 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	// markers / HUD chips / labels *over* tile images in the same
 	// DrawCanvas. Reverse ordering would be correct only if triangles/
 	// text were meant as backgrounds — which no in-tree consumer wants.
-	emitDrawCanvasImages(cached.Images, ox, oy, effClip, w)
+	emitDrawCanvasImages(cached.Images, ox, oy, effClip, shape, w)
 
 	// A gradient batch differs only by its VertexColors; every backend
 	// that consumes RenderSvg already reads that channel for SVG
@@ -120,7 +150,7 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	// paints before it. This is the only ordering the canvas keeps:
 	// images are always the back layer and text always the front,
 	// whatever order the OnDraw callback used.
-	emitDrawCanvasGeometry(&cached, ox, oy, w)
+	emitDrawCanvasGeometry(&cached, ox, oy, shape, w)
 
 	// Emit deferred text commands.
 	for i := range cached.Texts {
@@ -131,6 +161,19 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 			fontAscent = w.textMeasurer.FontAscent(t.Style)
 			textWidth = w.textMeasurer.TextWidth(t.Text, t.Style)
 		}
+
+		// Widget-level fade and disabled dim, mirroring
+		// renderText: the cached style must not be dimmed in
+		// place — the cache entry is recycled by the next
+		// redraw — so dim a local copy. Metrics above stay
+		// on the undimmed style; color carries no width.
+		style := t.Style
+		style.Color = dimColor(style.Color,
+			shape.Opacity, shape.Disabled)
+		style.BgColor = dimColor(style.BgColor,
+			shape.Opacity, shape.Disabled)
+		style.StrokeColor = dimColor(style.StrokeColor,
+			shape.Opacity, shape.Disabled)
 
 		tx := ox + t.X
 		ty := oy + t.Y
@@ -159,14 +202,15 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 			Kind:         RenderText,
 			X:            tx,
 			Y:            ty,
-			Color:        t.Style.Color,
+			Color:        style.Color,
 			Text:         t.Text,
-			FontName:     t.Style.Family,
-			FontSize:     t.Style.Size,
+			FontName:     style.Family,
+			FontSize:     style.Size,
 			FontAscent:   fontAscent,
 			TextWidth:    textWidth,
-			TextStylePtr: w.scratch.renderTextStyles.alloc(t.Style),
-			TextGradient: t.Style.Gradient,
+			TextStylePtr: w.scratch.renderTextStyles.alloc(style),
+			TextGradient: dimmedTextGradient(style.Gradient,
+				shape.Opacity, shape.Disabled),
 		}
 		if hasAffine {
 			cmd.LayoutTransform = w.scratch.renderAffineTransforms.alloc(
@@ -207,12 +251,13 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 // radial fills in the order the OnDraw callback produced them, walking
 // the two lists together by each gradient's batch counter.
 func emitDrawCanvasGeometry(cached *drawCanvasCache,
-	ox, oy float32, w *Window) {
+	ox, oy float32, shape *Shape, w *Window) {
 	gi := 0
 	for bi := range cached.Batches {
 		for gi < len(cached.Gradients) &&
 			cached.Gradients[gi].afterBatch <= bi {
-			emitDrawCanvasGradient(&cached.Gradients[gi], ox, oy, w)
+			emitDrawCanvasGradient(&cached.Gradients[gi], ox, oy,
+				shape, w)
 			gi++
 		}
 		batch := &cached.Batches[bi]
@@ -222,22 +267,25 @@ func emitDrawCanvasGeometry(cached *drawCanvasCache,
 		// coordinates the caller drew in. Scale stays 1 — it is the
 		// SVG path's own factor, and the two compose correctly.
 		emitRenderer(RenderCmd{
-			Kind:         RenderSvg,
-			Triangles:    batch.Triangles,
-			VertexColors: batch.VertexColors,
-			Color:        batch.Color,
-			X:            ox,
-			Y:            oy,
-			Scale:        1.0,
-			HasXform:     batch.hasXform,
-			ScaleX:       batch.xf.sx,
-			ScaleY:       batch.xf.sy,
-			TransX:       batch.xf.tx,
-			TransY:       batch.xf.ty,
+			Kind:      RenderSvg,
+			Triangles: batch.Triangles,
+			VertexColors: dimmedVColors(batch.VertexColors,
+				shape.Opacity, shape.Disabled, w),
+			Color: dimColor(batch.Color,
+				shape.Opacity, shape.Disabled),
+			X:        ox,
+			Y:        oy,
+			Scale:    1.0,
+			HasXform: batch.hasXform,
+			ScaleX:   batch.xf.sx,
+			ScaleY:   batch.xf.sy,
+			TransX:   batch.xf.tx,
+			TransY:   batch.xf.ty,
 		}, w)
 	}
 	for ; gi < len(cached.Gradients); gi++ {
-		emitDrawCanvasGradient(&cached.Gradients[gi], ox, oy, w)
+		emitDrawCanvasGradient(&cached.Gradients[gi], ox, oy,
+			shape, w)
 	}
 }
 
@@ -246,10 +294,10 @@ func emitDrawCanvasGeometry(cached *drawCanvasCache,
 // half its width: that rounds the quad down to exactly the circle the
 // shader's radial ramp already reaches the end of.
 func emitDrawCanvasGradient(e *DrawCanvasGradientEntry,
-	ox, oy float32, w *Window) {
+	ox, oy float32, shape *Shape, w *Window) {
 	emitRenderer(RenderCmd{
 		Kind:     RenderGradient,
-		Gradient: &e.Def,
+		Gradient: dimmedGradient(&e.Def, shape.Opacity, shape.Disabled),
 		X:        ox + e.X,
 		Y:        oy + e.Y,
 		W:        e.W,
@@ -259,7 +307,8 @@ func emitDrawCanvasGradient(e *DrawCanvasGradientEntry,
 }
 
 func emitDrawCanvasImages(
-	images []DrawCanvasImageEntry, ox, oy float32, clip drawClip, w *Window,
+	images []DrawCanvasImageEntry, ox, oy float32, clip drawClip,
+	shape *Shape, w *Window,
 ) {
 	// narrowed tracks whether the scissor currently in the command stream is
 	// one entry's own clip rather than the canvas clip, so the restore is
@@ -279,14 +328,15 @@ func emitDrawCanvasImages(
 		}
 		bg := ColorTransparent
 		if im.BgColor.IsSet() {
-			bg = im.BgColor
 			op := im.bgOpacity.Get(1.0)
 			if !isFiniteF(op) {
 				op = 1.0
 			}
-			if op = clampUnit(op); op < 1.0 {
-				bg = bg.WithOpacity(op)
-			}
+			// The entry's own opacity folds into the
+			// widget's before the single multiply, so a
+			// faded canvas over a faded entry dims once.
+			bg = dimColor(im.BgColor,
+				clampUnit(op)*shape.Opacity, shape.Disabled)
 		}
 		if im.Clipped {
 			sub, ok := intersectClips(clip, drawClip{

--- a/gui/render_draw_canvas_test.go
+++ b/gui/render_draw_canvas_test.go
@@ -201,6 +201,7 @@ func TestRenderDrawCanvasEmitsImage(t *testing.T) {
 		shapeType: shapeDrawCanvas,
 		X:         10, Y: 20,
 		Width: 100, Height: 100,
+		Opacity: 1.0,
 		Color:   ColorTransparent,
 		Padding: NewPadding(5, 5, 5, 5),
 		events: &eventHandlers{
@@ -260,7 +261,8 @@ func TestRenderDrawCanvasImageOpacityClamped(t *testing.T) {
 			shape := &Shape{
 				shapeType: shapeDrawCanvas,
 				Width:     50, Height: 50,
-				Color: ColorTransparent,
+				Opacity: 1.0,
+				Color:   ColorTransparent,
 				events: &eventHandlers{
 					OnDraw: func(dc *DrawContext) {
 						dc.Image(0, 0, 10, 10, "x.png", op, Blue)
@@ -985,6 +987,37 @@ func TestRenderDrawCanvasXformSurvivesPooling(t *testing.T) {
 				t.Fatalf("pass %d: xform lost (has=%v sx=%v sy=%v)",
 					pass, r.HasXform, r.ScaleX, r.ScaleY)
 			}
+		}
+	}
+}
+
+// TestRenderDrawCanvasOnDrawPanicIsolated proves one panicking widget
+// cannot abort the frame: the panic is contained, the partial batch
+// is discarded, and the warn-once flag is set.
+func TestRenderDrawCanvasOnDrawPanicIsolated(t *testing.T) {
+	w := makeWindowWithScratch()
+	shape := &Shape{
+		shapeType: shapeDrawCanvas,
+		Width:     100, Height: 100,
+		Color: RGB(100, 100, 100),
+		events: &eventHandlers{
+			OnDraw: func(dc *DrawContext) {
+				dc.FilledRect(0, 0, 50, 50, RGB(255, 0, 0))
+				panic("widget bug")
+			},
+		},
+	}
+
+	// Must not propagate.
+	renderDrawCanvas(shape, makeClip(0, 0, 200, 200), w)
+
+	if !w.drawPanicWarned {
+		t.Error("drawPanicWarned not set after OnDraw panic")
+	}
+	// Partial batch discarded: no content commands emitted.
+	for _, r := range w.renderers {
+		if r.Kind == RenderSvg {
+			t.Error("panicked canvas emitted a partial batch")
 		}
 	}
 }

--- a/gui/render_helpers.go
+++ b/gui/render_helpers.go
@@ -1,5 +1,9 @@
 package gui
 
+import (
+	"github.com/go-gui-org/go-glyph"
+)
+
 // rectsOverlap checks if two rectangles overlap (strict <).
 func rectsOverlap(r1, r2 drawClip) bool {
 	return r1.X < (r2.X+r2.Width) && r2.X < (r1.X+r1.Width) &&
@@ -10,6 +14,126 @@ func rectsOverlap(r1, r2 drawClip) bool {
 func dimAlpha(c Color) Color {
 	c.A /= 2
 	return c
+}
+
+// dimColor applies widget-level opacity, then the disabled dim, in
+// that order: WithOpacity scales the caller's alpha, dimAlpha
+// halves whatever remains. It mirrors what renderText does inline
+// so every path that cannot rely on renderShape's Color mutation —
+// shadows, gradients, images, grids, canvas content — dims
+// identically. An opacity at or above 1 applies nothing; NaN
+// compares false both ways and also applies nothing, matching
+// renderShape, which takes the unmodified branch for NaN.
+func dimColor(c Color, opacity float32, disabled bool) Color {
+	if opacity < 1.0 {
+		c = c.WithOpacity(opacity)
+	}
+	if disabled {
+		c = dimAlpha(c)
+	}
+	return c
+}
+
+// dimmedGradient returns def unchanged when neither opacity nor
+// disabled dimming applies; otherwise a copy with every stop run
+// through dimColor. A RenderGradient command carries no color of
+// its own, so a disabled or faded gradient container would
+// otherwise paint at full strength while its rect sibling dims.
+// The copy is heap-allocated, so callers must only reach it when
+// dimming actually applies — the fast path above is that gate.
+func dimmedGradient(
+	def *GradientDef, opacity float32, disabled bool,
+) *GradientDef {
+	if def == nil || (!disabled && !(opacity < 1.0)) {
+		return def
+	}
+	out := *def
+	stops := make([]GradientStop, len(def.Stops))
+	for i, s := range def.Stops {
+		s.Color = dimColor(s.Color, opacity, disabled)
+		stops[i] = s
+	}
+	out.Stops = stops
+	return &out
+}
+
+// dimmedTextGradient returns cfg unchanged when neither opacity
+// nor disabled dimming applies; otherwise a copy with every stop
+// alpha scaled by opacity and halved when disabled. Text gradients
+// live in the glyph module's color type, so this mirrors
+// dimmedGradient across the module boundary — the conversion is a
+// field-wise alpha copy, no cross-module change.
+func dimmedTextGradient(
+	cfg *glyph.GradientConfig, opacity float32, disabled bool,
+) *glyph.GradientConfig {
+	if cfg == nil || (!disabled && !(opacity < 1.0)) {
+		return cfg
+	}
+	out := *cfg
+	stops := make([]glyph.GradientStop, len(cfg.Stops))
+	for i, s := range cfg.Stops {
+		a := s.Color.A
+		if opacity < 1.0 {
+			a = uint8(float32(a) * f32Clamp(opacity, 0, 1))
+		}
+		if disabled {
+			a /= 2
+		}
+		s.Color.A = a
+		stops[i] = s
+	}
+	out.Stops = stops
+	return &out
+}
+
+// dimmedTermGrid returns tg unchanged when neither opacity nor
+// disabled dimming applies; otherwise a copy with every cell
+// foreground/background, the cursor, the selection, and the grid
+// font colors run through dimColor. The grid buffer is shared
+// across frames, so dimming in place would persist into the next
+// frame and stack — the copy is the same reason renderShape
+// restores shape.Color via defer.
+func dimmedTermGrid(
+	tg *TermGridData, opacity float32, disabled bool,
+) *TermGridData {
+	if tg == nil || (!disabled && !(opacity < 1.0)) {
+		return tg
+	}
+	out := *tg
+	cells := make([]TermCell, len(tg.Cells))
+	for i, c := range tg.Cells {
+		c.FG = dimColor(c.FG, opacity, disabled)
+		c.BG = dimColor(c.BG, opacity, disabled)
+		cells[i] = c
+	}
+	out.Cells = cells
+	out.Cursor.Color = dimColor(tg.Cursor.Color, opacity, disabled)
+	out.Selection.Color = dimColor(
+		tg.Selection.Color, opacity, disabled)
+	out.Style.Color = dimColor(tg.Style.Color, opacity, disabled)
+	out.Style.BgColor = dimColor(
+		tg.Style.BgColor, opacity, disabled)
+	out.Style.StrokeColor = dimColor(
+		tg.Style.StrokeColor, opacity, disabled)
+	return &out
+}
+
+// dimmedVColors returns vcols unchanged when neither opacity nor
+// disabled dimming applies; otherwise an arena copy with every
+// color run through dimColor. Canvas batches belong to the cache
+// entry and are recycled by the next redraw, so — like the grid
+// buffer above — they must never be dimmed in place.
+func dimmedVColors(
+	vcols []Color, opacity float32, disabled bool, w *Window,
+) []Color {
+	if len(vcols) == 0 || (!disabled && !(opacity < 1.0)) {
+		return vcols
+	}
+	out := w.scratch.takeVColors(len(vcols))
+	for i, c := range vcols {
+		out[i] = dimColor(c, opacity, disabled)
+	}
+	return out
 }
 
 // resolveClipRadius computes the effective rounded clip radius for

--- a/gui/render_image.go
+++ b/gui/render_image.go
@@ -9,10 +9,19 @@ func renderImage(shape *Shape, clip drawClip, w *Window) {
 
 	// Hide Color from renderContainer so it doesn't draw a
 	// redundant bg rect; the backend handles the fill itself.
-	bgColor := shape.Color
+	// Opacity already rides on shape.Color via renderShape's
+	// mutation; only the disabled dim is left to apply here.
+	// The dim goes to a local: restoring it onto shape.Color would
+	// halve again on the next frame, because renderShape only
+	// restores the shape when Opacity < 1.
+	origColor := shape.Color
+	bgColor := origColor
+	if shape.Disabled {
+		bgColor = dimAlpha(bgColor)
+	}
 	shape.Color = ColorTransparent
 	renderContainer(shape, ColorTransparent, clip, w)
-	shape.Color = bgColor
+	shape.Color = origColor
 
 	emitRenderer(RenderCmd{
 		Kind:       RenderImage,

--- a/gui/render_layout.go
+++ b/gui/render_layout.go
@@ -2,6 +2,12 @@ package gui
 
 // renderLayout walks the layout tree and emits RenderCmd entries
 // into window.renderers. Clip rectangles bracket clipped children.
+//
+// Every bracket opened here is closed by a deferred call, so a panic
+// in a child unwinds through balanced Begin/End pairs and restores
+// inFilter, stencilDepth and clipRadius. That state lives on the
+// Window across frames, so leaking it would corrupt every later
+// frame, not just the aborted one.
 func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
 	// Emit filter bracket when ColorFilter is set (containers only).
 	fx := layout.Shape.fx
@@ -14,6 +20,10 @@ func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
 			Layers:      1,
 			ColorMatrix: &fx.ColorFilter.matrix,
 		}, w)
+		defer func() {
+			emitRenderer(RenderCmd{Kind: RenderFilterEnd}, w)
+			w.inFilter = false
+		}()
 	}
 
 	renderShape(layout.Shape, bgColor, clip, w)
@@ -30,14 +40,20 @@ func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
 			shapeClip.Width = clip.Width
 		}
 		emitClipCmd(shapeClip, w)
+		defer func() {
+			emitClipCmd(clip, w)
+		}()
 	} else if layout.Shape.Clip {
 		shapeClip = clipContentBox(layout.Shape)
 		emitClipCmd(shapeClip, w)
+		defer func() {
+			emitClipCmd(clip, w)
+		}()
 	}
 
 	// Emit stencil clip bracket before children.
-	didIncrement := false
 	if layout.Shape.clipContents {
+		didIncrement := false
 		if w.stencilDepth < 255 {
 			w.stencilDepth++
 			didIncrement = true
@@ -53,15 +69,42 @@ func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
 		}, w)
 		// Also apply scissor clip as optimization (avoids
 		// rasterizing fragments outside bounding rect).
+		scissored := false
 		if !layout.Shape.Clip && !layout.Shape.OverDraw {
 			shapeClip = layout.Shape.shapeClip
 			emitClipCmd(shapeClip, w)
+			scissored = true
 		}
+		defer func() {
+			// Restore scissor if we pushed one.
+			if scissored {
+				emitClipCmd(clip, w)
+			}
+			emitRenderer(RenderCmd{
+				Kind:         RenderStencilEnd,
+				X:            layout.Shape.X,
+				Y:            layout.Shape.Y,
+				W:            layout.Shape.Width,
+				H:            layout.Shape.Height,
+				Radius:       layout.Shape.Radius,
+				StencilDepth: w.stencilDepth,
+			}, w)
+			if didIncrement {
+				w.stencilDepth--
+			}
+		}()
 	}
 
-	// Propagate rounded clip radius to child images.
+	// Propagate rounded clip radius to child images. Deferred only
+	// when changed: most shapes are not clipping containers, and an
+	// untouched value needs no restore.
 	savedClipRadius := w.clipRadius
 	w.clipRadius = resolveClipRadius(savedClipRadius, layout.Shape)
+	if w.clipRadius != savedClipRadius {
+		defer func() {
+			w.clipRadius = savedClipRadius
+		}()
+	}
 
 	// Emit rotation bracket before children.
 	if turns := layout.Shape.QuarterTurns; turns > 0 {
@@ -73,6 +116,9 @@ func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
 			RotCX:    cx,
 			RotCY:    cy,
 		}, w)
+		defer func() {
+			emitRenderer(RenderCmd{Kind: RenderRotateEnd}, w)
+		}()
 	}
 
 	color := bgColor
@@ -81,40 +127,6 @@ func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
 	}
 	for i := range layout.Children {
 		renderLayout(&layout.Children[i], color, shapeClip, w)
-	}
-
-	if layout.Shape.QuarterTurns > 0 {
-		emitRenderer(RenderCmd{Kind: RenderRotateEnd}, w)
-	}
-
-	w.clipRadius = savedClipRadius
-
-	if layout.Shape.clipContents {
-		// Restore scissor if we pushed one.
-		if !layout.Shape.Clip && !layout.Shape.OverDraw {
-			emitClipCmd(clip, w)
-		}
-		emitRenderer(RenderCmd{
-			Kind:         RenderStencilEnd,
-			X:            layout.Shape.X,
-			Y:            layout.Shape.Y,
-			W:            layout.Shape.Width,
-			H:            layout.Shape.Height,
-			Radius:       layout.Shape.Radius,
-			StencilDepth: w.stencilDepth,
-		}, w)
-		if didIncrement {
-			w.stencilDepth--
-		}
-	}
-
-	if layout.Shape.Clip || layout.Shape.OverDraw {
-		emitClipCmd(clip, w)
-	}
-
-	if hasColorFilter {
-		emitRenderer(RenderCmd{Kind: RenderFilterEnd}, w)
-		w.inFilter = false
 	}
 }
 
@@ -132,9 +144,13 @@ func renderShape(shape *Shape, parentColor Color, clip drawClip, w *Window) {
 		origBorder := shape.ColorBorder
 		shape.Color = shape.Color.WithOpacity(shape.Opacity)
 		shape.ColorBorder = shape.ColorBorder.WithOpacity(shape.Opacity)
+		// Deferred: a panic below must not leave the shape dimmed
+		// for the next frame. Shapes persist in the layout tree.
+		defer func() {
+			shape.Color = origColor
+			shape.ColorBorder = origBorder
+		}()
 		renderShapeInner(shape, parentColor, clip, w)
-		shape.Color = origColor
-		shape.ColorBorder = origBorder
 	} else {
 		renderShapeInner(shape, parentColor, clip, w)
 	}
@@ -202,9 +218,10 @@ func renderContainer(shape *Shape, _ Color, clip drawClip, w *Window) {
 			Radius:     shape.Radius,
 			BlurRadius: fx.Shadow.BlurRadius,
 			Spread:     fx.Shadow.Spread,
-			Color:      fx.Shadow.Color,
-			OffsetX:    fx.Shadow.OffsetX,
-			OffsetY:    fx.Shadow.OffsetY,
+			Color: dimColor(fx.Shadow.Color,
+				shape.Opacity, shape.Disabled),
+			OffsetX: fx.Shadow.OffsetX,
+			OffsetY: fx.Shadow.OffsetY,
 		}, w)
 	}
 
@@ -217,7 +234,12 @@ func renderContainer(shape *Shape, _ Color, clip drawClip, w *Window) {
 			W:      shape.Width,
 			H:      shape.Height,
 			Radius: shape.Radius,
-			Color:  shape.Color,
+			// Opacity 1: renderShape already scaled shape.Color
+			// by shape.Opacity, so only the disabled dim is left.
+			// The gradient and shadow siblings pass shape.Opacity
+			// because their colors are separate fields.
+			Color: dimColor(shape.Color,
+				1.0, shape.Disabled),
 			Shader: fx.Shader,
 		}, w)
 	} else
@@ -225,13 +247,14 @@ func renderContainer(shape *Shape, _ Color, clip drawClip, w *Window) {
 	// Gradient fill
 	if hasFX && fx.Gradient != nil {
 		emitRenderer(RenderCmd{
-			Kind:     RenderGradient,
-			X:        shape.X,
-			Y:        shape.Y,
-			W:        shape.Width,
-			H:        shape.Height,
-			Radius:   shape.Radius,
-			Gradient: fx.Gradient,
+			Kind:   RenderGradient,
+			X:      shape.X,
+			Y:      shape.Y,
+			W:      shape.Width,
+			H:      shape.Height,
+			Radius: shape.Radius,
+			Gradient: dimmedGradient(fx.Gradient,
+				shape.Opacity, shape.Disabled),
 		}, w)
 	} else if hasFX && fx.BlurRadius > 0 && shape.Color.A > 0 &&
 		fx.ColorFilter == nil {
@@ -262,7 +285,8 @@ func renderContainer(shape *Shape, _ Color, clip drawClip, w *Window) {
 				H:         shape.Height,
 				Radius:    shape.Radius,
 				Thickness: shape.SizeBorder,
-				Gradient:  fx.BorderGradient,
+				Gradient: dimmedGradient(fx.BorderGradient,
+					shape.Opacity, shape.Disabled),
 			}, w)
 		} else {
 			renderRectangle(shape, clip, w)
@@ -351,7 +375,8 @@ func renderCircle(shape *Shape, clip drawClip, w *Window) {
 				H:         dr.Height,
 				Radius:    radius,
 				Thickness: shape.SizeBorder,
-				Gradient:  fx.BorderGradient,
+				Gradient: dimmedGradient(fx.BorderGradient,
+					shape.Opacity, shape.Disabled),
 			}, w)
 		} else if shape.SizeBorder > 0 {
 			cb := shape.ColorBorder

--- a/gui/render_layout_test.go
+++ b/gui/render_layout_test.go
@@ -776,3 +776,60 @@ func TestTextWidthFallbackPasswordMask(t *testing.T) {
 }
 
 var sinkWidth float32
+
+// TestRenderLayoutPanicUnwindRestoresState drives a panic through a
+// node holding every bracket (filter, clip, stencil, rotate): the
+// panic must propagate, but window state must be restored and the
+// emitted list must stay balanced.
+func TestRenderLayoutPanicUnwindRestoresState(t *testing.T) {
+	w := makeWindow()
+	cf := &ColorFilter{}
+	parent := &Layout{Shape: &Shape{
+		shapeType: shapeRectangle,
+		Color:     RGB(100, 100, 100),
+		X:         10, Y: 10, Width: 50, Height: 50,
+		Clip:         true,
+		clipContents: true,
+		QuarterTurns: 1,
+		fx:           &shapeEffects{ColorFilter: cf},
+	}}
+	// Nil child shape panics on entry (framework-bug simulation).
+	parent.Children = []Layout{{Shape: nil}}
+	clip := makeClip(0, 0, 200, 200)
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic from nil child shape")
+			}
+		}()
+		renderLayout(parent, ColorTransparent, clip, w)
+	}()
+
+	if w.inFilter {
+		t.Error("inFilter leaked by panic unwind")
+	}
+	if w.stencilDepth != 0 {
+		t.Errorf("stencilDepth = %d, want 0", w.stencilDepth)
+	}
+	if w.clipRadius != 0 {
+		t.Errorf("clipRadius = %v, want 0", w.clipRadius)
+	}
+	counts := map[renderKind]int{}
+	for _, r := range w.renderers {
+		counts[r.Kind]++
+	}
+	for _, tc := range []struct {
+		begin, end renderKind
+		name       string
+	}{
+		{RenderFilterBegin, RenderFilterEnd, "filter"},
+		{RenderStencilBegin, RenderStencilEnd, "stencil"},
+		{RenderRotateBegin, RenderRotateEnd, "rotate"},
+	} {
+		if counts[tc.begin] != 1 || counts[tc.end] != 1 {
+			t.Errorf("%s bracket unbalanced: begin=%d end=%d",
+				tc.name, counts[tc.begin], counts[tc.end])
+		}
+	}
+}

--- a/gui/render_svg.go
+++ b/gui/render_svg.go
@@ -3,6 +3,8 @@ package gui
 import (
 	"log"
 	"time"
+
+	"github.com/go-gui-org/go-glyph"
 )
 
 // renderSvg renders an SVG shape by loading cached tessellation
@@ -129,7 +131,7 @@ func renderSvg(shape *Shape, clip drawClip, w *Window) {
 	nonUniform := validNonUniform(scaleX, scaleY, cached.Scale)
 	emitSvgGroup(cached.renderPaths, animByPID, cached.textDraws,
 		cached.textPathDraws, color, sx, sy,
-		cached.Scale, scaleX, scaleY, nonUniform, animState, w)
+		cached.Scale, scaleX, scaleY, nonUniform, animState, shape, w)
 
 	// Emit filtered groups.
 	for i, fg := range cached.FilteredGroups {
@@ -152,11 +154,15 @@ func renderSvg(shape *Shape, clip drawClip, w *Window) {
 			H:          fh,
 			Scale:      cached.Scale,
 			BlurRadius: blur,
-			Layers:     fg.Filter.BlurLayers,
+			// Clamped: past a handful of layers the glow is
+			// saturated and each extra pass is a full-layer
+			// blend in every backend. An untrusted document
+			// names an arbitrary feMergeNode count.
+			Layers: min(fg.Filter.BlurLayers, maxFilterCompositeLayers),
 		}, w)
 		emitSvgGroup(fg.renderPaths, animByPID, fg.textDraws,
 			fg.textPathDraws, color, sx, sy,
-			cached.Scale, scaleX, scaleY, nonUniform, animState, w)
+			cached.Scale, scaleX, scaleY, nonUniform, animState, shape, w)
 		emitRenderer(RenderCmd{
 			Kind: RenderFilterEnd,
 		}, w)
@@ -165,7 +171,7 @@ func renderSvg(shape *Shape, clip drawClip, w *Window) {
 		if fg.Filter.KeepSource {
 			emitSvgGroup(fg.renderPaths, animByPID, fg.textDraws,
 				fg.textPathDraws, color, sx, sy,
-				cached.Scale, scaleX, scaleY, nonUniform, animState, w)
+				cached.Scale, scaleX, scaleY, nonUniform, animState, shape, w)
 		}
 	}
 
@@ -224,7 +230,7 @@ func emitSvgGroup(
 	textPathDraws []cachedSvgTextPathDraw,
 	color Color, sx, sy, scale, scaleX, scaleY float32,
 	nonUniform bool,
-	animState map[uint32]svgAnimState, w *Window,
+	animState map[uint32]svgAnimState, shape *Shape, w *Window,
 ) {
 	for i := range paths {
 		p := paths[i]
@@ -233,13 +239,13 @@ func emitSvgGroup(
 				p.Triangles = tris
 			}
 		}
-		emitSvgPathRenderer(p, color, sx, sy, scale, scaleX, scaleY, nonUniform, animState, w)
+		emitSvgPathRenderer(p, color, sx, sy, scale, scaleX, scaleY, nonUniform, animState, shape, w)
 	}
 	for i := range textDraws {
-		emitCachedSvgTextDraw(&textDraws[i], sx, sy, w)
+		emitCachedSvgTextDraw(&textDraws[i], sx, sy, shape, w)
 	}
 	for i := range textPathDraws {
-		emitCachedSvgTextPathDraw(&textPathDraws[i], sx, sy, w)
+		emitCachedSvgTextPathDraw(&textPathDraws[i], sx, sy, shape, w)
 	}
 }
 
@@ -252,7 +258,7 @@ func emitSvgGroup(
 func emitSvgPathRenderer(path cachedSvgPath, tint Color,
 	x, y, scale, nsScaleX, nsScaleY float32,
 	nonUniform bool,
-	animState map[uint32]svgAnimState, w *Window) {
+	animState map[uint32]svgAnimState, shape *Shape, w *Window) {
 	hasVCols := len(path.VertexColors) > 0
 	c := path.Color
 	if tint.A > 0 && !hasVCols {
@@ -278,6 +284,18 @@ func emitSvgPathRenderer(path cachedSvgPath, tint Color,
 			}
 			c = tint
 		}
+	}
+
+	// A transparent tint means the shape named no color, so the
+	// paths above kept their own — and with them, full alpha. A
+	// faded or disabled widget would then paint at full strength
+	// while its tinted sibling dims. Scale alpha only, preserving
+	// RGB: the tint branch above already carried opacity and dim
+	// for the tinted case, and the SMIL section below composes
+	// multiplicatively on top.
+	if tint.A == 0 {
+		c = dimColor(c, shape.Opacity, shape.Disabled)
+		vcols = dimmedVColors(vcols, shape.Opacity, shape.Disabled, w)
 	}
 
 	var rotAngle, rotCX, rotCY float32
@@ -395,32 +413,60 @@ func emitSvgPathRenderer(path cachedSvgPath, tint Color,
 }
 
 // emitCachedSvgTextDraw emits a cached SVG text draw as a
-// RenderText command. Takes pointer into CachedSvg.TextDraws
-// slice so TextStylePtr remains stable.
+// RenderText command. draw points into the parse cache, so its
+// style must never be dimmed in place: the dimmed path copies the
+// style into the frame's scratch pool, which keeps TextStylePtr
+// stable until the frame ends. The undimmed path stays zero-alloc —
+// TextStylePtr into the cache and the shared gradient.
 func emitCachedSvgTextDraw(draw *cachedSvgTextDraw,
-	shapeX, shapeY float32, w *Window) {
+	shapeX, shapeY float32, shape *Shape, w *Window) {
+	style, gradient := dimmedSvgTextStyle(
+		&draw.TextStyle, draw.Gradient, shape, w)
 	emitRenderer(RenderCmd{
 		Kind:         RenderText,
 		Text:         draw.Text,
 		X:            shapeX + draw.X,
 		Y:            shapeY + draw.Y,
-		Color:        draw.TextStyle.Color,
-		FontName:     draw.TextStyle.Family,
-		FontSize:     draw.TextStyle.Size,
+		Color:        style.Color,
+		FontName:     style.Family,
+		FontSize:     style.Size,
 		TextWidth:    draw.TextWidth,
-		TextStylePtr: &draw.TextStyle,
-		TextGradient: draw.Gradient,
+		TextStylePtr: style,
+		TextGradient: gradient,
 	}, w)
 }
 
 func emitCachedSvgTextPathDraw(draw *cachedSvgTextPathDraw,
-	shapeX, shapeY float32, w *Window) {
+	shapeX, shapeY float32, shape *Shape, w *Window) {
+	style, _ := dimmedSvgTextStyle(&draw.TextStyle, nil, shape, w)
 	emitRenderer(RenderCmd{
 		Kind:         RenderTextPath,
 		Text:         draw.Text,
 		X:            shapeX,
 		Y:            shapeY,
-		TextStylePtr: &draw.TextStyle,
+		TextStylePtr: style,
 		textPath:     &draw.Path,
 	}, w)
+}
+
+// dimmedSvgTextStyle returns the style pointer and gradient to emit
+// for a cached SVG text draw. With no fade and no disabled dim it
+// hands back the cache's own pointers, which is the zero-alloc case
+// every opaque frame takes. Otherwise it copies the style into the
+// frame scratch pool — cached is the parse cache, shared across
+// frames, so dimming it in place would stack frame after frame.
+func dimmedSvgTextStyle(
+	cached *TextStyle, gradient *glyph.GradientConfig,
+	shape *Shape, w *Window,
+) (*TextStyle, *glyph.GradientConfig) {
+	if !shape.Disabled && !(shape.Opacity < 1.0) {
+		return cached, gradient
+	}
+	style := *cached
+	style.Color = dimColor(style.Color, shape.Opacity, shape.Disabled)
+	style.BgColor = dimColor(style.BgColor, shape.Opacity, shape.Disabled)
+	style.StrokeColor = dimColor(style.StrokeColor,
+		shape.Opacity, shape.Disabled)
+	return w.scratch.renderTextStyles.alloc(style),
+		dimmedTextGradient(gradient, shape.Opacity, shape.Disabled)
 }

--- a/gui/render_svg_harden_test.go
+++ b/gui/render_svg_harden_test.go
@@ -22,7 +22,7 @@ func TestEmitSvgPathRenderer_BaseTRSRoutesRotPivotToTranslate(t *testing.T) {
 		BaseRotAngle: 45,
 		HasBaseXform: true,
 	}
-	emitSvgPathRenderer(path, Color{}, 0, 0, 1, 0, 0, false, nil, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 1, 0, 0, false, nil, &Shape{Opacity: 1}, w)
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))
 	}
@@ -69,7 +69,7 @@ func TestEmitSvgPathRenderer_AnimStateRotCenterOverridesBase(t *testing.T) {
 			RotCX:    7, RotCY: 8,
 		},
 	}
-	emitSvgPathRenderer(path, Color{}, 0, 0, 1, 0, 0, false, animState, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 1, 0, 0, false, animState, &Shape{Opacity: 1}, w)
 	rc := w.renderers[0]
 	if rc.RotCX != 7 || rc.RotCY != 8 {
 		t.Fatalf("anim rotCenter lost: got (%v,%v) want (7,8)",
@@ -192,7 +192,7 @@ func TestEmitSvgPathRenderer_NonUniformCompoundsWithAnimXform(t *testing.T) {
 	// nsScaleX=2, nsScaleY=3, uniform=4 → nonUniform.
 	// Anim only: 2*0.25=0.5, 3*4=12. Base xform skipped (animApplied).
 
-	emitSvgPathRenderer(path, Color{}, 0, 0, 4, 2, 3, true, animState, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 4, 2, 3, true, animState, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))

--- a/gui/render_svg_test.go
+++ b/gui/render_svg_test.go
@@ -86,7 +86,7 @@ func TestEmitSvgPathRendererTint(t *testing.T) {
 		Color:     RGBA(0, 0, 0, 255),
 	}
 	tint := RGBA(255, 0, 0, 200)
-	emitSvgPathRenderer(path, tint, 0, 0, 1.0, 0, 0, false, nil, w)
+	emitSvgPathRenderer(path, tint, 0, 0, 1.0, 0, 0, false, nil, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d",
@@ -114,7 +114,7 @@ func TestEmitSvgPathRendererVertexColors(t *testing.T) {
 		},
 	}
 	// No tint (A=0) → vertex colors used.
-	emitSvgPathRenderer(path, Color{}, 0, 0, 1.0, 0, 0, false, nil, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 1.0, 0, 0, false, nil, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers[0].VertexColors) != 6 {
 		t.Fatalf("expected 6 vertex colors, got %d",
@@ -140,7 +140,7 @@ func TestEmitSvgPathRendererAnimatedVertexAlphaNoCopy(t *testing.T) {
 	animState := map[uint32]svgAnimState{
 		1: {Opacity: 0.5, FillOpacity: 1, StrokeOpacity: 1, Inited: true},
 	}
-	emitSvgPathRenderer(path, Color{}, 0, 0, 1.0, 0, 0, false, animState, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 1.0, 0, 0, false, animState, &Shape{Opacity: 1}, w)
 
 	r := w.renderers[0]
 	if !r.HasVertexAlpha {
@@ -166,7 +166,7 @@ func TestEmitCachedSvgTextDraw(t *testing.T) {
 		X: 5,
 		Y: 10,
 	}
-	emitCachedSvgTextDraw(&draw, 100, 200, w)
+	emitCachedSvgTextDraw(&draw, 100, 200, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d",
@@ -207,7 +207,7 @@ func TestEmitCachedSvgTextDrawWithStyle(t *testing.T) {
 		X: 10,
 		Y: 20,
 	}
-	emitCachedSvgTextDraw(&draw, 0, 0, w)
+	emitCachedSvgTextDraw(&draw, 0, 0, &Shape{Opacity: 1}, w)
 
 	r := w.renderers[0]
 	if r.TextStylePtr == nil {
@@ -241,7 +241,7 @@ func TestEmitCachedSvgTextPathDraw(t *testing.T) {
 			totalLen: 10,
 		},
 	}
-	emitCachedSvgTextPathDraw(&draw, 7, 9, w)
+	emitCachedSvgTextPathDraw(&draw, 7, 9, &Shape{Opacity: 1}, w)
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d",
 			len(w.renderers))
@@ -786,7 +786,7 @@ func TestEmitSvgPathRenderer_OpacityNaNClampedToZero(t *testing.T) {
 			Inited:        true,
 		},
 	}
-	emitSvgPathRenderer(path, Color{}, 0, 0, 1.0, 0, 0, false, animState, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 1.0, 0, 0, false, animState, &Shape{Opacity: 1}, w)
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))
 	}
@@ -817,7 +817,7 @@ func TestSvgRender_FillOpacityAnimDoesNotDimStroke(t *testing.T) {
 			Inited:        true,
 		},
 	}
-	emitSvgPathRenderer(strokePath, Color{}, 0, 0, 1.0, 0, 0, false, animState, w)
+	emitSvgPathRenderer(strokePath, Color{}, 0, 0, 1.0, 0, 0, false, animState, &Shape{Opacity: 1}, w)
 	if w.renderers[0].Color.A != 255 {
 		t.Fatalf("stroke should keep alpha 255 when only fill-opacity "+
 			"is animated, got %d", w.renderers[0].Color.A)
@@ -835,7 +835,7 @@ func TestSvgRender_FillOpacityAnimDoesNotDimStroke(t *testing.T) {
 			Inited:        true,
 		},
 	}
-	emitSvgPathRenderer(fillPath, Color{}, 0, 0, 1.0, 0, 0, false, animState, w)
+	emitSvgPathRenderer(fillPath, Color{}, 0, 0, 1.0, 0, 0, false, animState, &Shape{Opacity: 1}, w)
 	if w.renderers[0].Color.A != 255 {
 		t.Fatalf("fill should keep alpha 255 when only stroke-opacity "+
 			"is animated, got %d", w.renderers[0].Color.A)
@@ -1146,7 +1146,7 @@ func TestEmitSvgPathRenderer_NonUniformStretchNeutralisesScale(t *testing.T) {
 		Color:     RGBA(255, 255, 255, 255),
 	}
 	// nsScaleX=2, nsScaleY=3, uniform scale=4 → nonUniform.
-	emitSvgPathRenderer(path, Color{}, 0, 0, 4, 2, 3, true, nil, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 4, 2, 3, true, nil, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))
@@ -1179,7 +1179,7 @@ func TestEmitSvgPathRenderer_NonUniformCompoundsWithBaseXform(t *testing.T) {
 	}
 	// nsScaleX=2, nsScaleY=3, uniform scale=4 → nonUniform.
 	// Expected: ScaleX = 2 * 0.5 = 1, ScaleY = 3 * 2 = 6.
-	emitSvgPathRenderer(path, Color{}, 0, 0, 4, 2, 3, true, nil, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 4, 2, 3, true, nil, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))
@@ -1207,7 +1207,7 @@ func TestEmitSvgPathRenderer_NonUniformNoOpWhenUniform(t *testing.T) {
 		Triangles: []float32{0, 0, 10, 0, 5, 10, 5, 10, 10, 0, 10, 10},
 		Color:     RGBA(255, 255, 255, 255),
 	}
-	emitSvgPathRenderer(path, Color{}, 0, 0, 3, 0, 0, false, nil, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 3, 0, 0, false, nil, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))
@@ -1229,7 +1229,7 @@ func TestEmitSvgPathRenderer_NonUniformSkipsWhenScaleEquals(t *testing.T) {
 		Triangles: []float32{0, 0, 10, 0, 5, 10, 5, 10, 10, 0, 10, 10},
 		Color:     RGBA(255, 255, 255, 255),
 	}
-	emitSvgPathRenderer(path, Color{}, 0, 0, 3, 3, 3, false, nil, w)
+	emitSvgPathRenderer(path, Color{}, 0, 0, 3, 3, 3, false, nil, &Shape{Opacity: 1}, w)
 
 	if len(w.renderers) != 1 {
 		t.Fatalf("expected 1 renderer, got %d", len(w.renderers))

--- a/gui/render_termgrid.go
+++ b/gui/render_termgrid.go
@@ -22,6 +22,6 @@ func renderTermGrid(shape *Shape, clip drawClip, w *Window) {
 		Y:        shape.Y,
 		W:        shape.Width,
 		H:        shape.Height,
-		TermGrid: tg,
+		TermGrid: dimmedTermGrid(tg, shape.Opacity, shape.Disabled),
 	}, w)
 }

--- a/gui/render_termgrid_test.go
+++ b/gui/render_termgrid_test.go
@@ -50,7 +50,8 @@ func TestRenderTermGridEmitsOneCommand(t *testing.T) {
 		shapeType: shapeTermGrid,
 		X:         10, Y: 20,
 		Width: 32, Height: 32,
-		tg: tg,
+		Opacity: 1.0,
+		tg:      tg,
 	}
 	renderTermGrid(shape, makeClip(0, 0, 200, 200), w)
 

--- a/gui/render_text.go
+++ b/gui/render_text.go
@@ -140,6 +140,13 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 		preLayout, hasPreLayout = inputGlyphLayoutResolved(text, shape, renderStyle, w, true)
 	}
 
+	// A gradient fill carries no color of its own, so it needs the
+	// same treatment c got above — except under the disabled role,
+	// whose theme style already expresses the state.
+	gradDim := shape.Disabled && !tc.TextStyle.disabledRole
+	textGradient := dimmedTextGradient(renderStyle.Gradient,
+		shape.Opacity, gradDim)
+
 	if renderWithLayout && hasPreLayout {
 		cmd := RenderCmd{
 			Kind:         RenderLayout,
@@ -148,7 +155,7 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 			Text:         text,
 			LayoutPtr:    w.scratch.renderGlyphLayouts.alloc(preLayout),
 			TextStylePtr: w.scratch.renderTextStyles.alloc(renderStyle),
-			TextGradient: renderStyle.Gradient,
+			TextGradient: textGradient,
 		}
 		if renderStyle.hasTextTransform() {
 			transform := renderStyle.effectiveTextTransform()
@@ -174,7 +181,7 @@ func renderText(shape *Shape, clip drawClip, w *Window) {
 			FontAscent:   fontAscent,
 			TextWidth:    textWidth,
 			TextStylePtr: w.scratch.renderTextStyles.alloc(renderStyle),
-			TextGradient: renderStyle.Gradient,
+			TextGradient: textGradient,
 		}
 		if tc.TextMode == TextModeWrap ||
 			tc.TextMode == TextModeWrapKeepSpaces {

--- a/gui/render_validate.go
+++ b/gui/render_validate.go
@@ -1,5 +1,30 @@
 package gui
 
+// Security caps for render commands. Invalid oversized commands
+// are dropped by emitRendererIfValid before they reach backends,
+// which would otherwise allocate from attacker-controlled lengths
+// (DrawCanvas batches, crafted RenderCmd).
+const (
+	// maxSvgTriangleFloats caps RenderSvg.Triangles length in
+	// floats. 200k triangles (~4.8MB) sits above the SVG
+	// maxPathSegments=100k budget with headroom for tessellation
+	// fan-out, while bounding the per-frame vertex allocation in
+	// every backend's drawSvg path.
+	maxSvgTriangleFloats = 1_200_000
+	// maxRenderTextLen caps RenderText.Text in bytes. SVG text runs
+	// cap at 64KB; the non-SVG path had no cap, letting one string
+	// drive unbounded shaping work.
+	maxRenderTextLen = 1 << 20
+	// maxFilterCompositeLayers mirrors soft maxFilterLayers: past a
+	// handful the glow is saturated and each extra pass is a
+	// full-layer blend.
+	maxFilterCompositeLayers = 32
+	// maxShadowSpread bounds RenderShadow.Spread, which was
+	// finite-checked but unbounded and drives blur working-rect
+	// growth in every backend.
+	maxShadowSpread = float32(1000000)
+)
+
 // rendererValidForDraw checks whether a RenderCmd has valid
 // parameters for drawing. Returns false for NaN/Inf coordinates,
 // negative sizes, nil pointers, etc.
@@ -17,14 +42,24 @@ func rendererValidForDraw(r RenderCmd) bool {
 		return validCircleCmd(r)
 	case RenderText:
 		return validTextCmd(r)
+	case RenderLine:
+		return validLineCmd(r)
 	case RenderLayout:
 		return validLayoutCmd(r)
+	case RenderRTF:
+		return validRTFCmd(r)
+	case RenderTextPath:
+		return validTextPathCmd(r)
+	case RenderTermGrid:
+		return validTermGridCmd(r)
 	case RenderLayoutTransformed:
 		return validLayoutTransformedCmd(r)
 	case RenderImage:
 		return validImageCmd(r)
 	case RenderSvg:
 		return validSvgCmd(r)
+	case RenderFilterBegin:
+		return validFilterBeginCmd(r)
 	case RenderFilterComposite:
 		return validFilterCompositeCmd(r)
 	case RenderStencilBegin, RenderStencilEnd:
@@ -39,6 +74,12 @@ func rendererValidForDraw(r RenderCmd) bool {
 		return validCustomShaderCmd(r)
 	case RenderRotateBegin:
 		return validRotateBeginCmd(r)
+	// Bracket ends and markers carry no validatable payload beyond
+	// the kind itself. Listed explicitly so a new kind is a
+	// compile-visible decision rather than a silent default-true.
+	case RenderNone, RenderFilterEnd, RenderRotateEnd,
+		RenderLayoutPlaced:
+		return true
 	default:
 		return true
 	}
@@ -70,6 +111,9 @@ func validCircleCmd(r RenderCmd) bool {
 
 func validTextCmd(r RenderCmd) bool {
 	if !f32AllFinite2(r.X, r.Y) || len(r.Text) == 0 {
+		return false
+	}
+	if len(r.Text) > maxRenderTextLen {
 		return false
 	}
 	if r.LayoutTransform != nil {
@@ -106,6 +150,41 @@ func validImageCmd(r RenderCmd) bool {
 		r.W > 0 && r.H > 0 && f32IsFinite(r.ClipRadius)
 }
 
+func validLineCmd(r RenderCmd) bool {
+	return f32AllFinite4(r.X, r.Y, r.OffsetX, r.OffsetY)
+}
+
+func validRTFCmd(r RenderCmd) bool {
+	return f32AllFinite2(r.X, r.Y) && r.LayoutPtr != nil
+}
+
+func validTextPathCmd(r RenderCmd) bool {
+	if !f32AllFinite2(r.X, r.Y) || len(r.Text) == 0 {
+		return false
+	}
+	if len(r.Text) > maxRenderTextLen {
+		return false
+	}
+	if r.textPath != nil && !f32AllFinite(r.textPath.Polyline) {
+		return false
+	}
+	return true
+}
+
+func validTermGridCmd(r RenderCmd) bool {
+	tg := r.TermGrid
+	if tg == nil {
+		return false
+	}
+	// Mirrors the soft backend's validTermGrid, including the
+	// division form of the cell-count check so a hostile
+	// Cols*Rows cannot overflow the check itself.
+	return tg.Cols > 0 && tg.Rows > 0 &&
+		f32IsFinite(tg.CellW) && tg.CellW > 0 &&
+		f32IsFinite(tg.CellH) && tg.CellH > 0 &&
+		tg.Rows <= len(tg.Cells)/tg.Cols
+}
+
 func validSvgCmd(r RenderCmd) bool {
 	if !f32AllFinite3(r.X, r.Y, r.Scale) || r.Scale <= 0 {
 		return false
@@ -125,6 +204,9 @@ func validSvgCmd(r RenderCmd) bool {
 	if len(r.Triangles) == 0 || len(r.Triangles)%6 != 0 {
 		return false
 	}
+	if len(r.Triangles) > maxSvgTriangleFloats {
+		return false
+	}
 	if !f32AllFinite(r.Triangles) {
 		return false
 	}
@@ -137,7 +219,22 @@ func validSvgCmd(r RenderCmd) bool {
 
 func validFilterCompositeCmd(r RenderCmd) bool {
 	return f32AllFinite4(r.X, r.Y, r.W, r.H) &&
-		r.W > 0 && r.H > 0 && r.Layers > 0
+		r.W > 0 && r.H > 0 && r.Layers > 0 &&
+		r.Layers <= maxFilterCompositeLayers
+}
+
+func validFilterBeginCmd(r RenderCmd) bool {
+	if !f32IsFinite(r.BlurRadius) || r.Layers < 1 {
+		return false
+	}
+	// Layers has no upper bound here: the SVG emitter clamps to
+	// maxFilterCompositeLayers and every backend clamps again, so
+	// a hand-built command degrades to capped glow passes. Dropping
+	// the Begin instead would unbalance the Begin/End bracket.
+	if r.ColorMatrix != nil && !f32AllFinite(r.ColorMatrix[:]) {
+		return false
+	}
+	return true
 }
 
 func validStencilCmd(r RenderCmd) bool {
@@ -154,7 +251,7 @@ func validShadowCmd(r RenderCmd) bool {
 	return f32AllFinite6(r.X, r.Y, r.W, r.H, r.BlurRadius, r.Radius) &&
 		r.W >= 0 && r.H >= 0 &&
 		f32AllFinite2(r.OffsetX, r.OffsetY) &&
-		f32IsFinite(r.Spread) && r.Spread >= 0
+		f32IsFinite(r.Spread) && r.Spread >= 0 && r.Spread <= maxShadowSpread
 }
 
 func validBlurCmd(r RenderCmd) bool {

--- a/gui/render_validate_test.go
+++ b/gui/render_validate_test.go
@@ -176,6 +176,132 @@ func TestRendererValidSvgVertexColors(t *testing.T) {
 	}
 }
 
+func TestRendererValidSvgOversizedTriangles(t *testing.T) {
+	r := RenderCmd{
+		Kind:      RenderSvg,
+		Scale:     1,
+		Triangles: make([]float32, maxSvgTriangleFloats+6),
+	}
+	if rendererValidForDraw(r) {
+		t.Error("oversized triangles should fail")
+	}
+	// Boundary still passes.
+	r.Triangles = make([]float32, maxSvgTriangleFloats)
+	if !rendererValidForDraw(r) {
+		t.Error("boundary-size triangles should pass")
+	}
+}
+
+func TestRendererValidTextOversized(t *testing.T) {
+	r := RenderCmd{Kind: RenderText, X: 0, Y: 0,
+		Text: string(make([]byte, maxRenderTextLen+1))}
+	if rendererValidForDraw(r) {
+		t.Error("oversized text should fail")
+	}
+}
+
+func TestRendererValidFilterCompositeLayersCapped(t *testing.T) {
+	r := RenderCmd{
+		Kind: RenderFilterComposite, W: 10, H: 10,
+		Layers: maxFilterCompositeLayers + 1,
+	}
+	if rendererValidForDraw(r) {
+		t.Error("excess layers should fail")
+	}
+}
+
+func TestRendererValidShadowSpreadCapped(t *testing.T) {
+	r := RenderCmd{Kind: RenderShadow, W: 10, H: 10,
+		BlurRadius: 4, Radius: 3, Spread: maxShadowSpread + 1}
+	if rendererValidForDraw(r) {
+		t.Error("excess spread should fail")
+	}
+}
+
+func TestRendererValidLine(t *testing.T) {
+	r := RenderCmd{Kind: RenderLine, X: 0, Y: 0, OffsetX: 10, OffsetY: 10}
+	if !rendererValidForDraw(r) {
+		t.Error("valid line should pass")
+	}
+	r.OffsetX = float32(math.NaN())
+	if rendererValidForDraw(r) {
+		t.Error("NaN endpoint should fail")
+	}
+}
+
+func TestRendererValidRTF(t *testing.T) {
+	ly := &glyph.Layout{}
+	r := RenderCmd{Kind: RenderRTF, X: 0, Y: 0, LayoutPtr: ly}
+	if !rendererValidForDraw(r) {
+		t.Error("valid RTF should pass")
+	}
+	r.LayoutPtr = nil
+	if rendererValidForDraw(r) {
+		t.Error("nil layout should fail")
+	}
+}
+
+func TestRendererValidTextPath(t *testing.T) {
+	r := RenderCmd{Kind: RenderTextPath, X: 0, Y: 0, Text: "hi"}
+	if !rendererValidForDraw(r) {
+		t.Error("valid textPath should pass")
+	}
+	r.Text = ""
+	if rendererValidForDraw(r) {
+		t.Error("empty text should fail")
+	}
+}
+
+func TestRendererValidTermGrid(t *testing.T) {
+	cells := make([]TermCell, 6)
+	tg := &TermGridData{Cells: cells, Cols: 3, Rows: 2,
+		CellW: 8, CellH: 16}
+	r := RenderCmd{Kind: RenderTermGrid, X: 0, Y: 0, TermGrid: tg}
+	if !rendererValidForDraw(r) {
+		t.Error("valid termgrid should pass")
+	}
+	r.TermGrid = nil
+	if rendererValidForDraw(r) {
+		t.Error("nil termgrid should fail")
+	}
+	r.TermGrid = &TermGridData{Cells: cells, Cols: 3, Rows: 3,
+		CellW: 8, CellH: 16}
+	if rendererValidForDraw(r) {
+		t.Error("short cell buffer should fail")
+	}
+}
+
+func TestRendererValidFilterBegin(t *testing.T) {
+	m := &[16]float32{}
+	r := RenderCmd{Kind: RenderFilterBegin, BlurRadius: 4,
+		Layers: 2, ColorMatrix: m}
+	if !rendererValidForDraw(r) {
+		t.Error("valid filter begin should pass")
+	}
+	r.ColorMatrix = nil // SVG path carries no matrix
+	if !rendererValidForDraw(r) {
+		t.Error("nil matrix should pass (SVG filter path)")
+	}
+	r.Layers = 0
+	if rendererValidForDraw(r) {
+		t.Error("zero layers should fail")
+	}
+	r.Layers = 2
+	r.BlurRadius = float32(math.NaN())
+	if rendererValidForDraw(r) {
+		t.Error("NaN blur should fail")
+	}
+}
+
+func TestRendererValidNoPayloadKinds(t *testing.T) {
+	for _, k := range []renderKind{RenderNone, RenderFilterEnd,
+		RenderRotateEnd, RenderLayoutPlaced} {
+		if !rendererValidForDraw(RenderCmd{Kind: k}) {
+			t.Errorf("kind %d should pass", k)
+		}
+	}
+}
+
 func TestRendererValidFilterComposite(t *testing.T) {
 	r := RenderCmd{Kind: RenderFilterComposite, W: 10, H: 10, Layers: 2}
 	if !rendererValidForDraw(r) {

--- a/gui/termgrid.go
+++ b/gui/termgrid.go
@@ -14,6 +14,11 @@ import "math"
 // handing the buffer over. The grid is laid out like any other widget
 // (Fixed default sizing of Cols*CellW x Rows*CellH); the backend draws
 // glyphs pinned to exact cell positions so the grid never drifts.
+//
+// Deprecated: the whole TermGrid widget is deprecated and will be
+// removed in a future minor. The only terminal in the org, go-term,
+// renders its grid through DrawCanvas instead, and no other consumer
+// uses this widget. New code should draw grids on a DrawCanvas.
 
 // TermAttr is a per-cell attribute bitset. Combine with bitwise OR.
 type TermAttr uint8
@@ -79,6 +84,10 @@ type TermGridData struct {
 }
 
 // TermGridCfg configures a TermGrid widget.
+//
+// Deprecated: TermGrid is deprecated and will be removed in a
+// future minor. Render grids through DrawCanvas instead, as
+// go-term does.
 type TermGridCfg struct {
 	OnKeyDown     func(EventCtx)
 	OnClick       func(EventCtx)
@@ -109,6 +118,10 @@ type termGridView struct {
 // CellW, and CellH define the geometry; Cells is the row-major cell
 // buffer (len >= Cols*Rows). Default sizing is Fixed at
 // Cols*CellW x Rows*CellH.
+//
+// Deprecated: TermGrid is deprecated and will be removed in a
+// future minor. Render grids through DrawCanvas instead, as
+// go-term does.
 func TermGrid(cfg TermGridCfg) View {
 	cfg.Sizing = cfg.Sizing.Or(FixedFixed)
 	if cfg.TextStyle == (TextStyle{}) {
@@ -163,6 +176,9 @@ func (tv *termGridView) GenerateLayout(w *Window) Layout {
 		Shape: w.allocShape(Shape{
 			shapeType: shapeTermGrid,
 			ID:        c.ID,
+			// No Opacity knob on the cfg yet; default opaque so
+			// the emit paths can treat 0 as transparent.
+			Opacity:   1.0,
 			A11YRole:  a11yRole,
 			a11Y:      c.a11yInfo(""),
 			Width:     width,

--- a/gui/testdata/color_swatch.dark.golden
+++ b/gui/testdata/color_swatch.dark.golden
@@ -1,5 +1,5 @@
 Clip xy=15.00,15.00 wh=48.00,32.00
-Image xy=15.00,15.00 wh=48.00,32.00 res="mem:gui/checker/96-64-"
+Image xy=15.00,15.00 wh=48.00,32.00 res="mem:gui/checker/96-64-" cradius=6.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=15.00,15.00 wh=48.00,32.00 color=#5078c880 radius=6.00 fill
 StrokeRect xy=15.00,15.00 wh=48.00,32.00 color=#ffffff0e radius=6.00 thickness=1.00

--- a/gui/testdata/color_swatch.light.golden
+++ b/gui/testdata/color_swatch.light.golden
@@ -1,5 +1,5 @@
 Clip xy=14.00,14.00 wh=48.00,32.00
-Image xy=14.00,14.00 wh=48.00,32.00 res="mem:gui/checker/96-64-"
+Image xy=14.00,14.00 wh=48.00,32.00 res="mem:gui/checker/96-64-" cradius=6.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=14.00,14.00 wh=48.00,32.00 color=#5078c880 radius=6.00 fill
 StrokeRect xy=14.00,14.00 wh=48.00,32.00 color=#d8dde47f radius=6.00 thickness=1.00

--- a/gui/testdata/color_swatch_focused.dark.golden
+++ b/gui/testdata/color_swatch_focused.dark.golden
@@ -1,5 +1,5 @@
 Clip xy=15.00,15.00 wh=48.00,32.00
-Image xy=15.00,15.00 wh=48.00,32.00 res="mem:gui/checker/96-64-"
+Image xy=15.00,15.00 wh=48.00,32.00 res="mem:gui/checker/96-64-" cradius=6.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=15.00,15.00 wh=48.00,32.00 color=#5078c880 radius=6.00 fill
 StrokeRect xy=15.00,15.00 wh=48.00,32.00 color=#4d82f0ff radius=6.00 thickness=1.00

--- a/gui/testdata/color_swatch_focused.light.golden
+++ b/gui/testdata/color_swatch_focused.light.golden
@@ -1,5 +1,5 @@
 Clip xy=14.00,14.00 wh=48.00,32.00
-Image xy=14.00,14.00 wh=48.00,32.00 res="mem:gui/checker/96-64-"
+Image xy=14.00,14.00 wh=48.00,32.00 res="mem:gui/checker/96-64-" cradius=6.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=14.00,14.00 wh=48.00,32.00 color=#5078c880 radius=6.00 fill
 StrokeRect xy=14.00,14.00 wh=48.00,32.00 color=#2f6fe0ff radius=6.00 thickness=1.00

--- a/gui/testdata/markdown_blocks.dark.golden
+++ b/gui/testdata/markdown_blocks.dark.golden
@@ -1,12 +1,12 @@
-RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
-RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
-RTF xy=47.00,33.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
+RTF xy=47.00,33.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Clip xy=0.00,0.00 wh=0.00,0.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=30.00,61.00 wh=260.00,1.00 color=#ffffff14 fill
 Text xy=30.00,62.00 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
-RTF xy=60.80,62.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=60.80,62.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=30.00,81.60 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
-RTF xy=60.80,81.60 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=60.80,81.60 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=275.40,39.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
 Text xy=290.40,21.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/testdata/markdown_blocks.light.golden
+++ b/gui/testdata/markdown_blocks.light.golden
@@ -1,12 +1,12 @@
-RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
-RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
-RTF xy=45.00,31.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
+RTF xy=45.00,31.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Clip xy=0.00,0.00 wh=0.00,0.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=28.00,59.00 wh=264.00,1.00 color=#e6eaefff fill
 Text xy=28.00,60.00 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
-RTF xy=58.80,60.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=58.80,60.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=28.00,79.60 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
-RTF xy=58.80,79.60 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=58.80,79.60 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=277.40,37.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
 Text xy=291.40,20.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/testdata/markdown_callout.dark.golden
+++ b/gui/testdata/markdown_callout.dark.golden
@@ -1,5 +1,5 @@
-RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
-RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
+RTF xy=30.00,33.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Rect xy=30.00,33.00 wh=260.00,37.60 color=#4d82f028 radius=6.00 fill
 StrokeRect xy=30.00,33.00 wh=260.00,37.60 color=#4d82f0ff radius=6.00 thickness=1.00
 Text xy=39.00,42.00 wh=0.00,0.00 color=#e6e8ebff text="A quoted line." size=14.00
@@ -7,8 +7,8 @@ Clip xy=0.00,0.00 wh=0.00,0.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=30.00,98.60 wh=260.00,1.00 color=#ffffff14 fill
 Text xy=30.00,99.60 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
-RTF xy=60.80,99.60 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=60.80,99.60 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=30.00,119.20 wh=0.00,0.00 color=#e6e8ebff text="• " size=14.00
-RTF xy=60.80,119.20 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=60.80,119.20 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=275.40,77.57 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
 Text xy=290.40,21.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/testdata/markdown_callout.light.golden
+++ b/gui/testdata/markdown_callout.light.golden
@@ -1,5 +1,5 @@
-RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
-RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
+RTF xy=28.00,31.00 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Rect xy=28.00,31.00 wh=264.00,37.60 color=#2f6fe01e radius=6.00 fill
 StrokeRect xy=28.00,31.00 wh=264.00,37.60 color=#2f6fe0ff radius=6.00 thickness=1.00
 Text xy=37.00,40.00 wh=0.00,0.00 color=#1a1d21ff text="A quoted line." size=14.00
@@ -7,8 +7,8 @@ Clip xy=0.00,0.00 wh=0.00,0.00
 Clip xy=0.00,0.00 wh=320.00,240.00
 Rect xy=28.00,96.60 wh=264.00,1.00 color=#e6eaefff fill
 Text xy=28.00,97.60 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
-RTF xy=58.80,97.60 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=58.80,97.60 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=28.00,117.20 wh=0.00,0.00 color=#1a1d21ff text="• " size=14.00
-RTF xy=58.80,117.20 wh=0.00,0.00 text="" +glyphlayout
+RTF xy=58.80,117.20 wh=0.00,0.00 text="" +glyphlayout glyphs=0 items=0
 Text xy=277.40,75.57 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00
 Text xy=291.40,20.97 wh=0.00,0.00 color=#808080ff text="\uf1b1" size=11.00

--- a/gui/view_draw_canvas.go
+++ b/gui/view_draw_canvas.go
@@ -96,9 +96,12 @@ func (dv *drawCanvasView) GenerateLayout(w *Window) Layout {
 
 	layout := Layout{
 		Shape: w.allocShape(Shape{
-			shapeType:    shapeDrawCanvas,
-			ID:           c.ID,
-			Version:      c.Version,
+			shapeType: shapeDrawCanvas,
+			ID:        c.ID,
+			Version:   c.Version,
+			// No Opacity knob on the cfg yet; default opaque
+			// so the emit paths can treat 0 as transparent.
+			Opacity:      1.0,
 			A11YRole:     a11yRole,
 			a11Y:         c.a11yInfo(""),
 			Width:        c.Width,

--- a/gui/view_rtf.go
+++ b/gui/view_rtf.go
@@ -167,6 +167,9 @@ func (v *rtfView) GenerateLayout(w *Window) Layout {
 	shape := w.allocShape(Shape{
 		shapeType: shapeRTF,
 		ID:        v.ID,
+		// No Opacity knob on the cfg yet; default opaque so
+		// the emit paths can treat 0 as transparent.
+		Opacity:   1.0,
 		Focusable: v.Focusable,
 		A11YRole:  AccessRoleStaticText,
 		a11Y:      v.a11yInfo(""),

--- a/gui/window_state.go
+++ b/gui/window_state.go
@@ -19,6 +19,9 @@ type windowRender struct {
 	inFilter bool
 	// Render guard — warnings emitted once per kind (bitmask over RenderKind).
 	renderGuardWarned uint32
+	// OnDraw panic warning, emitted once. A panicking canvas would
+	// otherwise log on every frame.
+	drawPanicWarned bool
 }
 
 // windowAnimation holds animation lifecycle state.


### PR DESCRIPTION
Render pipeline review, tracks 1-4, plus TermGrid deprecation (option 1: deprecate now, remove next minor).

- Track 1 security caps: SVG/text/filter/shadow/texture input gates
- Track 2 bracket safety: defer-based unwind, OnDraw panic isolation
- Track 3 backend parity: GL/Web TermGrid ports, layer clamping, PDF rotate + termgrid print
- Track 4 disabled/opacity: unified dim rule, opaque factory defaults (TermGrid, RTF, DrawCanvas)
- TermGrid + TermGridCfg marked deprecated (entry points only, keeps SA1019 off impl code); go-term renders via DrawCanvas, sole consumer is examples/termgrid demo

Local gate: make prepush green.