### PR TITLE
fix(gui): harden animation loop — empty ID, heartbeat clock, spring NaN, hero morph, repeat storm, transition race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,77 @@ and this project adheres to
   demo. New code should draw grids on a `DrawCanvas`. Removal takes the
   `RenderTermGrid` command, its per-backend draws, and the print branch with it.
 
+### Fixed
+
+- **AnimationAdd now rejects an empty animation ID** — animations are keyed by
+  ID with replace semantics, so every unnamed `Animate` silently collided on
+  `""` and replaced the previous one. An empty ID now panics at registration,
+  matching `State[T]`'s treatment of programmer error. Correct callers are
+  unaffected; a caller relying on the collision was already corrupting its own
+  animation map.
+
+- **View-bound animations no longer die when a time-travel scrub ends** (#5) —
+  the liveness heartbeat was stamped and compared with the scrubbable clock, so
+  scrubbing 10 minutes back stamped every visible widget at T-10min and the
+  first tick after resume read 10 minutes of staleness against the 2 s
+  threshold, cancelling each animation while its widget was still on screen. The
+  heartbeat now uses the wall clock, which is never shown to a user and has no
+  reason to be scrubbable. The `Animation.Update` doc is also corrected: `dt` is
+  the nominal 16 ms step, not a measured elapsed time.
+
+- **A diverging spring animation now snaps to its target instead of running
+  forever with NaN** — `SpringAnimation` integrates with explicit Euler at a
+  fixed 16 ms timestep, so a stiffness above roughly 15600 (at `Mass: 1`)
+  amplified each step until velocity reached `+Inf` and position became `NaN`.
+  `NaN` fails every comparison, so the at-rest check never fired: the animation
+  stayed alive, called `OnValue` with `NaN` on every tick, pushed that value
+  into layout geometry, and forced a full layout refresh every 16 ms for the
+  life of the window. A diverged spring is now treated as arrived — it snaps to
+  the target, calls `OnValue` with the target and then `OnDone`, and retires.
+  Callers see a hard snap where they previously saw a frozen, CPU-burning
+  window.
+
+- **Hero transitions actually morph** — `NewHeroTransition` recorded no "before"
+  geometry, so the documented sequence (`AnimationAdd`, then `UpdateView`)
+  produced only a fade: every hero-marked element held its final position for
+  the whole transition and no element ever travelled between the two views.
+  `AnimationAdd` now captures the hero geometry of the current frame, which is
+  the last moment it exists, and a hero present on both sides morphs between the
+  two. A hero only on the new side still fades in; one that left the tree cannot
+  fade out, because it is no longer there to draw. The redundant incoming-side
+  snapshot map is gone — the apply walk runs over the incoming tree, so it never
+  told the morph anything the walk did not already know.
+
+- **A repeating animation no longer storms after a stall** — `Animate` with
+  `Repeat`, and the caret blink, advanced their start time by exactly one delay
+  per tick. After a stall — a minimized window, a debugger break, one very long
+  frame — start sat many delays in the past, so the missed intervals drained at
+  one callback per ~16 ms tick: a 5-second stall on a 16 ms repeat fired over
+  300 catch-up callbacks, and the caret strobed its way back to the present.
+  Once start falls more than one further delay behind, the missed intervals are
+  now dropped and the animation resyncs to the present. A tick that arrives on
+  time still steps by exactly one delay, so a long interval keeps its drift-free
+  cadence.
+
+- **Layout and hero transitions no longer race the animation goroutine** — the
+  amend pass read a running transition's `progress` and `stopped` on the main
+  thread after releasing `w.animMu`, while the animation goroutine wrote both
+  under that mutex on every tick. Each frame could interpolate against a
+  half-written progress, and `-race` reported it wherever a transition ran
+  during a real frame. Both accessors now copy the values out inside the
+  critical section, so a frame interpolates from one stable progress.
+
 ### Added
+
+- **Easing palette exported** — `EaseInQuad`, `EaseInCubic`, `EaseInOutCubic`,
+  `EaseInBack`, `EaseOutBack`, `EaseCSS`, `EaseInCSS`, `EaseOutCSS`,
+  `EaseInOutCSS`, and `CubicBezier` are now public. The exported `Easing` config
+  fields (`HeroTransitionCfg`, `LayoutTransitionCfg`, tween/keyframe easings)
+  previously accepted functions consumers could not spell for half the palette;
+  the full family is now reachable. Removed in the same pass: the unexported
+  `applyHeroRecursive`, `applyTransitionRecursive`, and `propagateOpacity`
+  wrappers, which production never called — tests now drive the `Depth` variants
+  directly.
 
 - **TermGrid renders on the GL and Web backends, and in print** — the terminal
   character grid previously painted only through the Metal and soft backends; on
@@ -42,19 +112,17 @@ and this project adheres to
   their pattern with no bound, so a non-finite endpoint hung the frame and a
   very long segment against a short pattern took the frame with it; both now
   screen their input and cap the walk. `FilledRect`, `Rect`, `Line`, `Polyline`,
-  `FilledPolygon`, `PolylineJoined`, `FilledRoundedRect`, `RoundedRect`,
-  `Arc`, `DashedLine`, `DashedPolyline` and `FillTrianglesColors` now reject
-  non-finite coordinates and stroke widths at record time — a bad vertex
-  reaching a batch cost
-  every other primitive that had merged into it, because the whole render
+  `FilledPolygon`, `PolylineJoined`, `FilledRoundedRect`, `RoundedRect`, `Arc`,
+  `DashedLine`, `DashedPolyline` and `FillTrianglesColors` now reject non-finite
+  coordinates and stroke widths at record time — a bad vertex reaching a batch
+  cost every other primitive that had merged into it, because the whole render
   command is dropped downstream — `FillTrianglesGradient` takes the same
-  non-finite screen `FillTrianglesColors` has, both take the same input
-  bound, and the shape-specific gradient fills screen their geometry before
-  recording. The recorder path (SVG/PDF export)
-  baked the canvas transform into a point list only up to a size threshold,
-  silently exporting a larger polyline at its unmapped local coordinates; every
-  length is now mapped, and the scratch buffer behind it is released on reset
-  with the rest.
+  non-finite screen `FillTrianglesColors` has, both take the same input bound,
+  and the shape-specific gradient fills screen their geometry before recording.
+  The recorder path (SVG/PDF export) baked the canvas transform into a point
+  list only up to a size threshold, silently exporting a larger polyline at its
+  unmapped local coordinates; every length is now mapped, and the scratch buffer
+  behind it is released on reset with the rest.
 
 - **Disabled and Opacity now reach every render path** — fading or disabling a
   widget previously dimmed only its flat fills, borders, blur, and plain text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ and this project adheres to
 
 ### Fixed
 
+- **Canvas draw hardening: z-order, dash loops, non-finite input** — five
+  defects found reviewing `DrawContext`. A flat fill recorded after a radial
+  gradient that was lowered to a shader quad merged back into the batch opened
+  before it, so it painted _under_ the glow it was drawn over; a lowered fill
+  now closes the batch it interrupts. `DashedLine` and `DashedPolyline` walked
+  their pattern with no bound, so a non-finite endpoint hung the frame and a
+  very long segment against a short pattern took the frame with it; both now
+  screen their input and cap the walk. `FilledRect`, `Rect`, `Line`, `Polyline`,
+  `FilledPolygon`, `PolylineJoined`, `FilledRoundedRect`, `RoundedRect`,
+  `Arc`, `DashedLine`, `DashedPolyline` and `FillTrianglesColors` now reject
+  non-finite coordinates and stroke widths at record time — a bad vertex
+  reaching a batch cost
+  every other primitive that had merged into it, because the whole render
+  command is dropped downstream — `FillTrianglesGradient` takes the same
+  non-finite screen `FillTrianglesColors` has, both take the same input
+  bound, and the shape-specific gradient fills screen their geometry before
+  recording. The recorder path (SVG/PDF export)
+  baked the canvas transform into a point list only up to a size threshold,
+  silently exporting a larger polyline at its unmapped local coordinates; every
+  length is now mapped, and the scratch buffer behind it is released on reset
+  with the rest.
+
 - **Disabled and Opacity now reach every render path** — fading or disabling a
   widget previously dimmed only its flat fills, borders, blur, and plain text.
   Shadows, custom-shader tint, gradient fills and borders, image fills, the

--- a/gui/animation.go
+++ b/gui/animation.go
@@ -84,11 +84,26 @@ func maxAnimationRefreshKind(current, incoming AnimationRefreshKind) AnimationRe
 }
 
 // Animation is the interface for all animation types. Update is
-// called each tick with the elapsed seconds since the previous tick
-// and an AnimationCommands batch into which the animation may enqueue
-// deferred callbacks (OnDone / OnValue) — those run after Update
-// returns so callback bodies cannot reenter the animation loop mutex.
+// called each tick with the nominal timestep in seconds (the fixed
+// 16 ms animation cycle), not a measured elapsed time — a late tick
+// still reports the nominal step. Duration-based animations re-derive
+// progress from the wall clock (see durationProgress); only the
+// spring integrator steps by dt, which is what its stability bound
+// is derived for. An AnimationCommands batch is supplied into which
+// the animation may enqueue deferred callbacks (OnDone / OnValue) —
+// those run after Update returns so callback bodies cannot reenter
+// the animation loop mutex.
 // Return false once the animation has stopped so the loop retires it.
+//
+// Update runs with the animation mutex held: it must not call
+// HasAnimation, AnimationAdd, AnimationRemove, animationAddViewBound
+// or touchViewBoundAnimation — each takes the same mutex and
+// self-deadlocks. One-shot and repeating work belongs in the deferred
+// callbacks, which run off the loop.
+//
+// Two live animations must not write the same state. The loop walks
+// the animation map, whose iteration order varies frame to frame, so
+// overlapping writers apply in a nondeterministic order.
 // exportaudit:keep — reachable from an exported signature
 type Animation interface {
 	ID() string

--- a/gui/animation_easing.go
+++ b/gui/animation_easing.go
@@ -14,7 +14,8 @@ func lerp(a, b, t float32) float32 {
 func EaseLinear(t float32) float32 { return t }
 
 // EaseInQuad starts slow and accelerates (quadratic).
-func easeInQuad(t float32) float32 { return t * t }
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseInQuad(t float32) float32 { return t * t }
 
 // EaseOutQuad starts fast and decelerates (quadratic).
 func EaseOutQuad(t float32) float32 { return 1 - (1-t)*(1-t) }
@@ -29,7 +30,8 @@ func EaseInOutQuad(t float32) float32 {
 }
 
 // EaseInCubic starts slow and accelerates (cubic).
-func easeInCubic(t float32) float32 { return t * t * t }
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseInCubic(t float32) float32 { return t * t * t }
 
 // EaseOutCubic starts fast and decelerates (cubic).
 func EaseOutCubic(t float32) float32 {
@@ -38,7 +40,8 @@ func EaseOutCubic(t float32) float32 {
 }
 
 // EaseInOutCubic accelerates then decelerates (cubic).
-func easeInOutCubic(t float32) float32 {
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseInOutCubic(t float32) float32 {
 	if t < 0.5 {
 		return 4 * t * t * t
 	}
@@ -47,14 +50,16 @@ func easeInOutCubic(t float32) float32 {
 }
 
 // EaseInBack pulls back slightly before accelerating forward.
-func easeInBack(t float32) float32 {
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseInBack(t float32) float32 {
 	const c1 = float32(1.70158)
 	c3 := c1 + 1
 	return c3*t*t*t - c1*t*t
 }
 
 // EaseOutBack overshoots the target then settles back.
-func easeOutBack(t float32) float32 {
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseOutBack(t float32) float32 {
 	const c1 = float32(1.70158)
 	c3 := c1 + 1
 	u := t - 1
@@ -135,20 +140,32 @@ var (
 )
 
 // EaseCSS returns CSS "ease" curve. Uses precomputed LUT.
-func easeCSS(t float32) float32 { return easeLUT.lookup(t) }
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseCSS(t float32) float32 { return easeLUT.lookup(t) }
 
 // EaseInCSS returns CSS "ease-in" curve. Uses precomputed LUT.
-func easeInCSS(t float32) float32 { return easeInLUT.lookup(t) }
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseInCSS(t float32) float32 { return easeInLUT.lookup(t) }
 
 // EaseOutCSS returns CSS "ease-out" curve. Uses precomputed LUT.
-func easeOutCSS(t float32) float32 { return easeOutLUT.lookup(t) }
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseOutCSS(t float32) float32 { return easeOutLUT.lookup(t) }
 
 // EaseInOutCSS returns CSS "ease-in-out" curve. Uses precomputed LUT.
-func easeInOutCSS(t float32) float32 { return easeInOutLUT.lookup(t) }
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func EaseInOutCSS(t float32) float32 { return easeInOutLUT.lookup(t) }
 
 // CubicBezier creates a custom easing function from bezier
 // control points. Works like CSS cubic-bezier().
-func cubicBezier(x1, y1, x2, y2 float32) EasingFn {
+//
+// Non-finite control points fall back to EaseLinear: they would
+// otherwise poison the Newton-Raphson iteration and hand NaN to
+// layout geometry.
+// exportaudit:keep — documented easing palette for consumer EasingFn fields
+func CubicBezier(x1, y1, x2, y2 float32) EasingFn {
+	if !f32AllFinite4(x1, y1, x2, y2) {
+		return EaseLinear
+	}
 	return func(t float32) float32 {
 		return bezierCalc(t, x1, y1, x2, y2)
 	}

--- a/gui/animation_easing_test.go
+++ b/gui/animation_easing_test.go
@@ -27,12 +27,12 @@ func TestEasingEndpoints(t *testing.T) {
 		fn   EasingFn
 	}{
 		{"Linear", EaseLinear},
-		{"InQuad", easeInQuad},
+		{"InQuad", EaseInQuad},
 		{"OutQuad", EaseOutQuad},
 		{"InOutQuad", EaseInOutQuad},
-		{"InCubic", easeInCubic},
+		{"InCubic", EaseInCubic},
 		{"OutCubic", EaseOutCubic},
-		{"InOutCubic", easeInOutCubic},
+		{"InOutCubic", EaseInOutCubic},
 		{"OutBounce", EaseOutBounce},
 	}
 	for _, tt := range fns {
@@ -48,20 +48,20 @@ func TestEasingEndpoints(t *testing.T) {
 }
 
 func TestEaseInBackEndpoints(t *testing.T) {
-	if easeInBack(0) != 0 {
+	if EaseInBack(0) != 0 {
 		t.Error("EaseInBack(0) != 0")
 	}
-	if math.Abs(float64(easeInBack(1))-1) > 0.001 {
-		t.Errorf("EaseInBack(1) = %f", easeInBack(1))
+	if math.Abs(float64(EaseInBack(1))-1) > 0.001 {
+		t.Errorf("EaseInBack(1) = %f", EaseInBack(1))
 	}
 }
 
 func TestEaseOutBackEndpoints(t *testing.T) {
-	if math.Abs(float64(easeOutBack(0))-0) > 0.001 {
-		t.Errorf("EaseOutBack(0) = %f", easeOutBack(0))
+	if math.Abs(float64(EaseOutBack(0))-0) > 0.001 {
+		t.Errorf("EaseOutBack(0) = %f", EaseOutBack(0))
 	}
-	if math.Abs(float64(easeOutBack(1))-1) > 0.001 {
-		t.Errorf("EaseOutBack(1) = %f", easeOutBack(1))
+	if math.Abs(float64(EaseOutBack(1))-1) > 0.001 {
+		t.Errorf("EaseOutBack(1) = %f", EaseOutBack(1))
 	}
 }
 
@@ -93,10 +93,10 @@ func TestEaseCSSEndpoints(t *testing.T) {
 		name string
 		fn   EasingFn
 	}{
-		{"CSS", easeCSS},
-		{"InCSS", easeInCSS},
-		{"OutCSS", easeOutCSS},
-		{"InOutCSS", easeInOutCSS},
+		{"CSS", EaseCSS},
+		{"InCSS", EaseInCSS},
+		{"OutCSS", EaseOutCSS},
+		{"InOutCSS", EaseInOutCSS},
 	}
 	for _, tt := range fns {
 		if tt.fn(0) != 0 {
@@ -109,10 +109,23 @@ func TestEaseCSSEndpoints(t *testing.T) {
 }
 
 func TestCubicBezierFactory(t *testing.T) {
-	fn := cubicBezier(0.25, 0.1, 0.25, 1.0)
+	fn := CubicBezier(0.25, 0.1, 0.25, 1.0)
 	v := fn(0.5)
 	if v <= 0 || v >= 1 {
 		t.Errorf("CubicBezier(0.5) = %f", v)
+	}
+}
+
+func TestCubicBezierNonFiniteFallsBackToLinear(t *testing.T) {
+	for _, pts := range [][4]float32{
+		{float32(math.NaN()), 0, 1, 1},
+		{0, float32(math.Inf(1)), 1, 1},
+		{0, 0, 1, float32(math.Inf(-1))},
+	} {
+		fn := CubicBezier(pts[0], pts[1], pts[2], pts[3])
+		if got := fn(0.5); got != 0.5 {
+			t.Errorf("CubicBezier(%v)(0.5) = %f, want 0.5 (linear fallback)", pts, got)
+		}
 	}
 }
 
@@ -134,7 +147,7 @@ func TestBezierLUTClamping(t *testing.T) {
 }
 
 func TestEaseInOutCubicSymmetry(t *testing.T) {
-	v := easeInOutCubic(0.5)
+	v := EaseInOutCubic(0.5)
 	if math.Abs(float64(v)-0.5) > 0.01 {
 		t.Errorf("EaseInOutCubic(0.5) = %f, want ~0.5", v)
 	}

--- a/gui/animation_hero.go
+++ b/gui/animation_hero.go
@@ -15,8 +15,16 @@ const heroTransitionID = "__hero_transition__"
 // HeroTransition can be active at a time (fixed internal ID).
 // exportaudit:keep — reachable from an exported signature
 type HeroTransition struct {
+	// outgoing holds the hero geometry of the frame the transition was
+	// registered on — the "before" side of the morph. AnimationAdd
+	// fills it; a transition never registered through AnimationAdd has
+	// no before side and every hero simply fades in.
+	//
+	// There is deliberately no incoming map. The apply walk runs over
+	// the incoming tree, so every hero it reaches is on the incoming
+	// side by construction, and the morph target is the shape's live
+	// post-layout geometry rather than a recorded value.
 	outgoing map[string]posSnapshot
-	incoming map[string]posSnapshot
 	transitionBase
 }
 
@@ -50,32 +58,42 @@ func NewHeroTransition(cfg HeroTransitionCfg) *HeroTransition {
 	}
 }
 
-// captureHeroSnapshots finds all hero-marked elements.
-func captureHeroSnapshots(layout Layout) map[string]posSnapshot {
+// captureHeroSnapshots finds all hero-marked elements. Takes a pointer:
+// Layout is a large struct and this runs on a frame's root.
+func captureHeroSnapshots(layout *Layout) map[string]posSnapshot {
 	snapshots := make(map[string]posSnapshot)
-	captureSnapshots(&layout, snapshots, true)
+	captureSnapshots(layout, snapshots, true)
 	return snapshots
 }
 
 // applyHeroTransition modifies layout during render for hero effect.
-// Called from layoutPipeline under w.mu. Acquires w.animMu to safely
-// read w.animations (the animation goroutine may concurrently delete).
+// Called from layoutPipeline under w.mu.
 func applyHeroTransition(layout *Layout, w *Window) {
-	w.animMu.Lock()
-	a, ok := w.animations[heroTransitionID]
-	w.animMu.Unlock()
+	progress, outgoing, ok := w.getHeroTransition()
 	if !ok {
 		return
 	}
-	ht, ok := a.(*HeroTransition)
-	if !ok || ht.stopped {
-		return
-	}
-	applyHeroRecursiveDepth(layout, ht.progress, ht.outgoing, ht.incoming, 0, 0, 0)
+	applyHeroRecursiveDepth(layout, progress, outgoing, 0, 0, 0)
 }
 
-func propagateOpacity(layout *Layout, opacity float32) {
-	propagateOpacityDepth(layout, opacity, 0)
+// getHeroTransition returns the running hero transition's progress and
+// its outgoing snapshots. Everything is copied out under w.animMu for
+// the reason getLayoutTransition spells out: progress and stopped move
+// every tick under the animation goroutine, so the frame takes one
+// stable value instead of dereferencing the animation after unlocking.
+// The map is write-once before the transition is published.
+func (w *Window) getHeroTransition() (float32, map[string]posSnapshot, bool) {
+	w.animMu.Lock()
+	defer w.animMu.Unlock()
+	a, ok := w.animations[heroTransitionID]
+	if !ok {
+		return 0, nil, false
+	}
+	ht, isHero := a.(*HeroTransition)
+	if !isHero || ht.stopped {
+		return 0, nil, false
+	}
+	return ht.progress, ht.outgoing, true
 }
 
 func propagateOpacityDepth(layout *Layout, opacity float32, depth int) {
@@ -88,18 +106,19 @@ func propagateOpacityDepth(layout *Layout, opacity float32, depth int) {
 	}
 }
 
-// applyHeroRecursive morphs each matched hero toward its incoming
-// geometry. dx/dy carry the nearest morphed ancestor's position shift,
-// the same rule applyTransitionRecursive follows: layout coordinates are
+// applyHeroRecursiveDepth morphs each hero that has an outgoing snapshot
+// toward its live post-layout geometry. A hero with no snapshot is new
+// on this side of the transition and fades in over the second half.
+// Fading is one-directional: a hero that LEFT the tree is not in the
+// walk at all, so it cannot fade out.
+//
+// dx/dy carry the nearest morphed ancestor's position shift,
+// the same rule the layout transition follows: layout coordinates are
 // absolute, so a morphing card's label — no ID, so no snapshot — would
 // otherwise stay at its final position while the card travelled. A hero
 // with its own snapshot replaces the carried shift instead of adding to
 // it, because the snapshot is an absolute position.
-func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map[string]posSnapshot, dx, dy float32) {
-	applyHeroRecursiveDepth(layout, progress, outgoing, incoming, dx, dy, 0)
-}
-
-func applyHeroRecursiveDepth(layout *Layout, progress float32, outgoing, incoming map[string]posSnapshot, dx, dy float32, depth int) {
+func applyHeroRecursiveDepth(layout *Layout, progress float32, outgoing map[string]posSnapshot, dx, dy float32, depth int) {
 	if overMaxDepth(depth) {
 		return
 	}
@@ -114,15 +133,13 @@ func applyHeroRecursiveDepth(layout *Layout, progress float32, outgoing, incomin
 		fadeProgress := f32Max(0, (progress-0.5)*2)
 
 		if out, hasOut := outgoing[id]; hasOut {
-			if _, hasIn := incoming[id]; hasIn {
-				finalX, finalY := layout.Shape.X, layout.Shape.Y
-				layout.Shape.X = lerp(out.x, finalX, morphProgress)
-				layout.Shape.Y = lerp(out.y, finalY, morphProgress)
-				layout.Shape.Width = lerp(out.width, layout.Shape.Width, morphProgress)
-				layout.Shape.Height = lerp(out.height, layout.Shape.Height, morphProgress)
-				dx, dy = layout.Shape.X-finalX, layout.Shape.Y-finalY
-				shifted = true
-			}
+			finalX, finalY := layout.Shape.X, layout.Shape.Y
+			layout.Shape.X = lerp(out.x, finalX, morphProgress)
+			layout.Shape.Y = lerp(out.y, finalY, morphProgress)
+			layout.Shape.Width = lerp(out.width, layout.Shape.Width, morphProgress)
+			layout.Shape.Height = lerp(out.height, layout.Shape.Height, morphProgress)
+			dx, dy = layout.Shape.X-finalX, layout.Shape.Y-finalY
+			shifted = true
 		} else {
 			propagateOpacityDepth(layout, fadeProgress, depth)
 		}
@@ -132,6 +149,6 @@ func applyHeroRecursiveDepth(layout *Layout, progress float32, outgoing, incomin
 		layout.Shape.Y += dy
 	}
 	for i := range layout.Children {
-		applyHeroRecursiveDepth(&layout.Children[i], progress, outgoing, incoming, dx, dy, depth+1)
+		applyHeroRecursiveDepth(&layout.Children[i], progress, outgoing, dx, dy, depth+1)
 	}
 }

--- a/gui/animation_hero.go
+++ b/gui/animation_hero.go
@@ -71,13 +71,20 @@ func applyHeroTransition(layout *Layout, w *Window) {
 	if !ok || ht.stopped {
 		return
 	}
-	applyHeroRecursive(layout, ht.progress, ht.outgoing, ht.incoming, 0, 0)
+	applyHeroRecursiveDepth(layout, ht.progress, ht.outgoing, ht.incoming, 0, 0, 0)
 }
 
 func propagateOpacity(layout *Layout, opacity float32) {
+	propagateOpacityDepth(layout, opacity, 0)
+}
+
+func propagateOpacityDepth(layout *Layout, opacity float32, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	layout.Shape.Opacity = opacity
 	for i := range layout.Children {
-		propagateOpacity(&layout.Children[i], opacity)
+		propagateOpacityDepth(&layout.Children[i], opacity, depth+1)
 	}
 }
 
@@ -89,6 +96,13 @@ func propagateOpacity(layout *Layout, opacity float32) {
 // with its own snapshot replaces the carried shift instead of adding to
 // it, because the snapshot is an absolute position.
 func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map[string]posSnapshot, dx, dy float32) {
+	applyHeroRecursiveDepth(layout, progress, outgoing, incoming, dx, dy, 0)
+}
+
+func applyHeroRecursiveDepth(layout *Layout, progress float32, outgoing, incoming map[string]posSnapshot, dx, dy float32, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	shifted := false
 	if layout.Shape.Hero && layout.Shape.ID != "" {
 		// Hero matching is identity-keyed: the same leaf under two
@@ -110,7 +124,7 @@ func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map
 				shifted = true
 			}
 		} else {
-			propagateOpacity(layout, fadeProgress)
+			propagateOpacityDepth(layout, fadeProgress, depth)
 		}
 	}
 	if !shifted {
@@ -118,6 +132,6 @@ func applyHeroRecursive(layout *Layout, progress float32, outgoing, incoming map
 		layout.Shape.Y += dy
 	}
 	for i := range layout.Children {
-		applyHeroRecursive(&layout.Children[i], progress, outgoing, incoming, dx, dy)
+		applyHeroRecursiveDepth(&layout.Children[i], progress, outgoing, incoming, dx, dy, depth+1)
 	}
 }

--- a/gui/animation_hero_test.go
+++ b/gui/animation_hero_test.go
@@ -14,7 +14,7 @@ func TestCaptureHeroSnapshots(t *testing.T) {
 			{Shape: &Shape{ID: "hero2", Hero: true, X: 30, Y: 40, Width: 200, Height: 100}},
 		},
 	}
-	snaps := captureHeroSnapshots(layout)
+	snaps := captureHeroSnapshots(&layout)
 	if len(snaps) != 2 {
 		t.Errorf("got %d snapshots, want 2", len(snaps))
 	}
@@ -47,11 +47,8 @@ func TestApplyHeroRecursive(t *testing.T) {
 	outgoing := map[string]posSnapshot{
 		"h": {x: 0, y: 0, width: 100, height: 100},
 	}
-	incoming := map[string]posSnapshot{
-		"h": {x: 100, y: 100, width: 200, height: 200},
-	}
 	// progress=0 → morphProgress=0 → should be at outgoing position
-	applyHeroRecursive(&layout, 0, outgoing, incoming, 0, 0)
+	applyHeroRecursiveDepth(&layout, 0, outgoing, 0, 0, 0)
 	if layout.Shape.X != 0 {
 		t.Errorf("X = %f, want 0", layout.Shape.X)
 	}
@@ -61,7 +58,7 @@ func TestApplyHeroRecursive(t *testing.T) {
 // (100,100,200x200) with an ID-less label inset 10pt from the card's
 // final corner. At progress 0.5 morphProgress is 1, so build the tree
 // per test and drive progress explicitly.
-func heroShiftTree() (*Layout, map[string]posSnapshot, map[string]posSnapshot) {
+func heroShiftTree() (*Layout, map[string]posSnapshot) {
 	layout := &Layout{
 		Shape: &Shape{ID: "card", Hero: true, X: 100, Y: 100, Width: 200, Height: 200, Opacity: 1},
 		Children: []Layout{{
@@ -72,38 +69,44 @@ func heroShiftTree() (*Layout, map[string]posSnapshot, map[string]posSnapshot) {
 		}},
 	}
 	outgoing := map[string]posSnapshot{"card": {x: 0, y: 0, width: 100, height: 100}}
-	incoming := map[string]posSnapshot{"card": {x: 100, y: 100, width: 200, height: 200}}
-	return layout, outgoing, incoming
+	return layout, outgoing
 }
 
 func TestApplyHeroShiftsIDLessChildren(t *testing.T) {
 	// progress 0.25 → morphProgress 0.5 → the card is halfway, so its
 	// contents must be halfway too, keeping their inset.
-	layout, outgoing, incoming := heroShiftTree()
-	applyHeroRecursive(layout, 0.25, outgoing, incoming, 0, 0)
+	layout, outgoing := heroShiftTree()
+	applyHeroRecursiveDepth(layout, 0.25, outgoing, 0, 0, 0)
 	checkShape(t, "card", layout.Shape, 50, 50, 150, 150)
 	checkShape(t, "label", layout.Children[0].Shape, 60, 60, 50, 20)
 	checkShape(t, "label child", layout.Children[0].Children[0].Shape, 70, 70, 10, 10)
 }
 
-func TestApplyHeroNoShiftWhenUnmatched(t *testing.T) {
-	// No incoming entry: the card only fades, so nothing moves.
-	layout, outgoing, _ := heroShiftTree()
-	applyHeroRecursive(layout, 0.25, outgoing, map[string]posSnapshot{}, 0, 0)
+func TestApplyHeroFadesInHeroWithNoSnapshot(t *testing.T) {
+	// A hero the outgoing side never had is new: it holds its final
+	// geometry and fades in over the second half of the transition.
+	layout, _ := heroShiftTree()
+	applyHeroRecursiveDepth(layout, 0.75, map[string]posSnapshot{}, 0, 0, 0)
 	checkShape(t, "card", layout.Shape, 100, 100, 200, 200)
 	checkShape(t, "label", layout.Children[0].Shape, 110, 110, 50, 20)
+	// fadeProgress = (0.75-0.5)*2 = 0.5, propagated to the subtree.
+	if got := layout.Shape.Opacity; got != 0.5 {
+		t.Errorf("card opacity = %v, want 0.5", got)
+	}
+	if got := layout.Children[0].Shape.Opacity; got != 0.5 {
+		t.Errorf("label opacity = %v, want 0.5", got)
+	}
 }
 
 func TestApplyHeroOwnSnapshotReplacesShift(t *testing.T) {
 	// A hero child with its own snapshot must not double-count the
 	// parent's morph — the snapshot is absolute and already accounts
 	// for the ancestor.
-	layout, outgoing, incoming := heroShiftTree()
+	layout, outgoing := heroShiftTree()
 	layout.Children[0].Shape.ID = "label"
 	layout.Children[0].Shape.Hero = true
 	outgoing["label"] = posSnapshot{x: 10, y: 10, width: 50, height: 20}
-	incoming["label"] = posSnapshot{x: 110, y: 110, width: 50, height: 20}
-	applyHeroRecursive(layout, 0.25, outgoing, incoming, 0, 0)
+	applyHeroRecursiveDepth(layout, 0.25, outgoing, 0, 0, 0)
 	// lerp(10, 110, 0.5) = 60 — the same place the carried shift would
 	// have put it, but derived from the label's own snapshot.
 	checkShape(t, "card", layout.Shape, 50, 50, 150, 150)
@@ -146,7 +149,7 @@ func TestPropagateOpacity(t *testing.T) {
 			{Shape: &Shape{Opacity: 1}},
 		},
 	}
-	propagateOpacity(&layout, 0.5)
+	propagateOpacityDepth(&layout, 0.5, 0)
 	if layout.Shape.Opacity != 0.5 {
 		t.Errorf("parent opacity = %f, want 0.5", layout.Shape.Opacity)
 	}
@@ -168,4 +171,43 @@ func TestHeroTransitionOnDone(t *testing.T) {
 	if !done {
 		t.Error("OnDone not called")
 	}
+}
+
+// TestAnimationAddCapturesHeroSnapshots is the wiring regression: the
+// documented sequence is AnimationAdd then UpdateView, so AnimationAdd
+// is the last moment the outgoing geometry exists. Before this was
+// wired, outgoing stayed nil and no hero ever morphed — every one of
+// them only faded in.
+func TestAnimationAddCapturesHeroSnapshots(t *testing.T) {
+	w := &Window{}
+	w.layout = Layout{
+		Shape: &Shape{ID: "root"},
+		Children: []Layout{
+			{Shape: &Shape{ID: "card", Hero: true, X: 0, Y: 0, Width: 100, Height: 100}},
+			{Shape: &Shape{ID: "plain", X: 5, Y: 5, Width: 10, Height: 10}},
+		},
+	}
+
+	ht := NewHeroTransition(HeroTransitionCfg{Duration: time.Second})
+	w.AnimationAdd(ht)
+
+	if len(ht.outgoing) != 1 {
+		t.Fatalf("captured %d hero snapshots, want 1 (non-hero shapes excluded)", len(ht.outgoing))
+	}
+	if out, ok := ht.outgoing["card"]; !ok || out.width != 100 {
+		t.Fatalf("card snapshot = %+v, ok=%v", out, ok)
+	}
+
+	// The view has changed and the new tree is arranged: the card now
+	// sits at (200,200) at twice the size. progress 0.25 doubles to a
+	// morphProgress of 0.5, so the card must be halfway.
+	ht.progress = 0.25
+	after := Layout{
+		Shape: &Shape{ID: "root"},
+		Children: []Layout{
+			{Shape: &Shape{ID: "card", Hero: true, X: 200, Y: 200, Width: 200, Height: 200}},
+		},
+	}
+	applyHeroTransition(&after, w)
+	checkShape(t, "card", after.Children[0].Shape, 100, 100, 150, 150)
 }

--- a/gui/animation_keyframe.go
+++ b/gui/animation_keyframe.go
@@ -13,10 +13,14 @@ type Keyframe struct {
 // with per-segment easing.
 // exportaudit:keep — reachable from an exported signature
 type KeyframeAnimation struct {
-	start     time.Time
-	OnValue   func(float32, *Window)
-	OnDone    func(*Window)
-	AnimID    string
+	start   time.Time
+	OnValue func(float32, *Window)
+	OnDone  func(*Window)
+	AnimID  string
+	// Keyframes must be sorted ascending by At: interpolation
+	// binary-searches the slice, and the completion path reports
+	// the last element as the final value. Out-of-order At gives
+	// silently wrong output.
 	Keyframes []Keyframe
 	Duration  time.Duration
 	Repeat    bool
@@ -43,6 +47,7 @@ func (k *KeyframeAnimation) Update(_ *Window, _ float32, ac *AnimationCommands) 
 }
 
 // NewKeyframeAnimation creates a KeyframeAnimation with defaults.
+// Keyframes must be sorted ascending by At (see the Keyframes field).
 func NewKeyframeAnimation(id string, keyframes []Keyframe, onValue func(float32, *Window)) *KeyframeAnimation {
 	return &KeyframeAnimation{
 		AnimID:    id,

--- a/gui/animation_layout.go
+++ b/gui/animation_layout.go
@@ -78,15 +78,15 @@ func (w *Window) AnimateLayout(cfg LayoutTransitionCfg) {
 			easing:   eas,
 			OnDone:   cfg.OnDone,
 		},
-		snapshots: captureLayoutSnapshots(w.layout),
+		snapshots: captureLayoutSnapshots(&w.layout),
 	}
 	w.AnimationAdd(lt)
 }
 
 // captureLayoutSnapshots recursively captures all element positions.
-func captureLayoutSnapshots(layout Layout) map[string]posSnapshot {
+func captureLayoutSnapshots(layout *Layout) map[string]posSnapshot {
 	snapshots := make(map[string]posSnapshot)
-	captureSnapshots(&layout, snapshots, false)
+	captureSnapshots(layout, snapshots, false)
 	return snapshots
 }
 
@@ -107,35 +107,42 @@ func captureSnapshots(layout *Layout, snapshots map[string]posSnapshot, heroOnly
 	}
 }
 
-// getLayoutTransition returns the active layout transition, if any.
-// Acquires w.animMu to safely read w.animations (the animation
-// goroutine may concurrently delete stopped animations).
-func (w *Window) getLayoutTransition() *layoutTransition {
+// getLayoutTransition returns the active layout transition's snapshots
+// and the progress it had reached, if a transition is running.
+//
+// The values are copied out inside the critical section rather than
+// returning the *layoutTransition for the caller to dereference:
+// progress and stopped are written by the animation goroutine on every
+// tick (updateTransition), so reading them after the lock is dropped is
+// a data race. The snapshots map is written once, before AnimationAdd
+// publishes the transition, so handing out the reference is safe — the
+// mutex supplies the happens-before edge and nothing writes it again.
+func (w *Window) getLayoutTransition() (map[string]posSnapshot, float32, bool) {
 	w.animMu.Lock()
+	defer w.animMu.Unlock()
 	a, ok := w.animations[layoutTransitionID]
-	w.animMu.Unlock()
 	if !ok {
-		return nil
+		return nil, 0, false
 	}
-	lt, ok := a.(*layoutTransition)
-	if !ok {
-		return nil
+	lt, isTransition := a.(*layoutTransition)
+	if !isTransition || lt.stopped {
+		return nil, 0, false
 	}
-	return lt
+	return lt.snapshots, lt.progress, true
 }
 
 // applyLayoutTransition interpolates positions during amend phase.
 func applyLayoutTransition(layout *Layout, w *Window) {
-	lt := w.getLayoutTransition()
-	if lt == nil || lt.stopped {
+	snapshots, progress, ok := w.getLayoutTransition()
+	if !ok {
 		return
 	}
-	applyTransitionRecursiveDepth(layout, lt, 0, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, snapshots, progress, 0, 0, 0, 0)
 }
 
-// applyTransitionRecursive lerps each covered channel toward the shape's
-// current (post-layout) value. snap is the mask inherited from the
-// ancestors; the walk already carries state, so inheritance is a
+// applyTransitionRecursiveDepth lerps each covered channel toward the
+// shape's current (post-layout) value. snap is the mask inherited from
+// the ancestors; the walk already carries state, so inheritance is a
 // parameter rather than a separate cascade pass.
 //
 // dx/dy carry the nearest interpolated ancestor's position shift. Layout
@@ -146,11 +153,12 @@ func applyLayoutTransition(layout *Layout, w *Window) {
 // replaces the shift rather than adding to it: the snapshot recorded an
 // absolute position, so it already accounts for wherever its ancestors
 // were.
-func applyTransitionRecursive(layout *Layout, lt *layoutTransition, snap AnimFlags, dx, dy float32) {
-	applyTransitionRecursiveDepth(layout, lt, snap, dx, dy, 0)
-}
-
-func applyTransitionRecursiveDepth(layout *Layout, lt *layoutTransition, snap AnimFlags, dx, dy float32, depth int) {
+//
+// Snapshots and progress arrive as values, not the *layoutTransition:
+// the walk runs on the main thread while the animation goroutine
+// advances that transition, so the frame works from one stable progress
+// rather than re-reading a field that moves underneath it.
+func applyTransitionRecursiveDepth(layout *Layout, snapshots map[string]posSnapshot, progress float32, snap AnimFlags, dx, dy float32, depth int) {
 	if overMaxDepth(depth) {
 		return
 	}
@@ -168,8 +176,8 @@ func applyTransitionRecursiveDepth(layout *Layout, lt *layoutTransition, snap An
 
 	shifted := false
 	if layout.Shape.ID != "" && snap != AnimSnapAll {
-		if old, ok := lt.snapshots[layout.Shape.idKey()]; ok {
-			t := lt.progress
+		if old, ok := snapshots[layout.Shape.idKey()]; ok {
+			t := progress
 			if snap&AnimSnapPos == 0 {
 				finalX, finalY := layout.Shape.X, layout.Shape.Y
 				layout.Shape.X = lerp(old.x, finalX, t)
@@ -191,6 +199,7 @@ func applyTransitionRecursiveDepth(layout *Layout, lt *layoutTransition, snap An
 	}
 
 	for i := range layout.Children {
-		applyTransitionRecursiveDepth(&layout.Children[i], lt, snap, dx, dy, depth+1)
+		applyTransitionRecursiveDepth(&layout.Children[i], snapshots, progress,
+			snap, dx, dy, depth+1)
 	}
 }

--- a/gui/animation_layout.go
+++ b/gui/animation_layout.go
@@ -130,7 +130,7 @@ func applyLayoutTransition(layout *Layout, w *Window) {
 	if lt == nil || lt.stopped {
 		return
 	}
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt, 0, 0, 0, 0)
 }
 
 // applyTransitionRecursive lerps each covered channel toward the shape's
@@ -147,6 +147,13 @@ func applyLayoutTransition(layout *Layout, w *Window) {
 // absolute position, so it already accounts for wherever its ancestors
 // were.
 func applyTransitionRecursive(layout *Layout, lt *layoutTransition, snap AnimFlags, dx, dy float32) {
+	applyTransitionRecursiveDepth(layout, lt, snap, dx, dy, 0)
+}
+
+func applyTransitionRecursiveDepth(layout *Layout, lt *layoutTransition, snap AnimFlags, dx, dy float32, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	// OR-inherit: a snapped parent snaps its whole subtree. With
 	// opt-out semantics there is deliberately no way for a child to
 	// escape an ancestor's mask — that escape hatch is where the
@@ -184,6 +191,6 @@ func applyTransitionRecursive(layout *Layout, lt *layoutTransition, snap AnimFla
 	}
 
 	for i := range layout.Children {
-		applyTransitionRecursive(&layout.Children[i], lt, snap, dx, dy)
+		applyTransitionRecursiveDepth(&layout.Children[i], lt, snap, dx, dy, depth+1)
 	}
 }

--- a/gui/animation_layout_test.go
+++ b/gui/animation_layout_test.go
@@ -13,7 +13,7 @@ func TestCaptureLayoutSnapshots(t *testing.T) {
 			{Shape: &Shape{X: 20, Y: 20, Width: 30, Height: 30}}, // no ID
 		},
 	}
-	snaps := captureLayoutSnapshots(layout)
+	snaps := captureLayoutSnapshots(&layout)
 	if len(snaps) != 2 {
 		t.Errorf("got %d snapshots, want 2 (root + a)", len(snaps))
 	}
@@ -52,7 +52,7 @@ func TestApplyTransitionRecursive(t *testing.T) {
 			"box": {x: 0, y: 0, width: 100, height: 100},
 		},
 	}
-	applyTransitionRecursive(&layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(&layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	// At progress=0.5: Lerp(0, 100, 0.5) = 50
 	if layout.Shape.X != 50 {
 		t.Errorf("X = %f, want 50", layout.Shape.X)
@@ -105,7 +105,7 @@ func TestApplyTransitionSnapChannels(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			layout, lt := snapTestTree(0, tc.snap)
-			applyTransitionRecursive(layout, lt, 0, 0, 0)
+			applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 			checkShape(t, "child", layout.Children[0].Shape, tc.x, tc.y, tc.w, tc.h)
 			// The mask is per-shape: an unflagged sibling is untouched.
 			checkShape(t, "sibling", layout.Children[1].Shape, 50, 50, 150, 150)
@@ -117,7 +117,7 @@ func TestApplyTransitionSnapInherits(t *testing.T) {
 	// A snapped parent snaps its whole subtree even though no child
 	// sets the flag.
 	layout, lt := snapTestTree(AnimSnapAll, 0)
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	checkShape(t, "root", layout.Shape, 100, 100, 200, 200)
 	checkShape(t, "child", layout.Children[0].Shape, 100, 100, 200, 200)
 	checkShape(t, "sibling", layout.Children[1].Shape, 100, 100, 200, 200)
@@ -126,7 +126,7 @@ func TestApplyTransitionSnapInherits(t *testing.T) {
 func TestApplyTransitionSnapDoesNotInheritUpward(t *testing.T) {
 	// A snapped child leaves its parent and its siblings animating.
 	layout, lt := snapTestTree(0, AnimSnapAll)
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	checkShape(t, "root", layout.Shape, 50, 50, 150, 150)
 	checkShape(t, "child", layout.Children[0].Shape, 100, 100, 200, 200)
 	checkShape(t, "sibling", layout.Children[1].Shape, 50, 50, 150, 150)
@@ -136,7 +136,7 @@ func TestApplyTransitionSnapPartialInheritCombines(t *testing.T) {
 	// Inheritance is a union: parent snaps position, child snaps size,
 	// so the child ends up fully still while the parent still resizes.
 	layout, lt := snapTestTree(AnimSnapPos, AnimSnapSize)
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	checkShape(t, "root", layout.Shape, 100, 100, 150, 150)
 	checkShape(t, "child", layout.Children[0].Shape, 100, 100, 200, 200)
 	checkShape(t, "sibling", layout.Children[1].Shape, 100, 100, 150, 150)
@@ -168,7 +168,7 @@ func TestApplyTransitionShiftsIDLessChildren(t *testing.T) {
 	// Layout coords are absolute, so without the carried shift the
 	// label would sit at its final position while the panel slid.
 	layout, lt := shiftTestTree(0)
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	checkShape(t, "panel", layout.Shape, 50, 50, 150, 150)
 	// Panel moved -50; the label and its own child follow by -50 and
 	// keep their offsets inside the panel (10 and 20).
@@ -179,7 +179,7 @@ func TestApplyTransitionShiftsIDLessChildren(t *testing.T) {
 func TestApplyTransitionSnapPosDoesNotShiftChildren(t *testing.T) {
 	// The panel holds its final position, so nothing under it moves.
 	layout, lt := shiftTestTree(AnimSnapPos)
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	checkShape(t, "panel", layout.Shape, 100, 100, 150, 150)
 	checkShape(t, "label", layout.Children[0].Shape, 110, 110, 50, 20)
 }
@@ -191,7 +191,7 @@ func TestApplyTransitionOwnSnapshotReplacesShift(t *testing.T) {
 	layout, lt := shiftTestTree(0)
 	layout.Children[0].Shape.ID = "label"
 	lt.snapshots["label"] = posSnapshot{x: 10, y: 10, width: 50, height: 20}
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	// lerp(10, 110, 0.5) = 60 — the same place the carried shift would
 	// have put it, but derived from the label's own snapshot.
 	checkShape(t, "label", layout.Children[0].Shape, 60, 60, 50, 20)
@@ -205,7 +205,7 @@ func TestApplyTransitionNewShapeRidesAncestorShift(t *testing.T) {
 	// its final coordinates.
 	layout, lt := shiftTestTree(0)
 	layout.Children[0].Shape.ID = "new-label"
-	applyTransitionRecursive(layout, lt, 0, 0, 0)
+	applyTransitionRecursiveDepth(layout, lt.snapshots, lt.progress, 0, 0, 0, 0)
 	checkShape(t, "panel", layout.Shape, 50, 50, 150, 150)
 	checkShape(t, "new label", layout.Children[0].Shape, 60, 60, 50, 20)
 }
@@ -262,4 +262,59 @@ func TestLayoutTransitionOnDone(t *testing.T) {
 	if !done {
 		t.Error("OnDone not called")
 	}
+}
+
+// TestTransitionAmendConcurrentWithLoop is a race regression test: the
+// amend pass reads a running transition's progress on the main thread
+// while the animation goroutine advances it. Both must happen under
+// w.animMu, so this fails under -race if either accessor drops the lock
+// before reading progress or stopped. It asserts nothing about the
+// interpolated values — the point is that -race stays silent.
+func TestTransitionAmendConcurrentWithLoop(t *testing.T) {
+	const ticks = 500
+
+	w := &Window{}
+	lt := &layoutTransition{
+		transitionBase: transitionBase{
+			duration: time.Second,
+			easing:   EaseLinear,
+		},
+		snapshots: map[string]posSnapshot{
+			"box": {x: 0, y: 0, width: 100, height: 100},
+		},
+	}
+	ht := NewHeroTransition(HeroTransitionCfg{Duration: time.Second})
+	ht.outgoing = map[string]posSnapshot{"box": {x: 0, y: 0, width: 100, height: 100}}
+	w.AnimationAdd(lt)
+	w.AnimationAdd(ht)
+
+	done := make(chan struct{})
+	go func() {
+		// Stands in for animationLoop's update pass: same call, same
+		// mutex, without needing the window's lifecycle channels.
+		defer close(done)
+		deferred := make([]queuedCommand, 0, 4)
+		for range ticks {
+			deferred = deferred[:0]
+			ac := newAnimationCommands(&deferred)
+			w.animMu.Lock()
+			updateTransition(&lt.transitionBase, &ac)
+			updateTransition(&ht.transitionBase, &ac)
+			w.animMu.Unlock()
+		}
+	}()
+
+	for range ticks {
+		// Rebuild each pass: the amend walk mutates the layout in
+		// place, and production hands it a freshly arranged tree.
+		layout := Layout{
+			Shape: &Shape{ID: "box", Hero: true, X: 100, Y: 100, Width: 200, Height: 200},
+			Children: []Layout{
+				{Shape: &Shape{X: 110, Y: 110, Width: 50, Height: 50}},
+			},
+		}
+		applyLayoutTransition(&layout, w)
+		applyHeroTransition(&layout, w)
+	}
+	<-done
 }

--- a/gui/animation_loop.go
+++ b/gui/animation_loop.go
@@ -8,9 +8,35 @@ const animationCycle = 16 * time.Millisecond
 // An animation not touched for this duration is cancelled automatically.
 const animViewBoundStale = 2 * int64(time.Second)
 
+// viewBoundNow is the clock for view-bound heartbeats. It is deliberately
+// time.Now() and not w.Now(): w.Now() follows the time-travel scrub pin,
+// which jumps backwards on restore and forwards again on resume. A
+// heartbeat stamped while the clock was pinned to a past instant, then
+// compared against live time after the resume, looks arbitrarily stale —
+// so every visible widget's animation would be cancelled on the first tick
+// after a scrub ends. The heartbeat measures liveness and is never shown to
+// a user, so it has no reason to be scrubbable.
+func viewBoundNow() int64 { return time.Now().UnixNano() }
+
 // AnimationAdd registers a new animation. If an animation with the
 // same ID exists, it is replaced.
+//
+// The ID must be non-empty: animations are keyed by ID, so every
+// unnamed animation would collide on "" and replace the previous one.
+// Empty IDs panic, matching State[T]'s treatment of programmer error.
+//
+// A HeroTransition is snapshotted here, the way AnimateLayout captures
+// before its caller changes the view: the "before" geometry only exists
+// until the next arrange, and the documented call sequence is
+// AnimationAdd followed by UpdateView. Re-adding a transition mid-flight
+// replaces it outright (the ID is fixed), so the new morph starts from
+// wherever the tree is at that moment.
 func (w *Window) AnimationAdd(a Animation) {
+	// Capture before taking animMu: the walk is O(tree) and would
+	// otherwise stall the animation goroutine for its duration.
+	if ht, ok := a.(*HeroTransition); ok && ht.outgoing == nil {
+		ht.outgoing = captureHeroSnapshots(&w.layout)
+	}
 	w.animMu.Lock()
 	defer w.animMu.Unlock()
 	w.animationAddLocked(a)
@@ -19,6 +45,9 @@ func (w *Window) AnimationAdd(a Animation) {
 // animationAddLocked is the lock-free core of AnimationAdd. Callers
 // must already hold w.animMu (e.g. syncBlinkCursor).
 func (w *Window) animationAddLocked(a Animation) {
+	if a.ID() == "" {
+		panic("gui: AnimationAdd requires a non-empty ID")
+	}
 	a.SetStart(time.Now())
 	if w.animations == nil {
 		w.animations = make(map[string]Animation)
@@ -62,7 +91,7 @@ func (w *Window) animationAddViewBound(a Animation) {
 	if w.animViewBound == nil {
 		w.animViewBound = make(map[string]int64)
 	}
-	w.animViewBound[a.ID()] = w.Now().UnixNano()
+	w.animViewBound[a.ID()] = viewBoundNow()
 }
 
 // touchViewBoundAnimation updates the heartbeat for a view-bound animation
@@ -75,7 +104,7 @@ func (w *Window) touchViewBoundAnimation(id string) bool {
 		return false
 	}
 	if _, ok := w.animViewBound[id]; ok {
-		w.animViewBound[id] = w.Now().UnixNano()
+		w.animViewBound[id] = viewBoundNow()
 	}
 	return true
 }
@@ -150,7 +179,7 @@ func (w *Window) animationLoop() {
 			}
 		}
 		// Auto-cancel view-bound animations whose widget left the view tree.
-		now := w.Now().UnixNano()
+		now := viewBoundNow()
 		for id, seen := range w.animViewBound {
 			if now-seen > animViewBoundStale {
 				stoppedIDs = append(stoppedIDs, id)
@@ -216,24 +245,44 @@ func updateAnimate(a *Animate, ac *AnimationCommands) bool {
 		a.stopped = true
 		return false
 	}
-	if time.Since(a.start) > a.Delay {
-		ac.appendAnimate(a.Callback, a)
-		if a.Repeat {
-			// Zero delay with repeat fires every tick (~16ms).
-			a.start = a.start.Add(a.Delay)
-		} else {
-			a.stopped = true
-		}
+	now := time.Now()
+	if now.Sub(a.start) <= a.Delay {
+		return false
+	}
+	ac.appendAnimate(a.Callback, a)
+	if !a.Repeat {
+		a.stopped = true
 		return true
 	}
-	return false
+	// Zero delay with repeat fires every tick (~16ms). Advancing by
+	// exactly one Delay keeps a longer cadence drift-free while ticks
+	// arrive on time.
+	a.start = a.start.Add(a.Delay)
+	a.start = resyncAfterStall(a.start, now, a.Delay)
+	return true
+}
+
+// resyncAfterStall drops the backlog a stalled animation accumulated.
+// A minimized window, a debugger break or one very long frame leaves
+// start many delays in the past; stepping one Delay per tick would then
+// drain that backlog at one callback every ~16ms — a burst of catch-up
+// fires long after the interval each belonged to. Once start is more
+// than one further delay behind, give up the missed intervals and
+// resync to now. Returns start unchanged on a tick that arrived on
+// time, so the drift-free cadence survives.
+func resyncAfterStall(start, now time.Time, delay time.Duration) time.Time {
+	if now.Sub(start) > delay {
+		return now
+	}
+	return start
 }
 
 func updateBlinkCursor(b *BlinkCursorAnimation, w *Window, ac *AnimationCommands) bool {
 	if b.stopped {
 		return false
 	}
-	if time.Since(b.start) > blinkCursorAnimationDelay {
+	now := time.Now()
+	if now.Sub(b.start) > blinkCursorAnimationDelay {
 		// Store(!Load()) is safe because all writers hold animMu:
 		// this (via animation goroutine) and resetBlinkCursorVisible
 		// (via main thread). If animMu is ever removed from either
@@ -245,6 +294,9 @@ func updateBlinkCursor(b *BlinkCursorAnimation, w *Window, ac *AnimationCommands
 		// Animate still promotes the tick to a layout refresh.
 		ac.appendOnDone(commandToggleCaretBlink)
 		b.start = b.start.Add(blinkCursorAnimationDelay)
+		// Without this the caret strobes after any stall, catching up
+		// one toggle per tick until it reaches the present.
+		b.start = resyncAfterStall(b.start, now, blinkCursorAnimationDelay)
 		return true
 	}
 	return false

--- a/gui/animation_loop_test.go
+++ b/gui/animation_loop_test.go
@@ -14,6 +14,16 @@ func TestAnimationAdd(t *testing.T) {
 	}
 }
 
+func TestAnimationAddEmptyIDPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("AnimationAdd with empty ID should panic")
+		}
+	}()
+	w := &Window{}
+	w.AnimationAdd(&Animate{Callback: func(*Animate, *Window) {}})
+}
+
 func TestAnimationRemove(t *testing.T) {
 	w := &Window{}
 	tw := NewTweenAnimation("t1", 0, 1, func(float32, *Window) {})
@@ -232,5 +242,137 @@ func TestAnimateRepeatNoDrift(t *testing.T) {
 	// start should advance by Delay, not reset to Now().
 	if a.start.After(time.Now().Add(-10 * time.Millisecond)) {
 		t.Error("start should not reset to Now(); should advance by Delay")
+	}
+}
+
+// TestUpdateAnimateRepeatDropsBacklogAfterStall pins the stall behaviour:
+// a repeating animation whose start sits far in the past fires once and
+// resyncs, rather than draining the missed intervals one per tick. Before
+// the resync it queued one callback on every one of these back-to-back
+// updates and start stayed seconds behind.
+func TestUpdateAnimateRepeatDropsBacklogAfterStall(t *testing.T) {
+	a := &Animate{
+		AnimID:   "a",
+		Delay:    16 * time.Millisecond,
+		Repeat:   true,
+		Callback: func(*Animate, *Window) {},
+	}
+	// Five seconds of missed ticks — a minimized window or a debugger
+	// break. At one 16ms step per tick that is a backlog of ~312.
+	a.SetStart(time.Now().Add(-5 * time.Second))
+
+	deferred := make([]queuedCommand, 0, 16)
+	ac := newAnimationCommands(&deferred)
+	for range 10 {
+		updateAnimate(a, &ac)
+	}
+
+	if len(deferred) != 1 {
+		t.Errorf("queued %d callbacks, want 1", len(deferred))
+	}
+	if behind := time.Since(a.start); behind > a.Delay {
+		t.Errorf("start still %v behind, want under %v", behind, a.Delay)
+	}
+	if a.stopped {
+		t.Error("repeating animation should not stop")
+	}
+}
+
+// TestUpdateAnimateRepeatKeepsCadence guards the other side: a tick that
+// arrives on time must still step by exactly one Delay, so a long
+// interval does not drift toward the tick period.
+func TestUpdateAnimateRepeatKeepsCadence(t *testing.T) {
+	a := &Animate{
+		AnimID:   "a",
+		Delay:    100 * time.Millisecond,
+		Repeat:   true,
+		Callback: func(*Animate, *Window) {},
+	}
+	start := time.Now().Add(-110 * time.Millisecond)
+	a.SetStart(start)
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	if !updateAnimate(a, &ac) {
+		t.Fatal("expected the animation to fire")
+	}
+	if want := start.Add(a.Delay); !a.start.Equal(want) {
+		t.Errorf("start = %v, want %v (one exact Delay step)", a.start, want)
+	}
+}
+
+// TestUpdateBlinkCursorDropsBacklogAfterStall pins the same rule for the
+// caret: one toggle after a stall, not a strobe back to the present.
+func TestUpdateBlinkCursorDropsBacklogAfterStall(t *testing.T) {
+	w := &Window{}
+	b := newBlinkCursorAnimation()
+	b.SetStart(time.Now().Add(-5 * time.Second))
+
+	deferred := make([]queuedCommand, 0, 16)
+	ac := newAnimationCommands(&deferred)
+	for range 10 {
+		updateBlinkCursor(b, w, &ac)
+	}
+
+	if len(deferred) != 1 {
+		t.Errorf("queued %d caret toggles, want 1", len(deferred))
+	}
+	if !w.viewState.inputCursorOn.Load() {
+		t.Error("caret should have toggled exactly once, to visible")
+	}
+}
+
+// TestViewBoundHeartbeatIgnoresScrubClock pins the virtual clock 10
+// minutes in the past (a time-travel scrub), stamps a view-bound
+// heartbeat, resumes, and asserts the heartbeat is wall-clock fresh.
+// Before the fix the stamp used w.Now(), so resume() compared live time
+// against a T-10min stamp and cancelled every visible widget's anim.
+func TestViewBoundHeartbeatIgnoresScrubClock(t *testing.T) {
+	w := &Window{}
+	past := time.Now().Add(-10 * time.Minute)
+	w.setVirtualNow(&past)
+
+	tw := NewTweenAnimation("vb-scrub", 0, 1, func(float32, *Window) {})
+	w.animationAddViewBound(tw)
+	if !w.touchViewBoundAnimation("vb-scrub") {
+		w.setVirtualNow(nil)
+		t.Fatal("touch should succeed while scrub-pinned")
+	}
+
+	seen := w.animViewBound["vb-scrub"]
+	if seen-past.UnixNano() < int64(9*time.Minute) {
+		w.setVirtualNow(nil)
+		t.Errorf("heartbeat followed the scrub clock (seen-past = %v)",
+			time.Duration(seen-past.UnixNano()))
+	}
+
+	w.setVirtualNow(nil) // resume(): virtual pin cleared, live time back
+	seen = w.animViewBound["vb-scrub"]
+	if age := viewBoundNow() - seen; age > animViewBoundStale {
+		t.Errorf("heartbeat looks stale after resume (age = %v)", time.Duration(age))
+	}
+}
+
+// TestViewBoundStaleStillEvictsWhilePinned covers the inverse: a
+// departed animation (heartbeat 3s old) must still read stale while a
+// scrub pin holds w.Now() in the past. A pinned comparison would go
+// negative and leak the animation for the scrub's duration.
+func TestViewBoundStaleStillEvictsWhilePinned(t *testing.T) {
+	w := &Window{}
+	tw := NewTweenAnimation("vb-pinned", 0, 1, func(float32, *Window) {})
+	w.animationAddViewBound(tw)
+	w.animMu.Lock()
+	w.animViewBound["vb-pinned"] = time.Now().Add(-3 * time.Second).UnixNano()
+	w.animMu.Unlock()
+
+	past := time.Now().Add(-10 * time.Minute)
+	w.setVirtualNow(&past)
+	defer w.setVirtualNow(nil)
+
+	w.animMu.Lock()
+	seen := w.animViewBound["vb-pinned"]
+	w.animMu.Unlock()
+	if viewBoundNow()-seen <= animViewBoundStale {
+		t.Error("stale heartbeat should still read stale while scrub-pinned")
 	}
 }

--- a/gui/animation_safety_test.go
+++ b/gui/animation_safety_test.go
@@ -54,3 +54,41 @@ func TestUpdateSpringNilOnValueStops(t *testing.T) {
 		t.Fatal("expected spring to stop when OnValue is nil")
 	}
 }
+
+// TestUpdateSpringDivergenceStops guards the fixed-timestep divergence
+// path: a stiffness the 16ms step cannot integrate drives velocity to
+// +Inf and position to NaN. NaN fails every threshold comparison, so
+// without an explicit finite check the animation never retires — it
+// pushes NaN through OnValue and forces a layout refresh every tick,
+// forever.
+func TestUpdateSpringDivergenceStops(t *testing.T) {
+	var last float32
+	sp := NewSpringAnimation("s", func(v float32, _ *Window) { last = v })
+	sp.Config = SpringCfg{Stiffness: 20000, Damping: 10, Mass: 1, Threshold: 0.01}
+	sp.SpringTo(0, 1)
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	// Divergence is reached in ~72 ticks; 500 leaves ample margin
+	// without letting a non-retiring spring run the test forever.
+	for range 500 {
+		if !updateSpring(sp, 0.016, &ac) {
+			break
+		}
+	}
+	if !sp.stopped {
+		t.Fatalf("diverged spring never stopped: pos=%v vel=%v",
+			sp.state.position, sp.state.velocity)
+	}
+	if !f32IsFinite(sp.state.position) || !f32IsFinite(sp.state.velocity) {
+		t.Fatalf("state left non-finite: pos=%v vel=%v",
+			sp.state.position, sp.state.velocity)
+	}
+	if sp.state.position != sp.state.target {
+		t.Errorf("position = %v, want target %v",
+			sp.state.position, sp.state.target)
+	}
+	if !f32IsFinite(last) {
+		t.Errorf("OnValue received non-finite value %v", last)
+	}
+}

--- a/gui/animation_spring.go
+++ b/gui/animation_spring.go
@@ -6,7 +6,8 @@ import "time"
 // exportaudit:keep — caller-facing config (issue #372)
 type SpringCfg struct {
 	// Stiffness controls spring force. Values >= ~15600 (with
-	// Mass=1) will diverge at the 16ms fixed timestep.
+	// Mass=1) diverge at the 16ms fixed timestep; a diverged spring
+	// snaps to its target and retires rather than emitting NaN.
 	// exportaudit:keep — caller-facing config (issue #372)
 	Stiffness float32
 	// exportaudit:keep — caller-facing config (issue #372)
@@ -118,7 +119,17 @@ func updateSpring(sp *SpringAnimation, dt float32, ac *AnimationCommands) bool {
 	sp.state.position += sp.state.velocity * dt
 	displacement = sp.state.position - sp.state.target
 
-	if f32Abs(sp.state.velocity) < cfg.Threshold && f32Abs(displacement) < cfg.Threshold {
+	// Explicit Euler at the fixed timestep amplifies a spring too stiff
+	// for the step (see SpringCfg.Stiffness): velocity reaches +Inf and
+	// position becomes NaN. NaN fails every comparison, so the rest
+	// check below would never fire — the spring would live forever,
+	// hand NaN to OnValue and force a layout refresh each tick. Treat
+	// divergence as arrival: snap to the target and retire, so the
+	// caller's OnDone still runs and no non-finite value escapes.
+	diverged := !f32AllFinite2(sp.state.position, sp.state.velocity)
+
+	if diverged ||
+		(f32Abs(sp.state.velocity) < cfg.Threshold && f32Abs(displacement) < cfg.Threshold) {
 		sp.state.position = sp.state.target
 		sp.state.velocity = 0
 		sp.state.atRest = true

--- a/gui/animation_test.go
+++ b/gui/animation_test.go
@@ -71,7 +71,7 @@ func TestUpdateTransitionNilEasingDefaultsToEaseOutCubic(t *testing.T) {
 func TestUpdateTransitionWithEasing(t *testing.T) {
 	tb := &transitionBase{
 		duration: 10 * time.Second,
-		easing:   easeInQuad,
+		easing:   EaseInQuad,
 		start:    time.Now().Add(-50 * time.Millisecond),
 	}
 	deferred := make([]queuedCommand, 0, 4)

--- a/gui/canvas_draw.go
+++ b/gui/canvas_draw.go
@@ -25,6 +25,9 @@ type DrawContext struct {
 	images          []DrawCanvasImageEntry
 	arcBuf          []float32
 	bezierBuf       []float32
+	roundRectBuf    []float32
+	joinNormalBuf   []strokeVec
+	joinOffsetBuf   []strokeOffset
 	gradTriBuf      []float32
 	gradSplitBuf    []float32
 	gradRadialBuf   []float32
@@ -56,10 +59,12 @@ type DrawContext struct {
 	xfActive bool
 
 	lastColor Color
-	// batchIsGradient marks the current batch as vertex-colored, which
-	// blocks the run-length merge below: a flat fill must never append
-	// its triangles to a batch carrying per-vertex colors, or the
-	// batch's two lengths stop agreeing.
+	// batchIsGradient closes the current batch to the run-length merge.
+	// It is set for a vertex-colored batch — a flat fill must never
+	// append its triangles to a batch carrying per-vertex colors, or the
+	// batch's two lengths stop agreeing — and by breakBatchRun for a
+	// lowered gradient, which records no batch but does take a position
+	// in the emit order.
 	batchIsGradient bool
 }
 
@@ -87,7 +92,7 @@ func (dc *DrawContext) getBatch(color Color) *DrawCanvasTriBatch {
 
 // FilledRect draws a filled rectangle as two triangles.
 func (dc *DrawContext) FilledRect(x, y, w, h float32, color Color) {
-	if w <= 0 || h <= 0 {
+	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h) {
 		return
 	}
 	if dc.recorder != nil {
@@ -122,7 +127,7 @@ func (dc *DrawContext) Line(x0, y0, x1, y1 float32, color Color, width float32) 
 // Polyline draws a stroked open polyline using simple
 // per-segment rectangle expansion (no joins/caps).
 func (dc *DrawContext) Polyline(points []float32, color Color, width float32) {
-	if len(points) < 4 || width <= 0 {
+	if len(points) < 4 || width <= 0 || !f32IsFinite(width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -134,6 +139,15 @@ func (dc *DrawContext) Polyline(points []float32, color Color, width float32) {
 	for i := 0; i+3 < len(points); i += 2 {
 		x0, y0 := points[i], points[i+1]
 		x1, y1 := points[i+2], points[i+3]
+		// Screened per segment rather than over the whole list: one bad
+		// point costs its two segments, and the rest of the polyline
+		// still draws. A non-finite vertex reaching the batch would cost
+		// far more than this primitive — validSvgCmd drops the whole
+		// command, and the run-length merge means the batch holds
+		// everything else drawn in the same color.
+		if hasNaNInf(x0, y0, x1, y1) {
+			continue
+		}
 		dx := x1 - x0
 		dy := y1 - y0
 		ln := float32(math.Sqrt(float64(dx*dx + dy*dy)))
@@ -159,7 +173,7 @@ func (dc *DrawContext) Polyline(points []float32, color Color, width float32) {
 // with overlap at corners. Overlap may cause alpha artifacts
 // with transparent colors.
 func (dc *DrawContext) Rect(x, y, w, h float32, color Color, width float32) {
-	if w <= 0 || h <= 0 || width <= 0 {
+	if w <= 0 || h <= 0 || width <= 0 || hasNaNInf(x, y, w, h, width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -196,6 +210,12 @@ func (dc *DrawContext) FilledPolygon(points []float32, color Color) {
 	if len(points) < 6 {
 		return
 	}
+	// A fan shares its first vertex with every triangle, so one bad
+	// point can poison the whole polygon. Screen the list and drop the
+	// primitive rather than emitting a partial shape.
+	if !f32AllFinite(points) {
+		return
+	}
 	if dc.recorder != nil {
 		dc.rec().FilledPolygon(points, color)
 		return
@@ -224,7 +244,7 @@ func (dc *DrawContext) Circle(cx, cy, radius float32, color Color, width float32
 
 // Arc draws a stroked elliptical arc.
 func (dc *DrawContext) Arc(cx, cy, rx, ry, start, sweep float32, color Color, width float32) {
-	if width <= 0 {
+	if width <= 0 || !f32IsFinite(width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -307,7 +327,7 @@ func (dc *DrawContext) arcPoints(cx, cy, rx, ry, start, sweep float32) []float32
 // FilledRoundedRect draws a filled rectangle with rounded corners.
 // Radius is clamped to half the smaller dimension.
 func (dc *DrawContext) FilledRoundedRect(x, y, w, h, radius float32, color Color) {
-	if w <= 0 || h <= 0 {
+	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h, radius) {
 		return
 	}
 	if dc.recorder != nil {
@@ -325,7 +345,7 @@ func (dc *DrawContext) FilledRoundedRect(x, y, w, h, radius float32, color Color
 
 // RoundedRect draws a stroked rectangle with rounded corners.
 func (dc *DrawContext) RoundedRect(x, y, w, h, radius float32, color Color, width float32) {
-	if w <= 0 || h <= 0 || width <= 0 {
+	if w <= 0 || h <= 0 || width <= 0 || hasNaNInf(x, y, w, h, radius, width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -340,8 +360,12 @@ func (dc *DrawContext) RoundedRect(x, y, w, h, radius float32, color Color, widt
 	r := radius
 	// Build polyline: top → TR arc → right → BR arc → bottom →
 	// BL arc → left → TL arc → close.
+	//
+	// Into a pooled buffer, not a fresh slice: this runs once per
+	// rounded rect per frame on an animated canvas, and the length is
+	// the same every time.
 	const segs = 8
-	pts := make([]float32, 0, (4*segs+4+1)*2)
+	pts := dc.roundRectBuf[:0]
 	// Top-left corner arc.
 	pts = appendArcPoints(pts, x+r, y+r, r, math.Pi, segs)
 	// Top-right corner arc.
@@ -352,103 +376,17 @@ func (dc *DrawContext) RoundedRect(x, y, w, h, radius float32, color Color, widt
 	pts = appendArcPoints(pts, x+r, y+h-r, r, math.Pi/2, segs)
 	// Close the shape.
 	pts = append(pts, pts[0], pts[1])
+	dc.roundRectBuf = pts
 	dc.Polyline(pts, color, width)
 }
 
-// DashedLine draws a dashed line segment. dashLen and gapLen
-// control the pattern. Zero or negative values fall back to
-// solid.
-func (dc *DrawContext) DashedLine(
-	x0, y0, x1, y1 float32,
-	color Color, width, dashLen, gapLen float32,
-) {
-	if dashLen <= 0 || gapLen <= 0 {
-		dc.Line(x0, y0, x1, y1, color, width)
-		return
-	}
-	if dc.recorder != nil {
-		dc.rec().DashedLine(x0, y0, x1, y1, color, width, dashLen, gapLen)
-		return
-	}
-	dx := x1 - x0
-	dy := y1 - y0
-	totalLen := float32(math.Sqrt(float64(dx*dx + dy*dy)))
-	if totalLen < 1e-6 {
-		return
-	}
-	ux := dx / totalLen
-	uy := dy / totalLen
-	patternLen := dashLen + gapLen
-	drawn := float32(0)
-	for drawn < totalLen {
-		end := drawn + dashLen
-		if end > totalLen {
-			end = totalLen
-		}
-		dc.Line(
-			x0+ux*drawn, y0+uy*drawn,
-			x0+ux*end, y0+uy*end,
-			color, width,
-		)
-		drawn += patternLen
-	}
-}
+// strokeVec is a segment normal and strokeOffset the left/right pair
+// of stroke boundary points at one vertex. Named types at package
+// scope rather than inside PolylineJoined so its two working lists can
+// live on the DrawContext and be reused across redraws.
+type strokeVec struct{ x, y float32 }
 
-// DashedPolyline draws a polyline with a dash pattern applied
-// continuously across all segments.
-func (dc *DrawContext) DashedPolyline(
-	points []float32,
-	color Color, width, dashLen, gapLen float32,
-) {
-	if len(points) < 4 {
-		return
-	}
-	if dashLen <= 0 || gapLen <= 0 {
-		dc.Polyline(points, color, width)
-		return
-	}
-	if dc.recorder != nil {
-		dc.rec().DashedPolyline(points, color, width, dashLen, gapLen)
-		return
-	}
-	patternLen := dashLen + gapLen
-	offset := float32(0) // position within pattern
-	for i := 0; i+3 < len(points); i += 2 {
-		x0, y0 := points[i], points[i+1]
-		x1, y1 := points[i+2], points[i+3]
-		dx := x1 - x0
-		dy := y1 - y0
-		segLen := float32(math.Sqrt(float64(dx*dx + dy*dy)))
-		if segLen < 1e-6 {
-			continue
-		}
-		ux := dx / segLen
-		uy := dy / segLen
-		pos := float32(0)
-		for pos < segLen {
-			inPattern := float32(math.Mod(float64(offset+pos),
-				float64(patternLen)))
-			if inPattern < dashLen {
-				// In dash portion.
-				remain := dashLen - inPattern
-				end := pos + remain
-				if end > segLen {
-					end = segLen
-				}
-				dc.Line(
-					x0+ux*pos, y0+uy*pos,
-					x0+ux*end, y0+uy*end,
-					color, width,
-				)
-				pos += remain
-			} else {
-				// In gap portion.
-				pos += patternLen - inPattern
-			}
-		}
-		offset += segLen
-	}
-}
+type strokeOffset struct{ lx, ly, rx, ry float32 }
 
 // PolylineJoined draws a stroked polyline with miter joins
 // at vertices. Falls back to bevel when the miter exceeds
@@ -457,7 +395,12 @@ func (dc *DrawContext) PolylineJoined(
 	points []float32, color Color, width float32,
 ) {
 	n := len(points) / 2
-	if n < 2 || width <= 0 {
+	if n < 2 || width <= 0 || !f32IsFinite(width) {
+		return
+	}
+	// Miter joins carry a bad point into its neighbours' offsets, so
+	// the screen is over the whole list rather than per segment.
+	if !f32AllFinite(points) {
 		return
 	}
 	if dc.recorder != nil {
@@ -468,26 +411,32 @@ func (dc *DrawContext) PolylineJoined(
 	const miterLimit = 4.0
 	b := dc.getBatch(color)
 
-	// Compute perpendicular normals per segment.
-	type vec struct{ x, y float32 }
-	normals := make([]vec, 0, n-1)
+	// Compute perpendicular normals per segment, into pooled buffers:
+	// a joined polyline is the shape a chart or a map redraws every
+	// frame, and both lists are re-derived at the same length each time.
+	normals := dc.joinNormalBuf[:0]
 	for i := 0; i < n-1; i++ {
 		dx := points[(i+1)*2] - points[i*2]
 		dy := points[(i+1)*2+1] - points[i*2+1]
 		ln := float32(math.Sqrt(float64(dx*dx + dy*dy)))
 		if ln < 1e-6 {
-			normals = append(normals, vec{0, 0})
+			normals = append(normals, strokeVec{0, 0})
 			continue
 		}
-		normals = append(normals, vec{-dy / ln, dx / ln})
+		normals = append(normals, strokeVec{-dy / ln, dx / ln})
 	}
+	dc.joinNormalBuf = normals
 
 	// Compute offset points (left/right) at each vertex.
-	type offsetPt struct{ lx, ly, rx, ry float32 }
-	offsets := make([]offsetPt, n)
+	offsets := dc.joinOffsetBuf[:0]
+	if cap(offsets) < n {
+		offsets = make([]strokeOffset, n)
+	}
+	offsets = offsets[:n]
+	dc.joinOffsetBuf = offsets
 
 	// First vertex: use first segment normal.
-	offsets[0] = offsetPt{
+	offsets[0] = strokeOffset{
 		lx: points[0] + normals[0].x*hw,
 		ly: points[1] + normals[0].y*hw,
 		rx: points[0] - normals[0].x*hw,
@@ -496,7 +445,7 @@ func (dc *DrawContext) PolylineJoined(
 	// Last vertex: use last segment normal.
 	last := n - 1
 	li := len(normals) - 1
-	offsets[last] = offsetPt{
+	offsets[last] = strokeOffset{
 		lx: points[last*2] + normals[li].x*hw,
 		ly: points[last*2+1] + normals[li].y*hw,
 		rx: points[last*2] - normals[li].x*hw,
@@ -507,13 +456,13 @@ func (dc *DrawContext) PolylineJoined(
 	for i := 1; i < last; i++ {
 		n0 := normals[i-1]
 		n1 := normals[i]
-		if (n0 == vec{0, 0}) || (n1 == vec{0, 0}) {
+		if (n0 == strokeVec{0, 0}) || (n1 == strokeVec{0, 0}) {
 			// Degenerate segment, use whichever is valid.
 			nv := n0
-			if nv == (vec{0, 0}) {
+			if nv == (strokeVec{0, 0}) {
 				nv = n1
 			}
-			offsets[i] = offsetPt{
+			offsets[i] = strokeOffset{
 				lx: points[i*2] + nv.x*hw,
 				ly: points[i*2+1] + nv.y*hw,
 				rx: points[i*2] - nv.x*hw,
@@ -527,7 +476,7 @@ func (dc *DrawContext) PolylineJoined(
 		ml := float32(math.Sqrt(float64(mx*mx + my*my)))
 		if ml < 1e-6 {
 			// Nearly opposite normals — bevel.
-			offsets[i] = offsetPt{
+			offsets[i] = strokeOffset{
 				lx: points[i*2] + n1.x*hw,
 				ly: points[i*2+1] + n1.y*hw,
 				rx: points[i*2] - n1.x*hw,
@@ -549,7 +498,7 @@ func (dc *DrawContext) PolylineJoined(
 			mx = n1.x
 			my = n1.y
 		}
-		offsets[i] = offsetPt{
+		offsets[i] = strokeOffset{
 			lx: points[i*2] + mx*miterLen,
 			ly: points[i*2+1] + my*miterLen,
 			rx: points[i*2] - mx*miterLen,

--- a/gui/canvas_draw_batch.go
+++ b/gui/canvas_draw_batch.go
@@ -60,6 +60,21 @@ func (dc *DrawContext) takeBatch(color Color, gradient bool,
 	return &dc.batches[dc.currentBatchIdx]
 }
 
+// breakBatchRun closes the current batch to the run-length merge, so
+// the next primitive opens a fresh one whatever its color.
+//
+// It exists for the lowered radial gradient, which records no batch of
+// its own but does take a position in the emit order. Without it the
+// merge key — color plus transform — cannot see that something was
+// drawn in between, and geometry recorded after the fill lands in a
+// batch emitted before it.
+func (dc *DrawContext) breakBatchRun() {
+	dc.lastColor = Color{}
+	// A gradient batch never merges, so this alone stops the next
+	// primitive reaching the batch that is open now.
+	dc.batchIsGradient = true
+}
+
 // takeGradient appends a gradient entry and gives it the stop buffer
 // the previous redraw's entry at the same index left behind, on the
 // same index-alignment argument as takeBatch: one canvas records its
@@ -113,6 +128,10 @@ func (dc *DrawContext) resetFor(w, h, scale float32, tm TextMeasurer,
 	dc.resetXform()
 
 	dc.arcBuf = keepScratch(dc.arcBuf)
+	dc.xfPtBuf = keepScratch(dc.xfPtBuf)
+	dc.roundRectBuf = keepScratch(dc.roundRectBuf)
+	dc.joinNormalBuf = keepScratch(dc.joinNormalBuf)
+	dc.joinOffsetBuf = keepScratch(dc.joinOffsetBuf)
 	dc.bezierBuf = keepScratch(dc.bezierBuf)
 	dc.gradTriBuf = keepScratch(dc.gradTriBuf)
 	dc.gradSplitBuf = keepScratch(dc.gradSplitBuf)

--- a/gui/canvas_draw_colors.go
+++ b/gui/canvas_draw_colors.go
@@ -21,14 +21,21 @@ package gui
 // subdivision. The caller's colors are the shading, interpolated across
 // each triangle by the backend.
 //
-// A malformed triangle list, or a color count that does not match the
-// vertex count, is a no-op — matching how FillTrianglesGradient treats a
+// A malformed triangle list, a non-finite vertex, a list past
+// maxFillTrisFloats, or a color count that does not match the vertex
+// count, is a no-op — matching how FillTrianglesGradient treats a
 // degenerate input rather than painting something the caller did not
 // ask for.
 func (dc *DrawContext) FillTrianglesColors(tris []float32,
 	colors []Color) {
 	if len(tris) == 0 || len(tris)%6 != 0 ||
 		len(colors)*2 != len(tris) {
+		return
+	}
+	// Bounded and screened on the same terms as FillTrianglesGradient:
+	// the mesh is walked twice here, and a non-finite vertex reaching
+	// the batch costs the whole command at validSvgCmd.
+	if len(tris) > maxFillTrisFloats || !f32AllFinite(tris) {
 		return
 	}
 	if dc.recorder != nil {

--- a/gui/canvas_draw_dash.go
+++ b/gui/canvas_draw_dash.go
@@ -1,0 +1,138 @@
+package gui
+
+// canvas_draw_dash.go — the dashed stroke primitives.
+//
+// Both walk a segment in pattern periods and hand each dash to Line,
+// so the dash geometry is the only thing here; the stroke expansion
+// itself lives with Polyline.
+
+import "math"
+
+// DashedLine draws a dashed line segment. dashLen and gapLen
+// control the pattern. Zero or negative values fall back to
+// solid.
+func (dc *DrawContext) DashedLine(
+	x0, y0, x1, y1 float32,
+	color Color, width, dashLen, gapLen float32,
+) {
+	if dashLen <= 0 || gapLen <= 0 {
+		dc.Line(x0, y0, x1, y1, color, width)
+		return
+	}
+	if width <= 0 || !f32IsFinite(width) || hasNaNInf(dashLen, gapLen) {
+		return
+	}
+	if dc.recorder != nil {
+		dc.rec().DashedLine(x0, y0, x1, y1, color, width, dashLen, gapLen)
+		return
+	}
+	if hasNaNInf(x0, y0, x1, y1) {
+		return
+	}
+	dx := x1 - x0
+	dy := y1 - y0
+	totalLen := float32(math.Sqrt(float64(dx*dx + dy*dy)))
+	if totalLen < 1e-6 {
+		return
+	}
+	ux := dx / totalLen
+	uy := dy / totalLen
+	patternLen := dashLen + gapLen
+	drawn := float32(0)
+	for n := dashCount(totalLen, patternLen); n > 0; n-- {
+		end := drawn + dashLen
+		if end > totalLen {
+			end = totalLen
+		}
+		dc.Line(
+			x0+ux*drawn, y0+uy*drawn,
+			x0+ux*end, y0+uy*end,
+			color, width,
+		)
+		drawn += patternLen
+	}
+}
+
+// maxDashes bounds the dashes one segment may emit. A pattern short
+// against the segment it walks — a 1e-6 gap over a 1e6 line, or a
+// finite but astronomical endpoint — would otherwise run the walk for
+// longer than the frame it sits in, and every dash past a pixel or two
+// of pattern is invisible anyway.
+const maxDashes = 1 << 16
+
+// dashCount is how many pattern periods fit in a segment, capped.
+// Computed in float64: totalLen/patternLen is past int64 for the
+// extreme inputs this cap exists for, and an out-of-range float-to-int
+// conversion is undefined in Go.
+func dashCount(totalLen, patternLen float32) int {
+	if !(patternLen > 0) || !(totalLen > 0) {
+		return 0
+	}
+	n := math.Ceil(float64(totalLen) / float64(patternLen))
+	return int(min(n, maxDashes))
+}
+
+// DashedPolyline draws a polyline with a dash pattern applied
+// continuously across all segments.
+func (dc *DrawContext) DashedPolyline(
+	points []float32,
+	color Color, width, dashLen, gapLen float32,
+) {
+	if len(points) < 4 {
+		return
+	}
+	if dashLen <= 0 || gapLen <= 0 {
+		dc.Polyline(points, color, width)
+		return
+	}
+	if width <= 0 || !f32IsFinite(width) || hasNaNInf(dashLen, gapLen) {
+		return
+	}
+	if dc.recorder != nil {
+		dc.rec().DashedPolyline(points, color, width, dashLen, gapLen)
+		return
+	}
+	patternLen := dashLen + gapLen
+	offset := float32(0) // position within pattern
+	for i := 0; i+3 < len(points); i += 2 {
+		x0, y0 := points[i], points[i+1]
+		x1, y1 := points[i+2], points[i+3]
+		if hasNaNInf(x0, y0, x1, y1) {
+			continue
+		}
+		dx := x1 - x0
+		dy := y1 - y0
+		segLen := float32(math.Sqrt(float64(dx*dx + dy*dy)))
+		if segLen < 1e-6 {
+			continue
+		}
+		ux := dx / segLen
+		uy := dy / segLen
+		pos := float32(0)
+		// Two dash steps per period at worst — a dash then a gap — so
+		// the period count bounds the walk with room to spare.
+		steps := 2 * dashCount(segLen, patternLen)
+		for ; pos < segLen && steps > 0; steps-- {
+			inPattern := float32(math.Mod(float64(offset+pos),
+				float64(patternLen)))
+			if inPattern < dashLen {
+				// In dash portion.
+				remain := dashLen - inPattern
+				end := pos + remain
+				if end > segLen {
+					end = segLen
+				}
+				dc.Line(
+					x0+ux*pos, y0+uy*pos,
+					x0+ux*end, y0+uy*end,
+					color, width,
+				)
+				pos += remain
+			} else {
+				// In gap portion.
+				pos += patternLen - inPattern
+			}
+		}
+		offset += segLen
+	}
+}

--- a/gui/canvas_draw_gradient.go
+++ b/gui/canvas_draw_gradient.go
@@ -8,11 +8,21 @@ import (
 
 // canvas_draw_gradient.go — the DrawContext gradient fills.
 //
+// maxFillTrisFloats bounds the caller-supplied mesh both this file's
+// FillTrianglesGradient and FillTrianglesColors will walk. Every fill
+// past it is a no-op: the subdivision pass caps its own output, but
+// the input is scanned before that cap applies.
+//
 // Each method tessellates through the same helpers its flat twin uses,
 // so a gradient fill and a flat fill of the same shape produce the same
 // vertices; only the coloring differs. The geometry lands in a scratch
 // buffer first, because the vertex colors cannot be assigned until the
 // subdivision pass has decided how many vertices there are.
+
+// maxFillTrisFloats is the longest caller-supplied triangle list a
+// fill will walk — 1<<20 floats, about 175 000 triangles, far past any
+// mesh a canvas draws by hand.
+const maxFillTrisFloats = 1 << 20
 
 // FillTrianglesGradient fills caller-supplied geometry with a gradient.
 // tris is a flat x,y triangle list — 6 floats per triangle, the same
@@ -30,9 +40,10 @@ func (dc *DrawContext) FillTrianglesGradient(tris []float32,
 		return
 	}
 	// Bound hostile geometry; gradmesh caps output but tRange still
-	// scans the input.
-	const maxGradientTrisFloats = 1 << 20
-	if len(tris) > maxGradientTrisFloats {
+	// scans the input. Screened on the same terms as
+	// FillTrianglesColors: a non-finite vertex reaching the batch
+	// costs the whole command at validSvgCmd.
+	if len(tris) > maxFillTrisFloats || !f32AllFinite(tris) {
 		return
 	}
 	if dc.recorder != nil {
@@ -175,7 +186,7 @@ func (dc *DrawContext) gradScratch() *[]float32 {
 // whose endpoints coincide runs top-to-bottom across the rect.
 func (dc *DrawContext) FilledRectGradient(x, y, w, h float32,
 	g *CanvasGradient) {
-	if w <= 0 || h <= 0 {
+	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h) {
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
@@ -203,6 +214,9 @@ func (dc *DrawContext) FilledRectGradient(x, y, w, h float32,
 //	})
 func (dc *DrawContext) FilledCircleGradient(cx, cy, radius float32,
 	g *CanvasGradient) {
+	if hasNaNInf(cx, cy, radius) {
+		return
+	}
 	if dc.emitRadialGradient(cx, cy, radius, g) {
 		return
 	}
@@ -319,6 +333,11 @@ func (dc *DrawContext) emitRadialGradient(cx, cy, r float32,
 	// the bounding square's top-left corner rather than its far one.
 	e.X, e.Y, e.W, e.H = dc.xfRect(cx-r, cy-r, 2*r, 2*r)
 	e.afterBatch = len(dc.batches)
+	// The fill sits between batch afterBatch-1 and batch afterBatch in
+	// the emit walk, so the batch open right now must be closed to it:
+	// a later flat fill of the same color and transform would otherwise
+	// merge back into it and paint UNDER a glow it was drawn over.
+	dc.breakBatchRun()
 	return true
 }
 
@@ -481,6 +500,9 @@ func (dc *DrawContext) concentricRings(stops []GradientStop,
 // gradient.
 func (dc *DrawContext) FilledArcGradient(cx, cy, rx, ry, start,
 	sweep float32, g *CanvasGradient) {
+	if hasNaNInf(cx, cy, rx, ry, start, sweep) {
+		return
+	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
 		dc.rec().FilledArc(cx, cy, rx, ry, start, sweep, mid)
 		return
@@ -498,7 +520,7 @@ func (dc *DrawContext) FilledArcGradient(cx, cy, rx, ry, start,
 // points is a flat x,y list.
 func (dc *DrawContext) FilledPolygonGradient(points []float32,
 	g *CanvasGradient) {
-	if len(points) < 6 {
+	if len(points) < 6 || !f32AllFinite(points) {
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
@@ -514,7 +536,7 @@ func (dc *DrawContext) FilledPolygonGradient(points []float32,
 // Radius is clamped to half the smaller dimension.
 func (dc *DrawContext) FilledRoundedRectGradient(x, y, w, h,
 	radius float32, g *CanvasGradient) {
-	if w <= 0 || h <= 0 {
+	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h, radius) {
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {

--- a/gui/canvas_draw_hardening_test.go
+++ b/gui/canvas_draw_hardening_test.go
@@ -1,0 +1,305 @@
+package gui
+
+import (
+	"math"
+	"testing"
+)
+
+// A fill recorded after a lowered radial gradient must not merge back
+// into a batch that was opened before it: the batch is emitted first,
+// so the later fill would paint under the glow it was drawn over.
+func TestLoweredGradientBreaksBatchRun(t *testing.T) {
+	dc := NewDrawContext(200, 200, nil)
+	red := RGB(255, 0, 0)
+	dc.FilledRect(0, 0, 10, 10, red)
+	dc.FilledCircleGradient(50, 50, 20, &CanvasGradient{
+		Radial: true,
+		Stops: []GradientStop{
+			{Color: RGB(0, 0, 255), Pos: 0},
+			{Color: RGB(0, 255, 0), Pos: 1},
+		},
+	})
+	dc.FilledRect(100, 100, 10, 10, red)
+
+	if got := len(dc.Gradients()); got != 1 {
+		t.Fatalf("gradients = %d, want 1 (fill did not lower)", got)
+	}
+	after := dc.Gradients()[0].afterBatch
+	if len(dc.Batches()) < 2 {
+		t.Fatalf("batches = %d, want 2: the second rect merged into the "+
+			"batch opened before the gradient", len(dc.Batches()))
+	}
+	if after != 1 {
+		t.Fatalf("afterBatch = %d, want 1", after)
+	}
+	// The rect drawn after the glow must live in a batch the emit walk
+	// reaches after it.
+	if len(dc.Batches()[1].Triangles) != 12 {
+		t.Fatalf("batch 1 floats = %d, want 12 (one rect)",
+			len(dc.Batches()[1].Triangles))
+	}
+}
+
+// Dash geometry drove an unbounded loop: a non-finite or very long
+// segment kept the pattern walk running for as long as the frame lived.
+func TestDashedGeometryTerminates(t *testing.T) {
+	inf := float32(math.Inf(1))
+	cases := []struct {
+		name            string
+		x1, y1          float32
+		dashLen, gapLen float32
+	}{
+		{"infinite endpoint", inf, 0, 4, 4},
+		{"nan endpoint", float32(math.NaN()), 0, 4, 4},
+		{"huge finite length", 1e30, 0, 1, 1},
+		{"tiny pattern", 1e6, 0, 1e-6, 1e-6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := NewDrawContext(200, 200, nil)
+			dc.DashedLine(0, 0, tc.x1, tc.y1, RGB(255, 0, 0), 1,
+				tc.dashLen, tc.gapLen)
+			pts := []float32{0, 0, tc.x1, tc.y1}
+			dc.DashedPolyline(pts, RGB(255, 0, 0), 1, tc.dashLen, tc.gapLen)
+		})
+	}
+}
+
+// A non-finite vertex reaching a batch costs every primitive that
+// merged into it, because validSvgCmd drops the whole command. Screen
+// at record time so a bad primitive costs only itself.
+func TestFlatPrimitivesScreenNonFinite(t *testing.T) {
+	nan := float32(math.NaN())
+	inf := float32(math.Inf(-1))
+	red := RGB(255, 0, 0)
+
+	draws := []struct {
+		name string
+		fn   func(dc *DrawContext)
+	}{
+		{"FilledRect", func(dc *DrawContext) {
+			dc.FilledRect(nan, 0, 10, 10, red)
+		}},
+		{"Rect", func(dc *DrawContext) {
+			dc.Rect(0, inf, 10, 10, red, 1)
+		}},
+		{"Line", func(dc *DrawContext) {
+			dc.Line(0, 0, nan, 5, red, 1)
+		}},
+		{"Polyline", func(dc *DrawContext) {
+			dc.Polyline([]float32{0, 0, 5, nan, 10, 10}, red, 1)
+		}},
+		{"FilledPolygon", func(dc *DrawContext) {
+			dc.FilledPolygon([]float32{0, 0, 10, 0, inf, 10}, red)
+		}},
+		{"PolylineJoined", func(dc *DrawContext) {
+			dc.PolylineJoined([]float32{0, 0, 5, 5, nan, 10}, red, 2)
+		}},
+		{"FillTrianglesColors", func(dc *DrawContext) {
+			dc.FillTrianglesColors(
+				[]float32{0, 0, 10, 0, 10, nan},
+				[]Color{red, red, red})
+		}},
+	}
+	for _, d := range draws {
+		t.Run(d.name, func(t *testing.T) {
+			dc := NewDrawContext(200, 200, nil)
+			// A good fill first: it must survive the bad one that
+			// follows, which is what merging used to break.
+			dc.FilledRect(0, 0, 10, 10, red)
+			d.fn(dc)
+			for bi, b := range dc.Batches() {
+				for i, v := range b.Triangles {
+					if math.IsNaN(float64(v)) ||
+						math.IsInf(float64(v), 0) {
+						t.Fatalf("batch %d vertex %d is %v: the bad "+
+							"primitive poisoned the batch", bi, i, v)
+					}
+				}
+			}
+			if len(dc.Batches()) == 0 ||
+				len(dc.Batches()[0].Triangles) != 12 {
+				t.Fatalf("the good rect was dropped: %d batches",
+					len(dc.Batches()))
+			}
+		})
+	}
+}
+
+// The recorder path bakes the transform into every coordinate. A point
+// list past the old scratch cap was handed over untransformed, which
+// silently misplaced it in an export.
+func TestXformRecorderBakesLargePointList(t *testing.T) {
+	// Past the cap the scratch buffer used to refuse, which handed the
+	// recorder the caller's raw points.
+	const n = (1 << 20) + 2
+	pts := make([]float32, n)
+	for i := 0; i+1 < n; i += 2 {
+		pts[i], pts[i+1] = 1, 2
+	}
+	r := &capturingRecorder{}
+	dc := NewDrawContext(100, 100, nil)
+	dc.SetRecorder(r)
+	dc.Translate(10, 20)
+	dc.Polyline(pts, RGB(255, 0, 0), 1)
+
+	if len(r.polyline) != n {
+		t.Fatalf("recorder got %d floats, want %d", len(r.polyline), n)
+	}
+	if r.polyline[0] != 11 || r.polyline[1] != 22 {
+		t.Fatalf("point 0 = (%v, %v), want (11, 22): the transform was "+
+			"not baked", r.polyline[0], r.polyline[1])
+	}
+}
+
+// capturingRecorder records the one call the test above asserts on and
+// no-ops the rest of the interface.
+type capturingRecorder struct {
+	polyline []float32
+}
+
+func (c *capturingRecorder) Polyline(points []float32, _ Color, _ float32) {
+	c.polyline = append(c.polyline[:0], points...)
+}
+
+func (c *capturingRecorder) Line(_, _, _, _ float32, _ Color, _ float32) {}
+func (c *capturingRecorder) FilledRect(_, _, _, _ float32, _ Color)      {}
+func (c *capturingRecorder) Rect(_, _, _, _ float32, _ Color, _ float32) {}
+func (c *capturingRecorder) FilledCircle(_, _, _ float32, _ Color)       {}
+func (c *capturingRecorder) Circle(_, _, _ float32, _ Color, _ float32)  {}
+func (c *capturingRecorder) FilledArc(_, _, _, _, _, _ float32, _ Color) {}
+func (c *capturingRecorder) Arc(_, _, _, _, _, _ float32, _ Color, _ float32) {
+}
+func (c *capturingRecorder) FilledPolygon(_ []float32, _ Color)               {}
+func (c *capturingRecorder) FilledRoundedRect(_, _, _, _, _ float32, _ Color) {}
+func (c *capturingRecorder) RoundedRect(_, _, _, _, _ float32, _ Color, _ float32) {
+}
+func (c *capturingRecorder) DashedLine(_, _, _, _ float32, _ Color, _, _, _ float32) {
+}
+func (c *capturingRecorder) DashedPolyline(_ []float32, _ Color, _, _, _ float32) {
+}
+func (c *capturingRecorder) PolylineJoined(_ []float32, _ Color, _ float32) {}
+func (c *capturingRecorder) QuadBezier(_, _, _, _, _, _ float32, _ Color, _ float32) {
+}
+func (c *capturingRecorder) CubicBezier(_, _, _, _, _, _, _, _ float32, _ Color, _ float32) {
+}
+func (c *capturingRecorder) Text(_, _ float32, _ string, _ TextStyle) {}
+
+// The stroked paths that still allocated per call must not: an animated
+// canvas redraws them every frame.
+func TestStrokedPathsRedrawWithoutAllocating(t *testing.T) {
+	dc := NewDrawContext(200, 200, nil)
+	red := RGB(255, 0, 0)
+	pts := []float32{0, 0, 20, 10, 40, 0, 60, 10}
+	// The same ping-pong renderDrawCanvas runs: this redraw claims the
+	// buffers the last one left behind.
+	var prev drawCanvasCache
+	draw := func() {
+		dc.resetFor(200, 200, 1, nil, prev)
+		dc.RoundedRect(0, 0, 100, 50, 8, red, 2)
+		dc.PolylineJoined(pts, red, 3)
+		prev = drawCanvasCache{Batches: dc.batches, spare: dc.batchPool}
+	}
+	draw() // warm the scratch and batch buffers
+	draw()
+	got := testing.AllocsPerRun(20, draw)
+	if got > 0 {
+		t.Fatalf("allocs per redraw = %v, want 0", got)
+	}
+}
+
+// resetFor releases every canvas scratch buffer that ran away, the
+// transform point buffer included.
+func TestResetForReleasesPointBuffer(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	dc.xfPtBuf = make([]float32, 0, canvasScratchRetainMax+1)
+	dc.resetFor(100, 100, 1, nil, drawCanvasCache{})
+	if cap(dc.xfPtBuf) != 0 {
+		t.Fatalf("xfPtBuf kept %d floats past the retain cap",
+			cap(dc.xfPtBuf))
+	}
+}
+
+// FillTrianglesColors takes the same input bound its gradient twin
+// takes: a hostile mesh must not be walked.
+func TestFillTrianglesColorsBoundsInput(t *testing.T) {
+	dc := NewDrawContext(100, 100, nil)
+	// Past the bound and still a well-formed mesh: 6 floats per
+	// triangle, one color per vertex, so only the bound can reject it.
+	n := maxFillTrisFloats + 2
+	tris := make([]float32, n)
+	cols := make([]Color, n/2)
+	dc.FillTrianglesColors(tris, cols)
+	if len(dc.Batches()) != 0 {
+		t.Fatalf("batches = %d, want 0: an over-long mesh was accepted",
+			len(dc.Batches()))
+	}
+}
+
+// A non-finite stroke width must not reach a batch: the expanded
+// quad inherits the NaN and poisons everything merged with it.
+func TestStrokedWidthsScreenNonFinite(t *testing.T) {
+	nan := float32(math.NaN())
+	inf := float32(math.Inf(1))
+	red := RGB(255, 0, 0)
+	for _, w := range []float32{nan, inf} {
+		dc := NewDrawContext(200, 200, nil)
+		dc.FilledRect(0, 0, 10, 10, red)
+		dc.Polyline([]float32{0, 0, 10, 10}, red, w)
+		dc.Arc(50, 50, 10, 10, 0, 1, red, w)
+		dc.DashedLine(0, 0, 10, 10, red, w, 4, 4)
+		dc.DashedPolyline([]float32{0, 0, 10, 10}, red, w, 4, 4)
+		for bi, b := range dc.Batches() {
+			for i, v := range b.Triangles {
+				if math.IsNaN(float64(v)) ||
+					math.IsInf(float64(v), 0) {
+					t.Fatalf("width %v: batch %d vertex %d is %v",
+						w, bi, i, v)
+				}
+			}
+		}
+		if len(dc.Batches()) == 0 ||
+			len(dc.Batches()[0].Triangles) != 12 {
+			t.Fatalf("width %v: the good rect was dropped", w)
+		}
+	}
+}
+
+// Rounded and gradient shapes screen their geometry before it can
+// reach a batch or a lowered quad.
+func TestRoundedAndGradientScreenNonFinite(t *testing.T) {
+	nan := float32(math.NaN())
+	red := RGB(255, 0, 0)
+	g := &CanvasGradient{
+		Stops: []GradientStop{
+			{Color: red, Pos: 0},
+			{Color: RGB(0, 0, 255), Pos: 1},
+		},
+	}
+	dc := NewDrawContext(200, 200, nil)
+	dc.FilledRect(0, 0, 10, 10, red)
+	dc.FilledRoundedRect(nan, 0, 10, 10, 2, red)
+	dc.RoundedRect(0, 0, 10, 10, nan, red, 1)
+	dc.FillTrianglesGradient([]float32{0, 0, 10, 0, 10, nan}, g)
+	dc.FilledRectGradient(nan, 0, 10, 10, g)
+	dc.FilledPolygonGradient([]float32{0, 0, 10, 0, nan, 10}, g)
+	dc.FilledRoundedRectGradient(0, nan, 10, 10, 2, g)
+	dc.FilledArcGradient(nan, 0, 10, 10, 0, 1, g)
+	dc.FilledCircleGradient(0, 0, nan, g)
+	for bi, b := range dc.Batches() {
+		for i, v := range b.Triangles {
+			if math.IsNaN(float64(v)) ||
+				math.IsInf(float64(v), 0) {
+				t.Fatalf("batch %d vertex %d is %v", bi, i, v)
+			}
+		}
+	}
+	if len(dc.Batches()) == 0 ||
+		len(dc.Batches()[0].Triangles) != 12 {
+		t.Fatalf("the good rect was dropped: %d batches",
+			len(dc.Batches()))
+	}
+	if len(dc.Gradients()) != 0 {
+		t.Fatalf("gradients = %d, want 0", len(dc.Gradients()))
+	}
+}

--- a/gui/canvas_draw_transform.go
+++ b/gui/canvas_draw_transform.go
@@ -178,18 +178,17 @@ func (dc *DrawContext) xfRect(x, y, w, h float32) (float32, float32, float32, fl
 	return min(x0, x1), min(y0, y1), xfAbs(x1 - x0), xfAbs(y1 - y0)
 }
 
-// maxXfPoints caps the scratch buffer retained by xfPoints. A single
-// unbounded Polyline would otherwise pin tens of megabytes across frames.
-const maxXfPoints = 1 << 20 // ~4 MiB of floats
-
 // xfPoints maps a caller's point slice into the context's scratch
 // buffer. The caller's slice is never written to: a recorder may hold
 // it, and callers pass their own backing arrays.
+//
+// Every length is mapped. An earlier cap here returned the caller's
+// points unmapped past a size threshold, which handed a recorder raw
+// local coordinates and silently misplaced a large polyline in an
+// export. A run-away buffer is released instead by resetFor, which
+// runs keepScratch over xfPtBuf with every other canvas scratch.
 func (dc *DrawContext) xfPoints(points []float32) []float32 {
 	if _, ok := dc.activeXform(); !ok {
-		return points
-	}
-	if len(points) > maxXfPoints {
 		return points
 	}
 	dc.xfPtBuf = append(dc.xfPtBuf[:0], points...)

--- a/gui/canvas_draw_transform_test.go
+++ b/gui/canvas_draw_transform_test.go
@@ -483,7 +483,7 @@ func TestXformIdentityIsNoOpForRecorder(t *testing.T) {
 }
 
 // Hostile point slices must not pin an unbounded scratch buffer.
-func TestXformPointsCap(t *testing.T) {
+func TestXformPointsLargeInput(t *testing.T) {
 	var dc DrawContext
 	dc.Translate(10, 10)
 	dc.ScaleBy(2, 2)
@@ -491,14 +491,23 @@ func TestXformPointsCap(t *testing.T) {
 	for i := range huge {
 		huge[i] = float32(i)
 	}
-	// Must not panic or allocate a retained 4 MiB+ buffer; returns
-	// the caller's slice unchanged when over cap.
+	// Every length is baked. An earlier cap returned the caller's slice
+	// unmapped, which misplaced a large polyline in a recorder export.
 	got := dc.xfPoints(huge)
-	if &got[0] != &huge[0] {
-		t.Error("xfPoints did not return the original slice for a huge input")
+	if &got[0] == &huge[0] {
+		t.Fatal("xfPoints returned the caller's slice instead of a mapped copy")
 	}
-	if got[0] != 0 || got[1] != 1 {
-		t.Error("huge slice was mutated or baked despite cap")
+	if got[0] != 10 || got[1] != 12 {
+		t.Errorf("point 0 = (%v, %v), want (10, 12)", got[0], got[1])
+	}
+	if huge[0] != 0 || huge[1] != 1 {
+		t.Error("the caller's slice was mutated")
+	}
+	// The buffer it took is released by the next redraw, which is what
+	// keeps a one-off giant polyline from pinning megabytes.
+	dc.resetFor(10, 10, 1, nil, drawCanvasCache{})
+	if cap(dc.xfPtBuf) > canvasScratchRetainMax {
+		t.Errorf("xfPtBuf retained %d floats", cap(dc.xfPtBuf))
 	}
 }
 

--- a/gui/canvas_draw_types.go
+++ b/gui/canvas_draw_types.go
@@ -115,16 +115,19 @@ func (b DrawCanvasTriBatch) Transform() (sx, sy, tx, ty float32, ok bool) {
 // Src matches the forms accepted by ImageCfg.Src: local path,
 // http/https URL, or data URL.
 //
-// BgOpacity modulates BgColor's alpha; it has no effect when
-// BgColor is unset.
+// The background opacity recorded with the entry modulates BgColor's
+// alpha; it has no effect when BgColor is unset. It is set through
+// DrawContext.Image's bgOpacity parameter and is not an exported field.
 //
-// Fetcher, when non-nil, overrides WindowCfg.ImageFetcher for this
-// entry's http/https download. Typical use is map-tile rendering
+// The entry's fetcher, when non-nil, overrides WindowCfg.ImageFetcher
+// for this entry's http/https download. It is set through
+// DrawContext.ImageWithFetcher, likewise not an exported field. Typical use is map-tile rendering
 // where each tile source wants its own User-Agent. Known limit:
 // downloads are URL-keyed and deduped process-wide, so the first
 // entry observed for a given URL binds the fetcher for that URL's
 // in-flight download. Consumers wiring two fetchers to overlapping
 // URL namespaces must route via URL prefix themselves.
+//
 // ClipX/ClipY/ClipW/ClipH restrict drawing to a sub-rectangle of the
 // canvas, in the same content-relative coordinates as X/Y/W/H. They
 // are honored only when Clipped is set (a zero rect would otherwise

--- a/gui/id_resolve.go
+++ b/gui/id_resolve.go
@@ -227,7 +227,7 @@ func resolveFocusOwners(layout *Layout, w *Window) {
 	// Read once per tree, not once per shape: the walk visits every
 	// shape in the frame and the gate cannot move while it does.
 	frames = resolveFocusOwnersWalk(
-		w, layout, "", frames, w.debugStampsChecked())
+		w, layout, "", frames, w.debugStampsChecked(), 0)
 	if w != nil {
 		// Drop a backing array one pathologically deep frame grew, so a
 		// transient tree cannot pin memory for the window's lifetime.
@@ -248,13 +248,16 @@ const maxIDScopeStackKeep = 256
 // sibling.
 func resolveFocusOwnersWalk(
 	w *Window, layout *Layout, scope string, frames []idFrame,
-	checkStamps bool,
+	checkStamps bool, depth int,
 ) []idFrame {
+	if overMaxDepth(depth) {
+		return frames
+	}
 	s := layout.Shape
 	if s == nil {
 		for i := range layout.Children {
 			frames = resolveFocusOwnersWalk(
-				w, &layout.Children[i], scope, frames, checkStamps)
+				w, &layout.Children[i], scope, frames, checkStamps, depth+1)
 		}
 		return frames
 	}
@@ -293,7 +296,7 @@ func resolveFocusOwnersWalk(
 	}
 	for i := range layout.Children {
 		frames = resolveFocusOwnersWalk(
-			w, &layout.Children[i], childScope, frames, checkStamps)
+			w, &layout.Children[i], childScope, frames, checkStamps, depth+1)
 	}
 	if pushed {
 		frames = frames[:len(frames)-1]

--- a/gui/layout.go
+++ b/gui/layout.go
@@ -31,21 +31,59 @@ type Layout struct {
 	Children []Layout
 }
 
+// Depth policy for the layout and render walks, stated once here and
+// referred to from each guarded walk.
+//
+// The event and focus walks have capped their recursion since
+// maxEventDepth was added (event_handlers.go): the breadth guard cannot
+// see a chain of single-child layouts, which recurses until the stack
+// gives out. The layout and render passes walk the same tree and were
+// left uncapped, so a tree deep enough to matter was refused input while
+// still being measured, positioned and drawn.
+//
+// Each walk below therefore takes the same budget. Past it the walk stops
+// descending rather than panicking: a node beyond the cap is left at its
+// zero state — unsized, unpositioned, unpainted — which degrades the
+// frame instead of the process. The cap is deliberately maxEventDepth
+// rather than a second constant, so the depth at which input stops and
+// the depth at which layout stops cannot drift apart.
+//
+// This is consistency with an existing decision, not a fix for a live
+// crash: the layout tree comes from application code, and real trees nest
+// dozens deep at most.
+
 // layoutParents sets the parent pointer of all nodes.
+//
+// A node past the depth cap keeps a nil Parent, the same state a detached
+// subtree already has.
 func layoutParents(layout *Layout, parent *Layout) {
+	layoutParentsDepth(layout, parent, 0)
+}
+
+func layoutParentsDepth(layout *Layout, parent *Layout, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	layout.Parent = parent
 	for i := range layout.Children {
-		layoutParents(&layout.Children[i], layout)
+		layoutParentsDepth(&layout.Children[i], layout, depth+1)
 	}
 }
 
 // layoutDisables walks the Layout and disables children that
 // have a disabled ancestor.
 func layoutDisables(layout *Layout, disabled bool) {
+	layoutDisablesDepth(layout, disabled, 0)
+}
+
+func layoutDisablesDepth(layout *Layout, disabled bool, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	isDisabled := disabled || layout.Shape.Disabled
 	layout.Shape.Disabled = isDisabled
 	for i := range layout.Children {
-		layoutDisables(&layout.Children[i], isDisabled)
+		layoutDisablesDepth(&layout.Children[i], isDisabled, depth+1)
 	}
 }
 

--- a/gui/layout_border_test.go
+++ b/gui/layout_border_test.go
@@ -4,13 +4,13 @@ import "testing"
 
 func TestLayoutWidthsWithBorder(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{
+		Shape: &Shape{shapeType: shapeRectangle,
 			Axis:       axisLeftToRight,
 			SizeBorder: 5,
 			Padding:    NewPadding(0, 10, 0, 10),
 		},
 		Children: []Layout{
-			{Shape: &Shape{Width: 50, MinWidth: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50, MinWidth: 50}},
 		},
 	}
 
@@ -27,13 +27,13 @@ func TestLayoutWidthsWithBorder(t *testing.T) {
 
 func TestLayoutHeightsWithBorder(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{
+		Shape: &Shape{shapeType: shapeRectangle,
 			Axis:       axisTopToBottom,
 			SizeBorder: 5,
 			Padding:    NewPadding(10, 0, 10, 0),
 		},
 		Children: []Layout{
-			{Shape: &Shape{Height: 50, MinHeight: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Height: 50, MinHeight: 50}},
 		},
 	}
 

--- a/gui/layout_depth_test.go
+++ b/gui/layout_depth_test.go
@@ -1,0 +1,350 @@
+package gui
+
+import "testing"
+
+// The layout and render walks share the event walks' depth budget
+// (maxEventDepth); see the depth-policy note in layout.go. These tests pin
+// that: an ordinary-depth tree is measured normally, and a chain past the
+// cap stops being descended instead of recursing until the stack gives out.
+
+// deepRectChain builds a single-child chain of rectangles n levels deep.
+// Only the leaf carries a size, so any pass that reaches the leaf shows up
+// at the root and any pass that stops short leaves the root at zero.
+func deepRectChain(n int) *Layout {
+	root := &Layout{Shape: &Shape{
+		shapeType: shapeRectangle,
+		Axis:      axisTopToBottom,
+	}}
+	cur := root
+	for range n {
+		cur.Children = []Layout{{Shape: &Shape{
+			shapeType: shapeRectangle,
+			Axis:      axisTopToBottom,
+		}}}
+		cur = &cur.Children[0]
+	}
+	cur.Shape.Width = 50
+	cur.Shape.Height = 20
+	cur.Shape.ID = "deep"
+	return root
+}
+
+// leafOf walks to the end of a chain built by deepRectChain.
+func leafOf(root *Layout) *Layout {
+	cur := root
+	for len(cur.Children) > 0 {
+		cur = &cur.Children[0]
+	}
+	return cur
+}
+
+func TestLayoutWidthsStopsAtDepthCap(t *testing.T) {
+	shallow := deepRectChain(100)
+	layoutWidths(shallow)
+	if !f32AreClose(shallow.Shape.Width, 50) {
+		t.Errorf("width at depth 100: got %f, want 50 (leaf must be reached)",
+			shallow.Shape.Width)
+	}
+
+	deep := deepRectChain(maxEventDepth + 50)
+	layoutWidths(deep)
+	if !f32AreClose(deep.Shape.Width, 0) {
+		t.Errorf("width past maxEventDepth (%d): got %f, want 0 (walk must "+
+			"stop descending)", maxEventDepth, deep.Shape.Width)
+	}
+}
+
+func TestLayoutHeightsStopsAtDepthCap(t *testing.T) {
+	shallow := deepRectChain(100)
+	layoutHeights(shallow)
+	if !f32AreClose(shallow.Shape.Height, 20) {
+		t.Errorf("height at depth 100: got %f, want 20", shallow.Shape.Height)
+	}
+
+	deep := deepRectChain(maxEventDepth + 50)
+	layoutHeights(deep)
+	if !f32AreClose(deep.Shape.Height, 0) {
+		t.Errorf("height past maxEventDepth: got %f, want 0", deep.Shape.Height)
+	}
+}
+
+func TestLayoutParentsStopsAtDepthCap(t *testing.T) {
+	shallow := deepRectChain(100)
+	layoutParents(shallow, nil)
+	if leafOf(shallow).Parent == nil {
+		t.Error("leaf at depth 100 has no parent")
+	}
+
+	deep := deepRectChain(maxEventDepth + 50)
+	layoutParents(deep, nil)
+	if leafOf(deep).Parent != nil {
+		t.Error("layoutParents reached a leaf past maxEventDepth")
+	}
+}
+
+func TestLayoutDisablesStopsAtDepthCap(t *testing.T) {
+	shallow := deepRectChain(100)
+	shallow.Shape.Disabled = true
+	layoutDisables(shallow, false)
+	if !leafOf(shallow).Shape.Disabled {
+		t.Error("leaf at depth 100 not disabled by its ancestor")
+	}
+
+	deep := deepRectChain(maxEventDepth + 50)
+	deep.Shape.Disabled = true
+	layoutDisables(deep, false)
+	if leafOf(deep).Shape.Disabled {
+		t.Error("layoutDisables reached a leaf past maxEventDepth")
+	}
+}
+
+func TestLayoutPositionsStopsAtDepthCap(t *testing.T) {
+	w := &Window{}
+
+	shallow := deepRectChain(100)
+	layoutPositions(shallow, 5, 7, w)
+	if !f32AreClose(leafOf(shallow).Shape.X, 5) {
+		t.Errorf("leaf X at depth 100: got %f, want 5",
+			leafOf(shallow).Shape.X)
+	}
+
+	deep := deepRectChain(maxEventDepth + 50)
+	layoutPositions(deep, 5, 7, w)
+	if !f32AreClose(leafOf(deep).Shape.X, 0) {
+		t.Errorf("layoutPositions reached a leaf past maxEventDepth: X %f",
+			leafOf(deep).Shape.X)
+	}
+}
+
+// sizeChain gives every node in a chain a real box. layoutSetShapeClips
+// intersects each node's rect with its parent's, so a chain of zero-width
+// nodes clips to nothing and would hide whether the walk arrived at all.
+func sizeChain(root *Layout) *Layout {
+	for cur := root; ; {
+		cur.Shape.Width = 100
+		cur.Shape.Height = 100
+		if len(cur.Children) == 0 {
+			return root
+		}
+		cur = &cur.Children[0]
+	}
+}
+
+func TestLayoutSetShapeClipsStopsAtDepthCap(t *testing.T) {
+	clip := drawClip{Width: 800, Height: 600}
+
+	shallow := sizeChain(deepRectChain(100))
+	layoutSetShapeClips(shallow, clip)
+	if leafOf(shallow).Shape.shapeClip.Width == 0 {
+		t.Error("leaf at depth 100 got no clip")
+	}
+
+	deep := sizeChain(deepRectChain(maxEventDepth + 50))
+	layoutSetShapeClips(deep, clip)
+	if leafOf(deep).Shape.shapeClip.Width != 0 {
+		t.Error("layoutSetShapeClips reached a leaf past maxEventDepth")
+	}
+}
+
+// nodeAt walks n levels down a chain built by deepRectChain.
+func nodeAt(root *Layout, n int) *Layout {
+	cur := root
+	for range n {
+		cur = &cur.Children[0]
+	}
+	return cur
+}
+
+func TestLayoutRotationSwapStopsAtDepthCap(t *testing.T) {
+	// A quarter-turned leaf swaps to 20x50; an unreached one keeps 50x20.
+	swapChain := func(n int) *Layout {
+		root := deepRectChain(n)
+		leaf := leafOf(root)
+		leaf.Shape.QuarterTurns = 1
+		return root
+	}
+
+	shallow := swapChain(100)
+	layoutRotationSwap(shallow)
+	if !f32AreClose(leafOf(shallow).Shape.Width, 20) {
+		t.Errorf("width at depth 100: got %f, want 20 (swapped)",
+			leafOf(shallow).Shape.Width)
+	}
+
+	deep := swapChain(maxEventDepth + 50)
+	layoutRotationSwap(deep)
+	if !f32AreClose(leafOf(deep).Shape.Width, 50) {
+		t.Errorf("width past maxEventDepth: got %f, want 50 (walk must "+
+			"stop descending)", leafOf(deep).Shape.Width)
+	}
+}
+
+func TestLayoutRemoveFloatingLayoutsStopsAtDepthCap(t *testing.T) {
+	// The only Float in the chain is the leaf; reaching it extracts one
+	// layout, stopping short extracts none.
+	floatChain := func(n int) *Layout {
+		root := deepRectChain(n)
+		leafOf(root).Shape.Float = true
+		return root
+	}
+
+	shallow := floatChain(100)
+	var shallowFloats []*Layout
+	layoutRemoveFloatingLayouts(shallow, nil, &shallowFloats)
+	if len(shallowFloats) != 1 {
+		t.Errorf("extracted %d floats at depth 100, want 1",
+			len(shallowFloats))
+	}
+
+	deep := floatChain(maxEventDepth + 50)
+	var deepFloats []*Layout
+	layoutRemoveFloatingLayouts(deep, nil, &deepFloats)
+	if len(deepFloats) != 0 {
+		t.Errorf("extracted %d floats past maxEventDepth, want 0",
+			len(deepFloats))
+	}
+}
+
+func TestResolveFocusOwnersStopsAtDepthCap(t *testing.T) {
+	// Root "a" with a "b" node scopes the leaf's owner reference to
+	// "a:b". Past the cap the "b" node is never visited, so the leaf's
+	// reference stays the bare "b".
+	ownerChain := func(n, bAt int) *Layout {
+		root := deepRectChain(n)
+		root.Shape.ID = "a"
+		nodeAt(root, bAt).Shape.ID = "b"
+		leafOf(root).Shape.focusOwner = "b"
+		return root
+	}
+
+	shallow := ownerChain(100, 60)
+	resolveFocusOwners(shallow, &Window{})
+	if got := leafOf(shallow).Shape.focusOwner; got != "a:b" {
+		t.Errorf("focusOwner at depth 100: got %q, want %q", got, "a:b")
+	}
+
+	deep := ownerChain(maxEventDepth+50, maxEventDepth+40)
+	resolveFocusOwners(deep, &Window{})
+	if got := leafOf(deep).Shape.focusOwner; got != "b" {
+		t.Errorf("focusOwner past maxEventDepth: got %q, want %q "+
+			"(walk must stop descending)", got, "b")
+	}
+}
+
+func TestApplyTransitionStopsAtDepthCap(t *testing.T) {
+	// The leaf lerps from X 100 toward snapshot X 0 at progress 0.5, so
+	// a reached leaf reads 50 and an unreached one keeps 100.
+	transitionChain := func(n int) (*Layout, *layoutTransition) {
+		root := deepRectChain(n)
+		leafOf(root).Shape.X = 100
+		lt := &layoutTransition{
+			transitionBase: transitionBase{progress: 0.5},
+			snapshots: map[string]posSnapshot{
+				"deep": {x: 0, y: 0, width: 50, height: 20},
+			},
+		}
+		return root, lt
+	}
+
+	shallow, shallowLT := transitionChain(100)
+	applyTransitionRecursive(shallow, shallowLT, 0, 0, 0)
+	if !f32AreClose(leafOf(shallow).Shape.X, 50) {
+		t.Errorf("leaf X at depth 100: got %f, want 50",
+			leafOf(shallow).Shape.X)
+	}
+
+	deep, deepLT := transitionChain(maxEventDepth + 50)
+	applyTransitionRecursive(deep, deepLT, 0, 0, 0)
+	if !f32AreClose(leafOf(deep).Shape.X, 100) {
+		t.Errorf("leaf X past maxEventDepth: got %f, want 100 (walk must "+
+			"stop descending)", leafOf(deep).Shape.X)
+	}
+}
+
+func TestApplyHeroStopsAtDepthCap(t *testing.T) {
+	// A hero leaf with no outgoing entry only fades: at progress 0.75 a
+	// reached leaf drops to opacity 0.5, an unreached one keeps 1.
+	heroChain := func(n int) *Layout {
+		root := deepRectChain(n)
+		leaf := leafOf(root)
+		leaf.Shape.Hero = true
+		leaf.Shape.Opacity = 1
+		return root
+	}
+	empty := map[string]posSnapshot{}
+
+	shallow := heroChain(100)
+	applyHeroRecursive(shallow, 0.75, empty, empty, 0, 0)
+	if !f32AreClose(leafOf(shallow).Shape.Opacity, 0.5) {
+		t.Errorf("leaf opacity at depth 100: got %f, want 0.5",
+			leafOf(shallow).Shape.Opacity)
+	}
+
+	deep := heroChain(maxEventDepth + 50)
+	applyHeroRecursive(deep, 0.75, empty, empty, 0, 0)
+	if !f32AreClose(leafOf(deep).Shape.Opacity, 1) {
+		t.Errorf("leaf opacity past maxEventDepth: got %f, want 1 (walk "+
+			"must stop descending)", leafOf(deep).Shape.Opacity)
+	}
+}
+
+func TestScrollAnchorShiftYStopsAtDepthCap(t *testing.T) {
+	shallow := deepRectChain(100)
+	scrollAnchorShiftY(shallow, 5)
+	if !f32AreClose(leafOf(shallow).Shape.Y, 5) {
+		t.Errorf("leaf Y at depth 100: got %f, want 5",
+			leafOf(shallow).Shape.Y)
+	}
+
+	deep := deepRectChain(maxEventDepth + 50)
+	scrollAnchorShiftY(deep, 5)
+	if !f32AreClose(leafOf(deep).Shape.Y, 0) {
+		t.Errorf("leaf Y past maxEventDepth: got %f, want 0 (walk must "+
+			"stop descending)", leafOf(deep).Shape.Y)
+	}
+}
+
+// nestView builds a single-child container chain n levels deep for the
+// generation-cap test. Only the leaf carries a size and an ID, so a
+// generation pass that reaches the leaf shows up in its identity and a
+// pass that stops short leaves a placeholder with neither.
+type nestView struct{ n int }
+
+func (v nestView) GenerateLayout(w *Window) Layout {
+	l := Layout{Shape: &Shape{
+		shapeType: shapeRectangle,
+		Axis:      axisTopToBottom,
+	}}
+	if v.n == 0 {
+		l.Shape.Width = 50
+		l.Shape.Height = 20
+		l.Shape.ID = "deep"
+		return l
+	}
+	appendChildViews(w, &l, []View{nestView{v.n - 1}})
+	return l
+}
+
+func TestGenerateViewLayoutStopsAtDepthCap(t *testing.T) {
+	w := &Window{}
+
+	shallow := generateViewLayout(nestView{100}, w)
+	if got := leafOf(&shallow).Shape.ID; got != "deep" {
+		t.Errorf("leaf ID at depth 100: got %q, want %q (view must be "+
+			"generated)", got, "deep")
+	}
+
+	deep := generateViewLayout(nestView{maxEventDepth + 50}, w)
+	leaf := leafOf(&deep)
+	if leaf.Shape.ID == "deep" {
+		t.Error("leaf past maxEventDepth was generated (generation must " +
+			"stop descending)")
+	}
+	if leaf.Shape.shapeType != shapeNone {
+		t.Error("truncated subtree is not a placeholder (want shapeNone)")
+	}
+	if got := w.viewState.genDepth; got != 0 {
+		t.Errorf("genDepth after generation: got %d, want 0 (balanced)",
+			got)
+	}
+}

--- a/gui/layout_depth_test.go
+++ b/gui/layout_depth_test.go
@@ -247,14 +247,14 @@ func TestApplyTransitionStopsAtDepthCap(t *testing.T) {
 	}
 
 	shallow, shallowLT := transitionChain(100)
-	applyTransitionRecursive(shallow, shallowLT, 0, 0, 0)
+	applyTransitionRecursiveDepth(shallow, shallowLT.snapshots, shallowLT.progress, 0, 0, 0, 0)
 	if !f32AreClose(leafOf(shallow).Shape.X, 50) {
 		t.Errorf("leaf X at depth 100: got %f, want 50",
 			leafOf(shallow).Shape.X)
 	}
 
 	deep, deepLT := transitionChain(maxEventDepth + 50)
-	applyTransitionRecursive(deep, deepLT, 0, 0, 0)
+	applyTransitionRecursiveDepth(deep, deepLT.snapshots, deepLT.progress, 0, 0, 0, 0)
 	if !f32AreClose(leafOf(deep).Shape.X, 100) {
 		t.Errorf("leaf X past maxEventDepth: got %f, want 100 (walk must "+
 			"stop descending)", leafOf(deep).Shape.X)
@@ -274,14 +274,14 @@ func TestApplyHeroStopsAtDepthCap(t *testing.T) {
 	empty := map[string]posSnapshot{}
 
 	shallow := heroChain(100)
-	applyHeroRecursive(shallow, 0.75, empty, empty, 0, 0)
+	applyHeroRecursiveDepth(shallow, 0.75, empty, 0, 0, 0)
 	if !f32AreClose(leafOf(shallow).Shape.Opacity, 0.5) {
 		t.Errorf("leaf opacity at depth 100: got %f, want 0.5",
 			leafOf(shallow).Shape.Opacity)
 	}
 
 	deep := heroChain(maxEventDepth + 50)
-	applyHeroRecursive(deep, 0.75, empty, empty, 0, 0)
+	applyHeroRecursiveDepth(deep, 0.75, empty, 0, 0, 0)
 	if !f32AreClose(leafOf(deep).Shape.Opacity, 1) {
 		t.Errorf("leaf opacity past maxEventDepth: got %f, want 1 (walk "+
 			"must stop descending)", leafOf(deep).Shape.Opacity)

--- a/gui/layout_float.go
+++ b/gui/layout_float.go
@@ -166,7 +166,18 @@ func floatAttachLayout(
 
 // layoutRemoveFloatingLayouts extracts floating elements from the
 // main layout tree, replacing them with placeholders.
+//
+// A float past the depth cap stays in the tree: the walk stops
+// descending rather than panicking, the same degradation the other
+// capped walks take (see maxEventDepth).
 func layoutRemoveFloatingLayouts(layout *Layout, w *Window, layouts *[]*Layout) {
+	layoutRemoveFloatingLayoutsDepth(layout, w, layouts, 0)
+}
+
+func layoutRemoveFloatingLayoutsDepth(layout *Layout, w *Window, layouts *[]*Layout, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	for i := range layout.Children {
 		if layout.Children[i].Shape.Float {
 			var heapLayout *Layout
@@ -180,7 +191,7 @@ func layoutRemoveFloatingLayouts(layout *Layout, w *Window, layouts *[]*Layout) 
 				heapLayout.Children[j].Parent = heapLayout
 			}
 			*layouts = append(*layouts, heapLayout)
-			layoutRemoveFloatingLayouts(heapLayout, w, layouts)
+			layoutRemoveFloatingLayoutsDepth(heapLayout, w, layouts, depth+1)
 			if w != nil {
 				layout.Children[i] = Layout{
 					Shape: w.scratch.allocPlaceholderShape(),
@@ -189,7 +200,7 @@ func layoutRemoveFloatingLayouts(layout *Layout, w *Window, layouts *[]*Layout) 
 				layout.Children[i] = layoutPlaceholder()
 			}
 		} else {
-			layoutRemoveFloatingLayouts(&layout.Children[i], w, layouts)
+			layoutRemoveFloatingLayoutsDepth(&layout.Children[i], w, layouts, depth+1)
 		}
 	}
 }

--- a/gui/layout_overflow.go
+++ b/gui/layout_overflow.go
@@ -2,8 +2,15 @@ package gui
 
 // layoutOverflow hides children that don't fit in an overflow container.
 func layoutOverflow(layout *Layout, w *Window) {
+	layoutOverflowDepth(layout, w, 0)
+}
+
+func layoutOverflowDepth(layout *Layout, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	for i := range layout.Children {
-		layoutOverflow(&layout.Children[i], w)
+		layoutOverflowDepth(&layout.Children[i], w, depth+1)
 	}
 
 	if !layout.Shape.Overflow {
@@ -106,8 +113,35 @@ func layoutOverflow(layout *Layout, w *Window) {
 	}
 }
 
+// hideOverflowChild takes a child out of the row: it stops drawing
+// (shapeNone), stops taking width, and clips so its own descendants —
+// which still render and still carry their sizes — collapse with it.
+//
+// Focusability is cleared across the whole subtree, not just the child.
+// Tab order comes from collectFocusCandidates, which walks every node and
+// gates only on canTakeFocus; it reads neither shapeType nor the clip, so
+// a hidden child and everything under it would otherwise stay reachable by
+// Tab while invisible. The walk covers descendants because an overflowed
+// item is often a container whose focusable widget sits inside it.
+//
+// Clearing Focusable in place is safe for the same reason the shapeType
+// write above is: these shapes are frame-scoped, rebuilt from the view
+// tree on the next generation pass.
 func hideOverflowChild(child *Layout) {
 	child.Shape.shapeType = shapeNone
 	child.Shape.Width = 0
 	child.Shape.Clip = true
+	clearSubtreeFocusable(child, 0)
+}
+
+// clearSubtreeFocusable drops Focusable from layout and every descendant.
+// Depth-capped like the other tree walks (see maxEventDepth).
+func clearSubtreeFocusable(layout *Layout, depth int) {
+	if layout == nil || layout.Shape == nil || overMaxDepth(depth) {
+		return
+	}
+	layout.Shape.Focusable = false
+	for i := range layout.Children {
+		clearSubtreeFocusable(&layout.Children[i], depth+1)
+	}
 }

--- a/gui/layout_overflow_test.go
+++ b/gui/layout_overflow_test.go
@@ -319,3 +319,48 @@ func TestOverflowFitWidthConstrained(t *testing.T) {
 		t.Error("trigger child should remain visible")
 	}
 }
+
+// TestHideOverflowChildDropsFocus guards tab order across an overflow
+// collapse. hideOverflowChild used to leave Focusable and ID untouched, and
+// collectFocusCandidates gates only on canTakeFocus — it reads neither
+// shapeType nor the clip. A child hidden by overflow therefore stayed
+// reachable by Tab while invisible, and so did any focusable widget nested
+// inside it.
+func TestHideOverflowChildDropsFocus(t *testing.T) {
+	// An overflowed item is often a container with the real widget inside,
+	// so the nested case is the one that matters.
+	child := Layout{
+		Shape: &Shape{
+			shapeType: shapeRectangle,
+			ID:        "toolbar_item",
+			Focusable: true,
+			Width:     50,
+		},
+		Children: []Layout{{
+			Shape: &Shape{
+				shapeType: shapeRectangle,
+				ID:        "toolbar_item_button",
+				Focusable: true,
+				Width:     50,
+			},
+		}},
+	}
+
+	var before []focusCandidate
+	collectFocusCandidates(&child, &before, map[string]struct{}{})
+	if len(before) != 2 {
+		t.Fatalf("before hiding: got %d tab stops, want 2", len(before))
+	}
+
+	hideOverflowChild(&child)
+
+	var after []focusCandidate
+	collectFocusCandidates(&child, &after, map[string]struct{}{})
+	if len(after) != 0 {
+		ids := make([]string, len(after))
+		for i, c := range after {
+			ids[i] = c.id
+		}
+		t.Errorf("hidden subtree still in tab order: %v", ids)
+	}
+}

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -47,8 +47,15 @@ func layoutPipeline(layout *Layout, w *Window) {
 // AmendLayout callbacks. Not for size changes — post-position
 // only.
 func layoutAmend(layout *Layout, w *Window) {
+	layoutAmendDepth(layout, w, 0)
+}
+
+func layoutAmendDepth(layout *Layout, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	for i := range layout.Children {
-		layoutAmend(&layout.Children[i], w)
+		layoutAmendDepth(&layout.Children[i], w, depth+1)
 	}
 	if layout.Shape.hasEvents() &&
 		layout.Shape.events.AmendLayout != nil {
@@ -62,6 +69,13 @@ func layoutAmend(layout *Layout, w *Window) {
 // SAFETY: mutates w.viewState.mousePosX/Y to compensate for child
 // rotation. Called from layoutArrange, which runs under w.mu.
 func layoutHover(layout *Layout, w *Window) bool {
+	return layoutHoverDepth(layout, w, 0)
+}
+
+func layoutHoverDepth(layout *Layout, w *Window, depth int) bool {
+	if overMaxDepth(depth) {
+		return false
+	}
 	if w.mouseIsLocked() {
 		return false
 	}
@@ -72,7 +86,7 @@ func layoutHover(layout *Layout, w *Window) bool {
 			rotateCoordsInverse(layout.Shape, savedX, savedY)
 	}
 	for i := range slices.Backward(layout.Children) {
-		if layoutHover(&layout.Children[i], w) {
+		if layoutHoverDepth(&layout.Children[i], w, depth+1) {
 			w.viewState.mousePosX, w.viewState.mousePosY = savedX, savedY
 			return true
 		}
@@ -107,6 +121,13 @@ func layoutHover(layout *Layout, w *Window) bool {
 // shape whose hover state transitioned inside→outside this frame. shape.ID
 // must be non-empty; shapes with an empty ID are silently skipped.
 func layoutMouseLeave(layout *Layout, w *Window) {
+	layoutMouseLeaveDepth(layout, w, 0)
+}
+
+func layoutMouseLeaveDepth(layout *Layout, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	if w.mouseIsLocked() {
 		return
 	}
@@ -116,7 +137,7 @@ func layoutMouseLeave(layout *Layout, w *Window) {
 			rotateCoordsInverse(layout.Shape, savedX, savedY)
 	}
 	for i := range layout.Children {
-		layoutMouseLeave(&layout.Children[i], w)
+		layoutMouseLeaveDepth(&layout.Children[i], w, depth+1)
 	}
 	w.viewState.mousePosX, w.viewState.mousePosY = savedX, savedY
 
@@ -167,8 +188,15 @@ func layoutWrapText(layout *Layout, w *Window) {
 }
 
 func layoutWrapTextWalk(layout *Layout, w *Window) {
+	layoutWrapTextWalkDepth(layout, w, 0)
+}
+
+func layoutWrapTextWalkDepth(layout *Layout, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	for i := range layout.Children {
-		layoutWrapTextWalk(&layout.Children[i], w)
+		layoutWrapTextWalkDepth(&layout.Children[i], w, depth+1)
 	}
 	shape := layout.Shape
 	tc := shape.TC

--- a/gui/layout_position.go
+++ b/gui/layout_position.go
@@ -2,6 +2,13 @@ package gui
 
 // layoutPositions sets positions and handles alignment.
 func layoutPositions(layout *Layout, offsetX, offsetY float32, w *Window) {
+	layoutPositionsDepth(layout, offsetX, offsetY, w, 0)
+}
+
+func layoutPositionsDepth(layout *Layout, offsetX, offsetY float32, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	layout.Shape.X += offsetX
 	layout.Shape.Y += offsetY
 
@@ -29,9 +36,9 @@ func layoutPositions(layout *Layout, offsetX, offsetY float32, w *Window) {
 		}
 
 		if isRTL && axis == axisLeftToRight {
-			layoutPositions(child, x-child.Shape.Width+xAlign, y+yAlign, w)
+			layoutPositionsDepth(child, x-child.Shape.Width+xAlign, y+yAlign, w, depth+1)
 		} else {
-			layoutPositions(child, x+xAlign, y+yAlign, w)
+			layoutPositionsDepth(child, x+xAlign, y+yAlign, w, depth+1)
 		}
 
 		if child.Shape.shapeType != shapeNone && !child.Shape.OverDraw {
@@ -196,6 +203,13 @@ func childCrossAxisHAlign(
 // so the two passes agree only while this walk applies the same insets
 // the renderer does.
 func layoutSetShapeClips(layout *Layout, clip drawClip) {
+	layoutSetShapeClipsDepth(layout, clip, 0)
+}
+
+func layoutSetShapeClipsDepth(layout *Layout, clip drawClip, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	shapeClip := shapeBounds(layout.Shape)
 	if r, ok := rectIntersection(shapeClip, clip); ok {
 		layout.Shape.shapeClip = r
@@ -235,12 +249,19 @@ func layoutSetShapeClips(layout *Layout, clip drawClip) {
 		if layout.Children[i].Shape.OverDraw {
 			cc = overClip
 		}
-		layoutSetShapeClips(&layout.Children[i], cc)
+		layoutSetShapeClipsDepth(&layout.Children[i], cc, depth+1)
 	}
 }
 
 // layoutAdjustScrollOffsets ensures scroll offsets are in range.
 func layoutAdjustScrollOffsets(layout *Layout, w *Window) {
+	layoutAdjustScrollOffsetsDepth(layout, w, 0)
+}
+
+func layoutAdjustScrollOffsetsDepth(layout *Layout, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	id := layout.Shape.idKey()
 	if layout.Shape.Scrollable && id != "" {
 		sx := w.scrollX()
@@ -259,6 +280,6 @@ func layoutAdjustScrollOffsets(layout *Layout, w *Window) {
 		}
 	}
 	for i := range layout.Children {
-		layoutAdjustScrollOffsets(&layout.Children[i], w)
+		layoutAdjustScrollOffsetsDepth(&layout.Children[i], w, depth+1)
 	}
 }

--- a/gui/layout_rotation.go
+++ b/gui/layout_rotation.go
@@ -4,8 +4,15 @@ package gui
 // QuarterTurns 1 or 3 (90° or 270°). Processes bottom-up so
 // nested rotations compose correctly.
 func layoutRotationSwap(layout *Layout) {
+	layoutRotationSwapDepth(layout, 0)
+}
+
+func layoutRotationSwapDepth(layout *Layout, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	for i := range layout.Children {
-		layoutRotationSwap(&layout.Children[i])
+		layoutRotationSwapDepth(&layout.Children[i], depth+1)
 	}
 	turns := layout.Shape.QuarterTurns
 	if turns != 1 && turns != 3 {
@@ -56,7 +63,7 @@ func recomputeFitWidth(layout *Layout) float32 {
 	case axisLeftToRight:
 		sp := layout.spacing()
 		for i := range layout.Children {
-			if layout.Children[i].Shape.OverDraw {
+			if skipLayoutChild(layout.Children[i].Shape) {
 				continue
 			}
 			w += layout.Children[i].Shape.Width
@@ -64,10 +71,16 @@ func recomputeFitWidth(layout *Layout) float32 {
 		w += padding + sp
 	case axisTopToBottom:
 		for i := range layout.Children {
+			if skipLayoutChild(layout.Children[i].Shape) {
+				continue
+			}
 			w = f32Max(w, layout.Children[i].Shape.Width+padding)
 		}
 	default:
 		for i := range layout.Children {
+			if skipLayoutChild(layout.Children[i].Shape) {
+				continue
+			}
 			w = f32Max(w, layout.Children[i].Shape.Width+padding)
 		}
 	}
@@ -89,7 +102,7 @@ func recomputeFitHeight(layout *Layout) float32 {
 	case axisTopToBottom:
 		sp := layout.spacing()
 		for i := range layout.Children {
-			if layout.Children[i].Shape.OverDraw {
+			if skipLayoutChild(layout.Children[i].Shape) {
 				continue
 			}
 			h += layout.Children[i].Shape.Height
@@ -97,10 +110,16 @@ func recomputeFitHeight(layout *Layout) float32 {
 		h += padding + sp
 	case axisLeftToRight:
 		for i := range layout.Children {
+			if skipLayoutChild(layout.Children[i].Shape) {
+				continue
+			}
 			h = f32Max(h, layout.Children[i].Shape.Height+padding)
 		}
 	default:
 		for i := range layout.Children {
+			if skipLayoutChild(layout.Children[i].Shape) {
+				continue
+			}
 			h = f32Max(h, layout.Children[i].Shape.Height+padding)
 		}
 	}

--- a/gui/layout_rotation_test.go
+++ b/gui/layout_rotation_test.go
@@ -96,6 +96,7 @@ func TestRotationSwapRecursive(t *testing.T) {
 func TestReaccumulateAncestorsFitWidth(t *testing.T) {
 	child := &Shape{
 		Width: 60, Height: 30,
+		shapeType: shapeRectangle,
 	}
 	parent := &Shape{
 		Width: 100, Height: 50,
@@ -139,7 +140,7 @@ func TestReaccumulateAncestorsStopsAtFixed(t *testing.T) {
 }
 
 func TestReaccumulateAncestorsStopsWhenNoChange(t *testing.T) {
-	child := &Shape{Width: 60, Height: 30}
+	child := &Shape{Width: 60, Height: 30, shapeType: shapeRectangle}
 	parent := &Shape{
 		Width: 60, Height: 50,
 		Axis:   axisLeftToRight,
@@ -185,8 +186,8 @@ func TestRecomputeFitWidthLTR(t *testing.T) {
 }
 
 func TestRecomputeFitWidthTTB(t *testing.T) {
-	c1 := &Shape{Width: 30, Height: 10}
-	c2 := &Shape{Width: 50, Height: 10}
+	c1 := &Shape{Width: 30, Height: 10, shapeType: shapeRectangle}
+	c2 := &Shape{Width: 50, Height: 10, shapeType: shapeRectangle}
 	parent := &Shape{
 		Axis:   axisTopToBottom,
 		Sizing: FitFit,
@@ -207,7 +208,7 @@ func TestRecomputeFitWidthTTB(t *testing.T) {
 }
 
 func TestRecomputeFitWidthClampsMinMax(t *testing.T) {
-	child := &Shape{Width: 10, Height: 10}
+	child := &Shape{Width: 10, Height: 10, shapeType: shapeRectangle}
 	parent := &Shape{
 		Axis:     axisLeftToRight,
 		Sizing:   FitFit,
@@ -233,8 +234,8 @@ func TestRecomputeFitWidthClampsMinMax(t *testing.T) {
 }
 
 func TestRecomputeFitHeightLTR(t *testing.T) {
-	c1 := &Shape{Width: 30, Height: 10}
-	c2 := &Shape{Width: 50, Height: 25}
+	c1 := &Shape{Width: 30, Height: 10, shapeType: shapeRectangle}
+	c2 := &Shape{Width: 50, Height: 25, shapeType: shapeRectangle}
 	parent := &Shape{
 		Axis:   axisLeftToRight,
 		Sizing: FitFit,
@@ -279,7 +280,7 @@ func TestRecomputeFitHeightTTB(t *testing.T) {
 }
 
 func TestRecomputeFitHeightClampsMinMax(t *testing.T) {
-	child := &Shape{Width: 10, Height: 5}
+	child := &Shape{Width: 10, Height: 5, shapeType: shapeRectangle}
 	parent := &Shape{
 		Axis:      axisTopToBottom,
 		Sizing:    FitFit,
@@ -323,5 +324,52 @@ func TestRecomputeFitWidthSkipsOverDraw(t *testing.T) {
 	// Only c1 contributes (c2 is OverDraw).
 	if got != 30 {
 		t.Errorf("recomputeFitWidth = %f, want 30 (skip OverDraw)", got)
+	}
+}
+
+// TestRecomputeFitSkipsOutOfFlow guards the child set the rotation
+// re-accumulation measures. recomputeFitWidth and recomputeFitHeight mirror
+// layoutWidths and layoutHeights for a single Fit node, so they must drop
+// the same children skipLayoutChild names — Float and shapeNone included,
+// not just OverDraw. A Float child otherwise widens the re-fit parent after
+// a rotation swap.
+func TestRecomputeFitSkipsOutOfFlow(t *testing.T) {
+	// fitBox builds a Fit row (LTR) or column (TTB) of one 40px in-flow
+	// child plus one wide out-of-flow child.
+	fitBox := func(axis Axis, extra *Shape) *Layout {
+		return &Layout{
+			Shape: &Shape{
+				Axis:      axis,
+				Sizing:    FitFit,
+				Spacing:   10,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{Width: 40, Height: 20, shapeType: shapeRectangle}},
+				{Shape: extra},
+			},
+		}
+	}
+
+	cases := []struct {
+		name  string
+		extra *Shape
+	}{
+		{"float", &Shape{Float: true, Width: 200, Height: 100, shapeType: shapeRectangle}},
+		{"shapeNone", &Shape{Width: 200, Height: 100, shapeType: shapeNone}},
+		{"overDraw", &Shape{OverDraw: true, Width: 200, Height: 100, shapeType: shapeRectangle}},
+	}
+	for _, tc := range cases {
+		t.Run("width/"+tc.name, func(t *testing.T) {
+			// One 40px child, no fence post for a single in-flow child.
+			if got := recomputeFitWidth(fitBox(axisLeftToRight, tc.extra)); !f32AreClose(got, 40) {
+				t.Errorf("recomputeFitWidth = %f, want 40", got)
+			}
+		})
+		t.Run("height/"+tc.name, func(t *testing.T) {
+			if got := recomputeFitHeight(fitBox(axisTopToBottom, tc.extra)); !f32AreClose(got, 20) {
+				t.Errorf("recomputeFitHeight = %f, want 20", got)
+			}
+		})
 	}
 }

--- a/gui/layout_sizing.go
+++ b/gui/layout_sizing.go
@@ -134,12 +134,30 @@ func layoutFillCrossAxis(layout *Layout, axis distributeAxis, fb *fillBuffers) {
 			totalChild = *sum
 		} else {
 			for j := range layout.Parent.Children {
+				// In-flow children only. The target below subtracts
+				// layout.Parent.spacing(), which counts this same set, so
+				// summing everything would let a Float or hidden sibling
+				// take budget that no fence post accounts for and leave
+				// this Fill child short.
+				//
+				// The total deliberately does not depend on which child is
+				// asking: it is cached on the parent and read by every
+				// sibling that fills on this axis.
+				if skipLayoutChild(layout.Parent.Children[j].Shape) {
+					continue
+				}
 				totalChild += getSize(layout.Parent.Children[j].Shape, axis)
 			}
 			*sum = totalChild
 			parentShape.siblingSumGen = fb.fillGen
 		}
-		sibling := totalChild - getSize(layout.Shape, axis)
+		// Remove self only when self is part of that sum. A Float or
+		// hidden container that still fills on the cross axis was never
+		// added, so subtracting it would hand out its size twice.
+		sibling := totalChild
+		if !skipLayoutChild(layout.Shape) {
+			sibling -= getSize(layout.Shape, axis)
+		}
 		target := getSize(layout.Parent.Shape, axis) - sibling -
 			layout.Parent.spacing() - getPadding(layout.Parent.Shape, axis)
 		setSize(layout.Shape, axis, f32Max(0, target))
@@ -165,6 +183,13 @@ func collectDistributionCandidates(layout *Layout, axis distributeAxis, mode dis
 		fb.fixedIndices = fb.fixedIndices[:0]
 	}
 	for i := range layout.Children {
+		// Out-of-flow children take no slot in the row, so they take no
+		// share of its budget either. The remaining budget above already
+		// drops them (matching layout.spacing()), so dealing them in here
+		// would let a Float Fill shrink its in-flow siblings.
+		if skipLayoutChild(layout.Children[i].Shape) {
+			continue
+		}
 		if getSizing(layout.Children[i].Shape, axis) == sizingFill {
 			fb.candidates = append(fb.candidates, i)
 		} else if mode == distributeShrink {
@@ -348,6 +373,13 @@ func distributeSpace(layout *Layout, remainingIn float32, mode distributeMode, a
 
 // layoutWidths arranges children horizontally (bottom-up).
 func layoutWidths(layout *Layout) {
+	layoutWidthsDepth(layout, 0)
+}
+
+func layoutWidthsDepth(layout *Layout, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	padding := layout.Shape.paddingWidth()
 	if layout.Shape.Axis == axisLeftToRight {
 		sp := layout.spacing()
@@ -359,7 +391,7 @@ func layoutWidths(layout *Layout) {
 		// children. Childless boxes still resolve to 0, unchanged.
 		if layout.Shape.Sizing.Width == sizingFixed && layout.Shape.Width > 0 {
 			for i := range layout.Children {
-				layoutWidths(&layout.Children[i])
+				layoutWidthsDepth(&layout.Children[i], depth+1)
 			}
 		} else {
 			// A wrapping or overflowing row can be narrower than the
@@ -375,8 +407,12 @@ func layoutWidths(layout *Layout) {
 				minWidths += sp
 			}
 			for i := range layout.Children {
-				layoutWidths(&layout.Children[i])
-				if layout.Children[i].Shape.OverDraw {
+				layoutWidthsDepth(&layout.Children[i], depth+1)
+				// Out-of-flow children (Float, shapeNone, OverDraw) are
+				// dropped here for the same reason layout.spacing() drops
+				// them from the fence-post count: a child that does not
+				// take a slot in the row must not widen it either.
+				if skipLayoutChild(layout.Children[i].Shape) {
 					continue
 				}
 				layout.Shape.Width += layout.Children[i].Shape.Width
@@ -406,8 +442,29 @@ func layoutWidths(layout *Layout) {
 		// (see the AxisLeftToRight note above / issue #94). Captured
 		// before the loop mutates Width, so it stays stable per child.
 		fitWidth := layout.Shape.Sizing.Width != sizingFixed || layout.Shape.Width == 0
+		// Padding is seeded rather than reaching the container only as
+		// part of some child's contribution below, so that skipping an
+		// out-of-flow child cannot also discard the container's own
+		// padding. An empty group box has exactly one child — a shapeNone
+		// placeholder (layoutPlaceholder) — and used to get its padding
+		// width from measuring it.
+		//
+		// Gated on having children at all, in flow or not: a container
+		// with none collapses to 0 rather than to its padding, which is
+		// what a closed Sidebar (zero children, 1px border each side)
+		// relies on to stay shut.
+		if fitWidth && len(layout.Children) > 0 {
+			layout.Shape.Width = f32Max(layout.Shape.Width, padding)
+		}
 		for i := range layout.Children {
-			layoutWidths(&layout.Children[i])
+			// Recurse first: an out-of-flow child still needs its own
+			// subtree measured. Only its contribution to this container's
+			// fit is dropped, matching computeContentWidth, which applies
+			// skipLayoutChild on the cross axis too.
+			layoutWidthsDepth(&layout.Children[i], depth+1)
+			if skipLayoutChild(layout.Children[i].Shape) {
+				continue
+			}
 			if fitWidth {
 				layout.Shape.Width = f32Max(layout.Shape.Width, layout.Children[i].Shape.Width+padding)
 				if !layout.Shape.Clip {
@@ -446,6 +503,13 @@ func layoutWidths(layout *Layout) {
 
 // layoutHeights arranges children vertically (bottom-up).
 func layoutHeights(layout *Layout) {
+	layoutHeightsDepth(layout, 0)
+}
+
+func layoutHeightsDepth(layout *Layout, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	padding := layout.Shape.paddingHeight()
 	if layout.Shape.Axis == axisTopToBottom {
 		sp := layout.spacing()
@@ -454,19 +518,30 @@ func layoutHeights(layout *Layout) {
 		// otherwise collapse every descendant's clip/hit-test region.
 		if layout.Shape.Sizing.Height == sizingFixed && layout.Shape.Height > 0 {
 			for i := range layout.Children {
-				layoutHeights(&layout.Children[i])
+				layoutHeightsDepth(&layout.Children[i], depth+1)
 			}
 		} else {
 			minHeights := padding + sp
 			for i := range layout.Children {
-				layoutHeights(&layout.Children[i])
-				if layout.Children[i].Shape.OverDraw {
+				layoutHeightsDepth(&layout.Children[i], depth+1)
+				// Float, shapeNone and OverDraw children sit outside the
+				// flow, so they must not contribute to the stacked height
+				// or its floor — the same set layout.spacing() drops from
+				// the fence-post count, and computeContentHeight from the
+				// content sum.
+				if skipLayoutChild(layout.Children[i].Shape) {
 					continue
 				}
 				layout.Shape.Height += layout.Children[i].Shape.Height
 				minHeights += layout.Children[i].Shape.MinHeight
 			}
-			layout.Shape.MinHeight = f32Max(minHeights, layout.Shape.MinHeight+padding+sp)
+			// A stated MinHeight is border-box, matching the row branch in
+			// layoutWidths (issue #385): it already counts padding and
+			// spacing, so adding them here charged the caller twice and made
+			// a Row and a Column state the same minimum and arrange at
+			// different sizes. The computed floor keeps its padding + sp
+			// because it sums bare child minimums.
+			layout.Shape.MinHeight = f32Max(minHeights, layout.Shape.MinHeight)
 			layout.Shape.Height += padding + sp
 			if layout.Shape.MaxHeight > 0 {
 				layout.Shape.Height = f32Min(layout.Shape.MaxHeight, layout.Shape.Height)
@@ -483,8 +558,19 @@ func layoutHeights(layout *Layout) {
 		// Fixed cross-axis with a 0 height degrades to content sizing
 		// (see issue #94). Captured before the loop mutates Height.
 		fitHeight := layout.Shape.Sizing.Height != sizingFixed || layout.Shape.Height == 0
+		// See layoutWidths: seeded so skipping an out-of-flow child cannot
+		// discard the container's padding, and gated on having children so
+		// a childless container still collapses to 0.
+		if fitHeight && len(layout.Children) > 0 {
+			layout.Shape.Height = f32Max(layout.Shape.Height, padding)
+		}
 		for i := range layout.Children {
-			layoutHeights(&layout.Children[i])
+			// See layoutWidths: recurse for every child, fit against the
+			// in-flow ones only.
+			layoutHeightsDepth(&layout.Children[i], depth+1)
+			if skipLayoutChild(layout.Children[i].Shape) {
+				continue
+			}
 			if fitHeight {
 				layout.Shape.Height = f32Max(layout.Shape.Height, layout.Children[i].Shape.Height+padding)
 				layout.Shape.MinHeight = f32Max(layout.Shape.MinHeight, layout.Children[i].Shape.MinHeight+padding)
@@ -520,12 +606,22 @@ func layoutFillWidths(layout *Layout, p *scratchPools) {
 }
 
 func layoutFillWidthsImpl(layout *Layout, fb *fillBuffers) {
+	layoutFillWidthsImplDepth(layout, fb, 0)
+}
+
+func layoutFillWidthsImplDepth(layout *Layout, fb *fillBuffers, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	remainingWidth := layout.Shape.Width - layout.Shape.paddingWidth()
 
 	switch layout.Shape.Axis {
 	case axisLeftToRight:
 		for i := range layout.Children {
-			if layout.Children[i].Shape.OverDraw {
+			// Must drop the same children layout.spacing() drops on the
+			// next line, or an out-of-flow child eats budget that no
+			// fence post accounts for and Fill siblings shrink.
+			if skipLayoutChild(layout.Children[i].Shape) {
 				continue
 			}
 			remainingWidth -= layout.Children[i].Shape.Width
@@ -543,7 +639,7 @@ func layoutFillWidthsImpl(layout *Layout, fb *fillBuffers) {
 	}
 
 	for i := range layout.Children {
-		layoutFillWidthsImpl(&layout.Children[i], fb)
+		layoutFillWidthsImplDepth(&layout.Children[i], fb, depth+1)
 	}
 
 	// Cache content width after all children have final widths.
@@ -574,12 +670,21 @@ func layoutFillWithPool(layout *Layout, p *scratchPools, impl func(*Layout, *fil
 }
 
 func layoutFillHeightsImpl(layout *Layout, fb *fillBuffers) {
+	layoutFillHeightsImplDepth(layout, fb, 0)
+}
+
+func layoutFillHeightsImplDepth(layout *Layout, fb *fillBuffers, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	remainingHeight := layout.Shape.Height - layout.Shape.paddingHeight()
 
 	switch layout.Shape.Axis {
 	case axisTopToBottom:
 		for i := range layout.Children {
-			if layout.Children[i].Shape.OverDraw {
+			// See layoutFillWidthsImpl: this must match the child set
+			// layout.spacing() uses on the next line.
+			if skipLayoutChild(layout.Children[i].Shape) {
 				continue
 			}
 			remainingHeight -= layout.Children[i].Shape.Height
@@ -598,7 +703,7 @@ func layoutFillHeightsImpl(layout *Layout, fb *fillBuffers) {
 	}
 
 	for i := range layout.Children {
-		layoutFillHeightsImpl(&layout.Children[i], fb)
+		layoutFillHeightsImplDepth(&layout.Children[i], fb, depth+1)
 	}
 
 	// Cache content height after all children have final heights.

--- a/gui/layout_sizing_test.go
+++ b/gui/layout_sizing_test.go
@@ -30,9 +30,9 @@ func TestLayoutHeightsEmptyContainer(t *testing.T) {
 
 func TestLayoutWidthsSingleChild(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{Axis: axisLeftToRight},
+		Shape: &Shape{shapeType: shapeRectangle, Axis: axisLeftToRight},
 		Children: []Layout{
-			{Shape: &Shape{Width: 40}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 40}},
 		},
 	}
 	layoutWidths(root)
@@ -43,9 +43,9 @@ func TestLayoutWidthsSingleChild(t *testing.T) {
 
 func TestLayoutHeightsSingleChild(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{Axis: axisTopToBottom},
+		Shape: &Shape{shapeType: shapeRectangle, Axis: axisTopToBottom},
 		Children: []Layout{
-			{Shape: &Shape{Height: 25}},
+			{Shape: &Shape{shapeType: shapeRectangle, Height: 25}},
 		},
 	}
 	layoutHeights(root)
@@ -56,13 +56,13 @@ func TestLayoutHeightsSingleChild(t *testing.T) {
 
 func TestLayoutWidthsMaxWidthClamp(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{
+		Shape: &Shape{shapeType: shapeRectangle,
 			Axis:     axisLeftToRight,
 			MaxWidth: 60,
 		},
 		Children: []Layout{
-			{Shape: &Shape{Width: 50}},
-			{Shape: &Shape{Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
 		},
 	}
 	layoutWidths(root)
@@ -73,13 +73,13 @@ func TestLayoutWidthsMaxWidthClamp(t *testing.T) {
 
 func TestLayoutHeightsMaxHeightClamp(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{
+		Shape: &Shape{shapeType: shapeRectangle,
 			Axis:      axisTopToBottom,
 			MaxHeight: 40,
 		},
 		Children: []Layout{
-			{Shape: &Shape{Height: 30}},
-			{Shape: &Shape{Height: 30}},
+			{Shape: &Shape{shapeType: shapeRectangle, Height: 30}},
+			{Shape: &Shape{shapeType: shapeRectangle, Height: 30}},
 		},
 	}
 	layoutHeights(root)
@@ -357,10 +357,10 @@ func TestLayoutWidthsFixedSizingSkipsAccumulation(t *testing.T) {
 func TestLayoutWidthsFixedZeroDegradesToContent(t *testing.T) {
 	// Main axis (row width).
 	row := &Layout{
-		Shape: &Shape{Axis: axisLeftToRight, Sizing: FixedFixed},
+		Shape: &Shape{shapeType: shapeRectangle, Axis: axisLeftToRight, Sizing: FixedFixed},
 		Children: []Layout{
-			{Shape: &Shape{Width: 50}},
-			{Shape: &Shape{Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 50}},
 		},
 	}
 	layoutWidths(row)
@@ -370,9 +370,9 @@ func TestLayoutWidthsFixedZeroDegradesToContent(t *testing.T) {
 
 	// Cross axis (column width).
 	col := &Layout{
-		Shape: &Shape{Axis: axisTopToBottom, Sizing: FixedFixed},
+		Shape: &Shape{shapeType: shapeRectangle, Axis: axisTopToBottom, Sizing: FixedFixed},
 		Children: []Layout{
-			{Shape: &Shape{Width: 70}},
+			{Shape: &Shape{shapeType: shapeRectangle, Width: 70}},
 		},
 	}
 	layoutWidths(col)
@@ -381,7 +381,7 @@ func TestLayoutWidthsFixedZeroDegradesToContent(t *testing.T) {
 	}
 
 	// Childless Fixed-zero box stays 0 (leaf images/svg unaffected).
-	leaf := &Layout{Shape: &Shape{Axis: axisLeftToRight, Sizing: FixedFixed}}
+	leaf := &Layout{Shape: &Shape{shapeType: shapeRectangle, Axis: axisLeftToRight, Sizing: FixedFixed}}
 	layoutWidths(leaf)
 	if !f32AreClose(leaf.Shape.Width, 0) {
 		t.Errorf("leaf width: got %f, want 0", leaf.Shape.Width)
@@ -392,10 +392,10 @@ func TestLayoutWidthsFixedZeroDegradesToContent(t *testing.T) {
 func TestLayoutHeightsFixedZeroDegradesToContent(t *testing.T) {
 	// Main axis (column height).
 	col := &Layout{
-		Shape: &Shape{Axis: axisTopToBottom, Sizing: FixedFixed},
+		Shape: &Shape{shapeType: shapeRectangle, Axis: axisTopToBottom, Sizing: FixedFixed},
 		Children: []Layout{
-			{Shape: &Shape{Height: 30}},
-			{Shape: &Shape{Height: 30}},
+			{Shape: &Shape{shapeType: shapeRectangle, Height: 30}},
+			{Shape: &Shape{shapeType: shapeRectangle, Height: 30}},
 		},
 	}
 	layoutHeights(col)
@@ -405,9 +405,9 @@ func TestLayoutHeightsFixedZeroDegradesToContent(t *testing.T) {
 
 	// Cross axis (row height).
 	row := &Layout{
-		Shape: &Shape{Axis: axisLeftToRight, Sizing: FixedFixed},
+		Shape: &Shape{shapeType: shapeRectangle, Axis: axisLeftToRight, Sizing: FixedFixed},
 		Children: []Layout{
-			{Shape: &Shape{Height: 45}},
+			{Shape: &Shape{shapeType: shapeRectangle, Height: 45}},
 		},
 	}
 	layoutHeights(row)
@@ -416,7 +416,7 @@ func TestLayoutHeightsFixedZeroDegradesToContent(t *testing.T) {
 	}
 
 	// Childless Fixed-zero box stays 0.
-	leaf := &Layout{Shape: &Shape{Axis: axisTopToBottom, Sizing: FixedFixed}}
+	leaf := &Layout{Shape: &Shape{shapeType: shapeRectangle, Axis: axisTopToBottom, Sizing: FixedFixed}}
 	layoutHeights(leaf)
 	if !f32AreClose(leaf.Shape.Height, 0) {
 		t.Errorf("leaf height: got %f, want 0", leaf.Shape.Height)
@@ -425,18 +425,18 @@ func TestLayoutHeightsFixedZeroDegradesToContent(t *testing.T) {
 
 func TestLayoutFillWidths_NilPool(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{
+		Shape: &Shape{shapeType: shapeRectangle,
 			Sizing: FixedFixed,
 			Width:  200,
 			Height: 100,
 			Axis:   axisLeftToRight,
 		},
 		Children: []Layout{
-			{Shape: &Shape{
+			{Shape: &Shape{shapeType: shapeRectangle,
 				Sizing: FillFixed,
 				Width:  50,
 			}},
-			{Shape: &Shape{
+			{Shape: &Shape{shapeType: shapeRectangle,
 				Sizing: FillFixed,
 				Width:  50,
 			}},
@@ -460,18 +460,18 @@ func TestLayoutFillWidths_NilPool(t *testing.T) {
 
 func TestLayoutFillHeights_NilPool(t *testing.T) {
 	root := &Layout{
-		Shape: &Shape{
+		Shape: &Shape{shapeType: shapeRectangle,
 			Sizing: FixedFixed,
 			Width:  200,
 			Height: 200,
 			Axis:   axisTopToBottom,
 		},
 		Children: []Layout{
-			{Shape: &Shape{
+			{Shape: &Shape{shapeType: shapeRectangle,
 				Sizing: FixedFill,
 				Height: 50,
 			}},
-			{Shape: &Shape{
+			{Shape: &Shape{shapeType: shapeRectangle,
 				Sizing: FixedFill,
 				Height: 50,
 			}},
@@ -660,5 +660,387 @@ func TestLayoutFillCrossAxis_SiblingSumCache(t *testing.T) {
 	c2w := parent.Children[2].Shape.Width
 	if !f32AreClose(c2w, 50) {
 		t.Errorf("child 2 width = %f, want 50", c2w)
+	}
+}
+
+// TestRowAndColumnMinHeightAgree is the height mirror of
+// TestRowAndColumnMinWidthAgree (issue #385). layoutHeights used to read a
+// stated MinHeight as content-box — it added padding and the inter-child gap
+// sum on top — while layoutWidths had already been corrected to border-box.
+// A Row and a Column with identical padding, spacing and stated minimum must
+// arrange at the same size on both axes.
+func TestRowAndColumnMinHeightAgree(t *testing.T) {
+	// minHeightBox builds a PadAll(5)/Spacing 10 box with two 20px-tall
+	// children; childMin is the MinHeight each child carries, 0 for none.
+	minHeightBox := func(axis Axis, stated, childMin float32) *Layout {
+		return &Layout{
+			Shape: &Shape{
+				Axis:      axis,
+				MinHeight: stated,
+				Padding:   PadAll(5),
+				Spacing:   10,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{Width: 40, Height: 20, MinHeight: childMin, shapeType: shapeRectangle}},
+				{Shape: &Shape{Width: 40, Height: 20, MinHeight: childMin, shapeType: shapeRectangle}},
+			},
+		}
+	}
+
+	col := minHeightBox(axisTopToBottom, 160, 0)
+	row := minHeightBox(axisLeftToRight, 160, 0)
+	layoutHeights(col)
+	layoutHeights(row)
+
+	if !f32AreClose(col.Shape.MinHeight, 160) {
+		t.Errorf("col MinHeight: got %f, want 160 (border-box, padding and "+
+			"spacing not added on top)", col.Shape.MinHeight)
+	}
+	if !f32AreClose(col.Shape.Height, 160) {
+		t.Errorf("col height: got %f, want 160", col.Shape.Height)
+	}
+	if !f32AreClose(row.Shape.MinHeight, 160) {
+		t.Errorf("row MinHeight: got %f, want 160", row.Shape.MinHeight)
+	}
+	if !f32AreClose(row.Shape.Height, 160) {
+		t.Errorf("row height: got %f, want 160", row.Shape.Height)
+	}
+
+	// The child-min floor still wins over a smaller stated MinHeight: the
+	// column sums bare child minimums and adds its own padding and spacing
+	// (5+5 padding + 10 spacing + 2*50), so the floor is 120, not the
+	// stated 40.
+	tall := minHeightBox(axisTopToBottom, 40, 50)
+	layoutHeights(tall)
+	if !f32AreClose(tall.Shape.MinHeight, 120) {
+		t.Errorf("col MinHeight with child minimums: got %f, want 120",
+			tall.Shape.MinHeight)
+	}
+}
+
+// TestOutOfFlowChildDoesNotSizeParent guards the child set the sizing passes
+// measure. layoutWidths, layoutHeights and the two fill passes used to skip
+// only OverDraw children, while layout.spacing() and computeContentWidth skip
+// everything skipLayoutChild names — Float and shapeNone included. A Float
+// child therefore added its width to the parent's content sum while taking no
+// fence post, so an out-of-flow child silently widened its container.
+func TestOutOfFlowChildDoesNotSizeParent(t *testing.T) {
+	// flowBox builds a Fit row of two 40px children, optionally with a
+	// wide out-of-flow child appended.
+	flowBox := func(extra *Shape) *Layout {
+		l := &Layout{
+			Shape: &Shape{
+				Axis:      axisLeftToRight,
+				Spacing:   10,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{Width: 40, Height: 20, shapeType: shapeRectangle}},
+				{Shape: &Shape{Width: 40, Height: 20, shapeType: shapeRectangle}},
+			},
+		}
+		if extra != nil {
+			l.Children = append(l.Children, Layout{Shape: extra})
+		}
+		return l
+	}
+
+	base := flowBox(nil)
+	layoutWidths(base)
+	// Two 40px children plus one 10px gap.
+	if !f32AreClose(base.Shape.Width, 90) {
+		t.Fatalf("baseline row width: got %f, want 90", base.Shape.Width)
+	}
+
+	cases := []struct {
+		name  string
+		extra *Shape
+	}{
+		{"float", &Shape{Float: true, Width: 200, Height: 20, shapeType: shapeRectangle}},
+		{"shapeNone", &Shape{Width: 200, Height: 20, shapeType: shapeNone}},
+		{"overDraw", &Shape{OverDraw: true, Width: 200, Height: 20, shapeType: shapeRectangle}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := flowBox(tc.extra)
+			layoutWidths(got)
+			if !f32AreClose(got.Shape.Width, base.Shape.Width) {
+				t.Errorf("row width with an out-of-flow child: got %f, want %f",
+					got.Shape.Width, base.Shape.Width)
+			}
+		})
+	}
+}
+
+// TestOutOfFlowChildDoesNotFitParentCrossAxis is the cross-axis half of
+// TestOutOfFlowChildDoesNotSizeParent. The cross-axis fit loops in
+// layoutWidths and layoutHeights measured every child, while
+// computeContentWidth applies skipLayoutChild on both axes — so a wide Float
+// inside a Column still stretched the Column to its width.
+func TestOutOfFlowChildDoesNotFitParentCrossAxis(t *testing.T) {
+	// colBox is a Fit-width Column of two 40px-wide children, optionally
+	// with a much wider out-of-flow child appended.
+	colBox := func(extra *Shape) *Layout {
+		l := &Layout{
+			Shape: &Shape{
+				Axis:      axisTopToBottom,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{Width: 40, Height: 20, shapeType: shapeRectangle}},
+				{Shape: &Shape{Width: 40, Height: 20, shapeType: shapeRectangle}},
+			},
+		}
+		if extra != nil {
+			l.Children = append(l.Children, Layout{Shape: extra})
+		}
+		return l
+	}
+
+	base := colBox(nil)
+	layoutWidths(base)
+	if !f32AreClose(base.Shape.Width, 40) {
+		t.Fatalf("baseline column width: got %f, want 40", base.Shape.Width)
+	}
+
+	cases := []struct {
+		name  string
+		extra *Shape
+	}{
+		{"float", &Shape{Float: true, Width: 300, Height: 20, shapeType: shapeRectangle}},
+		{"shapeNone", &Shape{Width: 300, Height: 20, shapeType: shapeNone}},
+		{"overDraw", &Shape{OverDraw: true, Width: 300, Height: 20, shapeType: shapeRectangle}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := colBox(tc.extra)
+			layoutWidths(got)
+			if !f32AreClose(got.Shape.Width, base.Shape.Width) {
+				t.Errorf("column width with an out-of-flow child: got %f, want %f",
+					got.Shape.Width, base.Shape.Width)
+			}
+		})
+	}
+
+	// The out-of-flow child is still measured; only its contribution to
+	// the parent's fit is dropped. A Float whose own width comes from its
+	// children must still resolve.
+	nested := colBox(&Shape{Float: true, Axis: axisLeftToRight, shapeType: shapeRectangle})
+	nested.Children[2].Children = []Layout{
+		{Shape: &Shape{Width: 70, Height: 10, shapeType: shapeRectangle}},
+	}
+	layoutWidths(nested)
+	if !f32AreClose(nested.Children[2].Shape.Width, 70) {
+		t.Errorf("float subtree not measured: got %f, want 70",
+			nested.Children[2].Shape.Width)
+	}
+}
+
+// TestCrossAxisFillIgnoresOutOfFlowSibling guards the sibling sum in
+// layoutFillCrossAxis. It summed every child but subtracted
+// layout.Parent.spacing(), which counts in-flow children only, so a Float
+// sibling stole width from a Scrollable cross-axis Fill child.
+func TestCrossAxisFillIgnoresOutOfFlowSibling(t *testing.T) {
+	// Same shape as TestLayoutFillCrossAxis_SiblingSumCache: an LTR parent
+	// whose TTB scrollable child fills across the parent's main axis, which
+	// is what reaches the sibling-sum branch.
+	rowWith := func(extra ...*Shape) *Layout {
+		l := &Layout{
+			Shape: &Shape{
+				Sizing:    FixedFixed,
+				Width:     300,
+				Height:    100,
+				Axis:      axisLeftToRight,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{
+					shapeType:  shapeRectangle,
+					Sizing:     FillFill,
+					Axis:       axisTopToBottom,
+					Scrollable: true,
+					ID:         "fill",
+					Width:      0, Height: 20,
+				}},
+				{Shape: &Shape{
+					shapeType: shapeRectangle,
+					Sizing:    FixedFixed,
+					Axis:      axisTopToBottom,
+					Width:     50, Height: 20,
+				}},
+			},
+		}
+		for _, e := range extra {
+			l.Children = append(l.Children, Layout{Shape: e})
+		}
+		layoutParents(l, nil)
+		return l
+	}
+
+	fillWidth := func(l *Layout) float32 {
+		var p scratchPools
+		p.beginFillPass()
+		layoutFillWidths(l, &p)
+		return l.Children[0].Shape.Width
+	}
+
+	// 300 parent less the 50px fixed sibling.
+	base := fillWidth(rowWith())
+	if !f32AreClose(base, 250) {
+		t.Fatalf("baseline fill width: got %f, want 250", base)
+	}
+
+	withFloat := fillWidth(rowWith(&Shape{
+		shapeType: shapeRectangle,
+		Sizing:    FixedFixed,
+		Axis:      axisTopToBottom,
+		Float:     true,
+		Width:     80, Height: 20,
+	}))
+	if !f32AreClose(withFloat, base) {
+		t.Errorf("fill width with a Float sibling: got %f, want %f",
+			withFloat, base)
+	}
+}
+
+// TestCrossAxisFitSeedsPadding pins the two ends of the cross-axis padding
+// rule, which the out-of-flow skip made load-bearing. Padding used to reach
+// a Fit container only as part of a child's contribution, so once the fit
+// stopped measuring out-of-flow children an empty group box — whose only
+// child is a shapeNone placeholder — collapsed to zero instead of to its
+// padding. Seeding it is gated on having children, because a container with
+// none must still collapse: a closed Sidebar has zero children and a 1px
+// border per side, and has to stay shut.
+func TestCrossAxisFitSeedsPadding(t *testing.T) {
+	withPlaceholder := &Layout{
+		Shape: &Shape{
+			Axis:      axisTopToBottom,
+			Padding:   PadAll(15),
+			shapeType: shapeRectangle,
+		},
+		Children: []Layout{layoutPlaceholder()},
+	}
+	layoutWidths(withPlaceholder)
+	if !f32AreClose(withPlaceholder.Shape.Width, 30) {
+		t.Errorf("placeholder-only container width: got %f, want 30 (its "+
+			"own padding)", withPlaceholder.Shape.Width)
+	}
+
+	childless := &Layout{
+		Shape: &Shape{
+			Axis:      axisTopToBottom,
+			Padding:   PadAll(15),
+			shapeType: shapeRectangle,
+		},
+	}
+	layoutWidths(childless)
+	if !f32AreClose(childless.Shape.Width, 0) {
+		t.Errorf("childless container width: got %f, want 0 (must collapse, "+
+			"not fall back to padding)", childless.Shape.Width)
+	}
+}
+
+// TestCrossAxisFitSeedsPaddingHeight is the height mirror of
+// TestCrossAxisFitSeedsPadding. The LTR cross-axis fit seeds Height to the
+// container's own padding for the same reason the TTB one seeds Width:
+// once out-of-flow children stop contributing, a placeholder-only box must
+// still resolve to its padding while a childless one collapses to 0.
+func TestCrossAxisFitSeedsPaddingHeight(t *testing.T) {
+	withPlaceholder := &Layout{
+		Shape: &Shape{
+			Axis:      axisLeftToRight,
+			Padding:   PadAll(15),
+			shapeType: shapeRectangle,
+		},
+		Children: []Layout{layoutPlaceholder()},
+	}
+	layoutHeights(withPlaceholder)
+	if !f32AreClose(withPlaceholder.Shape.Height, 30) {
+		t.Errorf("placeholder-only container height: got %f, want 30 (its "+
+			"own padding)", withPlaceholder.Shape.Height)
+	}
+
+	childless := &Layout{
+		Shape: &Shape{
+			Axis:      axisLeftToRight,
+			Padding:   PadAll(15),
+			shapeType: shapeRectangle,
+		},
+	}
+	layoutHeights(childless)
+	if !f32AreClose(childless.Shape.Height, 0) {
+		t.Errorf("childless container height: got %f, want 0 (must collapse, "+
+			"not fall back to padding)", childless.Shape.Height)
+	}
+}
+
+// TestFillDistributionIgnoresOutOfFlowFill guards the candidate set in
+// collectDistributionCandidates. The remaining budget drops out-of-flow
+// children (matching layout.spacing()), so dealing a Float Fill into the
+// distribution would let it take budget no fence post accounts for and
+// leave the in-flow Fill short: a 250px remainder split two ways instead
+// of going whole to the one child that takes a slot in the row.
+func TestFillDistributionIgnoresOutOfFlowFill(t *testing.T) {
+	rowWith := func(extra ...*Shape) *Layout {
+		l := &Layout{
+			Shape: &Shape{
+				Sizing:    FixedFixed,
+				Width:     300,
+				Height:    100,
+				Axis:      axisLeftToRight,
+				shapeType: shapeRectangle,
+			},
+			Children: []Layout{
+				{Shape: &Shape{
+					shapeType: shapeRectangle,
+					Sizing:    FillFixed,
+					Width:     0,
+				}},
+				{Shape: &Shape{
+					shapeType: shapeRectangle,
+					Sizing:    FixedFixed,
+					Width:     50,
+				}},
+			},
+		}
+		for _, e := range extra {
+			l.Children = append(l.Children, Layout{Shape: e})
+		}
+		layoutParents(l, nil)
+		return l
+	}
+
+	fillWidths := func(l *Layout) (inFlow, floatFill float32) {
+		var p scratchPools
+		p.beginFillPass()
+		layoutFillWidths(l, &p)
+		return l.Children[0].Shape.Width, l.Children[2].Shape.Width
+	}
+
+	// Baseline without the Float: 300 parent less the 50px fixed sibling.
+	base := rowWith()
+	var p scratchPools
+	p.beginFillPass()
+	layoutFillWidths(base, &p)
+	if !f32AreClose(base.Children[0].Shape.Width, 250) {
+		t.Fatalf("baseline fill width: got %f, want 250",
+			base.Children[0].Shape.Width)
+	}
+
+	withFloat := rowWith(&Shape{
+		shapeType: shapeRectangle,
+		Sizing:    FillFixed,
+		Float:     true,
+		Width:     0,
+	})
+	got, floatW := fillWidths(withFloat)
+	if !f32AreClose(got, 250) {
+		t.Errorf("in-flow fill with a Float Fill sibling: got %f, want 250",
+			got)
+	}
+	if !f32AreClose(floatW, 0) {
+		t.Errorf("Float Fill takes no share of the row budget: got %f, want 0",
+			floatW)
 	}
 }

--- a/gui/layout_test.go
+++ b/gui/layout_test.go
@@ -90,69 +90,52 @@ func TestContentHeightTTBSkipsHiddenFloatingAndOverDraw(t *testing.T) {
 }
 
 func TestLayoutWidthsLTR(t *testing.T) {
+	// Every shape states shapeRectangle. The zero value of shapeType is
+	// shapeNone, which the sizing, positioning and content-size passes all
+	// treat as out of flow — so a fixture that omits it measures nothing and
+	// silently drops the spacing fence post too. No real container carries
+	// shapeNone: buildContainerShape promotes it to shapeRectangle.
 	root := &Layout{
 		Shape: &Shape{
-			Axis:    axisLeftToRight,
-			Padding: NewPadding(0, 10, 0, 10),
-			Spacing: 5,
+			Axis:      axisLeftToRight,
+			Padding:   NewPadding(0, 10, 0, 10),
+			Spacing:   5,
+			shapeType: shapeRectangle,
 		},
 		Children: []Layout{
-			{Shape: &Shape{Width: 50, MinWidth: 40}},
-			{Shape: &Shape{Width: 30, MinWidth: 20}},
+			{Shape: &Shape{Width: 50, MinWidth: 40, shapeType: shapeRectangle}},
+			{Shape: &Shape{Width: 30, MinWidth: 20, shapeType: shapeRectangle}},
 		},
 	}
 
 	layoutWidths(root)
 
-	// Width: 50 + 30 + 5*1 + 20 = 105... let me recalculate
-	// spacing() = (2-1)*5 = 5
-	// Width: 50 + 30 + 20 + 5 = 105
-	// Actually: children widths + padding + spacing = 50+30 + (10+10) + 5 = 105
-	// V test expects 100. Let me re-check the V test carefully.
-	// V test: spacing(5), padding L=10 R=10
-	// layout_widths: layout.shape.width += child.shape.width (for each child: 50+30=80)
-	// then += padding + spacing: 80 + 20 + 5 = 105?
-	// Wait, spacing() is fence-post: (count-1) * spacing = 1 * 5 = 5
-	// So 80 + 20 + 5 = 105
-	// But V test expects 100!
-	// Re-reading V code: spacing is 5, 2 children, fence-post = (2-1)*5 = 5
-	// V test comment says Expected Width = 100. Let me re-examine:
-	// "Expected Width: Child1(50) + Child2(30) + Spacing(5) * 2 + Padding(10+10) = 95"
-	// Wait the comment says "Spacing(5) * 2" but then says "= 95"
-	// Actually 50+30+10+10 = 100 and the comment says "= 95" but assert is 100.
-	// The comment is wrong. Assert says 100. Let me check: spacing() = (2-1)*5 = 5
-	// Width = 50+30 + 20 + 5 = 105. But assert says 100!
-	// Hmm, I think the spacing() function: V code says spacing 5, two *visible* children
-	// So spacing = (2-1)*5 = 5. Let me re-check. The V comment says:
-	// "Expected Width: Child1(50) + Child2(30) + Spacing(5) * 2 + Padding(10+10) = 95"
-	// But that's 50+30+10+10 = 100. And the assert is 100.0.
-	// So the comment is misleading; actual spacing in the V test's layout_widths:
-	// layout_widths adds padding + spacing (from spacing() function).
-	// But the V test has spacing:5, 2 non-trivial children → spacing()=(2-1)*5=5
-	// Total=50+30+20+5=105. But assert says 100?!
-	// Wait, the V Shape has no shape_type set, so the children's shape_type is .none
-	// which means spacing() skips them! spacing counts children where
-	// shape_type != .none AND !float AND !over_draw.
-	// Both children have shape_type .none (default), so spacing() = 0.
-	// Width = 50+30+20+0 = 100. That's the answer!
-	if !f32AreClose(root.Shape.Width, 100.0) {
-		t.Errorf("width: got %f, want 100", root.Shape.Width)
+	// Width: children 50 + 30, plus padding 10 + 10, plus one 5px fence-post
+	// gap between the two children.
+	// MinWidth: padding 10 + 10, plus the same 5px gap, plus the children's
+	// stated minimums 40 + 20.
+	if !f32AreClose(root.Shape.Width, 105.0) {
+		t.Errorf("width: got %f, want 105", root.Shape.Width)
 	}
-	if !f32AreClose(root.Shape.MinWidth, 80.0) {
-		t.Errorf("min_width: got %f, want 80", root.Shape.MinWidth)
+	if !f32AreClose(root.Shape.MinWidth, 85.0) {
+		t.Errorf("min_width: got %f, want 85", root.Shape.MinWidth)
 	}
 }
 
 func TestLayoutWidthsTTB(t *testing.T) {
+	// shapeType stated for the same reason as TestLayoutWidthsLTR: the
+	// zero value is shapeNone, which the cross-axis fit treats as out of
+	// flow and does not measure.
 	root := &Layout{
 		Shape: &Shape{
-			Axis:    axisTopToBottom,
-			Padding: NewPadding(0, 5, 0, 5),
+			Axis:      axisTopToBottom,
+			Padding:   NewPadding(0, 5, 0, 5),
+			shapeType: shapeRectangle,
 		},
 		Children: []Layout{
-			{Shape: &Shape{Width: 100, MinWidth: 80}},
-			{Shape: &Shape{Width: 120, MinWidth: 100}},
-			{Shape: &Shape{Width: 90, MinWidth: 70}},
+			{Shape: &Shape{Width: 100, MinWidth: 80, shapeType: shapeRectangle}},
+			{Shape: &Shape{Width: 120, MinWidth: 100, shapeType: shapeRectangle}},
+			{Shape: &Shape{Width: 90, MinWidth: 70, shapeType: shapeRectangle}},
 		},
 	}
 

--- a/gui/layout_wrap.go
+++ b/gui/layout_wrap.go
@@ -100,8 +100,15 @@ func refitFitAncestors(layout *Layout, path []*Layout) {
 
 // layoutWrapContainers restructures wrap containers into column-of-rows.
 func layoutWrapContainers(layout *Layout, w *Window) {
+	layoutWrapContainersDepth(layout, w, 0)
+}
+
+func layoutWrapContainersDepth(layout *Layout, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	for i := range layout.Children {
-		layoutWrapContainers(&layout.Children[i], w)
+		layoutWrapContainersDepth(&layout.Children[i], w, depth+1)
 	}
 
 	if !layout.Shape.Wrap || layout.Shape.Axis != axisLeftToRight || len(layout.Children) == 0 {
@@ -166,7 +173,18 @@ func layoutWrapContainers(layout *Layout, w *Window) {
 
 	layout.Shape.Axis = axisTopToBottom
 
-	newChildren := make([]Layout, 0, len(rows))
+	// Row list comes from the frame-scoped arena, like the row shapes below
+	// and the child lists appendChildViews builds. Safe here even though
+	// resetViewPools runs before view generation and this pass runs after:
+	// the arena is grow-only within a frame, so a reservation taken now
+	// cannot disturb one taken earlier. The row slices below alias the old
+	// layout.Children, which stays alive through their slice headers.
+	var newChildren []Layout
+	if w != nil {
+		newChildren = w.scratch.takeLayoutChildren(len(rows))
+	} else {
+		newChildren = make([]Layout, 0, len(rows))
+	}
 	for i := range rows {
 		row := rows[i]
 		rowChildren := layout.Children[row.start:row.end:row.end]

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -231,22 +231,6 @@ func renderDrawCanvas(shape *Shape, clip drawClip, w *Window) {
 	}
 }
 
-// emitDrawCanvasImages emits RenderImage cmds for cached entries.
-// Skips any entry with non-finite coords/size or empty src; clamps
-// opacity into [0, 1]. Defense in depth: callers via DrawContext.Image
-// already reject bad inputs, but the cache field is public.
-//
-// For http/https srcs the entry is resolved to a local cache path
-// via ResolveImageSrc; an in-flight download returns "" and the
-// emit is skipped this frame. The window redraws when the
-// download completes.
-//
-// clip is the clip rect in effect for the canvas — the content box
-// when the shape clips, otherwise the parent's. An entry drawn via
-// ImageClipped narrows it to that entry's own rect (intersected,
-// since RenderClip *replaces* the scissor rather than nesting) and
-// restores clip afterwards, so a clipped entry cannot leak its
-// scissor onto the entries that follow.
 // emitDrawCanvasGeometry emits the triangle batches and the lowered
 // radial fills in the order the OnDraw callback produced them, walking
 // the two lists together by each gradient's batch counter.
@@ -306,6 +290,22 @@ func emitDrawCanvasGradient(e *DrawCanvasGradientEntry,
 	}, w)
 }
 
+// emitDrawCanvasImages emits RenderImage cmds for cached entries.
+// Skips any entry with non-finite coords/size or empty src; clamps
+// opacity into [0, 1]. Defense in depth: callers via DrawContext.Image
+// already reject bad inputs, but the cache field is public.
+//
+// For http/https srcs the entry is resolved to a local cache path
+// via ResolveImageSrc; an in-flight download returns "" and the
+// emit is skipped this frame. The window redraws when the
+// download completes.
+//
+// clip is the clip rect in effect for the canvas — the content box
+// when the shape clips, otherwise the parent's. An entry drawn via
+// ImageClipped narrows it to that entry's own rect (intersected,
+// since RenderClip *replaces* the scissor rather than nesting) and
+// restores clip afterwards, so a clipped entry cannot leak its
+// scissor onto the entries that follow.
 func emitDrawCanvasImages(
 	images []DrawCanvasImageEntry, ox, oy float32, clip drawClip,
 	shape *Shape, w *Window,

--- a/gui/render_layout.go
+++ b/gui/render_layout.go
@@ -9,6 +9,13 @@ package gui
 // Window across frames, so leaking it would corrupt every later
 // frame, not just the aborted one.
 func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
+	renderLayoutDepth(layout, bgColor, clip, w, 0)
+}
+
+func renderLayoutDepth(layout *Layout, bgColor Color, clip drawClip, w *Window, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	// Emit filter bracket when ColorFilter is set (containers only).
 	fx := layout.Shape.fx
 	hasColorFilter := fx != nil && fx.ColorFilter != nil && !w.inFilter
@@ -126,7 +133,7 @@ func renderLayout(layout *Layout, bgColor Color, clip drawClip, w *Window) {
 		color = layout.Shape.Color
 	}
 	for i := range layout.Children {
-		renderLayout(&layout.Children[i], color, shapeClip, w)
+		renderLayoutDepth(&layout.Children[i], color, shapeClip, w, depth+1)
 	}
 }
 

--- a/gui/scroll_anchor.go
+++ b/gui/scroll_anchor.go
@@ -153,8 +153,15 @@ func applyScrollAnchor(a scrollAnchor, sc *Layout, w *Window) {
 // descendant shifts because positions are absolute after the
 // position pass.
 func scrollAnchorShiftY(layout *Layout, dy float32) {
+	scrollAnchorShiftYDepth(layout, dy, 0)
+}
+
+func scrollAnchorShiftYDepth(layout *Layout, dy float32, depth int) {
+	if overMaxDepth(depth) {
+		return
+	}
 	layout.Shape.Y += dy
 	for i := range layout.Children {
-		scrollAnchorShiftY(&layout.Children[i], dy)
+		scrollAnchorShiftYDepth(&layout.Children[i], dy, depth+1)
 	}
 }

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -175,9 +175,15 @@ type Shape struct {
 	// tooltips, and drag indicators.
 	OverDraw bool
 
-	// Hero marks this element for hero transition animations.
-	// When a Hero element appears in two consecutive frames with
-	// the same ID, the renderer animates between positions.
+	// Hero marks this element for hero transition animations. A hero
+	// present both when NewHeroTransition is registered and after the
+	// view change morphs between the two geometries; one that is only
+	// on the new side fades in. A hero that LEFT the tree cannot fade
+	// out — it is no longer there to draw.
+	//
+	// Matching is by effective ID, so a hero needs a non-empty ID and
+	// the same ID-bearing ancestors on both sides. Hero without an ID
+	// is inert.
 	Hero bool
 
 	// Wrap enables row-wrapping in horizontal-axis containers.

--- a/gui/text_anim.go
+++ b/gui/text_anim.go
@@ -201,7 +201,7 @@ func textAnimDefaultEasing(k TextAnimKind) EasingFn {
 		return EaseLinear
 	case TextAnimPop:
 		// Overshoots slightly past full size, then settles.
-		return easeOutBack
+		return EaseOutBack
 	default:
 		return EaseOutCubic
 	}

--- a/gui/view.go
+++ b/gui/view.go
@@ -55,6 +55,17 @@ func GenerateViewLayout(view View, w *Window) Layout {
 // GenerateLayout via appendChildViews; what this function owns is
 // shape normalization and the identity stamp.
 func generateViewLayout(view View, w *Window) Layout {
+	// Depth cap shared with the layout, event and render walks
+	// (maxEventDepth): a view tree nested past the budget yields a
+	// placeholder rather than recursing until the stack gives out. The
+	// placeholder is shapeNone, so the sizing passes skip it and the
+	// container measures as if the subtree were absent — the same
+	// degrade-the-frame semantics the capped walks take. genDepth is
+	// the tree depth at entry (window_update brackets only the root
+	// view function), so the boundary matches the walks exactly.
+	if w != nil && w.viewState.genDepth > maxEventDepth {
+		return layoutPlaceholder()
+	}
 	scope := ""
 	// The depth is what lets EffID tell "no scope, top of the tree"
 	// from "no scope, not generating at all". Every generation path

--- a/gui/view_progress_bar.go
+++ b/gui/view_progress_bar.go
@@ -208,8 +208,8 @@ func progressBarAmendLayout(
 				Duration: 1500 * time.Millisecond,
 				Keyframes: []Keyframe{
 					{At: 0, Value: 0},
-					{At: 0.5, Value: 1, Easing: easeInOutCSS},
-					{At: 1, Value: 0, Easing: easeInOutCSS},
+					{At: 0.5, Value: 1, Easing: EaseInOutCSS},
+					{At: 1, Value: 0, Easing: EaseInOutCSS},
 				},
 				OnValue: func(v float32, w *Window) {
 					pm := StateMap[string, float32](

--- a/gui/view_sidebar.go
+++ b/gui/view_sidebar.go
@@ -76,7 +76,7 @@ func (sv *sidebarView) GenerateLayout(w *Window) Layout {
 	}
 	if cfg.TweenDuration == 0 && cfg.TweenEasing == nil {
 		cfg.TweenDuration = 300 * time.Millisecond
-		cfg.TweenEasing = easeInOutCubic
+		cfg.TweenEasing = EaseInOutCubic
 	}
 
 	if cfg.Invisible {

--- a/gui/view_skeleton.go
+++ b/gui/view_skeleton.go
@@ -99,7 +99,7 @@ func skeletonAmendLayout(
 			Duration: 1500 * time.Millisecond,
 			Keyframes: []Keyframe{
 				{At: 0, Value: 0},
-				{At: 1, Value: 1, Easing: easeInOutCSS},
+				{At: 1, Value: 1, Easing: EaseInOutCSS},
 			},
 			OnValue: func(v float32, w *Window) {
 				pm := StateMap[string, float32](

--- a/gui/view_toast.go
+++ b/gui/view_toast.go
@@ -372,7 +372,7 @@ func toastStartExit(w *Window, id uint64) {
 	w.AnimationAdd(&TweenAnimation{
 		AnimID:   animID,
 		Duration: toastExitDuration,
-		Easing:   easeInCubic,
+		Easing:   EaseInCubic,
 		From:     1,
 		To:       0,
 		OnValue: func(val float32, w *Window) {


### PR DESCRIPTION
Hardens the animation subsystem across six defects plus an exported easing palette.

- AnimationAdd panics on empty ID (replace-semantics collision on "").
- View-bound liveness heartbeat uses wall clock so time-travel scrub no longer kills visible animations; corrects Update dt doc to nominal 16ms step.
- Diverged spring snaps to target instead of NaN-spinning forever with full layout refresh every tick.
- Hero transitions capture before-geometry at AnimationAdd time and morph; enter-only heroes fade in.
- Repeating animations (Animate Repeat, caret blink) resync after stalls instead of catch-up callback storm.
- Transition/hero progress reads copy under animMu (race fix).
- Exports easing palette (EaseInQuad/Cubic, Back, CSS variants, CubicBezier); tests drive Depth variants directly.

Gate: make prepush green (fixed fmt-md).