### PR TITLE
feat(gui): Stream background producers to the window (#559)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **`Stream` bridges a background producer to the window (#559)** — `gui.Stream`
+  takes a channel and an apply function: each received value is applied on the
+  frame thread and followed by a full layout refresh, so a window fed from
+  stdin, a socket, or a ticker repaints as values arrive. Previously that shape
+  stalled — nothing scheduled a frame, so the window sat stale until the next
+  mouse move and then showed everything at once. Delivery is per item in channel
+  order with no coalescing; the goroutine exits when the channel closes or the
+  window closes. See the streaming section in `docs/dx-cheat-sheet.md`.
+
 ### Deprecated
 
 - **TermGrid widget deprecated, removal in a future minor** — `TermGrid`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,50 @@ and this project adheres to
 
 ### Fixed
 
+- **`OnMouseScroll` now receives shape-relative coordinates on both dispatch
+  paths** — scroll dispatch offers the event to the focused element first and
+  falls back to the shape under the cursor. The focused path handed the callback
+  shape-relative coordinates and the fallback path handed it window-absolute
+  ones, so which space `ctx.Event.MouseX` was in came down to whether the shape
+  happened to hold focus. A `DrawCanvas` or `TermGrid` zooming at the cursor
+  zoomed at the wrong point as soon as it was clicked. Both paths now go through
+  the same relative-coordinate helper every other pointer callback uses.
+
+- **Scrolling works again while a mouse button is held, on Windows and the web**
+  — wheel and arrow-key scroll dispatch matched `Event.Modifiers` exactly
+  against `ModNone` and `ModShift`, and the Windows and web backends OR the
+  buttons currently held into that same field. A wheel turn during a drag
+  therefore matched neither case and was silently dropped on those two platforms
+  while working on macOS. Dispatch now masks the held-button bits off before
+  matching.
+
+- **A container wider than 10,000 children no longer loses keyboard input** —
+  the 10,000-child cap is applied when the layout is generated, and event
+  dispatch re-checked it and returned early. The second check could only ever
+  fire on a hand-built `Layout`, and when it did it dropped that subtree's
+  typing, key and focus handling while leaving its mouse handling working.
+  Generation is now the only place the cap is applied.
+
+- **Touch double-tap now registers in datagrid** — the touch-to-mouse synthesis
+  path built its synthetic event without the frame stamp `EventFn` puts on every
+  backend event. Consumers that time multi-click gestures by differencing
+  `Event.FrameCount` — `datagrid`'s double-click-to-edit and
+  double-click-to-autofit — stored frame 0 as the last click and read it back as
+  "no prior click", so a second tap was never recognized as a double tap.
+
+- **A callback can no longer have its writes to the event silently reverted** —
+  pointer dispatch saved the whole `Event` before calling a callback and
+  restored it afterwards, reinstating `IsHandled` by hand as the single
+  exception. Any other field a callback wrote was discarded. Dispatch now saves
+  only the two coordinates it actually changes, which also takes a 352-byte copy
+  each way out of the per-callback path.
+
+- **Scroll and scrollbar ID lookups tolerate a shape-less layout node** — the
+  two walks that resolve a focus or scroll ID dereferenced `Layout.Shape`
+  without the nil check every other tree walk in the package performs. Generated
+  trees always carry a shape, so this reached only hand-built `Layout` values —
+  on the path that runs for every scroll event.
+
 - **AnimationAdd now rejects an empty animation ID** — animations are keyed by
   ID with replace semantics, so every unnamed `Animate` silently collided on
   `""` and replaced the previous one. An empty ID now panics at registration,

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -332,6 +332,56 @@ pure — build `View` structs, do not fetch or parse. It runs during
 for those. Hook writers own their IDs: compose with `ScopeID(el.DocID, …)`. See
 `docs/specs/markdown-render-callback.md`.
 
+## Streaming background data into a window
+
+A background producer — stdin, a socket, a ticker — must schedule a frame per
+value. A channel the view drains on its own never paints: the backend idles
+until the next input event, so the window sits stale until a mouse move and then
+shows everything at once (issue #559). `Stream` wraps the `QueueCommand` +
+`UpdateWindow` path for this shape:
+
+```go
+type streamLines struct {
+	Lines []string
+}
+
+func streamLinesView(w *gui.Window) gui.View {
+	state := gui.State[streamLines](w)
+	text := ""
+	if len(state.Lines) > 0 {
+		text = state.Lines[len(state.Lines)-1]
+	}
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		Content: []gui.View{gui.Label(text, gui.TextStyle{})},
+	})
+}
+
+func ExampleStream() {
+	w := gui.NewWindow(gui.WindowCfg{State: &streamLines{}})
+	defer w.WindowCleanup()
+	w.UpdateView(streamLinesView)
+
+	lines := make(chan string, 4)
+	done := gui.Stream(w, lines, func(w *gui.Window, line string) {
+		st := gui.State[streamLines](w)
+		st.Lines = append(st.Lines, line)
+	})
+	lines <- "hello"
+	lines <- "world"
+	close(lines)
+	<-done
+	w.FrameFn()
+
+	fmt.Println(gui.State[streamLines](w).Lines)
+	// Output: [hello world]
+}
+```
+
+Delivery is per item in channel order with no coalescing, so bound the cadence
+at the producer. The goroutine exits when the channel closes or the window
+closes, and the returned channel reports it.
+
 ## Find it early
 
 `gui.Debug(true)`, or `GOGUI_DEBUG=1`, checks the layout every frame. It reports

--- a/examples/process_monitor/main.go
+++ b/examples/process_monitor/main.go
@@ -89,41 +89,59 @@ func main() {
 
 // startSampler launches the background sampling loop. Sampling spawns a
 // subprocess (ps/tasklist), so it must run off the frame thread. Each pass
-// takes a snapshot, then publishes it under the window lock and requests a
-// layout refresh; UpdateWindow wakes the backend's idle loop, which
-// otherwise blocks until input arrives and would leave the readings stale.
+// takes a snapshot, then publishes it with QueueCommand: window state is
+// main-thread only, and Lock from another goroutine contends with the frame
+// pass and trips the frame-lock panic. The queued publish runs on the frame
+// thread and wakes the backend's idle loop, which otherwise blocks until
+// input arrives and would leave the readings stale. The sampler waits for
+// the publish before sleeping, so the sleep interval picks up toolbar
+// changes and samples cannot pile up faster than frames drain them.
 func startSampler(w *gui.Window) {
+	interval := state(w).Interval
+	if interval <= 0 {
+		interval = time.Second
+	}
 	go func() {
 		for {
 			snap, err := Collect()
 
-			w.Lock()
-			app := state(w)
-			app.Snapshot = snap
-			app.Err = err
-			if snap != nil {
-				app.LastRefresh = snap.Time
-				app.Store.Update(snap, app.Selected)
-				// Auto-select the top row on the first successful sample.
-				if app.Selected == nil {
-					less := colDefs[app.Sort.Column].less
-					rows := visibleRows(app.Store.Processes(), "", less, app.Sort.Desc, false)
-					if len(rows) > 0 {
-						app.Selected = rows[0]
+			published := make(chan time.Duration, 1)
+			w.QueueCommand(func(w *gui.Window) {
+				app := state(w)
+				app.Snapshot = snap
+				app.Err = err
+				if snap != nil {
+					app.LastRefresh = snap.Time
+					app.Store.Update(snap, app.Selected)
+					// Auto-select the top row on the first successful sample.
+					if app.Selected == nil {
+						less := colDefs[app.Sort.Column].less
+						rows := visibleRows(app.Store.Processes(), "", less, app.Sort.Desc, false)
+						if len(rows) > 0 {
+							app.Selected = rows[0]
+						}
 					}
 				}
-			}
-			interval := app.Interval
-			// UpdateWindow (not UpdateView) re-runs the view against fresh state
-			// WITHOUT clearing the state registry, so the filter input keeps
-			// focus and the process list keeps its scroll position.
-			w.UpdateWindow()
-			w.Unlock()
+				// UpdateWindow (not UpdateView) re-runs the view against fresh state
+				// WITHOUT clearing the state registry, so the filter input keeps
+				// focus and the process list keeps its scroll position.
+				w.UpdateWindow()
+				published <- app.Interval
+			})
 
+			select {
+			case interval = <-published:
+			case <-w.Ctx().Done():
+				return
+			}
 			if interval <= 0 {
 				interval = time.Second
 			}
-			time.Sleep(interval)
+			select {
+			case <-w.Ctx().Done():
+				return
+			case <-time.After(interval):
+			}
 		}
 	}()
 }

--- a/examples/showcase/sound_snippet_test.go
+++ b/examples/showcase/sound_snippet_test.go
@@ -6,57 +6,88 @@ import (
 	"testing"
 )
 
-// The "Sound Feedback" guide quotes examples/showcase/sound_player.go whole
-// rather than paraphrasing it, so a reader can paste the block and have it
-// compile. Nothing enforces that on its own: the guide is markdown and the
-// player is Go, and an edit to either is invisible to the other. This test is
-// the enforcement. It fails when the marked region and the quoted block stop
-// being byte-identical, in whichever direction the drift happened.
+// Guides quote Go sources so a reader can paste the block and have
+// it compile. Nothing enforces that on its own: a guide is markdown
+// and the source is Go, and an edit to either is invisible to the
+// other. This test is the enforcement. It fails when a marked region
+// and its quoted block stop being byte-identical, in whichever
+// direction the drift happened.
 
-const (
-	snippetSourceFile = "sound_player.go"
-	snippetBeginMark  = "// doc:snippet-begin player"
-	snippetEndMark    = "// doc:snippet-end player"
-)
-
-// soundGuides lists every copy of the guide. The repo keeps a mirror under
-// docs/ as well as the showcase's embedded copy, so both are checked; a fix
-// that lands in one and not the other is exactly the drift this catches.
-var soundGuides = []string{
-	"docs/widget_sound.md",
-	"../../docs/widget-sound.md",
+// snippetEntry pins one marked region to every guide quoting it.
+// The repo keeps mirrors of some guides (showcase embedded copies
+// plus docs/), so each entry lists all of them; a fix that lands in
+// one and not the other is exactly the drift this catches.
+type snippetEntry struct {
+	sourceFile string
+	beginMark  string
+	endMark    string
+	// anchor is a substring the marked region must contain. It
+	// catches the markers drifting off the code they pin.
+	anchor string
+	// heading keys the quoted fence in each guide, so adding a
+	// snippet earlier in a guide does not silently retarget this.
+	heading string
+	guides  []string
 }
 
-// markedRegion returns the source between the snippet markers, minus the
-// marker's own explanatory comment block (which ends at the first blank
-// line) and minus surrounding blank lines.
-func markedRegion(t *testing.T, src string) string {
+var snippetEntries = []snippetEntry{
+	{
+		sourceFile: "sound_player.go",
+		beginMark:  "// doc:snippet-begin player",
+		endMark:    "// doc:snippet-end player",
+		anchor:     "func (p cueSoundPlayer) PlaySound(",
+		heading:    "## A real player",
+		guides: []string{
+			"docs/widget_sound.md",
+			"../../docs/widget-sound.md",
+		},
+	},
+	{
+		sourceFile: "../../gui/window_stream_example_test.go",
+		beginMark:  "// doc:snippet-begin stream",
+		endMark:    "// doc:snippet-end stream",
+		anchor:     "func ExampleStream()",
+		heading:    "## Streaming background data into a window",
+		guides: []string{
+			"../../docs/dx-cheat-sheet.md",
+		},
+	},
+}
+
+// markedRegion returns the source between the snippet markers, minus
+// the marker's own explanatory comment block (which ends at the
+// first blank line) and minus surrounding blank lines.
+func markedRegion(
+	t *testing.T,
+	src, file, beginMark, endMark string,
+) string {
 	t.Helper()
-	if strings.Count(src, snippetBeginMark) != 1 ||
-		strings.Count(src, snippetEndMark) != 1 {
+	if strings.Count(src, beginMark) != 1 ||
+		strings.Count(src, endMark) != 1 {
 		t.Fatalf("%s must contain exactly one %q and one %q",
-			snippetSourceFile, snippetBeginMark, snippetEndMark)
+			file, beginMark, endMark)
 	}
-	_, rest, _ := strings.Cut(src, snippetBeginMark)
-	body, _, _ := strings.Cut(rest, snippetEndMark)
+	_, rest, _ := strings.Cut(src, beginMark)
+	body, _, _ := strings.Cut(rest, endMark)
 	_, code, found := strings.Cut(body, "\n\n")
 	if !found {
 		t.Fatalf("%s: no blank line after the snippet marker comment",
-			snippetSourceFile)
+			file)
 	}
 	return strings.Trim(code, "\n")
 }
 
-// guideSnippet returns the first fenced Go block that follows the "A real
-// player" heading. Keyed on the heading rather than on block order so that
-// adding a snippet earlier in the guide does not silently retarget the test.
-func guideSnippet(t *testing.T, guide, doc string) string {
+// guideSnippet returns the first fenced Go block that follows the
+// entry's heading. Keyed on the heading rather than on block order.
+func guideSnippet(
+	t *testing.T,
+	guide, doc, heading string,
+) string {
 	t.Helper()
-	const heading = "## A real player"
 	_, rest, found := strings.Cut(doc, heading)
 	if !found {
-		t.Fatalf("%s: no %q heading; the guide was restructured and this "+
-			"test needs retargeting", guide, heading)
+		t.Fatalf("%s: no %q heading; the guide was restructured and "+
+			"this test needs retargeting", guide, heading)
 	}
 	_, rest, found = strings.Cut(rest, "```go\n")
 	if !found {
@@ -69,48 +100,53 @@ func guideSnippet(t *testing.T, guide, doc string) string {
 	return strings.Trim(block, "\n")
 }
 
-func TestSoundGuideSnippetMatchesSource(t *testing.T) {
-	raw, err := os.ReadFile(snippetSourceFile)
-	if err != nil {
-		t.Fatalf("read %s: %v", snippetSourceFile, err)
-	}
-	want := markedRegion(t, string(raw))
-	if !strings.Contains(want, "func (p cueSoundPlayer) PlaySound(") {
-		t.Fatalf("%s: marked region no longer contains PlaySound; the "+
-			"markers have drifted off the player", snippetSourceFile)
-	}
+func TestGuideSnippetsMatchSource(t *testing.T) {
+	for _, e := range snippetEntries {
+		raw, err := os.ReadFile(e.sourceFile)
+		if err != nil {
+			t.Fatalf("read %s: %v", e.sourceFile, err)
+		}
+		want := markedRegion(t, string(raw), e.sourceFile,
+			e.beginMark, e.endMark)
+		if !strings.Contains(want, e.anchor) {
+			t.Fatalf("%s: marked region no longer contains %q; the "+
+				"markers have drifted off the code they pin",
+				e.sourceFile, e.anchor)
+		}
 
-	for _, guide := range soundGuides {
-		doc, errRead := os.ReadFile(guide)
-		if errRead != nil {
-			t.Errorf("read %s: %v", guide, errRead)
-			continue
-		}
-		got := guideSnippet(t, guide, string(doc))
-		if got == want {
-			continue
-		}
-		// Report the first differing line rather than dumping ~50 lines
-		// twice: the fix is always to copy one side over the other.
-		gotLines := strings.Split(got, "\n")
-		wantLines := strings.Split(want, "\n")
-		for i := 0; i < len(gotLines) || i < len(wantLines); i++ {
-			g, w := "<missing>", "<missing>"
-			if i < len(gotLines) {
-				g = gotLines[i]
-			}
-			if i < len(wantLines) {
-				w = wantLines[i]
-			}
-			if g == w {
+		for _, guide := range e.guides {
+			doc, errRead := os.ReadFile(guide)
+			if errRead != nil {
+				t.Errorf("read %s: %v", guide, errRead)
 				continue
 			}
-			t.Errorf("%s: snippet drifted from %s at block line %d\n"+
-				"  guide:  %s\n  source: %s\n"+
-				"fix: copy the region between the %q markers into the "+
-				"guide's Go fence verbatim",
-				guide, snippetSourceFile, i+1, g, w, snippetBeginMark)
-			break
+			got := guideSnippet(t, guide, string(doc), e.heading)
+			if got == want {
+				continue
+			}
+			// Report the first differing line rather than dumping
+			// both blocks twice: the fix is always to copy one
+			// side over the other.
+			gotLines := strings.Split(got, "\n")
+			wantLines := strings.Split(want, "\n")
+			for i := 0; i < len(gotLines) || i < len(wantLines); i++ {
+				g, w := "<missing>", "<missing>"
+				if i < len(gotLines) {
+					g = gotLines[i]
+				}
+				if i < len(wantLines) {
+					w = wantLines[i]
+				}
+				if g == w {
+					continue
+				}
+				t.Errorf("%s: snippet drifted from %s at block line %d\n"+
+					"  guide:  %s\n  source: %s\n"+
+					"fix: copy the region between the %q markers into "+
+					"the guide's Go fence verbatim",
+					guide, e.sourceFile, i+1, g, w, e.beginMark)
+				break
+			}
 		}
 	}
 }

--- a/gui/event_depth_test.go
+++ b/gui/event_depth_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 )
 
-// The breadth guard (maxEventChildren) cannot see a chain of
-// single-child layouts. These tests pin the depth budget
-// (maxEventDepth): walks stop descending past it instead of recursing
-// until the stack gives out, and ordinary-depth trees are unaffected.
+// Generation caps how wide one container gets (maxChildViews) and
+// nothing caps how deep a chain of single-child layouts runs. These
+// tests pin the depth budget (maxEventDepth): walks stop descending past
+// it instead of recursing until the stack gives out, and ordinary-depth
+// trees are unaffected.
 
 // deepChain builds a single-child chain n levels deep with a
 // focusable leaf. Hand-built, so idKey falls back to the leaf ID.

--- a/gui/event_dispatch_review_test.go
+++ b/gui/event_dispatch_review_test.go
@@ -1,0 +1,266 @@
+package gui
+
+import "testing"
+
+// Regressions for the event-dispatch review. Each test fails against the
+// code as it stood before its fix.
+
+// --- OnMouseScroll coordinate space ---
+
+// runScrollProbe dispatches one scroll at screen (150,80) over a shape
+// placed at (100,50) and returns the coordinates OnMouseScroll was
+// handed. focused selects which dispatch path reaches the handler.
+func runScrollProbe(focused bool) (gotX, gotY float32) {
+	w := &Window{focused: true}
+	sh := &Shape{
+		ID: "sc", Focusable: true,
+		X: 100, Y: 50, Width: 200, Height: 100,
+		shapeClip: drawClip{X: 100, Y: 50, Width: 200, Height: 100},
+	}
+	sh.events = &eventHandlers{
+		OnMouseScroll: func(ctx EventCtx) {
+			gotX, gotY = ctx.Event.MouseX, ctx.Event.MouseY
+			ctx.Consume()
+		},
+	}
+	root := &Layout{
+		Shape:    &Shape{ID: "root", shapeClip: drawClip{Width: 800, Height: 600}},
+		Children: []Layout{{Shape: sh}},
+	}
+	root.Children[0].Parent = root
+	if focused {
+		w.viewState.focusID = "sc"
+	}
+	mouseScrollHandler(root,
+		&Event{Type: EventMouseScroll, MouseX: 150, MouseY: 80, ScrollY: 3}, w)
+	return
+}
+
+// One callback must not see two coordinate spaces. The focused-target
+// path went through callRelative and handed over shape-relative
+// coordinates; the fallback path called the callback directly and handed
+// over screen-space ones. Whether a DrawCanvas zoomed at the cursor or
+// at the wrong point came down to whether it held focus.
+func TestScrollHandlerCoordsMatchOnBothPaths(t *testing.T) {
+	fx, fy := runScrollProbe(true)
+	ux, uy := runScrollProbe(false)
+	if fx != ux || fy != uy {
+		t.Errorf("focused path got (%v,%v), fallback got (%v,%v); "+
+			"one callback must see one coordinate space", fx, fy, ux, uy)
+	}
+	// Shape-relative is the convention every other pointer callback
+	// follows, so pin the value too, not only the agreement.
+	if fx != 50 || fy != 30 {
+		t.Errorf("got (%v,%v), want shape-relative (50,30)", fx, fy)
+	}
+}
+
+// --- callRelative save/restore width ---
+
+// callRelative used to copy the whole Event out and back, which reverted
+// every field a callback wrote, with IsHandled reinstated by hand as the
+// only exception. Dispatch owns the two coordinates and nothing else.
+func TestCallRelativePreservesCallbackWrites(t *testing.T) {
+	w := &Window{focused: true}
+	sh := &Shape{
+		X: 10, Y: 20, Width: 100, Height: 100,
+		shapeClip: drawClip{X: 10, Y: 20, Width: 100, Height: 100},
+	}
+	l := &Layout{Shape: sh}
+	e := &Event{Type: EventMouseDown, MouseX: 60, MouseY: 70}
+	cb := func(ctx EventCtx) {
+		// A field dispatch does not own. Writing it must stick.
+		ctx.Event.IMEText = "written by the callback"
+	}
+	callRelative(l, e, w, cb, evNotify)
+	if e.IMEText != "written by the callback" {
+		t.Errorf("callback write reverted: IMEText = %q", e.IMEText)
+	}
+	// The coordinates dispatch does own are restored.
+	if e.MouseX != 60 || e.MouseY != 70 {
+		t.Errorf("coords not restored: got (%v,%v), want (60,70)",
+			e.MouseX, e.MouseY)
+	}
+}
+
+// --- modifier masking ---
+
+// Two backends OR the held mouse buttons into Event.Modifiers. Matched
+// unmasked, a wheel turn during a drag equalled neither ModNone nor
+// ModShift, so scroll-while-dragging silently did nothing on Windows and
+// the web while working on macOS.
+// scrollableProbeTree builds a 100x100 scroll container holding a
+// 500x500 child, so there is room to scroll on both axes, and returns the
+// root plus the container.
+func scrollableProbeTree() (root, sc *Layout) {
+	// shapeRectangle, not the zero shapeType: skipLayoutChild drops a
+	// shapeNone child, which would leave the container no content to
+	// scroll and scrollVertical refusing the move for the wrong reason.
+	inner := &Shape{
+		shapeType: shapeRectangle,
+		X:         0, Y: 0, Width: 500, Height: 500,
+		shapeClip: drawClip{Width: 500, Height: 500},
+	}
+	container := &Shape{
+		shapeType: shapeRectangle,
+		ID:        "sc", Scrollable: true, Axis: axisTopToBottom,
+		X: 0, Y: 0, Width: 100, Height: 100,
+		shapeClip: drawClip{Width: 100, Height: 100},
+	}
+	root = &Layout{
+		Shape: &Shape{shapeType: shapeRectangle,
+			shapeClip: drawClip{Width: 200, Height: 200}},
+		Children: []Layout{{
+			Shape:    container,
+			Children: []Layout{{Shape: inner}},
+		}},
+	}
+	sc = &root.Children[0]
+	sc.Parent = root
+	sc.Children[0].Parent = sc
+	return
+}
+
+func TestScrollWorksWhileMouseButtonHeld(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mods Modifier
+	}{
+		{"no buttons", ModNone},
+		{"left held", ModLMB},
+		{"right held", ModRMB},
+		{"middle held", ModMMB},
+		{"left held plus shift", ModLMB | ModShift},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &Window{focused: true}
+			// No OnMouseScroll: the assertion is on the Scrollable
+			// branch, which is the one that matched modifiers exactly.
+			root, _ := scrollableProbeTree()
+			// Both deltas are set: masked to ModShift the dispatch
+			// reads ScrollX, masked to ModNone it reads ScrollY.
+			e := &Event{
+				Type: EventMouseScroll, MouseX: 50, MouseY: 50,
+				ScrollX: -10, ScrollY: -10,
+				ScrollPrecise: true, Modifiers: tc.mods,
+			}
+			mouseScrollHandler(root, e, w)
+			if !e.IsHandled {
+				t.Errorf("modifiers %#x: scroll not handled; the "+
+					"held-button bits must not defeat the match", tc.mods)
+			}
+		})
+	}
+}
+
+// keyDownScrollHandler matches modifiers the same way and needs the same
+// mask: arrow-key scrolling must survive a held mouse button.
+func TestKeyScrollWorksWhileMouseButtonHeld(t *testing.T) {
+	w := &Window{focused: true}
+	_, sc := scrollableProbeTree()
+	e := &Event{Type: EventKeyDown, KeyCode: KeyDown, Modifiers: ModLMB}
+	keyDownScrollHandler(sc, e, w)
+	if !e.IsHandled {
+		t.Error("arrow scroll dropped while a mouse button was held")
+	}
+}
+
+// --- synthetic mouse events carry a frame stamp ---
+
+// EventFn stamps FrameCount on every backend event; the touch-to-mouse
+// synthesis path did not, so consumers timing multi-click gestures by
+// differencing it saw frame 0 and never recognized a double tap.
+func TestSynthMouseStampsFrameCount(t *testing.T) {
+	w := &Window{focused: true, scratch: newScratchPools()}
+	w.frameCount = 4242
+	root := &Layout{Shape: &Shape{shapeClip: drawClip{Width: 200, Height: 200}}}
+	synthMouse(EventMouseDown, 10, 10, MouseLeft, root, w)
+	if got := w.scratch.gestureEvent.FrameCount; got != 4242 {
+		t.Errorf("FrameCount = %d, want the window's 4242", got)
+	}
+}
+
+// --- nil-Shape tolerance in the ID walks ---
+
+// findLayoutByFocusID runs on every scroll event through
+// focusedScrollTarget, and findLayoutByScrollID on every scrollbar
+// build. Both dereferenced layout.Shape unguarded while the rest of the
+// package treats a nil Shape as an ordinary state.
+func TestFindLayoutWalksToleratesNilShape(t *testing.T) {
+	root := &Layout{Children: []Layout{
+		{}, // nil Shape
+		{Shape: &Shape{ID: "f", Focusable: true}},  //
+		{Shape: &Shape{ID: "s", Scrollable: true}}, //
+	}}
+	for i := range root.Children {
+		root.Children[i].Parent = root
+	}
+	if ly, ok := findLayoutByFocusID(root, "f"); !ok || ly == nil {
+		t.Error("focus walk did not find the focusable past a nil Shape")
+	}
+	if ly, ok := findLayoutByScrollID(root, "s"); !ok || ly == nil {
+		t.Error("scroll walk did not find the scrollable past a nil Shape")
+	}
+}
+
+// --- nil root at every dispatch entry point ---
+
+// keyupHandler has tolerated a nil root since it was written, and the
+// guard sat in its recursive half where it was re-evaluated per node
+// while no other walk had it at all. The tolerance now lives at every
+// entry point and in none of the recursive halves.
+func TestDispatchEntryPointsTolerateNilRoot(t *testing.T) {
+	w := &Window{focused: true}
+	for name, call := range map[string]func(){
+		"char":     func() { charHandler(nil, &Event{CharCode: 'a'}, w) },
+		"keydown":  func() { keydownHandler(nil, &Event{KeyCode: KeyEnter}, w) },
+		"keyup":    func() { keyupHandler(nil, &Event{KeyCode: KeyEnter}, w) },
+		"mousedn":  func() { mouseDownHandler(nil, false, &Event{}, w) },
+		"mousemv":  func() { mouseMoveHandler(nil, &Event{}, w) },
+		"mouseup":  func() { mouseUpHandler(nil, &Event{}, w) },
+		"scroll":   func() { mouseScrollHandler(nil, &Event{}, w) },
+		"filedrop": func() { fileDropHandler(nil, &Event{}, w) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panicked on a nil root: %v", r)
+				}
+			}()
+			call()
+		})
+	}
+}
+
+// --- nil-Shape intermediates in the remaining walks ---
+
+// findByID used to stop at a shape-less node without searching below
+// it, while the focus and scroll ID walks recurse past one. A
+// hand-built Layout with a shape-less intermediate must still resolve
+// the descendant it contains.
+func TestFindByIDSearchesPastNilShape(t *testing.T) {
+	root := &Layout{
+		Shape: &Shape{ID: "root"},
+		Children: []Layout{{
+			Children: []Layout{{Shape: &Shape{ID: "target"}}},
+		}},
+	}
+	if _, ok := root.FindByID("target"); !ok {
+		t.Error("FindByID did not find the descendant past a nil Shape")
+	}
+}
+
+// collectFocusCandidates dereferenced Layout.Shape unguarded, so a
+// shape-less intermediate panicked tab traversal while the ID walks
+// beside it tolerated one.
+func TestFocusTraversalPastNilShape(t *testing.T) {
+	root := &Layout{
+		Shape: &Shape{ID: "root"},
+		Children: []Layout{{
+			Children: []Layout{{Shape: &Shape{ID: "f", Focusable: true}}},
+		}},
+	}
+	if s, ok := root.nextFocusable(nil); !ok || s == nil || s.ID != "f" {
+		t.Error("tab traversal did not reach the focusable past a nil Shape")
+	}
+}

--- a/gui/event_handlers.go
+++ b/gui/event_handlers.go
@@ -9,22 +9,32 @@ import "slices"
 // and (e, w) helpers below them hold no ctx, so they set e.IsHandled
 // directly — including the spacebar/enter-to-click pre-marks, which
 // claim the key for click activation before the callback runs.
+//
+// "Nothing is marked handled for you" describes propagation, not the
+// state of the flag on arrival. Three dispatch-internal claims land
+// before a callback runs, so a callback must not read
+// ctx.Event.IsHandled as "an earlier handler took this":
+//
+//  1. Taking focus on mouse-down (mouseDownHandlerDepth) marks the
+//     press handled on the way past, then still calls the shape's own
+//     OnMouseDown and OnClick. A focusable widget therefore sees the
+//     flag already set in its own click handler.
+//  2. The spacebar-to-click path claims the space before calling
+//     OnClick (charHandlerDepth).
+//  3. The enter-to-click path claims the key the same way
+//     (keydownHandlerDepth).
+//
+// What the convention guarantees is the other direction: dispatch never
+// infers consumption from the fact that a callback ran, so an ancestor
+// keeps receiving the event until some callback calls Consume.
 
-// maxEventChildren caps traversal depth to prevent DoS from
-// maliciously deep or wide layout trees.
-const maxEventChildren = 10000
-
-// maxEventDepth caps recursion depth for the tree walks below. The
-// breadth guard above cannot see a chain of single-child layouts,
-// which would otherwise recurse until the stack gives out. Real trees
-// nest dozens deep at most; past this the walk stops descending, so
-// the frame drops input rather than the process.
+// maxEventDepth caps recursion depth for the tree walks below. A chain
+// of single-child layouts would otherwise recurse until the stack gives
+// out, and the tree is not always the app's own: markdown and SVG build
+// subtrees out of documents the app did not write. Real trees nest dozens
+// deep at most; past this the walk stops descending, so the frame drops
+// input rather than the process.
 const maxEventDepth = 256
-
-// overMaxChildren reports whether layout has excessive children.
-func overMaxChildren(layout *Layout) bool {
-	return len(layout.Children) > maxEventChildren
-}
 
 // overMaxDepth reports whether a tree walk has descended past the
 // depth budget.
@@ -32,17 +42,36 @@ func overMaxDepth(depth int) bool {
 	return depth > maxEventDepth
 }
 
+// modKeyboard selects the keyboard bits of Event.Modifiers, dropping the
+// held-mouse-button bits.
+//
+// Scroll dispatch matches modifiers exactly — ModNone scrolls
+// vertically, ModShift horizontally — and two backends OR the buttons
+// currently held into the same field (ModLMB/ModRMB/ModMMB, set in
+// backend/internal/winkey and backend/web). Matched unmasked, a wheel
+// turn while any button is down equals neither case, so scrolling during
+// a drag worked on macOS and silently did nothing on Windows and the
+// web. Mask first, then match.
+const modKeyboard = ModShift | ModCtrl | ModAlt | ModSuper
+
+// A nil root is tolerated at every entry point below and nowhere else.
+// Production callers always pass an address — &w.layout, or a z-layer
+// child of it — so the check is for callers outside the frame loop;
+// keyupHandler has accepted nil since it was written and the rest now
+// agree with it. The recursive halves never re-check, because they only
+// ever receive &layout.Children[i].
+
 // charHandler handles character input events (typing).
 // Traverses forward (depth-first) and delivers to focused element.
 func charHandler(layout *Layout, e *Event, w *Window) {
+	if layout == nil {
+		return
+	}
 	charHandlerDepth(layout, e, w, 0)
 }
 
 func charHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
 	if overMaxDepth(depth) {
-		return
-	}
-	if overMaxChildren(layout) {
 		return
 	}
 	for i := range layout.Children {
@@ -95,16 +124,14 @@ func imeCompositionHandler(_ *Layout, e *Event, w *Window) {
 // Traverses forward and delivers to focused element. Falls back to
 // keyboard scroll if the focused scroll container has no handler.
 func keydownHandler(layout *Layout, e *Event, w *Window) {
+	if layout == nil {
+		return
+	}
 	keydownHandlerDepth(layout, e, w, 0)
 }
 
 func keydownHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
 	if overMaxDepth(depth) {
-		return
-	}
-
-	// Guard against excessive children count to prevent DoS.
-	if overMaxChildren(layout) {
 		return
 	}
 
@@ -154,21 +181,14 @@ func keydownHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
 // keyupHandler handles key up events.
 // Traverses forward and delivers to focused element.
 func keyupHandler(layout *Layout, e *Event, w *Window) {
+	if layout == nil {
+		return
+	}
 	keyupHandlerDepth(layout, e, w, 0)
 }
 
 func keyupHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
-	// Guard against nil layout to prevent panic
-	if layout == nil {
-		return
-	}
-
 	if overMaxDepth(depth) {
-		return
-	}
-
-	// Guard against excessive children count to prevent DoS
-	if overMaxChildren(layout) {
 		return
 	}
 
@@ -205,7 +225,7 @@ func keyDownScrollHandler(layout *Layout, e *Event, w *Window) {
 	deltaLine := th.ScrollDeltaLine
 	deltaPage := th.ScrollDeltaPage
 
-	switch e.Modifiers {
+	switch e.Modifiers & modKeyboard {
 	case ModNone:
 		switch e.KeyCode {
 		case KeyUp:
@@ -237,6 +257,9 @@ func keyDownScrollHandler(layout *Layout, e *Event, w *Window) {
 func mouseDownHandler(
 	layout *Layout, inHandler bool, e *Event, w *Window,
 ) {
+	if layout == nil {
+		return
+	}
 	mouseDownHandlerDepth(layout, inHandler, e, w, 0)
 }
 
@@ -299,6 +322,9 @@ func mouseDownHandlerDepth(
 // mouseMoveHandler handles mouse movement events.
 // Traverses reverse (topmost first).
 func mouseMoveHandler(layout *Layout, e *Event, w *Window) {
+	if layout == nil {
+		return
+	}
 	mouseMoveHandlerDepth(layout, e, w, 0)
 }
 
@@ -340,6 +366,9 @@ func mouseMoveHandlerDepth(layout *Layout, e *Event, w *Window, depth int) {
 // mouseUpHandler handles mouse button release events.
 // Traverses reverse (topmost first).
 func mouseUpHandler(layout *Layout, e *Event, w *Window) {
+	if layout == nil {
+		return
+	}
 	mouseUpHandlerDepth(layout, e, w, 0)
 }
 
@@ -396,6 +425,9 @@ func focusedScrollTarget(layout *Layout, w *Window) *Layout {
 // If no focused handler exists, traverses reverse (topmost first)
 // and falls back to the scroll container under cursor.
 func mouseScrollHandler(layout *Layout, e *Event, w *Window) {
+	if layout == nil {
+		return
+	}
 	if ly := focusedScrollTarget(layout, w); ly != nil {
 		// Cascade-on-unhandled is the designed contract, so there
 		// is no pre-mark here: an unhandled scroll falls through to
@@ -430,16 +462,22 @@ func mouseScrollFallbackHandlerDepth(layout *Layout, e *Event, w *Window, depth 
 	if layout.Shape == nil || layout.Shape.Disabled {
 		return
 	}
-	// Deliver to OnMouseScroll handler under cursor.
-	if layout.Shape.hasEvents() &&
-		layout.Shape.events.OnMouseScroll != nil {
-		if layout.Shape.PointInShape(e.MouseX, e.MouseY) {
-			// No pre-mark, so an unhandled scroll falls through to
-			// the scroll container below.
-			layout.Shape.events.OnMouseScroll(EventCtx{layout, e, w})
-			if e.IsHandled {
-				return
-			}
+	// Deliver to OnMouseScroll handler under cursor, through
+	// executeMouseCallback like every other pointer dispatch. It used to
+	// call the callback directly, which made the coordinate space depend
+	// on which path reached the handler: the focused-target branch in
+	// mouseScrollHandler goes through callRelative and handed the
+	// callback shape-relative coordinates, while this branch handed it
+	// screen-space ones. One callback, two meanings for MouseX, selected
+	// by whether the shape happened to hold focus — so a canvas zooming
+	// at the cursor zoomed at the wrong point as soon as it was clicked.
+	//
+	// Still no pre-mark: an unhandled scroll falls through to the scroll
+	// container below.
+	if layout.Shape.hasEvents() {
+		if executeMouseCallback(layout, e, w,
+			layout.Shape.events.OnMouseScroll, evNotify) {
+			return
 		}
 	}
 	// Handle scroll on scroll container under cursor. Discrete mouse
@@ -448,7 +486,7 @@ func mouseScrollFallbackHandlerDepth(layout *Layout, e *Event, w *Window, depth 
 	// momentum and scroll instantly.
 	if layout.Shape.Scrollable {
 		if layout.Shape.PointInShape(e.MouseX, e.MouseY) {
-			switch e.Modifiers {
+			switch e.Modifiers & modKeyboard {
 			case ModShift:
 				if e.ScrollPrecise {
 					e.IsHandled = scrollHorizontal(layout, e.ScrollX, w)
@@ -468,6 +506,9 @@ func mouseScrollFallbackHandlerDepth(layout *Layout, e *Event, w *Window, depth 
 
 // fileDropHandler handles file-drop events. Does not change focus.
 func fileDropHandler(layout *Layout, e *Event, w *Window) {
+	if layout == nil {
+		return
+	}
 	fileDropHandlerDepth(layout, e, w, 0)
 }
 

--- a/gui/event_handlers_test.go
+++ b/gui/event_handlers_test.go
@@ -937,31 +937,79 @@ func TestKeydownHandler_ClickOnEnter(t *testing.T) {
 	})
 }
 
-func TestCharHandler_ExcessiveChildren(t *testing.T) {
-	t.Parallel()
-	root := &Layout{
-		Children: make([]Layout, maxEventChildren+1),
+// wideTree builds a container with n children whose last child is a
+// focusable leaf carrying the given handlers.
+func wideTree(n int, ev *eventHandlers) *Layout {
+	root := &Layout{Shape: &Shape{}, Children: make([]Layout, n)}
+	for i := range root.Children {
+		root.Children[i].Shape = &Shape{}
+		root.Children[i].Parent = root
 	}
+	leaf := &root.Children[n-1]
+	leaf.Shape = &Shape{ID: "leaf", Focusable: true, events: ev}
+	return root
+}
+
+// A container wider than the generation cap must still deliver keyboard
+// input. Dispatch used to re-check the cap and return before reaching
+// any child or the node's own callback, so a wide container lost typing
+// and key handling while keeping its mouse handling, silently.
+func TestCharHandlerWideTreeStillTypes(t *testing.T) {
+	t.Parallel()
+	got := ""
+	root := wideTree(maxChildViews+1, &eventHandlers{
+		OnChar: func(ctx EventCtx) {
+			got += string(rune(ctx.Event.CharCode))
+			ctx.Consume()
+		},
+	})
 	w := &Window{}
+	w.viewState.focusID = "leaf"
 	e := &Event{CharCode: 'a'}
-	// Must not panic or hang.
 	charHandler(root, e, w)
-	if e.IsHandled {
-		t.Error("excessive children should return early, unhandled")
+	if got != "a" {
+		t.Errorf("OnChar got %q, want %q", got, "a")
+	}
+	if !e.IsHandled {
+		t.Error("consumed char should be marked handled")
 	}
 }
 
-func TestKeydownHandler_ExcessiveChildren(t *testing.T) {
+func TestKeydownHandlerWideTreeStillKeys(t *testing.T) {
 	t.Parallel()
-	root := &Layout{
-		Children: make([]Layout, maxEventChildren+1),
-	}
+	var gotKey KeyCode
+	root := wideTree(maxChildViews+1, &eventHandlers{
+		OnKeyDown: func(ctx EventCtx) {
+			gotKey = ctx.Event.KeyCode
+			ctx.Consume()
+		},
+	})
 	w := &Window{}
+	w.viewState.focusID = "leaf"
 	e := &Event{KeyCode: KeyEnter}
-	// Must not panic or hang.
 	keydownHandler(root, e, w)
-	if e.IsHandled {
-		t.Error("excessive children should return early, unhandled")
+	if gotKey != KeyEnter {
+		t.Errorf("OnKeyDown got key %d, want %d", gotKey, KeyEnter)
+	}
+	if !e.IsHandled {
+		t.Error("consumed key should be marked handled")
+	}
+}
+
+func TestKeyupHandlerWideTreeStillKeys(t *testing.T) {
+	t.Parallel()
+	fired := false
+	root := wideTree(maxChildViews+1, &eventHandlers{
+		OnKeyUp: func(ctx EventCtx) {
+			fired = true
+			ctx.Consume()
+		},
+	})
+	w := &Window{}
+	w.viewState.focusID = "leaf"
+	keyupHandler(root, &Event{KeyCode: KeyEnter}, w)
+	if !fired {
+		t.Error("OnKeyUp did not fire in a wide container")
 	}
 }
 

--- a/gui/event_traversal.go
+++ b/gui/event_traversal.go
@@ -51,13 +51,21 @@ func executeFocusCallback(
 // class names the event for the debug check and no longer selects a
 // dispatch rule. The pre-mark that used to land here — and the
 // save/restore ordering it forced — is gone with spec §4.3b.
+//
+// Only the two coordinates are saved, not the whole Event. This used to
+// copy *e out and back, which is 352 bytes each way to change eight,
+// and — the reason it matters — the restore reverted every field a
+// callback had written, with IsHandled reinstated by hand afterwards as
+// the single exception. A callback that wrote anything else to the event
+// had its write silently undone. Saving the two fields dispatch itself
+// changes leaves the callback's own writes alone.
 func callRelative(
 	layout *Layout, e *Event, w *Window,
 	callback shapeCallback, class evClass,
 ) bool {
-	saved := *e
-	e.MouseX = saved.MouseX - layout.Shape.X
-	e.MouseY = saved.MouseY - layout.Shape.Y
+	savedX, savedY := e.MouseX, e.MouseY
+	e.MouseX = savedX - layout.Shape.X
+	e.MouseY = savedY - layout.Shape.Y
 	// Sound fires before the callback and independently of whether the
 	// callback consumes: the cue confirms the widget was activated, it
 	// is not a propagation decision (issue #446).
@@ -66,10 +74,7 @@ func callRelative(
 	}
 	callback(EventCtx{layout, e, w})
 	handled := e.IsHandled
-	*e = saved
-	if handled {
-		e.IsHandled = true
-	}
+	e.MouseX, e.MouseY = savedX, savedY
 	// The debug check runs on the restored event: its ancestor test
 	// needs the coordinates in the enclosing shape's space, not the
 	// shape-relative ones the callback saw.

--- a/gui/gesture.go
+++ b/gui/gesture.go
@@ -581,6 +581,13 @@ func synthMouse(
 		MouseX:      x,
 		MouseY:      y,
 		MouseButton: btn,
+		// Stamped the way EventFn stamps a backend event. Consumers
+		// time multi-click gestures by differencing this — datagrid's
+		// double-click-to-edit and double-click-to-autofit both do —
+		// and a synthetic event left at frame 0 stored 0 as the last
+		// click frame, which their "> 0" sentinel then read as "no
+		// prior click". Double-tap was inert on touch.
+		FrameCount: w.frameCount,
 	}
 	switch typ {
 	case EventMouseDown:

--- a/gui/layout_query.go
+++ b/gui/layout_query.go
@@ -39,7 +39,13 @@ func findLayoutByFocusIDDepth(layout *Layout, effectiveID string, depth int) (*L
 	if overMaxDepth(depth) {
 		return nil, false
 	}
-	if effectiveID != "" && layout.Shape.Focusable && layout.Shape.idKey() == effectiveID {
+	// Shape is checked for nil the way every other tree walk in the
+	// package checks it. A generated tree always carries one, so the
+	// walk this guards is a hand-built Layout — which the package
+	// treats as a real case (DebugStampDrift reports one) and which
+	// reaches here on every scroll event through focusedScrollTarget.
+	if s := layout.Shape; effectiveID != "" && s != nil &&
+		s.Focusable && s.idKey() == effectiveID {
 		return layout, true
 	}
 	for i := range layout.Children {
@@ -61,7 +67,8 @@ func findLayoutByScrollIDDepth(layout *Layout, effectiveID string, depth int) (*
 	if overMaxDepth(depth) {
 		return nil, false
 	}
-	if effectiveID != "" && layout.Shape.Scrollable && layout.Shape.idKey() == effectiveID {
+	if s := layout.Shape; effectiveID != "" && s != nil &&
+		s.Scrollable && s.idKey() == effectiveID {
 		return layout, true
 	}
 	for i := range layout.Children {
@@ -112,10 +119,11 @@ func (layout *Layout) findByIDDepth(effectiveID string, depth int) (*Layout, boo
 	if effectiveID == "" {
 		return nil, false
 	}
-	if layout.Shape == nil {
-		return nil, false
-	}
-	if layout.Shape.idKey() == effectiveID {
+	// A nil Shape carries no ID but still has children: a hand-built
+	// Layout reaches here the same way it reaches the focus and scroll
+	// ID walks, so match the self only when there is a shape and always
+	// search below.
+	if s := layout.Shape; s != nil && s.idKey() == effectiveID {
 		return layout, true
 	}
 	for i := range layout.Children {
@@ -140,7 +148,7 @@ func collectFocusCandidatesDepth(layout *Layout, candidates *[]focusCandidate, s
 		return
 	}
 	s := layout.Shape
-	if s.canTakeFocus() && !s.FocusSkip {
+	if s != nil && s.canTakeFocus() && !s.FocusSkip {
 		// Candidates carry the effective ID: it is what the focus store
 		// holds, so it is what focusFindNext/Previous compare against.
 		//

--- a/gui/view.go
+++ b/gui/view.go
@@ -105,6 +105,15 @@ func generateViewLayout(view View, w *Window) Layout {
 	return layout
 }
 
+// maxChildViews caps how many direct children one container generates.
+// Truncation happens here, at generation, which is the single enforcement
+// point: the tree the rest of the frame sees is already within the cap,
+// so layout, render and event dispatch need no separate check. Event
+// dispatch used to re-check it and return early, which could only ever
+// fire on a hand-built Layout and silently dropped that subtree's
+// keyboard input when it did.
+const maxChildViews = 10000
+
 // appendChildViews generates children under parent's ID scope and
 // appends them to parent.Children, after whatever the parent already
 // put there.
@@ -121,8 +130,8 @@ func appendChildViews(w *Window, parent *Layout, children []View) {
 	if len(children) == 0 {
 		return
 	}
-	if len(children) > maxEventChildren {
-		children = children[:maxEventChildren]
+	if len(children) > maxChildViews {
+		children = children[:maxChildViews]
 	}
 	// Pre-size so append never reallocates; the reservation comes from the
 	// frame-scoped arena (reset in resetViewPools) to avoid a per-node heap

--- a/gui/view_form_test.go
+++ b/gui/view_form_test.go
@@ -944,13 +944,13 @@ func TestFormFieldStateUnaffectedByScoping(t *testing.T) {
 }
 
 // TestFormChildrenShareEventCap pins that the form's child append path
-// applies the same maxEventChildren cap every container gets. Before
-// this refactor the form appended children without the cap; the
-// dispatch gate (hasTooManyChildren) refuses >maxEventChildren anyway,
-// so the cap here only bounds generation work.
+// applies the same maxChildViews cap every container gets. Before this
+// refactor the form appended children without the cap. Generation is
+// now the only place the cap is applied, so this is the gate: nothing
+// downstream re-checks it.
 func TestFormChildrenShareEventCap(t *testing.T) {
 	w := newTestWindow()
-	n := maxEventChildren + 100
+	n := maxChildViews + 100
 	children := make([]View, n)
 	for i := range children {
 		children[i] = &stubView{id: "child"}
@@ -959,9 +959,9 @@ func TestFormChildrenShareEventCap(t *testing.T) {
 		ID:      "cap-form",
 		Content: children,
 	}), w)
-	if len(layout.Children) != maxEventChildren {
+	if len(layout.Children) != maxChildViews {
 		t.Errorf("form children = %d, want %d",
-			len(layout.Children), maxEventChildren)
+			len(layout.Children), maxChildViews)
 	}
 }
 

--- a/gui/view_test.go
+++ b/gui/view_test.go
@@ -1165,10 +1165,10 @@ func TestCursorHelpers(t *testing.T) {
 }
 
 func TestGenerateViewLayout_ExcessiveChildren(t *testing.T) {
-	// maxEventChildren caps direct children at 10000. The framework no
+	// maxChildViews caps direct children at 10000. The framework no
 	// longer walks a raw Content() — the cap lives in appendChildViews,
 	// so it is exercised through a container.
-	n := maxEventChildren + 100
+	n := maxChildViews + 100
 	children := make([]View, n)
 	for i := range children {
 		children[i] = &stubView{id: "child"}
@@ -1176,9 +1176,9 @@ func TestGenerateViewLayout_ExcessiveChildren(t *testing.T) {
 	v := Column(ContainerCfg{ID: "parent", Content: children})
 	layout := generateViewLayout(v, &Window{})
 
-	if len(layout.Children) != maxEventChildren {
+	if len(layout.Children) != maxChildViews {
 		t.Errorf("children: got %d, want capped to %d",
-			len(layout.Children), maxEventChildren)
+			len(layout.Children), maxChildViews)
 	}
 }
 

--- a/gui/window_stream.go
+++ b/gui/window_stream.go
@@ -1,0 +1,66 @@
+package gui
+
+// Stream bridges a background producer to the window: every value
+// received on ch is applied on the frame thread and followed by a
+// full layout refresh, so the frame the value belongs to is painted
+// promptly instead of whenever the next input event happens to
+// arrive.
+//
+// The motivation is the streaming shape — a goroutine reading
+// stdin, a socket, or a ticker channel and showing each line in the
+// window. Without a scheduled frame the backend idles (issue #559):
+// the producer's output piles up invisibly until a mouse move wakes
+// the loop, and then all of it appears at once. Stream schedules one
+// frame per value through the same QueueCommand + UpdateWindow path
+// the sampler examples already use by hand.
+//
+// Call it once per producer, typically from OnInit after
+// UpdateView has registered the view. Safe to call from any
+// window lock itself — the mutation runs inside a queued command on
+// the frame thread. apply therefore reads window state the way a
+// view function does, and must not block: a slow apply stalls every
+// frame behind it.
+//
+// Delivery is per item, in channel order (the channel preserves it
+// and the command queue is FIFO), with no coalescing: a producer
+// that outruns the frame rate grows the command queue, so bound the
+// cadence at the producer — a buffer of 1 plus a 100 ms tick, say —
+// rather than here. Two streams writing the same state interleave
+// nondeterministically, the same rule animations follow.
+//
+// The goroutine exits when ch is closed or the window's lifecycle
+// context ends, whichever comes first, and then closes the returned
+// channel. A nil window, nil channel, or nil apply spawns nothing
+// and answers an already-closed channel.
+func Stream[T any](
+	w *Window,
+	ch <-chan T,
+	apply func(*Window, T),
+) <-chan struct{} {
+	done := make(chan struct{})
+	if w == nil || ch == nil || apply == nil {
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-w.Ctx().Done():
+				return
+			case v, ok := <-ch:
+				if !ok {
+					return
+				}
+				// Per-iteration binding: the queued command may
+				// run frames later, after v has been reassigned.
+				value := v
+				w.QueueCommand(func(w *Window) {
+					apply(w, value)
+					w.UpdateWindow()
+				})
+			}
+		}
+	}()
+	return done
+}

--- a/gui/window_stream_example_test.go
+++ b/gui/window_stream_example_test.go
@@ -1,0 +1,53 @@
+package gui_test
+
+import (
+	"fmt"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// doc:snippet-begin stream
+//
+// Feed a background producer into the window through Stream: each
+// line is applied on the frame thread and followed by a refresh, so
+// the window repaints as lines arrive instead of stalling until the
+// next mouse move (issue #559). Copy this shape and change only the
+// state type, the channel element, and the apply body.
+
+type streamLines struct {
+	Lines []string
+}
+
+func streamLinesView(w *gui.Window) gui.View {
+	state := gui.State[streamLines](w)
+	text := ""
+	if len(state.Lines) > 0 {
+		text = state.Lines[len(state.Lines)-1]
+	}
+	return gui.Column(gui.ContainerCfg{
+		Sizing:  gui.FillFill,
+		Content: []gui.View{gui.Label(text, gui.TextStyle{})},
+	})
+}
+
+func ExampleStream() {
+	w := gui.NewWindow(gui.WindowCfg{State: &streamLines{}})
+	defer w.WindowCleanup()
+	w.UpdateView(streamLinesView)
+
+	lines := make(chan string, 4)
+	done := gui.Stream(w, lines, func(w *gui.Window, line string) {
+		st := gui.State[streamLines](w)
+		st.Lines = append(st.Lines, line)
+	})
+	lines <- "hello"
+	lines <- "world"
+	close(lines)
+	<-done
+	w.FrameFn()
+
+	fmt.Println(gui.State[streamLines](w).Lines)
+	// Output: [hello world]
+}
+
+// doc:snippet-end stream

--- a/gui/window_stream_test.go
+++ b/gui/window_stream_test.go
@@ -1,0 +1,135 @@
+package gui
+
+import (
+	"testing"
+	"time"
+)
+
+type streamTestState struct {
+	items []string
+}
+
+// streamAppend is the apply body the unit tests share: record the
+// value on window state. Stream runs it on the frame thread.
+func streamAppend(w *Window, s string) {
+	st := State[streamTestState](w)
+	st.items = append(st.items, s)
+}
+
+// drainStream flushes queued commands until want items are applied
+// or the deadline passes. Stream's producer runs on its own
+// goroutine, so the test pumps the frame side of the queue.
+func drainStream(
+	t *testing.T,
+	w *Window,
+	state *streamTestState,
+	want int,
+) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		w.flushCommands()
+		if len(state.items) == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("items: got %d, want %d", len(state.items), want)
+}
+
+func TestStreamAppliesItemsInOrder(t *testing.T) {
+	state := &streamTestState{}
+	w := NewWindow(WindowCfg{State: state})
+	defer w.WindowCleanup()
+	w.refreshLayout = false
+
+	ch := make(chan string, 4)
+	done := Stream(w, ch, streamAppend)
+	ch <- "a"
+	ch <- "b"
+	ch <- "c"
+	drainStream(t, w, state, 3)
+
+	for i, want := range []string{"a", "b", "c"} {
+		if state.items[i] != want {
+			t.Fatalf("items[%d]: got %q, want %q",
+				i, state.items[i], want)
+		}
+	}
+	// The #559 regression: values applied but no frame scheduled,
+	// so the window would sit stale until the next input event.
+	// Stream's UpdateWindow must have armed a full layout refresh.
+	if !w.refreshLayout {
+		t.Error("refreshLayout: got false, want true")
+	}
+
+	select {
+	case <-done:
+		t.Error("done closed while channel still open")
+	default:
+	}
+	close(ch)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("done not closed after channel close")
+	}
+}
+
+func TestStreamCtxDoneExits(t *testing.T) {
+	state := &streamTestState{}
+	w := NewWindow(WindowCfg{State: state})
+	defer w.WindowCleanup()
+
+	ch := make(chan string)
+	done := Stream(w, ch, streamAppend)
+	// No send ever arrives; ending the window must still retire
+	// the goroutine instead of leaking it on the receive.
+	w.WindowCleanup()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("done not closed after window cleanup")
+	}
+}
+
+func TestStreamClosedEmptyExits(t *testing.T) {
+	state := &streamTestState{}
+	w := NewWindow(WindowCfg{State: state})
+	defer w.WindowCleanup()
+
+	ch := make(chan string)
+	close(ch)
+	done := Stream(w, ch, func(w *Window, s string) {
+		t.Error("apply ran with no values sent")
+	})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("done not closed for a pre-closed channel")
+	}
+	w.flushCommands()
+	if len(state.items) != 0 {
+		t.Errorf("items: got %d, want 0", len(state.items))
+	}
+}
+
+func TestStreamNilNoOp(t *testing.T) {
+	state := &streamTestState{}
+	w := NewWindow(WindowCfg{State: state})
+	defer w.WindowCleanup()
+	apply := func(w *Window, s string) {}
+	ch := make(chan string)
+
+	for name, done := range map[string]<-chan struct{}{
+		"nil window": Stream[string](nil, ch, apply),
+		"nil chan":   Stream[string](w, nil, apply),
+		"nil apply":  Stream[string](w, ch, nil),
+	} {
+		select {
+		case <-done:
+		default:
+			t.Errorf("%s: done not pre-closed", name)
+		}
+	}
+}


### PR DESCRIPTION
Issue #559: a view that drains a producer channel never paints on its own. Nothing schedules a frame, so the backend idles until the next input event and the window sits stale until a mouse move.

Adds generic free function `gui.Stream(w, ch, apply)`: each received value is applied on the frame thread and followed by a full layout refresh. Per-item in-order delivery, no coalescing. The goroutine exits on channel close or window cleanup and reports it on the returned channel. Nil window/channel/apply spawns nothing.

Also: cheat-sheet section quoting a runnable example (snippet gate generalized to a table), CHANGELOG entry.