### PR TITLE
Unify finite-check idioms on f32IsFinite / f32AllFiniteN

### DIFF
--- a/gui/canvas_draw.go
+++ b/gui/canvas_draw.go
@@ -92,7 +92,7 @@ func (dc *DrawContext) getBatch(color Color) *DrawCanvasTriBatch {
 
 // FilledRect draws a filled rectangle as two triangles.
 func (dc *DrawContext) FilledRect(x, y, w, h float32, color Color) {
-	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h) {
+	if w <= 0 || h <= 0 || !f32AllFinite4(x, y, w, h) {
 		return
 	}
 	if dc.recorder != nil {
@@ -145,7 +145,7 @@ func (dc *DrawContext) Polyline(points []float32, color Color, width float32) {
 		// far more than this primitive — validSvgCmd drops the whole
 		// command, and the run-length merge means the batch holds
 		// everything else drawn in the same color.
-		if hasNaNInf(x0, y0, x1, y1) {
+		if !f32AllFinite4(x0, y0, x1, y1) {
 			continue
 		}
 		dx := x1 - x0
@@ -173,7 +173,7 @@ func (dc *DrawContext) Polyline(points []float32, color Color, width float32) {
 // with overlap at corners. Overlap may cause alpha artifacts
 // with transparent colors.
 func (dc *DrawContext) Rect(x, y, w, h float32, color Color, width float32) {
-	if w <= 0 || h <= 0 || width <= 0 || hasNaNInf(x, y, w, h, width) {
+	if w <= 0 || h <= 0 || width <= 0 || !f32AllFinite5(x, y, w, h, width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -283,9 +283,9 @@ func (dc *DrawContext) arcPoints(cx, cy, rx, ry, start, sweep float32) []float32
 	// NaN fails every ordered comparison, so r <= 0 below would let it through and
 	// math.Ceil(NaN) -> int is undefined in Go. Screen first, and no-op the way the
 	// r <= 0 case does — every caller already guards on len(pts).
-	if !isFiniteF(cx) || !isFiniteF(cy) ||
-		!isFiniteF(rx) || !isFiniteF(ry) ||
-		!isFiniteF(start) || !isFiniteF(sweep) {
+	if !f32IsFinite(cx) || !f32IsFinite(cy) ||
+		!f32IsFinite(rx) || !f32IsFinite(ry) ||
+		!f32IsFinite(start) || !f32IsFinite(sweep) {
 		return nil
 	}
 	r := rx
@@ -327,7 +327,7 @@ func (dc *DrawContext) arcPoints(cx, cy, rx, ry, start, sweep float32) []float32
 // FilledRoundedRect draws a filled rectangle with rounded corners.
 // Radius is clamped to half the smaller dimension.
 func (dc *DrawContext) FilledRoundedRect(x, y, w, h, radius float32, color Color) {
-	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h, radius) {
+	if w <= 0 || h <= 0 || !f32AllFinite5(x, y, w, h, radius) {
 		return
 	}
 	if dc.recorder != nil {
@@ -345,7 +345,7 @@ func (dc *DrawContext) FilledRoundedRect(x, y, w, h, radius float32, color Color
 
 // RoundedRect draws a stroked rectangle with rounded corners.
 func (dc *DrawContext) RoundedRect(x, y, w, h, radius float32, color Color, width float32) {
-	if w <= 0 || h <= 0 || width <= 0 || hasNaNInf(x, y, w, h, radius, width) {
+	if w <= 0 || h <= 0 || width <= 0 || !f32AllFinite6(x, y, w, h, radius, width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -517,16 +517,6 @@ func (dc *DrawContext) PolylineJoined(
 	}
 }
 
-// hasNaNInf returns true if any value is NaN or ±Inf.
-func hasNaNInf(vals ...float32) bool {
-	for _, v := range vals {
-		if v != v || v-v != 0 {
-			return true
-		}
-	}
-	return false
-}
-
 func (dc *DrawContext) resetBezierBuf(x0, y0 float32) []float32 {
 	if cap(dc.bezierBuf) < 64 {
 		dc.bezierBuf = make([]float32, 0, 64)
@@ -539,7 +529,7 @@ func (dc *DrawContext) resetBezierBuf(x0, y0 float32) []float32 {
 func (dc *DrawContext) QuadBezier(
 	x0, y0, cx, cy, x1, y1 float32, color Color, width float32,
 ) {
-	if width <= 0 || hasNaNInf(x0, y0, cx, cy, x1, y1, width) {
+	if width <= 0 || !f32AllFinite7(x0, y0, cx, cy, x1, y1, width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -561,7 +551,7 @@ func (dc *DrawContext) CubicBezier(
 	color Color, width float32,
 ) {
 	if width <= 0 ||
-		hasNaNInf(x0, y0, c1x, c1y, c2x, c2y, x1, y1, width) {
+		!f32AllFinite9(x0, y0, c1x, c1y, c2x, c2y, x1, y1, width) {
 		return
 	}
 	if dc.recorder != nil {
@@ -640,8 +630,8 @@ func (dc *DrawContext) ImageWithFetcher(
 	if w <= 0 || h <= 0 || src == "" {
 		return
 	}
-	if !isFiniteF(x) || !isFiniteF(y) ||
-		!isFiniteF(w) || !isFiniteF(h) {
+	if !f32IsFinite(x) || !f32IsFinite(y) ||
+		!f32IsFinite(w) || !f32IsFinite(h) {
 		return
 	}
 	if dc.recorder != nil {
@@ -680,8 +670,8 @@ func (dc *DrawContext) ImageClipped(
 	clipX, clipY, clipW, clipH float32,
 ) {
 	if clipW <= 0 || clipH <= 0 ||
-		!isFiniteF(clipX) || !isFiniteF(clipY) ||
-		!isFiniteF(clipW) || !isFiniteF(clipH) {
+		!f32IsFinite(clipX) || !f32IsFinite(clipY) ||
+		!f32IsFinite(clipW) || !f32IsFinite(clipH) {
 		return
 	}
 	before := len(dc.images)
@@ -694,12 +684,6 @@ func (dc *DrawContext) ImageClipped(
 	// in the same local space and bakes here.
 	e.ClipX, e.ClipY, e.ClipW, e.ClipH = dc.xfRect(clipX, clipY, clipW, clipH)
 	e.Clipped = true
-}
-
-// isFiniteF reports whether v is a finite float32 (not NaN or Inf).
-func isFiniteF(v float32) bool {
-	f := float64(v)
-	return !math.IsNaN(f) && !math.IsInf(f, 0)
 }
 
 // Texts returns accumulated text entries. Useful for testing

--- a/gui/canvas_draw_dash.go
+++ b/gui/canvas_draw_dash.go
@@ -19,14 +19,14 @@ func (dc *DrawContext) DashedLine(
 		dc.Line(x0, y0, x1, y1, color, width)
 		return
 	}
-	if width <= 0 || !f32IsFinite(width) || hasNaNInf(dashLen, gapLen) {
+	if width <= 0 || !f32IsFinite(width) || !f32AllFinite2(dashLen, gapLen) {
 		return
 	}
 	if dc.recorder != nil {
 		dc.rec().DashedLine(x0, y0, x1, y1, color, width, dashLen, gapLen)
 		return
 	}
-	if hasNaNInf(x0, y0, x1, y1) {
+	if !f32AllFinite4(x0, y0, x1, y1) {
 		return
 	}
 	dx := x1 - x0
@@ -85,7 +85,7 @@ func (dc *DrawContext) DashedPolyline(
 		dc.Polyline(points, color, width)
 		return
 	}
-	if width <= 0 || !f32IsFinite(width) || hasNaNInf(dashLen, gapLen) {
+	if width <= 0 || !f32IsFinite(width) || !f32AllFinite2(dashLen, gapLen) {
 		return
 	}
 	if dc.recorder != nil {
@@ -97,7 +97,7 @@ func (dc *DrawContext) DashedPolyline(
 	for i := 0; i+3 < len(points); i += 2 {
 		x0, y0 := points[i], points[i+1]
 		x1, y1 := points[i+2], points[i+3]
-		if hasNaNInf(x0, y0, x1, y1) {
+		if !f32AllFinite4(x0, y0, x1, y1) {
 			continue
 		}
 		dx := x1 - x0

--- a/gui/canvas_draw_gradient.go
+++ b/gui/canvas_draw_gradient.go
@@ -186,7 +186,7 @@ func (dc *DrawContext) gradScratch() *[]float32 {
 // whose endpoints coincide runs top-to-bottom across the rect.
 func (dc *DrawContext) FilledRectGradient(x, y, w, h float32,
 	g *CanvasGradient) {
-	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h) {
+	if w <= 0 || h <= 0 || !f32AllFinite4(x, y, w, h) {
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
@@ -214,7 +214,7 @@ func (dc *DrawContext) FilledRectGradient(x, y, w, h float32,
 //	})
 func (dc *DrawContext) FilledCircleGradient(cx, cy, radius float32,
 	g *CanvasGradient) {
-	if hasNaNInf(cx, cy, radius) {
+	if !f32AllFinite3(cx, cy, radius) {
 		return
 	}
 	if dc.emitRadialGradient(cx, cy, radius, g) {
@@ -500,7 +500,7 @@ func (dc *DrawContext) concentricRings(stops []GradientStop,
 // gradient.
 func (dc *DrawContext) FilledArcGradient(cx, cy, rx, ry, start,
 	sweep float32, g *CanvasGradient) {
-	if hasNaNInf(cx, cy, rx, ry, start, sweep) {
+	if !f32AllFinite6(cx, cy, rx, ry, start, sweep) {
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {
@@ -536,7 +536,7 @@ func (dc *DrawContext) FilledPolygonGradient(points []float32,
 // Radius is clamped to half the smaller dimension.
 func (dc *DrawContext) FilledRoundedRectGradient(x, y, w, h,
 	radius float32, g *CanvasGradient) {
-	if w <= 0 || h <= 0 || hasNaNInf(x, y, w, h, radius) {
+	if w <= 0 || h <= 0 || !f32AllFinite5(x, y, w, h, radius) {
 		return
 	}
 	if mid, ok := dc.gradientRecorderFallback(g); ok {

--- a/gui/canvas_draw_transform.go
+++ b/gui/canvas_draw_transform.go
@@ -80,7 +80,7 @@ func (x canvasXform) uniform() bool { return x.sx == x.sy }
 // Non-finite arguments are ignored rather than poisoning every
 // subsequent vertex.
 func (dc *DrawContext) Translate(dx, dy float32) {
-	if !isFiniteF(dx) || !isFiniteF(dy) {
+	if !f32IsFinite(dx) || !f32IsFinite(dy) {
 		return
 	}
 	dc.ensureXform()
@@ -98,7 +98,7 @@ func (dc *DrawContext) Translate(dx, dy float32) {
 // A zero scale is allowed and collapses geometry. Non-finite
 // arguments are ignored.
 func (dc *DrawContext) ScaleBy(sx, sy float32) {
-	if !isFiniteF(sx) || !isFiniteF(sy) {
+	if !f32IsFinite(sx) || !f32IsFinite(sy) {
 		return
 	}
 	dc.ensureXform()

--- a/gui/render_draw_canvas.go
+++ b/gui/render_draw_canvas.go
@@ -317,8 +317,8 @@ func emitDrawCanvasImages(
 	narrowed := false
 	for i := range images {
 		im := &images[i]
-		if !isFiniteF(im.X) || !isFiniteF(im.Y) ||
-			!isFiniteF(im.W) || !isFiniteF(im.H) ||
+		if !f32IsFinite(im.X) || !f32IsFinite(im.Y) ||
+			!f32IsFinite(im.W) || !f32IsFinite(im.H) ||
 			im.W <= 0 || im.H <= 0 || im.Src == "" {
 			continue
 		}
@@ -329,7 +329,7 @@ func emitDrawCanvasImages(
 		bg := ColorTransparent
 		if im.BgColor.IsSet() {
 			op := im.bgOpacity.Get(1.0)
-			if !isFiniteF(op) {
+			if !f32IsFinite(op) {
 				op = 1.0
 			}
 			// The entry's own opacity folds into the
@@ -370,8 +370,8 @@ func emitDrawCanvasImages(
 // intersectClips returns the overlap of two clip rects. Reports false when
 // they do not overlap, or when either is degenerate.
 func intersectClips(a, b drawClip) (drawClip, bool) {
-	if !isFiniteF(b.X) || !isFiniteF(b.Y) ||
-		!isFiniteF(b.Width) || !isFiniteF(b.Height) ||
+	if !f32IsFinite(b.X) || !f32IsFinite(b.Y) ||
+		!f32IsFinite(b.Width) || !f32IsFinite(b.Height) ||
 		b.Width <= 0 || b.Height <= 0 {
 		return drawClip{}, false
 	}

--- a/gui/render_svg.go
+++ b/gui/render_svg.go
@@ -47,7 +47,7 @@ func renderSvg(shape *Shape, clip drawClip, w *Window) {
 		// back to the uniform tessellation scale so detail
 		// level matches and the render stays stable.
 		if cached.Width > 0 && cached.Height > 0 &&
-			isFiniteF(cached.Width) && isFiniteF(cached.Height) {
+			f32IsFinite(cached.Width) && f32IsFinite(cached.Height) {
 			scaleX = shape.Width / cached.Width
 			scaleY = shape.Height / cached.Height
 		} else {
@@ -215,7 +215,7 @@ func PreserveAlignFractions(a SvgAlign) (float32, float32) {
 // rejected so they cannot propagate into backend xform commands.
 func validNonUniform(sx, sy, uniform float32) bool {
 	return sx > 0 && sy > 0 &&
-		isFiniteF(sx) && isFiniteF(sy) &&
+		f32IsFinite(sx) && f32IsFinite(sy) &&
 		(sx != uniform || sy != uniform)
 }
 

--- a/gui/render_svg_animation.go
+++ b/gui/render_svg_animation.go
@@ -121,11 +121,11 @@ func collectAnimContribs(
 		// render state. DurSec must be strictly positive for normal
 		// animations; <set> is zero-duration and bypasses this check.
 		if len(a.TargetPathIDs) == 0 ||
-			!isFiniteF(a.DurSec) ||
+			!f32IsFinite(a.DurSec) ||
 			(!a.IsSet && a.DurSec <= 0) ||
-			!isFiniteF(a.BeginSec) ||
-			!isFiniteF(a.Cycle) ||
-			!isFiniteF(elapsedSec) {
+			!f32IsFinite(a.BeginSec) ||
+			!f32IsFinite(a.Cycle) ||
+			!f32IsFinite(elapsedSec) {
 			continue
 		}
 		if elapsedSec < a.BeginSec && !a.FillBackwards {
@@ -282,7 +282,7 @@ func motionSample(a *SvgAnimation, frac float32) (float32, float32, float32) {
 		return 0, 0, 0
 	}
 	total := lens[n-1]
-	if !isFiniteF(total) || total < 0 {
+	if !f32IsFinite(total) || total < 0 {
 		return 0, 0, 0
 	}
 	target := clampUnit(frac) * total

--- a/gui/render_svg_test.go
+++ b/gui/render_svg_test.go
@@ -381,19 +381,19 @@ func TestRenderImageDispatch(t *testing.T) {
 	}
 }
 
-// --- isFiniteF ---
+// --- f32IsFinite ---
 
 func TestFiniteF32_NaNInfFinite(t *testing.T) {
-	if !isFiniteF(0) || !isFiniteF(1.5) || !isFiniteF(-1e20) {
+	if !f32IsFinite(0) || !f32IsFinite(1.5) || !f32IsFinite(-1e20) {
 		t.Fatal("finite values should report true")
 	}
-	if isFiniteF(float32(math.NaN())) {
+	if f32IsFinite(float32(math.NaN())) {
 		t.Fatal("NaN must report false")
 	}
-	if isFiniteF(float32(math.Inf(1))) {
+	if f32IsFinite(float32(math.Inf(1))) {
 		t.Fatal("+Inf must report false")
 	}
-	if isFiniteF(float32(math.Inf(-1))) {
+	if f32IsFinite(float32(math.Inf(-1))) {
 		t.Fatal("-Inf must report false")
 	}
 }

--- a/gui/render_validate.go
+++ b/gui/render_validate.go
@@ -300,6 +300,16 @@ func f32AllFinite6(a, b, c, d, e, f float32) bool {
 		f32IsFinite(e) && f32IsFinite(f)
 }
 
+func f32AllFinite7(a, b, c, d, e, f, g float32) bool {
+	return f32AllFinite4(a, b, c, d) &&
+		f32IsFinite(e) && f32IsFinite(f) && f32IsFinite(g)
+}
+
+func f32AllFinite9(a, b, c, d, e, f, g, h, i float32) bool {
+	return f32AllFinite4(a, b, c, d) &&
+		f32AllFinite5(e, f, g, h, i)
+}
+
 // guardRendererOrSkip returns true if valid. Logs a warning (once
 // per kind) for invalid renderers.
 func guardRendererOrSkip(r RenderCmd, w *Window) bool {

--- a/gui/render_validate_test.go
+++ b/gui/render_validate_test.go
@@ -507,3 +507,47 @@ func TestF32AllFinite(t *testing.T) {
 		t.Error("empty slice should pass")
 	}
 }
+
+// TestF32AllFiniteN checks the fixed-arity helpers. Each helper
+// accepts finite input and rejects NaN, +Inf, and -Inf.
+func TestF32AllFiniteN(t *testing.T) {
+	if !f32AllFinite2(1, 2) ||
+		!f32AllFinite3(1, 2, 3) ||
+		!f32AllFinite4(1, 2, 3, 4) ||
+		!f32AllFinite5(1, 2, 3, 4, 5) ||
+		!f32AllFinite6(1, 2, 3, 4, 5, 6) ||
+		!f32AllFinite7(1, 2, 3, 4, 5, 6, 7) ||
+		!f32AllFinite9(1, 2, 3, 4, 5, 6, 7, 8, 9) {
+		t.Error("finite values should pass")
+	}
+	nan := float32(math.NaN())
+	if f32AllFinite2(nan, 2) ||
+		f32AllFinite3(1, nan, 3) ||
+		f32AllFinite4(1, 2, 3, nan) ||
+		f32AllFinite5(1, 2, nan, 4, 5) ||
+		f32AllFinite6(1, 2, 3, 4, 5, nan) ||
+		f32AllFinite7(1, 2, 3, 4, 5, 6, nan) ||
+		f32AllFinite9(1, 2, 3, 4, 5, 6, 7, 8, nan) {
+		t.Error("NaN should fail")
+	}
+	pinf := float32(math.Inf(1))
+	if f32AllFinite2(pinf, 2) ||
+		f32AllFinite3(1, pinf, 3) ||
+		f32AllFinite4(1, 2, 3, pinf) ||
+		f32AllFinite5(1, 2, pinf, 4, 5) ||
+		f32AllFinite6(1, 2, 3, 4, 5, pinf) ||
+		f32AllFinite7(1, 2, 3, 4, 5, 6, pinf) ||
+		f32AllFinite9(1, 2, 3, 4, 5, 6, 7, 8, pinf) {
+		t.Error("+Inf should fail")
+	}
+	ninf := float32(math.Inf(-1))
+	if f32AllFinite2(ninf, 2) ||
+		f32AllFinite3(1, ninf, 3) ||
+		f32AllFinite4(1, 2, 3, ninf) ||
+		f32AllFinite5(1, 2, ninf, 4, 5) ||
+		f32AllFinite6(1, 2, 3, 4, 5, ninf) ||
+		f32AllFinite7(1, 2, 3, 4, 5, 6, ninf) ||
+		f32AllFinite9(1, 2, 3, 4, 5, 6, 7, 8, ninf) {
+		t.Error("-Inf should fail")
+	}
+}

--- a/gui/svg_hittest.go
+++ b/gui/svg_hittest.go
@@ -22,12 +22,12 @@ func (tp *TessellatedPath) ContainsPoint(px, py float32) bool {
 	// silently misbehave (NaN compares false in both directions, so
 	// the fast-reject would let NaN points through into the bary
 	// loop where they yield non-deterministic results).
-	if !isFiniteF(px) || !isFiniteF(py) {
+	if !f32IsFinite(px) || !f32IsFinite(py) {
 		return false
 	}
 	if tp.HasBaseXform {
 		px, py = inverseBaseXform(tp, px, py)
-		if !isFiniteF(px) || !isFiniteF(py) {
+		if !f32IsFinite(px) || !f32IsFinite(py) {
 			return false
 		}
 	}
@@ -91,16 +91,16 @@ func inverseBaseXform(tp *TessellatedPath, px, py float32) (float32, float32) {
 	sy := tp.BaseScaleY
 	// Coerce non-finite or zero scale to 1 — division would emit
 	// Inf/NaN that propagates through the bary test.
-	if sx == 0 || !isFiniteF(sx) {
+	if sx == 0 || !f32IsFinite(sx) {
 		sx = 1
 	}
-	if sy == 0 || !isFiniteF(sy) {
+	if sy == 0 || !f32IsFinite(sy) {
 		sy = 1
 	}
-	if !isFiniteF(tx) {
+	if !f32IsFinite(tx) {
 		tx = 0
 	}
-	if !isFiniteF(ty) {
+	if !f32IsFinite(ty) {
 		ty = 0
 	}
 	// Undo translate.
@@ -109,7 +109,7 @@ func inverseBaseXform(tp *TessellatedPath, px, py float32) (float32, float32) {
 	// Undo rotation about (BaseRotCX, BaseRotCY). Skip when angle
 	// is non-finite — sin/cos of NaN propagate as NaN and corrupt
 	// the result.
-	if tp.BaseRotAngle != 0 && isFiniteF(tp.BaseRotAngle) {
+	if tp.BaseRotAngle != 0 && f32IsFinite(tp.BaseRotAngle) {
 		rad := float64(tp.BaseRotAngle) * math.Pi / 180
 		cos := float32(math.Cos(rad))
 		sin := float32(math.Sin(rad))

--- a/gui/svg_load_test.go
+++ b/gui/svg_load_test.go
@@ -433,7 +433,7 @@ func TestCachedSvgTextDrawsAnchorEnd(t *testing.T) {
 
 // loadSvgWithOpts must compute a non-trivial scale when the
 // parsed SVG has finite dimensions that differ from the shape.
-// Guards against inadvertently inverting the isFiniteF guard
+// Guards against inadvertently inverting the f32IsFinite guard
 // so scale collapses to 1 for every normal SVG.
 func TestLoadSvgScaleComputedFromFiniteDimensions(t *testing.T) {
 	w := &Window{}


### PR DESCRIPTION
Closes #558.

Mechanical unification, no behavior change:
- Delete `isFiniteF` (dup of `f32IsFinite`); rewrite its sites 1:1.
- Replace `hasNaNInf(a, ...)` with `!f32AllFiniteN(a, ...)`; add `f32AllFinite7` (QuadBezier) and `f32AllFinite9` (CubicBezier).
- Retarget `TestFiniteF32_NaNInfFinite`; add `TestF32AllFiniteN` over helpers 2-9 (finite / NaN / +Inf / -Inf, head + tail positions).

Out of scope: `canvas_curve.go` NaN-only guards (behavior differs on Inf overflow; separate commit with golden check), `svg/isFiniteF32`, `gradmesh/finite`.