### PR TITLE
refactor(gui): rename UpdateView to SetView (#564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,17 @@ and this project adheres to
   `InvalidateRender` rebuilds only the render commands from the tree already
   arranged.
 
+- **`UpdateView` renamed to `SetView` (#564)** — it is a setter for one field
+  (`w.viewGenerator`), so Go's setter convention fits, and it pairs with
+  `SetTheme`. At the dominant call site it reads correctly now: `OnInit`
+  performs the first assignment, not an update (`w.SetView(mainView)`). The new
+  name still reads fine on the rarer swap-the-view path.
+
 ### Deprecated
 
+- **`UpdateView` (#564)** — remains as a forwarder to `SetView`, so existing
+  code (including the six siblings' `main.go` files) keeps compiling. It will be
+  removed in a future minor.
 - **`UpdateWindow` and `RequestRedraw` (#563)** — both remain as forwarders to
   `InvalidateLayout` and `InvalidateRender`, so existing code keeps compiling.
   They will be removed in a future minor. See

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ does **not** move children — use the float system
 that have children.
 
 **`AmendLayout` runs under the frame lock (`w.mu`), so no callback reached from
-it can call a window-mutating API.** `SetFocus`, `ClearFocus`, `UpdateView`,
+it can call a window-mutating API.** `SetFocus`, `ClearFocus`, `SetView`,
 `ClearDrawCanvasCache` and `Window.Lock` all take `w.mu`, which is not
 reentrant; they panic naming themselves. The remedy is
 `ctx.Window.QueueCommand`. Library code reaching app code from the pass raises

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ type App struct{ Clicks int }
 
 func main() {
     w := gui.SimpleWindow("Counter", 300, 150, &App{}, func(w *gui.Window) {
-        w.UpdateView(mainView)
+        w.SetView(mainView)
     })
 
     backend.Run(w)
@@ -163,7 +163,7 @@ w := gui.NewWindow(gui.WindowCfg{
     Height:    150,
     MinWidth:  200, // the OS stops the resize drag here
     MinHeight: 120,
-    OnInit:    func(w *gui.Window) { w.UpdateView(mainView) },
+    OnInit:    func(w *gui.Window) { w.SetView(mainView) },
 })
 
 gui.Button(gui.ButtonCfg{

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -108,9 +108,9 @@ fields: `FloatAnchor`, `FloatTieOff`, `FloatOffsetX`, `FloatOffsetY`.
 ### Do not call window APIs from a hook
 
 The hook runs inside the frame pass, which holds the window mutex. `SetFocus`,
-`ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take
-that mutex. It is not reentrant, so a call from a hook froze the app outright
-(issue #394). It now panics, naming the API. Queue the work instead:
+`ClearFocus`, `SetView`, `ClearDrawCanvasCache` and `Window.Lock` all take that
+mutex. It is not reentrant, so a call from a hook froze the app outright (issue
+#394). It now panics, naming the API. Queue the work instead:
 
 ```go
 AmendLayout: func(ctx gui.EventCtx) {
@@ -360,7 +360,7 @@ func streamLinesView(w *gui.Window) gui.View {
 func ExampleStream() {
 	w := gui.NewWindow(gui.WindowCfg{State: &streamLines{}})
 	defer w.WindowCleanup()
-	w.UpdateView(streamLinesView)
+	w.SetView(streamLinesView)
 
 	lines := make(chan string, 4)
 	done := gui.Stream(w, lines, func(w *gui.Window, line string) {

--- a/docs/specs/examples-explorer.md
+++ b/docs/specs/examples-explorer.md
@@ -295,7 +295,7 @@ tags.
   var screenshot = flag.String("screenshot", "", "write screenshot and exit")
   flag.Parse()
   if *screenshot != "" {
-      w := gui.SimpleWindow(title, width, height, state, func(w *gui.Window){ w.UpdateView(mainView) })
+      w := gui.SimpleWindow(title, width, height, state, func(w *gui.Window){ w.SetView(mainView) })
       if err := soft.RenderToPNG(w, 2, *screenshot); err != nil { log.Fatal(err) }
       os.Exit(0)
   }

--- a/docs/specs/frame-lock-callback-deferral.md
+++ b/docs/specs/frame-lock-callback-deferral.md
@@ -25,7 +25,7 @@ region reach app code:
 `w.mu` is a plain `sync.Mutex`. It is not reentrant, and the main goroutine _is_
 the platform event loop (`runtime.LockOSThread` in
 `gui/backend/metal/mainthread.go`). So an app callback reached from that region
-that calls `SetFocus`, `ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` or
+that calls `SetFocus`, `ClearFocus`, `SetView`, `ClearDrawCanvasCache` or
 `Window.Lock` blocks the main thread on a lock it already owns. The window
 freezes permanently, with no panic and no CPU burn.
 

--- a/docs/specs/markdown-render-callback.md
+++ b/docs/specs/markdown-render-callback.md
@@ -159,7 +159,7 @@ set `A11YRole`/`A11YLabel` where appropriate. There is no `AccessRoleNote`; a
 callout takes `AccessRoleGroup` with a label naming its kind.
 
 The hook runs during `GenerateLayout`, under the frame lock. `SetFocus`,
-`ClearFocus`, `UpdateView`, `ClearDrawCanvasCache` and `Window.Lock` all take
+`ClearFocus`, `SetView`, `ClearDrawCanvasCache` and `Window.Lock` all take
 `w.mu` and panic naming themselves. `QueueCommand` **is** permitted and is the
 documented remedy — it takes `w.commandsMu` (`gui/window_update.go:53`), never
 `w.mu`. See `docs/specs/frame-lock-callback-deferral.md`.

--- a/docs/specs/process-monitor-example.md
+++ b/docs/specs/process-monitor-example.md
@@ -168,12 +168,12 @@ func startSampler(w *gui.Window) {
 ```
 
 Critical detail: use `w.InvalidateLayout()` (alias `markLayoutRefresh`), **NOT**
-`w.UpdateView(fn)`. `UpdateView` clears the view-state registry every call,
-which drops input focus and scroll position on every sample.
-`InvalidateRender()` is render-only (no view re-run) so new rows do not appear —
-also wrong. `InvalidateLayout` re-runs the registered view generator against
-fresh state while preserving the registry. Register the generator once in
-`OnInit` via `w.UpdateView(rootView)`.
+`w.SetView(fn)`. `SetView` clears the view-state registry every call, which
+drops input focus and scroll position on every sample. `InvalidateRender()` is
+render-only (no view re-run) so new rows do not appear — also wrong.
+`InvalidateLayout` re-runs the registered view generator against fresh state
+while preserving the registry. Register the generator once in `OnInit` via
+`w.SetView(rootView)`.
 
 Reads of shared state during sampling and all mutations happen under `w.Lock()`
 / `w.Unlock()`. The view function itself runs under `w.mu` already (per

--- a/docs/specs/window-invalidate-naming.md
+++ b/docs/specs/window-invalidate-naming.md
@@ -73,4 +73,5 @@ the view registry and assigns `w.viewGenerator` — so it never lied the way
 `UpdateWindow` did. It is simply a setter, and at the dominant call site
 (`OnInit`) it performs the first assignment rather than an update. It carries
 129 in-repo call sites plus every sibling's `main.go`, and no correctness hazard
-behind it, so it does not ride along with this change.
+behind it, so it does not ride along with this change. (Resolved by #564, which
+renamed it to `SetView` and kept `UpdateView` as a deprecated forwarder.)

--- a/examples/2048/main.go
+++ b/examples/2048/main.go
@@ -54,7 +54,7 @@ func main() {
 		Height:    700,
 		FixedSize: true,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.AnimationAdd(&gui.Animate{
 				AnimID: "landing-pulsate",
 				Delay:  16 * time.Millisecond,

--- a/examples/android_demo/demo.go
+++ b/examples/android_demo/demo.go
@@ -22,7 +22,7 @@ func Init() {
 	w := gui.NewWindow(gui.WindowCfg{
 		State: &App{},
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(view)
+			w.SetView(view)
 		},
 	})
 	android.SetWindow(w)

--- a/examples/animation_stress/main.go
+++ b/examples/animation_stress/main.go
@@ -58,7 +58,7 @@ func main() {
 		Height: 800,
 		OnInit: func(w *gui.Window) {
 			addItems(w, 10)
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/animations/main.go
+++ b/examples/animations/main.go
@@ -60,7 +60,7 @@ func main() {
 		Height: 600,
 		OnInit: func(w *gui.Window) {
 			// Register the root view once; animation callbacks mutate state.
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 
@@ -404,14 +404,14 @@ func heroAnim(w *gui.Window) {
 	w.AnimationAdd(gui.NewHeroTransition(gui.HeroTransitionCfg{
 		Duration: 600 * time.Millisecond,
 	}))
-	w.UpdateView(detailView)
+	w.SetView(detailView)
 }
 
 func heroBack(w *gui.Window) {
 	w.AnimationAdd(gui.NewHeroTransition(gui.HeroTransitionCfg{
 		Duration: 600 * time.Millisecond,
 	}))
-	w.UpdateView(mainView)
+	w.SetView(mainView)
 }
 
 // Keyframe: multi-waypoint shake effect.

--- a/examples/animations/main_test.go
+++ b/examples/animations/main_test.go
@@ -36,7 +36,7 @@ func TestMainViewNoDuplicateIDs(t *testing.T) {
 		Width:  800,
 		Height: 600,
 	})
-	w.UpdateView(mainView)
+	w.SetView(mainView)
 	if dups := w.TestDuplicateIDs(); len(dups) > 0 {
 		t.Errorf("duplicate IDs: %v", dups)
 	}

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -104,7 +104,7 @@ func main() {
 		Height:  768,
 		Timings: true,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(benchView)
+			w.SetView(benchView)
 		},
 	})
 

--- a/examples/blur_demo/main.go
+++ b/examples/blur_demo/main.go
@@ -24,7 +24,7 @@ func main() {
 		Width:  800,
 		Height: 800,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/calculator/main.go
+++ b/examples/calculator/main.go
@@ -98,7 +98,7 @@ func main() {
 		FixedSize: true,
 		BgColor:   colorBackdrop,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.SetFocus(displayFocus)
 		},
 		OnEvent: handleKeyEvent,

--- a/examples/color_picker/main.go
+++ b/examples/color_picker/main.go
@@ -45,7 +45,7 @@ func main() {
 		Width:  900,
 		Height: 620,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/command_demo/main.go
+++ b/examples/command_demo/main.go
@@ -36,7 +36,7 @@ func main() {
 		Height: 500,
 		OnInit: func(w *gui.Window) {
 			registerCommands(w)
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/context_menu/main.go
+++ b/examples/context_menu/main.go
@@ -29,7 +29,7 @@ func main() {
 		Width:  500,
 		Height: 400,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/cursor_demo/main.go
+++ b/examples/cursor_demo/main.go
@@ -51,7 +51,7 @@ func main() {
 		Width:  900,
 		Height: 420,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/custom_shader/main.go
+++ b/examples/custom_shader/main.go
@@ -33,7 +33,7 @@ func main() {
 		Width:  600,
 		Height: 400,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.AnimationAdd(&gui.Animate{
 				// Keep the frame loop hot so the shader parameter updates continuously.
 				AnimID:   shaderTickAnimationID,

--- a/examples/data_grid_data_source/main.go
+++ b/examples/data_grid_data_source/main.go
@@ -44,7 +44,7 @@ func main() {
 			app.AllRows = makeRows(50000)
 			app.Columns = makeColumns()
 			rebuildSource(app)
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/date_picker_options/main.go
+++ b/examples/date_picker_options/main.go
@@ -75,7 +75,7 @@ func main() {
 		Width:  1200,
 		Height: 950,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/dialogs/main.go
+++ b/examples/dialogs/main.go
@@ -30,7 +30,7 @@ func main() {
 		Width:  640,
 		Height: 550,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/digital_rain/main.go
+++ b/examples/digital_rain/main.go
@@ -70,7 +70,7 @@ func main() {
 		Width:  800,
 		Height: 600,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			startTick(w)
 		},
 		OnEvent: handleEvent,

--- a/examples/dock_layout/main.go
+++ b/examples/dock_layout/main.go
@@ -30,7 +30,7 @@ func main() {
 		Width:  1000,
 		Height: 700,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/draw_canvas/main.go
+++ b/examples/draw_canvas/main.go
@@ -28,7 +28,7 @@ func main() {
 		Width:  640,
 		Height: 480,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/explorer/main.go
+++ b/examples/explorer/main.go
@@ -61,7 +61,7 @@ func main() {
 			Width:  1100,
 			Height: 700,
 			OnInit: func(w *gui.Window) {
-				w.UpdateView(explorerView)
+				w.SetView(explorerView)
 			},
 		})
 		if err := soft.RenderToPNG(w, 2, *screenshotFlag); err != nil {
@@ -135,7 +135,7 @@ func main() {
 		Width:  1100,
 		Height: 700,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(explorerView)
+			w.SetView(explorerView)
 		},
 	})
 	// Ensure child processes are killed when window closes.

--- a/examples/floating_layout/main.go
+++ b/examples/floating_layout/main.go
@@ -45,7 +45,7 @@ func main() {
 		Width:  500,
 		Height: 500,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/fontviewer/main.go
+++ b/examples/fontviewer/main.go
@@ -190,7 +190,7 @@ func main() {
 		Width:  initialWinW,
 		Height: initialWinH,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.SetFocus(sampleInputID)
 		},
 	})

--- a/examples/frameless/main.go
+++ b/examples/frameless/main.go
@@ -51,7 +51,7 @@ func main() {
 		Height:      280,
 		Decorations: decoration,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/get_started/README.md
+++ b/examples/get_started/README.md
@@ -1,7 +1,7 @@
 # Get Started
 
 > **Framework:** input **Description:** The smallest stateful app: one button
-> and one counter. Shows State, UpdateView, and event handling.
+> and one counter. Shows State, SetView, and event handling.
 
 ![Preview](screenshot.png)
 
@@ -17,7 +17,7 @@ go run ./examples/get_started/
 
 ## What it demonstrates
 
-The smallest stateful app: one button and one counter. Shows State, UpdateView,
-and event handling.
+The smallest stateful app: one button and one counter. Shows State, SetView, and
+event handling.
 
 See `main.go` for the implementation.

--- a/examples/get_started/main.go
+++ b/examples/get_started/main.go
@@ -22,7 +22,7 @@ func main() {
 	flag.Parse()
 
 	w := gui.SimpleWindow("Get Started", 300, 300, &App{}, func(w *gui.Window) {
-		w.UpdateView(mainView)
+		w.SetView(mainView)
 	})
 
 	if *screenshot != "" {

--- a/examples/gradient_demo/main.go
+++ b/examples/gradient_demo/main.go
@@ -75,7 +75,7 @@ func main() {
 		Width:  1000,
 		Height: 800,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/headless_png/main.go
+++ b/examples/headless_png/main.go
@@ -33,7 +33,7 @@ func main() {
 	// software renderer runs OnInit itself, as a backend does.
 	w := gui.SimpleWindow("Headless", 320, 200, &App{Clicks: 3},
 		func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		})
 
 	// Scale 2 captures at Retina density; 1 is one device pixel per

--- a/examples/headless_png/main_test.go
+++ b/examples/headless_png/main_test.go
@@ -14,7 +14,7 @@ func TestRendersToPNG(t *testing.T) {
 		State:  &App{Clicks: 3},
 		Width:  320,
 		Height: 200,
-		OnInit: func(win *gui.Window) { win.UpdateView(mainView) },
+		OnInit: func(win *gui.Window) { win.SetView(mainView) },
 	})
 	t.Cleanup(func() { soft.Release(w) })
 

--- a/examples/ios_demo/main.go
+++ b/examples/ios_demo/main.go
@@ -20,7 +20,7 @@ func init() {
 	w := gui.NewWindow(gui.WindowCfg{
 		State: &App{},
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(view)
+			w.SetView(view)
 		},
 	})
 	ios.SetWindow(w)

--- a/examples/key_up_demo/main.go
+++ b/examples/key_up_demo/main.go
@@ -32,7 +32,7 @@ func main() {
 		Width:  400,
 		Height: 300,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/listbox/main.go
+++ b/examples/listbox/main.go
@@ -43,7 +43,7 @@ func main() {
 		Width:  240,
 		Height: 420,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/markdown/main.go
+++ b/examples/markdown/main.go
@@ -39,7 +39,7 @@ func main() {
 		Height: 600,
 		Title:  "Markdown View",
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/menu_demo/main.go
+++ b/examples/menu_demo/main.go
@@ -33,7 +33,7 @@ func main() {
 		Width:  600,
 		Height: 400,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/minesweeper/main.go
+++ b/examples/minesweeper/main.go
@@ -80,7 +80,7 @@ func main() {
 		Height:    660,
 		FixedSize: true,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.AnimationAdd(&gui.Animate{
 				AnimID: timerAnim,
 				Delay:  time.Second,

--- a/examples/multi_window/main.go
+++ b/examples/multi_window/main.go
@@ -38,7 +38,7 @@ func main() {
 		Width:  400,
 		Height: 300,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 
@@ -48,7 +48,7 @@ func main() {
 		Width:  300,
 		Height: 200,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(inspectorView)
+			w.SetView(inspectorView)
 		},
 	})
 
@@ -119,7 +119,7 @@ func mainView(w *gui.Window) gui.View {
 							Width:  250,
 							Height: 150,
 							OnInit: func(w *gui.Window) {
-								w.UpdateView(inspectorView)
+								w.SetView(inspectorView)
 							},
 						})
 					}

--- a/examples/multiline_input/main.go
+++ b/examples/multiline_input/main.go
@@ -95,7 +95,7 @@ func main() {
 		Width:  400,
 		Height: 300,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.SetFocus(inputFocusID)
 		},
 	})

--- a/examples/native_menu/main.go
+++ b/examples/native_menu/main.go
@@ -33,7 +33,7 @@ func main() {
 		Height: 400,
 		OnInit: func(w *gui.Window) {
 			registerCommands(w)
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 
 			app.SetNativeMenubar(gui.NativeMenubarCfg{
 				AppName:         "Native Menu Demo",

--- a/examples/optical_centring/main.go
+++ b/examples/optical_centring/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	w := gui.SimpleWindow("Optical Centring", 900, 760,
 		&App{Typed: "128"}, func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		})
 
 	if *screenshot != "" {

--- a/examples/particles/main.go
+++ b/examples/particles/main.go
@@ -124,7 +124,7 @@ func main() {
 		Height:    windowH,
 		FixedSize: true,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.AnimationAdd(&gui.Animate{
 				AnimID: tickAnim,
 				Delay:  tickDelay,

--- a/examples/process_monitor/README.md
+++ b/examples/process_monitor/README.md
@@ -82,10 +82,10 @@ w.InvalidateLayout() // re-run the view against fresh state, preserving focus/sc
 w.Unlock()
 ```
 
-`InvalidateLayout` (not `UpdateView`) re-runs the registered view without
-clearing the state registry. The filter input keeps focus, and the list keeps
-its scroll position across refreshes. The backend's idle poll repaints within
-~100 ms, so these intervals need no explicit wake.
+`InvalidateLayout` (not `SetView`) re-runs the registered view without clearing
+the state registry. The filter input keeps focus, and the list keeps its scroll
+position across refreshes. The backend's idle poll repaints within ~100 ms, so
+these intervals need no explicit wake.
 
 ### Stable processes + rolling history
 

--- a/examples/process_monitor/main.go
+++ b/examples/process_monitor/main.go
@@ -73,7 +73,7 @@ func main() {
 		Height: 700,
 		OnInit: func(w *gui.Window) {
 			// Register the view once; the sampler re-runs it via InvalidateLayout.
-			w.UpdateView(rootView)
+			w.SetView(rootView)
 			startSampler(w)
 		},
 	})
@@ -122,7 +122,7 @@ func startSampler(w *gui.Window) {
 						}
 					}
 				}
-				// InvalidateLayout (not UpdateView) re-runs the view against fresh state
+				// InvalidateLayout (not SetView) re-runs the view against fresh state
 				// WITHOUT clearing the state registry, so the filter input keeps
 				// focus and the process list keeps its scroll position.
 				w.InvalidateLayout()

--- a/examples/rotated_box/main.go
+++ b/examples/rotated_box/main.go
@@ -25,7 +25,7 @@ func main() {
 		Height: 500,
 		State:  &app{},
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 
@@ -90,7 +90,7 @@ func mainView(w *gui.Window) gui.View {
 							OnClick: func(ctx gui.EventCtx) {
 								s := gui.State[app](ctx.Window)
 								s.clicks++
-								ctx.Window.UpdateView(mainView)
+								ctx.Window.SetView(mainView)
 							},
 							Content: []gui.View{
 								gui.Text(gui.TextCfg{

--- a/examples/rtf/main.go
+++ b/examples/rtf/main.go
@@ -27,7 +27,7 @@ func main() {
 		Width:  500,
 		Height: 400,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 		OnEvent: func(e *gui.Event, w *gui.Window) {
 			if e.Type == gui.EventKeyDown &&

--- a/examples/scroll_demo/main.go
+++ b/examples/scroll_demo/main.go
@@ -32,7 +32,7 @@ func main() {
 		Width:  400,
 		Height: 600,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			// Give the scroll panel focus so its scrollbar is visible on startup.
 			w.SetFocus("scroll-panel")
 		},

--- a/examples/scroll_demo/main_test.go
+++ b/examples/scroll_demo/main_test.go
@@ -15,7 +15,7 @@ func newTestWindow(t *testing.T) *gui.Window {
 		Width:  400,
 		Height: 600,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.SetFocus("scroll-panel")
 		},
 	})

--- a/examples/shadow_demo/main.go
+++ b/examples/shadow_demo/main.go
@@ -29,7 +29,7 @@ func main() {
 		Width:  800,
 		Height: 800,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 		OnEvent: func(e *gui.Event, w *gui.Window) {
 			if e.Type == gui.EventKeyDown &&

--- a/examples/showcase/demo_layout.go
+++ b/examples/showcase/demo_layout.go
@@ -572,7 +572,7 @@ func demoMultiWindow(w *gui.Window) gui.View {
 							sa := appState(parent)
 							sa.MultiWindowChildID = child.PlatformID()
 							parent.InvalidateLayout()
-							child.UpdateView(multiWindowChildView(parent))
+							child.SetView(multiWindowChildView(parent))
 						},
 					})
 				},

--- a/examples/showcase/docs/widget_inspector.md
+++ b/examples/showcase/docs/widget_inspector.md
@@ -13,7 +13,7 @@ Nothing to add to a view. The key hook lives on the window (`inspectorKeyHook`,
 ```go
 func main() {
     w := gui.SimpleWindow("My App", 800, 600, &App{}, func(w *gui.Window) {
-        w.UpdateView(mainView)
+        w.SetView(mainView)
     })
     backend.Run(w) // press F12 in the running window
 }

--- a/examples/showcase/docs/widget_multi_window.md
+++ b/examples/showcase/docs/widget_multi_window.md
@@ -12,7 +12,7 @@ main := gui.NewWindow(gui.WindowCfg{
     State: &MainState{},
     Title: "Main",
     OnInit: func(w *gui.Window) {
-        w.UpdateView(mainView)
+        w.SetView(mainView)
     },
 })
 backend.RunApp(app, main)
@@ -27,7 +27,7 @@ w.App().OpenWindow(gui.WindowCfg{
     Width:  300,
     Height: 200,
     OnInit: func(child *gui.Window) {
-        child.UpdateView(childView)
+        child.SetView(childView)
     },
 })
 ```

--- a/examples/showcase/docs/widget_window_opacity.md
+++ b/examples/showcase/docs/widget_window_opacity.md
@@ -34,7 +34,7 @@ frame the compositor ever shows — there is no opaque flash first.
 gui.NewWindow(gui.WindowCfg{
     OnInit: func(w *gui.Window) {
         w.SetWindowOpacity(0.85)
-        w.UpdateView(rootView)
+        w.SetView(rootView)
     },
 })
 ```

--- a/examples/showcase/main.go
+++ b/examples/showcase/main.go
@@ -58,7 +58,7 @@ func main() {
 					CanExecute: func(_ *gui.Window) bool { return false },
 				},
 			)
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/showcase/showcase_test.go
+++ b/examples/showcase/showcase_test.go
@@ -141,7 +141,7 @@ func TestShowcaseWidgetSoundWiring(t *testing.T) {
 	app.SelectedGroup = groupFeedback
 	app.SelectedComponent = "audio"
 	w := gui.NewTestWindow(gui.WindowCfg{State: app})
-	w.UpdateView(mainView)
+	w.SetView(mainView)
 
 	installWidgetSounds(w, soundPlayerSynth)
 	spy := &soundWiringSpy{}
@@ -583,7 +583,7 @@ func TestDetailPanel_BumpsAbortCounterWhenNavigatingAwayFromTree(t *testing.T) {
 // entry: a widget behind an unselected catalog item is not in the tree.
 func TestDemoPagesHaveNoIDDefects(t *testing.T) {
 	w := gui.NewTestWindow(gui.WindowCfg{State: newShowcaseApp()})
-	w.UpdateView(mainView)
+	w.SetView(mainView)
 	app := appState(w)
 
 	for _, entry := range demoEntries {

--- a/examples/snake/main.go
+++ b/examples/snake/main.go
@@ -45,7 +45,7 @@ func main() {
 		Height:    640,
 		FixedSize: true,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			// Advance the game on a repeating animation timer.
 			startGameLoop(w)
 		},

--- a/examples/solar_system/main.go
+++ b/examples/solar_system/main.go
@@ -206,7 +206,7 @@ func main() {
 		Height: windowH,
 		OnInit: func(w *gui.Window) {
 			startAmbience()
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.AnimationAdd(&gui.Animate{
 				AnimID: tickAnim,
 				Delay:  tickDelay,

--- a/examples/solitaire/main.go
+++ b/examples/solitaire/main.go
@@ -73,7 +73,7 @@ func main() {
 		Height:    740,
 		FixedSize: true,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.AnimationAdd(&gui.Animate{
 				AnimID: blinkAnim,
 				Delay:  500 * time.Millisecond,

--- a/examples/svg/main.go
+++ b/examples/svg/main.go
@@ -81,7 +81,7 @@ func main() {
 		Height: 400,
 		Title:  "SVG Examples",
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 		OnEvent: func(e *gui.Event, w *gui.Window) {
 			if e.Type == gui.EventKeyDown &&

--- a/examples/svg_a11y/main.go
+++ b/examples/svg_a11y/main.go
@@ -36,7 +36,7 @@ func main() {
 		Width:  640,
 		Height: 360,
 		Title:  "SVG A11y Metadata",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_aspect/main.go
+++ b/examples/svg_aspect/main.go
@@ -38,7 +38,7 @@ func main() {
 		Width:  900,
 		Height: 540,
 		Title:  "preserveAspectRatio",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_css_selectors/main.go
+++ b/examples/svg_css_selectors/main.go
@@ -110,7 +110,7 @@ func main() {
 		Width:  720,
 		Height: 540,
 		Title:  "CSS Selectors (v0.14.0)",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_css_states/main.go
+++ b/examples/svg_css_states/main.go
@@ -49,7 +49,7 @@ func main() {
 		Height: 360,
 		Title:  ":hover / :focus",
 		State:  &state{},
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_css_vars/main.go
+++ b/examples/svg_css_vars/main.go
@@ -67,7 +67,7 @@ func main() {
 		Height: 480,
 		Title:  "CSS var() + calc() (v0.14.0)",
 		State:  &appState{ThemeIdx: 0, StrokeBase: 2},
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {
@@ -94,7 +94,7 @@ func view(w *gui.Window) gui.View {
 
 			OnClick: func(ctx gui.EventCtx) {
 				app.ThemeIdx = idx
-				w.UpdateView(view)
+				w.SetView(view)
 			},
 		}))
 	}
@@ -112,7 +112,7 @@ func view(w *gui.Window) gui.View {
 
 			OnClick: func(ctx gui.EventCtx) {
 				app.StrokeBase = base
-				w.UpdateView(view)
+				w.SetView(view)
 			},
 		}))
 	}

--- a/examples/svg_flatness/main.go
+++ b/examples/svg_flatness/main.go
@@ -42,7 +42,7 @@ func main() {
 		Width:  900,
 		Height: 320,
 		Title:  "FlatnessTolerance",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_gradient_spread/main.go
+++ b/examples/svg_gradient_spread/main.go
@@ -49,7 +49,7 @@ func main() {
 		Width:  720,
 		Height: 540,
 		Title:  "Gradient spreadMethod",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_hittest/main.go
+++ b/examples/svg_hittest/main.go
@@ -42,7 +42,7 @@ func main() {
 		Width:  720,
 		Height: 480,
 		Title:  "Svg Hit Test",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_radial/main.go
+++ b/examples/svg_radial/main.go
@@ -109,7 +109,7 @@ func main() {
 		Width:  720,
 		Height: 540,
 		Title:  "Radial Gradients",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/svg_spinners/main.go
+++ b/examples/svg_spinners/main.go
@@ -63,10 +63,10 @@ func main() {
 		Height: 4 * cellSize,
 		OnInit: func(w *gui.Window) {
 			if useIsolation {
-				w.UpdateView(isolatedView)
+				w.SetView(isolatedView)
 				return
 			}
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/svg_use_symbol/main.go
+++ b/examples/svg_use_symbol/main.go
@@ -56,7 +56,7 @@ func main() {
 		Width:  720,
 		Height: 520,
 		Title:  "Use + Symbol",
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/system_tray/main.go
+++ b/examples/system_tray/main.go
@@ -37,7 +37,7 @@ func main() {
 		Width:  500,
 		Height: 300,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 
 			_, err := app.SetSystemTray(gui.SystemTrayCfg{
 				Tooltip: "Go-GUI Tray Demo",

--- a/examples/termgrid/main.go
+++ b/examples/termgrid/main.go
@@ -40,7 +40,7 @@ func main() {
 		Title:  "termgrid",
 		Width:  cols*cellW + 40,
 		Height: rows*cellH + 40,
-		OnInit: func(w *gui.Window) { w.UpdateView(view) },
+		OnInit: func(w *gui.Window) { w.SetView(view) },
 	})
 
 	if *screenshot != "" {

--- a/examples/time_travel/main.go
+++ b/examples/time_travel/main.go
@@ -69,7 +69,7 @@ func main() {
 		Height:          220,
 		DebugTimeTravel: true,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -72,7 +72,7 @@ func main() {
 		Height: windowHeight,
 		OnInit: func(w *gui.Window) {
 			// Render once and put the caret in the input field.
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			w.SetFocus(todoInputFocusID)
 		},
 	})

--- a/examples/transparent/main.go
+++ b/examples/transparent/main.go
@@ -54,7 +54,7 @@ func main() {
 			// slider starts from what it reports rather than from a
 			// number repeated here.
 			gui.State[App](w).Opacity = w.WindowOpacity()
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/vibrancy/main.go
+++ b/examples/vibrancy/main.go
@@ -35,7 +35,7 @@ func main() {
 		Height:  260,
 		OnInit: func(w *gui.Window) {
 			w.SetWindowVibrancy(gui.State[App](w).Material)
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/examples/virtual_list/main.go
+++ b/examples/virtual_list/main.go
@@ -81,7 +81,7 @@ func main() {
 		Width:  520,
 		Height: 620,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 			go appender(w)
 		},
 	})

--- a/examples/web_demo/main.go
+++ b/examples/web_demo/main.go
@@ -32,7 +32,7 @@ func main() {
 		Width:  640,
 		Height: 480,
 		OnInit: func(w *gui.Window) {
-			w.UpdateView(mainView)
+			w.SetView(mainView)
 		},
 	})
 

--- a/gui/animation_hero_test.go
+++ b/gui/animation_hero_test.go
@@ -174,7 +174,7 @@ func TestHeroTransitionOnDone(t *testing.T) {
 }
 
 // TestAnimationAddCapturesHeroSnapshots is the wiring regression: the
-// documented sequence is AnimationAdd then UpdateView, so AnimationAdd
+// documented sequence is AnimationAdd then SetView, so AnimationAdd
 // is the last moment the outgoing geometry exists. Before this was
 // wired, outgoing stayed nil and no hero ever morphed — every one of
 // them only faded in.

--- a/gui/animation_loop.go
+++ b/gui/animation_loop.go
@@ -28,7 +28,7 @@ func viewBoundNow() int64 { return time.Now().UnixNano() }
 // A HeroTransition is snapshotted here, the way AnimateLayout captures
 // before its caller changes the view: the "before" geometry only exists
 // until the next arrange, and the documented call sequence is
-// AnimationAdd followed by UpdateView. Re-adding a transition mid-flight
+// AnimationAdd followed by SetView. Re-adding a transition mid-flight
 // replaces it outright (the ID is fixed), so the new morph starts from
 // wherever the tree is at that moment.
 func (w *Window) AnimationAdd(a Animation) {

--- a/gui/backend/gl/events_win32_test.go
+++ b/gui/backend/gl/events_win32_test.go
@@ -16,7 +16,7 @@ import (
 func newCharTestBackend(t *testing.T) *Backend {
 	t.Helper()
 	w := gui.NewWindow(gui.WindowCfg{State: new(int), Width: 100, Height: 100})
-	w.UpdateView(func(_ *gui.Window) gui.View {
+	w.SetView(func(_ *gui.Window) gui.View {
 		return gui.Column(gui.ContainerCfg{})
 	})
 	w.FrameFn()

--- a/gui/backend/gl/render_backend_test.go
+++ b/gui/backend/gl/render_backend_test.go
@@ -14,7 +14,7 @@ func TestBackendRenderSmoke(t *testing.T) {
 		Width:  200,
 		Height: 200,
 	})
-	w.UpdateView(func(_ *gui.Window) gui.View {
+	w.SetView(func(_ *gui.Window) gui.View {
 		return gui.Column(gui.ContainerCfg{
 			Content: []gui.View{
 				gui.Rectangle(gui.RectangleCfg{

--- a/gui/backend/gl/render_test.go
+++ b/gui/backend/gl/render_test.go
@@ -14,7 +14,7 @@ func TestSmokeRenderPipeline(t *testing.T) {
 		Width:  200,
 		Height: 200,
 	})
-	w.UpdateView(func(_ *gui.Window) gui.View {
+	w.SetView(func(_ *gui.Window) gui.View {
 		return gui.Column(gui.ContainerCfg{
 			Content: []gui.View{
 				gui.Rectangle(gui.RectangleCfg{

--- a/gui/backend/metal/frame_pump_test.go
+++ b/gui/backend/metal/frame_pump_test.go
@@ -37,7 +37,7 @@ func runFramePumpMainThreadTests() {
 		Width:  200,
 		Height: 200,
 	})
-	w.UpdateView(func(_ *gui.Window) gui.View {
+	w.SetView(func(_ *gui.Window) gui.View {
 		return gui.Rectangle(gui.RectangleCfg{
 			Width:  100,
 			Height: 50,

--- a/gui/backend/metal/presentation_test.go
+++ b/gui/backend/metal/presentation_test.go
@@ -38,7 +38,7 @@ func runLiveResizePresentationTests() {
 		Width:  200,
 		Height: 200,
 	})
-	w.UpdateView(func(_ *gui.Window) gui.View {
+	w.SetView(func(_ *gui.Window) gui.View {
 		return gui.Rectangle(gui.RectangleCfg{
 			Width:  100,
 			Height: 50,

--- a/gui/backend/metal/render_test.go
+++ b/gui/backend/metal/render_test.go
@@ -38,7 +38,7 @@ func TestSmokeRenderPipeline(t *testing.T) {
 		Width:  200,
 		Height: 200,
 	})
-	w.UpdateView(func(_ *gui.Window) gui.View {
+	w.SetView(func(_ *gui.Window) gui.View {
 		return gui.Column(gui.ContainerCfg{
 			Content: []gui.View{
 				gui.Rectangle(gui.RectangleCfg{
@@ -82,7 +82,7 @@ func TestBackendRenderSmoke(t *testing.T) {
 		Width:  200,
 		Height: 200,
 	})
-	w.UpdateView(func(_ *gui.Window) gui.View {
+	w.SetView(func(_ *gui.Window) gui.View {
 		return gui.Column(gui.ContainerCfg{
 			Content: []gui.View{
 				gui.Rectangle(gui.RectangleCfg{

--- a/gui/backend/soft/doc.go
+++ b/gui/backend/soft/doc.go
@@ -8,7 +8,7 @@
 // Typical use is a screenshot or a pixel-level regression test:
 //
 //	w := gui.SimpleWindow("Demo", 400, 300, &App{}, func(w *gui.Window) {
-//		w.UpdateView(mainView)
+//		w.SetView(mainView)
 //	})
 //	err := soft.RenderToPNG(w, 2, "demo.png")
 //

--- a/gui/backend/soft/golden_test.go
+++ b/gui/backend/soft/golden_test.go
@@ -147,7 +147,7 @@ func renderPixelGolden(
 	w := gui.NewWindow(gui.WindowCfg{
 		Width:  pixelGoldenW,
 		Height: pixelGoldenH,
-		OnInit: func(w *gui.Window) { w.UpdateView(c.build) },
+		OnInit: func(w *gui.Window) { w.SetView(c.build) },
 	})
 	w.SetTheme(theme)
 	tm, err := prepare(w, 1)

--- a/gui/backend/soft/input_keypress_bench_test.go
+++ b/gui/backend/soft/input_keypress_bench_test.go
@@ -43,7 +43,7 @@ func keypressWindow(
 	tb.Cleanup(func() { tm.textSys.Free() })
 	w.SetTextMeasurer(tm)
 	reseed := func() {
-		w.UpdateView(func(w *gui.Window) gui.View {
+		w.SetView(func(w *gui.Window) gui.View {
 			return gui.Input(gui.InputCfg{
 				ID:     "f",
 				Text:   seed,

--- a/gui/backend/soft/render_test.go
+++ b/gui/backend/soft/render_test.go
@@ -25,7 +25,7 @@ func newWin(t *testing.T, w, h int, view func(*gui.Window) gui.View) *gui.Window
 		Width:   w,
 		Height:  h,
 		BgColor: gui.RGB(0, 0, 0),
-		OnInit:  func(win *gui.Window) { win.UpdateView(view) },
+		OnInit:  func(win *gui.Window) { win.SetView(view) },
 	})
 	t.Cleanup(func() { Release(win) })
 	return win
@@ -166,7 +166,7 @@ func TestRenderScaleChangeRebuilds(t *testing.T) {
 		BgColor: gui.RGB(0, 0, 0),
 		OnInit: func(w *gui.Window) {
 			onInit++
-			w.UpdateView(redView)
+			w.SetView(redView)
 		},
 	})
 	t.Cleanup(func() { Release(win) })

--- a/gui/constructors_test.go
+++ b/gui/constructors_test.go
@@ -172,7 +172,7 @@ func TestSimpleWindowForwards(t *testing.T) {
 	var installed func(*Window) View
 	w := SimpleWindow("T", 400, 300, &appState{n: 7}, func(w *Window) {
 		installed = func(w *Window) View { return Label("root", TextStyle{}) }
-		w.UpdateView(installed)
+		w.SetView(installed)
 	})
 
 	if w.Config.Title != "T" || w.Config.Width != 400 || w.Config.Height != 300 {

--- a/gui/datagrid/view_data_grid_test.go
+++ b/gui/datagrid/view_data_grid_test.go
@@ -711,7 +711,7 @@ func TestDataGridRowsDataEmptyFirstRow(t *testing.T) {
 // data-source state, and a missed resolve in any of them is the defect.
 func TestDataGridStateKeysResolveUnderScope(t *testing.T) {
 	w := gg.NewTestWindow(gg.WindowCfg{})
-	w.UpdateView(func(_ *gg.Window) gg.View {
+	w.SetView(func(_ *gg.Window) gg.View {
 		return gg.Column(gg.ContainerCfg{
 			ID:      "detail",
 			Sizing:  gg.FillFill,
@@ -728,7 +728,7 @@ func TestDataGridStateKeysResolveUnderScope(t *testing.T) {
 // SetFocus and FindByID must be given.
 func TestDataGridRootResolvesToEffectiveID(t *testing.T) {
 	w := gg.NewTestWindow(gg.WindowCfg{})
-	w.UpdateView(func(_ *gg.Window) gg.View {
+	w.SetView(func(_ *gg.Window) gg.View {
 		return gg.Column(gg.ContainerCfg{
 			ID:      "detail",
 			Sizing:  gg.FillFill,
@@ -752,7 +752,7 @@ func TestDataGridRootResolvesToEffectiveID(t *testing.T) {
 // identities, which is the case the unresolved key silently merged.
 func TestDataGridTwoScopesAreDistinct(t *testing.T) {
 	w := gg.NewTestWindow(gg.WindowCfg{})
-	w.UpdateView(func(_ *gg.Window) gg.View {
+	w.SetView(func(_ *gg.Window) gg.View {
 		return gg.Column(gg.ContainerCfg{
 			Sizing: gg.FillFill,
 			Content: []gg.View{
@@ -791,7 +791,7 @@ func scopedTestGrid(w *gg.Window) gg.View {
 // joining the enclosing scope onto a name that already carries it.
 func TestDataGridChildIDsAreNotJoinedTwice(t *testing.T) {
 	w := gg.NewTestWindow(gg.WindowCfg{})
-	w.UpdateView(func(_ *gg.Window) gg.View {
+	w.SetView(func(_ *gg.Window) gg.View {
 		return gg.Column(gg.ContainerCfg{
 			ID:      "detail",
 			Sizing:  gg.FillFill,

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -498,7 +498,7 @@ func TestDebugAuditMouseLeaveDisabledIsQuiet(t *testing.T) {
 // identity, so a window built only from them is silent.
 func TestTestDuplicateIDsCompositeWidgetsAreQuiet(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(w *Window) View {
+	w.SetView(func(w *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -522,7 +522,7 @@ func TestTestDuplicateIDsCompositeWidgetsAreQuiet(t *testing.T) {
 // a different identity from the button's "dup".
 func TestTestDuplicateIDsScopesNestedLeaf(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -546,7 +546,7 @@ func TestTestDuplicateIDsScopesNestedLeaf(t *testing.T) {
 // collide. Scoping joins explicit ancestor IDs and nothing else.
 func TestTestDuplicateIDsReportsSameScopeCollision(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -568,7 +568,7 @@ func TestTestDuplicateIDsReportsSameScopeCollision(t *testing.T) {
 // rather than silently sharing a slot.
 func TestTestDuplicateIDsReportsJoinedVsAbsolute(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -597,7 +597,7 @@ func TestTestDuplicateIDsReportsJoinedVsAbsolute(t *testing.T) {
 // the process reports.
 func TestTestDuplicateIDsRestoresDebugState(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing:  FillFill,
 			Content: []View{Button(ButtonCfg{ID: "ok"})},
@@ -759,7 +759,7 @@ func TestWrapOverflowGatedByCategory(t *testing.T) {
 // property, not a defect, so the default sweep stays quiet on it.
 func TestTestFindingsReachesOptInCategory(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing:  FillFill,
 			Content: []View{Button(ButtonCfg{ID: "bare", Label: "Save"})},
@@ -780,7 +780,7 @@ func TestTestFindingsReachesOptInCategory(t *testing.T) {
 func TestTestFindingsRestoresMask(t *testing.T) {
 	captureDebugMask(t, DebugMissingIDs)
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{Sizing: FillFill})
 	})
 
@@ -813,7 +813,7 @@ func TestEffIDDuringGenerationIsQuiet(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
 
 	var scoped, unscoped string
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			ID:     "panel",
 			Sizing: FillFill,
@@ -824,7 +824,7 @@ func TestEffIDDuringGenerationIsQuiet(t *testing.T) {
 		})
 	})
 	w.TestRender(nil)
-	w.UpdateView(func(vw *Window) View {
+	w.SetView(func(vw *Window) View {
 		unscoped = vw.EffID("save")
 		return Column(ContainerCfg{Sizing: FillFill})
 	})
@@ -886,7 +886,7 @@ func TestEffIDEagerFactoryUnderPanelReports(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
 
 	var resolved string
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return &eagerFactoryParent{resolved: &resolved}
 	})
 	w.TestRender(nil)
@@ -908,7 +908,7 @@ func TestEffIDAnswersAreFrameScoped(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
 
 	var resolved string
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return &eagerFactoryParent{resolved: &resolved}
 	})
 	w.TestRender(nil)

--- a/gui/doc.go
+++ b/gui/doc.go
@@ -25,7 +25,7 @@
 //			Title:  "hello",
 //			Width:  400,
 //			Height: 300,
-//			OnInit: func(w *gui.Window) { w.UpdateView(view) },
+//			OnInit: func(w *gui.Window) { w.SetView(view) },
 //		})
 //		backend.Run(w)
 //	}

--- a/gui/id_stamp_test.go
+++ b/gui/id_stamp_test.go
@@ -154,7 +154,7 @@ func (v splicedParentView) GenerateLayout(w *Window) Layout {
 // through that parent rather than the grandparent scope.
 func TestStampDriftNamesScopeThroughUnstampedParent(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -191,7 +191,7 @@ func TestStampDriftNamesScopeThroughUnstampedParent(t *testing.T) {
 // it on its bare leaf, and nothing else about the frame looks wrong.
 func TestStampDriftReportsAnUnstampedShape(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -226,7 +226,7 @@ func TestStampDriftReportsAnUnstampedShape(t *testing.T) {
 // advisory: every identity here sits under an ID-bearing ancestor.
 func TestNestedLayoutHasNoIdentityFindings(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			ID:     "screen",
@@ -278,7 +278,7 @@ func (v staleStampView) GenerateLayout(w *Window) Layout {
 // downstream finds them and nothing else about the frame looks wrong.
 func TestStampDriftReportsAStaleStamp(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -316,7 +316,7 @@ func TestStampDriftReportsAStaleStamp(t *testing.T) {
 // silent until the gate asks for it.
 func TestStampDriftIsSilentWhenTheCategoryIsOff(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -364,7 +364,7 @@ func (v unstampedParentView) GenerateLayout(w *Window) Layout {
 // as drifted, and the real fault — the parent — is buried under it.
 func TestUnstampedParentDoesNotMisplaceItsChildren(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{

--- a/gui/markdown_render_block_test.go
+++ b/gui/markdown_render_block_test.go
@@ -402,7 +402,7 @@ func TestMarkdownRenderBlockTailListUnhooked(t *testing.T) {
 // ScopeIDN they are unique per block, and the sweep stays quiet.
 func TestMarkdownRenderBlockIDsScoped(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(win *Window) View {
+	w.SetView(func(win *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{
@@ -434,7 +434,7 @@ func TestMarkdownRenderBlockIDsScoped(t *testing.T) {
 // state slot.
 func TestMarkdownRenderBlockIDCollisionReported(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(win *Window) View {
+	w.SetView(func(win *Window) View {
 		return Column(ContainerCfg{
 			Sizing: FillFill,
 			Content: []View{

--- a/gui/markdown_select_interaction_test.go
+++ b/gui/markdown_select_interaction_test.go
@@ -200,7 +200,7 @@ func newMdSelectHarnessNested(t *testing.T) *mdSelectHarness {
 // every frame, so changing the source and calling TestRender(nil) is
 // how a live document is swapped between frames — TestRender(nil)
 // re-runs the installed generator without clearing the registry (a
-// fresh generator would go through UpdateView, which clears per-widget
+// fresh generator would go through SetView, which clears per-widget
 // state by design and would mask the signature reset under test).
 func (h *mdSelectHarness) render() {
 	h.w.TestRender(func(win *Window) View {

--- a/gui/sound.go
+++ b/gui/sound.go
@@ -67,7 +67,7 @@ type SoundPlayer interface {
 	//
 	// Some cues are emitted from a path that already holds the frame
 	// lock — a form submit runs from AmendLayout — so an implementation
-	// must not call a window-mutating API (SetFocus, UpdateView,
+	// must not call a window-mutating API (SetFocus, SetView,
 	// Window.Lock): those take w.mu, which is not reentrant, and panic
 	// naming themselves.
 	PlaySound(cue SoundCue, gain float32)

--- a/gui/testing.go
+++ b/gui/testing.go
@@ -132,7 +132,7 @@ func NewTestWindow(cfg WindowCfg) *Window {
 // must not be read after it. Call TestRender(nil) again instead.
 func (w *Window) TestRender(view func(*Window) View) *Layout {
 	if view != nil {
-		w.UpdateView(view)
+		w.SetView(view)
 	}
 	w.markLayoutRefresh()
 	w.Update()

--- a/gui/time_travel.go
+++ b/gui/time_travel.go
@@ -426,7 +426,7 @@ func (w *Window) openDebugWindow() {
 		Width:  300,
 		Height: 150,
 		OnInit: func(dw *Window) {
-			dw.UpdateView(debugWindowView)
+			dw.SetView(debugWindowView)
 		},
 		// Closing the debug window must unfreeze the app,
 		// otherwise the user is stranded with input blocked

--- a/gui/view_input_test.go
+++ b/gui/view_input_test.go
@@ -1774,7 +1774,7 @@ func TestSetFocusReassertSameIDPreservesSelection(t *testing.T) {
 // The #156 pattern: a View function that re-asserts focus on every
 // frame (documented as legitimate in window_focus.go). TestRender(nil)
 // re-runs the installed generator without clearing the registry
-// (UpdateView would), so the second frame observes the state the first
+// (SetView would), so the second frame observes the state the first
 // frame's re-assert must not have wiped.
 func TestSetFocusReassertFromViewPreservesSelection(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})

--- a/gui/view_markdown.go
+++ b/gui/view_markdown.go
@@ -169,7 +169,7 @@ type MarkdownCfg struct {
 	// It runs once per block per frame over the cached styled blocks,
 	// so it must be cheap and pure: build View structs, do not fetch
 	// or parse. It runs during GenerateLayout, under the frame lock,
-	// so SetFocus, ClearFocus, UpdateView, ClearDrawCanvasCache and
+	// so SetFocus, ClearFocus, SetView, ClearDrawCanvasCache and
 	// Window.Lock all panic from it; QueueCommand is the remedy and
 	// is permitted. Hook writers own their IDs — compose them with
 	// ScopeID(el.DocID, …) or ScopeIDN — and their a11y roles.

--- a/gui/view_menubar_test.go
+++ b/gui/view_menubar_test.go
@@ -143,7 +143,7 @@ func TestFindMenuByID(t *testing.T) {
 // "<panel>:bar", which is what every assertion below is about.
 func menubarInPanels(panelIDs ...string) *Window {
 	w := NewTestWindow(WindowCfg{})
-	w.UpdateView(func(vw *Window) View {
+	w.SetView(func(vw *Window) View {
 		panels := make([]View, 0, len(panelIDs))
 		for _, id := range panelIDs {
 			panels = append(panels, Column(ContainerCfg{

--- a/gui/view_tooltip_test.go
+++ b/gui/view_tooltip_test.go
@@ -361,7 +361,7 @@ func tooltipsInPanels(panels ...tooltipPanel) *Window {
 	w := NewTestWindow(WindowCfg{})
 	w.viewState.mousePosX = 60
 	w.viewState.mousePosY = 60
-	w.UpdateView(func(vw *Window) View {
+	w.SetView(func(vw *Window) View {
 		views := make([]View, 0, len(panels))
 		for _, p := range panels {
 			views = append(views, Column(ContainerCfg{

--- a/gui/window.go
+++ b/gui/window.go
@@ -72,7 +72,7 @@ func ListSystemFonts(w *Window) []string {
 //
 //   - [Window.State] / [State] — typed per-window user data
 //   - [Window.Now] — virtual-clock-aware time (supports time-travel debug)
-//   - [Window.UpdateView] — request a full rebuild next frame
+//   - [Window.SetView] — request a full rebuild next frame
 //   - [Window.SetTitle] — update the OS window title
 //   - [Window.Close] — request window close (safe from any goroutine)
 //   - [Window.Backend] — access text measurement, clipboard, native dialogs

--- a/gui/window_deferred.go
+++ b/gui/window_deferred.go
@@ -6,7 +6,7 @@ package gui
 // and both reach code that fires app callbacks: an AmendLayout hook
 // detecting blur, a render pass reporting a caret rect. w.mu is a
 // plain sync.Mutex, so a callback that calls back into SetFocus,
-// UpdateView or any other w.mu-taking API deadlocks the main thread —
+// SetView or any other w.mu-taking API deadlocks the main thread —
 // a frozen window with no panic and no CPU burn (issue #394).
 //
 // The invariant this file restores: no app callback runs while the

--- a/gui/window_deferred_test.go
+++ b/gui/window_deferred_test.go
@@ -152,7 +152,7 @@ func TestFlushDeferredCallbacksReports(t *testing.T) {
 func TestFrameFnRerunsPassAfterDeferredCallbacks(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
 	label := "before"
-	w.UpdateView(func(*Window) View {
+	w.SetView(func(*Window) View {
 		return Text(TextCfg{ID: "label", Text: label})
 	})
 	w.deferCallback(func(*Window) { label = "after" })
@@ -176,7 +176,7 @@ func TestFrameFnRerunsPassAfterDeferredCallbacks(t *testing.T) {
 func TestFrameFnSinglePassWithoutDeferredCallbacks(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
 	gens := 0
-	w.UpdateView(func(*Window) View {
+	w.SetView(func(*Window) View {
 		gens++
 		return Text(TextCfg{ID: "t"})
 	})
@@ -194,7 +194,7 @@ func TestFrameFnSinglePassWithoutDeferredCallbacks(t *testing.T) {
 func TestFrameFnStopsAfterTwoPasses(t *testing.T) {
 	w := NewTestWindow(WindowCfg{})
 	gens := 0
-	w.UpdateView(func(w *Window) View {
+	w.SetView(func(w *Window) View {
 		gens++
 		w.InvalidateLayout() // dirty the window from inside the pass
 		return Text(TextCfg{ID: "t"})

--- a/gui/window_lifecycle_test.go
+++ b/gui/window_lifecycle_test.go
@@ -35,18 +35,18 @@ func TestNewWindowSetsFields(t *testing.T) {
 	}
 }
 
-func TestUpdateViewSetsGenerator(t *testing.T) {
+func TestSetViewSetsGenerator(t *testing.T) {
 	w := NewWindow(WindowCfg{Width: 100, Height: 100})
 	called := false
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		called = true
 		return Text(TextCfg{Text: "hi"})
 	})
 	if w.viewGenerator == nil {
-		t.Fatal("viewGenerator nil after UpdateView")
+		t.Fatal("viewGenerator nil after SetView")
 	}
 	if !w.refreshLayout {
-		t.Error("want refreshLayout=true after UpdateView")
+		t.Error("want refreshLayout=true after SetView")
 	}
 	// Call generator to verify it works.
 	w.viewGenerator(w)
@@ -410,9 +410,16 @@ func TestRefreshRequestsWakeMain(t *testing.T) {
 			wantRenderOnly: true,
 		},
 		{
-			name: "UpdateView",
+			name: "SetView",
 			call: func(w *Window) {
-				w.UpdateView(func(*Window) View { return nil })
+				w.SetView(func(*Window) View { return nil })
+			},
+			wantLayout: true,
+		},
+		{
+			name: "UpdateView (deprecated)",
+			call: func(w *Window) {
+				w.UpdateView(func(*Window) View { return nil }) //nolint:staticcheck // pins the forwarder
 			},
 			wantLayout: true,
 		},
@@ -565,14 +572,14 @@ func TestWindowCtxNilFallback(t *testing.T) {
 	}
 }
 
-func TestUpdateViewPreservesIDFocus(t *testing.T) {
+func TestSetViewPreservesIDFocus(t *testing.T) {
 	w := NewWindow(WindowCfg{State: new(int), Width: 100, Height: 100})
 	w.viewState.focusID = "f42"
-	w.UpdateView(func(_ *Window) View {
+	w.SetView(func(_ *Window) View {
 		return Text(TextCfg{Text: "hi"})
 	})
 	if w.FocusID() != "f42" {
-		t.Errorf("FocusID = %q, want f42 after UpdateView",
+		t.Errorf("FocusID = %q, want f42 after SetView",
 			w.FocusID())
 	}
 }

--- a/gui/window_stream.go
+++ b/gui/window_stream.go
@@ -15,7 +15,7 @@ package gui
 // the sampler examples already use by hand.
 //
 // Call it once per producer, typically from OnInit after
-// UpdateView has registered the view. Safe to call from any
+// SetView has registered the view. Safe to call from any
 // window lock itself — the mutation runs inside a queued command on
 // the frame thread. apply therefore reads window state the way a
 // view function does, and must not block: a slow apply stalls every

--- a/gui/window_stream_example_test.go
+++ b/gui/window_stream_example_test.go
@@ -33,7 +33,7 @@ func streamLinesView(w *gui.Window) gui.View {
 func ExampleStream() {
 	w := gui.NewWindow(gui.WindowCfg{State: &streamLines{}})
 	defer w.WindowCleanup()
-	w.UpdateView(streamLinesView)
+	w.SetView(streamLinesView)
 
 	lines := make(chan string, 4)
 	done := gui.Stream(w, lines, func(w *gui.Window, line string) {

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -174,9 +174,9 @@ func (w *Window) UpdateWindow() { w.InvalidateLayout() }
 //exportaudit:keep
 func (w *Window) RequestRedraw() { w.InvalidateRender() }
 
-// UpdateView sets the view generator and triggers a full refresh.
-func (w *Window) UpdateView(gen func(*Window) View) {
-	w.lockForAPI("UpdateView")
+// SetView sets the view generator and triggers a full refresh.
+func (w *Window) SetView(gen func(*Window) View) {
+	w.lockForAPI("SetView")
 	defer w.mu.Unlock()
 	w.viewState.registry.Clear()
 	w.viewGenerator = gen
@@ -185,6 +185,14 @@ func (w *Window) UpdateView(gen func(*Window) View) {
 	// event queue and takes no window lock, so it cannot re-enter.
 	w.wakeMain()
 }
+
+// UpdateView sets the view generator and triggers a full refresh.
+//
+// Deprecated: use [Window.SetView], which pairs with [Window.SetTheme] and
+// reads correctly at the dominant OnInit call site.
+//
+//exportaudit:keep
+func (w *Window) UpdateView(gen func(*Window) View) { w.SetView(gen) }
 
 // FrameFn is called by the backend each frame. It flushes
 // queued commands and rebuilds layout/renderers as needed.


### PR DESCRIPTION
Follow-up to #563. `UpdateView` is a setter for one field (`w.viewGenerator`), so Go's setter convention fits, and `SetView` pairs with `SetTheme`. At the dominant `OnInit` call site the call is the first assignment, not an update (`w.SetView(mainView)`).

- `UpdateView` stays as a deprecated forwarder (`//exportaudit:keep`), so the six siblings keep compiling across a release.
- Every in-repo caller moved (117 files), so no first-party code trips SA1019.
- The deprecated spelling rides the `TestRefreshRequestsWakeMain` table so the shim cannot rot into a no-op.
- CHANGELOG entry under Unreleased (Changed + Deprecated); resolution note in `docs/specs/window-invalidate-naming.md`. No new spec file — rename only, no semantics change.

Closes #564.