### PR TITLE
fix(gui): date picker roller focus, wheel scroll, required ID (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to
   performs the first assignment, not an update (`w.SetView(mainView)`). The new
   name still reads fine on the rarer swap-the-view path.
 
+- **BREAKING: `DatePickerRoller` requires a non-empty `Cfg.ID` (#565)** — focus
+  is keyed on that ID, so an empty one produced a widget that could not take
+  focus and answered no key. The factory now panics through `RequireID`, and
+  `DatePickerRollerCfg.ID` carries `gui:"required"` so the `requiredid` analyzer
+  reports the omission under `go vet` before the panic can happen. This matches
+  `DatePicker`, `Combobox` and `ListBox`. Migration: give every
+  `DatePickerRollerCfg` literal an `ID`.
+
 ### Deprecated
 
 - **`UpdateView` (#564)** — remains as a forwarder to `SetView`, so existing
@@ -36,6 +44,19 @@ and this project adheres to
   `InvalidateLayout` and `InvalidateRender`, so existing code keeps compiling.
   They will be removed in a future minor. See
   `docs/specs/window-invalidate-naming.md`.
+
+### Fixed
+
+- **Date Picker Roller holds focus and answers the keyboard under a scoped
+  parent (#565)** — `GenerateLayout` never resolved its effective ID, so
+  click-to-focus parked focus in the void: no focus border, and the arrow-key
+  and Shift/Alt year/month bindings never fired. It now resolves `cfg.ID` with
+  `w.EffID`, matching `DatePicker` and `Combobox`.
+
+- **Mouse wheel scrolls the Date Picker Roller drums (#565)** — the wheel
+  handler hit-tested the drums with the shape-relative coordinates dispatch
+  hands it against the drums' absolute positions, so no drum ever matched and
+  the wheel silently did nothing. It now translates back before hit-testing.
 
 ## [v0.73.0] - 2026-09-10
 

--- a/gui/view_date_picker_roller.go
+++ b/gui/view_date_picker_roller.go
@@ -26,7 +26,7 @@ type DatePickerRollerCfg struct {
 	TextStyle    TextStyle
 	SelectedDate time.Time
 	OnChange     func(time.Time, EventCtx)
-	ID           string
+	ID           string `gui:"required"`
 	A11YCfg
 	// MinYear clamps the year drum's lower bound. Zero takes 1900.
 	// exportaudit:keep — caller-facing config (issue #372)
@@ -76,12 +76,16 @@ type datePickerRollerView struct {
 
 // DatePickerRoller creates a roller-style date picker view.
 func DatePickerRoller(cfg DatePickerRollerCfg) View {
+	RequireID("DatePickerRoller", cfg.ID)
 	applyRollerDefaults(&cfg)
 	return &datePickerRollerView{cfg: cfg}
 }
 
 func (rv *datePickerRollerView) GenerateLayout(w *Window) Layout {
 	cfg := &rv.cfg
+
+	// One resolved identity for every key below; see (*Window).EffID.
+	cfg.ID = w.EffID(cfg.ID)
 	sel := cfg.SelectedDate
 
 	specs := rollerDrumSpecs(cfg, sel)
@@ -141,10 +145,16 @@ func (rv *datePickerRollerView) GenerateLayout(w *Window) Layout {
 				if ctx.Event.ScrollY > 0 {
 					delta = -1
 				}
+				// Dispatch hands the callback shape-relative
+				// coordinates (callRelative), but the drums carry
+				// arranged absolute positions, so translate back
+				// before hit-testing — without this no drum ever
+				// matches and the wheel silently does nothing.
+				mx := ctx.Event.MouseX + ctx.Layout.Shape.X
+				my := ctx.Event.MouseY + ctx.Layout.Shape.Y
 				for i, child := range ctx.Layout.Children {
 					if i < len(drumNames) &&
-						child.Shape.PointInShape(
-							ctx.Event.MouseX, ctx.Event.MouseY) {
+						child.Shape.PointInShape(mx, my) {
 						rollerDrumAdjust(drumNames[i],
 							delta, selectedDate,
 							minYear, maxYear, onChange, ctx.Window, wrapYear)

--- a/gui/view_date_picker_roller_test.go
+++ b/gui/view_date_picker_roller_test.go
@@ -17,6 +17,107 @@ func TestDatePickerRollerLayout(t *testing.T) {
 	}
 }
 
+// TestDatePickerRollerScopedFocusAndKeys is the regression test for
+// issue #565: under an ID-bearing parent the roller resolved no
+// effective ID, so click-to-focus parked focus in the void and key
+// dispatch never reached it.
+func TestDatePickerRollerScopedFocusAndKeys(t *testing.T) {
+	w := &Window{}
+	// EventFn drops key events on an unfocused window (eventAllowed).
+	w.focused = true
+	sel := time.Date(2025, 6, 15, 0, 0, 0, 0, time.Local)
+	changes := 0
+	v := Column(ContainerCfg{
+		ID: "panel",
+		Content: []View{
+			DatePickerRoller(DatePickerRollerCfg{
+				ID:           "roller",
+				Focusable:    true,
+				SelectedDate: sel,
+				OnChange: func(_ time.Time, _ EventCtx) {
+					changes++
+				},
+			}),
+		},
+	})
+	w.layout = generateViewLayout(v, w)
+	roller := &w.layout.Children[0]
+	if roller.Shape.events.OnClick == nil {
+		t.Fatal("OnClick handler missing")
+	}
+	roller.Shape.events.OnClick(EventCtx{roller, &Event{}, w})
+	if w.FocusID() != "panel:roller" {
+		t.Fatalf("focus = %q, want panel:roller", w.FocusID())
+	}
+	e := &Event{Type: EventKeyDown, KeyCode: KeyDown, Modifiers: ModNone}
+	w.EventFn(e)
+	if changes != 1 {
+		t.Errorf("OnChange fired %d times, want 1", changes)
+	}
+	if !e.IsHandled {
+		t.Error("KeyDown should be marked handled")
+	}
+}
+
+// TestDatePickerRollerMouseScroll covers the wheel path: the scroll
+// handler must hit-test the drum under the cursor. Dispatch hands it
+// shape-relative coordinates while the drums carry absolute ones, so
+// without the translate-back the wheel silently does nothing.
+func TestDatePickerRollerMouseScroll(t *testing.T) {
+	w := &Window{}
+	// A sized window: the pipeline seeds hit-test clips from it.
+	w.windowWidth = 800
+	w.windowHeight = 600
+	sel := time.Date(2025, 6, 15, 0, 0, 0, 0, time.Local)
+	var got time.Time
+	fired := 0
+	v := Column(ContainerCfg{
+		ID: "panel",
+		Content: []View{
+			// Push the roller away from the origin: near (0,0)
+			// shape-relative and absolute coordinates coincide,
+			// which would let a missing translate-back pass.
+			Column(ContainerCfg{Height: 300}),
+			DatePickerRoller(DatePickerRollerCfg{
+				ID:           "roller",
+				Focusable:    true,
+				SelectedDate: sel,
+				OnChange: func(d time.Time, _ EventCtx) {
+					fired++
+					got = d
+				},
+			}),
+		},
+	})
+	w.layout = generateViewLayout(v, w)
+	// layoutArrange runs AmendLayout, which installs OnMouseScroll;
+	// clips are seeded from the window rect as layoutPipeline does.
+	_ = layoutArrange(&w.layout, w)
+	layoutSetShapeClips(&w.layout, w.windowRect())
+	roller := &w.layout.Children[1]
+	if roller.Shape.events.OnMouseScroll == nil {
+		t.Fatal("OnMouseScroll missing: AmendLayout did not install it")
+	}
+	// Middle drum in day-month-year order is the month drum.
+	if len(roller.Children) < 3 {
+		t.Fatalf("drums = %d, want 3", len(roller.Children))
+	}
+	drum := &roller.Children[1]
+	mx := drum.Shape.X + drum.Shape.Width/2
+	my := drum.Shape.Y + drum.Shape.Height/2
+	e := &Event{Type: EventMouseScroll, MouseX: mx, MouseY: my, ScrollY: -1}
+	w.EventFn(e)
+	if fired != 1 {
+		t.Fatalf("OnChange fired %d times, want 1", fired)
+	}
+	if got.Month() != 7 {
+		t.Errorf("month = %v, want July", got.Month())
+	}
+	if !e.IsHandled {
+		t.Error("scroll should be marked handled")
+	}
+}
+
 func TestRollerDefaults(t *testing.T) {
 	cfg := DatePickerRollerCfg{}
 	applyRollerDefaults(&cfg)
@@ -403,4 +504,14 @@ func TestWrapRange(t *testing.T) {
 	if v := wrapRange(6, 1, 12); v != 6 {
 		t.Errorf("wrapRange(6,1,12) = %d, want 6", v)
 	}
+}
+
+// The factory keys focus and state on cfg.ID, so an empty one is a
+// programmer error caught at build time by the `gui:"required"` tag and
+// at runtime here. The literal omits the ID on purpose, so it carries
+// the directive that suppresses the analyzer for that one literal.
+func TestDatePickerRollerRequiresID(t *testing.T) {
+	assertPanicsRequiringID(t, "DatePickerRoller", func() {
+		_ = DatePickerRoller(DatePickerRollerCfg{}) // requiredid:ignore
+	})
 }


### PR DESCRIPTION
Roller ignored keyboard and never held focus under a scoped parent: GenerateLayout never resolved its effective ID, so click-to-focus parked focus in the void. Now resolves cfg.ID with w.EffID, matching DatePicker/Combobox.

Wheel scrolled nothing: the handler hit-tested drums with shape-relative dispatch coordinates against absolute positions. Now translates back before hit-testing.

DatePickerRoller requires a non-empty Cfg.ID (RequireID + gui:"required" tag), matching the rest of the family.

Regression tests: TestDatePickerRollerScopedFocusAndKeys, TestDatePickerRollerMouseScroll, TestDatePickerRollerRequiresID. make prepush green.