### PR TITLE
fix(gui): shader-only transparent container emits RenderCustomShader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **Shader-only container with a transparent color now draws (#574)** — the
+  render early-out treated gradient, border gradient and shadow as paint but not
+  the custom shader, so a container whose only paint was `Shader` emitted no
+  command and the shader never ran. The shader now counts as paint, and a
+  `RenderCustomShader` command is emitted.
+
 ## [v0.74.0] - 2026-09-11
 
 ### Changed

--- a/gui/render_layout.go
+++ b/gui/render_layout.go
@@ -172,7 +172,8 @@ func renderShapeInner(shape *Shape, parentColor Color, clip drawClip, w *Window)
 	isSvg := shape.shapeType == shapeSVG
 	isCanvas := shape.shapeType == shapeDrawCanvas
 	hasFX := shape.fx != nil && (shape.fx.Gradient != nil ||
-		shape.fx.BorderGradient != nil || shape.fx.Shadow != nil)
+		shape.fx.BorderGradient != nil || shape.fx.Shadow != nil ||
+		shape.fx.Shader != nil)
 
 	isRTF := shape.shapeType == shapeRTF
 

--- a/gui/render_layout_test.go
+++ b/gui/render_layout_test.go
@@ -62,6 +62,51 @@ func TestRenderLayoutColorFilterNilFX(t *testing.T) {
 	}
 }
 
+// A transparent container with only a shader must still emit.
+// The early-out in renderShapeInner skips paintless shapes,
+// so the shader counts as paint (issue #574).
+func TestRenderLayoutShaderOnlyEmits(t *testing.T) {
+	w := makeWindow()
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		Color:     ColorTransparent,
+		Width:     50, Height: 50,
+		fx: &shapeEffects{Shader: &Shader{
+			Metal: "metal-body",
+			GLSL:  "glsl-body",
+		}},
+	}
+	layout := &Layout{Shape: shape}
+	clip := makeClip(0, 0, 100, 100)
+
+	renderLayout(layout, ColorTransparent, clip, w)
+
+	for _, r := range w.renderers {
+		if r.Kind == RenderCustomShader {
+			return
+		}
+	}
+	t.Error("missing RenderCustomShader for shader-only container")
+}
+
+// A transparent container with no paint must emit nothing.
+func TestRenderLayoutEmptyTransparentEmitsNothing(t *testing.T) {
+	w := makeWindow()
+	shape := &Shape{
+		shapeType: shapeRectangle,
+		Color:     ColorTransparent,
+		Width:     50, Height: 50,
+	}
+	layout := &Layout{Shape: shape}
+	clip := makeClip(0, 0, 100, 100)
+
+	renderLayout(layout, ColorTransparent, clip, w)
+
+	if len(w.renderers) != 0 {
+		t.Errorf("got %d commands, want 0", len(w.renderers))
+	}
+}
+
 func TestRenderLayoutOverDrawVertical(t *testing.T) {
 	w := makeWindow()
 	parentClip := makeClip(0, 0, 200, 300)

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -164,14 +164,14 @@ func (w *Window) InvalidateRender() {
 // Deprecated: use [Window.InvalidateLayout]. The old name promised synchronous
 // work this never did — it only sets a flag for the next frame.
 //
-//exportaudit:keep
+// exportaudit:keep — deprecated forwarder; siblings migrate on their own schedule
 func (w *Window) UpdateWindow() { w.InvalidateLayout() }
 
 // RequestRedraw marks the window for a render-only refresh.
 //
 // Deprecated: use [Window.InvalidateRender], which names what went stale.
 //
-//exportaudit:keep
+// exportaudit:keep — deprecated forwarder; siblings migrate on their own schedule
 func (w *Window) RequestRedraw() { w.InvalidateRender() }
 
 // SetView sets the view generator and triggers a full refresh.
@@ -191,7 +191,7 @@ func (w *Window) SetView(gen func(*Window) View) {
 // Deprecated: use [Window.SetView], which pairs with [Window.SetTheme] and
 // reads correctly at the dominant OnInit call site.
 //
-//exportaudit:keep
+// exportaudit:keep — deprecated forwarder; siblings migrate on their own schedule
 func (w *Window) UpdateView(gen func(*Window) View) { w.SetView(gen) }
 
 // FrameFn is called by the backend each frame. It flushes


### PR DESCRIPTION
Closes #574.

A container whose only paint is a custom shader, with transparent color and no border/text/children, emitted no render command — the shader never drew. `renderShapeInner` built its early-out from gradient, border gradient and shadow only; `fx.Shader` was missing, so the frame returned before `renderContainer` could emit `RenderCustomShader`.

- `gui/render_layout.go`: `Shader` counts as paint in `hasFX`. Scoped to `Shader` only: `ColorFilter` brackets emit earlier in `renderLayoutDepth`, and the SDF blur branch already requires `Color.A > 0`.
- `gui/render_layout_test.go`: shape-level regression tests — shader-only transparent emits `RenderCustomShader` (fails before fix), fully empty transparent emits nothing.
- `CHANGELOG.md`: `Fixed` entry under Unreleased.
- `gui/window_update.go`: the v0.74.0 deprecated forwarders carried bare `//exportaudit:keep` markers, which go/ast strips as directives — the gate never saw them (pre-existing red on main). Spaced form with reason, matching the other 100+ sites.

Local: `go test ./gui/` green, `make check` green, authoritative export-audit replicated locally against fresh sibling clones: surface clean.

Step 1 of #573.