### PR TITLE
fix(gui): native menu key equivalents for punctuation shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to
 
 ### Fixed
 
+- **Native menu key equivalents for punctuation shortcuts (#576)** — the
+  macOS menu encoder only passed A-Z/0-9 through to AppKit, so an item with
+  a punctuation chord (e.g. Cmd+/) showed no key hint. The 12 printable
+  punctuation keys now map to their key equivalents; anything else still
+  encodes to nothing. Only the displayed hint changes — the chord itself
+  always fired through the command registry.
+
 - **Shader-only container with a transparent color now draws (#574)** — the
   render early-out treated gradient, border gradient and shadow as paint but not
   the custom shader, so a container whose only paint was `Shader` emitted no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to
 
 ### Fixed
 
-- **Native menu key equivalents for punctuation shortcuts (#576)** — the
-  macOS menu encoder only passed A-Z/0-9 through to AppKit, so an item with
-  a punctuation chord (e.g. Cmd+/) showed no key hint. The 12 printable
-  punctuation keys now map to their key equivalents; anything else still
-  encodes to nothing. Only the displayed hint changes — the chord itself
-  always fired through the command registry.
+- **Native menu key equivalents for punctuation shortcuts (#576)** — the macOS
+  menu encoder only passed A-Z/0-9 through to AppKit, so an item with a
+  punctuation chord (e.g. Cmd+/) showed no key hint. The 12 printable
+  punctuation keys now map to their key equivalents; anything else still encodes
+  to nothing. Only the displayed hint changes — the chord itself always fired
+  through the command registry.
 
 - **Shader-only container with a transparent color now draws (#574)** — the
   render early-out treated gradient, border gradient and shadow as paint but not

--- a/gui/backend/nativemenu/menu_darwin.go
+++ b/gui/backend/nativemenu/menu_darwin.go
@@ -148,6 +148,34 @@ func encodeShortcut(s gui.Shortcut) (C.char, C.int) {
 		ch = byte('A' + (k - gui.KeyA))
 	case k >= gui.Key0 && k <= gui.Key9:
 		ch = byte('0' + (k - gui.Key0))
+	// Punctuation keys pass straight through: each is a valid AppKit key
+	// equivalent, and the ObjC side's lowercase fold is a no-op for them.
+	// Spelled out per key rather than by ASCII range — the KeyCode values
+	// only coincide with ASCII by convention (see event.go).
+	case k == gui.KeySpace:
+		ch = ' '
+	case k == gui.KeyApostrophe:
+		ch = '\''
+	case k == gui.KeyComma:
+		ch = ','
+	case k == gui.KeyMinus:
+		ch = '-'
+	case k == gui.KeyPeriod:
+		ch = '.'
+	case k == gui.KeySlash:
+		ch = '/'
+	case k == gui.KeySemicolon:
+		ch = ';'
+	case k == gui.KeyEqual:
+		ch = '='
+	case k == gui.KeyLeftBracket:
+		ch = '['
+	case k == gui.KeyBackslash:
+		ch = '\\'
+	case k == gui.KeyRightBracket:
+		ch = ']'
+	case k == gui.KeyGraveAccent:
+		ch = '`'
 	default:
 		return 0, 0
 	}

--- a/gui/backend/nativemenu/menu_darwin_test.go
+++ b/gui/backend/nativemenu/menu_darwin_test.go
@@ -1,0 +1,42 @@
+//go:build darwin && !ios
+
+package nativemenu
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+func TestEncodeShortcut(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		in    gui.Shortcut
+		wantC byte
+		wantM int
+	}{
+		{"letter", gui.Shortcut{Key: gui.KeyA, Modifiers: gui.ModSuper}, 'A', 1},
+		{"digit", gui.Shortcut{Key: gui.Key0, Modifiers: gui.ModSuper}, '0', 1},
+		{"slash", gui.Shortcut{Key: gui.KeySlash, Modifiers: gui.ModSuper}, '/', 1},
+		{"comma", gui.Shortcut{Key: gui.KeyComma, Modifiers: gui.ModSuper}, ',', 1},
+		{
+			"punctuation with shift",
+			gui.Shortcut{Key: gui.KeyEqual, Modifiers: gui.ModSuper | gui.ModShift},
+			'=', 3,
+		},
+		{"unset", gui.Shortcut{}, 0, 0},
+		{"escape unsupported", gui.Shortcut{Key: gui.KeyEscape}, 0, 0},
+		{"function key unsupported", gui.Shortcut{Key: gui.KeyF1}, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotC, gotM := encodeShortcut(tt.in)
+			if byte(gotC) != tt.wantC || int(gotM) != tt.wantM {
+				t.Errorf("encodeShortcut(%v) = (%q, %d), want (%q, %d)",
+					tt.in, byte(gotC), int(gotM), tt.wantC, tt.wantM)
+			}
+		})
+	}
+}

--- a/gui/backend/nativemenu/menu_darwin_test.go
+++ b/gui/backend/nativemenu/menu_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios
+//go:build darwin && cgo && !ios
 
 package nativemenu
 


### PR DESCRIPTION
The macOS native-menu encoder only passed A-Z/0-9 through to AppKit, so a menu item with a punctuation chord (e.g. Cmd+/) showed no key hint. encodeShortcut now maps the 12 printable punctuation keys to their key equivalents; anything else still encodes to nothing. The chord itself always worked through the command registry — this only affects the displayed hint.