### PR TITLE
fix(gui): wrapped text follows container HAlign (#577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to
 
 ### Fixed
 
+- **Wrapped text now follows its container's `HAlign` (#577)** — a `Text` with
+  `TextModeWrap` defaults to `FillFit`, because wrapping needs a width to wrap
+  to. Filling the axis left the container's alignment nothing to move, so a
+  centered column appeared to ignore its wrapped child. After the wrap pass the
+  box now shrinks back to its longest line when its column aligns it, and the
+  existing alignment code places it. Naming `Sizing` or `TextStyle.Align`
+  yourself opts out, and a left-aligned parent is unchanged. Text long enough to
+  fill every line has no slack to return: use `TextStyle.Align` to place the
+  lines inside the box. See `docs/specs/wrap-text-halign.md`.
+
 - **Native menu key equivalents for punctuation shortcuts (#576)** — the macOS
   menu encoder only passed A-Z/0-9 through to AppKit, so an item with a
   punctuation chord (e.g. Cmd+/) showed no key hint. The 12 printable

--- a/docs/dx-cheat-sheet.md
+++ b/docs/dx-cheat-sheet.md
@@ -237,6 +237,32 @@ within and keeps the single-row sum. That combination behaves as a `Row`, not a
 wrap. When the wrap must always fill its parent, use Fill width, which is what
 every example in this repo does.
 
+## Centering wrapped text
+
+Two different controls, and they are not interchangeable:
+
+- `ContainerCfg.HAlign` places the **box** across a column's cross axis.
+- `TextStyle.Align` places the **lines** inside that box.
+
+`TextModeWrap` defaults `Sizing` to `FillFit`, because wrapping needs a width to
+wrap to. After the wrap pass the box shrinks back to its longest line when its
+column aligns it, so `HAlign: HAlignCenter` centers a short wrapped label with
+no extra config (issue #577). Text long enough to fill every line has no slack
+to give back, so the box stays full width and only `TextStyle.Align` moves
+anything:
+
+```go
+gui.Text(gui.TextCfg{
+    Text:      "a long paragraph that fills every line it is given",
+    Mode:      gui.TextModeWrap,
+    TextStyle: gui.TextStyle{Align: gui.TextAlignCenter},
+})
+```
+
+Naming `Sizing` yourself opts out of the shrink: an explicit `Sizing: FillFit`
+is an instruction, so the box keeps the full width. Same for `TextStyle.Align`,
+where the lines are already placed against the wrap width.
+
 ## Canvas gradients
 
 A `DrawContext` fill takes a `*gui.CanvasGradient` in place of a flat `Color`:

--- a/docs/specs/wrap-text-halign.md
+++ b/docs/specs/wrap-text-halign.md
@@ -1,0 +1,90 @@
+# Spec: wrapped text and container alignment
+
+Status: **implemented** — issue #577. Landed on `main` in the same pass as the
+fix and the `docs/dx-cheat-sheet.md` entry.
+
+## Problem
+
+A `Text` with `Mode: TextModeWrap` in a column with `HAlign: HAlignCenter`
+rendered at the left edge, while a plain `Text` sibling centered.
+
+Nothing in the alignment code was wrong. `Text` defaults a wrap mode to
+`FillFit` (`gui/view_text.go`), because wrapping needs a width to wrap to. The
+fill pass then set that child to the parent's content width, so
+`childCrossAxisHAlign` (`gui/layout_position.go`) computed `remaining == 0` and
+had nothing to move. The alignment of the lines _inside_ the box is a separate
+control, `TextStyle.Align`, which nothing pointed the reader at.
+
+## Two models
+
+| Toolkit | Box alignment        | Line alignment              | Container alignment centers wrapped text |
+| ------- | -------------------- | --------------------------- | ---------------------------------------- |
+| SwiftUI | `VStack(alignment:)` | `.multilineTextAlignment()` | No                                       |
+| Flutter | `crossAxisAlignment` | `Text(textAlign:)`          | No                                       |
+| CSS     | `align-items`        | `text-align` (inherits)     | Yes                                      |
+
+Go-Gui keeps the SwiftUI and Flutter split. The report is reasonable because the
+CSS model is equally common, and the API said nothing about which applied.
+
+## Decision
+
+Keep the box/line split. Make the box honest: after the wrap pass, a wrapped
+text box shrinks to its longest line, so the existing `HAlign` code has slack to
+move it. `shrinkWrapToInk` (`gui/layout_pipeline.go`) does this, gated so that
+only the reported case changes:
+
+1. the parent is a column whose resolved `HAlign` is not left
+2. the mode is `TextModeWrap` or `TextModeWrapKeepSpaces`
+3. the Fill width came from the factory, not the caller (`wrapSizingDefault`)
+4. the shape is not Input's text (`overflowScrollX`)
+5. the shape is not a float, which its anchor places rather than the container
+   it was declared in
+6. `Sizing.Width` is not `sizingFixed`
+7. `TextStyle.Align` is `TextAlignLeft`
+8. the measured longest line is finite and narrower than the box
+
+Gate 1 keeps every left-aligned wrapped text byte-identical, which is nearly all
+of them, the library's own included. Gate 7 matters because glyph already
+centers the lines against the wrap width; moving the box as well would double
+the offset.
+
+A shrink under a scrolling parent also refreshes that parent's `contentW` cache,
+which the fill pass took a pass earlier. Only a `Scrollable` or `Clip` parent
+gets the refresh: every reader of the cache is a scroll one, and recomputing it
+for each wrapped child of a plain column would be quadratic in the child count
+for a number nothing reads.
+
+Shrinking cannot cause a re-wrap. The glyph layout is already shaped at the old
+width, and `layoutFillWidths` resets the box to the parent's content width
+before the wrap pass runs again, so the width handed to the shaper is the same
+every frame. `shrinkWrapToInk` also rewrites `tc.textLayoutWidth` to the new
+width, so the render pass reuses the shaped layout instead of shaping the same
+text a second time — the line breaks at the longest line are the same breaks,
+because every line already fits it and a word that did not fit the wider box
+does not fit this one.
+
+## Not covered
+
+Text long enough to fill every line has no slack to return, so the box stays
+full width and only `TextStyle.Align` moves anything. That is documented rather
+than fixed.
+
+RTF and markdown blocks (`layoutWrapRTF`) are untouched. They need no exclusion
+branch, because every markdown block names its `Sizing` explicitly and gate 3
+skips it. Shrinking would also be wrong there: an RTF block paints code
+backgrounds, horizontal rules, tables and list indents to `shape.Width`.
+
+## Rejected Approaches
+
+- **Inherit the container's `HAlign` into the text's line alignment** (the CSS
+  model). Rejected: `TextAlignLeft` is the zero value of `TextAlignment`, so an
+  explicit left is indistinguishable from unset, and there is no way to respect
+  a caller who asked for left under a centered parent. It would also re-lay out
+  every wrapped text under a centered or right-aligned container across every
+  consumer, including the library's own widgets.
+- **Documentation only**, closing the issue as by design. Rejected: the surprise
+  comes from `Mode` silently changing `Sizing`, which is a second effect of a
+  field whose name says nothing about it. Docs alone leave the trap in place.
+- **A `gui.Debug` finding** for wrap text under a non-left `HAlign` parent with
+  no `TextStyle.Align`. Deferred, not rejected: it adds an exported
+  `DebugCategory`, which is its own design pass.

--- a/gui/layout_pipeline.go
+++ b/gui/layout_pipeline.go
@@ -218,7 +218,24 @@ func layoutWrapTextWalkDepth(layout *Layout, w *Window, depth int) {
 		if !plainTextNeedsGlyphLayout(shape, tc, style) {
 			return
 		}
-		layoutPlainText(shape, tc, style, w)
+		if layoutPlainText(
+			shape, tc, style, wrapParentHAlign(layout), w,
+		) {
+			// The box gave width back, so the parent's contentW cache
+			// — taken in the fill pass, before the glyph layout existed
+			// — is now too wide. Every reader of that cache is a scroll
+			// one (the clamp in layoutAdjustScrollOffsets, the
+			// scrollbar thumb), so only a viewport needs the refresh;
+			// recomputing for every wrapped child of a plain column
+			// would be quadratic in the child count for a number
+			// nothing reads. Only the immediate parent changes: every
+			// ancestor above it reads the parent's Width, which the
+			// shrink leaves alone.
+			if p := layout.Parent; p != nil && p.Shape != nil &&
+				(p.Shape.Scrollable || p.Shape.Clip) {
+				p.Shape.contentW = computeContentWidth(p)
+			}
+		}
 		if shape.inkOverflowW > 0 {
 			propagateInkOverflow(layout)
 		}
@@ -363,16 +380,36 @@ func layoutWrapRTF(shape *Shape, tc *shapeTextConfig, w *Window) {
 	})
 }
 
+// wrapParentHAlign reports the physical alignment the parent would give
+// this child across a column's cross axis, or HAlignLeft when there is
+// none to inherit.
+//
+// Only a column (axisTopToBottom) answers. In a row HAlign is the main
+// axis: it places the children as a group, so narrowing one of them
+// there would open a gap rather than move the text.
+func wrapParentHAlign(layout *Layout) HorizontalAlign {
+	parent := layout.Parent
+	if parent == nil || parent.Shape == nil ||
+		parent.Shape.Axis != axisTopToBottom {
+		return HAlignLeft
+	}
+	isRTL := effectiveTextDir(parent.Shape) == TextDirRTL
+	return resolveHAlign(parent.Shape.HAlign, isRTL)
+}
+
 // layoutPlainText computes final text dimensions after sizing.
 // Mirrors the initial estimate in view_text.go:GenerateLayout.
+// It reports whether shrinkWrapToInk narrowed the box, which the
+// caller needs so the parent's content-width cache can follow.
 func layoutPlainText(
 	shape *Shape,
 	tc *shapeTextConfig,
 	style TextStyle,
+	parentHAlign HorizontalAlign,
 	w *Window,
-) {
+) bool {
 	if len(tc.Text) == 0 {
-		return
+		return false
 	}
 	if w.textMeasurer == nil {
 		// Headless: approximate rather than leave the single-line
@@ -383,20 +420,21 @@ func layoutPlainText(
 		if h := plainTextHeightNoMeasurer(shape, tc, style, w); h > shape.Height {
 			shape.Height = h
 		}
-		return
+		return false
 	}
 	if tc.TextStyle == nil {
-		return
+		return false
 	}
 	l, ok := plainTextLayoutResolved(tc.Text, shape, style, w)
 	if !ok {
-		return
+		return false
 	}
 	shape.Height = plainTextBoxHeight(l, style, w)
 	if tc.TextMode == TextModeMultiline &&
 		shape.Sizing.Width != sizingFixed && l.Width > 0 {
 		shape.Width = l.Width
 	}
+	shrank := shrinkWrapToInk(shape, tc, style, l, parentHAlign)
 	// A wrapped run with no break opportunity is wider than the width it
 	// was wrapped to. Record the excess rather than growing the shape:
 	// the shape's width IS the wrap width, so growing it would re-wrap
@@ -413,4 +451,69 @@ func layoutPlainText(
 		// overflowScrollX, so no other shape pays for the caret.
 		shape.inkOverflowW = l.Width + inputCaretW
 	}
+	return shrank
+}
+
+// shrinkWrapToInk pulls a wrapped text box back to its longest line so
+// its container's HAlign has somewhere to move it (#577).
+//
+// A wrap box fills the axis because wrapping needs a width to wrap to.
+// That leaves childCrossAxisHAlign with remaining == 0, so a centered
+// column looks like it ignores its wrapped child. Shrinking the box to
+// the ink it actually holds gives the existing alignment code its slack
+// back, and the lines inside the box do not move: they are laid out
+// from the box's left edge, and no line is wider than the longest one.
+//
+// Re-wrapping cannot follow from this. The layout l is already shaped at
+// the old width, and next frame layoutFillWidths resets the box to the
+// parent's content width before this pass runs again, so the width fed
+// to the shaper is the same every frame.
+func shrinkWrapToInk(
+	shape *Shape,
+	tc *shapeTextConfig,
+	style TextStyle,
+	l glyph.Layout,
+	parentHAlign HorizontalAlign,
+) bool {
+	switch {
+	case parentHAlign == HAlignLeft:
+		// Nothing to move it to. Leaving the box full width keeps a
+		// background, border or hit box at the extent it has always
+		// had, which is every wrapped text that did not ask for this.
+		return false
+	case tc.TextMode != TextModeWrap &&
+		tc.TextMode != TextModeWrapKeepSpaces:
+		return false
+	case !tc.wrapSizingDefault:
+		// The caller named the Sizing. That is an instruction.
+		return false
+	case tc.overflowScrollX:
+		// Input's text shape: its width is the viewport the caret
+		// scrolls within, not a measurement of the text.
+		return false
+	case shape.Float:
+		// A float is placed by its anchor, not by the alignment of the
+		// container it was declared in, and layoutRemoveFloatingLayouts
+		// leaves Parent pointing at that container. Its HAlign says
+		// nothing about where this box goes.
+		return false
+	case shape.Sizing.Width == sizingFixed:
+		return false
+	case style.Align != TextAlignLeft:
+		// glyph centred the lines against the wrap width already.
+		// Moving the box now would double the offset.
+		return false
+	case !f32IsFinite(l.Width) || l.Width <= 0 ||
+		l.Width >= shape.Width-f32Tolerance:
+		return false
+	}
+	shape.Width = l.Width
+	// Keep the shaped layout current for the new width. The cache key is
+	// the width handed to the shaper, and re-wrapping at the longest line
+	// yields the same breaks — every line already fits it, and a word
+	// that did not fit the wider box does not fit this one — so the
+	// render pass can reuse what this pass shaped instead of shaping the
+	// same text a second time.
+	tc.textLayoutWidth = shape.Width
+	return true
 }

--- a/gui/layout_pipeline_test.go
+++ b/gui/layout_pipeline_test.go
@@ -460,9 +460,11 @@ func (m *stubTextMeasurer) LayoutText(text string, _ TextStyle, wrapWidth float3
 	if wrapWidth <= 0 || len(text) == 0 {
 		return glyph.Layout{Height: m.fontHeight}, nil
 	}
-	// Simulate word wrapping using charWidth.
+	// Simulate word wrapping using charWidth. maxW tracks the widest
+	// line, which is what glyph reports as Layout.Width — the shrink in
+	// layoutPlainText reads it, so the stub has to supply it.
 	lines := 1
-	var lineW float32
+	var lineW, maxW float32
 	start := 0
 	for i := 0; i <= len(text); i++ {
 		if i < len(text) && text[i] != ' ' && text[i] != '\n' {
@@ -471,12 +473,14 @@ func (m *stubTextMeasurer) LayoutText(text string, _ TextStyle, wrapWidth float3
 		wordW := float32(i-start) * m.charWidth
 		if lineW > 0 && lineW+wordW > wrapWidth {
 			lines++
+			maxW = max(maxW, lineW)
 			lineW = wordW
 		} else {
 			lineW += wordW
 		}
 		if i < len(text) && text[i] == '\n' {
 			lines++
+			maxW = max(maxW, lineW)
 			lineW = 0
 		} else if i < len(text) {
 			if lineW > 0 {
@@ -485,7 +489,11 @@ func (m *stubTextMeasurer) LayoutText(text string, _ TextStyle, wrapWidth float3
 		}
 		start = i + 1
 	}
-	return glyph.Layout{Height: float32(lines) * m.fontHeight}, nil
+	maxW = max(maxW, lineW)
+	return glyph.Layout{
+		Width:  maxW,
+		Height: float32(lines) * m.fontHeight,
+	}, nil
 }
 
 func TestLayoutWrapPlainText(t *testing.T) {
@@ -838,5 +846,293 @@ func TestLayoutWrapRTF_RtfFlatText_NotOverwrittenOnCacheHit(t *testing.T) {
 	if shape.TC.rTFFlatText != "already-set" {
 		t.Errorf("RTFFlatText overwritten on cache hit, got %q",
 			shape.TC.rTFFlatText)
+	}
+}
+
+// wrapHAlignLayout builds a fixed-size column with the given HAlign and
+// one wrapped Text child, runs the whole pipeline, and hands back the
+// text shape. The views are built through the factories on purpose:
+// only Text knows whether the caller chose the Fill sizing or the wrap
+// mode defaulted it, and the shrink in layoutPlainText reads that. #577
+func wrapHAlignLayout(
+	t *testing.T, hAlign HorizontalAlign, cfg TextCfg,
+) (*Shape, *Shape) {
+	t.Helper()
+	w := &Window{}
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	w.windowWidth = 400
+	w.windowHeight = 300
+
+	// No padding and no border: the assertions below compare against
+	// the column's own width, so the content box has to be the column.
+	col := generateViewLayout(Column(ContainerCfg{
+		Sizing:     FixedFixed,
+		Width:      400,
+		Height:     300,
+		HAlign:     hAlign,
+		Padding:    PaddingNone,
+		SizeBorder: NoBorder,
+		Content:    []View{Text(cfg)},
+	}), w)
+	col.Shape.MinWidth, col.Shape.MaxWidth = 400, 400
+	col.Shape.MinHeight, col.Shape.MaxHeight = 300, 300
+	layoutParents(&col, nil)
+	layoutPipeline(&col, w)
+
+	if len(col.Children) != 1 {
+		t.Fatalf("column children = %d, want 1", len(col.Children))
+	}
+	return col.Shape, col.Children[0].Shape
+}
+
+// A short wrapped text in a centered column ends up centered: the box
+// shrinks to its longest line, so HAlign has room to move it. #577
+func TestWrapTextCentersInCenteredColumn(t *testing.T) {
+	col, text := wrapHAlignLayout(t, HAlignCenter, TextCfg{
+		Text:      "wrap me",
+		TextStyle: TextStyle{Size: 16},
+		Mode:      TextModeWrap,
+	})
+
+	if text.Width >= col.Width {
+		t.Errorf("text width = %.1f, want < column width %.1f "+
+			"(box did not shrink to its longest line)",
+			text.Width, col.Width)
+	}
+	wantX := (col.Width - text.Width) / 2
+	if abs32(text.X-wantX) > 1 {
+		t.Errorf("text X = %.1f, want ~%.1f", text.X, wantX)
+	}
+}
+
+// HAlignRight pushes the shrunken box to the right edge. #577
+func TestWrapTextRightAlignsInRightAlignedColumn(t *testing.T) {
+	col, text := wrapHAlignLayout(t, HAlignRight, TextCfg{
+		Text:      "wrap me",
+		TextStyle: TextStyle{Size: 16},
+		Mode:      TextModeWrap,
+	})
+
+	wantX := col.Width - text.Width
+	if abs32(text.X-wantX) > 1 {
+		t.Errorf("text X = %.1f, want ~%.1f", text.X, wantX)
+	}
+}
+
+// The common case is untouched: a left-aligned column leaves the
+// wrapped box spanning the full content width, so a background or a
+// border behind it keeps the extent it has always had. #577
+func TestWrapTextKeepsFullWidthWhenLeftAligned(t *testing.T) {
+	col, text := wrapHAlignLayout(t, HAlignLeft, TextCfg{
+		Text:      "wrap me",
+		TextStyle: TextStyle{Size: 16},
+		Mode:      TextModeWrap,
+	})
+
+	if abs32(text.Width-col.Width) > 1 {
+		t.Errorf("text width = %.1f, want ~%.1f (full width)",
+			text.Width, col.Width)
+	}
+	if abs32(text.X) > 1 {
+		t.Errorf("text X = %.1f, want ~0", text.X)
+	}
+}
+
+// An explicit Sizing from the caller is an instruction, not a default:
+// a caller who asked for FillFit keeps the full-width box. #577
+func TestWrapTextExplicitFillKeepsFullWidth(t *testing.T) {
+	col, text := wrapHAlignLayout(t, HAlignCenter, TextCfg{
+		Text:      "wrap me",
+		TextStyle: TextStyle{Size: 16},
+		Mode:      TextModeWrap,
+		Sizing:    FillFit,
+	})
+
+	if abs32(text.Width-col.Width) > 1 {
+		t.Errorf("text width = %.1f, want ~%.1f (explicit FillFit)",
+			text.Width, col.Width)
+	}
+}
+
+// TextStyle.Align already centers the lines inside the full-width box.
+// Shrinking there would move the box away from the offsets glyph
+// computed against the wrap width, so that case opts out. #577
+func TestWrapTextWithTextAlignKeepsFullWidth(t *testing.T) {
+	col, text := wrapHAlignLayout(t, HAlignCenter, TextCfg{
+		Text:      "wrap me",
+		TextStyle: TextStyle{Size: 16, Align: TextAlignCenter},
+		Mode:      TextModeWrap,
+	})
+
+	if abs32(text.Width-col.Width) > 1 {
+		t.Errorf("text width = %.1f, want ~%.1f (TextStyle.Align set)",
+			text.Width, col.Width)
+	}
+}
+
+// Text long enough to fill every line has no slack to give back, so the
+// box stays full width and nothing moves. #577
+func TestWrapTextLongTextStaysFullWidth(t *testing.T) {
+	long := "wrapping text that is long enough to fill every single " +
+		"line of the box it is given and then some more words"
+	col, text := wrapHAlignLayout(t, HAlignCenter, TextCfg{
+		Text:      long,
+		TextStyle: TextStyle{Size: 16},
+		Mode:      TextModeWrap,
+	})
+
+	if text.Width > col.Width+1 {
+		t.Errorf("text width = %.1f, want <= %.1f",
+			text.Width, col.Width)
+	}
+	if text.Height <= 20 {
+		t.Errorf("text height = %.1f, want > 20 (wrapped)",
+			text.Height)
+	}
+}
+
+// HAlign on a row is the main axis: it places the children as a group,
+// so narrowing one of them would open a gap rather than move the text.
+// A row parent therefore leaves the wrapped box alone. #577
+func TestWrapTextInRowKeepsFullWidth(t *testing.T) {
+	w := &Window{}
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	w.windowWidth = 400
+	w.windowHeight = 300
+
+	row := generateViewLayout(Row(ContainerCfg{
+		Sizing:     FixedFixed,
+		Width:      400,
+		Height:     300,
+		HAlign:     HAlignCenter,
+		Padding:    PaddingNone,
+		SizeBorder: NoBorder,
+		Content: []View{Text(TextCfg{
+			Text:      "wrap me",
+			TextStyle: TextStyle{Size: 16},
+			Mode:      TextModeWrap,
+		})},
+	}), w)
+	row.Shape.MinWidth, row.Shape.MaxWidth = 400, 400
+	row.Shape.MinHeight, row.Shape.MaxHeight = 300, 300
+	layoutParents(&row, nil)
+	layoutPipeline(&row, w)
+
+	text := row.Children[0].Shape
+	if abs32(text.Width-row.Shape.Width) > 1 {
+		t.Errorf("text width = %.1f, want ~%.1f (row parent)",
+			text.Width, row.Shape.Width)
+	}
+}
+
+// A float is placed by its anchor, not by the alignment of the
+// container it was declared in, so it keeps its box. #577
+func TestShrinkWrapToInkSkipsFloat(t *testing.T) {
+	tc := &shapeTextConfig{
+		Text:              "wrap me",
+		TextMode:          TextModeWrap,
+		wrapSizingDefault: true,
+	}
+	shape := &Shape{Width: 400, Sizing: FillFit, TC: tc, Float: true}
+	l := glyph.Layout{Width: 70, Height: 20}
+
+	if shrinkWrapToInk(shape, tc, TextStyle{}, l, HAlignCenter) {
+		t.Fatal("shrinkWrapToInk shrank a float box")
+	}
+	if shape.Width != 400 {
+		t.Errorf("width = %.1f, want 400", shape.Width)
+	}
+
+	// Same shape, not floating: the shrink applies.
+	shape.Float = false
+	if !shrinkWrapToInk(shape, tc, TextStyle{}, l, HAlignCenter) {
+		t.Fatal("shrinkWrapToInk skipped a non-float box")
+	}
+	if shape.Width != 70 {
+		t.Errorf("width = %.1f, want 70", shape.Width)
+	}
+}
+
+// Input's text shape is a scroll viewport the caret moves within, not
+// a measurement of the text, so it never shrinks even when every other
+// gate would allow it. #577
+func TestShrinkWrapToInkSkipsOverflowScrollX(t *testing.T) {
+	tc := &shapeTextConfig{
+		Text:              "wrap me",
+		TextMode:          TextModeWrap,
+		wrapSizingDefault: true,
+		overflowScrollX:   true,
+	}
+	shape := &Shape{Width: 400, Sizing: FillFit, TC: tc}
+	l := glyph.Layout{Width: 70, Height: 20}
+
+	if shrinkWrapToInk(shape, tc, TextStyle{}, l, HAlignCenter) {
+		t.Fatal("shrinkWrapToInk shrank an overflowScrollX box")
+	}
+	if shape.Width != 400 {
+		t.Errorf("width = %.1f, want 400", shape.Width)
+	}
+}
+
+// TextModeWrapKeepSpaces takes the same shrink path as TextModeWrap:
+// a short kept-spaces text in a centered column ends up centered. #577
+func TestWrapTextWrapKeepSpacesCentersInCenteredColumn(t *testing.T) {
+	col, text := wrapHAlignLayout(t, HAlignCenter, TextCfg{
+		Text:      "wrap me",
+		TextStyle: TextStyle{Size: 16},
+		Mode:      TextModeWrapKeepSpaces,
+	})
+
+	if text.Width >= col.Width {
+		t.Errorf("text width = %.1f, want < column width %.1f "+
+			"(box did not shrink to its longest line)",
+			text.Width, col.Width)
+	}
+	wantX := (col.Width - text.Width) / 2
+	if abs32(text.X-wantX) > 1 {
+		t.Errorf("text X = %.1f, want ~%.1f", text.X, wantX)
+	}
+}
+
+// A shrink under a scrolling parent refreshes that parent's contentW
+// cache, which the fill pass took before the glyph layout existed.
+// Without the refresh the scroll clamp and scrollbar thumb read the
+// stale full width. #577
+func TestWrapTextShrinkRefreshesScrollableContentW(t *testing.T) {
+	w := &Window{}
+	w.textMeasurer = &stubTextMeasurer{charWidth: 10, fontHeight: 20}
+	w.windowWidth = 400
+	w.windowHeight = 300
+
+	col := generateViewLayout(Column(ContainerCfg{
+		ID:         "wrap-scroll",
+		Sizing:     FixedFixed,
+		Width:      400,
+		Height:     300,
+		HAlign:     HAlignCenter,
+		Padding:    PaddingNone,
+		SizeBorder: NoBorder,
+		Scrollable: true,
+		Content: []View{Text(TextCfg{
+			Text:      "wrap me",
+			TextStyle: TextStyle{Size: 16},
+			Mode:      TextModeWrap,
+		})},
+	}), w)
+	col.Shape.MinWidth, col.Shape.MaxWidth = 400, 400
+	col.Shape.MinHeight, col.Shape.MaxHeight = 300, 300
+	layoutParents(&col, nil)
+	layoutPipeline(&col, w)
+
+	// The scrollbars append after the content, so the text is first.
+	text := col.Children[0].Shape
+	if text.Width >= col.Shape.Width {
+		t.Fatalf("text width = %.1f, want < column width %.1f "+
+			"(box did not shrink to its longest line)",
+			text.Width, col.Shape.Width)
+	}
+	if abs32(col.Shape.contentW-text.Width) > 1 {
+		t.Errorf("contentW = %.1f, want ~%.1f (stale cache)",
+			col.Shape.contentW, text.Width)
 	}
 }

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -427,6 +427,10 @@ type shapeTextConfig struct {
 	// container can reach it. Only Input's text shape sets it, which
 	// keeps the content-width change off every other wrapped text.
 	overflowScrollX bool
+	// wrapSizingDefault marks a wrap box whose Fill width came from the
+	// Text factory rather than the caller, so layoutPlainText may shrink
+	// it back to its longest line under an aligning parent (#577).
+	wrapSizingDefault bool
 }
 
 // hasRtfLayout returns true if the shape has an RTF layout.
@@ -441,6 +445,10 @@ type textMode uint8
 const (
 	TextModeSingleLine textMode = iota
 	TextModeMultiline
+	// TextModeWrap wraps at word boundaries. It defaults Sizing to
+	// FillFit, because wrapping needs a width to wrap to; the box then
+	// shrinks back to its longest line when its container aligns it.
+	// The lines inside the box are placed by TextStyle.Align.
 	TextModeWrap
 	TextModeWrapKeepSpaces
 )

--- a/gui/view_container.go
+++ b/gui/view_container.go
@@ -132,7 +132,12 @@ type ContainerCfg struct {
 	ColorBorder Color
 
 	// Sizing
-	Sizing   Sizing
+	Sizing Sizing
+
+	// HAlign places the child boxes, not the text inside them. A child
+	// that fills the axis has nowhere to move, so alignment does
+	// nothing to it. To align the lines within a text box, set
+	// TextStyle.Align.
 	HAlign   HorizontalAlign // ergonomics-audit:opt-plain — zero (HAlignStart) is the natural default; no distinct unset behavior
 	VAlign   verticalAlign   // ergonomics-audit:opt-plain — zero (VAlignTop) is the natural default; no distinct unset behavior
 	TextDir  textDirection

--- a/gui/view_text.go
+++ b/gui/view_text.go
@@ -22,6 +22,10 @@ type TextCfg struct {
 
 	// Mode controls text wrapping and overflow behavior. See
 	// TextMode constants.
+	//
+	// A wrap mode also defaults Sizing to FillFit, because wrapping
+	// needs a width to wrap to. Sizing places the box; the alignment
+	// of the lines inside it is TextStyle.Align.
 	Mode textMode
 
 	Invisible  bool
@@ -33,6 +37,12 @@ type TextCfg struct {
 	// PlaceholderActive enables placeholder styling (dimmed).
 	// Set by input widgets; not typically set directly.
 	placeholderActive bool
+
+	// wrapSizingDefault records that Text, not the caller, chose the
+	// Fill width for a wrap mode. Only such a box shrinks back to its
+	// longest line under an aligning parent (#577): an explicit
+	// Sizing from the caller is an instruction, not a default.
+	wrapSizingDefault bool
 
 	// Hero marks this text element for hero transition
 	// animations between views.
@@ -116,6 +126,7 @@ func (tv *textView) GenerateLayout(w *Window) Layout {
 		TextTabSize:       c.TabSize,
 		textReadOnly:      c.readOnly,
 		overflowScrollX:   c.scrollOverflowX,
+		wrapSizingDefault: c.wrapSizingDefault,
 	}
 
 	layout := Layout{
@@ -203,7 +214,12 @@ func Text(cfg TextCfg) View {
 	if !sizing.IsSet() {
 		if cfg.Mode == TextModeWrap ||
 			cfg.Mode == TextModeWrapKeepSpaces {
+			// Wrapping needs a width to wrap to, so the box fills the
+			// axis. layoutPlainText pulls it back to the longest line
+			// afterwards when an aligning parent has somewhere to put
+			// it — see wrapSizingDefault (#577).
 			sizing = FillFit
+			cfg.wrapSizingDefault = true
 		} else {
 			sizing = FitFit
 		}


### PR DESCRIPTION
## Summary

A `Text` with a wrap `Mode` defaults `Sizing` to `FillFit`, because
wrapping needs a width to wrap to. That left `childCrossAxisHAlign`
with nothing to move: the box already spanned the container's content
width, so a centered or right-aligned column looked like it ignored
its wrapped child, while a plain (non-wrapping) `Text` sibling
centered normally.

## Fix

`shrinkWrapToInk` (`gui/layout_pipeline.go`) pulls the wrapped box
back to its measured longest line after the wrap pass, so the existing
`HAlign` code has slack to move it. Gated to change only the reported
case:

1. parent is a column with a resolved `HAlign` other than left
2. mode is `TextModeWrap` / `TextModeWrapKeepSpaces`
3. the `Fill` sizing came from the factory default, not an explicit
   caller `Sizing`
4. not Input's text shape (`overflowScrollX`)
5. not a float (placed by its anchor, not the container's alignment)
6. `Sizing.Width` isn't fixed
7. `TextStyle.Align` is left (glyph already centers/right-aligns lines
   otherwise — moving the box too would double the offset)
8. the measured longest line is finite and narrower than the box

Left-aligned wrapped text — the overwhelming majority, library
internals included — stays byte-identical. RTF/markdown blocks are
untouched (they always name `Sizing` explicitly, so gate 3 already
skips them, and shrinking there would cut backgrounds/rules short).

## Docs

- `TextCfg.Mode`, `ContainerCfg.HAlign`: documented at the two places a
  reader meets the box/line split.
- `docs/dx-cheat-sheet.md`: worked example — `TextStyle.Align` moves
  the lines, `HAlign` moves the box.
- `docs/specs/wrap-text-halign.md`: the decision, the SwiftUI /
  Flutter / CSS comparison, and rejected approaches (CSS-style
  inherit, docs-only, a `gui.Debug` finding deferred as its own design
  pass).
- `CHANGELOG.md` under `## [Unreleased]` → `### Fixed`.

## Tests

`gui/layout_pipeline_test.go`: centered/right/left column cases,
explicit `Sizing` opt-out, `TextStyle.Align` opt-out, long text with no
slack to give back, row parent (HAlign is the main axis there) leaves
the box alone, and a direct unit test of the float gate.

Fixes #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)