### PR TITLE
feat(gui): per-field date format for InputDate (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ and this project adheres to
   format drives all four places the field uses one: the text it shows, the input
   mask, the placeholder hint, and the parse of what the user types. Unset keeps
   the locale's short date, so existing fields are unchanged. A month-name token
-  (`MMM`, `MMMM`) panics at construction, because the field masks digits and a
-  text month could be shown but never typed back. To change every field at once,
-  set the locale instead: `SetLocaleID("de-DE")` already carries `D.M.YYYY`.
+  (`MMM`, `MMMM`), a 2-digit year (`YY`) and time tokens (`HH`, `mm`, `ss`)
+  panic at construction, because the field masks digits and the parse only reads
+  `YYYY`, `MM`, `M`, `DD`, `D`: anything else could be shown but never typed
+  back. To change every field at once, set the locale instead:
+  `SetLocaleID("de-DE")` already carries `D.M.YYYY`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **`InputDateCfg.DateFormat` sets the date format per field (#578)** — the date
+  input read its format from one process-global value, the active locale's short
+  date, so a caller who wanted `24.12.2026` had to change the locale for every
+  date widget in the app. `DateFormat` now spells it on the field, in the same
+  token language the locale bundles use: `YYYY`, `MM`, `M`, `DD`, `D` and
+  literal separators — `"DD.MM.YYYY"`, `"DD/MM/YYYY"`, `"YYYY-MM-DD"`. The
+  format drives all four places the field uses one: the text it shows, the input
+  mask, the placeholder hint, and the parse of what the user types. Unset keeps
+  the locale's short date, so existing fields are unchanged. A month-name token
+  (`MMM`, `MMMM`) panics at construction, because the field masks digits and a
+  text month could be shown but never typed back. To change every field at once,
+  set the locale instead: `SetLocaleID("de-DE")` already carries `D.M.YYYY`.
+
 ### Fixed
 
 - **Wrapped text now follows its container's `HAlign` (#577)** — a `Text` with

--- a/docs/specs/input-date-format.md
+++ b/docs/specs/input-date-format.md
@@ -1,0 +1,86 @@
+# Spec: per-field date format for InputDate
+
+Status: **implemented** — issue #578. Landed on `main` with the tests, the
+golden case, the showcase demo and the `CHANGELOG.md` entry.
+
+## Problem
+
+`InputDate` read its date format from one process-global value,
+`ActiveLocale.Date.ShortDate` (`gui/locale.go`), which is `"M/D/YYYY"` for
+en-US. The format drives four things in the field: the text it shows, the input
+mask, the placeholder hint, and the parse of what the user types.
+
+A caller who wanted `24.12.2026` had two bad options. Change the locale, which
+changes every date widget in the process. Or write to `Locale.Date.ShortDate`
+through `CurrentLocale()` and `SetLocale`, an undocumented round trip through an
+unexported struct type. Neither lets two fields in one form differ.
+
+## Candidates
+
+| Design                                       | Exported surface         | Failure when misused                                   |
+| -------------------------------------------- | ------------------------ | ------------------------------------------------------ |
+| **A. `InputDateCfg.DateFormat string`**      | 1 struct field           | Bad token string, caught by a panic at construction    |
+| B. App-wide `SetDateFormat(string)`          | 1 func plus a new global | Silent: two libraries write the same global            |
+| C. Named constants (`DateFormatDMYDot`, ...) | Type plus N constants    | Closed set: a format not in the list cannot be spelled |
+
+## Decision: A
+
+The smallest surface. It reuses the formatter that was already there
+(`LocaleFormatDate`, `localeDatePadFormat`, `localeDateMaskPattern`,
+`localeParseDate`, all in `gui/locale_format.go`), so there is no second format
+path to keep in step. Two date fields in one form can differ, which a global
+cannot express. The locale stays the default, so an app that wants an app-wide
+change still sets the locale.
+
+## Shape
+
+`InputDateCfg.DateFormat` takes the token language the locale bundles already
+use: `YYYY`, `MM`, `M`, `DD`, `D` and literal separators.
+
+`inputDateFormat` (`gui/view_input_date.go`) is the one resolve point. It pads
+`M` to `MM` and `D` to `DD`, and falls back to the locale when the field is
+empty. `GenerateLayout` calls it once per frame and threads the result to the
+display text, the mask, the placeholder and the parse. Re-deriving the format at
+each site is how the four drift apart, so none of them reads the locale directly
+any more.
+
+`requireDateFormat` panics from the `InputDate` factory on a format the field
+cannot honour: a month-name token (`MMM`, `MMMM`), or a format with no `YYYY`,
+`MM` or `DD`. This matches the `RequireID` precedent in `gui/state_registry.go`.
+
+The `opticalDigitCenter: true` assumption stays true because of that check.
+`docs/specs/text-optical-centring.md` records that the date field centres on its
+ink because the mask admits digits and separators only.
+
+## Rejected Approaches
+
+- **An app-wide `SetDateFormat`.** The locale layer already is the app-wide
+  seam: `(*Window).SetLocale`, `SetLocaleID`, and the `gui/locales/*.json`
+  bundles, which carry `de-DE` as `D.M.YYYY` today. A second global would be a
+  parallel source of truth for the same value.
+- **Named format constants.** The token language is open. An enum closes it, and
+  every new order or separator then needs a release.
+- **Go reference layouts (`"02.01.2006"`).** This would disagree with the
+  `short_date` spelling in the locale bundles and need a second pad and mask
+  path for the same result.
+- **The same field on `DatePickerCfg` or the roller.** The picker header shows a
+  month and a year (`ActiveLocale.Date.MonthYear`), not a short date. The roller
+  already sets its order with `DisplayMode` and `LongMonths`. Neither is what
+  the issue asks for.
+- **A silent fallback to the locale on a bad format.** A format the mask cannot
+  express gives a field that looks correct and refuses every keystroke. The
+  failure must be at construction, where the cause is visible.
+
+## Tests
+
+`gui/view_input_date_test.go` pins the unset fallback, the display text, the
+placeholder, the mask, and both panics. `TestInputDateFormatParsesCommit` drives
+an Enter commit through the inner `Input` and asserts that `"24.12.2026"`
+reaches `OnSelect` as 24 December: under the locale's `MM/DD/YYYY` the same text
+fails to parse and `OnSelect` never fires.
+
+`gui/locale_format_test.go` gains `TestLocaleParseDate`. That function is the
+only parse in the date path and had no test before this change.
+
+The golden case `input_date_format` pairs with `input_date`. Only the date text
+differs between the two recordings; no geometry moves.

--- a/docs/specs/input-date-format.md
+++ b/docs/specs/input-date-format.md
@@ -45,8 +45,11 @@ each site is how the four drift apart, so none of them reads the locale directly
 any more.
 
 `requireDateFormat` panics from the `InputDate` factory on a format the field
-cannot honour: a month-name token (`MMM`, `MMMM`), or a format with no `YYYY`,
-`MM` or `DD`. This matches the `RequireID` precedent in `gui/state_registry.go`.
+cannot honour: a month-name token (`MMM`, `MMMM`), a 2-digit year (`YY` without
+`YYYY`), a time token (`HH`, `mm`, `ss` — the display path substitutes them but
+`localeParseDate` leaves them as literals, so a commit can never round-trip), or
+a format with no `YYYY`, `MM` or `DD`. This matches the `RequireID` precedent in
+`gui/state_registry.go`.
 
 The `opticalDigitCenter: true` assumption stays true because of that check.
 `docs/specs/text-optical-centring.md` records that the date field centres on its

--- a/examples/showcase/demo_input.go
+++ b/examples/showcase/demo_input.go
@@ -397,6 +397,22 @@ func demoInputDate(w *gui.Window) gui.View {
 				Text:      "Selected: " + gui.LocaleFormatDate(app.InputDate, gui.CurrentLocale().Date.ShortDate),
 				TextStyle: gui.CurrentTheme().N3,
 			}),
+			// The same date through a field-level DateFormat. The
+			// format drives the text, the mask, the placeholder and
+			// the parse, so this field types day-first (issue #578).
+			gui.InputDate(gui.InputDateCfg{
+				ID:         "input-date-fmt",
+				Label:      "DateFormat: \"DD.MM.YYYY\"",
+				Date:       app.InputDate,
+				DateFormat: "DD.MM.YYYY",
+				Sizing:     gui.FillFit,
+				OnSelect: func(dates []time.Time, ctx gui.EventCtx) {
+					if len(dates) == 0 {
+						return
+					}
+					appState(ctx.Window).InputDate = dates[0]
+				},
+			}),
 		},
 	})
 }

--- a/examples/showcase/docs/widget_input_date.md
+++ b/examples/showcase/docs/widget_input_date.md
@@ -33,8 +33,10 @@ gui.InputDate(gui.InputDateCfg{
 Leave `DateFormat` empty to use the locale. To change every date field at once,
 set the locale instead: `ctx.Window.SetLocaleID("de-DE")`.
 
-Month-name tokens (`MMM`, `MMMM`) are not permitted. The field accepts digits
-and separators only, so a month name could be shown but never typed back.
+Month-name tokens (`MMM`, `MMMM`), a 2-digit year (`YY`) and time tokens (`HH`,
+`mm`, `ss`) are not permitted. The field accepts digits and separators only and
+the parse reads `YYYY`, `MM`, `M`, `DD`, `D`, so anything else could be shown
+but never typed back.
 
 ## With Filtering
 

--- a/examples/showcase/docs/widget_input_date.md
+++ b/examples/showcase/docs/widget_input_date.md
@@ -1,6 +1,6 @@
 Text input with calendar popup for date entry. Combines a text field with an
-inline date picker dropdown. Displays the selected date formatted via the
-current locale.
+inline date picker dropdown. The date shows in the current locale's format
+unless `DateFormat` sets one for the field.
 
 ## Usage
 
@@ -15,6 +15,26 @@ gui.InputDate(gui.InputDateCfg{
     },
 })
 ```
+
+## Date Format
+
+`DateFormat` sets the format for one field. It controls the text the field
+shows, the input mask, the placeholder hint, and the parse of what the user
+types. Use the tokens `YYYY`, `MM`, `M`, `DD`, `D` and the separator you want.
+
+```go
+gui.InputDate(gui.InputDateCfg{
+    ID:         "id-de",
+    Date:       app.Date,
+    DateFormat: "DD.MM.YYYY", // 24.12.2026
+})
+```
+
+Leave `DateFormat` empty to use the locale. To change every date field at once,
+set the locale instead: `ctx.Window.SetLocaleID("de-DE")`.
+
+Month-name tokens (`MMM`, `MMMM`) are not permitted. The field accepts digits
+and separators only, so a month name could be shown but never typed back.
 
 ## With Filtering
 
@@ -39,6 +59,7 @@ gui.InputDate(gui.InputDateCfg{
 | -------------------- | -------------------- | --------------------------------- |
 | Date                 | time.Time            | Current date value                |
 | Placeholder          | string               | Hint text shown when empty        |
+| DateFormat           | string               | Date format for this field        |
 | SelectMultiple       | bool                 | Allow multiple date selection     |
 | MondayFirstDayOfWeek | bool                 | Start week on Monday              |
 | ShowAdjacentMonths   | bool                 | Show prev/next month days         |

--- a/gui/golden_cases_test.go
+++ b/gui/golden_cases_test.go
@@ -815,6 +815,20 @@ func goldenCases() []goldenCase {
 			},
 		},
 		{
+			// Same date as `input_date` above, drawn through a
+			// caller-supplied DateFormat. The pairing is the point:
+			// this case shows the dotted day-first spelling while
+			// `input_date` must stay on the locale's (issue #578).
+			name: "input_date_format",
+			build: func(_ *Window) View {
+				return InputDate(InputDateCfg{
+					ID:         "id",
+					DateFormat: "DD.MM.YYYY",
+					Date:       time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC),
+				})
+			},
+		},
+		{
 			name: "progress_bar",
 			build: func(_ *Window) View {
 				return ProgressBar(ProgressBarCfg{

--- a/gui/locale_format_test.go
+++ b/gui/locale_format_test.go
@@ -134,3 +134,45 @@ func TestLocaleT(t *testing.T) {
 		t.Fatalf("got %q, want missing", got)
 	}
 }
+
+// localeParseDate is the only parse in the date path and had no test
+// before issue #578 gave callers control of the format.
+func TestLocaleParseDate(t *testing.T) {
+	tests := []struct {
+		format  string
+		text    string
+		wantErr bool
+		year    int
+		month   time.Month
+		day     int
+	}{
+		{"MM/DD/YYYY", "12/24/2026", false, 2026, time.December, 24},
+		{"DD.MM.YYYY", "24.12.2026", false, 2026, time.December, 24},
+		{"DD/MM/YYYY", "24/12/2026", false, 2026, time.December, 24},
+		{"YYYY-MM-DD", "2026-12-24", false, 2026, time.December, 24},
+		{"M/D/YYYY", "1/5/2026", false, 2026, time.January, 5},
+		// The separators must match the format.
+		{"DD.MM.YYYY", "24/12/2026", true, 0, 0, 0},
+		// A day the month does not have.
+		{"DD.MM.YYYY", "31.02.2026", true, 0, 0, 0},
+	}
+	for _, tt := range tests {
+		got, err := localeParseDate(tt.text, tt.format)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("%s / %s: want error, got %v",
+					tt.format, tt.text, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s / %s: %v", tt.format, tt.text, err)
+			continue
+		}
+		if got.Year() != tt.year || got.Month() != tt.month ||
+			got.Day() != tt.day {
+			t.Errorf("%s / %s = %v, want %d-%02d-%02d",
+				tt.format, tt.text, got, tt.year, tt.month, tt.day)
+		}
+	}
+}

--- a/gui/testdata/input_date_format.dark.golden
+++ b/gui/testdata/input_date_format.dark.golden
@@ -1,0 +1,7 @@
+Rect xy=15.00,15.00 wh=160.00,31.60 color=#262a2fff radius=6.00 fill
+StrokeRect xy=15.00,15.00 wh=160.00,31.60 color=#ffffff1c radius=6.00 thickness=1.00
+Clip xy=26.00,21.00 wh=123.60,19.60
+Text xy=26.00,21.99 wh=0.00,0.00 color=#e6e8ebff text="15.08.2026" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=155.60,21.00 wh=8.40,19.60 color=#262a2fff radius=6.00 fill
+Text xy=155.60,22.24 wh=0.00,0.00 color=#e6e8ebff text="📅" size=14.00

--- a/gui/testdata/input_date_format.light.golden
+++ b/gui/testdata/input_date_format.light.golden
@@ -1,0 +1,6 @@
+Rect xy=14.00,14.00 wh=160.00,29.60 color=#ffffffff radius=6.00 fill
+Clip xy=24.00,19.00 wh=125.60,19.60
+Text xy=24.00,19.99 wh=0.00,0.00 color=#1a1d21ff text="15.08.2026" size=14.00
+Clip xy=0.00,0.00 wh=320.00,240.00
+Rect xy=155.60,19.00 wh=8.40,19.60 color=#ffffffff radius=6.00 fill
+Text xy=155.60,20.24 wh=0.00,0.00 color=#1a1d21ff text="📅" size=14.00

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -2,6 +2,8 @@ package gui
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -18,6 +20,14 @@ type InputDateCfg struct {
 	OnSelect         func([]time.Time, EventCtx)
 	ID               string `gui:"required,focus"`
 	Placeholder      string
+	// DateFormat spells the date the field shows, masks and parses,
+	// in the locale token language: YYYY, MM, M, DD, D and literal
+	// separators — "DD.MM.YYYY", "YYYY-MM-DD". Unset takes the
+	// active locale's short date, which is what every field did
+	// before issue #578. Month-name tokens (MMM, MMMM) are
+	// rejected: the field is a masked numeric entry, so a text
+	// month could be displayed but never typed back.
+	DateFormat string
 
 	A11YCfg
 	Dates           []time.Time
@@ -83,6 +93,7 @@ type inputDateView struct {
 func InputDate(cfg InputDateCfg) View {
 	applyInputDateDefaults(&cfg)
 	requireFocusID("InputDate", cfg.FocusDisabled, cfg.ID)
+	requireDateFormat("InputDate", cfg.DateFormat)
 	cfg.A11YLabel = a11yLabel(cfg.A11YLabel, cfg.Label)
 	return labelledField(
 		cfg.Label, cfg.TextStyle, HAlignLeft, cfg.Sizing,
@@ -99,6 +110,9 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 	// View tree, so the scope stack is still empty there. See issue
 	// #518.
 	cfgID := w.EffID(cfg.ID)
+	// One resolve per frame: display, mask, parse and placeholder all
+	// read this, and re-deriving it at each site is how they drift.
+	format := inputDateFormat(cfg)
 	// A read-only date field never opens the calendar popup, closing
 	// the picker's OnSelect mutation path structurally regardless of any
 	// stored open state.
@@ -112,8 +126,7 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 
 	dateText := ""
 	if len(dates) == 1 {
-		dateText = LocaleFormatDate(dates[0],
-			localeDatePadFormat(ActiveLocale.Date.ShortDate))
+		dateText = LocaleFormatDate(dates[0], format)
 	} else if len(dates) > 1 {
 		dateText = fmt.Sprintf("%d dates selected", len(dates))
 	}
@@ -143,7 +156,7 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 			Spacing:    Some(SpacingSmall),
 			VAlign:     VAlignMiddle,
 			Content: []View{
-				inputDateTextField(cfg, cfgID, isOpen, editText),
+				inputDateTextField(cfg, cfgID, format, isOpen, editText),
 				Button(ButtonCfg{
 					// Namespaced by the field's ID: a form can hold
 					// several date inputs.
@@ -257,7 +270,7 @@ func (idv *inputDateView) GenerateLayout(w *Window) Layout {
 // inputDateTextField returns an Input for single/no dates (editable)
 // or a Text for multi-select display ("N dates selected").
 func inputDateTextField(
-	cfg *InputDateCfg, cfgID string, isOpen bool,
+	cfg *InputDateCfg, cfgID, format string, isOpen bool,
 	dateText string,
 ) View {
 	if len(cfg.Dates) > 1 {
@@ -274,8 +287,8 @@ func inputDateTextField(
 		FocusDisabled: cfg.FocusDisabled,
 		ReadOnly:      cfg.ReadOnly,
 		Text:          dateText,
-		Placeholder:   inputDatePlaceholder(cfg),
-		Mask:          localeDateMaskPattern(ActiveLocale.Date.ShortDate),
+		Placeholder:   inputDatePlaceholder(cfg, format),
+		Mask:          localeDateMaskPattern(format),
 		// The mask admits digits and separators only, so the reserved
 		// descent is provably empty and the date can be centred on its
 		// ink rather than on its line box (issue #346).
@@ -305,8 +318,7 @@ func inputDateTextField(
 				ctx.Window.InvalidateLayout()
 				return
 			}
-			t, err := localeParseDate(text,
-				localeDatePadFormat(ActiveLocale.Date.ShortDate))
+			t, err := localeParseDate(text, format)
 			if err != nil {
 				return
 			}
@@ -324,11 +336,11 @@ func inputDateTextField(
 	})
 }
 
-func inputDatePlaceholder(cfg *InputDateCfg) string {
+func inputDatePlaceholder(cfg *InputDateCfg, format string) string {
 	if cfg.Placeholder != "" {
 		return cfg.Placeholder
 	}
-	return localeDatePadFormat(ActiveLocale.Date.ShortDate)
+	return format
 }
 
 func inputDateToggle(id string, w *Window) {
@@ -343,6 +355,39 @@ func inputDateClose(id string, w *Window) {
 	sm := StateMap[string, bool](w, nsInputDate, capModerate)
 	sm.Set(id, false)
 	w.InvalidateLayout()
+}
+
+// inputDateFormat resolves the one format the field shows, masks and
+// parses with. Every read goes through here so display, mask, parse
+// and placeholder cannot drift apart; the padded form is what all four
+// want, because a masked field always has both digits (issue #578).
+func inputDateFormat(cfg *InputDateCfg) string {
+	if cfg.DateFormat != "" {
+		return localeDatePadFormat(cfg.DateFormat)
+	}
+	return localeDatePadFormat(ActiveLocale.Date.ShortDate)
+}
+
+// requireDateFormat panics on a DateFormat the masked numeric field
+// cannot honour. A month name renders but cannot be typed back, and a
+// format with no date token at all masks to a row of literals, so both
+// produce a field that looks right and refuses every keystroke. Fail at
+// construction instead, the way RequireID does (issue #578).
+func requireDateFormat(widget, format string) {
+	if format == "" {
+		return
+	}
+	if strings.Contains(format, "MMM") {
+		panic("gui: " + widget + " DateFormat " + strconv.Quote(format) +
+			" uses a month-name token; the field masks digits only")
+	}
+	padded := localeDatePadFormat(format)
+	if !strings.Contains(padded, "YYYY") &&
+		!strings.Contains(padded, "MM") &&
+		!strings.Contains(padded, "DD") {
+		panic("gui: " + widget + " DateFormat " + strconv.Quote(format) +
+			" has no YYYY, MM or DD token")
+	}
 }
 
 func applyInputDateDefaults(cfg *InputDateCfg) {

--- a/gui/view_input_date.go
+++ b/gui/view_input_date.go
@@ -24,9 +24,11 @@ type InputDateCfg struct {
 	// in the locale token language: YYYY, MM, M, DD, D and literal
 	// separators — "DD.MM.YYYY", "YYYY-MM-DD". Unset takes the
 	// active locale's short date, which is what every field did
-	// before issue #578. Month-name tokens (MMM, MMMM) are
-	// rejected: the field is a masked numeric entry, so a text
-	// month could be displayed but never typed back.
+	// before issue #578. Month-name tokens (MMM, MMMM), a 2-digit
+	// year (YY) and time tokens (HH, mm, ss) are rejected: the
+	// field is a masked numeric entry, so a text month could be
+	// displayed but never typed back, and the parse only reads
+	// YYYY, MM, M, DD, D.
 	DateFormat string
 
 	A11YCfg
@@ -369,9 +371,11 @@ func inputDateFormat(cfg *InputDateCfg) string {
 }
 
 // requireDateFormat panics on a DateFormat the masked numeric field
-// cannot honour. A month name renders but cannot be typed back, and a
-// format with no date token at all masks to a row of literals, so both
-// produce a field that looks right and refuses every keystroke. Fail at
+// cannot honour. A month name renders but cannot be typed back, a
+// 2-digit year and a time token display one thing and parse another
+// (localeParseDate only reads YYYY, MM, M, DD, D), and a format with
+// no date token at all masks to a row of literals, so each produces a
+// field that looks right and refuses every keystroke. Fail at
 // construction instead, the way RequireID does (issue #578).
 func requireDateFormat(widget, format string) {
 	if format == "" {
@@ -380,6 +384,17 @@ func requireDateFormat(widget, format string) {
 	if strings.Contains(format, "MMM") {
 		panic("gui: " + widget + " DateFormat " + strconv.Quote(format) +
 			" uses a month-name token; the field masks digits only")
+	}
+	if strings.Contains(format, "YY") &&
+		!strings.Contains(format, "YYYY") {
+		panic("gui: " + widget + " DateFormat " + strconv.Quote(format) +
+			" uses a 2-digit year; spell YYYY")
+	}
+	if strings.Contains(format, "HH") ||
+		strings.Contains(format, "mm") ||
+		strings.Contains(format, "ss") {
+		panic("gui: " + widget + " DateFormat " + strconv.Quote(format) +
+			" uses a time token; the field is date-only")
 	}
 	padded := localeDatePadFormat(format)
 	if !strings.Contains(padded, "YYYY") &&

--- a/gui/view_input_date_test.go
+++ b/gui/view_input_date_test.go
@@ -287,3 +287,121 @@ func TestInputDateFocusDisabled(t *testing.T) {
 		t.Error("FocusDisabled: true should produce a non-focusable outer Column")
 	}
 }
+
+// --- DateFormat (issue #578) ---
+
+// An unset DateFormat keeps the pre-#578 behaviour: the field reads the
+// active locale's short date, padded.
+func TestInputDateFormatUnsetUsesLocale(t *testing.T) {
+	cfg := InputDateCfg{ID: "id-fmt-unset"}
+	want := localeDatePadFormat(ActiveLocale.Date.ShortDate)
+	if got := inputDateFormat(&cfg); got != want {
+		t.Errorf("inputDateFormat = %q, want %q", got, want)
+	}
+}
+
+// A set DateFormat wins over the locale and is padded the same way, so
+// "D.M.YYYY" and "DD.MM.YYYY" both reach the widget as the padded form.
+func TestInputDateFormatSetWinsOverLocale(t *testing.T) {
+	cfg := InputDateCfg{ID: "id-fmt-set", DateFormat: "D.M.YYYY"}
+	if got := inputDateFormat(&cfg); got != "DD.MM.YYYY" {
+		t.Errorf("inputDateFormat = %q, want %q", got, "DD.MM.YYYY")
+	}
+}
+
+func TestInputDateFormatDisplayText(t *testing.T) {
+	w := &Window{}
+	v := InputDate(InputDateCfg{
+		ID:         "id-fmt-text",
+		DateFormat: "DD.MM.YYYY",
+		Date:       time.Date(2026, 12, 24, 0, 0, 0, 0, time.Local),
+	})
+	layout := generateViewLayout(v, w)
+	if !layoutContainsText(&layout, "24.12.2026") {
+		t.Error("layout does not contain 24.12.2026")
+	}
+}
+
+// With no date and no explicit Placeholder the field shows the format
+// itself, so the hint follows DateFormat rather than the locale.
+func TestInputDateFormatPlaceholder(t *testing.T) {
+	w := &Window{}
+	v := InputDate(InputDateCfg{
+		ID:         "id-fmt-ph",
+		DateFormat: "YYYY-MM-DD",
+	})
+	layout := generateViewLayout(v, w)
+	if !layoutContainsText(&layout, "YYYY-MM-DD") {
+		t.Error("layout does not contain the YYYY-MM-DD placeholder")
+	}
+}
+
+// The mask admits the separators the format spells, so a dotted format
+// gates on dots rather than on the locale's slashes.
+func TestInputDateFormatMask(t *testing.T) {
+	cfg := InputDateCfg{ID: "id-fmt-mask", DateFormat: "DD.MM.YYYY"}
+	got := localeDateMaskPattern(inputDateFormat(&cfg))
+	if got != "99.99.9999" {
+		t.Errorf("mask = %q, want %q", got, "99.99.9999")
+	}
+}
+
+// Committing typed text parses against DateFormat, not the locale: with
+// the locale's MM/DD/YYYY the same digits would read as a different day.
+func TestInputDateFormatParsesCommit(t *testing.T) {
+	w := newTestWindow()
+	var got []time.Time
+	v := InputDate(InputDateCfg{
+		ID:         "id-fmt-commit",
+		DateFormat: "DD.MM.YYYY",
+		Date:       time.Date(2026, 1, 2, 0, 0, 0, 0, time.Local),
+		OnSelect: func(dates []time.Time, _ EventCtx) {
+			got = dates
+		},
+	})
+	// Seed the edit text the way typing would, with the sync marker
+	// already matching the rendered date so generation does not
+	// overwrite it (see the sync guard in GenerateLayout).
+	sm := StateMap[string, string](w, nsInputDateText, capModerate)
+	sm.Set("id-fmt-commit", "24.12.2026")
+	sm.Set(ScopeID("id-fmt-commit", "sync"), "02.01.2026")
+
+	layout := generateViewLayout(v, w)
+	inner, ok := layout.findByID("id-fmt-commit:input")
+	if !ok {
+		t.Fatal("inner Input not found")
+	}
+	setInputState(w, "id-fmt-commit:input", inputState{CursorPos: 10})
+	w.SetFocus("id-fmt-commit:input")
+	e := &Event{Type: EventKeyDown, KeyCode: KeyEnter}
+	inner.Shape.events.OnKeyDown(EventCtx{inner, e, w})
+
+	if len(got) != 1 {
+		t.Fatalf("OnSelect got %d dates, want 1", len(got))
+	}
+	if got[0].Year() != 2026 || got[0].Month() != time.December ||
+		got[0].Day() != 24 {
+		t.Errorf("parsed %v, want 2026-12-24", got[0])
+	}
+}
+
+// A month-name token cannot be masked or typed back, so the factory
+// rejects it rather than shipping a field that refuses every keystroke.
+func TestInputDateFormatRejectsMonthName(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("InputDate accepted a month-name DateFormat")
+		}
+	}()
+	InputDate(InputDateCfg{ID: "id-fmt-bad", DateFormat: "DD MMM YYYY"})
+}
+
+// A format with no date token at all is equally unusable.
+func TestInputDateFormatRejectsNoTokens(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("InputDate accepted a token-free DateFormat")
+		}
+	}()
+	InputDate(InputDateCfg{ID: "id-fmt-empty", DateFormat: "---"})
+}

--- a/gui/view_input_date_test.go
+++ b/gui/view_input_date_test.go
@@ -405,3 +405,28 @@ func TestInputDateFormatRejectsNoTokens(t *testing.T) {
 	}()
 	InputDate(InputDateCfg{ID: "id-fmt-empty", DateFormat: "---"})
 }
+
+// A 2-digit year shows literally and never parses: the mask keeps the
+// YY as literals while localeParseDate only reads YYYY, so typing the
+// year back fails. Reject at construction (issue #578).
+func TestInputDateFormatRejectsTwoDigitYear(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("InputDate accepted a 2-digit-year DateFormat")
+		}
+	}()
+	InputDate(InputDateCfg{ID: "id-fmt-yy", DateFormat: "DD.MM.YY"})
+}
+
+// A time token displays one thing and parses another: the display
+// path substitutes HH/mm/ss but localeParseDate leaves them as
+// literals, so a committed time can never round-trip. The field is
+// date-only, so reject at construction (issue #578).
+func TestInputDateFormatRejectsTimeToken(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("InputDate accepted a time-token DateFormat")
+		}
+	}()
+	InputDate(InputDateCfg{ID: "id-fmt-time", DateFormat: "DD.MM.YYYY HH:mm"})
+}


### PR DESCRIPTION
Closes #578.

## Problem

`InputDate` read its date format from one process-global value,
`ActiveLocale.Date.ShortDate` (`M/D/YYYY` for en-US). That value drives four
things in the field: the text it shows, the input mask, the placeholder hint,
and the parse of what the user types. A caller who wanted `24.12.2026` had to
change the locale for every date widget in the app, and two fields in one form
could not differ.

## Change

`InputDateCfg.DateFormat` sets the format per field, in the token language the
locale bundles already use — `YYYY`, `MM`, `M`, `DD`, `D` and literal
separators:

```go
gui.InputDate(gui.InputDateCfg{ID: "due", DateFormat: "DD.MM.YYYY"})
```

`inputDateFormat` is the one resolve point. `GenerateLayout` calls it once per
frame and threads the result to all four sites, so none of them reads the
locale directly any more and they cannot drift apart. Unset falls back to the
locale, so existing fields are unchanged.

A month-name token (`MMM`, `MMMM`) or a format with no date token panics from
the factory, matching the `RequireID` precedent. The field masks digits and
separators only, so such a format would render a control that looks right and
refuses every keystroke. That check is also what keeps the
`opticalDigitCenter` assumption in `docs/specs/text-optical-centring.md` true.

An app-wide change is still the locale: `SetLocaleID("de-DE")` already carries
`D.M.YYYY`. Rejected alternatives are recorded in
`docs/specs/input-date-format.md`.

## Tests

- `gui/view_input_date_test.go` — unset fallback, display text, placeholder,
  mask, both panics, and `TestInputDateFormatParsesCommit`, which drives an
  Enter commit through the inner `Input`: under the locale's `MM/DD/YYYY` the
  same text fails to parse and `OnSelect` never fires.
- `gui/locale_format_test.go` — `TestLocaleParseDate`. That function is the
  only parse in the date path and had no test before.
- Golden case `input_date_format` pairs with `input_date`. Only the date text
  differs between the two recordings; no geometry moves.

`make prepush` green.

## Try it

`go run ./examples/showcase/` → Input demo → the second date field, labelled
`DateFormat: "DD.MM.YYYY"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)