### PR TITLE
fix(gui): focus, a11y, animation and diagnostics quality pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,54 +10,71 @@ and this project adheres to
 
 ### Fixed
 
+- **Repeating keyframes resync after a stall instead of draining the backlog** —
+  a minimized window or debugger break left a repeating `KeyframeAnimation` many
+  durations behind, and each tick advanced only one duration, firing the final
+  value once per tick until caught up. The repeat path now shares
+  `resyncAfterStall` with `Animate` and the caret blink. A repeating keyframe
+  with a non-positive duration also retires as a one-shot instead of returning
+  true every tick forever.
+- **Snapshot capture stops at the shared depth budget** — layout and hero
+  snapshot capture recursed without the 256-deep guard the apply walks use, so a
+  deeply nested document-built subtree could exhaust the stack. Capture now
+  takes the same budget and tolerates nil shapes.
+- **Tween, keyframe, spring, and transition outputs stay finite** — a custom
+  easing hook returning NaN/Inf, non-finite tween endpoints or keyframe values,
+  a non-finite spring target, and non-finite spring config now fall back or drop
+  the frame instead of handing NaN to layout geometry. A zero-value
+  `TweenAnimation` also eases with `EaseOutCubic`, matching `NewTweenAnimation`
+  and the transitions.
+- **View-bound heartbeats use the monotonic clock** — stamps are `time.Time`
+  rather than `UnixNano`, so a wall-clock step no longer mass-cancels visible
+  widgets' animations. Negative layout and hero durations take their defaults,
+  the stopped scroll smoother releases its entries once the final value is
+  applied, and the typewriter default duration counts runes only when
+  registering its driver.
 - **Modified Tab chords no longer move focus** — `Ctrl+Tab`, `Alt+Tab`,
-  `Super+Tab`, and `Shift` combined with any of those fell through to
-  focus traversal (`Ctrl+Tab` advanced to the next stop, `Shift+Ctrl+Tab`
-  went forward instead of back), stealing chords the focused widget or
-  the OS owns. Traversal now matches on the keyboard modifier bits only:
-  plain `Tab` advances, plain `Shift+Tab` goes back, and any other
-  combination is left for the focused widget.
-- **A scoped widget can no longer inherit the dialog's focused dispatch**
-  — the reserved dialog ID matched on the leaf, so any widget whose leaf
-  spelled it became a keyboard-focus target. The match is now on the
-  effective ID, which only the dialog itself (its own float root)
-  satisfies.
-- **Focus eligibility keys on the effective ID** — `canTakeFocus` tested
-  the leaf while the focus store holds the stamped identity. The two
-  agree for every generated layout; hand-built layouts no longer
-  disagree.
-- **Deep accessibility trees stop at the depth budget** — the a11y
-  collect and lookup walks were the only tree walks without the shared
-  256-deep guard, so a deeply nested document-built subtree (Markdown,
-  SVG) could exhaust the stack. Nodes past the budget are now dropped
-  from the pushed snapshot instead.
-- **Scoped focus is announced to assistive tech** — the a11y focused
-  index compared the leaf ID against the effective focus ID, so a widget
-  under an ID-bearing ancestor was never reported as focused. The match
-  is now on the effective ID.
-- **Assistive-tech actions queue onto the main thread** — platform
-  action callbacks (VoiceOver, Android JNI, D-Bus workers) arrived on
-  foreign threads and walked the live layout directly. They now run
-  through `QueueCommand` at the next frame start. Disabled widgets also
-  refuse all five actions now, not just Press.
-- **Live regions are keyed by identity, not label** — two regions
-  sharing a label (or none) collapsed onto one entry, announcing for
-  the wrong region or staying silent on change. ID-bearing regions pin
-  by effective ID across any tree or label movement; ID-less regions
-  key by label and node index, going silent for a frame on moves rather
-  than announcing spuriously.
-- **An emptied accessibility tree is pushed, not skipped** — content
-  that emptied never synced, so assistive tech kept the stale tree and
-  the live baselines went stale with it. Zero-node syncs now clear the
-  native tree on every backend, and returning content reads as new
-  rather than changed.
-- **Each window owns its accessibility bridge (macOS, Linux)** — the
-  macOS VoiceOver tree and the Linux AT-SPI2 bridge were process-global,
-  so a second window hijacked the first window's tree and actions.
-  macOS now keeps one tree per window with the owning window routed
-  back alongside each action; Linux gives each window its own bridge.
-  The web backend was already per-window, and Android runs exactly one
-  window by construction.
+  `Super+Tab`, and `Shift` combined with any of those fell through to focus
+  traversal (`Ctrl+Tab` advanced to the next stop, `Shift+Ctrl+Tab` went forward
+  instead of back), stealing chords the focused widget or the OS owns. Traversal
+  now matches on the keyboard modifier bits only: plain `Tab` advances, plain
+  `Shift+Tab` goes back, and any other combination is left for the focused
+  widget.
+- **A scoped widget can no longer inherit the dialog's focused dispatch** — the
+  reserved dialog ID matched on the leaf, so any widget whose leaf spelled it
+  became a keyboard-focus target. The match is now on the effective ID, which
+  only the dialog itself (its own float root) satisfies.
+- **Focus eligibility keys on the effective ID** — `canTakeFocus` tested the
+  leaf while the focus store holds the stamped identity. The two agree for every
+  generated layout; hand-built layouts no longer disagree.
+- **Deep accessibility trees stop at the depth budget** — the a11y collect and
+  lookup walks were the only tree walks without the shared 256-deep guard, so a
+  deeply nested document-built subtree (Markdown, SVG) could exhaust the stack.
+  Nodes past the budget are now dropped from the pushed snapshot instead.
+- **Scoped focus is announced to assistive tech** — the a11y focused index
+  compared the leaf ID against the effective focus ID, so a widget under an
+  ID-bearing ancestor was never reported as focused. The match is now on the
+  effective ID.
+- **Assistive-tech actions queue onto the main thread** — platform action
+  callbacks (VoiceOver, Android JNI, D-Bus workers) arrived on foreign threads
+  and walked the live layout directly. They now run through `QueueCommand` at
+  the next frame start. Disabled widgets also refuse all five actions now, not
+  just Press.
+- **Live regions are keyed by identity, not label** — two regions sharing a
+  label (or none) collapsed onto one entry, announcing for the wrong region or
+  staying silent on change. ID-bearing regions pin by effective ID across any
+  tree or label movement; ID-less regions key by label and node index, going
+  silent for a frame on moves rather than announcing spuriously.
+- **An emptied accessibility tree is pushed, not skipped** — content that
+  emptied never synced, so assistive tech kept the stale tree and the live
+  baselines went stale with it. Zero-node syncs now clear the native tree on
+  every backend, and returning content reads as new rather than changed.
+- **Each window owns its accessibility bridge (macOS, Linux)** — the macOS
+  VoiceOver tree and the Linux AT-SPI2 bridge were process-global, so a second
+  window hijacked the first window's tree and actions. macOS now keeps one tree
+  per window with the owning window routed back alongside each action; Linux
+  gives each window its own bridge. The web backend was already per-window, and
+  Android runs exactly one window by construction.
 
 ## [v0.75.0] - 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,22 @@ and this project adheres to
   config typos. `ColorLookup` trims space, folds case (so `" Red "` matches),
   accepts `#RRGGBB[AA]`, and reports failure, including the previously missing
   `"magenta"` name. `ColorFromString` keeps its signature and fallback.
+- **`AnimationCommands.AppendOnDone` and `AppendOnValue` are public** — the type
+  was exported for third-party `Animation` implementations, but only the
+  unexported spellings existed, so outside packages could not enqueue callbacks.
+  The exported methods are nil-safe; the old spellings remain as delegates.
 
 ### Fixed
 
+- **Command registry is race-safe and stops swallowing keys** — `Register`,
+  `Unregister`, lookup, palette, and dispatch share a mutex and run user
+  callbacks off-lock from a snapshot, so registration during dispatch cannot
+  deadlock or race. A command with nil `Execute` no longer marks the event
+  handled, nil events never match, `RegisterCommands` is atomic (all or none),
+  empty IDs are rejected, `Unregister` clears the tail slot so closures release,
+  `flushCommands` skips nil callbacks, and the native menubar honors
+  `CanExecute` and nil `Execute`. `Execute` may receive a nil `*Event` and must
+  nil-check it.
 - **App registry is race-safe and survives a main-window close** — `OpenWindow`
   and `SetWakeMainFn` no longer race on the wake callback, and `Window.App` and
   `Window.PlatformID` are atomic, so readers on any goroutine stay consistent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **The full named color palette is public** — `Magenta`, `Indigo`, `Pink`,
+  `Violet`, `DarkBlue`, `DarkGreen`, `DarkRed`, `LightGray`, `LightGreen`,
+  `LightRed`, and `RoyalBlue` join the exported palette alongside `Red`,
+  `CornflowerBlue`, and the rest, so app code no longer re-spells them with
+  `RGBA` literals. The previous lowercase spellings remain as internal aliases.
+- **`ColorLookup` parses a color name or hex string with `ok=false` on miss** —
+  `ColorFromString` silently returns opaque black for unknown input, which hides
+  config typos. `ColorLookup` trims space, folds case (so `" Red "` matches),
+  accepts `#RRGGBB[AA]`, and reports failure, including the previously missing
+  `"magenta"` name. `ColorFromString` keeps its signature and fallback.
+
 ### Fixed
 
 - **App registry is race-safe and survives a main-window close** — `OpenWindow`
@@ -83,6 +96,25 @@ and this project adheres to
   per window with the owning window routed back alongside each action; Linux
   gives each window its own bridge. The web backend was already per-window, and
   Android runs exactly one window by construction.
+- **Combining two unset colors stays unset** — `Add`, `Sub`, and `Over` returned
+  an explicitly-set color even when both inputs were the zero value, conjuring a
+  color where none was specified. The result is now set if either input is set.
+  `Over` also rounds to the nearest channel value instead of truncating,
+  matching the HSL/HSV conversions.
+- **The saturation/lightness plane renders its cache key's hue** — `planeSrc`
+  keyed on the quantized hue but painted the raw one, so two sub-quantum hues
+  shared a key and the second showed the first's pixels. The buffer now paints
+  the quantized hue, as the wheel already did.
+- **HSV construction clamps and rejects non-finite input** — out-of-range
+  saturation/value and NaN/Inf hues fell through float math (including an
+  implementation-defined float-to-int step) into channel bytes. Inputs now map
+  to zero/clamp at the entry point, mirroring `HSLA.Normalized`.
+- **The HSLA readout never prints a 360° hue** — rounding carried 359.6° to
+  `hsla(360, ...)`. It now wraps to `hsla(0, ...)`.
+- **Color filter singletons hand out copies** — `ColorFilterIdentity`,
+  `Grayscale`, `Sepia`, and `Invert` returned the shared package singleton, and
+  `colorFilterCompose` aliased its input on a nil side, so one in-package write
+  would leak across users. Each call now returns a fresh copy.
 
 ## [v0.75.0] - 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,38 @@ and this project adheres to
   the leaf while the focus store holds the stamped identity. The two
   agree for every generated layout; hand-built layouts no longer
   disagree.
+- **Deep accessibility trees stop at the depth budget** — the a11y
+  collect and lookup walks were the only tree walks without the shared
+  256-deep guard, so a deeply nested document-built subtree (Markdown,
+  SVG) could exhaust the stack. Nodes past the budget are now dropped
+  from the pushed snapshot instead.
+- **Scoped focus is announced to assistive tech** — the a11y focused
+  index compared the leaf ID against the effective focus ID, so a widget
+  under an ID-bearing ancestor was never reported as focused. The match
+  is now on the effective ID.
+- **Assistive-tech actions queue onto the main thread** — platform
+  action callbacks (VoiceOver, Android JNI, D-Bus workers) arrived on
+  foreign threads and walked the live layout directly. They now run
+  through `QueueCommand` at the next frame start. Disabled widgets also
+  refuse all five actions now, not just Press.
+- **Live regions are keyed by identity, not label** — two regions
+  sharing a label (or none) collapsed onto one entry, announcing for
+  the wrong region or staying silent on change. ID-bearing regions pin
+  by effective ID across any tree or label movement; ID-less regions
+  key by label and node index, going silent for a frame on moves rather
+  than announcing spuriously.
+- **An emptied accessibility tree is pushed, not skipped** — content
+  that emptied never synced, so assistive tech kept the stale tree and
+  the live baselines went stale with it. Zero-node syncs now clear the
+  native tree on every backend, and returning content reads as new
+  rather than changed.
+- **Each window owns its accessibility bridge (macOS, Linux)** — the
+  macOS VoiceOver tree and the Linux AT-SPI2 bridge were process-global,
+  so a second window hijacked the first window's tree and actions.
+  macOS now keeps one tree per window with the owning window routed
+  back alongside each action; Linux gives each window its own bridge.
+  The web backend was already per-window, and Android runs exactly one
+  window by construction.
 
 ## [v0.75.0] - 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **Modified Tab chords no longer move focus** — `Ctrl+Tab`, `Alt+Tab`,
+  `Super+Tab`, and `Shift` combined with any of those fell through to
+  focus traversal (`Ctrl+Tab` advanced to the next stop, `Shift+Ctrl+Tab`
+  went forward instead of back), stealing chords the focused widget or
+  the OS owns. Traversal now matches on the keyboard modifier bits only:
+  plain `Tab` advances, plain `Shift+Tab` goes back, and any other
+  combination is left for the focused widget.
+- **A scoped widget can no longer inherit the dialog's focused dispatch**
+  — the reserved dialog ID matched on the leaf, so any widget whose leaf
+  spelled it became a keyboard-focus target. The match is now on the
+  effective ID, which only the dialog itself (its own float root)
+  satisfies.
+- **Focus eligibility keys on the effective ID** — `canTakeFocus` tested
+  the leaf while the focus store holds the stamped identity. The two
+  agree for every generated layout; hand-built layouts no longer
+  disagree.
+
 ## [v0.75.0] - 2026-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ### Fixed
 
+- **App registry is race-safe and survives a main-window close** — `OpenWindow`
+  and `SetWakeMainFn` no longer race on the wake callback, and `Window.App` and
+  `Window.PlatformID` are atomic, so readers on any goroutine stay consistent.
+  `Unregister` hands the main ID to the oldest survivor instead of stranding
+  menubar and tray calls on a dead ID, and menubar and tray actions resolve the
+  live main window when they fire. Buffer-full `OpenWindow` drops log at most
+  once per second with a running total, and tray creation rejects non-positive
+  platform IDs.
 - **Repeating keyframes resync after a stall instead of draining the backlog** —
   a minimized window or debugger break left a repeating `KeyframeAnimation` many
   durations behind, and each tick advanced only one duration, firing the final

--- a/gui/a11y_tree.go
+++ b/gui/a11y_tree.go
@@ -32,8 +32,29 @@ type A11yNode struct {
 }
 
 type liveNode struct {
-	label string
+	key   liveKey
 	value string
+}
+
+// liveKey identifies a live region across syncs. A non-empty id pins
+// a designed, ID-bearing region on its own, across any tree or label
+// movement; label and idx keep ID-less regions distinct per position.
+// A region that moves reads as new and stays silent for a frame —
+// never a spurious announcement — while its next value change
+// announces normally.
+type liveKey struct {
+	id    string
+	label string
+	idx   int
+}
+
+// liveKeyFor builds the identity for one live region: the effective
+// ID where the shape has one, else its label and node index.
+func liveKeyFor(id, label string, idx int) liveKey {
+	if id != "" {
+		return liveKey{id: id}
+	}
+	return liveKey{label: label, idx: idx}
 }
 
 // a11ySyncInterval is the minimum time between accessibility
@@ -44,7 +65,7 @@ const a11ySyncInterval = 100 * time.Millisecond
 // a11y holds per-window accessibility backend state.
 type a11y struct {
 	lastSync       time.Time // throttle sync calls
-	prevLiveValues map[string]string
+	prevLiveValues map[liveKey]string
 	nodes          []A11yNode // reused across frames
 	liveNodes      []liveNode // reused across frames
 	// dirty is set by updateLocked (any layout rebuild) and
@@ -71,7 +92,14 @@ func (w *Window) initA11y() {
 
 	if w.nativePlatform != nil {
 		w.nativePlatform.A11yInit(func(action, index int) {
-			a11yActionCallback(w, action, index)
+			// Platform action callbacks arrive on foreign threads —
+			// VoiceOver re-entry, Android JNI, D-Bus workers — never
+			// the main thread the layout belongs to. Queue onto it;
+			// the command runs at the next frame start, against the
+			// arranged tree rather than one mutating underfoot.
+			w.QueueCommand(func(*Window) {
+				a11yActionCallback(w, action, index)
+			})
 		})
 	}
 }
@@ -112,15 +140,13 @@ func (w *Window) syncA11y() {
 		&w.a11y.liveNodes,
 	)
 
-	if len(w.a11y.nodes) == 0 {
-		return
-	}
-
+	// An emptied tree still pushes (possibly zero nodes) so the native
+	// side clears its stale content instead of keeping it.
 	w.nativePlatform.A11ySync(w.a11y.nodes, len(w.a11y.nodes), focusedIdx)
 
 	// Live region change detection.
 	for _, ln := range w.a11y.liveNodes {
-		if prev, ok := w.a11y.prevLiveValues[ln.label]; ok {
+		if prev, ok := w.a11y.prevLiveValues[ln.key]; ok {
 			if prev != ln.value {
 				w.nativePlatform.A11yAnnounce(ln.value)
 			}
@@ -128,11 +154,11 @@ func (w *Window) syncA11y() {
 	}
 	// Update previous values.
 	if w.a11y.prevLiveValues == nil {
-		w.a11y.prevLiveValues = make(map[string]string)
+		w.a11y.prevLiveValues = make(map[liveKey]string)
 	}
 	clear(w.a11y.prevLiveValues)
 	for _, ln := range w.a11y.liveNodes {
-		w.a11y.prevLiveValues[ln.label] = ln.value
+		w.a11y.prevLiveValues[ln.key] = ln.value
 	}
 }
 
@@ -146,7 +172,25 @@ func a11yCollect(
 	focusID string,
 	live *[]liveNode,
 ) int {
+	return a11yCollectDepth(layout, parentIdx, nodes, focusID, live, 0)
+}
+
+func a11yCollectDepth(
+	layout *Layout,
+	parentIdx int,
+	nodes *[]A11yNode,
+	focusID string,
+	live *[]liveNode,
+	depth int,
+) int {
 	focusedIdx := -1
+	// Past the budget the walk stops descending, like every other
+	// tree walk: the tree is not always the app's own — Markdown and
+	// SVG build subtrees out of documents the app did not write —
+	// so the frame drops deep input rather than the process.
+	if overMaxDepth(depth) {
+		return focusedIdx
+	}
 	if layout.Shape == nil {
 		return focusedIdx
 	}
@@ -155,7 +199,7 @@ func a11yCollect(
 	// Skip shapes without a11y role but recurse children.
 	if s.A11YRole == AccessRoleNone {
 		for i := range layout.Children {
-			if fi := a11yCollect(&layout.Children[i], parentIdx, nodes, focusID, live); fi >= 0 {
+			if fi := a11yCollectDepth(&layout.Children[i], parentIdx, nodes, focusID, live, depth+1); fi >= 0 {
 				focusedIdx = fi
 			}
 		}
@@ -204,19 +248,24 @@ func a11yCollect(
 		ParentIdx:   parentIdx,
 	})
 
-	if focusID != "" && s.Focusable && s.ID == focusID {
+	if focusID != "" && s.Focusable && s.idKey() == focusID {
 		focusedIdx = nodeIdx
 	}
 
-	// Track live regions.
+	// Track live regions, keyed by identity rather than label:
+	// labels collide across regions and vanish on unlabeled values,
+	// and either case announced for the wrong region.
 	if state.Has(AccessStateLive) {
-		*live = append(*live, liveNode{label: label, value: value})
+		*live = append(*live, liveNode{
+			key:   liveKeyFor(s.idKey(), label, nodeIdx),
+			value: value,
+		})
 	}
 
 	// Process children.
 	childrenStart := len(*nodes)
 	for i := range layout.Children {
-		if fi := a11yCollect(&layout.Children[i], nodeIdx, nodes, focusID, live); fi >= 0 {
+		if fi := a11yCollectDepth(&layout.Children[i], nodeIdx, nodes, focusID, live, depth+1); fi >= 0 {
 			focusedIdx = fi
 		}
 	}
@@ -248,6 +297,13 @@ func shapeA11yLabel(s *Shape) string {
 
 // a11yActionCallback routes native accessibility actions to
 // the layout node at the given index in the a11y node array.
+//
+// Main-thread only: it walks the live layout and runs app callbacks
+// with no lock held. Platform entry points never call this directly —
+// initA11y queues them through QueueCommand. Tests call it directly.
+// Disabled refuses every action (see the single check below);
+// layoutDisables stamps Disabled onto every descendant, so it also
+// covers a disabled ancestor.
 func a11yActionCallback(w *Window, action, index int) {
 	if index < 0 || index >= len(w.a11y.nodes) {
 		return
@@ -257,9 +313,15 @@ func a11yActionCallback(w *Window, action, index int) {
 		return
 	}
 	ev := l.Shape.events
+	// A disabled widget refuses every action; layoutDisables stamps
+	// Disabled onto every descendant, so this also covers a
+	// disabled ancestor. One check, not one per arm.
+	if l.Shape.Disabled {
+		return
+	}
 	switch action {
 	case A11yActionPress:
-		if ev.OnClick != nil && !l.Shape.Disabled {
+		if ev.OnClick != nil {
 			e := &Event{Type: EventMouseDown}
 			playShapeSound(l, w)
 			ev.OnClick(EventCtx{l, e, w})
@@ -291,10 +353,13 @@ func a11yActionCallback(w *Window, action, index int) {
 // a11yCollect and returns the layout at the given node index.
 func a11yFindLayout(layout *Layout, target int) *Layout {
 	counter := 0
-	return a11yFindLayoutWalk(layout, target, &counter)
+	return a11yFindLayoutWalk(layout, target, &counter, 0)
 }
 
-func a11yFindLayoutWalk(layout *Layout, target int, counter *int) *Layout {
+func a11yFindLayoutWalk(layout *Layout, target int, counter *int, depth int) *Layout {
+	if overMaxDepth(depth) {
+		return nil
+	}
 	if layout.Shape == nil {
 		return nil
 	}
@@ -302,7 +367,7 @@ func a11yFindLayoutWalk(layout *Layout, target int, counter *int) *Layout {
 	// (same logic as a11yCollect).
 	if layout.Shape.A11YRole == AccessRoleNone {
 		for i := range layout.Children {
-			if found := a11yFindLayoutWalk(&layout.Children[i], target, counter); found != nil {
+			if found := a11yFindLayoutWalk(&layout.Children[i], target, counter, depth+1); found != nil {
 				return found
 			}
 		}
@@ -313,7 +378,7 @@ func a11yFindLayoutWalk(layout *Layout, target int, counter *int) *Layout {
 	}
 	*counter++
 	for i := range layout.Children {
-		if found := a11yFindLayoutWalk(&layout.Children[i], target, counter); found != nil {
+		if found := a11yFindLayoutWalk(&layout.Children[i], target, counter, depth+1); found != nil {
 			return found
 		}
 	}

--- a/gui/a11y_tree_test.go
+++ b/gui/a11y_tree_test.go
@@ -28,6 +28,64 @@ func TestA11yCollectNilShape(t *testing.T) {
 	}
 }
 
+// buildDeepA11yChain returns a single-child chain of n role-bearing
+// layouts. Document-built subtrees (Markdown, SVG) can nest
+// arbitrarily deep, which is what the depth guard exists for.
+func buildDeepA11yChain(n int) *Layout {
+	root := &Layout{Shape: &Shape{A11YRole: AccessRoleGroup}}
+	cur := root
+	for i := 1; i < n; i++ {
+		cur.Children = []Layout{{Shape: &Shape{A11YRole: AccessRoleGroup}}}
+		cur = &cur.Children[0]
+	}
+	return root
+}
+
+func TestA11yCollectStopsAtMaxDepth(t *testing.T) {
+	root := buildDeepA11yChain(maxEventDepth + 50)
+	var nodes []A11yNode
+	var live []liveNode
+	if idx := a11yCollect(root, -1, &nodes, "", &live); idx != -1 {
+		t.Errorf("focusedIdx: got %d, want -1", idx)
+	}
+	if len(nodes) > maxEventDepth+1 {
+		t.Errorf("nodes: got %d, want at most %d — the walk descended past the depth budget",
+			len(nodes), maxEventDepth+1)
+	}
+}
+
+func TestA11yFindLayoutStopsAtMaxDepth(t *testing.T) {
+	root := buildDeepA11yChain(maxEventDepth + 50)
+	if l := a11yFindLayout(root, 0); l != root {
+		t.Error("node 0 should resolve to the root")
+	}
+	if l := a11yFindLayout(root, maxEventDepth+49); l != nil {
+		t.Error("a node past the depth budget should not resolve")
+	}
+}
+
+func TestA11yCollectScopedFocus(t *testing.T) {
+	// The focus store holds effective IDs, so a scoped widget is
+	// addressed by its full path, not the leaf its Cfg was written
+	// with. Assistive tech must hear that focus.
+	layout := Layout{
+		Shape: &Shape{A11YRole: AccessRoleGroup},
+		Children: []Layout{{Shape: &Shape{
+			ID: "field", effID: "settings:field",
+			Focusable: true, A11YRole: AccessRoleTextField,
+		}}},
+	}
+	var nodes []A11yNode
+	var live []liveNode
+	idx := a11yCollect(&layout, -1, &nodes, "settings:field", &live)
+	if idx < 0 {
+		t.Fatal("scoped focused widget was not reported as focused")
+	}
+	if nodes[idx].Role != AccessRoleTextField {
+		t.Errorf("focused node role: got %d, want TextField", nodes[idx].Role)
+	}
+}
+
 func TestA11yCollectSkipNoneRole(t *testing.T) {
 	layout := Layout{
 		Shape: &Shape{A11YRole: AccessRoleNone},
@@ -193,8 +251,8 @@ func TestA11yCollectLiveRegion(t *testing.T) {
 	if len(live) != 1 {
 		t.Fatalf("expected 1 live node, got %d", len(live))
 	}
-	if live[0].label != "status" {
-		t.Errorf("label: got %q", live[0].label)
+	if live[0].key.label != "status" {
+		t.Errorf("label: got %q", live[0].key.label)
 	}
 }
 
@@ -418,6 +476,87 @@ func TestA11yActionCallbackDecrement(t *testing.T) {
 	}
 }
 
+// A disabled widget answers no action: Press already refused, but
+// Increment, Decrement, Confirm and Cancel fired into disabled
+// controls. layoutDisables stamps Disabled onto every descendant, so
+// one check also covers a disabled ancestor.
+func TestA11yActionCallbackDisabledSkipsAllActions(t *testing.T) {
+	fired := 0
+	layout := Layout{
+		Shape: &Shape{
+			A11YRole: AccessRoleSlider,
+			Disabled: true,
+			events: &eventHandlers{
+				OnClick:   func(EventCtx) { fired++ },
+				OnKeyDown: func(EventCtx) { fired++ },
+			},
+		},
+	}
+	w := newTestWindow()
+	w.layout = layout
+	w.a11y.nodes = w.a11y.nodes[:0]
+	var live []liveNode
+	a11yCollect(&w.layout, -1, &w.a11y.nodes, "", &live)
+
+	for _, action := range []int{
+		A11yActionPress, A11yActionIncrement, A11yActionDecrement,
+		A11yActionConfirm, A11yActionCancel,
+	} {
+		a11yActionCallback(w, action, 0)
+	}
+	if fired != 0 {
+		t.Errorf("disabled widget fired %d action(s), want 0", fired)
+	}
+}
+
+// mockA11yActionPlatform captures the action callback initA11y hands
+// to the native side, so tests can invoke it the way a platform
+// thread would.
+type mockA11yActionPlatform struct {
+	noopNativePlatform
+	actionCb func(action, index int)
+}
+
+func (m *mockA11yActionPlatform) A11yInit(cb func(action, index int)) {
+	m.actionCb = cb
+}
+
+// Platform action callbacks arrive on foreign threads (VoiceOver,
+// Android JNI, D-Bus workers), never the main thread the layout
+// belongs to. They must queue onto it, not walk the live tree from
+// wherever the platform called.
+func TestA11yActionRoutesThroughQueueCommand(t *testing.T) {
+	clicked := false
+	layout := Layout{
+		Shape: &Shape{
+			A11YRole: AccessRoleButton,
+			events: &eventHandlers{
+				OnClick: func(EventCtx) { clicked = true },
+			},
+		},
+	}
+	w := newTestWindow()
+	w.layout = layout
+	w.a11y.nodes = w.a11y.nodes[:0]
+	var live []liveNode
+	a11yCollect(&w.layout, -1, &w.a11y.nodes, "", &live)
+
+	p := &mockA11yActionPlatform{}
+	w.nativePlatform = p
+	w.initA11y()
+	if p.actionCb == nil {
+		t.Fatal("initA11y did not register an action callback")
+	}
+	p.actionCb(A11yActionPress, 0)
+	if clicked {
+		t.Error("platform action dispatched synchronously from a foreign thread")
+	}
+	w.flushCommands()
+	if !clicked {
+		t.Error("queued platform action never dispatched")
+	}
+}
+
 func TestA11yActionCallbackOutOfBounds(_ *testing.T) {
 	w := newTestWindow()
 	w.a11y.nodes = nil
@@ -537,6 +676,7 @@ type mockA11yPlatform struct {
 	noopNativePlatform
 	synced   []A11yNode
 	syncCnt  int
+	calls    int
 	focusIdx int
 	announce []string
 }
@@ -547,6 +687,7 @@ func (m *mockA11yPlatform) A11ySync(
 	// Copy nodes to avoid aliasing reused slice.
 	m.synced = append(m.synced[:0], nodes[:count]...)
 	m.syncCnt = count
+	m.calls++
 	m.focusIdx = focusedIdx
 }
 
@@ -599,9 +740,55 @@ func TestSyncA11yEmptyNodes(t *testing.T) {
 	w.layout = Layout{
 		Shape: &Shape{A11YRole: AccessRoleNone},
 	}
+	w.a11y.lastSync = time.Time{}
 	w.syncA11y()
-	if mp := w.nativePlatform.(*mockA11yPlatform); mp.syncCnt != 0 {
-		t.Error("A11ySync should not be called when nodes are empty")
+	// An emptied tree still pushes, so the native side clears its
+	// stale content instead of keeping it.
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if mp.calls != 1 {
+		t.Fatalf("empty tree: %d sync calls, want 1", mp.calls)
+	}
+	if mp.syncCnt != 0 {
+		t.Errorf("empty tree node count: got %d, want 0", mp.syncCnt)
+	}
+	if mp.focusIdx != -1 {
+		t.Errorf("empty tree focus: got %d, want -1", mp.focusIdx)
+	}
+}
+
+// Content that empties and returns must not announce on return: the
+// empty push resets the live baselines, so restored values read as
+// new rather than changed.
+func TestSyncA11yEmptyClearsLiveBaseline(t *testing.T) {
+	w := newA11yWindow()
+	w.initA11y()
+	liveShape := func() *Shape {
+		return &Shape{
+			A11YRole:  AccessRoleStaticText,
+			A11YState: AccessStateLive,
+			a11Y:      &accessInfo{Label: "status", ValueNum: 1},
+		}
+	}
+	w.layout = Layout{Shape: liveShape()}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y() // baseline, no announces
+
+	w.layout = Layout{Shape: &Shape{A11YRole: AccessRoleNone}}
+	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
+	w.syncA11y()
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if mp.calls != 2 || mp.syncCnt != 0 {
+		t.Fatalf("empty push: calls=%d count=%d, want 2/0",
+			mp.calls, mp.syncCnt)
+	}
+
+	w.layout = Layout{Shape: liveShape()}
+	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
+	w.syncA11y()
+	if len(mp.announce) != 0 {
+		t.Errorf("restored content announced: %v", mp.announce)
 	}
 }
 
@@ -833,6 +1020,96 @@ func TestSyncA11yLiveRegionNoChange(t *testing.T) {
 	mp := w.nativePlatform.(*mockA11yPlatform)
 	if len(mp.announce) != 0 {
 		t.Errorf("expected 0 announces, got %d", len(mp.announce))
+	}
+}
+
+// Two unlabeled live regions share the "" key under label keying, so
+// a change to one announces for the other too. Identity keying keeps
+// them apart.
+func TestSyncA11yLiveRegionUnlabeledPair(t *testing.T) {
+	w := newA11yWindow()
+	w.initA11y()
+	mkLive := func(v float32) Layout {
+		return Layout{Shape: &Shape{
+			A11YRole:  AccessRoleStaticText,
+			A11YState: AccessStateLive,
+			a11Y:      &accessInfo{ValueNum: v},
+		}}
+	}
+	w.layout = Layout{
+		Shape:    &Shape{A11YRole: AccessRoleGroup},
+		Children: []Layout{mkLive(1), mkLive(2)},
+	}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y() // baseline, no announces
+
+	w.layout.Children[1].Shape.a11Y.ValueNum = 3
+	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
+	w.syncA11y()
+
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if len(mp.announce) != 1 || mp.announce[0] != "3" {
+		t.Errorf("announces: got %v, want [3] — no spurious announce for the untouched region",
+			mp.announce)
+	}
+}
+
+// Two regions sharing one label collapse onto one prev entry under
+// label keying, so an unchanged resync announces spuriously for the
+// region whose value differs from its sibling's.
+func TestSyncA11yLiveRegionSharedLabelNoChange(t *testing.T) {
+	w := newA11yWindow()
+	w.initA11y()
+	mkLive := func(v float32) Layout {
+		return Layout{Shape: &Shape{
+			A11YRole:  AccessRoleStaticText,
+			A11YState: AccessStateLive,
+			a11Y:      &accessInfo{Label: "s", ValueNum: v},
+		}}
+	}
+	w.layout = Layout{
+		Shape:    &Shape{A11YRole: AccessRoleGroup},
+		Children: []Layout{mkLive(1), mkLive(2)},
+	}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y() // baseline, no announces
+
+	// Nothing changed — resync must stay silent.
+	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
+	w.syncA11y()
+
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if len(mp.announce) != 0 {
+		t.Errorf("expected 0 announces, got %v", mp.announce)
+	}
+}
+
+// An ID-bearing region is pinned by its identity: a simultaneous
+// label and value change still announces the new value, where label
+// keying read it as a brand-new region and stayed silent.
+func TestSyncA11yLiveRegionIDSurvivesLabelChange(t *testing.T) {
+	w := newA11yWindow()
+	w.initA11y()
+	w.layout = Layout{Shape: &Shape{
+		ID:        "dl",
+		A11YRole:  AccessRoleStaticText,
+		A11YState: AccessStateLive,
+		a11Y:      &accessInfo{Label: "old", ValueNum: 1},
+	}}
+	w.a11y.lastSync = time.Time{}
+	w.syncA11y() // baseline, no announces
+
+	w.layout.Shape.a11Y.Label = "new"
+	w.layout.Shape.a11Y.ValueNum = 2
+	w.a11y.lastSync = time.Time{}
+	w.a11y.dirty = true
+	w.syncA11y()
+
+	mp := w.nativePlatform.(*mockA11yPlatform)
+	if len(mp.announce) != 1 || mp.announce[0] != "2" {
+		t.Errorf("announces: got %v, want [2]", mp.announce)
 	}
 }
 

--- a/gui/animation.go
+++ b/gui/animation.go
@@ -38,7 +38,13 @@ func updateTransition(tb *transitionBase, ac *AnimationCommands) bool {
 	if easing == nil {
 		easing = EaseOutCubic
 	}
-	tb.progress = easing(progress)
+	if eased := easing(progress); f32IsFinite(eased) {
+		tb.progress = eased
+	} else {
+		// A custom easing hook returned NaN/Inf: fall back to linear
+		// progress rather than baking it into layout geometry.
+		tb.progress = progress
+	}
 	return true
 }
 
@@ -82,6 +88,13 @@ func maxAnimationRefreshKind(current, incoming AnimationRefreshKind) AnimationRe
 	}
 	return current
 }
+
+// Only Animate carries a configurable Refresh: its callback runs once per
+// interval and declares whether it repaints or rebuilds. The value
+// animations (tween, spring, keyframe) and the transitions fix
+// AnimationRefreshLayout because their per-tick OnValue is arbitrary
+// caller code — it may change tree contents, not just paint — so the
+// safe kind is a full rebuild every tick that emits.
 
 // Animation is the interface for all animation types. Update is
 // called each tick with the nominal timestep in seconds (the fixed

--- a/gui/animation_hero.go
+++ b/gui/animation_hero.go
@@ -42,7 +42,7 @@ func (h *HeroTransition) Update(_ *Window, _ float32, ac *AnimationCommands) boo
 // NewHeroTransition creates a HeroTransition with defaults.
 func NewHeroTransition(cfg HeroTransitionCfg) *HeroTransition {
 	dur := cfg.Duration
-	if dur == 0 {
+	if dur <= 0 {
 		dur = 300 * time.Millisecond
 	}
 	eas := cfg.Easing
@@ -62,7 +62,7 @@ func NewHeroTransition(cfg HeroTransitionCfg) *HeroTransition {
 // Layout is a large struct and this runs on a frame's root.
 func captureHeroSnapshots(layout *Layout) map[string]posSnapshot {
 	snapshots := make(map[string]posSnapshot)
-	captureSnapshots(layout, snapshots, true)
+	captureSnapshots(layout, snapshots, true, 0)
 	return snapshots
 }
 

--- a/gui/animation_keyframe.go
+++ b/gui/animation_keyframe.go
@@ -68,18 +68,39 @@ func updateKeyframe(kf *KeyframeAnimation, ac *AnimationCommands) bool {
 	progress, done := durationProgress(kf.start, kf.Duration)
 	if done {
 		if len(kf.Keyframes) > 0 {
-			ac.appendOnValue(kf.OnValue, kf.Keyframes[len(kf.Keyframes)-1].Value)
+			if v := kf.Keyframes[len(kf.Keyframes)-1].Value; f32IsFinite(v) {
+				ac.appendOnValue(kf.OnValue, v)
+			}
 		}
 		if kf.Repeat {
+			// A non-positive Duration is always done (see
+			// durationProgress): looping on it would return true
+			// every tick forever. Retire as a one-shot instead.
+			if kf.Duration <= 0 {
+				ac.appendOnDone(kf.OnDone)
+				kf.stopped = true
+				return true
+			}
+			now := time.Now()
 			kf.start = kf.start.Add(kf.Duration)
+			// Drop the backlog a stall accumulated, the same rule
+			// Animate and the caret blink follow: without it a
+			// minimized window drains one missed interval per tick.
+			kf.start = resyncAfterStall(kf.start, now, kf.Duration)
 			return true
 		}
 		ac.appendOnDone(kf.OnDone)
 		kf.stopped = true
 		return true
 	}
-	ac.appendOnValue(kf.OnValue, interpolateKeyframes(kf.Keyframes, progress))
-	return true
+	if v := interpolateKeyframes(kf.Keyframes, progress); f32IsFinite(v) {
+		ac.appendOnValue(kf.OnValue, v)
+		return true
+	}
+	// A non-finite sample comes from a Custom easing hook or a
+	// non-finite waypoint: drop the frame rather than poison layout
+	// geometry. No refresh needed — nothing changed.
+	return false
 }
 
 func interpolateKeyframes(keyframes []Keyframe, progress float32) float32 {
@@ -109,6 +130,9 @@ func interpolateKeyframes(keyframes []Keyframe, progress float32) float32 {
 		return curr.Value
 	}
 	local := (progress - prev.At) / segLen
+	// Clamped so an out-of-order At cannot drive a custom easing
+	// hook far outside [0,1]: sorted input never touches the clamp.
+	local = f32Clamp(local, 0, 1)
 	easing := curr.Easing
 	if easing == nil {
 		easing = EaseLinear

--- a/gui/animation_layout.go
+++ b/gui/animation_layout.go
@@ -65,7 +65,7 @@ func (l *layoutTransition) Update(_ *Window, _ float32, ac *AnimationCommands) b
 // making layout changes to capture current positions.
 func (w *Window) AnimateLayout(cfg LayoutTransitionCfg) {
 	dur := cfg.Duration
-	if dur == 0 {
+	if dur <= 0 {
 		dur = 200 * time.Millisecond
 	}
 	eas := cfg.Easing
@@ -86,15 +86,22 @@ func (w *Window) AnimateLayout(cfg LayoutTransitionCfg) {
 // captureLayoutSnapshots recursively captures all element positions.
 func captureLayoutSnapshots(layout *Layout) map[string]posSnapshot {
 	snapshots := make(map[string]posSnapshot)
-	captureSnapshots(layout, snapshots, false)
+	captureSnapshots(layout, snapshots, false, 0)
 	return snapshots
 }
 
-func captureSnapshots(layout *Layout, snapshots map[string]posSnapshot, heroOnly bool) {
+func captureSnapshots(layout *Layout, snapshots map[string]posSnapshot, heroOnly bool, depth int) {
+	// Depth-guarded like the apply walks: the tree is not always the
+	// app's own (markdown and SVG build subtrees out of documents the
+	// app did not write), so an unbounded capture recurses until the
+	// stack gives out on a deeply nested document.
+	if layout == nil || overMaxDepth(depth) {
+		return
+	}
 	// Snapshots key on the effective ID, so a widget keeps its identity
 	// across a transition only while its ID-bearing ancestors do — the
 	// same rule the stores use.
-	if layout.Shape.ID != "" && (!heroOnly || layout.Shape.Hero) {
+	if layout.Shape != nil && layout.Shape.ID != "" && (!heroOnly || layout.Shape.Hero) {
 		snapshots[layout.Shape.idKey()] = posSnapshot{
 			x:      layout.Shape.X,
 			y:      layout.Shape.Y,
@@ -103,7 +110,7 @@ func captureSnapshots(layout *Layout, snapshots map[string]posSnapshot, heroOnly
 		}
 	}
 	for i := range layout.Children {
-		captureSnapshots(&layout.Children[i], snapshots, heroOnly)
+		captureSnapshots(&layout.Children[i], snapshots, heroOnly, depth+1)
 	}
 }
 

--- a/gui/animation_loop.go
+++ b/gui/animation_loop.go
@@ -6,7 +6,7 @@ const animationCycle = 16 * time.Millisecond
 
 // animViewBoundStale is the heartbeat threshold for view-bound animations.
 // An animation not touched for this duration is cancelled automatically.
-const animViewBoundStale = 2 * int64(time.Second)
+const animViewBoundStale = 2 * time.Second
 
 // viewBoundNow is the clock for view-bound heartbeats. It is deliberately
 // time.Now() and not w.Now(): w.Now() follows the time-travel scrub pin,
@@ -16,7 +16,11 @@ const animViewBoundStale = 2 * int64(time.Second)
 // so every visible widget's animation would be cancelled on the first tick
 // after a scrub ends. The heartbeat measures liveness and is never shown to
 // a user, so it has no reason to be scrubbable.
-func viewBoundNow() int64 { return time.Now().UnixNano() }
+//
+// The stamp is a time.Time rather than a UnixNano so the comparison uses
+// the monotonic reading: a wall-clock step (NTP, sleep/wake) must not
+// mass-cancel every visible widget's animation.
+func viewBoundNow() time.Time { return time.Now() }
 
 // AnimationAdd registers a new animation. If an animation with the
 // same ID exists, it is replaced.
@@ -89,7 +93,7 @@ func (w *Window) animationAddViewBound(a Animation) {
 	defer w.animMu.Unlock()
 	w.animationAddLocked(a)
 	if w.animViewBound == nil {
-		w.animViewBound = make(map[string]int64)
+		w.animViewBound = make(map[string]time.Time)
 	}
 	w.animViewBound[a.ID()] = viewBoundNow()
 }
@@ -134,6 +138,13 @@ func (w *Window) HasAnimation(id string) bool {
 // tick and dispatching deferred callbacks via the command queue.
 // The ticker starts paused and resumes when animationAdd signals
 // via animationResumeCh. It pauses again when all animations stop.
+//
+// Update calls run with animMu held so a tick's retire decisions and
+// heartbeat evictions apply atomically: nothing is added or removed
+// mid-walk. The cost is contention — HasAnimation/AnimationAdd from a
+// view function wait out the tick's Updates (each a time.Now plus
+// arithmetic). Keep Update bodies O(1); per-frame work belongs in the
+// deferred callbacks, which run off the loop on the main thread.
 func (w *Window) animationLoop() {
 	if w.animationDone != nil {
 		defer close(w.animationDone)
@@ -181,7 +192,7 @@ func (w *Window) animationLoop() {
 		// Auto-cancel view-bound animations whose widget left the view tree.
 		now := viewBoundNow()
 		for id, seen := range w.animViewBound {
-			if now-seen > animViewBoundStale {
+			if now.Sub(seen) > animViewBoundStale {
 				stoppedIDs = append(stoppedIDs, id)
 			}
 		}

--- a/gui/animation_loop_test.go
+++ b/gui/animation_loop_test.go
@@ -163,7 +163,7 @@ func TestTouchViewBoundAnimation_ExistsUpdatesHeartbeat(t *testing.T) {
 	if !w.touchViewBoundAnimation("vb2") {
 		t.Error("should return true for existing view-bound animation")
 	}
-	if w.animViewBound["vb2"] <= old {
+	if !w.animViewBound["vb2"].After(old) {
 		t.Error("heartbeat should advance after touch")
 	}
 }
@@ -210,7 +210,7 @@ func TestViewBoundStaleEviction(t *testing.T) {
 	}
 	w.mu.Lock()
 	w.animationAddViewBound(anim)
-	w.animViewBound["stale1"] = 0 // Unix epoch — always stale
+	w.animViewBound["stale1"] = time.Now().Add(-time.Hour) // always stale
 	w.mu.Unlock()
 
 	deadline := time.Now().Add(200 * time.Millisecond)
@@ -340,16 +340,16 @@ func TestViewBoundHeartbeatIgnoresScrubClock(t *testing.T) {
 	}
 
 	seen := w.animViewBound["vb-scrub"]
-	if seen-past.UnixNano() < int64(9*time.Minute) {
+	if seen.Sub(past) < 9*time.Minute {
 		w.setVirtualNow(nil)
 		t.Errorf("heartbeat followed the scrub clock (seen-past = %v)",
-			time.Duration(seen-past.UnixNano()))
+			seen.Sub(past))
 	}
 
 	w.setVirtualNow(nil) // resume(): virtual pin cleared, live time back
 	seen = w.animViewBound["vb-scrub"]
-	if age := viewBoundNow() - seen; age > animViewBoundStale {
-		t.Errorf("heartbeat looks stale after resume (age = %v)", time.Duration(age))
+	if age := viewBoundNow().Sub(seen); age > animViewBoundStale {
+		t.Errorf("heartbeat looks stale after resume (age = %v)", age)
 	}
 }
 
@@ -362,7 +362,7 @@ func TestViewBoundStaleStillEvictsWhilePinned(t *testing.T) {
 	tw := NewTweenAnimation("vb-pinned", 0, 1, func(float32, *Window) {})
 	w.animationAddViewBound(tw)
 	w.animMu.Lock()
-	w.animViewBound["vb-pinned"] = time.Now().Add(-3 * time.Second).UnixNano()
+	w.animViewBound["vb-pinned"] = time.Now().Add(-3 * time.Second)
 	w.animMu.Unlock()
 
 	past := time.Now().Add(-10 * time.Minute)
@@ -372,7 +372,7 @@ func TestViewBoundStaleStillEvictsWhilePinned(t *testing.T) {
 	w.animMu.Lock()
 	seen := w.animViewBound["vb-pinned"]
 	w.animMu.Unlock()
-	if viewBoundNow()-seen <= animViewBoundStale {
+	if viewBoundNow().Sub(seen) <= animViewBoundStale {
 		t.Error("stale heartbeat should still read stale while scrub-pinned")
 	}
 }

--- a/gui/animation_review_fixes_test.go
+++ b/gui/animation_review_fixes_test.go
@@ -1,0 +1,365 @@
+package gui
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+// Repeating keyframes drop the stall backlog like Animate: one done tick
+// resyncs instead of draining a missed interval per tick.
+func TestKeyframeRepeatDropsBacklogAfterStall(t *testing.T) {
+	kf := NewKeyframeAnimation("k-stall",
+		[]Keyframe{
+			{At: 0, Value: 0},
+			{At: 1, Value: 100, Easing: EaseLinear},
+		},
+		func(float32, *Window) {},
+	)
+	kf.Repeat = true
+	kf.Duration = 16 * time.Millisecond
+	kf.SetStart(time.Now().Add(-5 * time.Second))
+
+	deferred := make([]queuedCommand, 0, 16)
+	ac := newAnimationCommands(&deferred)
+	updateKeyframe(kf, &ac)
+
+	if behind := time.Since(kf.start); behind > kf.Duration {
+		t.Errorf("start still %v behind, want under %v", behind, kf.Duration)
+	}
+	if kf.stopped {
+		t.Error("repeating keyframe should not stop")
+	}
+}
+
+// A non-positive repeating Duration is always done: retire as a one-shot
+// instead of returning true every tick forever.
+func TestKeyframeRepeatNonPositiveDurationRetires(t *testing.T) {
+	for _, d := range []time.Duration{0, -100 * time.Millisecond} {
+		done := false
+		kf := NewKeyframeAnimation("k-zero",
+			[]Keyframe{{At: 0, Value: 0}, {At: 1, Value: 100}},
+			func(float32, *Window) {},
+		)
+		kf.Repeat = true
+		kf.Duration = d
+		kf.OnDone = func(*Window) { done = true }
+		kf.SetStart(time.Now().Add(-time.Second))
+
+		deferred := make([]queuedCommand, 0, 4)
+		ac := newAnimationCommands(&deferred)
+		updateKeyframe(kf, &ac)
+		runQueuedCommands(deferred)
+		if !kf.stopped {
+			t.Errorf("duration %v: repeating keyframe should retire", d)
+		}
+		if !done {
+			t.Errorf("duration %v: OnDone should run", d)
+		}
+	}
+}
+
+// A NaN easing sample is dropped: nothing queued, no refresh, still live.
+func TestKeyframeNaNEasingDropsFrame(t *testing.T) {
+	nanEase := func(float32) float32 { return float32(math.NaN()) }
+	kf := NewKeyframeAnimation("k-nan",
+		[]Keyframe{{At: 0, Value: 0}, {At: 1, Value: 100, Easing: nanEase}},
+		func(float32, *Window) {},
+	)
+	kf.Duration = time.Hour // mid-flight, not done
+	kf.SetStart(time.Now())
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	if updateKeyframe(kf, &ac) {
+		t.Error("NaN sample should not request a refresh")
+	}
+	if len(deferred) != 0 {
+		t.Errorf("queued %d commands, want 0", len(deferred))
+	}
+	if kf.stopped {
+		t.Error("should stay live after a dropped frame")
+	}
+}
+
+// A non-finite completion value is skipped but OnDone still runs.
+func TestKeyframeNaNFinalValueSkipped(t *testing.T) {
+	var got []float32
+	done := false
+	kf := NewKeyframeAnimation("k-nanfinal",
+		[]Keyframe{{At: 0, Value: 0}, {At: 1, Value: float32(math.NaN())}},
+		func(v float32, _ *Window) { got = append(got, v) },
+	)
+	kf.OnDone = func(*Window) { done = true }
+	kf.SetStart(time.Now().Add(-time.Second))
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	updateKeyframe(kf, &ac)
+	runQueuedCommands(deferred)
+	for _, v := range got {
+		if math.IsNaN(float64(v)) {
+			t.Errorf("OnValue received NaN")
+		}
+	}
+	if !done {
+		t.Error("OnDone should run")
+	}
+	if !kf.stopped {
+		t.Error("should stop")
+	}
+}
+
+// Zero-value tween easing matches the constructor default (EaseOutCubic).
+func TestTweenNilEasingMatchesConstructor(t *testing.T) {
+	var got float32
+	tw := &TweenAnimation{
+		AnimID:   "t-nil",
+		Duration: 300 * time.Millisecond,
+		From:     0,
+		To:       100,
+		OnValue:  func(v float32, _ *Window) { got = v },
+	}
+	tw.SetStart(time.Now().Add(-150 * time.Millisecond))
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	updateTween(tw, &ac)
+	runQueuedCommands(deferred)
+	// EaseOutCubic(0.5) = 0.875 → 87.5; linear would give ~50.
+	if got < 75 || got > 95 {
+		t.Errorf("value = %v, want ~87.5 (EaseOutCubic)", got)
+	}
+}
+
+// Non-finite tween endpoints never reach OnValue.
+func TestTweenNonFiniteEndpointsDropped(t *testing.T) {
+	tw := NewTweenAnimation("t-nan",
+		float32(math.NaN()), float32(math.Inf(1)),
+		func(v float32, _ *Window) {
+			t.Errorf("OnValue received %v", v)
+		})
+	tw.SetStart(time.Now())
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	if updateTween(tw, &ac) {
+		t.Error("poisoned endpoints should not request a refresh")
+	}
+	if tw.stopped {
+		t.Error("should stay live until duration ends")
+	}
+
+	tw2 := NewTweenAnimation("t-nanto",
+		0, float32(math.NaN()),
+		func(v float32, _ *Window) {
+			if math.IsNaN(float64(v)) {
+				t.Errorf("OnValue received NaN")
+			}
+		})
+	done := false
+	tw2.OnDone = func(*Window) { done = true }
+	tw2.SetStart(time.Now().Add(-time.Second))
+	deferred = deferred[:0]
+	ac = newAnimationCommands(&deferred)
+	updateTween(tw2, &ac)
+	runQueuedCommands(deferred)
+	if !done || !tw2.stopped {
+		t.Error("completion should still run OnDone and stop")
+	}
+}
+
+// Non-finite spring config falls back instead of snapping instantly.
+func TestSpringNaNConfigFallsBackToDefault(t *testing.T) {
+	var got []float32
+	sp := NewSpringAnimation("s-nan", func(v float32, _ *Window) {
+		got = append(got, v)
+	})
+	sp.Config = SpringCfg{
+		Stiffness: float32(math.NaN()),
+		Damping:   float32(math.NaN()),
+		Mass:      float32(math.NaN()),
+		Threshold: float32(math.NaN()),
+	}
+	sp.SpringTo(0, 1)
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	updateSpring(sp, 0.016, &ac)
+	if sp.stopped {
+		t.Fatal("sanitized spring should not snap on the first tick")
+	}
+	runQueuedCommands(deferred)
+	if len(got) != 1 || got[0] == 1 {
+		t.Errorf("got %v, want one mid-flight sample", got)
+	}
+}
+
+// Negative spring config falls back instead of diverging.
+func TestSpringNegativeConfigFallsBack(t *testing.T) {
+	var got float32
+	sp := NewSpringAnimation("s-neg", func(v float32, _ *Window) { got = v })
+	sp.Config = SpringCfg{Stiffness: -50, Damping: -5, Mass: 1, Threshold: 0.01}
+	sp.SpringTo(0, 1)
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	updateSpring(sp, 0.016, &ac)
+	if sp.stopped {
+		t.Error("negative config should sanitize, not snap")
+	}
+	runQueuedCommands(deferred)
+	if math.IsNaN(float64(got)) || math.IsInf(float64(got), 0) {
+		t.Errorf("sample = %v, want finite", got)
+	}
+	if got == 1 {
+		t.Error("sanitized spring should ease in, not arrive on tick one")
+	}
+}
+
+// A non-finite spring target retires without emitting.
+func TestSpringNaNTargetRetiresCleanly(t *testing.T) {
+	sp := NewSpringAnimation("s-nantarget", func(v float32, _ *Window) {
+		t.Errorf("OnValue received %v", v)
+	})
+	done := false
+	sp.OnDone = func(*Window) { done = true }
+	sp.SpringTo(0, float32(math.NaN()))
+
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	updateSpring(sp, 0.016, &ac)
+	runQueuedCommands(deferred)
+	if !sp.stopped || !done {
+		t.Error("should retire with OnDone and no value")
+	}
+}
+
+// A NaN easing hook cannot poison a transition's progress.
+func TestTransitionNaNEasingFallsBack(t *testing.T) {
+	tb := &transitionBase{
+		duration: time.Hour,
+		easing:   func(float32) float32 { return float32(math.NaN()) },
+	}
+	tb.SetStart(time.Now())
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	updateTransition(tb, &ac)
+	if math.IsNaN(float64(tb.progress)) {
+		t.Fatal("progress is NaN")
+	}
+	if tb.progress < 0 || tb.progress > 1 {
+		t.Errorf("progress = %v, want linear fallback in [0,1]", tb.progress)
+	}
+}
+
+// Snapshot capture stops at the shared depth budget.
+func TestCaptureSnapshotsRespectsDepthBudget(t *testing.T) {
+
+	const chainLen = 1000
+	root := &Layout{Shape: &Shape{}}
+	cur := root
+	for i := range chainLen {
+		cur.Children = []Layout{{Shape: &Shape{ID: fmt.Sprintf("n%d", i)}}}
+		cur = &cur.Children[0]
+	}
+	got := captureLayoutSnapshots(root)
+	if len(got) >= chainLen {
+		t.Errorf("captured %d snapshots, want under %d", len(got), chainLen)
+	}
+	if len(got) > maxEventDepth+1 {
+		t.Errorf("captured %d snapshots, want at most %d", len(got), maxEventDepth+1)
+	}
+}
+
+// A nil shape never panics capture; the walk skips it and continues.
+func TestCaptureSnapshotsNilSafe(t *testing.T) {
+	root := &Layout{Shape: &Shape{ID: "root"}}
+	root.Children = []Layout{{Shape: nil}, {Shape: &Shape{ID: "leaf"}}}
+	got := captureLayoutSnapshots(root)
+	if len(got) != 2 {
+		t.Errorf("captured %d snapshots, want 2", len(got))
+	}
+	var nilRoot *Layout
+	if out := captureLayoutSnapshots(nilRoot); len(out) != 0 {
+		t.Errorf("nil root captured %d snapshots, want 0", len(out))
+	}
+}
+
+// Out-of-order waypoints stay bounded: the segment fraction is clamped
+// so a custom easing hook never sees input far outside [0,1]. With the
+// waypoints below, progress 0.5 lands in slice-segment [0.2,0.4] with a
+// raw fraction of 1.5, which EaseInQuad would amplify to 2.25.
+func TestInterpolateUnsortedAtStaysBounded(t *testing.T) {
+	kfs := []Keyframe{
+		{At: 0.6, Value: 60},
+		{At: 0.2, Value: 20},
+		{At: 0.4, Value: 40, Easing: EaseInQuad},
+	}
+	if got := interpolateKeyframes(kfs, 0.5); got < 20 || got > 60 {
+		t.Errorf("got %v, want within [20,60]", got)
+	}
+}
+
+// Negative transition durations take the default instead of retiring.
+func TestNegativeTransitionDurationsDefault(t *testing.T) {
+	w := &Window{}
+	w.layout = Layout{Shape: &Shape{}}
+	w.AnimateLayout(LayoutTransitionCfg{Duration: -100 * time.Millisecond})
+	lt, ok := w.animations[layoutTransitionID].(*layoutTransition)
+	if !ok {
+		t.Fatal("layout transition not registered")
+	}
+	if lt.duration != 200*time.Millisecond {
+		t.Errorf("duration = %v, want 200ms", lt.duration)
+	}
+	ht := NewHeroTransition(HeroTransitionCfg{Duration: -time.Second})
+	if ht.duration != 300*time.Millisecond {
+		t.Errorf("hero duration = %v, want 300ms", ht.duration)
+	}
+}
+
+// A stopped smoother releases its entries instead of retaining one per
+// scrollable ever touched.
+func TestScrollSmoothReleasesEntriesOnStop(t *testing.T) {
+	ss := &scrollSmoothAnimation{
+		entries: []scrollSmoothEntry{
+			{id: "a", axis: scrollAxisY},
+			{id: "b", axis: scrollAxisX},
+		},
+	}
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	if ss.Update(nil, 0, &ac) {
+		t.Error("idle smoother should not request a refresh")
+	}
+	if !ss.stopped {
+		t.Error("idle smoother should stop")
+	}
+	if len(ss.entries) != 0 {
+		t.Errorf("retained %d entries, want 0", len(ss.entries))
+	}
+}
+
+// An unapplied final value survives the stop: the tick must not drop a
+// dirty entry the main thread has not flushed yet, or the ease ends
+// fractionally short of its target.
+func TestScrollSmoothKeepsDirtyEntriesOnStop(t *testing.T) {
+	ss := &scrollSmoothAnimation{
+		entries: []scrollSmoothEntry{
+			{id: "a", axis: scrollAxisY, current: -50, dirty: true},
+		},
+	}
+	deferred := make([]queuedCommand, 0, 4)
+	ac := newAnimationCommands(&deferred)
+	if ss.Update(nil, 0, &ac) {
+		t.Error("idle smoother should not request a refresh")
+	}
+	if !ss.stopped {
+		t.Error("idle smoother should stop")
+	}
+	if len(ss.entries) != 1 {
+		t.Fatal("dirty entry dropped before its final value was applied")
+	}
+}

--- a/gui/animation_review_fixes_test.go
+++ b/gui/animation_review_fixes_test.go
@@ -68,7 +68,12 @@ func TestKeyframeNaNEasingDropsFrame(t *testing.T) {
 		func(float32, *Window) {},
 	)
 	kf.Duration = time.Hour // mid-flight, not done
-	kf.SetStart(time.Now())
+	// Start in the past: at progress exactly 0 interpolation
+	// returns the first waypoint without invoking the easing
+	// hook, and a coarse clock can report a just-set start as
+	// elapsed 0. A 1ms head start keeps the NaN sample on-path
+	// on every platform.
+	kf.SetStart(time.Now().Add(-time.Millisecond))
 
 	deferred := make([]queuedCommand, 0, 4)
 	ac := newAnimationCommands(&deferred)

--- a/gui/animation_spring.go
+++ b/gui/animation_spring.go
@@ -104,11 +104,29 @@ func updateSpring(sp *SpringAnimation, dt float32, ac *AnimationCommands) bool {
 		return false
 	}
 	cfg := sp.Config
-	if cfg.Mass <= 0 {
+	if !f32IsFinite(cfg.Mass) || cfg.Mass <= 0 {
 		cfg.Mass = SpringDefault.Mass
 	}
-	if cfg.Threshold <= 0 {
+	if !f32IsFinite(cfg.Threshold) || cfg.Threshold <= 0 {
 		cfg.Threshold = SpringDefault.Threshold
+	}
+	// A negative or non-finite stiffness repels from the target and a
+	// negative or non-finite damping injects energy: either diverges
+	// into the snap path below. Fall back to the default instead of
+	// surprising the caller with an instant arrival.
+	if !f32IsFinite(cfg.Stiffness) || cfg.Stiffness < 0 {
+		cfg.Stiffness = SpringDefault.Stiffness
+	}
+	if !f32IsFinite(cfg.Damping) || cfg.Damping < 0 {
+		cfg.Damping = SpringDefault.Damping
+	}
+	// A non-finite target (via SpringTo/retarget) has nowhere to snap
+	// to: retire without emitting so NaN never reaches OnValue.
+	if !f32IsFinite(sp.state.target) {
+		sp.state.atRest = true
+		ac.appendOnDone(sp.OnDone)
+		sp.stopped = true
+		return true
 	}
 	displacement := sp.state.position - sp.state.target
 	springForce := -cfg.Stiffness * displacement

--- a/gui/animation_tween.go
+++ b/gui/animation_tween.go
@@ -5,7 +5,9 @@ import "time"
 // TweenAnimation interpolates a value from A to B over a fixed
 // duration with easing.
 type TweenAnimation struct {
-	start    time.Time
+	start time.Time
+	// Easing shapes progress before interpolation. Nil takes
+	// EaseOutCubic, matching NewTweenAnimation and the transitions.
 	Easing   EasingFn
 	OnValue  func(float32, *Window)
 	OnDone   func(*Window)
@@ -57,16 +59,30 @@ func updateTween(tw *TweenAnimation, ac *AnimationCommands) bool {
 	}
 	progress, done := durationProgress(tw.start, tw.Duration)
 	if done {
-		ac.appendOnValue(tw.OnValue, tw.To)
+		// A non-finite To would poison layout geometry: skip the
+		// value but still run OnDone so the caller can clean up.
+		if f32IsFinite(tw.To) {
+			ac.appendOnValue(tw.OnValue, tw.To)
+		}
 		ac.appendOnDone(tw.OnDone)
 		tw.stopped = true
 		return true
 	}
+	// Non-finite endpoints can never produce a paintable value.
+	if !f32IsFinite(tw.From) || !f32IsFinite(tw.To) {
+		return false
+	}
 	easing := tw.Easing
 	if easing == nil {
-		easing = EaseLinear
+		easing = EaseOutCubic
 	}
 	eased := easing(progress)
-	ac.appendOnValue(tw.OnValue, lerp(tw.From, tw.To, eased))
+	v := lerp(tw.From, tw.To, eased)
+	// A custom easing hook may return NaN/Inf: drop the frame rather
+	// than hand it to layout. Nothing changed, so no refresh.
+	if !f32IsFinite(v) {
+		return false
+	}
+	ac.appendOnValue(tw.OnValue, v)
 	return true
 }

--- a/gui/app.go
+++ b/gui/app.go
@@ -300,6 +300,12 @@ func (a *App) SetNativeMenubar(cfg NativeMenubarCfg) {
 		}
 		cur.QueueCommand(func(w *Window) {
 			if cmd, ok := w.CommandByID(id); ok {
+				if cmd.Execute == nil {
+					return
+				}
+				if !cmd.canExecute(w) {
+					return
+				}
 				cmd.Execute(nil, w)
 			} else if cfg.OnAction != nil {
 				cfg.OnAction(id)

--- a/gui/app.go
+++ b/gui/app.go
@@ -4,9 +4,22 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
-// ExitMode controls when the application exits.
+// pendingCap bounds queued window-creation requests. OpenWindow
+// never blocks; requests past this are dropped with a warning.
+const pendingCap = 16
+
+// dropLogInterval throttles the buffer-full warning so a burst
+// of OpenWindow calls logs once, not once per dropped request.
+const dropLogInterval = int64(time.Second)
+
+// ExitMode controls when the application exits. Use the
+// ExitOnMainClose / ExitOnTrayRemoved constants; the zero value
+// is ExitOnMainClose. The type is unexported to restrict values
+// to those constants — infer it with := rather than naming it.
 type exitMode int
 
 const (
@@ -18,6 +31,11 @@ const (
 )
 
 // App manages multiple windows in a single application.
+//
+// The zero value is not usable; construct with NewApp.
+// Register/Unregister are called by backends on the main thread.
+// OpenWindow, SetWakeMainFn, Window, Windows, and Broadcast are
+// safe to call from any goroutine.
 type App struct {
 	windows  map[uint32]*Window
 	pending  chan WindowCfg
@@ -26,70 +44,108 @@ type App struct {
 	ExitMode exitMode
 	mu       sync.Mutex
 	mainID   uint32
+	// wakeMu guards wakeMainFn separately from mu so OpenWindow
+	// (any goroutine) never blocks on map operations, and so
+	// Register can queue the debug window without lock ordering
+	// issues.
+	wakeMu sync.RWMutex
 	// wakeMainFn unblocks the backend's idle event loop when OpenWindow
 	// queues a window from another goroutine. Set by backends whose
 	// idle wait cannot select on pending itself (metal, win32); nil
 	// elsewhere (x11 selects on the pending channel directly).
 	wakeMainFn func()
+	// dropped counts OpenWindow requests lost to a full buffer.
+	// lastDropLog is the UnixNano of the last buffer-full warning.
+	dropped     atomic.Uint64
+	lastDropLog atomic.Int64
 }
 
 // NewApp creates an App with an empty window registry.
+// The default exit mode is ExitOnMainClose.
 func NewApp() *App {
 	return &App{
 		windows: make(map[uint32]*Window),
-		pending: make(chan WindowCfg, 16),
+		pending: make(chan WindowCfg, pendingCap),
+		trays:   make(map[int]*SystemTrayHandle),
 	}
 }
 
 // Register associates a platform window ID with a Window.
-// Duplicate IDs are ignored with a warning.
+// Duplicate IDs are ignored with a warning. Nil app or window
+// is ignored with a warning. Called by backends on the main
+// thread. The window linkage (App, PlatformID) is atomic, so
+// readers on other goroutines observe a consistent value.
 func (a *App) Register(id uint32, w *Window) {
+	if a == nil || w == nil {
+		log.Printf("gui: App.Register: nil app or window "+
+			"(id %d) ignored", id)
+		return
+	}
 	a.mu.Lock()
-	defer a.mu.Unlock()
+	if a.windows == nil {
+		a.windows = make(map[uint32]*Window)
+	}
 	if _, exists := a.windows[id]; exists {
+		a.mu.Unlock()
 		log.Printf("gui: App.Register: duplicate window ID %d ignored", id)
 		return
 	}
 	a.windows[id] = w
 	a.order = append(a.order, id)
-	w.app = a
-	w.platformID = id
 	if len(a.order) == 1 {
 		a.mainID = id
 	}
-	if w.Config.DebugTimeTravel {
+	// Config is immutable after NewWindow, so this read is safe.
+	needDebug := w.Config.DebugTimeTravel
+	a.mu.Unlock()
+	w.app.Store(a)
+	w.platformID.Store(id)
+	if needDebug {
 		// Auto-spawn the scrubber for the newly registered
-		// window. OpenDebugWindow→App.OpenWindow is a
-		// non-blocking channel send on a.pending, which is
-		// independent of a.mu, so it's safe to call here.
+		// window. Runs outside a.mu: OpenWindow takes wakeMu
+		// and must never nest inside the map lock.
 		w.openDebugWindow()
 	}
 }
 
 // Unregister removes a window. Returns true if the app should
-// exit based on ExitMode.
+// exit based on ExitMode. Unknown IDs still evaluate the exit
+// rule against the remaining set.
 //
-// Clears w.app and w.platformID without holding Window.mu. This is
-// safe because Unregister runs on the main thread, which is also the
-// only thread that reads these fields.
+// The window linkage clears atomically, so App() and PlatformID()
+// are safe from any goroutine. When the main window leaves while
+// siblings remain, mainID fails over to the oldest survivor (or
+// zero when none remain) so menubar and tray calls keep working
+// instead of stranding on a dead ID.
 func (a *App) Unregister(id uint32) bool {
+	if a == nil {
+		return false
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	w := a.windows[id]
-	if w != nil {
-		w.app = nil
-		w.platformID = 0
+	if w := a.windows[id]; w != nil {
+		w.app.Store(nil)
+		w.platformID.Store(0)
 	}
 	delete(a.windows, id)
 	for i, oid := range a.order {
 		if oid == id {
-			a.order = append(a.order[:i], a.order[i+1:]...)
+			copy(a.order[i:], a.order[i+1:])
+			a.order[len(a.order)-1] = 0
+			a.order = a.order[:len(a.order)-1]
 			break
+		}
+	}
+	wasMain := id == a.mainID
+	if wasMain {
+		a.mainID = 0
+		if len(a.order) > 0 {
+			a.mainID = a.order[0]
 		}
 	}
 	switch a.ExitMode {
 	case ExitOnMainClose:
-		return id == a.mainID
+		return wasMain
 	case ExitOnTrayRemoved:
 		return len(a.windows) == 0 && len(a.trays) == 0
 	default:
@@ -98,15 +154,33 @@ func (a *App) Unregister(id uint32) bool {
 }
 
 // Window returns the Window for the given platform ID, or nil.
+// Safe to call from any goroutine.
 func (a *App) Window(id uint32) *Window {
+	if a == nil {
+		return nil
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.windows[id]
 }
 
+// mainWindow returns the current main window, or nil. Callers
+// must not hold a.mu; the lookup is self-contained.
+func (a *App) mainWindow() *Window {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.windows[a.mainID]
+}
+
 // Windows returns all registered windows in creation order.
 // exportaudit:keep — collides with the windows map field
 func (a *App) Windows() []*Window {
+	if a == nil {
+		return nil
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	ws := make([]*Window, 0, len(a.order))
@@ -119,40 +193,68 @@ func (a *App) Windows() []*Window {
 }
 
 // OpenWindow queues a new window for creation on the next frame.
-// The internal buffer holds up to 16 pending requests. Requests
-// beyond that are dropped with a log warning.
+// The internal buffer holds up to pendingCap pending requests.
+// Requests beyond that are dropped; the warning logs at most
+// once per second with a running total, so a burst cannot spam
+// stderr. Safe to call from any goroutine.
 func (a *App) OpenWindow(cfg WindowCfg) {
+	if a == nil {
+		return
+	}
 	select {
 	case a.pending <- cfg:
 	default:
-		log.Println("gui: App.OpenWindow: pending buffer full, " +
-			"window request dropped")
+		n := a.dropped.Add(1)
+		now := time.Now().UnixNano()
+		last := a.lastDropLog.Load()
+		if now-last > dropLogInterval &&
+			a.lastDropLog.CompareAndSwap(last, now) {
+			log.Printf("gui: App.OpenWindow: pending buffer full, "+
+				"window request dropped (%d total)", n)
+		}
 		return
 	}
 	// The backend event loop may be blocked in an idle wait that
 	// cannot observe the pending channel (issue #405) — wake it so
 	// the window is created promptly instead of at the next event.
-	if fn := a.wakeMainFn; fn != nil {
+	a.wakeMu.RLock()
+	fn := a.wakeMainFn
+	a.wakeMu.RUnlock()
+	if fn != nil {
 		fn()
 	}
 }
 
 // SetWakeMainFn sets the function called to wake the main event loop
 // when OpenWindow queues a window from another goroutine. The backend
-// sets this at init time.
+// sets this at init time. Safe to call from any goroutine.
 func (a *App) SetWakeMainFn(fn func()) {
+	if a == nil {
+		return
+	}
+	a.wakeMu.Lock()
 	a.wakeMainFn = fn
+	a.wakeMu.Unlock()
 }
 
 // PendingOpen returns the channel of window configs to create.
 func (a *App) PendingOpen() <-chan WindowCfg {
+	if a == nil {
+		return nil
+	}
 	return a.pending
 }
 
 // Broadcast calls fn for every registered window. Snapshots the
 // window list under lock, then iterates without holding the lock
-// so fn may safely call other App methods.
+// so fn may safely call other App methods. A nil fn is a no-op.
+// Safe to call from any goroutine, but fn itself runs on the
+// caller's goroutine; queue window work with QueueCommand when
+// off the main thread.
 func (a *App) Broadcast(fn func(*Window)) {
+	if a == nil || fn == nil {
+		return
+	}
 	a.mu.Lock()
 	windows := make([]*Window, 0, len(a.order))
 	for _, id := range a.order {
@@ -168,11 +270,19 @@ func (a *App) Broadcast(fn func(*Window)) {
 
 // SetNativeMenubar installs a native OS menubar. Resolves
 // CommandID fields from the main window's command registry
-// and routes actions through QueueCommand.
+// and routes actions through QueueCommand. Silently does nothing
+// when there is no main window or no native platform, so backends
+// without menubar support need no guard at the call site.
+//
+// The action callback resolves the current main window when it
+// fires, not when the menubar installs, so a main-window change
+// between install and click still reaches the live window. With
+// no window alive, a fallback OnAction still runs directly.
 func (a *App) SetNativeMenubar(cfg NativeMenubarCfg) {
-	a.mu.Lock()
-	mainW := a.windows[a.mainID]
-	a.mu.Unlock()
+	if a == nil {
+		return
+	}
+	mainW := a.mainWindow()
 	if mainW == nil {
 		return
 	}
@@ -181,7 +291,14 @@ func (a *App) SetNativeMenubar(cfg NativeMenubarCfg) {
 		return
 	}
 	actionCb := func(id string) {
-		mainW.QueueCommand(func(w *Window) {
+		cur := a.mainWindow()
+		if cur == nil {
+			if cfg.OnAction != nil {
+				cfg.OnAction(id)
+			}
+			return
+		}
+		cur.QueueCommand(func(w *Window) {
 			if cmd, ok := w.CommandByID(id); ok {
 				cmd.Execute(nil, w)
 			} else if cfg.OnAction != nil {
@@ -192,11 +309,14 @@ func (a *App) SetNativeMenubar(cfg NativeMenubarCfg) {
 	np.SetNativeMenubar(cfg, actionCb)
 }
 
-// ClearNativeMenubar removes the native OS menubar.
+// ClearNativeMenubar removes the native OS menubar. Silently
+// does nothing when there is no main window or no native
+// platform.
 func (a *App) ClearNativeMenubar() {
-	a.mu.Lock()
-	mainW := a.windows[a.mainID]
-	a.mu.Unlock()
+	if a == nil {
+		return
+	}
+	mainW := a.mainWindow()
 	if mainW == nil {
 		return
 	}
@@ -207,13 +327,17 @@ func (a *App) ClearNativeMenubar() {
 	np.ClearNativeMenubar()
 }
 
-// SetSystemTray creates a system tray icon with menu.
+// SetSystemTray creates a system tray icon with menu. Unlike the
+// silent menubar/tray updaters, creation reports failure: no main
+// window, no native platform, a platform error, or a non-positive
+// platform tray ID (platforms must return unique positive IDs).
 func (a *App) SetSystemTray(
 	cfg SystemTrayCfg,
 ) (*SystemTrayHandle, error) {
-	a.mu.Lock()
-	mainW := a.windows[a.mainID]
-	a.mu.Unlock()
+	if a == nil {
+		return nil, errors.New("gui: no main window")
+	}
+	mainW := a.mainWindow()
 	if mainW == nil {
 		return nil, errors.New("gui: no main window")
 	}
@@ -222,15 +346,23 @@ func (a *App) SetSystemTray(
 		return nil, errors.New("gui: no native platform")
 	}
 	actionCb := func(id string) {
-		if cfg.OnAction != nil {
-			mainW.QueueCommand(func(_ *Window) {
+		if cfg.OnAction == nil {
+			return
+		}
+		if cur := a.mainWindow(); cur != nil {
+			cur.QueueCommand(func(_ *Window) {
 				cfg.OnAction(id)
 			})
+		} else {
+			cfg.OnAction(id)
 		}
 	}
 	trayID, err := np.CreateSystemTray(cfg, actionCb)
 	if err != nil {
 		return nil, err
+	}
+	if trayID <= 0 {
+		return nil, errors.New("gui: invalid tray id")
 	}
 	h := &SystemTrayHandle{id: trayID}
 	a.mu.Lock()
@@ -243,15 +375,16 @@ func (a *App) SetSystemTray(
 }
 
 // UpdateSystemTray updates an existing system tray entry.
+// Silently does nothing for a nil handle, a missing main window,
+// or a missing native platform, so teardown paths need no guard.
+// Unknown handle IDs forward to the platform, which ignores them.
 func (a *App) UpdateSystemTray(
 	h *SystemTrayHandle, cfg SystemTrayCfg,
 ) {
-	if h == nil {
+	if a == nil || h == nil {
 		return
 	}
-	a.mu.Lock()
-	mainW := a.windows[a.mainID]
-	a.mu.Unlock()
+	mainW := a.mainWindow()
 	if mainW == nil {
 		return
 	}
@@ -262,9 +395,12 @@ func (a *App) UpdateSystemTray(
 	np.UpdateSystemTray(h.id, cfg)
 }
 
-// RemoveSystemTray removes a system tray icon.
+// RemoveSystemTray removes a system tray icon. The handle leaves
+// app tracking even when no window or platform remains to notify,
+// so a late remove never leaks the entry; the platform call is
+// then skipped. Silently does nothing for a nil handle.
 func (a *App) RemoveSystemTray(h *SystemTrayHandle) {
-	if h == nil {
+	if a == nil || h == nil {
 		return
 	}
 	a.mu.Lock()

--- a/gui/app_native_test.go
+++ b/gui/app_native_test.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -16,6 +17,7 @@ type mockAppPlatform struct {
 	trayCBs    map[int]func(string)
 	nextTrayID int
 	failCreate bool
+	zeroID     bool
 }
 
 func (m *mockAppPlatform) SetNativeMenubar(cfg NativeMenubarCfg, cb func(string)) {
@@ -30,7 +32,10 @@ func (m *mockAppPlatform) ClearNativeMenubar() {
 
 func (m *mockAppPlatform) CreateSystemTray(cfg SystemTrayCfg, cb func(string)) (int, error) {
 	if m.failCreate {
-		return 0, &testError{msg: "platform error"}
+		return 0, errors.New("platform error")
+	}
+	if m.zeroID {
+		return 0, nil
 	}
 	if m.trayCfgs == nil {
 		m.trayCfgs = make(map[int]SystemTrayCfg)
@@ -53,10 +58,6 @@ func (m *mockAppPlatform) RemoveSystemTray(id int) {
 	delete(m.trayCfgs, id)
 	delete(m.trayCBs, id)
 }
-
-type testError struct{ msg string }
-
-func (e *testError) Error() string { return e.msg }
 
 // --- App.SetNativeMenubar ---
 
@@ -407,5 +408,109 @@ func TestAppExitOnTrayRemoved_NoTraysAllowsExit(t *testing.T) {
 	// No trays registered — removing last window should exit.
 	if !app.Unregister(1) {
 		t.Error("should exit: no windows and no trays")
+	}
+}
+
+func TestAppSetSystemTrayInvalidID(t *testing.T) {
+	app := NewApp()
+	mp := &mockAppPlatform{zeroID: true}
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(mp)
+	app.Register(1, w)
+
+	if _, err := app.SetSystemTray(SystemTrayCfg{Tooltip: "Test"}); err == nil {
+		t.Error("expected error for non-positive tray id")
+	} else if !strings.Contains(err.Error(), "invalid tray id") {
+		t.Errorf("error = %q, want 'invalid tray id'", err.Error())
+	}
+}
+
+func TestAppMenubarActionFollowsMainFailover(t *testing.T) {
+	app := NewApp()
+	mp1 := &mockAppPlatform{}
+	mp2 := &mockAppPlatform{}
+	w1 := NewWindow(WindowCfg{State: new(struct{})})
+	w2 := NewWindow(WindowCfg{State: new(struct{})})
+	w1.SetNativePlatform(mp1)
+	w2.SetNativePlatform(mp2)
+	app.Register(1, w1)
+	app.Register(2, w2)
+
+	app.SetNativeMenubar(NativeMenubarCfg{
+		AppName:  "Test",
+		OnAction: func(string) {},
+	})
+	if mp1.menubarCB == nil {
+		t.Fatal("menubar callback should install on main")
+	}
+
+	// Main closes; the survivor takes over. The installed
+	// callback must queue onto the live window, not the dead one.
+	app.Unregister(1)
+	mp1.menubarCB("quit")
+
+	queued := func(w *Window) int {
+		w.commandsMu.Lock()
+		defer w.commandsMu.Unlock()
+		return len(w.commands)
+	}
+	if got := queued(w1); got != 0 {
+		t.Fatalf("dead window queued %d, want 0", got)
+	}
+	if got := queued(w2); got != 1 {
+		t.Fatalf("live window queued %d, want 1", got)
+	}
+}
+
+func TestAppNoopTrayIDsUnique(t *testing.T) {
+	app := NewApp()
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(&noopNativePlatform{})
+	app.Register(1, w)
+
+	h1, err := app.SetSystemTray(SystemTrayCfg{Tooltip: "First"})
+	if err != nil {
+		t.Fatalf("first tray: %v", err)
+	}
+	h2, err := app.SetSystemTray(SystemTrayCfg{Tooltip: "Second"})
+	if err != nil {
+		t.Fatalf("second tray: %v", err)
+	}
+	if h1 == h2 {
+		t.Error("noop handles should be distinct")
+	}
+}
+
+func TestAppActionFallbackWithoutMain(t *testing.T) {
+	app := NewApp()
+	mp := &mockAppPlatform{}
+	w := NewWindow(WindowCfg{State: new(struct{})})
+	w.SetNativePlatform(mp)
+	app.Register(1, w)
+
+	menuFired := 0
+	app.SetNativeMenubar(NativeMenubarCfg{
+		AppName:  "Test",
+		OnAction: func(string) { menuFired++ },
+	})
+	trayFired := 0
+	h, err := app.SetSystemTray(SystemTrayCfg{
+		Tooltip:  "Test",
+		OnAction: func(string) { trayFired++ },
+	})
+	if err != nil {
+		t.Fatalf("tray: %v", err)
+	}
+
+	// All windows gone: captured callbacks must still reach
+	// the fallback directly instead of queueing nowhere.
+	app.Unregister(1)
+	mp.menubarCB("quit")
+	mp.trayCBs[h.id]("show")
+	if menuFired != 1 {
+		t.Fatalf("menu fallback fired %d, want 1", menuFired)
+	}
+	if trayFired != 1 {
+		t.Fatalf("tray fallback fired %d, want 1", trayFired)
 	}
 }

--- a/gui/app_test.go
+++ b/gui/app_test.go
@@ -115,14 +115,15 @@ func TestAppOpenWindowWakes(t *testing.T) {
 	}
 
 	// Buffer full: the request is dropped, so no wake.
-	for range 16 {
+	for range pendingCap {
 		app.OpenWindow(WindowCfg{Title: "ok"})
 	}
 	app.OpenWindow(WindowCfg{Title: "dropped"})
-	// 15 of the 16 fit (one slot is still taken); the dropped 17th
-	// must not wake.
-	if wakes != 16 {
-		t.Fatalf("wakes = %d, want 16 (no wake on dropped request)", wakes)
+	// pendingCap-1 of the pendingCap fit (one slot is still
+	// taken); the dropped request must not wake.
+	if wakes != pendingCap {
+		t.Fatalf("wakes = %d, want %d (no wake on dropped request)",
+			wakes, pendingCap)
 	}
 }
 
@@ -213,11 +214,11 @@ func TestAppRegisterDuplicate(t *testing.T) {
 
 func TestAppOpenWindowBufferFull(t *testing.T) {
 	app := NewApp()
-	// Fill the buffer (cap 16).
-	for range 16 {
+	// Fill the buffer (cap pendingCap).
+	for range pendingCap {
 		app.OpenWindow(WindowCfg{Title: "ok"})
 	}
-	// 17th should be dropped without panic.
+	// Next one should be dropped without panic.
 	app.OpenWindow(WindowCfg{Title: "dropped"})
 
 	count := 0
@@ -230,8 +231,8 @@ func TestAppOpenWindowBufferFull(t *testing.T) {
 		}
 	}
 done:
-	if count != 16 {
-		t.Fatalf("drained %d pending, want 16", count)
+	if count != pendingCap {
+		t.Fatalf("drained %d pending, want %d", count, pendingCap)
 	}
 }
 
@@ -254,4 +255,98 @@ func TestAppBroadcastDuringUnregister(t *testing.T) {
 	if *State[int](w2) != 0 {
 		t.Fatal("broadcast should not reach unregistered w2")
 	}
+}
+
+func TestAppMainFailover(t *testing.T) {
+	app := NewApp()
+	w1 := NewWindow(WindowCfg{})
+	w2 := NewWindow(WindowCfg{})
+	app.Register(1, w1)
+	app.Register(2, w2)
+
+	// Closing the main window reports exit (ExitOnMainClose)
+	// but hands mainID to the oldest survivor.
+	if !app.Unregister(1) {
+		t.Fatal("closing main should signal exit")
+	}
+	if got := app.mainWindow(); got != w2 {
+		t.Fatalf("mainWindow = %v, want w2", got)
+	}
+	if w1.App() != nil {
+		t.Fatal("unregistered w1 should detach")
+	}
+	if w1.PlatformID() != 0 {
+		t.Fatalf("w1.PlatformID() = %d, want 0", w1.PlatformID())
+	}
+
+	// Last window out clears the main ID.
+	app.Unregister(2)
+	if got := app.mainWindow(); got != nil {
+		t.Fatalf("mainWindow = %v, want nil", got)
+	}
+}
+
+func TestAppMainFailoverTrayMode(t *testing.T) {
+	app := NewApp()
+	app.ExitMode = ExitOnTrayRemoved
+	w1 := NewWindow(WindowCfg{})
+	w2 := NewWindow(WindowCfg{})
+	app.Register(1, w1)
+	app.Register(2, w2)
+	app.trays[7] = &SystemTrayHandle{id: 7}
+
+	// Tray keeps the app alive past a main-window close, and
+	// the survivor answers as main.
+	if app.Unregister(1) {
+		t.Fatal("tray mode must not exit while windows remain")
+	}
+	if got := app.mainWindow(); got != w2 {
+		t.Fatalf("mainWindow = %v, want w2", got)
+	}
+}
+
+func TestAppRegisterNil(t *testing.T) {
+	app := NewApp()
+	// Must not panic.
+	app.Register(1, nil)
+	var nilApp *App
+	nilApp.Register(1, NewWindow(WindowCfg{}))
+	if app.Window(1) != nil {
+		t.Fatal("nil window must not register")
+	}
+	nilApp.Broadcast(func(*Window) { t.Error("nil app broadcast ran") })
+	nilApp.OpenWindow(WindowCfg{})
+	nilApp.SetWakeMainFn(func() {})
+	if nilApp.Window(1) != nil || nilApp.Windows() != nil {
+		t.Fatal("nil app must answer nil")
+	}
+	if nilApp.PendingOpen() != nil {
+		t.Fatal("nil app must answer nil channel")
+	}
+
+	// Zero-value App (no NewApp) must accept a registration.
+	var zero App
+	w := NewWindow(WindowCfg{})
+	zero.Register(1, w)
+	if got := zero.Window(1); got != w {
+		t.Fatal("zero-value App should register after lazy init")
+	}
+	if w.App() != &zero || w.PlatformID() != 1 {
+		t.Fatal("zero-value App should link the window")
+	}
+}
+
+func TestAppWakeMainFnConcurrent(t *testing.T) {
+	// OpenWindow and SetWakeMainFn run on different goroutines
+	// in production; -race must stay silent.
+	app := NewApp()
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Go(func() {
+			app.SetWakeMainFn(func() {})
+			app.OpenWindow(WindowCfg{Title: "race"})
+			_ = i
+		})
+	}
+	wg.Wait()
 }

--- a/gui/backend/android/a11y.go
+++ b/gui/backend/android/a11y.go
@@ -10,6 +10,11 @@ import (
 
 // a11y state shared between Go (writer) and Kotlin (reader via
 // gomobile-exported functions).
+//
+// Process-global by design, not by accident: Android runs exactly one
+// window (androidWindow in backend.go), so no second tree can ever
+// collide here. Any future multi-window support must shard this state
+// per window first, as the Metal and Linux bridges already do.
 var (
 	a11yMu       sync.RWMutex
 	a11yNodes    []gui.A11yNode
@@ -29,6 +34,12 @@ func initA11y(cb func(action, index int)) {
 // syncA11y copies the node slice under write lock.
 func syncA11y(nodes []gui.A11yNode, count, focusedIdx int) {
 	a11yMu.Lock()
+	if count < 0 {
+		count = 0
+	}
+	if count > len(nodes) {
+		count = len(nodes)
+	}
 	// Grow or reuse backing slice.
 	if cap(a11yNodes) < count {
 		a11yNodes = make([]gui.A11yNode, count)

--- a/gui/backend/android/a11y_android_test.go
+++ b/gui/backend/android/a11y_android_test.go
@@ -1,0 +1,28 @@
+//go:build android
+
+package android
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// Counts past the slice end clamp instead of panicking on the
+// slice expression; negative counts clear.
+func TestSyncA11yClampsCount(t *testing.T) {
+	nodes := []gui.A11yNode{{Role: gui.AccessRoleButton}}
+	syncA11y(nil, 5, 0)
+	if got := A11yNodeCount(); got != 0 {
+		t.Fatalf("over-count: got %d nodes, want 0", got)
+	}
+	syncA11y(nodes, -1, 0)
+	if got := A11yNodeCount(); got != 0 {
+		t.Fatalf("negative: got %d nodes, want 0", got)
+	}
+	syncA11y(nodes, 3, 0)
+	if got := A11yNodeCount(); got != 1 {
+		t.Fatalf("clamped: got %d nodes, want 1", got)
+	}
+	destroyA11y()
+}

--- a/gui/backend/atspi/atspi_bridge_linux_test.go
+++ b/gui/backend/atspi/atspi_bridge_linux_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package atspi
+
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
+
+// Two bridges must route actions to their own window's callback: a
+// shared bridge would deliver window 1's VoiceOver press to window 2.
+func TestBridgesRouteActionsToOwningWindow(t *testing.T) {
+	var got1, got2 [][2]int
+	b1 := &Bridge{}
+	b2 := &Bridge{}
+	// No session bus headless: Init stays transport-less but must
+	// retain the callback.
+	b1.Init(func(action, index int) {
+		got1 = append(got1, [2]int{action, index})
+	})
+	b2.Init(func(action, index int) {
+		got2 = append(got2, [2]int{action, index})
+	})
+
+	ok, _ := (&nodeHandler{bridge: b1, index: 3}).DoAction(0)
+	if !ok {
+		t.Fatal("DoAction on bridge 1 failed")
+	}
+	if len(got1) != 1 || got1[0] != [2]int{gui.A11yActionPress, 3} {
+		t.Errorf("bridge 1 actions: got %v, want [[press 3]]", got1)
+	}
+	if len(got2) != 0 {
+		t.Errorf("bridge 2 heard window 1's action: %v", got2)
+	}
+
+	ok, _ = (&nodeHandler{bridge: b2, index: 5}).DoAction(1)
+	if !ok {
+		t.Fatal("DoAction on bridge 2 failed")
+	}
+	if len(got2) != 1 || got2[0] != [2]int{gui.A11yActionConfirm, 5} {
+		t.Errorf("bridge 2 actions: got %v, want [[confirm 5]]", got2)
+	}
+	if len(got1) != 1 {
+		t.Errorf("bridge 1 heard window 2's action: %v", got1)
+	}
+}

--- a/gui/backend/gl/a11y_linux.go
+++ b/gui/backend/gl/a11y_linux.go
@@ -7,27 +7,35 @@ import (
 	"github.com/go-gui-org/go-gui/gui/backend/atspi"
 )
 
-var a11yBridge *atspi.Bridge
-
 func (n *nativePlatform) A11yInit(cb func(int, int)) {
-	a11yBridge = &atspi.Bridge{}
-	a11yBridge.Init(cb)
+	// Fresh bridge per init, as before: initializing twice must not
+	// stack a second live bus connection onto the first.
+	n.A11yDestroy()
+	n.a11y = &atspi.Bridge{}
+	n.a11y.Init(cb)
 }
 
 func (n *nativePlatform) A11ySync(nodes []gui.A11yNode, count, focusedIdx int) {
-	if a11yBridge != nil {
-		a11yBridge.Sync(nodes, count, focusedIdx)
+	if n.a11y != nil {
+		if count < 0 {
+			count = 0
+		}
+		if count > len(nodes) {
+			count = len(nodes)
+		}
+		n.a11y.Sync(nodes, count, focusedIdx)
 	}
 }
 
 func (n *nativePlatform) A11yDestroy() {
-	if a11yBridge != nil {
-		a11yBridge.Destroy()
+	if n.a11y != nil {
+		n.a11y.Destroy()
+		n.a11y = nil
 	}
 }
 
 func (n *nativePlatform) A11yAnnounce(text string) {
-	if a11yBridge != nil {
-		a11yBridge.Announce(text)
+	if n.a11y != nil {
+		n.a11y.Announce(text)
 	}
 }

--- a/gui/backend/gl/a11y_other.go
+++ b/gui/backend/gl/a11y_other.go
@@ -6,5 +6,11 @@ import "github.com/go-gui-org/go-gui/gui"
 
 func (n *nativePlatform) A11yInit(_ func(action, index int))  {}
 func (n *nativePlatform) A11ySync(_ []gui.A11yNode, _, _ int) {}
-func (n *nativePlatform) A11yDestroy()                        {}
-func (n *nativePlatform) A11yAnnounce(_ string)               {}
+func (n *nativePlatform) A11yDestroy() {
+	// Off Linux there is never a bridge, so this is already nil. The
+	// assignment keeps the Linux-only field referenced on platforms
+	// whose stubs never touch it (windows cross-build trips unused
+	// otherwise).
+	n.a11y = nil
+}
+func (n *nativePlatform) A11yAnnounce(_ string) {}

--- a/gui/backend/gl/a11y_perwindow_linux_test.go
+++ b/gui/backend/gl/a11y_perwindow_linux_test.go
@@ -1,0 +1,43 @@
+//go:build linux && !android
+
+package gl
+
+import "testing"
+
+// Each window must own its AT-SPI2 bridge: one shared bridge would
+// deliver a second window's actions and tree into the first window.
+func TestNativePlatformA11yBridgePerWindow(t *testing.T) {
+	n1 := &nativePlatform{}
+	n2 := &nativePlatform{}
+	n1.A11yInit(func(_, _ int) {})
+	n2.A11yInit(func(_, _ int) {})
+	if n1.a11y == nil || n2.a11y == nil {
+		t.Fatal("each window must own a bridge after A11yInit")
+	}
+	if n1.a11y == n2.a11y {
+		t.Error("windows share one bridge — actions hijack across windows")
+	}
+	// Destroying one window's bridge must not disturb the other's.
+	n1.A11yDestroy()
+	if n2.a11y == nil {
+		t.Error("destroying window 1 cleared window 2's bridge")
+	}
+}
+
+// Re-initializing must replace the bridge, not stack a second live
+// bus connection onto the first.
+func TestNativePlatformA11yReinitReplacesBridge(t *testing.T) {
+	n := &nativePlatform{}
+	n.A11yInit(func(_, _ int) {})
+	first := n.a11y
+	n.A11yInit(func(_, _ int) {})
+	if n.a11y == nil {
+		t.Fatal("re-init must leave a live bridge")
+	}
+	if n.a11y == first {
+		t.Error("re-init must replace the bridge, not reuse it")
+	}
+	// An over-count sync clamps instead of panicking.
+	n.A11ySync(nil, 5, 0)
+	n.A11yDestroy()
+}

--- a/gui/backend/gl/native_platform.go
+++ b/gui/backend/gl/native_platform.go
@@ -4,6 +4,7 @@ package gl
 
 import (
 	"github.com/go-gui-org/go-gui/gui"
+	"github.com/go-gui-org/go-gui/gui/backend/atspi"
 	"github.com/go-gui-org/go-gui/gui/backend/internal/nativehost"
 )
 
@@ -11,7 +12,14 @@ import (
 //
 // b is the owning backend: IME calls have to reach per-window platform
 // state. Everything else here is process-wide and ignores it.
-type nativePlatform struct{ b *Backend }
+//
+// a11y is the window's own AT-SPI2 bridge (Linux only; nil elsewhere).
+// Owned per window — never shared — so a second window's actions and
+// tree cannot reach the first window's callbacks.
+type nativePlatform struct {
+	b    *Backend
+	a11y *atspi.Bridge
+}
 
 // --- URI ---
 

--- a/gui/backend/ios/native_platform.go
+++ b/gui/backend/ios/native_platform.go
@@ -7,12 +7,17 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync/atomic"
 
 	"github.com/go-gui-org/go-gui/gui"
 	"github.com/go-gui-org/go-gui/gui/backend/filedialog"
 	"github.com/go-gui-org/go-gui/gui/backend/printdialog"
 	"github.com/go-gui-org/go-gui/gui/backend/spellcheck"
 )
+
+// iosTrayIDs hands out unique positive tray IDs. iOS has no tray;
+// the no-op still reports success, so handles must stay distinct.
+var iosTrayIDs atomic.Int64
 
 // nativePlatform implements gui.NativePlatform for iOS.
 type nativePlatform struct{}
@@ -99,9 +104,10 @@ func (n *nativePlatform) SpellLearn(word string) { spellcheck.Learn(word) }
 func (n *nativePlatform) SetNativeMenubar(_ gui.NativeMenubarCfg, _ func(string)) {}
 func (n *nativePlatform) ClearNativeMenubar()                                     {}
 
-// System tray — no-op on iOS.
+// System tray — no-op on iOS. Reports success with a unique
+// handle so App bookkeeping stays consistent.
 func (n *nativePlatform) CreateSystemTray(_ gui.SystemTrayCfg, _ func(string)) (int, error) {
-	return 0, nil
+	return int(iosTrayIDs.Add(1)), nil
 }
 func (n *nativePlatform) UpdateSystemTray(_ int, _ gui.SystemTrayCfg) {}
 func (n *nativePlatform) RemoveSystemTray(_ int)                      {}

--- a/gui/backend/metal/a11y_darwin.go
+++ b/gui/backend/metal/a11y_darwin.go
@@ -17,18 +17,38 @@ import (
 	"github.com/go-gui-org/go-gui/gui"
 )
 
-// a11yActionCallback stores the Go callback invoked from ObjC
-// when VoiceOver triggers an action.
-var a11yActionCallback func(action, index int)
+// a11yCallbacks routes VoiceOver actions to the owning window: one
+// live tree per window, so one callback per window. Guarded by a11yMu
+// alongside the marshaling buffers below.
+var a11yCallbacks = make(map[uintptr]func(action, index int))
 
-func setA11yCallback(cb func(action, index int)) {
-	a11yActionCallback = cb
+func a11yToken(w C.GoGuiNSWindow) uintptr {
+	return uintptr(unsafe.Pointer(w))
+}
+
+func setA11yCallback(token uintptr, cb func(action, index int)) {
+	a11yMu.Lock()
+	defer a11yMu.Unlock()
+	if cb == nil {
+		delete(a11yCallbacks, token)
+		return
+	}
+	a11yCallbacks[token] = cb
+}
+
+func clearA11yCallback(token uintptr) {
+	a11yMu.Lock()
+	defer a11yMu.Unlock()
+	delete(a11yCallbacks, token)
 }
 
 //export goA11yAction
-func goA11yAction(action, index C.int) {
-	if a11yActionCallback != nil {
-		a11yActionCallback(int(action), int(index))
+func goA11yAction(action, index C.int, token C.uintptr_t) {
+	a11yMu.Lock()
+	cb := a11yCallbacks[uintptr(token)]
+	a11yMu.Unlock()
+	if cb != nil {
+		cb(int(action), int(index))
 	}
 }
 
@@ -43,8 +63,20 @@ var (
 // unbounded C allocations from buggy or malicious callers.
 const maxA11yNodes = 50000
 
-func a11ySyncBridge(nodes []gui.A11yNode, count, focusedIdx int, windowH float32) {
+func a11ySyncBridge(w C.GoGuiNSWindow, nodes []gui.A11yNode, count, focusedIdx int, windowH float32) {
+	// Clamp first: a count past the slice end reads out of bounds,
+	// and a clamped-to-zero count must take the clearing path
+	// below rather than indexing an empty buffer.
+	if count > len(nodes) {
+		count = len(nodes)
+	}
 	if count <= 0 {
+		// Push the emptied tree so the previous content clears on
+		// the ObjC side rather than lingering. Nil nodes are safe:
+		// the callee clears without dereferencing.
+		a11yMu.Lock()
+		defer a11yMu.Unlock()
+		C.a11ySync(w, nil, C.int(0), C.int(focusedIdx), C.float(windowH))
 		return
 	}
 	if count > maxA11yNodes {
@@ -81,6 +113,7 @@ func a11ySyncBridge(nodes []gui.A11yNode, count, focusedIdx int, windowH float32
 	}
 
 	C.a11ySync(
+		w,
 		&cNodeBuf[0],
 		C.int(count),
 		C.int(focusedIdx),
@@ -104,10 +137,6 @@ func cStringOrNil(s string, collector *[]*C.char) *C.char {
 	cs := C.CString(s)
 	*collector = append(*collector, cs)
 	return cs
-}
-
-func a11yDestroyBridge() {
-	C.a11yDestroy()
 }
 
 func a11yAnnounceBridge(text string) {

--- a/gui/backend/metal/a11y_darwin.h
+++ b/gui/backend/metal/a11y_darwin.h
@@ -1,6 +1,8 @@
 #ifndef A11Y_DARWIN_H
 #define A11Y_DARWIN_H
 
+#include <stdint.h>
+
 #include "metal_window.h"
 
 // Role constants matching gui.AccessRole iota order (0-34).
@@ -65,21 +67,23 @@ typedef struct {
     int         childrenCount;
 } A11yCNode;
 
-// Initialize the accessibility element tree.
+// Initialize the accessibility element tree for one window. Each
+// window owns its tree; a second window never disturbs the first's.
 void a11yInit(GoGuiNSWindow w);
 
-// Sync the accessibility tree with the current frame's nodes.
-void a11ySync(const A11yCNode *nodes, int count, int focusedIdx,
-              float windowH);
+// Sync one window's accessibility tree with the current frame's nodes.
+void a11ySync(GoGuiNSWindow w, const A11yCNode *nodes, int count,
+              int focusedIdx, float windowH);
 
-// Destroy the accessibility tree and release all elements.
-void a11yDestroy(void);
+// Destroy one window's accessibility tree and release its elements.
+void a11yDestroy(GoGuiNSWindow w);
 
 // Post an announcement via VoiceOver.
 void a11yAnnounce(const char *text);
 
 // Implemented in Go — called from ObjC when VoiceOver triggers
-// an action on an element.
-extern void goA11yAction(int action, int index);
+// an action on an element. token is the owning window, routing the
+// action to that window's callback.
+extern void goA11yAction(int action, int index, uintptr_t token);
 
 #endif

--- a/gui/backend/metal/a11y_darwin.m
+++ b/gui/backend/metal/a11y_darwin.m
@@ -61,8 +61,30 @@ enum {
     STATE_DISABLED  = 512,
 };
 
-// Forward declaration — used by isAccessibilityFocused.
-static int _curFocusedIdx = -1;
+// ─── Per-window state ────────────────────────────────────────
+// One live VoiceOver tree per window: a second window's init/sync
+// never disturbs the first's. Contexts are keyed by the opaque
+// window handle and dropped by a11yDestroy. Declared before the
+// element implementation, which reads the focused index off it.
+
+@class GUIAccessibilityElement;
+
+@interface A11yContext : NSObject
+
+@property (nonatomic, weak) NSWindow *nsWindow;
+@property (nonatomic, weak) NSView   *nsView;
+@property (nonatomic, strong) NSMutableArray<
+    GUIAccessibilityElement *> *pool;
+@property (nonatomic, strong) GUIAccessibilityElement *root;
+@property (nonatomic) int activeCount;
+@property (nonatomic) int curFocusedIdx;
+@property (nonatomic) int prevFocusedIdx;
+
+@end
+
+@implementation A11yContext
+
+@end
 
 // ─── GUIAccessibilityElement ─────────────────────────────────
 
@@ -75,6 +97,11 @@ static int _curFocusedIdx = -1;
 @property (nonatomic, copy) NSString *nodeValue;
 @property (nonatomic, copy) NSString *nodeDescription;
 @property (nonatomic) NSRect      nodeFrame;
+
+// Owning window's context (weak: the context map owns it) and the
+// opaque window token handed back to Go with actions.
+@property (nonatomic, weak) A11yContext *ctx;
+@property (nonatomic) uintptr_t  ownerToken;
 
 @property (nonatomic, strong) NSMutableArray<
     GUIAccessibilityElement *> *nodeChildren;
@@ -146,116 +173,141 @@ static int _curFocusedIdx = -1;
 }
 
 - (BOOL)isAccessibilityFocused {
-    return _nodeIndex == _curFocusedIdx;
+    return _ctx && _nodeIndex == _ctx.curFocusedIdx;
 }
 
 // ─── Actions ─────────────────────────────────────────────────
 
 - (BOOL)accessibilityPerformPress {
-    goA11yAction(A11Y_ACTION_PRESS, _nodeIndex);
+    goA11yAction(A11Y_ACTION_PRESS, _nodeIndex, _ownerToken);
     return YES;
 }
 
 - (BOOL)accessibilityPerformIncrement {
-    goA11yAction(A11Y_ACTION_INCREMENT, _nodeIndex);
+    goA11yAction(A11Y_ACTION_INCREMENT, _nodeIndex, _ownerToken);
     return YES;
 }
 
 - (BOOL)accessibilityPerformDecrement {
-    goA11yAction(A11Y_ACTION_DECREMENT, _nodeIndex);
+    goA11yAction(A11Y_ACTION_DECREMENT, _nodeIndex, _ownerToken);
     return YES;
 }
 
 - (BOOL)accessibilityPerformConfirm {
-    goA11yAction(A11Y_ACTION_CONFIRM, _nodeIndex);
+    goA11yAction(A11Y_ACTION_CONFIRM, _nodeIndex, _ownerToken);
     return YES;
 }
 
 - (BOOL)accessibilityPerformCancel {
-    goA11yAction(A11Y_ACTION_CANCEL, _nodeIndex);
+    goA11yAction(A11Y_ACTION_CANCEL, _nodeIndex, _ownerToken);
     return YES;
 }
 
 @end
 
-// ─── Pool + State ────────────────────────────────────────────
+// ─── Context registry ────────────────────────────────────────
 
-static NSMutableArray<GUIAccessibilityElement *> *_elementPool;
-static int _activeCount;
-static NSWindow *_nsWindow;
-static NSView   *_nsView;
-static int       _prevFocusedIdx = -1;
+static NSMutableDictionary<NSValue *, A11yContext *> *_contexts;
 
-// Root element acts as the accessibility container attached to
-// the content view.
-static GUIAccessibilityElement *_rootElement;
+static A11yContext *ctxForHandle(GoGuiNSWindow w) {
+    if (!w || !_contexts) {
+        return nil;
+    }
+    return _contexts[[NSValue valueWithPointer:w]];
+}
 
-static GUIAccessibilityElement *poolGet(int idx) {
-    while (idx >= (int)_elementPool.count) {
+static GUIAccessibilityElement *poolGet(A11yContext *ctx, int idx) {
+    while (idx >= (int)ctx.pool.count) {
         GUIAccessibilityElement *el =
             [[GUIAccessibilityElement alloc] init];
         el.nodeChildren =
             [[NSMutableArray alloc] initWithCapacity:8];
-        [_elementPool addObject:el];
+        [ctx.pool addObject:el];
     }
-    return _elementPool[idx];
+    return ctx.pool[idx];
 }
 
 // ─── Coordinate Conversion ───────────────────────────────────
 // Framework uses top-left origin; macOS uses bottom-left screen
 // coords.
 
-static NSRect convertFrame(float x, float y, float w, float h,
-                           float windowH) {
+static NSRect convertFrame(A11yContext *ctx, float x, float y,
+                           float w, float h, float windowH) {
     float flippedY = windowH - y - h;
     NSRect localRect = NSMakeRect(x, flippedY, w, h);
-    NSRect windowRect = [_nsView convertRect:localRect toView:nil];
-    return [_nsWindow convertRectToScreen:windowRect];
+    NSRect windowRect = [ctx.nsView convertRect:localRect toView:nil];
+    return [ctx.nsWindow convertRectToScreen:windowRect];
 }
 
 // ─── Public API ──────────────────────────────────────────────
 
 void a11yInit(GoGuiNSWindow w) {
     initRoleMap();
+    if (!_contexts) {
+        _contexts = [[NSMutableDictionary alloc] init];
+    }
 
     // Extract NSWindow/NSView from native window handle.
-    _nsWindow = (__bridge NSWindow *)metalWindowGetNSWindow(w);
-    if (!_nsWindow) return;
-    _nsView = [_nsWindow contentView];
-    if (!_nsView) {
+    NSWindow *nsWindow = (__bridge NSWindow *)metalWindowGetNSWindow(w);
+    if (!nsWindow) return;
+    NSView *nsView = [nsWindow contentView];
+    if (!nsView) {
         return;
     }
 
-    _elementPool =
-        [[NSMutableArray alloc] initWithCapacity:256];
-    _activeCount = 0;
-    _prevFocusedIdx = -1;
+    NSValue *key = [NSValue valueWithPointer:w];
+    A11yContext *ctx = ctxForHandle(w);
+    if (!ctx) {
+        ctx = [[A11yContext alloc] init];
+        ctx.curFocusedIdx = -1;
+        _contexts[key] = ctx;
+    }
+    ctx.nsWindow = nsWindow;
+    ctx.nsView = nsView;
+
+    ctx.pool = [[NSMutableArray alloc] initWithCapacity:256];
+    ctx.activeCount = 0;
+    ctx.prevFocusedIdx = -1;
 
     // Create root container element.
-    _rootElement = [[GUIAccessibilityElement alloc] init];
-    _rootElement.nodeLabel = @"Application";
-    _rootElement.nodeRole = A11Y_ROLE_GROUP;
-    _rootElement.nodeParent = _nsView;
-    _rootElement.nodeChildren =
+    ctx.root = [[GUIAccessibilityElement alloc] init];
+    ctx.root.nodeLabel = @"Application";
+    ctx.root.nodeRole = A11Y_ROLE_GROUP;
+    ctx.root.nodeParent = nsView;
+    ctx.root.ctx = ctx;
+    ctx.root.ownerToken = (uintptr_t)w;
+    ctx.root.nodeChildren =
         [[NSMutableArray alloc] initWithCapacity:64];
 
     // Attach root element to the content view's accessibility
     // children.
-    _nsView.accessibilityChildren = @[_rootElement];
+    nsView.accessibilityChildren = @[ctx.root];
 }
 
-void a11ySync(const A11yCNode *nodes, int count,
+void a11ySync(GoGuiNSWindow w, const A11yCNode *nodes, int count,
               int focusedIdx, float windowH) {
-    if (!_rootElement || !nodes || count <= 0) {
+    A11yContext *ctx = ctxForHandle(w);
+    if (!ctx || !nodes || count <= 0) {
+        // An emptied tree clears rather than lingers: drop all
+        // children so VoiceOver sees nothing, not the previous
+        // content. Re-sync repopulates from an empty pool state.
+        if (ctx) {
+            [ctx.root.nodeChildren removeAllObjects];
+            ctx.activeCount = 0;
+            ctx.curFocusedIdx = -1;
+            ctx.prevFocusedIdx = -1;
+        }
         return;
     }
 
     // Update or grow pool elements.
     for (int i = 0; i < count; i++) {
-        GUIAccessibilityElement *el = poolGet(i);
+        GUIAccessibilityElement *el = poolGet(ctx, i);
         const A11yCNode *n = &nodes[i];
 
         el.nodeIndex = i;
+        el.ctx = ctx;
+        el.ownerToken = (uintptr_t)w;
         el.nodeRole  = n->role;
         el.nodeState = n->state;
         el.nodeLabel = n->label
@@ -265,62 +317,65 @@ void a11ySync(const A11yCNode *nodes, int count,
         el.nodeDescription = n->description
             ? [NSString stringWithUTF8String:n->description]
             : @"";
-        el.nodeFrame = convertFrame(
+        el.nodeFrame = convertFrame(ctx,
             n->x, n->y, n->w, n->h, windowH);
         [el.nodeChildren removeAllObjects];
 
         // Parent: root if parentIdx < 0, else pool element.
-        if (n->parentIdx < 0) {
-            el.nodeParent = _rootElement;
+        // Out-of-range input attaches to the root rather than
+        // growing the pool without bound.
+        if (n->parentIdx < 0 || n->parentIdx >= count) {
+            el.nodeParent = ctx.root;
         } else {
-            el.nodeParent = poolGet(n->parentIdx);
+            el.nodeParent = poolGet(ctx, n->parentIdx);
         }
     }
-    _activeCount = count;
+    ctx.activeCount = count;
 
     // Wire children arrays.
-    [_rootElement.nodeChildren removeAllObjects];
+    [ctx.root.nodeChildren removeAllObjects];
     for (int i = 0; i < count; i++) {
         const A11yCNode *n = &nodes[i];
-        GUIAccessibilityElement *el = _elementPool[i];
+        GUIAccessibilityElement *el = ctx.pool[i];
 
         if (n->parentIdx < 0) {
-            [_rootElement.nodeChildren addObject:el];
+            [ctx.root.nodeChildren addObject:el];
         } else if (n->parentIdx < count) {
-            [_elementPool[n->parentIdx].nodeChildren
+            [ctx.pool[n->parentIdx].nodeChildren
                 addObject:el];
         }
     }
 
     // Update root frame to cover the whole window.
-    _rootElement.nodeFrame = convertFrame(
-        0, 0, (float)_nsView.bounds.size.width,
-        (float)_nsView.bounds.size.height, windowH);
+    ctx.root.nodeFrame = convertFrame(ctx,
+        0, 0, (float)ctx.nsView.bounds.size.width,
+        (float)ctx.nsView.bounds.size.height, windowH);
 
     // Update current focused index for isAccessibilityFocused.
-    _curFocusedIdx = focusedIdx;
+    ctx.curFocusedIdx = focusedIdx;
 
     // Focus notification.
-    if (focusedIdx != _prevFocusedIdx && focusedIdx >= 0 &&
+    if (focusedIdx != ctx.prevFocusedIdx && focusedIdx >= 0 &&
         focusedIdx < count) {
-        _prevFocusedIdx = focusedIdx;
+        ctx.prevFocusedIdx = focusedIdx;
         NSAccessibilityPostNotification(
-            _elementPool[focusedIdx],
+            ctx.pool[focusedIdx],
             NSAccessibilityFocusedUIElementChangedNotification);
     }
 }
 
-void a11yDestroy(void) {
-    if (_nsView) {
-        _nsView.accessibilityChildren = nil;
+void a11yDestroy(GoGuiNSWindow w) {
+    if (!_contexts) {
+        return;
     }
-    _rootElement = nil;
-    [_elementPool removeAllObjects];
-    _elementPool = nil;
-    _activeCount = 0;
-    _prevFocusedIdx = -1;
-    _nsWindow = nil;
-    _nsView = nil;
+    NSValue *key = [NSValue valueWithPointer:w];
+    A11yContext *ctx = _contexts[key];
+    if (ctx) {
+        if (ctx.nsView) {
+            ctx.nsView.accessibilityChildren = nil;
+        }
+        [_contexts removeObjectForKey:key];
+    }
 }
 
 void a11yAnnounce(const char *text) {

--- a/gui/backend/metal/a11y_darwin_test.go
+++ b/gui/backend/metal/a11y_darwin_test.go
@@ -2,7 +2,11 @@
 
 package metal
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/go-gui-org/go-gui/gui"
+)
 
 func TestCStringOrNil_Empty(t *testing.T) {
 	var buf []cchar
@@ -57,21 +61,66 @@ func TestCStringOrNil_MultipleStrings(t *testing.T) {
 }
 
 func TestA11ySyncBridge_ZeroCount(t *testing.T) {
-	// Zero or negative count must return without panicking.
-	a11ySyncBridge(nil, 0, 0, 0)
-	a11ySyncBridge(nil, -1, 0, 0)
+	// Zero or negative count must push the empty clear without
+	// panicking, even with no window behind the token.
+	a11ySyncBridge(nil, nil, 0, 0, 0)
+	a11ySyncBridge(nil, nil, -1, 0, 0)
+}
+
+func TestA11ySyncBridge_CountBeyondNodesClears(t *testing.T) {
+	// A count past the slice end clamps instead of panicking: nil
+	// nodes clear, a short slice syncs only what it holds. A nil
+	// window resolves to no context, so both paths return headless.
+	a11ySyncBridge(nil, nil, 3, 0, 0)
+	a11ySyncBridge(nil, []gui.A11yNode{{Role: gui.AccessRoleButton}}, 3, 0, 600)
 }
 
 func TestSetA11yCallback(t *testing.T) {
 	called := false
-	setA11yCallback(func(action, index int) {
+	const token = 1
+	setA11yCallback(token, func(action, index int) {
 		called = true
 	})
-	goA11yAction(1, 2)
+	goA11yAction(1, 2, token)
 	if !called {
 		t.Fatal("callback not invoked via goA11yAction")
 	}
 	// Nil callback must not panic.
-	setA11yCallback(nil)
-	goA11yAction(0, 0)
+	setA11yCallback(token, nil)
+	goA11yAction(0, 0, token)
+}
+
+// Actions must reach the owning window's callback: with two windows
+// live, window 1's VoiceOver press must not fire window 2's handler.
+func TestA11yCallbacksRoutePerWindow(t *testing.T) {
+	var got1, got2 [][2]int
+	setA11yCallback(11, func(action, index int) {
+		got1 = append(got1, [2]int{action, index})
+	})
+	setA11yCallback(22, func(action, index int) {
+		got2 = append(got2, [2]int{action, index})
+	})
+	t.Cleanup(func() {
+		clearA11yCallback(11)
+		clearA11yCallback(22)
+	})
+
+	goA11yAction(0, 3, 11)
+	if len(got1) != 1 || got1[0] != [2]int{0, 3} {
+		t.Errorf("window 1 actions: got %v, want [[0 3]]", got1)
+	}
+	if len(got2) != 0 {
+		t.Errorf("window 2 heard window 1's action: %v", got2)
+	}
+
+	// Destroying one window's callback must not disturb the other's.
+	clearA11yCallback(11)
+	goA11yAction(0, 3, 11)
+	goA11yAction(4, 5, 22)
+	if len(got1) != 1 {
+		t.Errorf("cleared callback still fires: %v", got1)
+	}
+	if len(got2) != 1 || got2[0] != [2]int{4, 5} {
+		t.Errorf("window 2 actions: got %v, want [[4 5]]", got2)
+	}
 }

--- a/gui/backend/metal/native_platform.go
+++ b/gui/backend/metal/native_platform.go
@@ -74,18 +74,19 @@ func (n *nativePlatform) BookmarkStopAccess(_ []byte)                  {}
 // --- Accessibility ---
 
 func (n *nativePlatform) A11yInit(cb func(action, index int)) {
-	setA11yCallback(cb)
+	setA11yCallback(a11yToken(n.window), cb)
 	C.a11yInit(n.window)
 }
 
 func (n *nativePlatform) A11ySync(nodes []gui.A11yNode, count, focusedIdx int) {
 	var logW, logH C.int
 	C.metalWindowGetSize(n.window, &logW, &logH)
-	a11ySyncBridge(nodes, count, focusedIdx, float32(logH))
+	a11ySyncBridge(n.window, nodes, count, focusedIdx, float32(logH))
 }
 
 func (n *nativePlatform) A11yDestroy() {
-	C.a11yDestroy()
+	clearA11yCallback(a11yToken(n.window))
+	C.a11yDestroy(n.window)
 }
 
 func (n *nativePlatform) A11yAnnounce(text string) {

--- a/gui/color.go
+++ b/gui/color.go
@@ -1,6 +1,9 @@
 package gui
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Color represents a 32-bit color value in sRGB format.
 // The set field distinguishes "not set" (zero value) from intentionally
@@ -12,6 +15,8 @@ type Color struct {
 }
 
 // Predefined colors.
+// exportaudit:keep — public palette for app and consumer code;
+// newly exported names gain outside references as siblings adopt them.
 var (
 	Black            = Color{0, 0, 0, 255, true}
 	Gray             = Color{128, 128, 128, 255, true}
@@ -20,23 +25,31 @@ var (
 	Green            = Color{0, 255, 0, 255, true}
 	Blue             = Color{0, 0, 255, 255, true}
 	Yellow           = Color{255, 255, 0, 255, true}
-	magenta          = Color{255, 0, 255, 255, true}
+	Magenta          = Color{255, 0, 255, 255, true}
 	Orange           = Color{255, 165, 0, 255, true}
 	Purple           = Color{128, 0, 128, 255, true}
-	indigo           = Color{75, 0, 130, 255, true}
-	pink             = Color{255, 192, 203, 255, true}
-	violet           = Color{238, 130, 238, 255, true}
-	darkBlue         = Color{0, 0, 139, 255, true}
+	Indigo           = Color{75, 0, 130, 255, true}
+	Pink             = Color{255, 192, 203, 255, true}
+	Violet           = Color{238, 130, 238, 255, true}
+	DarkBlue         = Color{0, 0, 139, 255, true}
 	DarkGray         = Color{169, 169, 169, 255, true}
-	darkGreen        = Color{0, 100, 0, 255, true}
-	darkRed          = Color{139, 0, 0, 255, true}
+	DarkGreen        = Color{0, 100, 0, 255, true}
+	DarkRed          = Color{139, 0, 0, 255, true}
 	LightBlue        = Color{173, 216, 230, 255, true}
-	lightGray        = Color{211, 211, 211, 255, true}
-	lightGreen       = Color{144, 238, 144, 255, true}
-	lightRed         = Color{255, 204, 203, 255, true}
+	LightGray        = Color{211, 211, 211, 255, true}
+	LightGreen       = Color{144, 238, 144, 255, true}
+	LightRed         = Color{255, 204, 203, 255, true}
 	CornflowerBlue   = Color{100, 149, 237, 255, true}
-	royalBlue        = Color{65, 105, 225, 255, true}
+	RoyalBlue        = Color{65, 105, 225, 255, true}
 	ColorTransparent = Color{0, 0, 0, 0, true}
+)
+
+// Lowercase aliases for the pre-export spellings still used inside
+// this module (error placeholders, benchmarks). New code uses the
+// exported names above.
+var (
+	magenta   = Magenta
+	lightGray = LightGray
 )
 
 // Hex creates a Color from a hexadecimal integer (0xRRGGBB).
@@ -78,17 +91,20 @@ func (c Color) WithOpacity(opacity float32) Color {
 }
 
 // Add returns c + b, clamping each channel to 255.
+// The result is set if either input is set: combining two unset
+// colors must stay unset rather than conjure an explicit color.
 func (c Color) Add(b Color) Color {
 	return Color{
 		R:   clampAdd(c.R, b.R),
 		G:   clampAdd(c.G, b.G),
 		B:   clampAdd(c.B, b.B),
 		A:   clampAdd(c.A, b.A),
-		set: true,
+		set: c.set || b.set,
 	}
 }
 
 // Sub returns c - b, clamping each channel to 0.
+// Set-propagation mirrors Add: unset in, unset out.
 func (c Color) Sub(b Color) Color {
 	ca := clampSub(c.A, b.A)
 	return Color{
@@ -96,7 +112,7 @@ func (c Color) Sub(b Color) Color {
 		G:   clampSub(c.G, b.G),
 		B:   clampSub(c.B, b.B),
 		A:   ca,
-		set: true,
+		set: c.set || b.set,
 	}
 }
 
@@ -106,17 +122,20 @@ func (c Color) Over(b Color) Color {
 	ba := float32(b.A) / 255
 	ra := ca + ba*(1-ca)
 	if ra == 0 {
-		return ColorTransparent
+		if c.set || b.set {
+			return ColorTransparent
+		}
+		return Color{}
 	}
 	rr := (float32(c.R)*ca + float32(b.R)*ba*(1-ca)) / ra
 	gr := (float32(c.G)*ca + float32(b.G)*ba*(1-ca)) / ra
 	br := (float32(c.B)*ca + float32(b.B)*ba*(1-ca)) / ra
 	return Color{
-		R:   uint8(rr),
-		G:   uint8(gr),
-		B:   uint8(br),
-		A:   uint8(ra * 255),
-		set: true,
+		R:   uint8(rr + 0.5),
+		G:   uint8(gr + 0.5),
+		B:   uint8(br + 0.5),
+		A:   uint8(ra*255 + 0.5),
+		set: c.set || b.set,
 	}
 }
 
@@ -145,9 +164,11 @@ func (c Color) aBGR8() int {
 	return int(uint32(c.A)<<24 | uint32(c.B)<<16 | uint32(c.G)<<8 | uint32(c.R))
 }
 
-// ToCSSString returns CSS-compatible "rgba(r,g,b,a)".
+// ToCSSString returns CSS-compatible "rgba(r,g,b,a)" with alpha in
+// 0–1, e.g. "rgba(10,20,30,0.50)".
 func (c Color) toCSSString() string {
-	return fmt.Sprintf("rgba(%d,%d,%d,%d)", c.R, c.G, c.B, c.A)
+	return fmt.Sprintf("rgba(%d,%d,%d,%.2f)",
+		c.R, c.G, c.B, float64(c.A)/255)
 }
 
 var stringColors = map[string]Color{
@@ -155,37 +176,55 @@ var stringColors = map[string]Color{
 	"red":             Red,
 	"green":           Green,
 	"yellow":          Yellow,
+	"magenta":         Magenta,
 	"orange":          Orange,
 	"purple":          Purple,
 	"black":           Black,
 	"gray":            Gray,
-	"indigo":          indigo,
-	"pink":            pink,
-	"violet":          violet,
+	"indigo":          Indigo,
+	"pink":            Pink,
+	"violet":          Violet,
 	"white":           White,
 	"cornflower_blue": CornflowerBlue,
-	"royal_blue":      royalBlue,
-	"dark_blue":       darkBlue,
+	"royal_blue":      RoyalBlue,
+	"dark_blue":       DarkBlue,
 	"dark_gray":       DarkGray,
-	"dark_green":      darkGreen,
-	"dark_red":        darkRed,
+	"dark_green":      DarkGreen,
+	"dark_red":        DarkRed,
 	"light_blue":      LightBlue,
-	"light_gray":      lightGray,
-	"light_green":     lightGreen,
-	"light_red":       lightRed,
+	"light_gray":      LightGray,
+	"light_green":     LightGreen,
+	"light_red":       LightRed,
+}
+
+// ColorLookup returns the Color for a name ("red", "cornflower_blue")
+// or "#RRGGBB[AA]" hex string, reporting ok=false for unknown input.
+// Lookup trims surrounding space and folds case, so " Red " and
+// "RED" both match. A hex field uses this while the user is still
+// typing: ok=false leaves the current color untouched.
+//
+// exportaudit:keep — app-facing config/user-input lookup.
+func ColorLookup(s string) (Color, bool) {
+	t := strings.TrimSpace(s)
+	// No valid input is longer than "cornflower_blue" (14): reject
+	// longer strings before ToLower allocates for them.
+	if len(t) > 32 {
+		return Color{}, false
+	}
+	if len(t) > 0 && t[0] == '#' {
+		return colorFromHexString(t)
+	}
+	if c, ok := stringColors[strings.ToLower(t)]; ok {
+		return c, true
+	}
+	return Color{}, false
 }
 
 // ColorFromString returns a Color for the given name or "#RRGGBB" hex
-// string. Returns Black if not found.
+// string. Unknown input returns opaque black; use ColorLookup when
+// the caller must tell a typo apart from black.
 func ColorFromString(s string) Color {
-	if len(s) > 0 && s[0] == '#' {
-		c, ok := colorFromHexString(s)
-		if ok {
-			return c
-		}
-		return Color{A: 255, set: true}
-	}
-	if c, ok := stringColors[s]; ok {
+	if c, ok := ColorLookup(s); ok {
 		return c
 	}
 	return Color{A: 255, set: true}

--- a/gui/color_buffers.go
+++ b/gui/color_buffers.go
@@ -219,7 +219,9 @@ func planeSrc(v HSLA, size int) string {
 	if src, ok := memImageSrc(key); ok {
 		return src
 	}
-	return UseImage(string(key), size, size, planePixels(v.H, size))
+	// Render with the quantized hue, not the raw one: two hues in
+	// one quantum share this key, so they must share its pixels.
+	return UseImage(string(key), size, size, planePixels(float32(qh), size))
 }
 
 func planePixels(hue float32, size int) []byte {

--- a/gui/color_buffers_test.go
+++ b/gui/color_buffers_test.go
@@ -245,6 +245,33 @@ func TestBufferSrcCacheHitDoesNotAllocate(t *testing.T) {
 	}
 }
 
+// Sub-quantum hues share one key, so they must also share one pixel
+// buffer: rendering the raw hue would serve the first hue's pixels
+// to the second hue under the same key.
+func TestPlaneSrcRendersQuantizedHue(t *testing.T) {
+	resetMemImages(t)
+	const size = 16
+	a := HSLA{H: 200.1, S: 0.5, L: 0.5, A: 1}
+	b := HSLA{H: 200.4, S: 0.5, L: 0.5, A: 1}
+	srcA := planeSrc(a, size)
+	if srcB := planeSrc(b, size); srcB != srcA {
+		t.Fatalf("sub-quantum hues keyed differently: %q vs %q", srcA, srcB)
+	}
+	_, _, got, ok := LookupImage(srcA)
+	if !ok {
+		t.Fatal("plane buffer not registered")
+	}
+	want := planePixels(200, size)
+	if len(got) != len(want) {
+		t.Fatalf("buffer len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("pixel byte %d = %d, want %d (quantized hue 200)", i, got[i], want[i])
+		}
+	}
+}
+
 func TestColorChannelAccessors(t *testing.T) {
 	v := HSLA{H: 180, S: 0.25, L: 0.75, A: 0.5}
 	cases := []struct {

--- a/gui/color_filter.go
+++ b/gui/color_filter.go
@@ -38,15 +38,28 @@ var (
 	}}
 )
 
-// ColorFilterIdentity returns a no-op color filter.
+// ColorFilterIdentity returns a no-op color filter. The result is a
+// fresh copy: callers never alias the package singleton, so no future
+// in-package mutation can leak across users.
 // exportaudit:keep — collides with the colorFilterIdentity singleton var
-func ColorFilterIdentity() *ColorFilter { return &colorFilterIdentity }
+func ColorFilterIdentity() *ColorFilter {
+	f := colorFilterIdentity
+	return &f
+}
 
 // ColorFilterGrayscale converts to luminance-weighted grayscale.
-func ColorFilterGrayscale() *ColorFilter { return &colorFilterGrayscale }
+// Returns a copy, as ColorFilterIdentity does.
+func ColorFilterGrayscale() *ColorFilter {
+	f := colorFilterGrayscale
+	return &f
+}
 
 // ColorFilterSepia applies a warm sepia tone.
-func ColorFilterSepia() *ColorFilter { return &colorFilterSepia }
+// Returns a copy, as ColorFilterIdentity does.
+func ColorFilterSepia() *ColorFilter {
+	f := colorFilterSepia
+	return &f
+}
 
 // ColorFilterSaturate adjusts saturation. 0=grayscale, 1=identity,
 // >1=oversaturated.
@@ -104,17 +117,27 @@ func ColorFilterHueRotate(degrees float32) *ColorFilter {
 
 // ColorFilterInvert negates RGB, keeps alpha. Uses the alpha
 // column to inject bias (output.rgb = alpha - input.rgb).
+// Returns a copy, as ColorFilterIdentity does.
 // exportaudit:keep — collides with the colorFilterInvert singleton var
-func ColorFilterInvert() *ColorFilter { return &colorFilterInvert }
+func ColorFilterInvert() *ColorFilter {
+	f := colorFilterInvert
+	return &f
+}
 
 // ColorFilterCompose multiplies two color filters (a applied
-// first, then b). Returns a new filter representing b*a.
+// first, then b). Returns a new filter representing b*a; a nil side
+// yields a copy of the other side, never an alias of it.
 func colorFilterCompose(a, b *ColorFilter) *ColorFilter {
+	if a == nil && b == nil {
+		return nil
+	}
 	if a == nil {
-		return b
+		out := *b
+		return &out
 	}
 	if b == nil {
-		return a
+		out := *a
+		return &out
 	}
 	var out ColorFilter
 	for col := range 4 {

--- a/gui/color_filter_test.go
+++ b/gui/color_filter_test.go
@@ -185,6 +185,25 @@ func TestColorFilterNilMatrix(t *testing.T) {
 	}
 }
 
+// Singleton constructors must hand out copies: mutating a result
+// must not leak into the next call or into compose inputs.
+func TestColorFilterSingletonsAreCopies(t *testing.T) {
+	a := ColorFilterGrayscale()
+	a.matrix[0] = -999
+	if b := ColorFilterGrayscale(); b.matrix[0] == -999 {
+		t.Error("Grayscale() aliases the singleton")
+	}
+	gs := ColorFilterGrayscale()
+	composed := colorFilterCompose(gs, nil)
+	composed.matrix[0] = -999
+	if fresh := ColorFilterGrayscale(); fresh.matrix[0] == -999 {
+		t.Error("compose(nil-side) aliases its input")
+	}
+	if colorFilterCompose(nil, nil) != nil {
+		t.Error("compose(nil, nil) should be nil")
+	}
+}
+
 func TestRenderFilterBracketWithColorFilter(t *testing.T) {
 	w := newTestWindow()
 	cf := ColorFilterGrayscale()

--- a/gui/color_hsl.go
+++ b/gui/color_hsl.go
@@ -119,9 +119,15 @@ func ColorToHSLA(c Color) HSLA {
 // shows: hsla(210, 70%, 55%, 0.85).
 func (v HSLA) String() string {
 	n := v.Normalized()
+	// Rounding can carry H to 360 (e.g. 359.6°); wrap it back to 0
+	// so the readout never shows an out-of-range hue.
+	hue := int64(n.H + 0.5)
+	if hue >= 360 {
+		hue -= 360
+	}
 	b := make([]byte, 0, 32)
 	b = append(b, "hsla("...)
-	b = strconv.AppendInt(b, int64(n.H+0.5), 10)
+	b = strconv.AppendInt(b, hue, 10)
 	b = append(b, ", "...)
 	b = strconv.AppendInt(b, int64(n.S*100+0.5), 10)
 	b = append(b, "%, "...)

--- a/gui/color_hsl_test.go
+++ b/gui/color_hsl_test.go
@@ -120,6 +120,11 @@ func TestHSLAString(t *testing.T) {
 	if got != want {
 		t.Errorf("String() = %q, want %q", got, want)
 	}
+	// Rounding 359.6° must wrap to 0, not print a 360° hue.
+	wrapped := (HSLA{359.6, 1, 0.5, 1}).String()
+	if wrapped != "hsla(0, 100%, 50%, 1.00)" {
+		t.Errorf("wrapped String() = %q", wrapped)
+	}
 }
 
 func TestColorHexExports(t *testing.T) {

--- a/gui/color_hsv.go
+++ b/gui/color_hsv.go
@@ -1,7 +1,5 @@
 package gui
 
-import "fmt"
-
 // ToHSV converts an RGB Color to HSV components.
 // Returns h (0–360), s (0–1), v (0–1).
 func (c Color) ToHSV() (h, s, v float32) {
@@ -43,8 +41,22 @@ func ColorFromHSV(h, s, v float32) Color {
 }
 
 // ColorFromHSVA creates a Color from HSVA values.
-// h: 0–360, s: 0–1, v: 0–1, a: 0–255.
+// h: 0–360 (wrapping), s: 0–1, v: 0–1, a: 0–255.
+// Out-of-range s/v are clamped and non-finite inputs map to zero,
+// mirroring HSLA.Normalized: f32Mod lets NaN through and the
+// float→uint8 conversion below is implementation-defined for it.
 func colorFromHSVA(h, s, v float32, a uint8) Color {
+	if !f32IsFinite(h) {
+		h = 0
+	}
+	if !f32IsFinite(s) {
+		s = 0
+	}
+	if !f32IsFinite(v) {
+		v = 0
+	}
+	s = f32Clamp(s, 0, 1)
+	v = f32Clamp(v, 0, 1)
 	h = f32Mod(h, 360)
 	if h < 0 {
 		h += 360
@@ -85,11 +97,24 @@ func hueColor(h float32) Color {
 }
 
 // ToHexString returns "#RRGGBB" or "#RRGGBBAA" when alpha != 255.
+// Built with a hex table into a stack-sized buffer instead of fmt:
+// this runs on the readout path.
 func (c Color) toHexString() string {
+	const digits = "0123456789ABCDEF"
+	var buf [9]byte
+	buf[0] = '#'
+	buf[1] = digits[c.R>>4]
+	buf[2] = digits[c.R&0xF]
+	buf[3] = digits[c.G>>4]
+	buf[4] = digits[c.G&0xF]
+	buf[5] = digits[c.B>>4]
+	buf[6] = digits[c.B&0xF]
 	if c.A == 255 {
-		return fmt.Sprintf("#%02X%02X%02X", c.R, c.G, c.B)
+		return string(buf[:7])
 	}
-	return fmt.Sprintf("#%02X%02X%02X%02X", c.R, c.G, c.B, c.A)
+	buf[7] = digits[c.A>>4]
+	buf[8] = digits[c.A&0xF]
+	return string(buf[:9])
 }
 
 // ColorFromHexString parses "#RRGGBB" or "#RRGGBBAA".

--- a/gui/color_hsv_test.go
+++ b/gui/color_hsv_test.go
@@ -197,6 +197,44 @@ func TestHexPairInvalid(t *testing.T) {
 	}
 }
 
+func TestColorFromHSVNonFiniteAndClamped(t *testing.T) {
+	nan := float32(math.NaN())
+	inf := float32(math.Inf(1))
+	for _, tc := range []struct {
+		name    string
+		h, s, v float32
+	}{
+		{"nan_hue", nan, 1, 1},
+		{"nan_sat", 120, nan, 1},
+		{"nan_val", 120, 1, nan},
+		{"inf_hue", inf, 1, 1},
+		{"inf_sat", 120, inf, 1},
+		{"neg_sat", 120, -2, 1},
+		{"over_sat", 120, 5, 1},
+		{"neg_val", 120, 1, -3},
+		{"over_val", 120, 1, 4},
+	} {
+		c := ColorFromHSV(tc.h, tc.s, tc.v)
+		if !c.IsSet() {
+			t.Errorf("%s: result should be set", tc.name)
+		}
+	}
+	// All-NaN maps to zeroed inputs: hue 0, s/v clamped to 0 → black.
+	if got := ColorFromHSV(nan, nan, nan); got != RGBA(0, 0, 0, 255) {
+		t.Errorf("all-NaN: got %v, want black", got)
+	}
+	// Clamping pins to the same result as the boundary value.
+	if got := ColorFromHSV(0, 5, 1); got != ColorFromHSV(0, 1, 1) {
+		t.Errorf("s>1 not clamped: got %v", got)
+	}
+	if got := ColorFromHSV(0, 1, 9); got != ColorFromHSV(0, 1, 1) {
+		t.Errorf("v>1 not clamped: got %v", got)
+	}
+	if got := ColorFromHSV(0, -1, -1); got != RGBA(0, 0, 0, 255) {
+		t.Errorf("negative s/v: got %v, want black", got)
+	}
+}
+
 func closeEnough(a, b float32) bool {
 	return float32(math.Abs(float64(a-b))) < 0.02
 }

--- a/gui/color_test.go
+++ b/gui/color_test.go
@@ -1,6 +1,9 @@
 package gui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestColorIsSet(t *testing.T) {
 	t.Parallel()
@@ -179,9 +182,55 @@ func TestColorString(t *testing.T) {
 func TestColorToCSSString(t *testing.T) {
 	t.Parallel()
 	c := RGBA(10, 20, 30, 128)
-	want := "rgba(10,20,30,128)"
+	want := "rgba(10,20,30,0.50)"
 	if got := c.toCSSString(); got != want {
 		t.Errorf("ToCSSString() = %q, want %q", got, want)
+	}
+	if got := RGB(10, 20, 30).toCSSString(); got != "rgba(10,20,30,1.00)" {
+		t.Errorf("opaque ToCSSString() = %q", got)
+	}
+	if got := ColorTransparent.toCSSString(); got != "rgba(0,0,0,0.00)" {
+		t.Errorf("transparent ToCSSString() = %q", got)
+	}
+}
+
+func TestColorLookup(t *testing.T) {
+	t.Parallel()
+	if c, ok := ColorLookup("red"); !ok || !c.eq(Red) {
+		t.Errorf("ColorLookup(red) = %v,%v, want Red", c, ok)
+	}
+	if c, ok := ColorLookup("Magenta"); !ok || !c.eq(Magenta) {
+		t.Errorf("ColorLookup(Magenta) = %v,%v, want Magenta", c, ok)
+	}
+	if c, ok := ColorLookup("  cornflower_blue  "); !ok || !c.eq(CornflowerBlue) {
+		t.Errorf("ColorLookup(padded) = %v,%v", c, ok)
+	}
+	if c, ok := ColorLookup("#FF0000"); !ok || c.R != 255 || c.G != 0 || c.B != 0 {
+		t.Errorf("ColorLookup(#FF0000) = %v,%v", c, ok)
+	}
+	for _, s := range []string{"chartreuse", "#ZZZZZZ", "", "#", "   "} {
+		if c, ok := ColorLookup(s); ok {
+			t.Errorf("ColorLookup(%q) = %v, want ok=false", s, c)
+		}
+	}
+	if _, ok := ColorLookup(strings.Repeat("r", 64)); ok {
+		t.Error("ColorLookup(oversize) should return ok=false")
+	}
+}
+
+func TestColorFromStringNormalized(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		in   string
+		want Color
+	}{
+		{"RED", Red},
+		{" Magenta ", Magenta},
+		{"CORNFLOWER_BLUE", CornflowerBlue},
+	} {
+		if got := ColorFromString(tc.in); !got.eq(tc.want) {
+			t.Errorf("ColorFromString(%q) = %v, want %v", tc.in, got, tc.want)
+		}
 	}
 }
 
@@ -218,6 +267,25 @@ func TestOverSemiTransparent(t *testing.T) {
 	}
 }
 
+func TestOverRoundsToNearest(t *testing.T) {
+	t.Parallel()
+	// Half-opaque red over opaque blue: R≈128, G=0, B≈127, A=255.
+	// Tolerance ±1 keeps float32 error out of the assertion while
+	// catching a truncation regression (which reads 1 low).
+	r := RGBA(255, 0, 0, 128).Over(RGBA(0, 0, 255, 255))
+	for _, ch := range []struct {
+		name string
+		got  uint8
+		want uint8
+	}{
+		{"R", r.R, 128}, {"G", r.G, 0}, {"B", r.B, 127}, {"A", r.A, 255},
+	} {
+		if d := int(ch.got) - int(ch.want); d < -1 || d > 1 {
+			t.Errorf("Over %s = %d, want ~%d", ch.name, ch.got, ch.want)
+		}
+	}
+}
+
 func TestAddClampsTo255(t *testing.T) {
 	t.Parallel()
 	r := RGB(200, 200, 200).Add(RGB(200, 200, 200))
@@ -236,5 +304,49 @@ func TestWithOpacityClampsRange(t *testing.T) {
 	under := c.WithOpacity(-1.0)
 	if under.A != 0 {
 		t.Errorf("WithOpacity(-1.0) should clamp: got alpha %d", under.A)
+	}
+}
+
+func TestArithUnsetPropagation(t *testing.T) {
+	t.Parallel()
+	var unset Color
+	if got := unset.Add(unset); got.IsSet() {
+		t.Errorf("Add(unset, unset) = %v, want unset", got)
+	}
+	if got := unset.Sub(unset); got.IsSet() {
+		t.Errorf("Sub(unset, unset) = %v, want unset", got)
+	}
+	if got := unset.Over(unset); got.IsSet() {
+		t.Errorf("Over(unset, unset) = %v, want unset", got)
+	}
+	// One set input keeps the result set.
+	if got := Red.Add(unset); !got.IsSet() {
+		t.Errorf("Add(set, unset) = %v, want set", got)
+	}
+	if got := unset.Sub(Red); !got.IsSet() {
+		t.Errorf("Sub(unset, set) = %v, want set", got)
+	}
+	if got := unset.Over(Red); !got.IsSet() {
+		t.Errorf("Over(unset, set) = %v, want set", got)
+	}
+}
+
+func TestPredefinedColorsSet(t *testing.T) {
+	t.Parallel()
+	for name, c := range map[string]Color{
+		"Black": Black, "Gray": Gray, "White": White,
+		"Red": Red, "Green": Green, "Blue": Blue,
+		"Yellow": Yellow, "Magenta": Magenta, "Orange": Orange,
+		"Purple": Purple, "Indigo": Indigo, "Pink": Pink,
+		"Violet": Violet, "DarkBlue": DarkBlue, "DarkGray": DarkGray,
+		"DarkGreen": DarkGreen, "DarkRed": DarkRed,
+		"LightBlue": LightBlue, "LightGray": LightGray,
+		"LightGreen": LightGreen, "LightRed": LightRed,
+		"CornflowerBlue": CornflowerBlue, "RoyalBlue": RoyalBlue,
+		"ColorTransparent": ColorTransparent,
+	} {
+		if !c.IsSet() {
+			t.Errorf("%s should be set", name)
+		}
 	}
 }

--- a/gui/command.go
+++ b/gui/command.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"strconv"
 )
@@ -16,7 +17,11 @@ type Shortcut struct {
 func (s Shortcut) IsSet() bool { return s.Key != KeyInvalid }
 
 // matches returns true if the event matches this shortcut.
+// Nil-safe: a nil event never matches.
 func (s Shortcut) matches(e *Event) bool {
+	if e == nil {
+		return false
+	}
 	return s.Key != KeyInvalid &&
 		e.KeyCode == s.Key && e.Modifiers == s.Modifiers
 }
@@ -70,6 +75,7 @@ func shortcutStringOther(m Modifier, buf []byte) []byte {
 }
 
 // keyNameMap maps individual key codes to display names.
+// Read-only after init; never mutate (concurrent reads).
 var keyNameMap = map[KeyCode]string{
 	KeySpace:        "Space",
 	KeyEnter:        "Enter",
@@ -120,6 +126,14 @@ func keyName(k KeyCode) string {
 
 // Command bundles an action with its identity, shortcut,
 // and enable/disable logic.
+//
+// Execute may receive a nil *Event when invoked off the key path
+// (native menubar, command palette), so it must nil-check e
+// before reading key fields. CanExecute must be pure and fast:
+// it runs on every key press and palette build, possibly twice
+// per frame, so it must not block or mutate state. Both run
+// synchronously on the event path; a panic propagates, like
+// every other event handler, and is not recovered.
 type Command struct {
 	Execute    func(*Event, *Window)
 	CanExecute func(*Window) bool // nil = always enabled
@@ -132,49 +146,110 @@ type Command struct {
 }
 
 // RegisterCommand adds a command to the window registry.
-// Returns an error on duplicate ID or duplicate shortcut.
+// Returns an error on empty ID, duplicate ID, or duplicate
+// shortcut. Safe for concurrent use with dispatch; user
+// callbacks run without the registry lock held.
 func (w *Window) RegisterCommand(cmd Command) error {
+	if cmd.ID == "" {
+		return errors.New("gui: command ID must not be empty")
+	}
+	w.cmdMu.Lock()
+	defer w.cmdMu.Unlock()
 	for i := range w.cmdRegistry {
 		if w.cmdRegistry[i].ID == cmd.ID {
-			return errors.New(
-				"gui: duplicate command ID: " + cmd.ID)
+			return fmt.Errorf("gui: duplicate command ID: %q", cmd.ID)
 		}
 		if cmd.Shortcut.IsSet() &&
 			w.cmdRegistry[i].Shortcut == cmd.Shortcut {
-			return errors.New(
-				"gui: duplicate shortcut for commands: " +
-					w.cmdRegistry[i].ID + " and " + cmd.ID)
+			return fmt.Errorf(
+				"gui: duplicate shortcut for commands: %q and %q",
+				w.cmdRegistry[i].ID, cmd.ID)
 		}
 	}
 	w.cmdRegistry = append(w.cmdRegistry, cmd)
 	return nil
 }
 
-// RegisterCommands adds multiple commands. Stops and returns
-// the first error encountered.
+// RegisterCommands adds multiple commands atomically: either all
+// are registered or none are. Returns the first validation error
+// without mutating the registry.
 func (w *Window) RegisterCommands(cmds ...Command) error {
-	for _, cmd := range cmds {
-		if err := w.RegisterCommand(cmd); err != nil {
-			return err
+	if len(cmds) == 0 {
+		return nil
+	}
+	w.cmdMu.Lock()
+	defer w.cmdMu.Unlock()
+	// Index the existing registry once so validation is linear
+	// in len(cmds) rather than quadratic: a large batch against
+	// a large registry must not cost O(batch*registry).
+	existingIDs := make(map[string]struct{}, len(w.cmdRegistry)+len(cmds))
+	existingShortcuts := make(map[Shortcut]string, len(w.cmdRegistry)+len(cmds))
+	for i := range w.cmdRegistry {
+		existing := &w.cmdRegistry[i]
+		existingIDs[existing.ID] = struct{}{}
+		if existing.Shortcut.IsSet() {
+			existingShortcuts[existing.Shortcut] = existing.ID
 		}
 	}
+	for _, cmd := range cmds {
+		if cmd.ID == "" {
+			return errors.New("gui: command ID must not be empty")
+		}
+		if _, dup := existingIDs[cmd.ID]; dup {
+			return fmt.Errorf("gui: duplicate command ID: %q", cmd.ID)
+		}
+		existingIDs[cmd.ID] = struct{}{}
+		if cmd.Shortcut.IsSet() {
+			if prev, dup := existingShortcuts[cmd.Shortcut]; dup {
+				return fmt.Errorf(
+					"gui: duplicate shortcut for commands: %q and %q",
+					prev, cmd.ID)
+			}
+			existingShortcuts[cmd.Shortcut] = cmd.ID
+		}
+	}
+	w.cmdRegistry = append(w.cmdRegistry, cmds...)
 	return nil
 }
 
 // UnregisterCommand removes a command by ID. No-op if
 // not found.
 func (w *Window) UnregisterCommand(id string) {
+	w.cmdMu.Lock()
+	defer w.cmdMu.Unlock()
 	for i := range w.cmdRegistry {
 		if w.cmdRegistry[i].ID == id {
-			w.cmdRegistry = append(
-				w.cmdRegistry[:i], w.cmdRegistry[i+1:]...)
+			copy(w.cmdRegistry[i:], w.cmdRegistry[i+1:])
+			// Clear the orphaned tail so its closures can be
+			// collected rather than lingering in spare capacity.
+			w.cmdRegistry[len(w.cmdRegistry)-1] = Command{}
+			w.cmdRegistry = w.cmdRegistry[:len(w.cmdRegistry)-1]
 			return
 		}
 	}
 }
 
-// CommandByID returns a registered command by ID.
+// canExecute reports whether the command is currently enabled.
+// Nil CanExecute means always enabled.
+func (c *Command) canExecute(w *Window) bool {
+	return c.CanExecute == nil || c.CanExecute(w)
+}
+
+// snapshotCommands copies the registry so user callbacks
+// (CanExecute/Execute) run without the registry lock held.
+func (w *Window) snapshotCommands() []Command {
+	w.cmdMu.RLock()
+	defer w.cmdMu.RUnlock()
+	snapshot := make([]Command, len(w.cmdRegistry))
+	copy(snapshot, w.cmdRegistry)
+	return snapshot
+}
+
+// CommandByID returns a registered command by ID. The returned
+// value is a copy; mutating it does not update the registry.
 func (w *Window) CommandByID(id string) (Command, bool) {
+	w.cmdMu.RLock()
+	defer w.cmdMu.RUnlock()
 	for i := range w.cmdRegistry {
 		if w.cmdRegistry[i].ID == id {
 			return w.cmdRegistry[i], true
@@ -190,22 +265,25 @@ func (w *Window) commandCanExecute(id string) bool {
 	if !ok {
 		return false
 	}
-	if cmd.CanExecute == nil {
-		return true
-	}
-	return cmd.CanExecute(w)
+	return cmd.canExecute(w)
 }
 
 // CommandPaletteItems returns palette items from
 // registered commands. Excludes commands with empty Label.
+// Snapshots the registry so CanExecute callbacks run without
+// the registry lock held.
 func (w *Window) CommandPaletteItems() []CommandPaletteItem {
-	items := make([]CommandPaletteItem, 0, len(w.cmdRegistry))
-	for i := range w.cmdRegistry {
-		cmd := &w.cmdRegistry[i]
+	snapshot := w.snapshotCommands()
+	items := make([]CommandPaletteItem, 0, len(snapshot))
+	for i := range snapshot {
+		cmd := &snapshot[i]
 		if cmd.Label == "" {
 			continue
 		}
-		disabled := cmd.CanExecute != nil && !cmd.CanExecute(w)
+		// Read CanExecute from the snapshot, not via a second
+		// registry lookup: the entry may have been unregistered
+		// after the snapshot, and a per-item lookup is O(n^2).
+		disabled := !cmd.canExecute(w)
 		items = append(items, CommandPaletteItem{
 			ID:       cmd.ID,
 			Label:    cmd.Label,
@@ -221,12 +299,23 @@ func (w *Window) CommandPaletteItems() []CommandPaletteItem {
 // commandDispatch scans commands matching the event's
 // key+modifiers. If globalOnly is true, only Global=true
 // commands are checked; if false, only Global=false.
-// Returns true if a command was executed.
+// Returns true if a command was executed. Nil events never
+// match. Commands with nil Execute never consume the event,
+// so an action-less binding cannot swallow a keypress.
+// The registry is snapshotted so Execute/CanExecute run
+// without the lock held (they may register commands).
 func (w *Window) commandDispatch(
 	e *Event, globalOnly bool,
 ) bool {
-	for i := range w.cmdRegistry {
-		cmd := &w.cmdRegistry[i]
+	if e == nil {
+		return false
+	}
+	snapshot := w.snapshotCommands()
+	if len(snapshot) == 0 {
+		return false
+	}
+	for i := range snapshot {
+		cmd := &snapshot[i]
 		if cmd.Global != globalOnly {
 			continue
 		}
@@ -236,12 +325,13 @@ func (w *Window) commandDispatch(
 		if !cmd.Shortcut.matches(e) {
 			continue
 		}
-		if cmd.CanExecute != nil && !cmd.CanExecute(w) {
+		if !cmd.canExecute(w) {
 			continue
 		}
-		if cmd.Execute != nil {
-			cmd.Execute(e, w)
+		if cmd.Execute == nil {
+			continue
 		}
+		cmd.Execute(e, w)
 		e.IsHandled = true
 		return true
 	}

--- a/gui/command_queue.go
+++ b/gui/command_queue.go
@@ -40,8 +40,17 @@ func newAnimationCommands(deferred *[]queuedCommand) AnimationCommands {
 
 // AppendOnDone queues fn to run after the current frame's Update
 // pass. Nil fn is a no-op so callers can pass a pointer to an
-// optional callback field unconditionally.
-func (ac *AnimationCommands) appendOnDone(fn func(*Window)) {
+// optional callback field unconditionally. Nil-safe on a nil
+// receiver or uninitialized value, so an Animation used without
+// the loop wrapper cannot panic.
+//
+// Exported so third-party Animation implementations can enqueue
+// OnDone callbacks from another package without reaching for
+// the private queuedCommand type.
+//
+// exportaudit:keep — called by third-party Animation impls
+// outside gui/; the in-repo scan sees only internal callers.
+func (ac *AnimationCommands) AppendOnDone(fn func(*Window)) {
 	if fn == nil || ac == nil || ac.inner == nil {
 		return
 	}
@@ -50,15 +59,33 @@ func (ac *AnimationCommands) appendOnDone(fn func(*Window)) {
 	})
 }
 
+// appendOnDone keeps the previous unexported spelling working;
+// it delegates to AppendOnDone.
+func (ac *AnimationCommands) appendOnDone(fn func(*Window)) {
+	ac.AppendOnDone(fn)
+}
+
 // AppendOnValue queues fn with the supplied value. Typical use: a
 // per-frame interpolation callback from a tween / spring animation.
-func (ac *AnimationCommands) appendOnValue(fn func(float32, *Window), v float32) {
+// Nil-safe and a nil fn is a no-op, like AppendOnDone.
+//
+// Exported for third-party Animation implementations.
+//
+// exportaudit:keep — called by third-party Animation impls
+// outside gui/; the in-repo scan sees only internal callers.
+func (ac *AnimationCommands) AppendOnValue(fn func(float32, *Window), v float32) {
 	if fn == nil || ac == nil || ac.inner == nil {
 		return
 	}
 	*ac.inner = append(*ac.inner, queuedCommand{
 		kind: queuedCommandValueFn, valueFn: fn, value: v,
 	})
+}
+
+// appendOnValue keeps the previous unexported spelling working;
+// it delegates to AppendOnValue.
+func (ac *AnimationCommands) appendOnValue(fn func(float32, *Window), v float32) {
+	ac.AppendOnValue(fn, v)
 }
 
 // appendAnimate is Animate's self-dispatch helper — enqueues the

--- a/gui/command_queue_test.go
+++ b/gui/command_queue_test.go
@@ -79,3 +79,35 @@ func TestCommandMarkRenderOnlyRefreshSetsFlag(t *testing.T) {
 		t.Error("refreshRenderOnly should be true")
 	}
 }
+
+func TestAnimationCommands_ExportedAppend(t *testing.T) {
+	var cmds []queuedCommand
+	ac := newAnimationCommands(&cmds)
+	ac.AppendOnDone(func(_ *Window) {})
+	ac.AppendOnValue(func(float32, *Window) {}, 7)
+	if len(cmds) != 2 {
+		t.Fatalf("len = %d, want 2", len(cmds))
+	}
+	if cmds[0].kind != queuedCommandWindowFn {
+		t.Errorf("kind = %d, want windowFn", cmds[0].kind)
+	}
+	if cmds[1].kind != queuedCommandValueFn || cmds[1].value != 7 {
+		t.Errorf("value cmd mismatch: %+v", cmds[1])
+	}
+}
+
+func TestAnimationCommands_ExportedNilSafe(t *testing.T) {
+	var nilAC *AnimationCommands
+	nilAC.AppendOnDone(func(*Window) {})
+	nilAC.AppendOnValue(func(float32, *Window) {}, 1)
+	emptyAC := AnimationCommands{}
+	emptyAC.AppendOnDone(func(*Window) {})
+	emptyAC.AppendOnValue(func(float32, *Window) {}, 1)
+	var cmds []queuedCommand
+	exportedAC := newAnimationCommands(&cmds)
+	exportedAC.AppendOnDone(nil)
+	exportedAC.AppendOnValue(nil, 1)
+	if len(cmds) != 0 {
+		t.Errorf("len = %d, want 0 for nil fns", len(cmds))
+	}
+}

--- a/gui/command_test.go
+++ b/gui/command_test.go
@@ -547,3 +547,214 @@ func TestShortcutMatchesZeroValue(t *testing.T) {
 		t.Error("zero-value shortcut should not match")
 	}
 }
+
+func TestShortcutMatchesNilEvent(t *testing.T) {
+	s := Shortcut{Key: KeyS, Modifiers: ModCtrl}
+	if s.matches(nil) {
+		t.Error("nil event must never match")
+	}
+}
+
+func TestCommandDispatchNilEvent(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:       "n",
+		Shortcut: Shortcut{Key: KeyN, Modifiers: ModCtrl},
+		Execute:  func(_ *Event, _ *Window) {},
+	})
+	if w.commandDispatch(nil, false) {
+		t.Error("nil event must not dispatch")
+	}
+}
+
+func TestCommandDispatchNilExecuteDoesNotConsume(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:       "noexec",
+		Shortcut: Shortcut{Key: KeyE, Modifiers: ModCtrl},
+	})
+	e := &Event{KeyCode: KeyE, Modifiers: ModCtrl}
+	if w.commandDispatch(e, false) {
+		t.Error("nil Execute must not report dispatched")
+	}
+	if e.IsHandled {
+		t.Error("nil Execute must not consume the event")
+	}
+}
+
+func TestRegisterCommandEmptyIDReturnsError(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	if err := w.RegisterCommand(Command{Label: "No ID"}); err == nil {
+		t.Error("expected error on empty command ID")
+	}
+	if _, ok := w.CommandByID(""); ok {
+		t.Error("empty ID must not be registered")
+	}
+}
+
+func TestRegisterCommandsAtomicOnDuplicateID(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	err := w.RegisterCommands(
+		Command{ID: "atomic.a", Label: "A"},
+		Command{ID: "atomic.a", Label: "Dupe"},
+	)
+	if err == nil {
+		t.Fatal("expected error on duplicate ID in batch")
+	}
+	if _, ok := w.CommandByID("atomic.a"); ok {
+		t.Error("failed batch must leave registry unchanged")
+	}
+}
+
+func TestRegisterCommandsAtomicOnDuplicateShortcut(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	shortcut := Shortcut{Key: KeyQ, Modifiers: ModCtrl}
+	err := w.RegisterCommands(
+		Command{ID: "atomic.q1", Shortcut: shortcut},
+		Command{ID: "atomic.q2", Shortcut: shortcut},
+	)
+	if err == nil {
+		t.Fatal("expected error on duplicate shortcut in batch")
+	}
+	if _, ok := w.CommandByID("atomic.q1"); ok {
+		t.Error("failed batch must leave registry unchanged")
+	}
+	if _, ok := w.CommandByID("atomic.q2"); ok {
+		t.Error("failed batch must leave registry unchanged")
+	}
+}
+
+func TestCommandByIDReturnsCopy(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{ID: "copy", Label: "Orig"})
+	got, ok := w.CommandByID("copy")
+	if !ok {
+		t.Fatal("command not found")
+	}
+	got.Label = "Mutated"
+	again, ok := w.CommandByID("copy")
+	if !ok {
+		t.Fatal("command not found")
+	}
+	if again.Label != "Orig" {
+		t.Errorf("mutating copy leaked into registry, got %q", again.Label)
+	}
+}
+
+func TestUnregisterCommandReleasesSlot(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:      "slot",
+		Execute: func(_ *Event, _ *Window) {},
+	})
+	w.UnregisterCommand("slot")
+	w.RegisterCommand(Command{
+		ID:    "slot",
+		Label: "Reused",
+	})
+	got, ok := w.CommandByID("slot")
+	if !ok || got.Label != "Reused" {
+		t.Error("slot should be reusable after unregister")
+	}
+}
+
+func TestFlushCommandsSkipsNilFns(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.queueCommand(queuedCommand{kind: queuedCommandWindowFn})
+	w.queueCommand(queuedCommand{kind: queuedCommandValueFn, value: 1})
+	w.queueCommand(queuedCommand{kind: queuedCommandAnimateFn})
+	// Must not panic.
+	w.flushCommands()
+}
+
+func TestCommandRegistryConcurrentDispatch(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{
+		ID:       "race.base",
+		Shortcut: Shortcut{Key: KeyR, Modifiers: ModCtrl},
+		Execute:  func(_ *Event, _ *Window) {},
+	})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 50 {
+			id := ScopeIDN("race", "id", i)
+			_ = w.RegisterCommand(Command{ID: id})
+			_, _ = w.CommandByID(id)
+			w.UnregisterCommand(id)
+		}
+	}()
+	for range 50 {
+		e := &Event{KeyCode: KeyR, Modifiers: ModCtrl}
+		w.commandDispatch(e, false)
+		_ = w.CommandPaletteItems()
+	}
+	<-done
+}
+
+func TestRegisterCommandsAtomicAgainstExisting(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommand(Command{ID: "atomic.keep", Label: "Keep"})
+	err := w.RegisterCommands(
+		Command{ID: "atomic.fresh", Label: "Fresh"},
+		Command{ID: "atomic.keep", Label: "Collision"},
+	)
+	if err == nil {
+		t.Fatal("expected error on collision with registered ID")
+	}
+	if _, ok := w.CommandByID("atomic.fresh"); ok {
+		t.Error("failed batch must not add the non-colliding entry")
+	}
+	kept, ok := w.CommandByID("atomic.keep")
+	if !ok || kept.Label != "Keep" {
+		t.Error("existing entry must survive a failed batch")
+	}
+}
+
+func TestRegisterCommandsAtomicEmptyID(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	err := w.RegisterCommands(
+		Command{ID: "atomic.ok", Label: "OK"},
+		Command{ID: "", Label: "No ID"},
+	)
+	if err == nil {
+		t.Fatal("expected error on empty ID in batch")
+	}
+	if _, ok := w.CommandByID("atomic.ok"); ok {
+		t.Error("failed batch must leave registry unchanged")
+	}
+}
+
+func TestCommandPaletteItemsRespectsCanExecute(t *testing.T) {
+	w := NewWindow(WindowCfg{State: new(int)})
+	w.RegisterCommands(
+		Command{
+			ID:         "pal.off",
+			Label:      "Off",
+			CanExecute: func(_ *Window) bool { return false },
+		},
+		Command{
+			ID:         "pal.on",
+			Label:      "On",
+			CanExecute: func(_ *Window) bool { return true },
+		},
+		Command{ID: "pal.plain", Label: "Plain"},
+	)
+	items := w.CommandPaletteItems()
+	byID := make(map[string]CommandPaletteItem, len(items))
+	for _, item := range items {
+		byID[item.ID] = item
+	}
+	if len(items) != 3 {
+		t.Fatalf("got %d items, want 3", len(items))
+	}
+	if !byID["pal.off"].Disabled {
+		t.Error("CanExecute=false entry should be disabled")
+	}
+	if byID["pal.on"].Disabled {
+		t.Error("CanExecute=true entry should not be disabled")
+	}
+	if byID["pal.plain"].Disabled {
+		t.Error("nil CanExecute entry should not be disabled")
+	}
+}

--- a/gui/debug.go
+++ b/gui/debug.go
@@ -260,10 +260,16 @@ func envTruthy(name string) bool {
 //   - a scrollable shape with no ID (scroll offset shared with every
 //     other ID-less scrollable in the window)
 //   - a shape with an OnMouseLeave and no ID (the callback never fires)
+//   - a text animation with no ID (nothing to key its progress on)
 //   - a scrollable listbox that resolved to height 0 (virtualization
-//     off, every row builds each frame)
+//     off, every row builds each frame), a variable-height list past
+//     the per-item storage cap (uniform row height fallback), or a
+//     virtual list that widens frame after frame (measurement ratchet)
 //   - a fill gradient with more stops than the GPU shader uniform limit
 //     (silently resampled down to the limit on GPU backends)
+//   - input text truncated to the rune budget, or text the shaper
+//     refused so the frame fell back to approximate metrics
+//     (degraded caret, selection and delete precision)
 //   - a container that sets both Wrap and Overflow (wrap wins, overflow
 //     is ignored)
 //   - a state key that is a bare leaf while an ancestor join rewrote
@@ -272,6 +278,8 @@ func envTruthy(name string) bool {
 //   - a frame that finished with a focus ID no focusable shape claims
 //   - a shape whose stamp disagrees with the scope it was arranged
 //     under, or an ID-bearing shape with no stamp at all
+//   - an ID lookup that found nothing while the frame stamped the same
+//     leaf under a scope (a leaf spelled where an effective ID fits)
 //   - a window-level feature the platform could not deliver
 //
 // It also reports, from dispatch rather than from the frame audit, a
@@ -283,8 +291,8 @@ func envTruthy(name string) bool {
 // [DebugCategories] enables these classes independently; Debug is the
 // same API with both extremes (all on, all off).
 //
-// Findings go to stderr, once per finding per window. Turning a
-// category off and on again clears that memory, so a re-enabled gate
+// Findings go to stderr, once per finding per window. Turning the
+// gate off and on again clears that memory, so a re-enabled gate
 // reports the state of the frame in front of it.
 //
 // The gate is also set at startup by GOGUI_DEBUG=1.
@@ -306,9 +314,11 @@ func Debug(on bool) {
 // the unconsumed-event noise.
 //
 // A zero mask is everything off; [DebugAll] is every category [Debug]
-// turns on, which excludes [DebugUnscopedIDs]. Turning a category on
-// after it was off clears that category's warn-once memory, so a
-// re-enabled category reports the frame in front of it.
+// turns on, which excludes [DebugUnscopedIDs]. Turning the gate on
+// after it was off moves a generation that discards warn-once memory,
+// so a re-enabled gate reports the frame in front of it. Enabling one
+// more category while others stay on needs no clearing: a finding is
+// never remembered while its category is off.
 // exportaudit:keep — dev-diagnostic API for app authors
 func DebugCategories(mask DebugCategory) {
 	for {
@@ -340,6 +350,12 @@ type debugWarnKey struct {
 	subject string
 	check   debugCheck
 }
+
+// maxDebugWarned bounds one window's warn-once memory. Distinct
+// subjects are bounded by the tree in practice, but a gate left on in
+// a long-running app must not grow without limit; past the cap a new
+// finding is suppressed, which is the quieter failure.
+const maxDebugWarned = 4096
 
 // debugState is a window's warn-once memory. Zero value is ready.
 type debugState struct {
@@ -420,7 +436,7 @@ func (w *Window) debugCheckFocusTarget(ids *debugIDs) {
 	if _, claimed := ids.claimed[id]; claimed {
 		hint = "a shape of that name is in this frame but is not focusable"
 	} else if near := focusableByLeaf(ids, lastIDSegment(id)); len(near) > 0 {
-		hint = "the frame stamped " + strings.Join(near, ", ") +
+		hint = "the frame stamped " + quoteJoin(near) +
 			" for that leaf"
 	}
 	w.debugWarn(debugCheckUnknownFocus, id,
@@ -565,12 +581,15 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids *debugIDs) {
 	// keyed by ID. Render the path only when there is something to
 	// report.
 	focusBad := s.Focusable && !s.FocusSkip && !s.Disabled
+	// A disabled subtree never receives events or scrolls, so a
+	// disabled shape is quiet on every ID-less check, not just focus.
+	scrollBad := s.Scrollable && !s.Disabled
 	// OnMouseLeave is tracked through a map keyed by ID
 	// (layoutMouseLeave, layout_pipeline.go), and that guard has no
 	// Focusable precondition — so this fires on shapes the focus check
 	// deliberately passes over, including FocusDisabled controls.
 	leaveBad := !s.Disabled && s.events != nil && s.events.OnMouseLeave != nil
-	if !focusBad && !s.Scrollable && !leaveBad {
+	if !focusBad && !scrollBad && !leaveBad {
 		return
 	}
 	p := debugPath(path)
@@ -579,7 +598,7 @@ func (w *Window) debugCheckShape(s *Shape, path []int, ids *debugIDs) {
 			"focusable shape at %s has no ID; focus traversal is keyed by "+
 				"ID, so it renders and clicks but never joins the tab order", p)
 	}
-	if s.Scrollable {
+	if scrollBad {
 		w.debugWarn(debugCheckScrollNoID, p,
 			"scrollable shape at %s has no ID; scroll offsets are keyed by "+
 				"ID, so it shares one offset with every other ID-less "+
@@ -683,6 +702,9 @@ func (w *Window) debugWarn(check debugCheck, subject, format string, args ...any
 	if _, seen := w.debug.warned[key]; seen {
 		return
 	}
+	if len(w.debug.warned) >= maxDebugWarned {
+		return
+	}
 	if w.debug.warned == nil {
 		w.debug.warned = make(map[debugWarnKey]struct{})
 	}
@@ -706,14 +728,15 @@ func (w *Window) DebugGradientResampled(x, y float32, kept, total int) {
 	// NaN never equals itself, so a NaN map key could never match and
 	// the warn-once memory would grow a key every frame. Fold NaN in
 	// the discriminator only; the message keeps the true position.
-	if x != x {
-		x = 0
+	foldX, foldY := x, y
+	if foldX != foldX {
+		foldX = 0
 	}
-	if y != y {
-		y = 0
+	if foldY != foldY {
+		foldY = 0
 	}
 	w.debugWarn(debugCheckGradientResampled,
-		fmt.Sprintf("gradient %g,%g", x, y),
+		fmt.Sprintf("gradient %g,%g", foldX, foldY),
 		"gradient at (%g, %g) has %d stops; resampled to %d "+
 			"(GPU shader uniform limit)", x, y, total, kept)
 }

--- a/gui/debug_checks.go
+++ b/gui/debug_checks.go
@@ -1,5 +1,7 @@
 package gui
 
+import "strconv"
+
 // The internal check identifiers and their mapping to the public
 // categories that gate them. Split from debug.go, which holds the
 // gate itself, the per-window warn-once state and the frame audit.
@@ -113,6 +115,8 @@ func checkCategory(check debugCheck) DebugCategory {
 		return DebugUnknownFocus
 	case debugCheckGlyphLayoutFallback, debugCheckTextTruncated:
 		return DebugGlyphLayoutFallback
+	default:
+		panic("gui: checkCategory has no category for debugCheck " +
+			strconv.Itoa(int(check)))
 	}
-	return 0
 }

--- a/gui/debug_event.go
+++ b/gui/debug_event.go
@@ -211,15 +211,22 @@ func (w *Window) TestUnconsumedEvents() []string {
 		return nil
 	}
 	var found []string
-	prevOn := DebugEnabled()
+	// Restore the exact mask, not just on/off: a caller may have a
+	// narrower gate installed that this sweep must not widen for good.
+	// Mirrors TestFindings; see gui/debug.go.
+	prevMask := DebugCategory(debugMask.Load())
 	// A fresh warn-once map: a sweep should report the window in front
 	// of it, not skip what an earlier sweep or a stray frame reported.
 	prevWarned := w.debug.warned
 	w.debug.warned = nil
 	w.debug.collect = &found
-	Debug(true)
+	DebugCategories(DebugAll)
+	// The generation only moves on an off -> on transition, so widening
+	// an already-on gate would keep stale warn-once memory. The nil map
+	// above covers that; this keeps the two in step.
+	w.debug.gen = debugGen.Load()
 	defer func() {
-		Debug(prevOn)
+		DebugCategories(prevMask)
 		w.debug.collect = nil
 		w.debug.warned = prevWarned
 	}()

--- a/gui/debug_lookup.go
+++ b/gui/debug_lookup.go
@@ -133,6 +133,13 @@ func lookupWarnSeen(api, effectiveID string, mark bool) bool {
 	if lookupWarned == nil {
 		lookupWarned = make(map[debugLookupKey]struct{})
 	}
+	if len(lookupWarned) >= maxLookupWarned {
+		// Bound the memory a gate left on in a long-running app can
+		// hold: dynamic IDs would otherwise grow it without limit.
+		// The finding is suppressed rather than re-reported every
+		// frame, which is the quieter failure for a diagnostic.
+		return true
+	}
 	lookupWarned[key] = struct{}{}
 	return false
 }
@@ -143,6 +150,12 @@ func lookupWarnSeen(api, effectiveID string, mark bool) bool {
 // buries the message it is trying to deliver. The first few are enough
 // to show the shape of the scope that was missed.
 const lookupCandidateLimit = 5
+
+// maxLookupWarned bounds the warn-once memory. Dynamic IDs in a
+// long-running app would otherwise grow it without limit; the bound is
+// what keeps a gate left on from leaking. Mirrors maxEffIDAnswers in
+// debug_state_keys.go.
+const maxLookupWarned = 4096
 
 // quoteJoin renders the candidate identities as a quoted, comma
 // separated list, capped at lookupCandidateLimit with a count of what

--- a/gui/debug_state_keys.go
+++ b/gui/debug_state_keys.go
@@ -153,7 +153,10 @@ func (w *Window) debugCheckEffIDAnswers(ids *debugIDs) {
 	// Cleared whether or not anything is reported, so the next frame
 	// starts from what that frame actually resolved.
 	defer clear(w.debug.effIDAnswers)
-	for leaf, answered := range w.debug.effIDAnswers {
+	// Sorted leaves, so a window with several findings reports them
+	// the same way on every run.
+	for _, leaf := range slices.Sorted(maps.Keys(w.debug.effIDAnswers)) {
+		answered := w.debug.effIDAnswers[leaf]
 		if answered != leaf {
 			// The resolve picked up a scope. Whether it picked up the
 			// right one is the duplicate-ID check's business.

--- a/gui/debug_test.go
+++ b/gui/debug_test.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"math"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -265,13 +266,18 @@ func TestCheckCategoryMapping(t *testing.T) {
 		{debugCheckMouseLeaveNoID, DebugMissingIDs},
 		{debugCheckUnconsumed, DebugUnconsumed},
 		{debugCheckListBoxNoHeight, DebugListBoxNoHeight},
+		{debugCheckListHeightsCapped, DebugListBoxNoHeight},
+		{debugCheckListWidthRatchet, DebugListBoxNoHeight},
+		{debugCheckTextAnimNoID, DebugMissingIDs},
 		{debugCheckUnscopedID, DebugUnscopedIDs},
 		{debugCheckGradientResampled, DebugGradientResampled},
 		{debugCheckWrapOverflow, DebugWrapOverflow},
 		{debugCheckDeferredLoop, DebugCallbacks},
+		{debugCheckLinkNotOpened, DebugCallbacks},
 		{debugCheckWindowTransparency, DebugWindowDegraded},
 		{debugCheckWindowOpacity, DebugWindowDegraded},
 		{debugCheckUnresolvedKey, DebugUnresolvedKeys},
+		{debugCheckEffIDPhase, DebugUnresolvedKeys},
 		{debugCheckStampDrift, DebugStampDrift},
 		{debugCheckUnknownFocus, DebugUnknownFocus},
 		{debugCheckGlyphLayoutFallback, DebugGlyphLayoutFallback},
@@ -916,5 +922,202 @@ func TestEffIDAnswersAreFrameScoped(t *testing.T) {
 	if len(w.debug.effIDAnswers) != 0 {
 		t.Fatalf("the record must be cleared after the audit, got %v",
 			w.debug.effIDAnswers)
+	}
+}
+
+// An unmapped check is a programmer error and must fail loudly rather
+// than drop the finding.
+func TestCheckCategoryPanicsOnUnknown(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Errorf("want a panic for an unmapped check")
+		}
+	}()
+	_ = checkCategory(debugCheck(255))
+}
+
+// The sweep installs its mask only for its own duration. A narrower
+// gate a caller had installed must survive it unwidened.
+func TestTestUnconsumedEventsRestoresMask(t *testing.T) {
+	captureDebugMask(t, DebugDuplicates)
+	w := NewTestWindow(WindowCfg{})
+	w.SetView(func(_ *Window) View {
+		return Column(ContainerCfg{Sizing: FillFill})
+	})
+
+	w.TestUnconsumedEvents()
+
+	if got := DebugCategory(debugMask.Load()); got != DebugDuplicates {
+		t.Fatalf("want the caller's mask restored, got %v", got)
+	}
+
+	// An off gate must come back off, not all-on.
+	DebugCategories(0)
+	w.TestUnconsumedEvents()
+
+	if got := DebugCategory(debugMask.Load()); got != 0 {
+		t.Fatalf("want the off gate restored, got %v", got)
+	}
+}
+
+// A disabled subtree never scrolls, so a disabled ID-less scrollable
+// is quiet like its focusable and leave-tracking siblings. The enabled
+// control pins the test: it must still report.
+func TestDebugAuditDisabledScrollableIsQuiet(t *testing.T) {
+	buf := captureDebug(t)
+	w := &Window{}
+
+	disabled := debugTree(&Shape{Scrollable: true, Disabled: true})
+	w.debugAudit(&disabled)
+	if got := buf.String(); got != "" {
+		t.Fatalf("disabled scrollable must stay silent, got %q", got)
+	}
+
+	buf.Reset()
+	enabled := debugTree(&Shape{Scrollable: true})
+	w.debugAudit(&enabled)
+	if got := buf.String(); !strings.Contains(got, "scrollable shape") {
+		t.Fatalf("enabled scrollable must still report, got %q", got)
+	}
+}
+
+// A leaf stamped under many scopes names only the first few in the
+// focus hint, like the lookup finding does.
+func TestDebugUnknownFocusHintCapsCandidates(t *testing.T) {
+	buf := captureDebugMask(t, DebugUnknownFocus)
+	w := &Window{}
+	w.viewState.focusID = "nav"
+	ids := &debugIDs{
+		claimed:   map[string]string{},
+		focusable: map[string]struct{}{},
+	}
+	for i := range 7 {
+		ids.focusable["p"+strconv.Itoa(i)+":nav"] = struct{}{}
+	}
+
+	w.debugCheckFocusTarget(ids)
+
+	got := buf.String()
+	if !strings.Contains(got, "(and 2 more)") {
+		t.Fatalf("want the hint capped with a remainder count, got %q", got)
+	}
+	if strings.Contains(got, "p5:nav") {
+		t.Fatalf("want candidates past the cap left out, got %q", got)
+	}
+}
+
+// The NaN fold is discriminator-only: the message names the position
+// the backend passed, so a NaN rect is recognizable in the output.
+func TestDebugGradientResampledNaNKeepsPosition(t *testing.T) {
+	buf := captureDebugMask(t, DebugGradientResampled)
+	w := &Window{}
+	nan := float32(math.NaN())
+	inf := float32(math.Inf(1))
+
+	w.DebugGradientResampled(nan, nan, 5, 7)
+
+	if got := buf.String(); !strings.Contains(got, "gradient at (NaN, NaN)") {
+		t.Fatalf("want the message to keep the true position, got %q", got)
+	}
+
+	// +Inf formats stably, so it dedupes like any other position.
+	w.DebugGradientResampled(inf, 1, 5, 7)
+	w.DebugGradientResampled(inf, 1, 5, 7)
+	if n := strings.Count(buf.String(), "resampled"); n != 2 {
+		t.Fatalf("Inf coords must dedupe to one finding, got %d", n)
+	}
+}
+
+// The package-level lookup memory is bounded: past the cap a new pair
+// is suppressed rather than grown without limit.
+func TestLookupWarnSeenBoundsMemory(t *testing.T) {
+	lookupWarnMu.Lock()
+	savedWarned := lookupWarned
+	savedGen := lookupWarnGen
+	full := make(map[debugLookupKey]struct{}, maxLookupWarned)
+	for i := range maxLookupWarned {
+		full[debugLookupKey{api: "TestAPI", id: "id-" + strconv.Itoa(i)}] =
+			struct{}{}
+	}
+	lookupWarned = full
+	lookupWarnGen = debugGen.Load()
+	lookupWarnMu.Unlock()
+	t.Cleanup(func() {
+		lookupWarnMu.Lock()
+		lookupWarned = savedWarned
+		lookupWarnGen = savedGen
+		lookupWarnMu.Unlock()
+	})
+
+	if !lookupWarnSeen("TestAPI", "one-more", true) {
+		t.Fatalf("a pair past the cap must report as seen")
+	}
+	lookupWarnMu.Lock()
+	n := len(lookupWarned)
+	lookupWarnMu.Unlock()
+	if n != maxLookupWarned {
+		t.Fatalf("memory must stay bounded at %d, got %d", maxLookupWarned, n)
+	}
+}
+
+// The window-level diagnostics tolerate a nil window like the other
+// debug entry points, since backends call them where the platform
+// answer is known and must never crash the app to report it.
+func TestDebugWindowNilGuardsQuiet(t *testing.T) {
+	var w *Window
+	w.DebugWindowTransparency("no ARGB visual")
+	w.DebugWindowOpacity("platform refused")
+}
+
+// Several bad resolves in one frame report in sorted leaf order, so
+// the finding is stable across runs.
+func TestEffIDAnswersReportInSortedOrder(t *testing.T) {
+	buf := captureDebugMask(t, DebugUnresolvedKeys)
+	w := &Window{}
+	w.debug.effIDAnswers = map[string]string{
+		"zebra": "zebra",
+		"mango": "mango",
+		"apple": "apple",
+	}
+	ids := &debugIDs{scoped: map[string]string{
+		"zebra": "panel:zebra",
+		"mango": "panel:mango",
+		"apple": "panel:apple",
+	}}
+
+	w.debugCheckEffIDAnswers(ids)
+
+	got := buf.String()
+	appleIdx := strings.Index(got, `EffID("apple")`)
+	mangoIdx := strings.Index(got, `EffID("mango")`)
+	zebraIdx := strings.Index(got, `EffID("zebra")`)
+	if appleIdx < 0 || mangoIdx < 0 || zebraIdx < 0 {
+		t.Fatalf("want a finding per leaf, got %q", got)
+	}
+	if appleIdx >= mangoIdx || mangoIdx >= zebraIdx {
+		t.Fatalf("want findings in sorted leaf order, got %q", got)
+	}
+}
+
+// One window's warn-once memory is bounded: past the cap a new
+// finding is suppressed rather than grown without limit.
+func TestDebugWarnBoundsMemory(t *testing.T) {
+	buf := captureDebugMask(t, DebugDuplicates)
+	w := &Window{}
+	warned := make(map[debugWarnKey]struct{}, maxDebugWarned)
+	for i := range maxDebugWarned {
+		warned[debugWarnKey{check: debugCheckDupID,
+			subject: "id-" + strconv.Itoa(i)}] = struct{}{}
+	}
+	w.debug.warned = warned
+	w.debug.gen = debugGen.Load()
+
+	w.debugWarn(debugCheckDupID, "one-more", "duplicate ID %q", "one-more")
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("a finding past the cap must be suppressed, got %q", got)
+	}
+	if n := len(w.debug.warned); n != maxDebugWarned {
+		t.Fatalf("memory must stay bounded at %d, got %d", maxDebugWarned, n)
 	}
 }

--- a/gui/debug_window.go
+++ b/gui/debug_window.go
@@ -15,6 +15,9 @@ package gui
 // discriminator, so each distinct cause is reported once.
 // exportaudit:keep — dev-diagnostic API called from gui/backend
 func (w *Window) DebugWindowTransparency(reason string) {
+	if w == nil {
+		return
+	}
 	w.debugWarn(debugCheckWindowTransparency, reason,
 		"window: Transparent requested but %s", reason)
 }
@@ -26,6 +29,9 @@ func (w *Window) DebugWindowTransparency(reason string) {
 // cause is reported once.
 // exportaudit:keep — dev-diagnostic API called from gui/backend
 func (w *Window) DebugWindowOpacity(reason string) {
+	if w == nil {
+		return
+	}
 	w.debugWarn(debugCheckWindowOpacity, reason,
 		"window: opacity requested but %s", reason)
 }

--- a/gui/diagram_store.go
+++ b/gui/diagram_store.go
@@ -8,7 +8,11 @@ import (
 )
 
 // storeDiagramPNG writes PNG bytes to a temp file and returns
-// the file path. Native implementation.
+// the file path. Native implementation. The prefix names the
+// diagram kind and must come from internal constants (for
+// example "mermaid" or "math"). Do not pass user input here.
+// A failed write or close deletes the file and returns an
+// error, so callers never cache the path of a partial file.
 func storeDiagramPNG(
 	pngBytes []byte, hash int64, prefix string,
 ) (string, error) {
@@ -18,12 +22,25 @@ func storeDiagramPNG(
 		return "", err
 	}
 	path := f.Name()
-	if _, err := f.Write(pngBytes); err != nil {
+	written, err := f.Write(pngBytes)
+	if err != nil {
 		_ = f.Close()
 		_ = os.Remove(path)
 		return "", err
 	}
-	_ = f.Close()
+	if written != len(pngBytes) {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return "", fmt.Errorf(
+			"storeDiagramPNG: short write %d of %d bytes",
+			written, len(pngBytes))
+	}
+	// Close can report a deferred write error (for example a
+	// full disk). Check it before you return the path.
+	if closeErr := f.Close(); closeErr != nil {
+		_ = os.Remove(path)
+		return "", closeErr
+	}
 	return path, nil
 }
 

--- a/gui/diagram_store_js.go
+++ b/gui/diagram_store_js.go
@@ -5,9 +5,11 @@ package gui
 import "encoding/base64"
 
 // storeDiagramPNG base64-encodes PNG bytes and returns a
-// data URL. WASM implementation.
+// data URL. WASM implementation. The hash and prefix stay in
+// the signature for parity with the native version, which
+// uses them for the temp file name.
 func storeDiagramPNG(
-	pngBytes []byte, hash int64, prefix string,
+	pngBytes []byte, _ int64, _ string,
 ) (string, error) {
 	b64 := base64.StdEncoding.EncodeToString(pngBytes)
 	return "data:image/png;base64," + b64, nil

--- a/gui/diagram_store_test.go
+++ b/gui/diagram_store_test.go
@@ -3,7 +3,9 @@
 package gui
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -19,13 +21,8 @@ func TestStoreDiagramPNGWritesFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != len(data) {
-		t.Errorf("file size %d, want %d", len(got), len(data))
-	}
-	for i := range data {
-		if got[i] != data[i] {
-			t.Fatalf("byte %d: got %d, want %d", i, got[i], data[i])
-		}
+	if !bytes.Equal(got, data) {
+		t.Errorf("file holds %v, want %v", got, data)
 	}
 }
 
@@ -44,7 +41,9 @@ func TestRemoveDiagramPNGDeletesFile(t *testing.T) {
 	}
 }
 
-func TestRemoveDiagramPNGNonexistent(_ *testing.T) {
-	// Should not panic on missing file.
-	removeDiagramPNG("/tmp/nonexistent_diagram_test_12345.png")
+func TestRemoveDiagramPNGNonexistent(t *testing.T) {
+	// Should not panic on missing file. Build the path from
+	// the temp dir so the test stays portable.
+	missing := filepath.Join(t.TempDir(), "missing.png")
+	removeDiagramPNG(missing)
 }

--- a/gui/event_traversal.go
+++ b/gui/event_traversal.go
@@ -11,16 +11,19 @@ func isFocusedTarget(layout *Layout, w *Window) bool {
 	if layout.Shape == nil {
 		return false
 	}
-	if layout.Shape.ID == reservedDialogID {
+	if layout.Shape.idKey() == reservedDialogID {
 		return true
 	}
 	if !layout.Shape.canTakeFocus() {
 		return false
 	}
 	// The focus store holds effective IDs, so compare on idKey, not on
-	// the leaf the widget was written with. reservedDialogID above stays
-	// a leaf comparison: a dialog is its own float root, where leaf and
-	// effID are equal.
+	// the leaf the widget was written with. The reserved-dialog arm
+	// above matches on idKey for the same reason: a dialog is its own
+	// float root, where leaf and effID are equal, while a scoped
+	// widget whose leaf merely spells the reserved ID addresses
+	// "scope:___dialog_reserved_do_not_use___" and must not inherit
+	// the dialog's dispatch.
 	return w.IsFocus(layout.Shape.idKey())
 }
 

--- a/gui/event_traversal_test.go
+++ b/gui/event_traversal_test.go
@@ -18,6 +18,18 @@ func TestIsFocusedTargetReservedDialog(t *testing.T) {
 	}
 }
 
+func TestIsFocusedTargetScopedReservedDialogID(t *testing.T) {
+	w := &Window{}
+	// A scoped widget whose leaf spells the reserved dialog ID
+	// addresses "scope:___dialog_reserved_do_not_use___", not the
+	// dialog. Matching on the leaf would hand it the dialog's
+	// focused dispatch.
+	l := &Layout{Shape: &Shape{ID: reservedDialogID, effID: "scope:" + reservedDialogID}}
+	if isFocusedTarget(l, w) {
+		t.Error("scoped reservedDialogID leaf should not be a focus target")
+	}
+}
+
 func TestIsFocusedTargetZeroIDFocus(t *testing.T) {
 	w := &Window{}
 	l := &Layout{Shape: &Shape{Focusable: true, ID: "f0"}}

--- a/gui/markdown_diagram_fetch_test.go
+++ b/gui/markdown_diagram_fetch_test.go
@@ -4,10 +4,9 @@ package gui
 // markdown_mermaid.go / markdown_math.go: the stale-result guard
 // (diagramCacheShouldApplyResult), the decode-and-store completion
 // path (finishDiagramFetch) driven through the injected fetcher seam,
-// and the two default HTTP fetchers (assessed as testable via a
-// swapped transport — they hit a fixed hostname but the shared
-// diagramHTTPClient can point at a stub transport, so no network is
-// touched).
+// and the two default HTTP fetchers (they hit a fixed hostname
+// but setDiagramHTTPClient can point the shared client at a stub
+// transport, so no network is touched).
 
 import (
 	"bytes"
@@ -42,15 +41,13 @@ func testPNGBytes(t *testing.T, w, h int) []byte {
 // waitForDiagramCommand polls until at least one command is queued
 // (finishDiagramFetch/queueDiagramError run on the fetcher goroutine,
 // so the queue fills asynchronously after the fetcher returns) and
-// then drains the queue with a frame.
+// then drains the queue with a frame. It reads the queue through
+// pendingCommandCount so the lock discipline stays with the queue.
 func waitForDiagramCommand(t *testing.T, w *Window) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for {
-		w.commandsMu.Lock()
-		pending := len(w.commands)
-		w.commandsMu.Unlock()
-		if pending > 0 {
+		if w.pendingCommandCount() > 0 {
 			w.FrameFn()
 			return
 		}
@@ -62,8 +59,12 @@ func waitForDiagramCommand(t *testing.T, w *Window) {
 }
 
 // newDiagramWindow returns a window with an empty diagram cache.
+// It runs the production lazy init first so a break there fails
+// here too, then installs a small isolated cache to keep tests
+// fast and independent.
 func newDiagramWindow() *Window {
 	w := NewTestWindow(WindowCfg{Width: 100, Height: 100})
+	ensureDiagramCache(w)
 	w.viewState.diagramCache = newBoundedDiagramCache(10)
 	return w
 }
@@ -162,21 +163,28 @@ func TestFetchMermaidAsyncStoresReadyEntry(t *testing.T) {
 	if entry.pNGPath == "" {
 		t.Fatal("ready entry has no stored PNG path")
 	}
+	storedPath := entry.pNGPath
 	if runtime.GOOS == "js" {
 		// The WASM build stores diagrams as data URLs, not temp
 		// files (diagram_store_js.go) — there is no filesystem to
 		// stat. Pin the wasm contract instead: the entry's "path" is
 		// a base64 data URL of the fetched PNG.
-		if !strings.HasPrefix(entry.pNGPath,
+		if !strings.HasPrefix(storedPath,
 			"data:image/png;base64,") {
 			t.Errorf("entry pNGPath = %q, want a PNG data URL on "+
-				"wasm", entry.pNGPath)
+				"wasm", storedPath)
 		}
 	} else {
-		if _, err := os.Stat(entry.pNGPath); err != nil {
-			t.Errorf("stored PNG missing: %v", err)
+		// Delete the temp file when the test ends. Register
+		// before the reads below so a failure cannot leak it.
+		t.Cleanup(func() { removeDiagramPNG(storedPath) })
+		stored, err := os.ReadFile(storedPath)
+		if err != nil {
+			t.Fatalf("stored PNG missing: %v", err)
 		}
-		t.Cleanup(func() { removeDiagramPNG(entry.pNGPath) })
+		if !bytes.Equal(stored, body) {
+			t.Error("stored PNG differs from the fetched body")
+		}
 	}
 }
 
@@ -390,18 +398,32 @@ func (s stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // withStubHTTPClient swaps the shared diagramHTTPClient for one backed
-// by stub and restores it when the test ends. Safe because no other
-// test in the package uses t.Parallel while touching diagrams.
+// by stub and restores it when the test ends. The swap goes through
+// the mutex-guarded setter so it stays race-clean against fetches on
+// background goroutines. Tests in this package must not run in
+// parallel while touching diagrams, or one test would observe
+// another test's stub.
 func withStubHTTPClient(t *testing.T, status int, body []byte) *[]string {
 	t.Helper()
 	var urls []string
-	prev := diagramHTTPClient
-	diagramHTTPClient = &http.Client{
+	prev := getDiagramHTTPClient()
+	setDiagramHTTPClient(&http.Client{
 		Timeout:   diagramFetchTimeout,
 		Transport: stubTransport{status: status, body: body, urls: &urls},
-	}
-	t.Cleanup(func() { diagramHTTPClient = prev })
+	})
+	t.Cleanup(func() { setDiagramHTTPClient(prev) })
 	return &urls
+}
+
+// TestSetDiagramHTTPClientNilKeepsCurrent asserts a nil swap
+// leaves the shared client in place instead of breaking later
+// fetches with a nil-pointer call.
+func TestSetDiagramHTTPClientNilKeepsCurrent(t *testing.T) {
+	before := getDiagramHTTPClient()
+	setDiagramHTTPClient(nil)
+	if getDiagramHTTPClient() != before {
+		t.Error("nil swap replaced the shared client")
+	}
 }
 
 func TestDefaultMermaidFetcherHTTP(t *testing.T) {
@@ -465,8 +487,57 @@ func TestDefaultMathFetcherHTTP(t *testing.T) {
 		t.Errorf("request URL lacks \\color{white} for a bright "+
 			"foreground: %q", u)
 	}
-	if !strings.Contains(u, "x%5E2") && !strings.Contains(u, "x^2") {
-		t.Errorf("request URL lacks the latex payload: %q", u)
+	if !strings.Contains(u, "x%5E2") {
+		t.Errorf("request URL lacks the encoded latex "+
+			"payload (want x%%5E2): %q", u)
+	}
+}
+
+// TestDefaultMathFetcherURLEncodesReservedChars feeds a formula
+// with URL-reserved characters and asserts each one arrives
+// encoded, so the formula cannot change the request itself.
+func TestDefaultMathFetcherURLEncodesReservedChars(t *testing.T) {
+	body := testPNGBytes(t, 25, 25)
+	urls := withStubHTTPClient(t, 200, body)
+
+	_, err := defaultMathFetcher(
+		context.Background(), "a+b%c&d#e?f=g h", 150,
+		RGB(0, 0, 0))
+	if err != nil {
+		t.Fatalf("defaultMathFetcher: %v", err)
+	}
+	if len(*urls) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*urls))
+	}
+	u := (*urls)[0]
+	for _, want := range []string{
+		"a%2Bb", "%25", "%26", "%23", "%3F", "%3D", "g{}h",
+	} {
+		if !strings.Contains(u, want) {
+			t.Errorf("request URL = %q, want it to hold %q",
+				u, want)
+		}
+	}
+	_, formula, found := strings.Cut(u, "?")
+	if !found {
+		t.Fatalf("request URL = %q, want a ? separator", u)
+	}
+	if strings.Contains(formula, "&") {
+		t.Errorf("request URL holds a raw &: %q", u)
+	}
+}
+
+// TestDefaultMathFetcher_SourceTooLarge asserts the size guard
+// fires before any URL is built.
+func TestDefaultMathFetcher_SourceTooLarge(t *testing.T) {
+	longSource := strings.Repeat("x", markdown.MaxLatexSourceLen+1)
+	_, err := defaultMathFetcher(
+		context.Background(), longSource, 150, RGB(0, 0, 0))
+	if err == nil {
+		t.Fatal("expected error for oversized source")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error should mention size: %v", err)
 	}
 }
 

--- a/gui/markdown_math.go
+++ b/gui/markdown_math.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/go-gui-org/go-gui/gui/markdown"
@@ -107,6 +108,12 @@ func queueDiagramError(
 func defaultMathFetcher(
 	ctx context.Context, latex string, dpi int, fgColor Color,
 ) ([]byte, error) {
+	// Defense-in-depth: the async caller sanitizes and caps
+	// this, but clamp here so a direct call cannot pass an
+	// unbounded payload into the URL builder below.
+	if len(latex) > markdown.MaxLatexSourceLen {
+		return nil, errors.New("latex source too large")
+	}
 	// Clamp DPI to a reasonable range. Values outside this
 	// can produce enormous or invisible images on the renderer.
 	if dpi < 24 {
@@ -125,19 +132,24 @@ func defaultMathFetcher(
 	}
 	prefix := fmt.Sprintf(`\dpi{%d}%s`, dpi, colorCmd)
 
-	encoded := strings.ReplaceAll(
-		prefix+latex, " ", "{}")
-	encoded = strings.ReplaceAll(encoded, "#", "%23")
-	encoded = strings.ReplaceAll(encoded, "&", "%26")
+	// Encode the user formula for the URL query. Escape only
+	// the formula: the prefix holds literal codecogs commands
+	// that must stay raw. QueryEscape turns spaces into "+",
+	// which codecogs does not read as a space, so restore the
+	// "{}" space form after encoding. Full encoding also keeps
+	// reserved characters ("%", "+", "?", "=" and more) in the
+	// formula from changing the request itself.
+	escaped := url.QueryEscape(latex)
+	escaped = strings.ReplaceAll(escaped, "+", "{}")
 	reqURL := "https://latex.codecogs.com/png.image?" +
-		encoded
+		prefix + escaped
 
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := diagramHTTPClient.Do(req)
+	resp, err := getDiagramHTTPClient().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/gui/markdown_mermaid.go
+++ b/gui/markdown_mermaid.go
@@ -12,6 +12,7 @@ import (
 	"image/png"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/go-gui-org/go-gui/gui/markdown"
@@ -25,7 +26,34 @@ const (
 
 // diagramHTTPClient is shared by defaultMathFetcher and
 // defaultMermaidFetcher to avoid per-request allocation.
-var diagramHTTPClient = &http.Client{Timeout: diagramFetchTimeout}
+// Access it through the helpers below. Tests swap in a stub
+// transport, and fetches run on background goroutines, so
+// direct reads and writes race.
+var (
+	diagramHTTPClient   = &http.Client{Timeout: diagramFetchTimeout}
+	diagramHTTPClientMu sync.RWMutex
+)
+
+// getDiagramHTTPClient returns the shared diagram client.
+func getDiagramHTTPClient() *http.Client {
+	diagramHTTPClientMu.RLock()
+	defer diagramHTTPClientMu.RUnlock()
+	return diagramHTTPClient
+}
+
+// setDiagramHTTPClient swaps the shared diagram client.
+// Production code never calls it. Tests call it to install
+// a stub transport, and they must restore the previous
+// client when the test ends. A nil client keeps the current
+// one, so a bad swap cannot break later fetches.
+func setDiagramHTTPClient(c *http.Client) {
+	if c == nil {
+		return
+	}
+	diagramHTTPClientMu.Lock()
+	defer diagramHTTPClientMu.Unlock()
+	diagramHTTPClient = c
+}
 
 // DiagramState represents the loading state of a diagram.
 type diagramState uint8
@@ -260,7 +288,7 @@ func defaultMermaidFetcher(ctx context.Context, source string) ([]byte, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := diagramHTTPClient.Do(req)
+	resp, err := getDiagramHTTPClient().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/gui/native_platform_noop.go
+++ b/gui/native_platform_noop.go
@@ -1,5 +1,12 @@
 package gui
 
+import "sync/atomic"
+
+// noopTrayIDs hands out unique positive tray IDs process-wide.
+// NoopNativePlatform is a zero-value struct, so per-instance
+// counters are impossible; the global keeps handles distinct.
+var noopTrayIDs atomic.Int64
+
 // NoopNativePlatform is a zero-value NativePlatform where every
 // method is a no-op. Embed it in test mocks and override only
 // the methods under test.
@@ -54,7 +61,7 @@ func (noopNativePlatform) SpellLearn(_ string)                                 {
 func (noopNativePlatform) SetNativeMenubar(_ NativeMenubarCfg, _ func(string)) {}
 func (noopNativePlatform) ClearNativeMenubar()                                 {}
 func (noopNativePlatform) CreateSystemTray(_ SystemTrayCfg, _ func(string)) (int, error) {
-	return 0, nil
+	return int(noopTrayIDs.Add(1)), nil
 }
 func (noopNativePlatform) UpdateSystemTray(_ int, _ SystemTrayCfg) {}
 func (noopNativePlatform) RemoveSystemTray(_ int)                  {}

--- a/gui/scroll_smooth.go
+++ b/gui/scroll_smooth.go
@@ -78,8 +78,12 @@ func (s *scrollSmoothAnimation) SetStart(t time.Time) { s.start = t }
 // w.animMu is held (see animationLoop).
 func (s *scrollSmoothAnimation) Update(_ *Window, _ float32, ac *AnimationCommands) bool {
 	anyActive := false
+	anyDirty := false
 	for i := range s.entries {
 		e := &s.entries[i]
+		if e.dirty {
+			anyDirty = true
+		}
 		if !e.active {
 			continue
 		}
@@ -105,6 +109,16 @@ func (s *scrollSmoothAnimation) Update(_ *Window, _ float32, ac *AnimationComman
 		anyActive = true
 	}
 	if !anyActive {
+		// All entries are inactive: drop them rather than retaining one
+		// per scrollable ever touched for the window's lifetime. The
+		// next ease rebuilds its entry from the displayed offset (see
+		// scrollSmoothArm), so nothing is lost. Entries with a dirty
+		// value the main thread has not applied yet are kept: the
+		// apply pass is keyed on dirty, and a slow flush must still
+		// apply the final value instead of ending fractionally short.
+		if !anyDirty {
+			s.entries = s.entries[:0]
+		}
 		s.stopped = true
 		return false
 	}
@@ -300,19 +314,28 @@ func commandApplyScrollSmooth(w *Window) {
 	}
 	w.animMu.Lock()
 	ss.pending = ss.pending[:0]
+	// Reap fully-quiesced entries below: the animation tick cannot
+	// clear a final value the main thread has not applied yet (see
+	// Update), so the apply pass releases them once applied.
+	quiesced := true
 	for i := range ss.entries {
 		e := &ss.entries[i]
 		// Keyed on dirty, not active: a settled entry retires on
 		// the tick after its final value is computed, and a slow
 		// flush must still apply that value instead of ending the
 		// ease fractionally short of its target.
-		if !e.dirty {
-			continue
+		if e.dirty {
+			e.dirty = false
+			ss.pending = append(ss.pending, scrollApply{
+				id: e.id, axis: e.axis, val: e.current,
+			})
 		}
-		e.dirty = false
-		ss.pending = append(ss.pending, scrollApply{
-			id: e.id, axis: e.axis, val: e.current,
-		})
+		if e.active {
+			quiesced = false
+		}
+	}
+	if quiesced {
+		ss.entries = ss.entries[:0]
 	}
 	w.animMu.Unlock()
 

--- a/gui/shape.go
+++ b/gui/shape.go
@@ -622,6 +622,9 @@ func (s *Shape) focusKey() string {
 
 // canTakeFocus reports whether a shape is eligible to hold keyboard
 // focus: focusable, addressed by a non-empty ID, and not disabled.
+// The ID arm reads idKey, the effective ID the focus store holds,
+// not the leaf: the two agree for every generated shape, and the
+// fallback covers a hand-built Layout the generator never stamped.
 // FocusSkip is deliberately absent: a skipped widget is out of tab
 // order but still takes click-focus. There is no Invisible arm:
 // invisibility never reaches a shape, because every widget maps an
@@ -631,7 +634,7 @@ func (s *Shape) focusKey() string {
 // (collectFocusCandidates), mouse focus (mouseDownHandler) and the
 // debug gate's focusable set from drifting apart again.
 func (s *Shape) canTakeFocus() bool {
-	return s.Focusable && s.ID != "" && !s.Disabled
+	return s.Focusable && s.idKey() != "" && !s.Disabled
 }
 
 // rendersFocusState reports whether this shape draws caret, selection

--- a/gui/shape_test.go
+++ b/gui/shape_test.go
@@ -82,3 +82,19 @@ func TestShapeHasEvents(t *testing.T) {
 		t.Error("should be true with events")
 	}
 }
+
+func TestCanTakeFocusEffIDOnly(t *testing.T) {
+	// The focus store holds effective IDs, so the gate must too:
+	// a focusable shape stamped with an effID is addressable even
+	// when its leaf is empty (hand-built layouts in tests).
+	s := &Shape{Focusable: true, effID: "scope:field"}
+	if !s.canTakeFocus() {
+		t.Error("focusable shape with effID should take focus")
+	}
+	if s := (&Shape{Focusable: true}); s.canTakeFocus() {
+		t.Error("focusable shape with no ID at all should not take focus")
+	}
+	if s := (&Shape{Focusable: true, effID: "scope:field", Disabled: true}); s.canTakeFocus() {
+		t.Error("disabled shape should not take focus")
+	}
+}

--- a/gui/testing_test.go
+++ b/gui/testing_test.go
@@ -307,6 +307,54 @@ func TestTestTabTraversesInOrder(t *testing.T) {
 	}
 }
 
+// A Tab chord with any keyboard modifier beyond Shift must not
+// traverse: Ctrl+Tab, Alt+Tab and friends belong to the focused
+// widget (or the OS), not to focus order. Shift+Ctrl+Tab in
+// particular must not fall through to the next-stop branch.
+func TestTestTabIgnoresModifiedTab(t *testing.T) {
+	w := newCounterWindow(t)
+	if got, _ := w.testTab(tabForward); got != "inc" {
+		t.Fatalf("first Tab focused %q, want %q", got, "inc")
+	}
+	for _, mods := range []Modifier{
+		ModCtrl, ModAlt, ModSuper, ModShift | ModCtrl, ModCtrl | ModAlt,
+	} {
+		e := Event{Type: EventKeyDown, KeyCode: KeyTab, Modifiers: mods}
+		w.EventFn(&e)
+		w.settle()
+		if got := w.FocusID(); got != "inc" {
+			t.Errorf("Tab with modifiers %v moved focus to %q, want %q",
+				mods, got, "inc")
+		}
+	}
+	// Plain Tab still advances: the guard must ignore chords, not Tab.
+	if got, _ := w.testTab(tabForward); got != "dec" {
+		t.Fatalf("Tab after modified chords focused %q, want %q", got, "dec")
+	}
+}
+
+// Held mouse buttons ride in Event.Modifiers on two backends, so the
+// Tab guard masks them out like scroll dispatch does: Tab while
+// dragging still traverses.
+func TestTestTabWhileDraggingTraverses(t *testing.T) {
+	w := newCounterWindow(t)
+	if got, _ := w.testTab(tabForward); got != "inc" {
+		t.Fatalf("first Tab focused %q, want %q", got, "inc")
+	}
+	e := Event{Type: EventKeyDown, KeyCode: KeyTab, Modifiers: ModLMB}
+	w.EventFn(&e)
+	w.settle()
+	if got := w.FocusID(); got != "dec" {
+		t.Errorf("Tab with LMB held focused %q, want %q", got, "dec")
+	}
+	e = Event{Type: EventKeyDown, KeyCode: KeyTab, Modifiers: ModLMB | ModShift}
+	w.EventFn(&e)
+	w.settle()
+	if got := w.FocusID(); got != "inc" {
+		t.Errorf("Shift-Tab with LMB held focused %q, want %q", got, "inc")
+	}
+}
+
 // A widget with Focusable but no ID never joins tab order. This is the
 // silent no-op phase 1 made impossible for the nine input factories;
 // containers can still express it, and TestTab must show it.

--- a/gui/text_anim.go
+++ b/gui/text_anim.go
@@ -304,16 +304,18 @@ func applyTextAnim(tv *textView, w *Window, sh *Shape) TextAnimFrame {
 	key := w.EffID(tv.cfg.ID)
 	animID := ScopeID("textanim", key)
 
-	dur := cfg.Duration
-	if dur <= 0 {
-		// RuneCountInString, not len([]rune(...)): the latter allocates
-		// a rune slice, and this runs on every frame of the animation.
-		dur = textAnimDefaultDuration(
-			cfg.Kind, utf8.RuneCountInString(tv.cfg.Text))
-	}
-
 	st := StateReadOr(w, nsTextAnim, key, textAnimState{})
 	if !w.touchViewBoundAnimation(animID) && !st.done {
+		// Resolve the duration only when registering the driver: the
+		// typewriter default counts runes (O(n)), and this frame runs
+		// on every tick of the animation.
+		dur := cfg.Duration
+		if dur <= 0 {
+			// RuneCountInString, not len([]rune(...)): the latter
+			// allocates a rune slice.
+			dur = textAnimDefaultDuration(
+				cfg.Kind, utf8.RuneCountInString(tv.cfg.Text))
+		}
 		w.animationAddViewBound(newTextAnimDriver(
 			animID, key, dur, cfg.Delay, cfg.Repeat,
 		))

--- a/gui/time_travel_hardening_test.go
+++ b/gui/time_travel_hardening_test.go
@@ -178,8 +178,8 @@ func TestJumpSyncsSliderValue(t *testing.T) {
 func TestOpenDebugWindowCloseResumes(t *testing.T) {
 	app := NewApp()
 	w := &Window{state: &testState{}}
-	w.app = app
-	w.platformID = 1
+	w.app.Store(app)
+	w.platformID.Store(1)
 	w.enableHistory(0)
 	w.Freeze()
 	if !w.isFrozen() {
@@ -207,8 +207,8 @@ func TestOpenDebugWindowCloseResumes(t *testing.T) {
 func TestOpenDebugWindowDimensions(t *testing.T) {
 	app := NewApp()
 	w := &Window{state: &testState{}}
-	w.app = app
-	w.platformID = 1
+	w.app.Store(app)
+	w.platformID.Store(1)
 	w.enableHistory(0)
 	w.openDebugWindow()
 
@@ -274,8 +274,8 @@ func TestBoundedMapCloneEmpty(t *testing.T) {
 func TestOpenDebugWindowTruncatesLongTitle(t *testing.T) {
 	app := NewApp()
 	w := &Window{state: &testState{}}
-	w.app = app
-	w.platformID = 1
+	w.app.Store(app)
+	w.platformID.Store(1)
 	w.Config.Title = strings.Repeat("x", 4096)
 	w.enableHistory(0)
 	w.openDebugWindow()

--- a/gui/time_travel_view_test.go
+++ b/gui/time_travel_view_test.go
@@ -270,8 +270,8 @@ func TestOpenDebugWindowQueuesCfg(t *testing.T) {
 	app := NewApp()
 	s := &testState{counter: 1}
 	w := &Window{state: s}
-	w.app = app
-	w.platformID = 1
+	w.app.Store(app)
+	w.platformID.Store(1)
 	w.Config.Title = "MyApp"
 	w.enableHistory(0)
 	w.history.push(s.Snapshot(), time.Now(), "init")

--- a/gui/window.go
+++ b/gui/window.go
@@ -91,8 +91,10 @@ type Window struct {
 	// in-flight async goroutines (HTTP fetches, notifications, etc.).
 	ctx context.Context
 
-	// Multi-window: parent App and platform window ID.
-	app *App
+	// Multi-window: parent App and platform window ID. Atomic:
+	// App.Register/Unregister publish from the main thread while
+	// App() and PlatformID() may read from any goroutine.
+	app atomic.Pointer[App]
 
 	// View generator — produces the root View each frame.
 	viewGenerator func(*Window) View
@@ -230,7 +232,9 @@ type Window struct {
 	mu         sync.Mutex // guards layout/renderer state
 	commandsMu sync.Mutex // guards command queue
 
-	platformID uint32
+	// platformID is the platform-native window ID (0 when
+	// unregistered). Atomic for the same reason as app above.
+	platformID atomic.Uint32
 	closeReq   atomic.Bool
 
 	// BackingScale is the device pixel ratio set by the backend each frame
@@ -533,10 +537,22 @@ func (w *Window) MouseCursorState() MouseCursor {
 }
 
 // App returns the parent App, or nil for single-window mode.
-func (w *Window) App() *App { return w.app }
+// Safe to call from any goroutine.
+func (w *Window) App() *App {
+	if w == nil {
+		return nil
+	}
+	return w.app.Load()
+}
 
 // PlatformID returns the platform-native window ID (0 if not yet registered).
-func (w *Window) PlatformID() uint32 { return w.platformID }
+// Safe to call from any goroutine.
+func (w *Window) PlatformID() uint32 {
+	if w == nil {
+		return 0
+	}
+	return w.platformID.Load()
+}
 
 // Close requests the window be closed on the next frame.
 // Safe to call from any goroutine.

--- a/gui/window.go
+++ b/gui/window.go
@@ -128,8 +128,11 @@ type Window struct {
 	commands []queuedCommand
 
 	// Command registry — registered commands for shortcut
-	// dispatch, menu/button integration.
+	// dispatch, menu/button integration. Guarded by cmdMu;
+	// dispatch snapshots under RLock so user callbacks
+	// (CanExecute/Execute) run without the lock held.
 	cmdRegistry []Command
+	cmdMu       sync.RWMutex
 
 	// Scratch queue used to avoid reallocating command storage each frame.
 	commandScratch []queuedCommand

--- a/gui/window_event.go
+++ b/gui/window_event.go
@@ -133,14 +133,21 @@ func (w *Window) handleKeyDownEvent(layout *Layout, e *Event) {
 	if !e.IsHandled {
 		keydownHandler(layout, e, w)
 	}
-	if !e.IsHandled && e.KeyCode == KeyTab &&
-		e.Modifiers == ModShift {
-		if shape, ok := layout.previousFocusable(w); ok {
-			w.SetFocus(shape.idKey())
-		}
-	} else if !e.IsHandled && e.KeyCode == KeyTab {
-		if shape, ok := layout.nextFocusable(w); ok {
-			w.SetFocus(shape.idKey())
+	if !e.IsHandled && e.KeyCode == KeyTab {
+		// Match on the keyboard bits only, like scroll dispatch:
+		// two backends OR held mouse buttons into Modifiers, and a
+		// Ctrl/Alt/Super chord is the focused widget's (or the
+		// OS's), not a traversal. Shift+Ctrl+Tab therefore goes
+		// nowhere rather than falling through to the next stop.
+		switch e.Modifiers & modKeyboard {
+		case ModShift:
+			if shape, ok := layout.previousFocusable(w); ok {
+				w.SetFocus(shape.idKey())
+			}
+		case ModNone:
+			if shape, ok := layout.nextFocusable(w); ok {
+				w.SetFocus(shape.idKey())
+			}
 		}
 	}
 	// Non-global commands fire as fallback.

--- a/gui/window_focus.go
+++ b/gui/window_focus.go
@@ -7,6 +7,10 @@ import "time"
 // FocusID returns the current focus ID. The value is an effective ID,
 // so it is already in the form [Window.SetFocus] and [Layout.FindByID]
 // take.
+//
+// Main-thread only: no lock is taken, so a call from any other
+// goroutine races with [Window.SetFocus]. Route worker-goroutine
+// reads through [Window.QueueCommand].
 func (w *Window) FocusID() string {
 	return w.viewState.focusID
 }
@@ -16,7 +20,8 @@ func (w *Window) FocusID() string {
 // that already holds focus leaves selections alone. Acquires w.mu
 // (focusID); the caret-blink animation is managed from the render
 // pass, not here (see syncBlinkCursor). Use ClearFocus to remove
-// focus.
+// focus. From any goroutine other than the main thread, use
+// [Window.QueueCommand] instead of calling this directly.
 //
 // effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
@@ -115,6 +120,10 @@ func resetBlinkCursorVisible(w *Window) {
 // effectiveID is the widget's effective ID: a leaf under an ID-bearing
 // ancestor is addressed by its full path ("detail:nav"), not by the
 // leaf its Cfg was written with. Read it back with [Window.ResolveID].
+//
+// Main-thread only, like [Window.FocusID]: no lock is taken, so a
+// call from any other goroutine races with [Window.SetFocus]. Route
+// worker-goroutine reads through [Window.QueueCommand].
 func (w *Window) IsFocus(effectiveID string) bool {
 	return w.viewState.focusID != "" && w.viewState.focusID == effectiveID
 }

--- a/gui/window_state.go
+++ b/gui/window_state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // windowRender holds render-walk state reset each frame.
@@ -29,9 +30,11 @@ type windowAnimation struct {
 	animMu sync.Mutex // guards animations, animViewBound
 	// Active animations keyed by ID.
 	animations map[string]Animation
-	// View-bound animation heartbeats: animID → last-seen UnixNano.
-	// Nil until first view-bound animation is registered.
-	animViewBound map[string]int64
+	// View-bound animation heartbeats: animID → last-seen time.
+	// time.Time (not UnixNano) so the monotonic reading survives wall
+	// clock steps; see viewBoundNow. Nil until first view-bound
+	// animation is registered.
+	animViewBound map[string]time.Time
 	// Animation loop lifecycle.
 	animationStop      chan struct{}
 	animationDone      chan struct{}

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -67,6 +67,16 @@ func (w *Window) queueCommandsBatch(cmds []queuedCommand) {
 	w.commandsMu.Unlock()
 }
 
+// pendingCommandCount reports the number of queued commands.
+// It is a test seam: async tests wait for a queued completion
+// through it instead of reaching into the queue fields, so the
+// lock discipline stays with the queue implementation.
+func (w *Window) pendingCommandCount() int {
+	w.commandsMu.Lock()
+	defer w.commandsMu.Unlock()
+	return len(w.commands)
+}
+
 // reclaimCommandScratch reclaims the scratch buffer when the main
 // command slice is nil. Caller must hold commandsMu.
 func (w *Window) reclaimCommandScratch() {

--- a/gui/window_update.go
+++ b/gui/window_update.go
@@ -97,11 +97,17 @@ func (w *Window) flushCommands() {
 		cmd := toRun[i]
 		switch cmd.kind {
 		case queuedCommandWindowFn:
-			cmd.windowFn(w)
+			if cmd.windowFn != nil {
+				cmd.windowFn(w)
+			}
 		case queuedCommandValueFn:
-			cmd.valueFn(cmd.value, w)
+			if cmd.valueFn != nil {
+				cmd.valueFn(cmd.value, w)
+			}
 		case queuedCommandAnimateFn:
-			cmd.animateFn(cmd.animate, w)
+			if cmd.animateFn != nil {
+				cmd.animateFn(cmd.animate, w)
+			}
 		}
 	}
 


### PR DESCRIPTION
Batch of gui quality fixes on focus handling, accessibility bridges, animation heartbeats, debug diagnostics, and race safety.

- fix(gui): modified Tab chords no longer move focus, dialog focus spoof closed
- fix(gui): per-window a11y bridges, empty-tree clear, live-region identity
- fix(gui): animation stall resync, finite outputs, monotonic heartbeats
- fix(gl): reference Linux-only a11y field from no-op stubs for windows lint
- fix(gui): race-safe App registry with main failover and atomic window linkage
- fix(gui): export full color palette, harden conversions, fix plane cache key
- fix(gui): race-safe command registry, nil-safe dispatch, public animation enqueue
- fix(gui): debug diagnostics quality pass — mask restore, bounded warn-once, deterministic findings
- fix(gui): diagram store errors, math URL encoding, race-safe client

Local gate: `make prepush` green.